### PR TITLE
bootstrap: do not show disabled sources as errors if enabled sources fail

### DIFF
--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -220,14 +220,12 @@ def test_source_is_disabled(mutable_config):
 
     # The source is not explicitly enabled or disabled, so the following
     # call should raise to skip using it for bootstrapping
-    with pytest.raises(ValueError):
-        spack.bootstrap.core.source_is_enabled_or_raise(conf)
+    assert not spack.bootstrap.core.source_is_enabled(conf)
 
     # Try to explicitly disable the source and verify that the behavior
     # is the same as above
     spack.config.add("bootstrap:trusted:{0}:{1}".format(conf["name"], False))
-    with pytest.raises(ValueError):
-        spack.bootstrap.core.source_is_enabled_or_raise(conf)
+    assert not spack.bootstrap.core.source_is_enabled(conf)
 
 
 @pytest.mark.regression("45247")


### PR DESCRIPTION
Remove the "errors" of not being able to bootstrap from sources the user has disabled. They distract from actual errors.

Also the wording was outdated. We use "enabled" instead of "trusted".

See e.g. https://github.com/spack/spack/actions/runs/12906253395/job/35987639082 for an example of bad errors.