### PR TITLE
pika: Revert #46291

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -149,8 +149,6 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("apex", when="+apex")
     depends_on("cuda@11:", when="+cuda")
     depends_on("hip@5.2:", when="@0.8: +rocm")
-    # https://github.com/pika-org/pika/issues/1238
-    conflicts("%gcc@13:", when="+rocm")
     depends_on("hipblas", when="@:0.8 +rocm")
     depends_on("mpi", when="+mpi")
     with when("+stdexec"):


### PR DESCRIPTION
The conflict that I introduced in #46291 in the pika package between HIP and GCC is too strict and prevents usable combinations from being concretized. Some packages (dla-future) depend on pika, but do not include headers that cause issues in HIP device code files, and can thus be compiled even with the bad combination of HIP and GCC versions.

The issue still exists but would need an alternative formulation to make sense. At the moment I'm not proposing an alternative, more relaxed, conflict.