### PR TITLE
[WIP] `spack config change`: `git.` versions

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -304,6 +304,8 @@ def _config_change_requires_scope(path, spec, scope, match_spec=None):
                 return True
         # Else if either spec has a git version, they don't conflict
         elif constrains_version(spec) and assigns_git_version(spec):
+            # We know from above that if we are setting a git version,
+            # then we aren't setting anything else, so there is no conflict
             return False
         elif constrains_version(x) and assigns_git_version(x):
             if assigns_more_than_version(x):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -277,10 +277,13 @@ def _config_change_requires_scope(path, spec, scope, match_spec=None):
 
     changed = False
 
+    #spec.attach_git_version_lookup()
+
     def override_cfg_spec(spec_str):
         nonlocal changed
 
         init_spec = spack.spec.Spec(spec_str)
+        #init_spec.attach_git_version_lookup()
         # Overridden spec cannot be anonymous
         init_spec.name = spec.name
         if match_spec and not init_spec.satisfies(match_spec):
@@ -350,9 +353,10 @@ def _config_change(config_path, match_spec_str=None):
                 if spack.config.get(key_path, scope=scope):
                     ideal_scope_to_modify = scope
                     break
+            write_scope = ideal_scope_to_modify or spack.config.default_modify_scope()
 
             update_path = f"{key_path}:[{str(spec)}]"
-            spack.config.add(update_path, scope=ideal_scope_to_modify)
+            spack.config.add(update_path, scope=write_scope)
     else:
         raise ValueError("'config change' can currently only change 'require' sections")
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -20,6 +20,8 @@ import spack.store
 import spack.util.spack_yaml as syaml
 from spack.cmd.common import arguments
 from spack.util.editor import editor
+from spack.version import any_version
+from spack.version.version_types import GitVersion
 
 description = "get and set configuration options"
 section = "config"
@@ -269,10 +271,6 @@ def _can_update_config_file(scope: spack.config.ConfigScope, cfg_file):
     return False
 
 
-from spack.version.version_types import GitVersion
-from spack.version import any_version
-
-
 def _config_change_requires_scope(path, spec, scope, match_spec=None):
     """Return whether or not anything changed."""
     require = spack.config.get(path, scope=scope)
@@ -285,13 +283,11 @@ def _config_change_requires_scope(path, spec, scope, match_spec=None):
     def assigns_git_version(x):
         return x.versions.concrete and isinstance(x.version, GitVersion)
 
-    version_update = constrains_version(spec)
-
     if spec.versions.concrete and isinstance(spec.version, GitVersion):
         test = spack.spec.Spec(spec.name)
         test.versions = spec.versions
         if test != spec:
-            raise ValueError(f"When setting @git. versions, the spec can only contain a version")
+            raise ValueError("When setting @git. versions, the spec can only contain a version")
 
     def specs_conflict(s1, s2):
         # If both specs have a version, and either one is a git version
@@ -317,7 +313,6 @@ def _config_change_requires_scope(path, spec, scope, match_spec=None):
         nonlocal changed
 
         init_spec = spack.spec.Spec(spec_str)
-        #init_spec.attach_git_version_lookup()
         # Overridden spec cannot be anonymous
         init_spec.name = spec.name
         if match_spec and not init_spec.satisfies(match_spec):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -307,7 +307,8 @@ def _config_change_requires_scope(path, spec, scope, match_spec=None):
         elif constrains_version(s2) and assigns_git_version(s2):
             return False
 
-        # Else
+        # At this point, neither spec assigns a git version, so we can safely
+        # call .intersects
         return not s1.intersects(s2)
 
     changed = False


### PR DESCRIPTION
Trying to add a `git.`-based version requirement like

`spack config change packages:umpire:require:@git.develop`

was resulting in an error

`spack.version.common.VersionLookupError: git ref 'develop' cannot be looked up: call attach_lookup first`

I don't think config manipulations should require Git ref lookups, so my goal here was to avoid all cases of calling `.intersects` on specs with `git.` versions.

Anything that ends up avoiding git ref lookups would be good IMO, so for example having a special `AbstractGitVersion` that is able to do comparisons on the unresolved ref.

This can be avoided in the meantime by using `=` like `git.<ref>=<number-version>`, but without a change like this, if a user ever forgets to do that, there will be errors with `spack config change` until the config is manually edited.

Also this updates the fallback modification scope to be the default write scope : for `spack config change`, the default is to modify the scope with the conflicting config, but when that didn't exist, it was modifying `scope=None`, which was having a strange effect (pulling the full config, and then writing it to the highest-level modification scope).