### PR TITLE
gtkplus: add conflict with GCC 14

### DIFF
--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -88,6 +88,8 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
     depends_on("cups", when="+cups")
     depends_on("libxfixes", when="@:2")
 
+    conflicts("%gcc@14:", when="@:3.24.29")
+
     patch("no-demos.patch", when="@2.0:2")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -88,7 +88,7 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
     depends_on("cups", when="+cups")
     depends_on("libxfixes", when="@:2")
 
-    conflicts("%gcc@14:", when="@:3.24.29")
+    conflicts("%gcc@14:", when="@:3.24.35")
 
     patch("no-demos.patch", when="@2.0:2")
 


### PR DESCRIPTION
When compiling with GCC 14 version 3.24.29 I find the following error:

```
     2065    gtklabel.c: In function 'gtk_label_style_updated':
  >> 2066    gtklabel.c:4234:32: error: passing argument 1 of 'gtk_widget_queue
             _resize' from incompatible pointer type [-Wincompatible-pointer-ty
             pes]
     2067     4234 |       gtk_widget_queue_resize (label);
     2068          |                                ^~~~~
     2069          |                                |
     2070          |                                GtkLabel * {aka struct _Gtk
             Label *}
     2071    In file included from ../gtk/deprecated/gtkmisc.h:33,
     2072                     from gtklabel.h:32,
     2073                     from gtklabel.c:30:
     2074    ../gtk/gtkwidget.h:663:65: note: expected 'GtkWidget *' {aka 'stru
             ct _GtkWidget *'} but argument is of type 'GtkLabel *' {aka 'struc
             t _GtkLabel *'}
     2075      663 | void       gtk_widget_queue_resize        (GtkWidget      
                  *widget);
     2076          |                                            ~~~~~~~~~~~~~~~
             ~~~~~~^~~~~~
  >> 2077    make[3]: *** [Makefile:6589: libgtk_3_la-gtklabel.lo] Error 1
```

The next version in the recipe, 3.24.41, works fine. I just compiled 3.24.29 with GCC 11 and GCC 13, so I think it's only an issue for GCC 14.