### PR TITLE
ROCmPackage: Change llvm-amdgpu to a build dependency

### DIFF
--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -140,7 +140,7 @@ class ROCmPackage(PackageBase):
         when="+rocm",
     )
 
-    depends_on("llvm-amdgpu", when="+rocm")
+    depends_on("llvm-amdgpu", type="build", when="+rocm")
     depends_on("hsa-rocr-dev", when="+rocm")
     depends_on("hip +rocm", when="+rocm")
 


### PR DESCRIPTION
Make `llvm-amdgpu` a build only dependency of `rocm`, instead of a build and link dependency. This avoids llvm's include directory from being added to the spack compiler wrapper's SPACK_INCLUDE_DIRS, which was causing issues in certain cases.

Thanks to @becker33 for suggesting this fix!