### PR TITLE
Refactor installer to use pathlib over os.path

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -894,7 +894,7 @@ def chgrp_if_not_world_writable(path, group):
 
 
 def mkdirp(
-    *paths: str,
+    *paths,
     mode: Optional[int] = None,
     group: Optional[Union[str, int]] = None,
     default_perms: Optional[str] = None,

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -219,7 +219,7 @@ class DirectoryLayout:
         return os.path.join(self.metadata_path(spec), "install_environment.json")
 
     def build_packages_path(self, spec):
-        return os.path.join(self.metadata_path(spec), self.packages_dir)
+        return Path(self.metadata_path(spec), self.packages_dir)
 
     def create_install_directory(self, spec):
         _check_concrete(spec)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -274,7 +274,7 @@ def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
 
     # Install fake command
     prefix_bin = PurePath(pkg.prefix.bin)
-    fs.mkdirp(prefix_bin)
+    fs.mkdirp(str(prefix_bin))
     fs.touch(prefix_bin / command)
     if sys.platform != "win32":
         chmod = which("chmod", required=True)
@@ -282,12 +282,12 @@ def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
 
     # Install fake header file
     prefix_include = PurePath(pkg.prefix.include)
-    fs.mkdirp(prefix_include)
+    fs.mkdirp(str(prefix_include))
     fs.touch(prefix_include / (header + ".h"))
 
     # Install fake shared and static libraries
     prefix_lib = PurePath(pkg.prefix.lib)
-    fs.mkdirp(prefix_lib)
+    fs.mkdirp(str(prefix_lib))
     for suffix in [dso_suffix, plat_static]:
         fs.touch(prefix_lib / (library + suffix))
 
@@ -538,7 +538,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
         path: the path to the build packages directory
     """
     path = Path(path)
-    fs.mkdirp(path)
+    fs.mkdirp(str(path))
 
     # Copy in package.py files from any dependencies.
     # Note that we copy them in as they are in the *install* directory
@@ -662,9 +662,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
     # Finally, archive files that are specific to each package
     with fs.working_dir(pkg.stage.path):
         errors = io.StringIO()
-        target_dir = Path(
-            spack.store.STORE.layout.metadata_path(pkg.spec), "archived-files"
-        )
+        target_dir = Path(spack.store.STORE.layout.metadata_path(pkg.spec), "archived-files")
 
         for glob_expr in spack.builder.create(pkg).archive_files:
             # Check that we are trying to copy things that are
@@ -683,7 +681,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
                     target = target_dir / f
                     # We must ensure that the directory exists before
                     # copying a file in
-                    fs.mkdirp(target.parent)
+                    fs.mkdirp(str(target.parent))
                     fs.install(f, target)
                 except Exception as e:
                     tty.debug(e)
@@ -695,7 +693,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
 
         if errors.getvalue():
             error_file = target_dir / "errors.txt"
-            fs.mkdirp(target_dir)
+            fs.mkdirp(str(target_dir))
             with open(error_file, "w", encoding="utf-8") as err:
                 err.write(errors.getvalue())
             tty.warn(f"Errors occurred when archiving files.\n\tSee: {error_file}")
@@ -2524,7 +2522,7 @@ def deprecate(spec: "spack.spec.Spec", deprecator: "spack.spec.Spec", link_fn) -
 
     # copy spec metadata to "deprecated" dir of deprecator
     depr_specfile = Path(spack.store.STORE.layout.deprecated_file_path(spec, deprecator))
-    fs.mkdirp(depr_specfile.parent)
+    fs.mkdirp(str(depr_specfile.parent))
     shutil.copy2(specfile, depr_specfile)
 
     # Any specs deprecated in favor of this spec are re-deprecated in favor of its new deprecator

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -37,6 +37,7 @@ import sys
 import time
 from collections import defaultdict
 from gzip import GzipFile
+from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import llnl.util.filesystem as fs
@@ -67,6 +68,7 @@ import spack.util.path
 import spack.util.timer as timer
 from spack.util.environment import EnvironmentModifications, dump_environment
 from spack.util.executable import which
+from spack.util.path import abstract_path, concrete_path, fs_path
 
 #: Counter to support unique spec sequencing that is used to ensure packages
 #: with the same priority are (initially) processed in the order in which they
@@ -272,20 +274,23 @@ def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
     dso_suffix = ".dylib" if sys.platform == "darwin" else plat_shared
 
     # Install fake command
-    fs.mkdirp(pkg.prefix.bin)
-    fs.touch(os.path.join(pkg.prefix.bin, command))
+    prefix_bin = abstract_path(pkg.prefix.bin)
+    fs.mkdirp(prefix_bin)
+    fs.touch(prefix_bin / command)
     if sys.platform != "win32":
         chmod = which("chmod", required=True)
-        chmod("+x", os.path.join(pkg.prefix.bin, command))
+        chmod("+x", fs_path(prefix_bin / command))
 
     # Install fake header file
-    fs.mkdirp(pkg.prefix.include)
-    fs.touch(os.path.join(pkg.prefix.include, header + ".h"))
+    prefix_include = abstract_path(pkg.prefix.include)
+    fs.mkdirp(prefix_include)
+    fs.touch(prefix_include / (header + ".h"))
 
     # Install fake shared and static libraries
-    fs.mkdirp(pkg.prefix.lib)
+    prefix_lib = abstract_path(pkg.prefix.lib)
+    fs.mkdirp(prefix_lib)
     for suffix in [dso_suffix, plat_static]:
-        fs.touch(os.path.join(pkg.prefix.lib, library + suffix))
+        fs.touch(prefix_lib / (library + suffix))
 
     # Install fake man page
     fs.mkdirp(pkg.prefix.man.man1)
@@ -521,7 +526,7 @@ def combine_phase_logs(phase_log_files: List[str], log_path: str) -> None:
                 shutil.copyfileobj(phase_log, log_file)
 
 
-def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
+def dump_packages(spec: "spack.spec.Spec", path: str | Path) -> None:
     """
     Dump all package information for a spec and its dependencies.
 
@@ -533,6 +538,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
         spec: the Spack spec whose package information is to be dumped
         path: the path to the build packages directory
     """
+    path = concrete_path(path)
     fs.mkdirp(path)
 
     # Copy in package.py files from any dependencies.
@@ -544,7 +550,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
             # Locate the dependency package in the install tree and find
             # its provenance information.
             source = spack.store.STORE.layout.build_packages_path(node)
-            source_repo_root = os.path.join(source, node.namespace)
+            source_repo_root = source / node.namespace
 
             # If there's no provenance installed for the package, skip it.
             # If it's external, skip it because it either:
@@ -553,12 +559,12 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
             # (currently) use Spack metadata to associate repos with externals
             # built by other Spack instances.
             # Spack can always get something current from the builtin repo.
-            if node.external or not os.path.isdir(source_repo_root):
+            if node.external or not source_repo_root.is_dir():
                 continue
 
             # Create a source repo and get the pkg directory out of it.
             try:
-                source_repo = spack.repo.from_path(source_repo_root)
+                source_repo = spack.repo.from_path(fs_path(source_repo_root))
                 source_pkg_dir = source_repo.dirname_for_package_name(node.name)
             except spack.repo.RepoError as err:
                 tty.debug(f"Failed to create source repo for {node.name}: {str(err)}")
@@ -566,10 +572,10 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
                 tty.warn(f"Warning: Couldn't copy in provenance for {node.name}")
 
         # Create a destination repository
-        dest_repo_root = os.path.join(path, node.namespace)
-        if not os.path.exists(dest_repo_root):
-            spack.repo.create_repo(dest_repo_root)
-        repo = spack.repo.from_path(dest_repo_root)
+        dest_repo_root = path / node.namespace
+        if not dest_repo_root.exists():
+            spack.repo.create_repo(fs_path(dest_repo_root))
+        repo = spack.repo.from_path(fs_path(dest_repo_root))
 
         # Get the location of the package in the dest repo.
         dest_pkg_dir = repo.dirname_for_package_name(node.name)
@@ -657,7 +663,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
     # Finally, archive files that are specific to each package
     with fs.working_dir(pkg.stage.path):
         errors = io.StringIO()
-        target_dir = os.path.join(
+        target_dir = concrete_path(
             spack.store.STORE.layout.metadata_path(pkg.spec), "archived-files"
         )
 
@@ -675,10 +681,10 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
             files = glob.glob(glob_expr)
             for f in files:
                 try:
-                    target = os.path.join(target_dir, f)
+                    target = target_dir / f
                     # We must ensure that the directory exists before
                     # copying a file in
-                    fs.mkdirp(os.path.dirname(target))
+                    fs.mkdirp(target.parent)
                     fs.install(f, target)
                 except Exception as e:
                     tty.debug(e)
@@ -689,7 +695,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
                     errors.write(f"[FAILED TO ARCHIVE]: {f}")
 
         if errors.getvalue():
-            error_file = os.path.join(target_dir, "errors.txt")
+            error_file = target_dir / "errors.txt"
             fs.mkdirp(target_dir)
             with open(error_file, "w", encoding="utf-8") as err:
                 err.write(errors.getvalue())
@@ -1065,7 +1071,8 @@ class Task:
             pkg: the package to be built and installed
         """
         # Move to a module level method.
-        if not os.path.exists(pkg.spec.prefix):
+        prefix = concrete_path(pkg.spec.prefix)
+        if not prefix.exists():
             path = spack.util.path.debug_padded_filter(pkg.spec.prefix)
             tty.debug(f"Creating the installation directory {path}")
             spack.store.STORE.layout.create_install_directory(pkg.spec)
@@ -1490,7 +1497,8 @@ class PackageInstaller:
 
             # Make sure the installation directory is in the desired state
             # for uninstalled specs.
-            if os.path.isdir(task.pkg.spec.prefix):
+            task_prefix = concrete_path(task.pkg.spec.prefix)
+            if task_prefix.is_dir():
                 if not keep_prefix:
                     task.pkg.remove_prefix()
                 else:
@@ -2003,7 +2011,8 @@ class PackageInstaller:
 
         # If the install prefix is missing, warn about it, and proceed with
         # normal install.
-        if not os.path.exists(task.pkg.prefix):
+        task_prefix = concrete_path(task.pkg.prefix)
+        if not task_prefix.exists():
             tty.debug("Missing installation to overwrite")
             return InstallAction.INSTALL
 
@@ -2385,10 +2394,10 @@ class BuildProcessInstaller:
     def _install_source(self) -> None:
         """Install source code from stage into share/pkg/src if necessary."""
         pkg = self.pkg
-        if not os.path.isdir(pkg.stage.source_path):
+        if not concrete_path(pkg.stage.source_path).is_dir():
             return
 
-        src_target = os.path.join(pkg.spec.prefix, "share", pkg.name, "src")
+        src_target = concrete_path(pkg.spec.prefix, "share", pkg.name, "src")
         tty.debug(f"{self.pre} Copying source to {src_target}")
 
         fs.install_tree(pkg.stage.source_path, src_target)
@@ -2426,11 +2435,12 @@ class BuildProcessInstaller:
             # Spawn a daemon that reads from a pipe and redirects
             # everything to log_path, and provide the phase for logging
             builder = spack.builder.create(pkg)
+            log_path = abstract_path(pkg.log_path)
             for i, phase_fn in enumerate(builder):
                 # Keep a log file for each phase
-                log_dir = os.path.dirname(pkg.log_path)
+                log_dir = log_path.parent
                 log_file = "spack-build-%02d-%s-out.txt" % (i + 1, phase_fn.name.lower())
-                log_file = os.path.join(log_dir, log_file)
+                log_file = fs_path(log_dir / log_file)
 
                 try:
                     # DEBUGGING TIP - to debug this section, insert an IPython
@@ -2514,8 +2524,8 @@ def deprecate(spec: "spack.spec.Spec", deprecator: "spack.spec.Spec", link_fn) -
         specfile = spack.store.STORE.layout.spec_file_path(spec)
 
     # copy spec metadata to "deprecated" dir of deprecator
-    depr_specfile = spack.store.STORE.layout.deprecated_file_path(spec, deprecator)
-    fs.mkdirp(os.path.dirname(depr_specfile))
+    depr_specfile = concrete_path(spack.store.STORE.layout.deprecated_file_path(spec, deprecator))
+    fs.mkdirp(depr_specfile.parent)
     shutil.copy2(specfile, depr_specfile)
 
     # Any specs deprecated in favor of this spec are re-deprecated in favor of its new deprecator

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -273,21 +273,21 @@ def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
     dso_suffix = ".dylib" if sys.platform == "darwin" else plat_shared
 
     # Install fake command
-    prefix_bin = PurePath(pkg.prefix.bin)
-    fs.mkdirp(str(prefix_bin))
+    prefix_bin = Path(pkg.prefix.bin)
+    fs.mkdirp(prefix_bin)
     fs.touch(prefix_bin / command)
     if sys.platform != "win32":
         chmod = which("chmod", required=True)
         chmod("+x", os.fspath(prefix_bin / command))
 
     # Install fake header file
-    prefix_include = PurePath(pkg.prefix.include)
-    fs.mkdirp(str(prefix_include))
+    prefix_include = Path(pkg.prefix.include)
+    fs.mkdirp(prefix_include)
     fs.touch(prefix_include / (header + ".h"))
 
     # Install fake shared and static libraries
-    prefix_lib = PurePath(pkg.prefix.lib)
-    fs.mkdirp(str(prefix_lib))
+    prefix_lib = Path(pkg.prefix.lib)
+    fs.mkdirp(prefix_lib)
     for suffix in [dso_suffix, plat_static]:
         fs.touch(prefix_lib / (library + suffix))
 
@@ -538,7 +538,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
         path: the path to the build packages directory
     """
     path = Path(path)
-    fs.mkdirp(str(path))
+    fs.mkdirp(path)
 
     # Copy in package.py files from any dependencies.
     # Note that we copy them in as they are in the *install* directory
@@ -681,7 +681,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
                     target = target_dir / f
                     # We must ensure that the directory exists before
                     # copying a file in
-                    fs.mkdirp(str(target.parent))
+                    fs.mkdirp(target.parent)
                     fs.install(f, target)
                 except Exception as e:
                     tty.debug(e)
@@ -693,7 +693,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
 
         if errors.getvalue():
             error_file = target_dir / "errors.txt"
-            fs.mkdirp(str(target_dir))
+            fs.mkdirp(target_dir)
             with open(error_file, "w", encoding="utf-8") as err:
                 err.write(errors.getvalue())
             tty.warn(f"Errors occurred when archiving files.\n\tSee: {error_file}")
@@ -2522,7 +2522,7 @@ def deprecate(spec: "spack.spec.Spec", deprecator: "spack.spec.Spec", link_fn) -
 
     # copy spec metadata to "deprecated" dir of deprecator
     depr_specfile = Path(spack.store.STORE.layout.deprecated_file_path(spec, deprecator))
-    fs.mkdirp(str(depr_specfile.parent))
+    fs.mkdirp(depr_specfile.parent)
     shutil.copy2(specfile, depr_specfile)
 
     # Any specs deprecated in favor of this spec are re-deprecated in favor of its new deprecator

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -37,7 +37,6 @@ import sys
 import time
 from collections import defaultdict
 from gzip import GzipFile
-from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import llnl.util.filesystem as fs
@@ -526,7 +525,7 @@ def combine_phase_logs(phase_log_files: List[str], log_path: str) -> None:
                 shutil.copyfileobj(phase_log, log_file)
 
 
-def dump_packages(spec: "spack.spec.Spec", path: str | Path) -> None:
+def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
     """
     Dump all package information for a spec and its dependencies.
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -278,7 +278,7 @@ def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
     fs.touch(prefix_bin / command)
     if sys.platform != "win32":
         chmod = which("chmod", required=True)
-        chmod("+x", os.fspath(prefix_bin / command))
+        chmod("+x", str(prefix_bin / command))
 
     # Install fake header file
     prefix_include = Path(pkg.prefix.include)
@@ -563,7 +563,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
 
             # Create a source repo and get the pkg directory out of it.
             try:
-                source_repo = spack.repo.from_path(os.fspath(source_repo_root))
+                source_repo = spack.repo.from_path(source_repo_root)
                 source_pkg_dir = source_repo.dirname_for_package_name(node.name)
             except spack.repo.RepoError as err:
                 tty.debug(f"Failed to create source repo for {node.name}: {str(err)}")
@@ -573,8 +573,8 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
         # Create a destination repository
         dest_repo_root = path / node.namespace
         if not dest_repo_root.exists():
-            spack.repo.create_repo(os.fspath(dest_repo_root))
-        repo = spack.repo.from_path(os.fspath(dest_repo_root))
+            spack.repo.create_repo(dest_repo_root)
+        repo = spack.repo.from_path(dest_repo_root)
 
         # Get the location of the package in the dest repo.
         dest_pkg_dir = repo.dirname_for_package_name(node.name)
@@ -650,7 +650,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
         # FIXME : this potentially catches too many things...
         tty.debug(e)
 
-    archive_install_logs(pkg, os.path.dirname(packages_dir))
+    archive_install_logs(pkg, str(packages_dir.parent))
 
     # Archive the environment modifications for the build.
     fs.install(pkg.env_mods_path, pkg.install_env_path)
@@ -2432,10 +2432,9 @@ class BuildProcessInstaller:
             # Spawn a daemon that reads from a pipe and redirects
             # everything to log_path, and provide the phase for logging
             builder = spack.builder.create(pkg)
-            log_path = PurePath(pkg.log_path)
+            log_dir = PurePath(pkg.log_path).parent
             for i, phase_fn in enumerate(builder):
                 # Keep a log file for each phase
-                log_dir = log_path.parent
                 log_file = "spack-build-%02d-%s-out.txt" % (i + 1, phase_fn.name.lower())
                 log_file = os.fspath(log_dir / log_file)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -37,6 +37,7 @@ import sys
 import time
 from collections import defaultdict
 from gzip import GzipFile
+from pathlib import Path, PurePath
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import llnl.util.filesystem as fs
@@ -67,7 +68,6 @@ import spack.util.path
 import spack.util.timer as timer
 from spack.util.environment import EnvironmentModifications, dump_environment
 from spack.util.executable import which
-from spack.util.path import abstract_path, concrete_path, fs_path
 
 #: Counter to support unique spec sequencing that is used to ensure packages
 #: with the same priority are (initially) processed in the order in which they
@@ -273,20 +273,20 @@ def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
     dso_suffix = ".dylib" if sys.platform == "darwin" else plat_shared
 
     # Install fake command
-    prefix_bin = abstract_path(pkg.prefix.bin)
+    prefix_bin = PurePath(pkg.prefix.bin)
     fs.mkdirp(prefix_bin)
     fs.touch(prefix_bin / command)
     if sys.platform != "win32":
         chmod = which("chmod", required=True)
-        chmod("+x", fs_path(prefix_bin / command))
+        chmod("+x", os.fspath(prefix_bin / command))
 
     # Install fake header file
-    prefix_include = abstract_path(pkg.prefix.include)
+    prefix_include = PurePath(pkg.prefix.include)
     fs.mkdirp(prefix_include)
     fs.touch(prefix_include / (header + ".h"))
 
     # Install fake shared and static libraries
-    prefix_lib = abstract_path(pkg.prefix.lib)
+    prefix_lib = PurePath(pkg.prefix.lib)
     fs.mkdirp(prefix_lib)
     for suffix in [dso_suffix, plat_static]:
         fs.touch(prefix_lib / (library + suffix))
@@ -537,7 +537,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
         spec: the Spack spec whose package information is to be dumped
         path: the path to the build packages directory
     """
-    path = concrete_path(path)
+    path = Path(path)
     fs.mkdirp(path)
 
     # Copy in package.py files from any dependencies.
@@ -563,7 +563,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
 
             # Create a source repo and get the pkg directory out of it.
             try:
-                source_repo = spack.repo.from_path(fs_path(source_repo_root))
+                source_repo = spack.repo.from_path(os.fspath(source_repo_root))
                 source_pkg_dir = source_repo.dirname_for_package_name(node.name)
             except spack.repo.RepoError as err:
                 tty.debug(f"Failed to create source repo for {node.name}: {str(err)}")
@@ -573,8 +573,8 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
         # Create a destination repository
         dest_repo_root = path / node.namespace
         if not dest_repo_root.exists():
-            spack.repo.create_repo(fs_path(dest_repo_root))
-        repo = spack.repo.from_path(fs_path(dest_repo_root))
+            spack.repo.create_repo(os.fspath(dest_repo_root))
+        repo = spack.repo.from_path(os.fspath(dest_repo_root))
 
         # Get the location of the package in the dest repo.
         dest_pkg_dir = repo.dirname_for_package_name(node.name)
@@ -662,7 +662,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
     # Finally, archive files that are specific to each package
     with fs.working_dir(pkg.stage.path):
         errors = io.StringIO()
-        target_dir = concrete_path(
+        target_dir = Path(
             spack.store.STORE.layout.metadata_path(pkg.spec), "archived-files"
         )
 
@@ -1070,7 +1070,7 @@ class Task:
             pkg: the package to be built and installed
         """
         # Move to a module level method.
-        prefix = concrete_path(pkg.spec.prefix)
+        prefix = Path(pkg.spec.prefix)
         if not prefix.exists():
             path = spack.util.path.debug_padded_filter(pkg.spec.prefix)
             tty.debug(f"Creating the installation directory {path}")
@@ -1496,7 +1496,7 @@ class PackageInstaller:
 
             # Make sure the installation directory is in the desired state
             # for uninstalled specs.
-            task_prefix = concrete_path(task.pkg.spec.prefix)
+            task_prefix = Path(task.pkg.spec.prefix)
             if task_prefix.is_dir():
                 if not keep_prefix:
                     task.pkg.remove_prefix()
@@ -2010,7 +2010,7 @@ class PackageInstaller:
 
         # If the install prefix is missing, warn about it, and proceed with
         # normal install.
-        task_prefix = concrete_path(task.pkg.prefix)
+        task_prefix = Path(task.pkg.prefix)
         if not task_prefix.exists():
             tty.debug("Missing installation to overwrite")
             return InstallAction.INSTALL
@@ -2393,10 +2393,10 @@ class BuildProcessInstaller:
     def _install_source(self) -> None:
         """Install source code from stage into share/pkg/src if necessary."""
         pkg = self.pkg
-        if not concrete_path(pkg.stage.source_path).is_dir():
+        if not Path(pkg.stage.source_path).is_dir():
             return
 
-        src_target = concrete_path(pkg.spec.prefix, "share", pkg.name, "src")
+        src_target = Path(pkg.spec.prefix, "share", pkg.name, "src")
         tty.debug(f"{self.pre} Copying source to {src_target}")
 
         fs.install_tree(pkg.stage.source_path, src_target)
@@ -2434,12 +2434,12 @@ class BuildProcessInstaller:
             # Spawn a daemon that reads from a pipe and redirects
             # everything to log_path, and provide the phase for logging
             builder = spack.builder.create(pkg)
-            log_path = abstract_path(pkg.log_path)
+            log_path = PurePath(pkg.log_path)
             for i, phase_fn in enumerate(builder):
                 # Keep a log file for each phase
                 log_dir = log_path.parent
                 log_file = "spack-build-%02d-%s-out.txt" % (i + 1, phase_fn.name.lower())
-                log_file = fs_path(log_dir / log_file)
+                log_file = os.fspath(log_dir / log_file)
 
                 try:
                     # DEBUGGING TIP - to debug this section, insert an IPython
@@ -2523,7 +2523,7 @@ def deprecate(spec: "spack.spec.Spec", deprecator: "spack.spec.Spec", link_fn) -
         specfile = spack.store.STORE.layout.spec_file_path(spec)
 
     # copy spec metadata to "deprecated" dir of deprecator
-    depr_specfile = concrete_path(spack.store.STORE.layout.deprecated_file_path(spec, deprecator))
+    depr_specfile = Path(spack.store.STORE.layout.deprecated_file_path(spec, deprecator))
     fs.mkdirp(depr_specfile.parent)
     shutil.copy2(specfile, depr_specfile)
 

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -225,4 +225,4 @@ def test_yaml_directory_layout_build_path(tmpdir, default_mock_concretization):
     spec = default_mock_concretization("python")
     layout = DirectoryLayout(str(tmpdir))
     rel_path = os.path.join(layout.metadata_dir, layout.packages_dir)
-    assert layout.build_packages_path(spec) == os.path.join(spec.prefix, rel_path)
+    assert layout.build_packages_path(spec) == Path(spec.prefix, rel_path)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -6,6 +6,7 @@ import glob
 import os
 import shutil
 import sys
+from pathlib import Path
 from typing import List, Optional, Union
 
 import py
@@ -30,7 +31,6 @@ import spack.store
 import spack.util.lock as lk
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
-from spack.util.path import concrete_path, fs_path
 
 
 def _mock_repo(root, namespace):
@@ -428,7 +428,7 @@ def test_fake_install(install_mockery):
 
     pkg = spec.package
     inst._do_fake_install(pkg)
-    lib = concrete_path(pkg.prefix.lib)
+    lib = Path(pkg.prefix.lib)
     assert lib.is_dir()
 
 
@@ -440,7 +440,7 @@ def test_dump_packages_deps_ok(install_mockery, tmpdir, mock_packages):
     inst.dump_packages(spec, str(tmpdir))
 
     repo = mock_packages.repos[0]
-    dest_pkg = concrete_path(repo.filename_for_package_name(spec_name))
+    dest_pkg = Path(repo.filename_for_package_name(spec_name))
     assert dest_pkg.is_file()
 
 
@@ -454,7 +454,7 @@ def test_dump_packages_deps_errs(install_mockery, tmp_path, monkeypatch, capsys)
         # Perform the original function
         source = orig_bpp(spec)
         # Mock the required directory structure for the repository
-        _mock_repo(fs_path(source / spec.namespace), spec.namespace)
+        _mock_repo(os.fspath(source / spec.namespace), spec.namespace)
         return source
 
     def _repoerr(repo, name):
@@ -504,11 +504,11 @@ def test_clear_failures_success(tmpdir):
     assert len(os.listdir(failures.dir)) == 0
 
     # Ensure the core directory and failure lock file still exist
-    assert concrete_path(failures.dir).is_dir()
+    assert Path(failures.dir).is_dir()
 
     # Locks on windows are a no-op
     if sys.platform != "win32":
-        assert concrete_path(failures.locker.lock_path).is_file()
+        assert Path(failures.locker.lock_path).is_file()
 
 
 @pytest.mark.not_on_windows("chmod does not prevent removal on Win")
@@ -1185,7 +1185,7 @@ def test_overwrite_install_backup_success(temporary_store, config, mock_packages
     task = installer._pop_task()
 
     # Make sure the install prefix exists with some trivial file
-    installed_file = concrete_path(task.pkg.prefix, "some_file")
+    installed_file = Path(task.pkg.prefix, "some_file")
     fs.touchp(installed_file)
 
     class InstallerThatWipesThePrefixDir:
@@ -1245,7 +1245,7 @@ def test_overwrite_install_backup_failure(temporary_store, config, mock_packages
     task = installer._pop_task()
 
     # Make sure the install prefix exists
-    installed_file = concrete_path(task.pkg.prefix, "some_file")
+    installed_file = Path(task.pkg.prefix, "some_file")
     fs.touchp(installed_file)
 
     fake_installer = InstallerThatAccidentallyDeletesTheBackupDir()

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -468,11 +468,12 @@ def test_dump_packages_deps_errs(install_mockery, tmp_path, monkeypatch, capsys)
     monkeypatch.setattr(spack.store.STORE.layout, "build_packages_path", bpp_path)
 
     spec = spack.concretize.concretize_one("simple-inheritance")
+    path = str(tmp_path)
 
     # The call to install_tree will raise the exception since not mocking
     # creation of dependency package files within *install* directories.
-    with pytest.raises(IOError, match=tmp_path if sys.platform != "win32" else ""):
-        inst.dump_packages(spec, tmp_path)
+    with pytest.raises(IOError, match=path if sys.platform != "win32" else ""):
+        inst.dump_packages(spec, path)
 
     # Now try the error path, which requires the mock directory structure
     # above

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -30,7 +30,7 @@ import spack.store
 import spack.util.lock as lk
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
-from spack.util.path import abstract_path, concrete_path, fs_path
+from spack.util.path import concrete_path, fs_path
 
 
 def _mock_repo(root, namespace):
@@ -471,7 +471,7 @@ def test_dump_packages_deps_errs(install_mockery, tmp_path, monkeypatch, capsys)
 
     # The call to install_tree will raise the exception since not mocking
     # creation of dependency package files within *install* directories.
-    with pytest.raises(IOError, match=path if sys.platform != "win32" else ""):
+    with pytest.raises(IOError, match=tmp_path if sys.platform != "win32" else ""):
         inst.dump_packages(spec, tmp_path)
 
     # Now try the error path, which requires the mock directory structure

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -185,7 +185,7 @@ def substitute_config_variables(path):
         return m if repl is NOMATCH else str(repl)
 
     # Replace $var or ${var}.
-    return re.sub(r"(\$\w+\b|\$\{\w+\})", repl, path)
+    return re.sub(r"(\$\w+\b|\$\{\w+\})", repl, str(path))
 
 
 def substitute_path_variables(path):

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 from datetime import date
+from pathlib import Path, PurePath
 
 import llnl.util.tty as tty
 from llnl.util.lang import memoized
@@ -186,6 +187,23 @@ def substitute_config_variables(path):
 
     # Replace $var or ${var}.
     return re.sub(r"(\$\w+\b|\$\{\w+\})", repl, path)
+
+
+def abstract_path(*path_strings):
+    """Cast string path or combine parts of a path to a PurePath object"""
+    return PurePath(*path_strings)
+
+
+def concrete_path(*path_strings):
+    """Cast string path or combine parts of a path to a Path object"""
+    return Path(*path_strings)
+
+
+def fs_path(path):
+    """Return underlying path representation of path-like object.
+    If parameter is str or byte, it is returned unchanged. If path-like object it
+    returns underlying representation. Otherwise, a TypeError will be raised."""
+    return os.fspath(path)
 
 
 def substitute_path_variables(path):

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -14,7 +14,6 @@ import subprocess
 import sys
 import tempfile
 from datetime import date
-from pathlib import Path, PurePath
 
 import llnl.util.tty as tty
 from llnl.util.lang import memoized
@@ -187,23 +186,6 @@ def substitute_config_variables(path):
 
     # Replace $var or ${var}.
     return re.sub(r"(\$\w+\b|\$\{\w+\})", repl, path)
-
-
-def abstract_path(*path_strings):
-    """Cast string path or combine parts of a path to a PurePath object"""
-    return PurePath(*path_strings)
-
-
-def concrete_path(*path_strings):
-    """Cast string path or combine parts of a path to a Path object"""
-    return Path(*path_strings)
-
-
-def fs_path(path):
-    """Return underlying path representation of path-like object.
-    If parameter is str or byte, it is returned unchanged. If path-like object it
-    returns underlying representation. Otherwise, a TypeError will be raised."""
-    return os.fspath(path)
 
 
 def substitute_path_variables(path):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Refactors installer module to use pathlib instead of os.path