### PR TITLE
build_environment.py: clear CONFIG_SITE for configure scripts

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -301,11 +301,13 @@ def clean_environment():
     env.unset("CPLUS_INCLUDE_PATH")
     env.unset("OBJC_INCLUDE_PATH")
 
+    # prevent configure scripts from sourcing variables from config site file (AC_SITE_LOAD).
+    env.set("CONFIG_SITE", os.devnull)
     env.unset("CMAKE_PREFIX_PATH")
+
     env.unset("PYTHONPATH")
     env.unset("R_HOME")
     env.unset("R_ENVIRON")
-
     env.unset("LUA_PATH")
     env.unset("LUA_CPATH")
 


### PR DESCRIPTION
Closes #48679
Closes #37171
Closes #39551
Closes #40110
Supersedes #48575
Supersedes #39837

Should be sufficient to set `CONFIG_SITE` to `/dev/null` before running configure to prevent any config site file to be loaded, which currently causes non-determinism in builds.

Setting the variable `CONFIG_SITE` prevents configure files to check `$prefix/share/config.site`, `$prefix/etc/config.site`, `$ac_default_prefix/share/config.site`, `$ac_default_prefix/etc/config.site` so we don't have to patch a block of code. 

I'm reasonably sure `/dev/null` works for us. I just noticed that as of autoconf 2.65 (Nov 21, 2009) a branch was added to special case `/dev/null`, with a note that sourcing `/dev/null` doesn't work on older versions of bash and on systems where `/dev/null` is emulated as a regular file...

```sh
if test /dev/null != "$ac_site_file" && test -r "$ac_site_file"
```

but then that branch was deleted again in favor of

```sh
if test -f "$ac_site_file" && test -r "$ac_site_file"
```

so, I'm fine with `/dev/null` unless somebody wants me to set it to `/something/hopefully/nonexistent`.