### PR TITLE
Stable splice-topo order for resolving splicing

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1741,7 +1741,7 @@ class SpackSolverSetup:
                     if any(
                         v in cond.variants or v in spec_to_splice.variants for v in match_variants
                     ):
-                        raise Exception(
+                        raise spack.error.PackageError(
                             "Overlap between match_variants and explicitly set variants"
                         )
                     variant_constraints = self._gen_match_variant_splice_constraints(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -37,6 +37,7 @@ import spack.package_base
 import spack.package_prefs
 import spack.platforms
 import spack.repo
+import spack.solver.splicing
 import spack.spec
 import spack.store
 import spack.util.crypto
@@ -3374,14 +3375,6 @@ class RuntimePropertyRecorder:
         self._setup.effect_rules()
 
 
-# This should be a dataclass, but dataclasses don't work on Python 3.6
-class Splice:
-    def __init__(self, splice_node: NodeArgument, child_name: str, child_hash: str):
-        self.splice_node = splice_node
-        self.child_name = child_name
-        self.child_hash = child_hash
-
-
 class SpecBuilder:
     """Class with actions to rebuild a spec from ASP results."""
 
@@ -3421,7 +3414,7 @@ class SpecBuilder:
         self._specs: Dict[NodeArgument, spack.spec.Spec] = {}
 
         # Matches parent nodes to splice node
-        self._splices: Dict[NodeArgument, List[Splice]] = {}
+        self._splices: Dict[spack.spec.Spec, List[spack.solver.splicing.Splice]] = {}
         self._result = None
         self._command_line_specs = specs
         self._flag_sources: Dict[Tuple[NodeArgument, str], Set[str]] = collections.defaultdict(
@@ -3628,50 +3621,12 @@ class SpecBuilder:
         child_name: str,
         child_hash: str,
     ):
-        splice = Splice(splice_node, child_name=child_name, child_hash=child_hash)
-        self._splices.setdefault(parent_node, []).append(splice)
-
-    def _resolve_automatic_splices(self):
-        """After all of the specs have been concretized, apply all immediate splices.
-
-        Use reverse topological order to ensure that all dependencies are resolved
-        before their parents, allowing for maximal sharing and minimal copying.
-
-        """
-        fixed_specs = {}
-
-        # create a mapping from dag hash to an integer representing position in reverse topo order.
-        specs = self._specs.values()
-        topo_order = list(traverse.traverse_nodes(specs, order="topo", key=traverse.by_dag_hash))
-        topo_lookup = {spec.dag_hash(): index for index, spec in enumerate(reversed(topo_order))}
-
-        # iterate over specs, children before parents
-        for node, spec in sorted(self._specs.items(), key=lambda x: topo_lookup[x[1].dag_hash()]):
-            immediate = self._splices.get(node, [])
-            if not immediate and not any(
-                edge.spec in fixed_specs for edge in spec.edges_to_dependencies()
-            ):
-                continue
-            new_spec = spec.copy(deps=False)
-            new_spec.clear_caches(ignore=("package_hash",))
-            new_spec.build_spec = spec
-            for edge in spec.edges_to_dependencies():
-                depflag = edge.depflag & ~dt.BUILD
-                if any(edge.spec.dag_hash() == splice.child_hash for splice in immediate):
-                    splice = [s for s in immediate if s.child_hash == edge.spec.dag_hash()][0]
-                    new_spec.add_dependency_edge(
-                        self._specs[splice.splice_node], depflag=depflag, virtuals=edge.virtuals
-                    )
-                elif edge.spec in fixed_specs:
-                    new_spec.add_dependency_edge(
-                        fixed_specs[edge.spec], depflag=depflag, virtuals=edge.virtuals
-                    )
-                else:
-                    new_spec.add_dependency_edge(
-                        edge.spec, depflag=depflag, virtuals=edge.virtuals
-                    )
-            self._specs[node] = new_spec
-            fixed_specs[spec] = new_spec
+        parent_spec = self._specs[parent_node]
+        splice_spec = self._specs[splice_node]
+        splice = spack.solver.splicing.Splice(
+            splice_spec, child_name=child_name, child_hash=child_hash
+        )
+        self._splices.setdefault(parent_spec, []).append(splice)
 
     @staticmethod
     def sort_fn(function_tuple) -> Tuple[int, int]:
@@ -3764,7 +3719,15 @@ class SpecBuilder:
         for root in roots.values():
             root._finalize_concretization()
 
-        self._resolve_automatic_splices()
+        # Only attempt to resolve automatic splices if the solver produced any
+        if self._splices:
+            resolved_splices = spack.solver.splicing._resolve_collected_splices(
+                list(self._specs.values()), self._splices
+            )
+            new_specs = {}
+            for node, spec in self._specs.items():
+                new_specs[node] = resolved_splices.get(spec, spec)
+            self._specs = new_specs
 
         for s in self._specs.values():
             spack.spec.Spec.ensure_no_deprecated(s)

--- a/lib/spack/spack/solver/splicing.py
+++ b/lib/spack/spack/solver/splicing.py
@@ -9,28 +9,13 @@ from spack.spec import Spec
 from spack.traverse import by_dag_hash, traverse_nodes
 
 
-class Splice:
-    """A class representing a single splice. These will always be indexed in a
-    dict by the parent spec that they are being spliced into. Note: this should
-    be a dataclass, but Python 3.6 dose not support dataclasses.
-
-    splice_spec (Spec): the spec being spliced into a parent
-    child_name (str): the name of the child that `splice_spec` is replacing
-    child_hash (str): the hash of the child that `splice_spec` is replacing
-    """
-
-    def __init__(self, splice_spec: Spec, child_name: str, child_hash: str):
-        self.splice_spec = splice_spec
-        self.child_name = child_name
-        self.child_hash = child_hash
-
-    def __repr__(self) -> str:
-        output = (
-            f"Splice spec {self.splice_spec}, "
-            f"replacing child {self.child_name} "
-            f"with hash {self.child_hash}"
-        )
-        return output
+class Splice(NamedTuple):
+    #: The spec being spliced into a parent
+    splice_spec: Spec
+    #: The name of the child that splice spec is replacing
+    child_name: str
+    #: The hash of the child that `splice_spec` is replacing
+    child_hash: str
 
 
 def _resolve_collected_splices(
@@ -56,16 +41,13 @@ def _resolve_collected_splices(
         else:
             return 0
 
-    already_resolved: Dict[Spec, Spec] = {}
-    # create a mapping from dag hash to an integer representing position in reverse topo order.
     splice_order = sorted(specs, key=cmp_to_key(splice_cmp))
     reverse_topo_order = reversed(
-        list(traverse_nodes(splice_order, order="topo", key=by_dag_hash))
+        [x for x in traverse_nodes(splice_order, order="topo", key=by_dag_hash) if x in specs]
     )
-    splice_lookup = {spec.dag_hash(): index for index, spec in enumerate(reverse_topo_order)}
-    # iterate over specs, children before parents
 
-    for spec in sorted(specs, key=lambda x: splice_lookup[x.dag_hash()]):
+    already_resolved: Dict[Spec, Spec] = {}
+    for spec in reverse_topo_order:
         immediate = splices.get(spec, [])
         if not immediate and not any(
             edge.spec in already_resolved for edge in spec.edges_to_dependencies()

--- a/lib/spack/spack/solver/splicing.py
+++ b/lib/spack/spack/solver/splicing.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from functools import cmp_to_key
-from typing import Dict, List
+from typing import Dict, List, NamedTuple
 
 import spack.deptypes as dt
 from spack.spec import Spec

--- a/lib/spack/spack/solver/splicing.py
+++ b/lib/spack/spack/solver/splicing.py
@@ -1,0 +1,90 @@
+from functools import cmp_to_key
+from typing import Dict, List
+
+import spack.deptypes as dt
+from spack.spec import Spec
+from spack.traverse import by_dag_hash, traverse_nodes
+
+
+class Splice:
+    """A class representing a single splice. These will always be indexed in a
+    dict by the parent spec that they are being spliced into. Note: this should
+    be a dataclass, but Python 3.6 dose not support dataclasses.
+
+    splice_spec (Spec): the spec being spliced into a parent
+    child_name (str): the name of the child that `splice_spec` is replacing
+    child_hash (str): the hash of the child that `splice_spec` is replacing
+    """
+
+    def __init__(self, splice_spec: Spec, child_name: str, child_hash: str):
+        self.splice_spec = splice_spec
+        self.child_name = child_name
+        self.child_hash = child_hash
+
+    def __repr__(self) -> str:
+        output = (
+            f"Splice spec {self.splice_spec}, "
+            f"replacing child {self.child_name} "
+            f"with hash {self.child_hash}"
+        )
+        return output
+
+
+def _resolve_collected_splices(
+    specs: List[Spec], splices: Dict[Spec, List[Splice]]
+) -> Dict[Spec, Spec]:
+    """After all of the specs have been concretized, apply all immediate splices.
+    Returns a dict mapping original specs to their resolved counterparts
+    """
+
+    def splice_topo_cmp(s1: Spec, s2: Spec):
+        """This function can be used to sort a list of specs into "reverse
+        splice-topological order". This order imposes the additional requirement
+        on reverse-topo order that any spec which will be spliced into a parent
+        comes before the parent it will be spliced into. This order ensures that
+        transitive splices will be executed in the correct order.
+
+        This assumes that the specs are already sorted in reverse topo-order
+        """
+
+        s1_splices = splices.get(s1, [])
+        s2_splices = splices.get(s2, [])
+        if any([s2.dag_hash() == splice.splice_spec.dag_hash() for splice in s1_splices]):
+            return -1
+        elif any([s1.dag_hash() == splice.splice_spec.dag_hash() for splice in s2_splices]):
+            return 1
+        else:
+            return 0
+
+    already_resolved: Dict[Spec, Spec] = {}
+    # create a mapping from dag hash to an integer representing position in reverse topo order.
+    reverse_topo_order = reversed(list(traverse_nodes(specs, order="topo", key=by_dag_hash)))
+    splice_order = sorted(reverse_topo_order, key=cmp_to_key(splice_topo_cmp))
+    splice_lookup = {spec.dag_hash(): index for index, spec in enumerate(splice_order)}
+
+    # iterate over specs, children before parents
+
+    for spec in sorted(specs, key=lambda x: splice_lookup[x.dag_hash()]):
+        immediate = splices.get(spec, [])
+        if not immediate and not any(
+            edge.spec in already_resolved for edge in spec.edges_to_dependencies()
+        ):
+            continue
+        new_spec = spec.copy(deps=False)
+        new_spec.clear_caches(ignore=("package_hash",))
+        new_spec.build_spec = spec
+        for edge in spec.edges_to_dependencies():
+            depflag = edge.depflag & ~dt.BUILD
+            if any(edge.spec.dag_hash() == splice.child_hash for splice in immediate):
+                splice = [s for s in immediate if s.child_hash == edge.spec.dag_hash()][0]
+                # If the spec being splice in is also spliced
+                splice_spec = already_resolved.get(splice.splice_spec, splice.splice_spec)
+                new_spec.add_dependency_edge(splice_spec, depflag=depflag, virtuals=edge.virtuals)
+            elif edge.spec in already_resolved:
+                new_spec.add_dependency_edge(
+                    already_resolved[edge.spec], depflag=depflag, virtuals=edge.virtuals
+                )
+            else:
+                new_spec.add_dependency_edge(edge.spec, depflag=depflag, virtuals=edge.virtuals)
+        already_resolved[spec] = new_spec
+    return already_resolved

--- a/lib/spack/spack/solver/splicing.py
+++ b/lib/spack/spack/solver/splicing.py
@@ -1,3 +1,6 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from functools import cmp_to_key
 from typing import Dict, List
 

--- a/lib/spack/spack/test/abi_splicing.py
+++ b/lib/spack/spack/test/abi_splicing.py
@@ -103,7 +103,6 @@ def test_splice_build_splice_node(install_specs, mutable_config):
     assert concrete["splice-h"].build_spec.dag_hash() == concrete["splice-h"].dag_hash()
 
 
-@pytest.mark.xfail(reason="the spliced splice-h has sometimes the original splice-h hash")
 def test_double_splice(install_specs, mutable_config):
     """Tests splicing two dependencies of an installed spec, for other installed specs"""
     splice_t, splice_h, splice_z = install_specs(


### PR DESCRIPTION
fixes #48596

#48596 exposes an issue where the order of the topological sort used in splicing was unstable and could lead to spurious results. The problem stemmed from the fact that the topological order of unconnected DAGs is non-deterministic and thus topological order is not a strong enough criterion for ensuring splices are executed correctly. 

This PR does 3 things: 
1. Solve the problem above, by using "reverse splice topo order". This order ensures that if A is going to replace a dependency of B by splicing, then A must come before B.
2. Lays the groundwork for unifying splicing implementations by splitting the automatic splicing reconstruction into its own module. This module will later include the code necessary to unify with explicit splicing (future PR).
3. Removes the XFAIL necessitated by the issue above from `test/abi_splicing.py`  

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
