### PR TITLE
pmdk: add cmake dependency back

### DIFF
--- a/var/spack/repos/builtin/packages/pmdk/package.py
+++ b/var/spack/repos/builtin/packages/pmdk/package.py
@@ -39,6 +39,7 @@ class Pmdk(Package):
     variant("rpmem", default=False, description="Build remote persistent memory components")
 
     depends_on("gmake", type="build")
+    depends_on("cmake", type="build")
     depends_on("pkgconfig", when="@1.12.1:", type="build")
     depends_on("ncurses", when="@1.6:")
     depends_on("libfabric", when="+rpmem")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds back `cmake` as a dependency to `pmdk`. Contrary to what I thought in https://github.com/spack/spack/pull/48544, pmdk's Makefile does have a call to cmake buried somewhere. My tests removing cmake just happened to work because I had cmake in /usr/bin anyway, but on a platform without cmake installed, the build of pmdk fails.