### PR TITLE
HIP: use gcc toolchain in Cached CMake packages

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -293,6 +293,13 @@ class CachedCMakeBuilder(CMakeBuilder):
                 entries.append(cmake_cache_string("AMDGPU_TARGETS", arch_str))
                 entries.append(cmake_cache_string("GPU_TARGETS", arch_str))
 
+            if spec.satisfies("%gcc"):
+                entries.append(
+                    cmake_cache_string(
+                        "CMAKE_HIP_FLAGS", f"--gcc-toolchain={self.pkg.compiler.prefix}"
+                    )
+                )
+
         return entries
 
     def std_initconfig_entries(self):


### PR DESCRIPTION
When using HIP and a gcc host compiler, ensure that amdclang is using correct version of gcc by setting the gcc toolchain path. This fixes "undefined reference" errors when linking to std library functions.

Similar to fix in https://github.com/spack/spack/pull/46573, but we need to set the CMake flag in the host config file rather than relying on environment variables for Cached CMake packages.