### PR TITLE
Add cmake_bla_vendor attribute to various blas/lapack providers

### DIFF
--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -120,3 +120,10 @@ class Amdblis(BlisBase):
             shared=self.spec.satisfies("libs=shared"),
             recursive=True,
         )
+
+    @property
+    def cmake_bla_vendor(self):
+        if self.spec.satisfies("threads=none"):
+            return "AOCL"
+        else:
+            return "AOCL_mt"

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -120,6 +120,10 @@ class Amdlibflame(CMakePackage, LibflameBase):
             "libflame", root=self.prefix, shared="+shared" in self.spec, recursive=True
         )
 
+    @property
+    def cmake_bla_vendor(self):
+        return "AOCL"
+
     def flag_handler(self, name, flags):
         if name == "cflags":
             if (

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -122,7 +122,10 @@ class Amdlibflame(CMakePackage, LibflameBase):
 
     @property
     def cmake_bla_vendor(self):
-        return "AOCL"
+        if self.spec.satisfies("threads=none"):
+            return "AOCL"
+        else:
+            return "AOCL_mt"
 
     def flag_handler(self, name, flags):
         if name == "cflags":

--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -76,6 +76,10 @@ class Atlas(Package):
 
     parallel = False
 
+    @property
+    def cmake_bla_vendor(self):
+        return "ATLAS"
+
     def url_for_version(self, version):
         url = "https://sourceforge.net/projects/math-atlas/files/"
 

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -143,3 +143,7 @@ class Blis(BlisBase):
     # Problems with permissions on installed libraries:
     # https://github.com/flame/blis/issues/343
     patch("Makefile_0.6.0.patch", when="@0.4.0:0.6.0")
+
+    @property
+    def cmake_bla_vendor(self):
+        return "FLAME"

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -175,7 +175,9 @@ class Eckit(CMakePackage):
 
         if self.spec.satisfies("linalg=lapack"):
             if hasattr(self.spec["lapack"].package, "cmake_bla_vendor"):
-                args.append(self.define("BLA_VENDOR", self.spec["lapack"].package.cmake_bla_vendor))
+                args.append(
+                    self.define("BLA_VENDOR", self.spec["lapack"].package.cmake_bla_vendor)
+                )
 
         if "+admin" in self.spec and "+termlib" in self.spec["ncurses"]:
             # Make sure that libeckit_cmd is linked to a library that resolves 'setupterm',

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -173,6 +173,10 @@ class Eckit(CMakePackage):
             # (the LAPACK backend is still built though):
             args.append(self.define("ENABLE_LAPACK", "linalg=lapack" in self.spec))
 
+        if self.spec.satisfies("linalg=lapack"):
+            if hasattr(self.spec["lapack"].package, "cmake_bla_vendor"):
+                args.append(self.define("BLA_VENDOR", self.spec["lapack"].package.cmake_bla_vendor))
+
         if "+admin" in self.spec and "+termlib" in self.spec["ncurses"]:
             # Make sure that libeckit_cmd is linked to a library that resolves 'setupterm',
             # 'tputs', etc. That is either libncurses (when 'ncurses~termlib') or libtinfo (when

--- a/var/spack/repos/builtin/packages/essl/package.py
+++ b/var/spack/repos/builtin/packages/essl/package.py
@@ -71,3 +71,7 @@ class Essl(BundlePackage):
             ["liblapackforessl", "liblapackforessl_"], root=self.prefix.lib64, shared=True
         )
         return essl_libs
+
+    @property
+    def cmake_bla_vendor(self):
+        return "IBMESSL"

--- a/var/spack/repos/builtin/packages/flexiblas/package.py
+++ b/var/spack/repos/builtin/packages/flexiblas/package.py
@@ -29,5 +29,9 @@ class Flexiblas(CMakePackage):
     provides("blas")
     provides("lapack")
 
+    @property
+    def cmake_bla_vendor(self):
+        return "FlexiBLAS"
+
     def cmake_args(self):
         return [self.define("SYSCONFDIR", self.prefix.etc)]

--- a/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
@@ -132,3 +132,7 @@ class FujitsuSsl2(Package):
         path = join_path(self.spec.prefix, "clang-comp")
         headers = find_headers("cssl", path, recursive=True)
         return headers
+
+    @property
+    def cmake_bla_vendor(self):
+        return "Fujitsu_SSL2"

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -228,6 +228,17 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         else:
             return IntelOneApiStaticLibraryList(libs, system_libs)
 
+    @property
+    def cmake_bla_vendor(self):
+        if self.spec.satisfies("+ilp64") and not self.spec.satisfies("threads=none"):
+            return "Intel10_64ilp"
+        elif self.spec.satisfies("+ilp64 threads=none"):
+            return "Intel10_64ilp_seq"
+        elif self.spec.satisfies("~ilp64") and not self.spec.satisfies("threads=none"):
+            return "Intel10_64lp"
+        elif self.spec.satisfies("~ilp64 threads=none"):
+            return "Intel10_64lp_seq"
+
     def setup_dependent_build_environment(self, env, dependent_spec):
         # Only if environment modifications are desired (default is +envmods)
         if self.spec.satisfies("+envmods"):

--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -94,14 +94,8 @@ class Ip(CMakePackage):
             args.append(self.define_from_variant("BUILD_DEPRECATED", "deprecated"))
 
         if self.spec.satisfies("@5.1:"):
-            # Use the LAPACK provider set by Spack even if the compiler supports native BLAS
-            bla_vendors = {"openblas": "OpenBLAS"}
-            lapack_provider = self.spec["lapack"].name
-            if lapack_provider in bla_vendors.keys():
-                bla_vendor = bla_vendors[lapack_provider]
-            else:
-                bla_vendor = "All"
-            args.append(self.define("BLA_VENDOR", bla_vendor))
+            if hasattr(self.spec["lapack"].package, "cmake_bla_vendor"):
+                args.append(self.define("BLA_VENDOR", self.spec["lapack"].package.cmake_bla_vendor))
 
         return args
 

--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -95,7 +95,9 @@ class Ip(CMakePackage):
 
         if self.spec.satisfies("@5.1:"):
             if hasattr(self.spec["lapack"].package, "cmake_bla_vendor"):
-                args.append(self.define("BLA_VENDOR", self.spec["lapack"].package.cmake_bla_vendor))
+                args.append(
+                    self.define("BLA_VENDOR", self.spec["lapack"].package.cmake_bla_vendor)
+                )
 
         return args
 

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -221,6 +221,10 @@ class NetlibLapack(CMakePackage):
         lapacke_h = join_path(include_dir, "lapacke.h")
         return HeaderList([cblas_h, lapacke_h])
 
+    @property
+    def cmake_bla_vendor(self):
+        return "Generic"
+
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -602,3 +602,7 @@ class Nvhpc(Package, CompilerPackage):
 
     # Avoid binding stub libraries by absolute path
     non_bindable_shared_objects = ["stubs"]
+
+    @property
+    def cmake_bla_vendor(self):
+        return "NVHPC"

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -330,6 +330,10 @@ class Openblas(CMakePackage, MakefilePackage):
 
         return find_libraries(name, spec.prefix, shared=search_shared, recursive=True)
 
+    @property
+    def cmake_bla_vendor(self):
+        return "OpenBLAS"
+
 
 class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     @staticmethod


### PR DESCRIPTION
CMake's FindBLAS.cmake accepts an optional input variable to set the BLAS/LAPACK provider for the build. Most of the time it doesn't need to be set, but it can get confused and use the wrong one (i.e., not the Spack-specified blas/lapack provider), especially when the compiler or compiler wrapper has built-in linear algebra support but that the user does not intend to use. This PR adds a `cmake_bla_vendor` attribute to the vendors supported in FindBLAS.cmake (see https://cmake.org/cmake/help/latest/module/FindBLAS.html), which blas/lapack dependents may then use to set BLA_VENDOR in their cmake call. As examples, I have added this functionality to eckit and ip.

Fixes spack/spack-packages#1043