### PR TITLE
ngspice: new version 44

### DIFF
--- a/var/spack/repos/builtin/packages/ngspice/package.py
+++ b/var/spack/repos/builtin/packages/ngspice/package.py
@@ -21,6 +21,7 @@ class Ngspice(AutotoolsPackage):
 
     # Master version by default adds the experimental adms feature
     version("master", branch="master")
+    version("44", sha256="3865d13ab44f1f01f68c7ac0e0716984e45dce5a86d126603c26d8df30161e9b")
     version("43", sha256="14dd6a6f08531f2051c13ae63790a45708bd43f3e77886a6a84898c297b13699")
     version("42", sha256="737fe3846ab2333a250dfadf1ed6ebe1860af1d8a5ff5e7803c772cc4256e50a")
     version("41", sha256="1ce219395d2f50c33eb223a1403f8318b168f1e6d1015a7db9dbf439408de8c4")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Release notes:
https://sourceforge.net/projects/ngspice/files/ng-spice-rework/44/ReleaseNotes.txt/download
Ngspice-44, December 29th, 2024
============
- New features:
    + Add function ngSpice_Reset(void) to completely reset shared ngspice.
    + Bail out when state file is not found.
    + Define 1e-12 as a minimum resistor value.
    + Update VBIC model.
    + d_cosim supports Icarus Verilog.
    + Extend bsim4 operating point info list.
    + Make several error messages more verbose by
      adding source file name (and line number).
    + Command 'let' will handle V(/nname).
    + Enable using fftw3 as a build option of shared ngspice on Windows.
    + Set lower case for variables or vectors names in command 'echo'.
    + Add optional series resistance or junction capacitance for diode
      model, if none is defined in the .model statement.
    + Allow plotting a single point in an ascii plot.
    + Bail out when the number of s parameter ports is less than 2.
    + Add function ngSpice_nospiceinit(void) if you don't want to
      read .spiceinit (shared ngspice only).
    + Reorder and renovate timer functions.
    + Enhance sensitivity analysis with an option to choose the parameters
      to be varied.  Shell-style wildcards ("*?") are supported.
    + Enable strings as parameters across subckt boundaries.
    + Replace all BOOLEAN, BOOL, _Bool by bool.