### PR TITLE
Convert mirrors to pathlib

### DIFF
--- a/lib/spack/spack/mirrors/layout.py
+++ b/lib/spack/spack/mirrors/layout.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import os.path
+from pathlib import Path
 from typing import Optional
 
 import llnl.url
@@ -46,10 +47,11 @@ class DefaultLayout(MirrorLayout):
         if not self.digest_path:
             return
 
-        alias, digest = os.path.join(root, self.alias), os.path.join(root, self.digest_path)
+        root = Path(root)
+        alias, digest = root / self.alias, root / self.digest_path
 
-        alias_dir = os.path.dirname(alias)
-        relative_dst = os.path.relpath(digest, start=alias_dir)
+        alias_dir = alias.parent
+        relative_dst = digest.relative_to(alias_dir, walk_up=True)
 
         mkdirp(alias_dir)
         tmp = f"{alias}.tmp"

--- a/lib/spack/spack/mirrors/layout.py
+++ b/lib/spack/spack/mirrors/layout.py
@@ -51,7 +51,7 @@ class DefaultLayout(MirrorLayout):
         alias, digest = root / self.alias, root / self.digest_path
 
         alias_dir = alias.parent
-        relative_dst = digest.relative_to(alias_dir, walk_up=True)
+        relative_dst = os.path.relpath(digest, start=alias_dir)
 
         mkdirp(os.fspath(alias_dir))
         tmp = f"{alias}.tmp"

--- a/lib/spack/spack/mirrors/layout.py
+++ b/lib/spack/spack/mirrors/layout.py
@@ -53,7 +53,7 @@ class DefaultLayout(MirrorLayout):
         alias_dir = alias.parent
         relative_dst = digest.relative_to(alias_dir, walk_up=True)
 
-        mkdirp(alias_dir)
+        mkdirp(os.fspath(alias_dir))
         tmp = f"{alias}.tmp"
         llnl.util.symlink.symlink(relative_dst, tmp)
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -1,9 +1,8 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
-import os.path
 import traceback
+from pathlib import Path
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp
@@ -132,7 +131,8 @@ def mirror_cache_and_stats(path, skip_unstable_versions=False):
             ``fetch_strategy.stable_target``)
     """
     # Get the absolute path of the root before we start jumping around.
-    if not os.path.isdir(path):
+    path = Path(path)
+    if not path.is_dir():
         try:
             mkdirp(path)
         except OSError as e:

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -11,6 +11,7 @@ import posixpath
 import re
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Optional
 
 from spack.util.path import sanitize_filename
@@ -40,9 +41,10 @@ def local_file_path(url):
 
 
 def path_to_file_url(path):
-    if not os.path.isabs(path):
-        path = os.path.abspath(path)
-    return urllib.parse.urljoin("file:", urllib.request.pathname2url(path))
+    path = Path(path)
+    if not path.is_absolute():
+        path = path.resolve()
+    return urllib.parse.urljoin("file:", urllib.request.pathname2url(os.fspath(path)))
 
 
 def file_url_string_to_path(url):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Refactor mirror modules to use pathlib rather than os.path