### PR TITLE
Update configure opts for libbfd

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -228,8 +228,7 @@ class Scorep(AutotoolsPackage):
         # but add similar spec.satisfies clauses for any that you need.
         # -- wrwilliams 12/2024
         if spec.satisfies("^binutils"):
-            config_args.append("--with-libbfd-lib=%s" % spec["binutils"].prefix.lib)
-            config_args.append("--with-libbfd-include=%s" % spec["binutils"].prefix.include)
+            config_args.append("--with-libbfd=%s" % spec["binutils"].prefix)
 
         config_args.extend(
             [


### PR DESCRIPTION
So far the options passed to configure assume that libbfd is installed in a directory `$prefix/lib`. On many systems, however, it is installed in `$prefix/lib64`. 
Fixed recipe to allow configure to find libbfd in both cases.