### PR TITLE
petsc+rocm: add dependency on hipblas-common

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -704,7 +704,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 hip_ipkgs.extend(["rocrand"])
             else:
                 hip_lpkgs.extend(["rocrand"])
-            if spec.satisfies("^hipblas-common@6.3.0:"):
+            if spec.satisfies("^hipblas@6.3.0:"):
                 hip_ipkgs.extend(["hipblas-common"])
             hip_inc = ""
             hip_lib = ""

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -704,6 +704,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 hip_ipkgs.extend(["rocrand"])
             else:
                 hip_lpkgs.extend(["rocrand"])
+            if spec.satisfies("^hipblas-common@6.3.0:"):
+                hip_ipkgs.extend(["hipblas-common"])
             hip_inc = ""
             hip_lib = ""
             for pkg in hip_ipkgs:


### PR DESCRIPTION
hipblas@6.3.0 added in a new dependency on hipblas-common
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
