### PR TITLE
rsync: add v3.4.0, v3.4.1 (fixes CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/rsync/package.py
+++ b/var/spack/repos/builtin/packages/rsync/package.py
@@ -15,10 +15,31 @@ class Rsync(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
-    version("3.3.0", sha256="7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90")
-    version("3.2.7", sha256="4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb")
-    version("3.2.6", sha256="fb3365bab27837d41feaf42e967c57bd3a47bc8f10765a3671efd6a3835454d3")
-    version("3.2.5", sha256="2ac4d21635cdf791867bc377c35ca6dda7f50d919a58be45057fd51600c69aba")
+    version("3.4.1", sha256="2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52")
+    version("3.4.0", sha256="8e942f95a44226a012fe822faffa6c7fc38c34047add3a0c941e9bc8b8b93aa4")
+
+    # Releases before 3.4.0 are deprecated because of CVE-2024-12084
+    # https://nvd.nist.gov/vuln/detail/CVE-2024-12084
+    version(
+        "3.3.0",
+        sha256="7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90",
+        deprecated=True,
+    )
+    version(
+        "3.2.7",
+        sha256="4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb",
+        deprecated=True,
+    )
+    version(
+        "3.2.6",
+        sha256="fb3365bab27837d41feaf42e967c57bd3a47bc8f10765a3671efd6a3835454d3",
+        deprecated=True,
+    )
+    version(
+        "3.2.5",
+        sha256="2ac4d21635cdf791867bc377c35ca6dda7f50d919a58be45057fd51600c69aba",
+        deprecated=True,
+    )
 
     # Releases before 3.2.5 are deprecated because of CVE-2022-29154
     # https://nvd.nist.gov/vuln/detail/CVE-2022-29154


### PR DESCRIPTION
This PR adds `rsync`, v3.4.0 and v3.4.1, which fixes CVE-2024-12084, CVE-2024-12085, CVE-2024-12086, CVE-2024-12087, CVE-2024-12088, CVE-2024-12747. Previous versions deprecated since critical.

Test build:
```
==> Installing rsync-3.4.1-5ri272iw7noqqvmpqe7e6mwktczo7gow [12/13]
==> No binary for rsync-3.4.1-5ri272iw7noqqvmpqe7e6mwktczo7gow found: installing from source
==> Fetching https://download.samba.org/pub/rsync/src/rsync-3.4.1.tar.gz
==> No patches needed for rsync
==> rsync: Executing phase: 'autoreconf'
==> rsync: Executing phase: 'configure'
==> rsync: Executing phase: 'build'
==> rsync: Executing phase: 'install'
==> rsync: Successfully installed rsync-3.4.1-5ri272iw7noqqvmpqe7e6mwktczo7gow
  Stage: 2.02s.  Autoreconf: 0.00s.  Configure: 24.91s.  Build: 12.93s.  Install: 0.14s.  Post-install: 0.28s.  Total: 40.42s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/rsync-3.4.1-5ri272iw7noqqvmpqe7e6mwktczo7gow
```