### PR TITLE
SIPPackage: add gmake as a build dependency to be able to build py-pyqt5

### DIFF
--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -41,6 +41,7 @@ class SIPPackage(spack.package_base.PackageBase):
     with when("build_system=sip"):
         extends("python", type=("build", "link", "run"))
         depends_on("py-sip", type="build")
+        depends_on("gmake", type="build")
 
     @property
     def import_modules(self):

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -20,6 +20,8 @@ class PyPyqt5(SIPPackage):
 
     depends_on("cxx", type="build")  # generated
 
+    depends_on("gmake", type="build")
+
     # pyproject.toml
     depends_on("py-sip@6.6.2:6", type="build")
     depends_on("py-pyqt-builder@1.14.1:1", type="build")

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -20,8 +20,6 @@ class PyPyqt5(SIPPackage):
 
     depends_on("cxx", type="build")  # generated
 
-    depends_on("gmake", type="build")
-
     # pyproject.toml
     depends_on("py-sip@6.6.2:6", type="build")
     depends_on("py-pyqt-builder@1.14.1:1", type="build")


### PR DESCRIPTION
I found the following error building on Alma 9 with GCC 14, Ubuntu 22.04 with GCC 11 and Ubuntu 24.04 with GCC 14:

```
==> Error: UndeclaredDependencyError: py-pyqt5 is using make without declaring a dependency on gmake

/spack/lib/spack/spack/build_systems/sip.py:156, in build:
        153        args = self.build_args()
        154
        155        with working_dir(self.build_directory):
  >>    156            pkg.module.make(*args)

See build log for details:
  /tmp/root/spack-stage/spack-stage-py-pyqt5-5.15.9-2jkhrb5swa34i2rryf4creryp3zvi7ez/spack-build-out.txt
```
and the original change I did was to add `depends_on("gmake, type="build")` to the recipe of `py-pyqt5` and that worked.