### PR TITLE
thepeg: extend the rivet@:3 dependency up to version 2.3

### DIFF
--- a/var/spack/repos/builtin/packages/thepeg/package.py
+++ b/var/spack/repos/builtin/packages/thepeg/package.py
@@ -72,7 +72,7 @@ class Thepeg(AutotoolsPackage):
     depends_on("fastjet", when="@2.0.0:")
     depends_on("rivet hepmc=2", when="@2.0.3: +rivet hepmc=2")
     depends_on("rivet hepmc=3", when="@2.0.3: +rivet hepmc=3")
-    depends_on("rivet@:3", when="@:2.2 +rivet")
+    depends_on("rivet@:3", when="@:2.3 +rivet")
     depends_on("boost +test", when="@2.1.1:")
 
     depends_on("autoconf", type="build")


### PR DESCRIPTION
It doesn't build with rivet@4 (failures when parsing the rivet version and also when building) so we should extend it so that 2.3.0 is covered.