### PR TITLE
pandoramonitoring: add patch for compiling with C++20

### DIFF
--- a/var/spack/repos/builtin/packages/pandoramonitoring/package.py
+++ b/var/spack/repos/builtin/packages/pandoramonitoring/package.py
@@ -26,11 +26,14 @@ class Pandoramonitoring(CMakePackage):
     depends_on("root@6.18.04: +x +opengl")
     depends_on("pandorasdk")
 
-    patch(
-        "https://github.com/PandoraPFA/PandoraMonitoring/pull/13.patch?full_index=1",
-        sha256="3a8f38c2158f151ba352368fe3241a61eab73fc51597c73afe72c92ad9af9e61",
-        when="@:3.6.0",
-    )
+    # https://github.com/PandoraPFA/PandoraMonitoring/pull/13
+    @when("@:3.6.0")
+    def patch(self):
+        filter_file(
+            "TTreeWrapper::Branch<T>::~Branch<T>",
+            "TTreeWrapper::Branch<T>::~Branch",
+            "src/TTreeWrapper.cc",
+        )
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/pandoramonitoring/package.py
+++ b/var/spack/repos/builtin/packages/pandoramonitoring/package.py
@@ -26,6 +26,12 @@ class Pandoramonitoring(CMakePackage):
     depends_on("root@6.18.04: +x +opengl")
     depends_on("pandorasdk")
 
+    patch(
+        "https://github.com/PandoraPFA/PandoraMonitoring/pull/13.patch?full_index=1",
+        sha256="3a8f38c2158f151ba352368fe3241a61eab73fc51597c73afe72c92ad9af9e61",
+        when="@:3.6.0",
+    )
+
     def cmake_args(self):
         args = [
             self.define("CMAKE_MODULE_PATH", self.spec["pandorapfa"].prefix.cmakemodules),


### PR DESCRIPTION
See https://github.com/PandoraPFA/PandoraMonitoring/pull/13. Assume it will be merged by the next version. Also works when compiling on C++17.