### PR TITLE
bcl2fastq2: fix boost variant issues

### DIFF
--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -8,7 +8,6 @@ import os
 import llnl.util.tty as tty
 
 from spack.package import *
-from spack.pkg.builtin.boost import Boost
 
 
 # This application uses cmake to build, but they wrap it with a
@@ -32,18 +31,23 @@ class Bcl2fastq2(Package):
 
     conflicts("platform=darwin", msg="malloc.h/etc requirements break build on macs")
 
-    depends_on("boost@1.54.0:1.55")
+    # Pulled from the fallback vendored-build of boost
+    # TODO: supporting boost > 1.54 will require patching bcl2fastq/src/cxx/lib/io/Xml.cpp
+    # as described in https://gist.github.com/jblachly/f8dc0f328d66659d9ee005548a5a2d2e
+    depends_on("boost@1.54")
 
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
-    depends_on("cmake@2.8.9:", type="build")
+    # The boost default variants no longer work for older version of boost
+    depends_on(
+        "boost+chrono+date_time+filesystem+iostreams+program_options+regex"
+        "+serialization+system+thread+timer"
+    )
+    with default_args(type="build"):
+        depends_on("cmake@2.8.9:")
+        depends_on("gmake")
     depends_on("libxml2@2.7.8")
     depends_on("libxslt@1.1.26~crypto")
     depends_on("libgcrypt")
     depends_on("zlib-api")
-    depends_on("gmake", type="build")
 
     # Their cmake macros don't set the flag when they find a library
     # that makes them happy.


### PR DESCRIPTION
Reported on slack: https://spackpm.slack.com/archives/C5W7NKZJT/p1737352316164109
```
==> Installing boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk [16/21]
==> No binary for boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/ff/fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52.tar.bz2
==> Applied patch /hpc/spack/v0.23/var/spack/repos/builtin/packages/boost/python_jam_pre156.patch
==> Applied patch /hpc/spack/v0.23/var/spack/repos/builtin/packages/boost/call_once_variadic.patch
==> Applied patch /hpc/spack/v0.23/var/spack/repos/builtin/packages/boost/clang-linux_add_option2.patch
==> Ran patch() for boost
==> boost: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 1:
    './b2' '--clean' '-j' '16' '--user-config=/tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/user-config.jam' 'variant=release' '-s' 'ICU_PATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-11.4.1/icu4c-74.2-47mmqkdpv7d6j5eftxmfvgt6mau6ng2k' '-s' 'BZIP2_INCLUDE=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/bzip2-1.0.8-kaxuby3qdbfjls5ekish6oo7yvoquo4k/include' '-s' 'BZIP2_LIBPATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/bzip2-1.0.8-kaxuby3qdbfjls5ekish6oo7yvoquo4k/lib' '-s' 'ZLIB_INCLUDE=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/zlib-ng-2.2.1-bsbmfx76ljqclwwu7urucgzims7emfvy/include' '-s' 'ZLIB_LIBPATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/zlib-ng-2.2.1-bsbmfx76ljqclwwu7urucgzims7emfvy/lib' '-s' 'LZMA_INCLUDE=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/xz-5.4.6-jnc6dovtzslhilhuwybcnoj6wyexnic3/include' '-s' 'LZMA_LIBPATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/xz-5.4.6-jnc6dovtzslhilhuwybcnoj6wyexnic3/lib' '-s' 'ZSTD_INCLUDE=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/zstd-1.5.6-yf2mlwej4z5rxbfca6zpjlufssfwgbuq/include' '-s' 'ZSTD_LIBPATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/zstd-1.5.6-yf2mlwej4z5rxbfca6zpjlufssfwgbuq/lib' 'link=static,shared' '--layout=system' 'toolset=gcc' 'cxxflags="-std=c++11"'

16 errors found in build log:
     19    
     20       - Boost.Build documentation:
     21         http://www.boost.org/boost-build2/doc/html/index.html
     22    
     23    ==> [2025-01-20-16:49:12.600098] FILTER FILE: /tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/project-config.jam [replacing "^\s*using gcc.*"]
     24    ==> [2025-01-20-16:49:12.609415] './b2' '--clean' '-j' '16' '--user-config=/tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/user-config.jam' 'variant=relea
           se' '-s' 'ICU_PATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-11.4.1/icu4c-74.2-47mmqkdpv7d6j5eftxmfvgt6mau6ng2k' '-s' 'BZIP2_INCLUDE=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc
           -13.3.1/bzip2-1.0.8-kaxuby3qdbfjls5ekish6oo7yvoquo4k/include' '-s' 'BZIP2_LIBPATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/bzip2-1.0.8-kaxuby3qdbfjls5ekish6oo7yvoquo4k/lib' '-s'
            'ZLIB_INCLUDE=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/zlib-ng-2.2.1-bsbmfx76ljqclwwu7urucgzims7emfvy/include' '-s' 'ZLIB_LIBPATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybrid
           ge/gcc-13.3.1/zlib-ng-2.2.1-bsbmfx76ljqclwwu7urucgzims7emfvy/lib' '-s' 'LZMA_INCLUDE=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/xz-5.4.6-jnc6dovtzslhilhuwybcnoj6wyexnic3/include' 
           '-s' 'LZMA_LIBPATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/xz-5.4.6-jnc6dovtzslhilhuwybcnoj6wyexnic3/lib' '-s' 'ZSTD_INCLUDE=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gc
           c-13.3.1/zstd-1.5.6-yf2mlwej4z5rxbfca6zpjlufssfwgbuq/include' '-s' 'ZSTD_LIBPATH=/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-13.3.1/zstd-1.5.6-yf2mlwej4z5rxbfca6zpjlufssfwgbuq/lib' 'link=
           static,shared' '--layout=system' 'toolset=gcc' 'cxxflags="-std=c++11"'
  >> 25    link.jam: No such file or directory
     26    
     27    Building the Boost C++ Libraries.
     28    
     29    
     30    Performing configuration checks
     31    

     ...

     37        - x86                      : yes
     38        - compiler-supports-ssse3  : yes
     39        - compiler-supports-avx2   : yes
     40        - gcc visibility           : yes
     41        - long double support      : yes
     42        - zlib                     : yes
  >> 43    /tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/tools/build/v2/build/virtual-target.jam:1099: in virtual-target.register-actual-name from module virtual-t
           arget
  >> 44    error: Duplicate name of actual target: <llibs!locale!build/gcc-13/release/threading-multi>icudata
  >> 45    error: previous virtual target { %.no-action-icudata.SEARCHED_LIB }
  >> 46    error: created from libs/locale/build/icudt
  >> 47    error: another virtual target { %.no-action-icudata.SEARCHED_LIB }
  >> 48    error: created from libs/locale/build/icudt_64
  >> 49    error: added properties: <search>/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-11.4.1/icu4c-74.2-47mmqkdpv7d6j5eftxmfvgt6mau6ng2k/lib64
  >> 50    error: removed properties: <search>/hpc/spack/v0.23/opt/spack/linux-rhel9-ivybridge/gcc-11.4.1/icu4c-74.2-47mmqkdpv7d6j5eftxmfvgt6mau6ng2k/lib
  >> 51    /tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/tools/build/v2/build/virtual-target.jam:484: in actualize-no-scanner from module object(searched-lib-targe
           t)@@1814
  >> 52    /tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/tools/build/v2/build/virtual-target.jam:134: in class@@virtual-target.actualize from module object(searched
           -lib-target)@@1814
  >> 53    /tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/tools/build/v2/build-system.jam:164: in actual-clean-targets from module build-system
  >> 54    /tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/tools/build/v2/build-system.jam:952: in load from module build-system
  >> 55    /tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/tools/build/v2/kernel/modules.jam:289: in import from module modules
  >> 56    /tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/tools/build/v2/kernel/bootstrap.jam:139: in boost-build from module
  >> 57    /tmp/root/spack-stage/spack-stage-boost-1.55.0-dz6ty2tx3jkp4icvvq2zxph2yrcrzauk/spack-src/boost-build.jam:17: in module scope from module
     58    ```

Looks like `Boost.with_default_variants` doesn't work for older/deprecated versions of boost. Also noting a path for future fixes to add compatibility with non-deprecated boost versions.