### PR TITLE
root: depends_on r-rcpp@:1.0.12 when @:6.32.02

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -385,6 +385,7 @@ class Root(CMakePackage):
     depends_on("pythia8", when="+pythia8")
     depends_on("r", when="+r", type=("build", "run"))
     depends_on("r-rcpp", when="+r", type=("build", "run"))
+    depends_on("r-rcpp@:1.0.12", when="+r @:6.32.02", type=("build", "run"))
     depends_on("r-rinside", when="+r", type=("build", "run"))
     depends_on("readline", when="+r")
     depends_on("shadow", when="+shadow")


### PR DESCRIPTION
Rcpp-1.0.13 changed some functionality that ROOT relied upon, and which was only [modified](https://github.com/root-project/root/pull/16075) in time for backporting to 6.32.02. This PR ensures that older versions of ROOT don't run with newer versions of Rcpp, and thereby resolves https://gitlab.spack.io/spack/spack/-/jobs/14665088.