### PR TITLE
Package update: add libxc7 support to sirius

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/libxc7.patch
+++ b/var/spack/repos/builtin/packages/sirius/libxc7.patch
@@ -1,0 +1,16 @@
+--- a/src/potential/xc_functional_base.hpp
++++ b/src/potential/xc_functional_base.hpp
+@@ -15,6 +15,13 @@
+ #define __XC_FUNCTIONAL_BASE_HPP__
+ 
+ #include <xc.h>
++
++/* libxc >= 7 split the functional definition in a different file from xc.h */
++
++#if (XC_MAJOR_VERSION >= 7)
++#include <xc_funcs.h>
++#endif
++
+ #include <string.h>
+ #include <memory>
+ #include <map>

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -164,8 +164,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
         # spla removed the openmp option in 1.6.0
         conflicts("^spla@:1.5~openmp", when="+openmp")
 
-    with when("+libxc"):
-        patch("libxc7.patch", when="@7.6:")
+    patch("libxc7.patch", when="@7.6:")
 
     depends_on("nlcglib", when="+nlcglib")
     depends_on("nlcglib+rocm", when="+nlcglib+rocm")

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -130,7 +130,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("fftw-api@3")
     depends_on("libxc@3.0.0:")
     depends_on("libxc@4.0.0:", when="@7.2.0:")
-    depends_on("libxc@:7", when="@:7.6.1")
+    depends_on("libxc@:7", when="@:7.5")
     depends_on("spglib")
     depends_on("hdf5+hl")
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -130,7 +130,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("fftw-api@3")
     depends_on("libxc@3.0.0:")
     depends_on("libxc@4.0.0:", when="@7.2.0:")
-    depends_on("libxc@:6", when="@:7.6.1")
+    depends_on("libxc@:7", when="@:7.6.1")
     depends_on("spglib")
     depends_on("hdf5+hl")
     depends_on("pkgconfig", type="build")
@@ -163,6 +163,9 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("spla+rocm", when="+rocm")
         # spla removed the openmp option in 1.6.0
         conflicts("^spla@:1.5~openmp", when="+openmp")
+
+    with when("+libxc"):
+        patch("libxc7.patch", when="@7.6:")
 
     depends_on("nlcglib", when="+nlcglib")
     depends_on("nlcglib+rocm", when="+nlcglib+rocm")


### PR DESCRIPTION
Add the possibility to compile SIRIUS with libxc@7

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
