### PR TITLE
add typehints for directory_layout / Spec.prefix

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2118,20 +2118,20 @@ class Spec:
         return self.cformat(spec_format)
 
     @property
-    def prefix(self):
+    def prefix(self) -> spack.util.prefix.Prefix:
         if not self._concrete:
-            raise spack.error.SpecError("Spec is not concrete: " + str(self))
+            raise spack.error.SpecError(f"Spec is not concrete: {self}")
 
         if self._prefix is None:
-            upstream, record = spack.store.STORE.db.query_by_spec_hash(self.dag_hash())
+            _, record = spack.store.STORE.db.query_by_spec_hash(self.dag_hash())
             if record and record.path:
-                self.prefix = record.path
+                self.set_prefix(record.path)
             else:
-                self.prefix = spack.store.STORE.layout.path_for_spec(self)
+                self.set_prefix(spack.store.STORE.layout.path_for_spec(self))
+        assert self._prefix is not None
         return self._prefix
 
-    @prefix.setter
-    def prefix(self, value):
+    def set_prefix(self, value: str) -> None:
         self._prefix = spack.util.prefix.Prefix(llnl.path.convert_to_platform_path(value))
 
     def spec_hash(self, hash):
@@ -2737,7 +2737,7 @@ class Spec:
         return spec_builder(spec_dict)
 
     @staticmethod
-    def from_dict(data):
+    def from_dict(data) -> "Spec":
         """Construct a spec from JSON/YAML.
 
         Args:
@@ -2760,7 +2760,7 @@ class Spec:
         return spec
 
     @staticmethod
-    def from_yaml(stream):
+    def from_yaml(stream) -> "Spec":
         """Construct a spec from YAML.
 
         Args:
@@ -2770,7 +2770,7 @@ class Spec:
         return Spec.from_dict(data)
 
     @staticmethod
-    def from_json(stream):
+    def from_json(stream) -> "Spec":
         """Construct a spec from JSON.
 
         Args:
@@ -2780,7 +2780,7 @@ class Spec:
             data = sjson.load(stream)
             return Spec.from_dict(data)
         except Exception as e:
-            raise sjson.SpackJSONError("error parsing JSON spec:", str(e)) from e
+            raise sjson.SpackJSONError("error parsing JSON spec:", e) from e
 
     @staticmethod
     def extract_json_from_clearsig(data):

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -388,7 +388,7 @@ def test_wrapper_variables(
     root = spack.concretize.concretize_one("dt-diamond")
 
     for s in root.traverse():
-        s.prefix = "/{0}-prefix/".format(s.name)
+        s.set_prefix(f"/{s.name}-prefix/")
 
     dep_pkg = root["dt-diamond-left"].package
     dep_lib_paths = ["/test/path/to/ex1.so", "/test/path/to/subdir/ex2.so"]
@@ -396,7 +396,7 @@ def test_wrapper_variables(
     dep_libs = LibraryList(dep_lib_paths)
 
     dep2_pkg = root["dt-diamond-right"].package
-    dep2_pkg.spec.prefix = str(installation_dir_with_headers)
+    dep2_pkg.spec.set_prefix(str(installation_dir_with_headers))
 
     setattr(dep_pkg, "libs", dep_libs)
     try:

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -403,8 +403,8 @@ def test_autoreconf_search_path_args_multiple(default_mock_concretization, tmpdi
     aclocal_fst = str(tmpdir.mkdir("fst").mkdir("share").mkdir("aclocal"))
     aclocal_snd = str(tmpdir.mkdir("snd").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
-    build_dep_one.prefix = str(tmpdir.join("fst"))
-    build_dep_two.prefix = str(tmpdir.join("snd"))
+    build_dep_one.set_prefix(str(tmpdir.join("fst")))
+    build_dep_two.set_prefix(str(tmpdir.join("snd")))
     assert spack.build_systems.autotools._autoreconf_search_path_args(spec) == [
         "-I",
         aclocal_fst,
@@ -422,8 +422,8 @@ def test_autoreconf_search_path_args_skip_automake(default_mock_concretization, 
     aclocal_snd = str(tmpdir.mkdir("snd").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
     build_dep_one.name = "automake"
-    build_dep_one.prefix = str(tmpdir.join("fst"))
-    build_dep_two.prefix = str(tmpdir.join("snd"))
+    build_dep_one.set_prefix(str(tmpdir.join("fst")))
+    build_dep_two.set_prefix(str(tmpdir.join("snd")))
     assert spack.build_systems.autotools._autoreconf_search_path_args(spec) == ["-I", aclocal_snd]
 
 
@@ -434,7 +434,7 @@ def test_autoreconf_search_path_args_external_order(default_mock_concretization,
     aclocal_snd = str(tmpdir.mkdir("snd").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
     build_dep_one.external_path = str(tmpdir.join("fst"))
-    build_dep_two.prefix = str(tmpdir.join("snd"))
+    build_dep_two.set_prefix(str(tmpdir.join("snd")))
     assert spack.build_systems.autotools._autoreconf_search_path_args(spec) == [
         "-I",
         aclocal_snd,
@@ -447,8 +447,8 @@ def test_autoreconf_search_path_skip_nonexisting(default_mock_concretization, tm
     """Skip -I flags for non-existing directories"""
     spec = default_mock_concretization("dttop")
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
-    build_dep_one.prefix = str(tmpdir.join("fst"))
-    build_dep_two.prefix = str(tmpdir.join("snd"))
+    build_dep_one.set_prefix(str(tmpdir.join("fst")))
+    build_dep_two.set_prefix(str(tmpdir.join("snd")))
     assert spack.build_systems.autotools._autoreconf_search_path_args(spec) == []
 
 

--- a/lib/spack/spack/test/verification.py
+++ b/lib/spack/spack/test/verification.py
@@ -133,7 +133,7 @@ def test_check_prefix_manifest(tmpdir):
 
     spec = spack.spec.Spec("libelf")
     spec._mark_concrete()
-    spec.prefix = prefix
+    spec.set_prefix(prefix)
 
     results = spack.verify.check_spec_manifest(spec)
     assert results.has_errors()

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -35,8 +35,8 @@ def test_view_with_spec_not_contributing_files(mock_packages, tmpdir):
 
     a = Spec("pkg-a")
     b = Spec("pkg-b")
-    a.prefix = os.path.join(tmpdir, "a")
-    b.prefix = os.path.join(tmpdir, "b")
+    a.set_prefix(os.path.join(tmpdir, "a"))
+    b.set_prefix(os.path.join(tmpdir, "b"))
     a._mark_concrete()
     b._mark_concrete()
 

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -68,7 +68,9 @@ def project_env_mods(
     *specs: spack.spec.Spec, view, env: environment.EnvironmentModifications
 ) -> None:
     """Given a list of environment modifications, project paths changes to the view."""
-    prefix_to_prefix = {s.prefix: view.get_projection_for_spec(s) for s in specs if not s.external}
+    prefix_to_prefix = {
+        str(s.prefix): view.get_projection_for_spec(s) for s in specs if not s.external
+    }
     # Avoid empty regex if all external
     if not prefix_to_prefix:
         return


### PR DESCRIPTION
`Spec.prefix` returns `spack.util.prefix.Prefix` or raises, but static analysis says it can be `None` which is rather annoying.

mypy struggles with getters/setters, so replace the setter with an ordinary function `Spec.set_prefix(...)`, which is also easier to find as a symbol.

---

In the near (?) future we can consider dropping automatic `Spec.prefix` since it couples Spec to a specific store. But it's unlikely to be removed, just it would throw if Spec.set_prefix(...) wasn't called.