### PR TITLE
Add new package: grpp library

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -169,7 +169,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("grpp@2023.12.25", when="+grpp")
     depends_on("trexio", when="+trexio")
     # trexio does not depend on grpp but cp2k support of trexio requires it
-    depends_on("grpp", when="+trexio")
+    depends_on("grpp@2023.12.25", when="+trexio")
 
     # Force openmp propagation on some providers of blas / fftw-api
     with when("+openmp"):

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -166,7 +166,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("lapack")
     depends_on("fftw-api@3")
 
-    depends_on("grpp", when="+grpp")
+    depends_on("grpp@2023.12.25", when="+grpp")
     depends_on("trexio", when="+trexio")
     # trexio does not depend on grpp but cp2k support of trexio requires it
     depends_on("grpp", when="+trexio")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -119,7 +119,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant("dftd4", when="@2024.2:", default=False, description="Enable DFT-D4 support")
     variant("mpi_f08", default=False, description="Use MPI F08 module")
     variant("smeagol", default=False, description="Enable libsmeagol support", when="@2025.2:")
-    variant("grpp", default=False, description="Enable libgrrp support")
+    variant("grpp", default=False, description="Enable libgrpp support", when="@master")
     variant("trexio", default=False, description="Enable Trex-IO support", when="+grpp")
     variant(
         "enable_regtests",

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -167,9 +167,13 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("fftw-api@3")
 
     depends_on("grpp@2023.12.25", when="+grpp")
-    depends_on("trexio", when="+trexio")
-    # trexio does not depend on grpp but cp2k support of trexio requires it
-    depends_on("grpp@2023.12.25", when="+trexio")
+
+    with when("+trexio"):
+        depends_on("trexio")
+        depends_on("grpp@2023.12.25")
+
+    # the regtests depend on both libraries to be present otherwise they fail
+    conflicts("trexio", when="~grpp")
 
     # Force openmp propagation on some providers of blas / fftw-api
     with when("+openmp"):

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -173,7 +173,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("grpp@2023.12.25")
 
     # the regtests depend on both libraries to be present otherwise they fail
-    conflicts("trexio", when="~grpp")
+    conflicts("+trexio", when="~grpp")
 
     # Force openmp propagation on some providers of blas / fftw-api
     with when("+openmp"):

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -121,7 +121,6 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant("smeagol", default=False, description="Enable libsmeagol support", when="@2025.2:")
     variant("grpp", default=False, description="Enable libgrpp support", when="@2025.2:")
     variant("trexio", default=False, description="Enable Trex-IO support", when="@2025.2:")
-    variant("grpp", default=True, description="Enable Trex-IO support", when="@2025.2: +trexio")
     variant(
         "enable_regtests",
         default=False,

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -119,8 +119,9 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant("dftd4", when="@2024.2:", default=False, description="Enable DFT-D4 support")
     variant("mpi_f08", default=False, description="Use MPI F08 module")
     variant("smeagol", default=False, description="Enable libsmeagol support", when="@2025.2:")
-    variant("grpp", default=False, description="Enable libgrpp support", when="@2025.2")
-    variant("trexio", default=False, description="Enable Trex-IO support", when="+grpp")
+    variant("grpp", default=False, description="Enable libgrpp support", when="@2025.2:")
+    variant("trexio", default=False, description="Enable Trex-IO support", when="@2025.2:")
+    variant("grpp", default=True, description="Enable Trex-IO support", when="@2025.2: +trexio")
     variant(
         "enable_regtests",
         default=False,

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -119,7 +119,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant("dftd4", when="@2024.2:", default=False, description="Enable DFT-D4 support")
     variant("mpi_f08", default=False, description="Use MPI F08 module")
     variant("smeagol", default=False, description="Enable libsmeagol support", when="@2025.2:")
-    variant("grpp", default=False, description="Enable libgrpp support", when="@master")
+    variant("grpp", default=False, description="Enable libgrpp support", when="@2025.2")
     variant("trexio", default=False, description="Enable Trex-IO support", when="+grpp")
     variant(
         "enable_regtests",

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -167,13 +167,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("fftw-api@3")
 
     depends_on("grpp@2023.12.25", when="+grpp")
-
-    with when("+trexio"):
-        depends_on("trexio")
-        depends_on("grpp@2023.12.25")
-
-    # the regtests depend on both libraries to be present otherwise they fail
-    conflicts("+trexio", when="~grpp")
+    depends_on("trexio", when="+trexio")
 
     # Force openmp propagation on some providers of blas / fftw-api
     with when("+openmp"):

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -119,7 +119,8 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant("dftd4", when="@2024.2:", default=False, description="Enable DFT-D4 support")
     variant("mpi_f08", default=False, description="Use MPI F08 module")
     variant("smeagol", default=False, description="Enable libsmeagol support", when="@2025.2:")
-
+    variant("grpp", default=False, description="Enable libgrrp support")
+    variant("trexio", default=False, description="Enable Trex-IO support", when="+grpp")
     variant(
         "enable_regtests",
         default=False,
@@ -164,6 +165,11 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     depends_on("blas")
     depends_on("lapack")
     depends_on("fftw-api@3")
+
+    depends_on("grpp", when="+grpp")
+    depends_on("trexio", when="+trexio")
+    # trexio does not depend on grpp but cp2k support of trexio requires it
+    depends_on("grpp", when="+trexio")
 
     # Force openmp propagation on some providers of blas / fftw-api
     with when("+openmp"):
@@ -1018,6 +1024,8 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("CP2K_USE_DFTD4", "dftd4"),
             self.define_from_variant("CP2K_USE_MPI_F08", "mpi_f08"),
             self.define_from_variant("CP2K_USE_LIBSMEAGOL", "smeagol"),
+            self.define_from_variant("CP2K_USE_TREXIO", "trexio"),
+            self.define_from_variant("CP2K_USE_GRPP", "grpp"),
         ]
 
         # we force the use elpa openmp threading support. might need to be revisited though

--- a/var/spack/repos/builtin/packages/grpp/grpp-cmake.patch
+++ b/var/spack/repos/builtin/packages/grpp/grpp-cmake.patch
@@ -16,7 +16,7 @@ index b5cc84f..efd61cf 100644
 +set(VERSION_MINOR 12)
 +set(VERSION_PATCH 25)
 +
-+project(libgrpp
++project(grpp
 +        DESCRIPTION "A library for the evaluation of molecular integrals of the generalized relativistic pseudopotential operator (GRPP) over Gaussian functions."
 +        HOMEPAGE_URL https://github.com/aoleynichenko/libgrpp
 +        VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}

--- a/var/spack/repos/builtin/packages/grpp/grpp-cmake.patch
+++ b/var/spack/repos/builtin/packages/grpp/grpp-cmake.patch
@@ -1,0 +1,164 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b5cc84f..efd61cf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,12 +6,29 @@
+ #
+ 
+ cmake_minimum_required(VERSION 3.19)
+-project(test_libgrpp_c.x C)
+-project(test_libgrpp_f90.x Fortran)
++
++include(CMakeDependentOption)
++include(CMakePackageConfigHelpers)
++ 
++set(VERSION_MAJOR 2023)
++set(VERSION_MINOR 12)
++set(VERSION_PATCH 25)
++
++project(libgrpp
++        DESCRIPTION "A library for the evaluation of molecular integrals of the generalized relativistic pseudopotential operator (GRPP) over Gaussian functions."
++        HOMEPAGE_URL https://github.com/aoleynichenko/libgrpp
++        VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
++        LANGUAGES Fortran C)
+ 
+ set(CMAKE_C_STANDARD 11)
+ find_package(OpenMP)
+ 
++# imply -O3 -DNDEBUG, can be changed with cmake -DCMAKE_BUILD_TYPE=DEBUG,etc....
++
++set(CMAKE_BUILD_TYPE Release)
++
++set(libgrpp_APIVERSION ${libgrpp_VERSION_MAJOR}.${libgrpp_VERSION_MINOR})
++
+ add_subdirectory(libgrpp)
+ 
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -O3")
+@@ -43,10 +60,9 @@ add_executable(test_libgrpp_f90.x
+         test_libgrpp_f90/libgrpp.f90
+         )
+ 
+-target_link_libraries(test_libgrpp_c.x libgrpp -lm ${OpenMP_C_LIBRARIES}) # -pg)
+-target_link_libraries(test_libgrpp_f90.x libgrpp -lm ${OpenMP_C_LIBRARIES})
+-
+-
++target_link_libraries(test_libgrpp_c.x grpp OpenMP::OpenMP_C m)
++target_link_libraries(test_libgrpp_f90.x grpp OpenMP::OpenMP_Fortran m)
++set_target_properties(test_libgrpp_f90.x PROPERTIES Fortran_MODULE_DIRECTORY "fortran_modules")
+ # enable testing functionality
+ enable_testing()
+ 
+@@ -63,3 +79,42 @@ add_test(NAME UO2    WORKING_DIRECTORY ../test/UO2    COMMAND bash run_test.sh)
+ foreach (t KCs)
+     set_property(TEST ${t} PROPERTY ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}:$ENV{PATH}")
+ endforeach ()
++
++include(GNUInstallDirs)
++
++write_basic_package_version_file(
++  "${PROJECT_BINARY_DIR}/grppConfigVersion.cmake"
++  VERSION "${libgrpp_VERSION}"
++  COMPATIBILITY SameMajorVersion)
++
++if(NOT CMAKE_INSTALL_Fortran_MODULES)
++  set(CMAKE_INSTALL_Fortran_MODULES "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}"
++  )
++endif()
++
++configure_file("${PROJECT_SOURCE_DIR}/cmake/grppConfig.cmake.in"
++               "${PROJECT_BINARY_DIR}/grppConfig.cmake" @ONLY)
++
++configure_file(cmake/libgrpp.pc.in libgrpp.pc @ONLY)
++
++install(FILES "${PROJECT_BINARY_DIR}/grppConfig.cmake"
++              "${PROJECT_BINARY_DIR}/grppConfigVersion.cmake"
++	      DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
++
++install(FILES "${PROJECT_BINARY_DIR}/libgrpp.pc"
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++
++
++
++install(
++  DIRECTORY "${PROJECT_BINARY_DIR}/fortran_modules"
++  DESTINATION "${CMAKE_INSTALL_Fortran_MODULES}/${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}"
++  FILES_MATCHING
++  PATTERN "*.mod")
++
++install(
++  DIRECTORY "${PROJECT_SOURCE_DIR}/libgrpp"
++	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++	FILES_MATCHING
++	PATTERN "*.h")
++
+diff --git a/cmake/grppConfig.cmake.in b/cmake/grppConfig.cmake.in
+new file mode 100644
+index 0000000..ce54dc2
+--- /dev/null
++++ b/cmake/grppConfig.cmake.in
+@@ -0,0 +1,6 @@
++cmake_minimum_required(VERSION 3.19)
++include(CMakeFindDependencyMacro)
++
++if(NOT TARGET grpp::grpp)
++  include("${CMAKE_CURRENT_LIST_DIR}/grppTargets.cmake")
++endif()
+diff --git a/cmake/libgrpp.pc.in b/cmake/libgrpp.pc.in
+new file mode 100644
+index 0000000..dfa3a9b
+--- /dev/null
++++ b/cmake/libgrpp.pc.in
+@@ -0,0 +1,11 @@
++prefix="@CMAKE_INSTALL_PREFIX@"
++exec_prefix="${prefix}"
++libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
++includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
++
++Name: @PROJECT_NAME@
++Description: @CMAKE_PROJECT_DESCRIPTION@
++URL: @CMAKE_PROJECT_HOMEPAGE_URL@
++Version: @PROJECT_VERSION@
++Cflags: -I"${includedir}/libgrpp" -I"${includedir}/libgrpp/@CMAKE_Fortran_COMPILER_ID@-@CMAKE_Fortran_COMPILER_VERSION@/fortran_modules"
++Libs: -L"${libdir}" -lgrpp
+diff --git a/libgrpp/CMakeLists.txt b/libgrpp/CMakeLists.txt
+index f579f7b..ad3408c 100644
+--- a/libgrpp/CMakeLists.txt
++++ b/libgrpp/CMakeLists.txt
+@@ -5,16 +5,7 @@
+ #  Copyright (C) 2021-2023 Alexander Oleynichenko
+ #
+ 
+-cmake_minimum_required(VERSION 3.19)
+-project(libgrpp C)
+-
+-set(CMAKE_C_STANDARD 11)
+-
+-find_package(OpenMP)
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -O3")
+-#add_compile_options(-pg)
+-
+-add_library(libgrpp
++add_library(grpp
+         angular_integrals.c
+         binomial.c
+         diff_gaussian.c
+@@ -53,4 +44,18 @@ add_library(libgrpp
+         utils.c
+ )
+ 
+-target_link_libraries(libgrpp -lm)
++set_target_properties(grpp PROPERTIES POSITION_INDEPENDENT_CODE ON
++                                      VERSION ${grpp_VERSION}
++                                      SOVERSION ${grpp_APIVERSION})
++include(GNUInstallDirs)
++install(
++  TARGETS grpp
++  EXPORT libgrpp_targets
++  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
++
++install(EXPORT libgrpp_targets
++        FILE grppTargets.cmake
++        NAMESPACE grpp::
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
++
++

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -26,7 +26,9 @@ class Grpp(CMakePackage):
     build_system("cmake")
 
     version("main", branch="main")
-    version("2023.12.25", commit="64d157f1dc95815096b1fd437a5851abeb3425929cf7b2092bf8262db9c5e33d")
+    version(
+        "2023.12.25", commit="64d157f1dc95815096b1fd437a5851abeb3425929cf7b2092bf8262db9c5e33d"
+    )
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -1,0 +1,36 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.build_systems import autotools, cmake
+from spack.package import *
+
+
+class Grpp(CMakePackage):
+    """ GRPP: A library for the evaluation of molecular integrals
+       of the generalized relativistic pseudopotential operator
+       (GRPP) over Gaussian functions."""
+
+    #
+    # The package has no official version and did not see a lot
+    # of development activities in 2024. It is used in cp2k and
+    # is needed when cp2k is build with trexio support
+    #
+
+    homepage = "https://github.com/aoleynichenko/libgrpp"
+    git = "https://github.com/aoleynichenko/libgrpp.git"
+
+    # notify when the package is updated.
+    maintainers("mtaillefumier")
+
+    license("BSD-3-Clause")
+
+    build_system("cmake")
+
+    version("master", branch="main")
+
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+    depends_on("cmake", type="build")
+
+    patch("grpp-cmake.patch")

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.build_systems import autotools, cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -26,6 +26,7 @@ class Grpp(CMakePackage):
     build_system("cmake")
 
     version("main", branch="main")
+    version("2023.12.25", commit="64d157f1dc95815096b1fd437a5851abeb3425929cf7b2092bf8262db9c5e33d")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -26,7 +26,7 @@ class Grpp(CMakePackage):
 
     build_system("cmake")
 
-    version("master", branch="main")
+    version("main", branch="main")
 
     depends_on("c", type="build")  # generated
     depends_on("fortran", type="build")  # generated

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -21,7 +21,7 @@ class Grpp(CMakePackage):
 
     maintainers("mtaillefumier")
 
-    license("MIT-License")
+    license("MIT", checked_by="mtaillefumier")
 
     version("main", branch="main")
     version("2023.12.25", commit="6e63e88f75385b811837efbbb143b2dcd83b00e8")

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -27,8 +27,8 @@ class Grpp(CMakePackage):
 
     version("main", branch="main")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
     depends_on("cmake", type="build")
 
     patch("grpp-cmake.patch")

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -7,9 +7,9 @@ from spack.package import *
 
 
 class Grpp(CMakePackage):
-    """ GRPP: A library for the evaluation of molecular integrals
-       of the generalized relativistic pseudopotential operator
-       (GRPP) over Gaussian functions."""
+    """GRPP: A library for the evaluation of molecular integrals
+    of the generalized relativistic pseudopotential operator
+    (GRPP) over Gaussian functions."""
 
     #
     # The package has no official version and did not see a lot

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -19,7 +19,6 @@ class Grpp(CMakePackage):
     homepage = "https://github.com/aoleynichenko/libgrpp"
     git = "https://github.com/aoleynichenko/libgrpp.git"
 
-    # notify when the package is updated.
     maintainers("mtaillefumier")
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/grpp/package.py
+++ b/var/spack/repos/builtin/packages/grpp/package.py
@@ -21,17 +21,12 @@ class Grpp(CMakePackage):
 
     maintainers("mtaillefumier")
 
-    license("BSD-3-Clause")
-
-    build_system("cmake")
+    license("MIT-License")
 
     version("main", branch="main")
-    version(
-        "2023.12.25", commit="64d157f1dc95815096b1fd437a5851abeb3425929cf7b2092bf8262db9c5e33d"
-    )
+    version("2023.12.25", commit="6e63e88f75385b811837efbbb143b2dcd83b00e8")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
-    depends_on("cmake", type="build")
 
     patch("grpp-cmake.patch")


### PR DESCRIPTION
This package has no official version and the repository does not show any recent activities. The dependency is still used by cp2k. 

Important changes:
- patched cmake build system to make it compatible with `cmake` and `pkgconfig`
- Added support of grpp and trexio in cp2k

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
