### PR TITLE
octave: new version 9.3.0 and correct a Qt issue

### DIFF
--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -29,6 +29,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    version("9.3.0", sha256="809fa39a7acc84815bf4dc4d2d7e6b228ce75a07f3b2413f3313aa8e0aaa3287")
     version("9.1.0", sha256="3f8c6c6ecfa249a47c97e18e651be4db8499be2f5de1a095a3eea53efc01d6a1")
     version("8.4.0", sha256="6b38dd9751678424aeb3a9d666432b1f378eb3971a21290a90cd3d35119d56ad")
     version("8.2.0", sha256="57d17f918a940d38ca3348211e110b34d735a322a87db71c177c4692a49a9c84")
@@ -327,12 +328,12 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         if "+qhull" in spec:
             config_args.extend(
                 [
-                    "--with-qhull-includedir=%s" % spec["qhull"].prefix.include,
-                    "--with-qhull-libdir=%s" % spec["qhull"].prefix.lib,
+                    "--with-qhull_r-includedir=%s" % spec["qhull"].prefix.include,
+                    "--with-qhull_r-libdir=%s" % spec["qhull"].prefix.lib,
                 ]
             )
         else:
-            config_args.append("--without-qhull")
+            config_args.append("--without-qhull_r")
 
         if "+qrupdate" in spec:
             config_args.extend(
@@ -370,7 +371,9 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         config_args.append("--enable-fortran-calling-convention=gfortran")
 
         # Make sure we do not use qtchooser
-        config_args.append("ac_cv_prog_ac_ct_QTCHOOSER=")
+        if spec.satisfies("+qt"):
+            config_args.append("ac_cv_prog_ac_ct_QTCHOOSER=")
+            config_args.append("--with-qt={0}".format(str(spec["qt"].version.up_to(1))))
 
         return config_args
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
New version is standard, but also corrects:
1)
`configure: WARNING: unrecognized options: --without-qhull`
2)
```
checking Qt version 6... checking for Qt6Core Qt6Gui Qt6Help Qt6Network Qt6OpenGL Qt6OpenGLWidgets Qt6PrintSupport Qt6Xml Qt6Core5Compat... no
configure: WARNING: Your installation of Qt version 6 appears incomplete or broken in some way.  Fix that or use --with-qt=VER to use another version.
configure: WARNING: Qt libraries not found; disabling Qt GUI
```
The second issue made spack install octave+qt invalidate qt, so the gui was not built, and when asking for it:
```
$ octave --gui
octave: GUI features missing or disabled in this build
```
