### PR TITLE
compat with mypy 1.14

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1740,8 +1740,7 @@ def find(
 
 
 def _log_file_access_issue(e: OSError, path: str) -> None:
-    errno_name = errno.errorcode.get(e.errno, "UNKNOWN")
-    tty.debug(f"find must skip {path}: {errno_name} {e}")
+    tty.debug(f"find must skip {path}: {e}")
 
 
 def _file_id(s: os.stat_result) -> Tuple[int, int]:

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -297,7 +297,7 @@ def disambiguate_spec(
 
 def disambiguate_spec_from_hashes(
     spec: spack.spec.Spec,
-    hashes: List[str],
+    hashes: Optional[List[str]],
     local: bool = False,
     installed: Union[bool, InstallRecordStatus] = True,
     first: bool = False,

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1706,7 +1706,7 @@ class Database:
             )
 
         results = list(local_results) + list(x for x in upstream_results if x not in local_results)
-        results.sort()
+        results.sort()  # type: ignore[call-overload]
         return results
 
     def query_one(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -749,7 +749,7 @@ class KnownCompiler(NamedTuple):
 
     spec: spack.spec.Spec
     os: str
-    target: str
+    target: Optional[str]
     available: bool
     compiler_obj: Optional[spack.compiler.Compiler]
 
@@ -1132,7 +1132,7 @@ class SpackSolverSetup:
             set
         )
 
-        self.possible_compilers: List = []
+        self.possible_compilers: List[KnownCompiler] = []
         self.possible_oses: Set = set()
         self.variant_values_from_specs: Set = set()
         self.version_constraints: Set = set()


### PR DESCRIPTION
- `OSError.errno` apparently is `int | None` but already part of `OSError.__str__`, so no need to use it
- Fix `disambiguate_spec_from_hashes`
- `List[Spec].sort()` complains, ignore it
- Fix typing of `KnownCompiler` and use it in asp.py

