### PR TITLE
Refactor test modules to use pathlib over os.path

### DIFF
--- a/lib/spack/llnl/path.py
+++ b/lib/spack/llnl/path.py
@@ -29,6 +29,7 @@ def format_os_path(path: str, mode: int = Path.unix) -> str:
     """
     if not path:
         return path
+    path = str(path)
     if mode == Path.windows:
         path = path.replace("/", "\\")
     else:

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import sys
 
 import pytest
@@ -78,7 +77,7 @@ def test_spack_entry_point_config(tmp_path, mock_get_entry_points):
     if config_path is None:
         raise ValueError("Did not find entry point config in %s" % str(config_paths))
     else:
-        assert os.path.samefile(config_path, my_config_path)
+        assert my_config_path.samefile(config_path)
     config = spack.config.create()
     assert config.get("config:install_tree:root", scope="plugin-mypackage_config") == "/spam/opt"
 
@@ -87,15 +86,15 @@ def test_spack_entry_point_extension(tmp_path, mock_get_entry_points):
     """Test config scope entry point"""
     my_ext = tmp_path / "spack/spack-myext"
     extensions = spack.extensions.get_extension_paths()
-    found = bool([ext for ext in extensions if os.path.samefile(ext, my_ext)])
+    found = bool([ext for ext in extensions if my_ext.samefile(ext)])
     if not found:
         raise ValueError("Did not find extension in %s" % ", ".join(extensions))
     extensions = spack.extensions.extension_paths_from_entry_points()
-    found = bool([ext for ext in extensions if os.path.samefile(ext, my_ext)])
+    found = bool([ext for ext in extensions if my_ext.samefile(ext)])
     if not found:
         raise ValueError("Did not find extension in %s" % ", ".join(extensions))
     root = spack.extensions.load_extension("myext")
-    assert os.path.samefile(root, my_ext)
+    assert my_ext.samefile(root)
     module = spack.extensions.get_module("spam")
     assert module is not None
 

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
-import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -24,7 +24,8 @@ def _true(*args, **kwargs):
 
 
 def ensure_results(filename, expected, present=True):
-    assert os.path.exists(filename)
+    filename = Path(filename)
+    assert filename.exists()
     with open(filename, "r", encoding="utf-8") as fd:
         lines = fd.readlines()
         have = False
@@ -60,7 +61,7 @@ def test_test_ensure_stage(mock_test_stage, mock_packages):
     test_suite = spack.install_test.TestSuite([spec], test_name)
     test_suite.ensure_stage()
 
-    assert os.path.isdir(test_suite.stage)
+    assert Path(test_suite.stage).is_dir()
     assert mock_test_stage in test_suite.stage
 
 

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -13,8 +14,8 @@ from spack.installer import PackageInstaller
 from spack.spec import Spec
 
 
-def test_remove_extensions_ordered(install_mockery, mock_fetch, tmpdir):
-    view_dir = str(tmpdir.join("view"))
+def test_remove_extensions_ordered(install_mockery, mock_fetch, tmp_path):
+    view_dir = str(tmp_path / "view")
     layout = DirectoryLayout(view_dir)
     view = YamlFilesystemView(view_dir, layout)
     e2 = spack.concretize.concretize_one("extension2")
@@ -26,25 +27,25 @@ def test_remove_extensions_ordered(install_mockery, mock_fetch, tmpdir):
 
 
 @pytest.mark.regression("32456")
-def test_view_with_spec_not_contributing_files(mock_packages, tmpdir):
-    view_dir = os.path.join(str(tmpdir), "view")
-    os.mkdir(view_dir)
+def test_view_with_spec_not_contributing_files(mock_packages, tmp_path):
+    view_dir = tmp_path / "view"
+    view_dir.mkdir()
 
     layout = DirectoryLayout(view_dir)
     view = SimpleFilesystemView(view_dir, layout)
 
     a = Spec("pkg-a")
     b = Spec("pkg-b")
-    a.prefix = os.path.join(tmpdir, "a")
-    b.prefix = os.path.join(tmpdir, "b")
+    a.prefix = tmp_path / "a"
+    b.prefix = tmp_path / "b"
     a._mark_concrete()
     b._mark_concrete()
 
     # Create directory structure for a and b, and view
     os.makedirs(a.prefix.subdir)
     os.makedirs(b.prefix.subdir)
-    os.makedirs(os.path.join(a.prefix, ".spack"))
-    os.makedirs(os.path.join(b.prefix, ".spack"))
+    os.makedirs(Path(a.prefix, ".spack"))
+    os.makedirs(Path(b.prefix, ".spack"))
 
     # Add files to b's prefix, but not to a's
     with open(b.prefix.file, "w", encoding="utf-8") as f:
@@ -63,5 +64,5 @@ def test_view_with_spec_not_contributing_files(mock_packages, tmpdir):
 
     # Create view and see if files are linked.
     view.add_specs(a, b)
-    assert os.path.lexists(os.path.join(view_dir, "file"))
-    assert os.path.lexists(os.path.join(view_dir, "subdir", "file"))
+    assert os.path.lexists(view_dir / "file")
+    assert os.path.lexists(view_dir / "subdir" / "file")

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -6,11 +6,11 @@
 Utility functions for parsing, formatting, and manipulating URLs.
 """
 
-import os
 import posixpath
 import re
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Optional
 
 from spack.util.path import sanitize_filename
@@ -40,9 +40,10 @@ def local_file_path(url):
 
 
 def path_to_file_url(path):
-    if not os.path.isabs(path):
-        path = os.path.abspath(path)
-    return urllib.parse.urljoin("file:", urllib.request.pathname2url(path))
+    path = Path(path)
+    if not path.is_absolute():
+        path = path.absolute()
+    return urllib.parse.urljoin("file:", urllib.request.pathname2url(str(path)))
 
 
 def file_url_string_to_path(url):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Refactors entry_points tests so as to use pathlib