### PR TITLE
Fix duplicate 'https://' typo in two homepage URLs

### DIFF
--- a/var/spack/repos/builtin/packages/bpp-popgen/package.py
+++ b/var/spack/repos/builtin/packages/bpp-popgen/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 class BppPopgen(CMakePackage):
     """The Bio++ Population Genetics Library"""
 
-    homepage = "https://https://github.com/BioPP/bpp-popgen"
+    homepage = "https://github.com/BioPP/bpp-popgen"
     url = "https://github.com/BioPP/bpp-popgen/archive/refs/tags/v2.4.1.tar.gz"
 
     maintainers("snehring")

--- a/var/spack/repos/builtin/packages/py-ml-collections/package.py
+++ b/var/spack/repos/builtin/packages/py-ml-collections/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 class PyMlCollections(PythonPackage):
     """ML Collections is a library of Python collections designed for ML usecases."""
 
-    homepage = "https://https://github.com/google/ml_collections"
+    homepage = "https://github.com/google/ml_collections"
     pypi = "ml_collections/ml_collections-0.1.0.tar.gz"
     git = "https://github.com/google/ml_collections"
 


### PR DESCRIPTION
Fix two instances of a typo in which `https://` prefix at the start of a homepage URL is repeated an extra time, leading to a broken link.

Confirmed by grepping that these are the only two instances of this particular typo. Also checked that the fixed links are no longer broken.