### PR TITLE
spack_yaml.py / spec.py: use dict instead of OrderedDict

### DIFF
--- a/lib/spack/spack/operating_systems/_operating_system.py
+++ b/lib/spack/spack/operating_systems/_operating_system.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import llnl.util.lang
 
-import spack.util.spack_yaml as syaml
-
 
 @llnl.util.lang.lazy_lexicographic_ordering
 class OperatingSystem:
@@ -42,4 +40,4 @@ class OperatingSystem:
         yield self.version
 
     def to_dict(self):
-        return syaml.syaml_dict([("name", self.name), ("version", self.version)])
+        return {"name": self.name, "version": self.version}

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -11,8 +11,6 @@
   default unorderd dict.
 
 """
-import collections
-import collections.abc
 import ctypes
 import enum
 import functools

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -32,8 +32,7 @@ __all__ = ["load", "dump", "SpackYAMLError"]
 
 
 # Make new classes so we can add custom attributes.
-# Also, use OrderedDict instead of just dict.
-class syaml_dict(collections.OrderedDict):
+class syaml_dict(dict):
     def __repr__(self):
         mappings = (f"{k!r}: {v!r}" for k, v in self.items())
         return "{%s}" % ", ".join(mappings)

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -33,21 +33,19 @@ __all__ = ["load", "dump", "SpackYAMLError"]
 
 # Make new classes so we can add custom attributes.
 class syaml_dict(dict):
-    def __repr__(self):
-        mappings = (f"{k!r}: {v!r}" for k, v in self.items())
-        return "{%s}" % ", ".join(mappings)
+    pass
 
 
 class syaml_list(list):
-    __repr__ = list.__repr__
+    pass
 
 
 class syaml_str(str):
-    __repr__ = str.__repr__
+    pass
 
 
 class syaml_int(int):
-    __repr__ = int.__repr__
+    pass
 
 
 #: mapping from syaml type -> primitive type

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -6,7 +6,6 @@ import re
 from bisect import bisect_left
 from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
-from spack.util.spack_yaml import syaml_dict
 from spack.util.typing import SupportsRichComparison
 
 from .common import (
@@ -1044,8 +1043,8 @@ class VersionList(VersionType):
     def to_dict(self) -> Dict:
         """Generate human-readable dict for YAML."""
         if self.concrete:
-            return syaml_dict([("version", str(self[0]))])
-        return syaml_dict([("versions", [str(v) for v in self])])
+            return {"version": str(self[0])}
+        return {"versions": [str(v) for v in self]}
 
     @staticmethod
     def from_dict(dictionary) -> "VersionList":


### PR DESCRIPTION
* for config: let `syaml_dict` inherit from `dict` instead of `OrderedDict`. `syaml_dict` now only exists as a mutable wrapper for yaml related metadata.
* for spec serialization / hashing: use `dict` directly

This is possible since we only support cpython 3.6+ in which dicts are ordered.

This improves performance of hash computation a bit. For a larger spec I'm getting 9.22ms instead of 11.9ms, so 22.5% reduction in runtime.