### PR TITLE
Refactor database to use pathlib over os.path

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1060,7 +1060,7 @@ class Database:
             self._state_is_inconsistent = True
             return
 
-        temp_file = self._index_path.parent / f"{self._index_path.name}.{_getfqdn()}.{os.getpid()}.temp"
+        temp_file = str(self._index_path) + (".%s.%s.temp" % (_getfqdn(), os.getpid()))
 
         # Write a temporary database file them move it into place
         try:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1060,7 +1060,7 @@ class Database:
             self._state_is_inconsistent = True
             return
 
-        temp_file = str(self._index_path) + (".%s.%s.temp" % (_getfqdn(), os.getpid()))
+        temp_file = self._index_path.parent / f"{self._index_path.name}.{_getfqdn()}.{os.getpid()}.temp"
 
         # Write a temporary database file them move it into place
         try:
@@ -1076,8 +1076,8 @@ class Database:
         except BaseException as e:
             tty.debug(e)
             # Clean up temp file if something goes wrong.
-            if os.path.exists(temp_file):
-                os.remove(temp_file)
+            if temp_file.exists():
+                temp_file.unlink()
             raise
 
     def _read(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Refactors database and its associated test file so pathlib is used as opposed to os.path