### PR TITLE
easi: add v1.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/easi/package.py
+++ b/var/spack/repos/builtin/packages/easi/package.py
@@ -20,6 +20,7 @@ class Easi(CMakePackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("1.5.1", tag="v1.5.1", commit="d12f3371ed26c7371e4efcc11e3cd468063ffdda")
     version("1.5.0", tag="v1.5.0", commit="391698ab0072f66280d08441974c2bdb04a65ce0")
     version("1.4.0", tag="v1.4.0", commit="0d8fcf936574d93ddbd1d9222d46a93d4b119231")
     version("1.3.0", tag="v1.3.0", commit="99309a0fa78bf11d668c599b3ee469224f04d55b")
@@ -36,17 +37,19 @@ class Easi(CMakePackage):
     variant("asagi", default=True, description="build with ASAGI support")
     variant(
         "jit",
-        default="impalajit,lua",
+        default="lua",
         description="build with JIT support",
         values=("impalajit", "impalajit-llvm", "lua"),
         multi=True,
     )
 
     depends_on("asagi +mpi +mpi3", when="+asagi")
-    depends_on("yaml-cpp@0.6.2")
+    depends_on("yaml-cpp@0.6:")
+
+    conflicts("yaml-cpp@0.7", when="@1.4.0:1.5.0")
 
     depends_on("impalajit@llvm-1.0.0", when="jit=impalajit-llvm")
-    depends_on("lua@5.3.2", when="jit=lua")
+    depends_on("lua@5.3:5.4", when="jit=lua")
     depends_on("impalajit@main", when="jit=impalajit")
 
     depends_on("py-pybind11@2.6.2:", type="build", when="+python")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
* Add easi@1.5.1
* Relax version requirements (don't enforce yaml-cpp@0.6.2 anymore; nor lua@5.3.2)
* Change the default `jit` variant to `lua` only (the ImpalaJIT functionality has been included into easi with @1.5.0:)
