### PR TITLE
improve error handling in urlopen / socket read

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -801,7 +801,7 @@ def _specs_from_cache_fallback(url: str):
         try:
             _, _, spec_file = web_util.read_from_url(url)
             contents = codecs.getreader("utf-8")(spec_file).read()
-        except web_util.SpackWebError as e:
+        except (web_util.SpackWebError, OSError) as e:
             tty.error(f"Error reading specfile: {url}: {e}")
         return contents
 
@@ -2009,7 +2009,7 @@ def download_tarball(spec, unsigned: Optional[bool] = False, mirrors_for_spec=No
 
                 # Download the config = spec.json and the relevant tarball
                 try:
-                    manifest = json.loads(response.read())
+                    manifest = json.load(response)
                     spec_digest = spack.oci.image.Digest.from_string(manifest["config"]["digest"])
                     tarball_digest = spack.oci.image.Digest.from_string(
                         manifest["layers"][-1]["digest"]
@@ -2590,11 +2590,14 @@ def try_direct_fetch(spec, mirrors=None):
         )
         try:
             _, _, fs = web_util.read_from_url(buildcache_fetch_url_signed_json)
+            specfile_contents = codecs.getreader("utf-8")(fs).read()
             specfile_is_signed = True
-        except web_util.SpackWebError as e1:
+        except (web_util.SpackWebError, OSError) as e1:
             try:
                 _, _, fs = web_util.read_from_url(buildcache_fetch_url_json)
-            except web_util.SpackWebError as e2:
+                specfile_contents = codecs.getreader("utf-8")(fs).read()
+                specfile_is_signed = False
+            except (web_util.SpackWebError, OSError) as e2:
                 tty.debug(
                     f"Did not find {specfile_name} on {buildcache_fetch_url_signed_json}",
                     e1,
@@ -2604,7 +2607,6 @@ def try_direct_fetch(spec, mirrors=None):
                     f"Did not find {specfile_name} on {buildcache_fetch_url_json}", e2, level=2
                 )
                 continue
-        specfile_contents = codecs.getreader("utf-8")(fs).read()
 
         # read the spec from the build cache file. All specs in build caches
         # are concrete (as they are built) so we need to mark this spec
@@ -2698,8 +2700,9 @@ def get_keys(install=False, trust=False, force=False, mirrors=None):
 
         try:
             _, _, json_file = web_util.read_from_url(keys_index)
-            json_index = sjson.load(codecs.getreader("utf-8")(json_file))
-        except web_util.SpackWebError as url_err:
+            json_index = sjson.load(json_file)
+        except (web_util.SpackWebError, OSError, ValueError) as url_err:
+            # TODO: avoid repeated request
             if web_util.url_exists(keys_index):
                 tty.error(
                     f"Unable to find public keys in {url_util.format(fetch_url)},"
@@ -2949,11 +2952,11 @@ class DefaultIndexFetcher:
         url_index_hash = url_util.join(self.url, BUILD_CACHE_RELATIVE_PATH, INDEX_HASH_FILE)
         try:
             response = self.urlopen(urllib.request.Request(url_index_hash, headers=self.headers))
-        except (TimeoutError, urllib.error.URLError):
+            remote_hash = response.read(64)
+        except OSError:
             return None
 
         # Validate the hash
-        remote_hash = response.read(64)
         if not re.match(rb"[a-f\d]{64}$", remote_hash):
             return None
         return remote_hash.decode("utf-8")
@@ -2971,13 +2974,13 @@ class DefaultIndexFetcher:
 
         try:
             response = self.urlopen(urllib.request.Request(url_index, headers=self.headers))
-        except (TimeoutError, urllib.error.URLError) as e:
-            raise FetchIndexError("Could not fetch index from {}".format(url_index), e) from e
+        except OSError as e:
+            raise FetchIndexError(f"Could not fetch index from {url_index}", e) from e
 
         try:
             result = codecs.getreader("utf-8")(response).read()
-        except ValueError as e:
-            raise FetchIndexError("Remote index {} is invalid".format(url_index), e) from e
+        except (ValueError, OSError) as e:
+            raise FetchIndexError(f"Remote index {url_index} is invalid") from e
 
         computed_hash = compute_hash(result)
 
@@ -3021,12 +3024,12 @@ class EtagIndexFetcher:
                 # Not modified; that means fresh.
                 return FetchIndexResult(etag=None, hash=None, data=None, fresh=True)
             raise FetchIndexError(f"Could not fetch index {url}", e) from e
-        except (TimeoutError, urllib.error.URLError) as e:
+        except OSError as e:  # URLError, socket.timeout, etc.
             raise FetchIndexError(f"Could not fetch index {url}", e) from e
 
         try:
             result = codecs.getreader("utf-8")(response).read()
-        except ValueError as e:
+        except (ValueError, OSError) as e:
             raise FetchIndexError(f"Remote index {url} is invalid", e) from e
 
         headers = response.headers
@@ -3058,11 +3061,11 @@ class OCIIndexFetcher:
                     headers={"Accept": "application/vnd.oci.image.manifest.v1+json"},
                 )
             )
-        except (TimeoutError, urllib.error.URLError) as e:
+        except OSError as e:
             raise FetchIndexError(f"Could not fetch manifest from {url_manifest}", e) from e
 
         try:
-            manifest = json.loads(response.read())
+            manifest = json.load(response)
         except Exception as e:
             raise FetchIndexError(f"Remote index {url_manifest} is invalid", e) from e
 
@@ -3077,14 +3080,16 @@ class OCIIndexFetcher:
             return FetchIndexResult(etag=None, hash=None, data=None, fresh=True)
 
         # Otherwise fetch the blob / index.json
-        response = self.urlopen(
-            urllib.request.Request(
-                url=self.ref.blob_url(index_digest),
-                headers={"Accept": "application/vnd.oci.image.layer.v1.tar+gzip"},
+        try:
+            response = self.urlopen(
+                urllib.request.Request(
+                    url=self.ref.blob_url(index_digest),
+                    headers={"Accept": "application/vnd.oci.image.layer.v1.tar+gzip"},
+                )
             )
-        )
-
-        result = codecs.getreader("utf-8")(response).read()
+            result = codecs.getreader("utf-8")(response).read()
+        except (OSError, ValueError) as e:
+            raise FetchIndexError(f"Remote index {url_manifest} is invalid", e) from e
 
         # Make sure the blob we download has the advertised hash
         if compute_hash(result) != index_digest.digest:

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -14,7 +14,6 @@ import tempfile
 import zipfile
 from collections import namedtuple
 from typing import Callable, Dict, List, Set
-from urllib.error import HTTPError, URLError
 from urllib.request import HTTPHandler, Request, build_opener
 
 import llnl.util.filesystem as fs
@@ -472,12 +471,9 @@ def generate_pipeline(env: ev.Environment, args) -> None:
     # Use all unpruned specs to populate the build group for this set
     cdash_config = cfg.get("cdash")
     if options.cdash_handler and options.cdash_handler.auth_token:
-        try:
-            options.cdash_handler.populate_buildgroup(
-                [options.cdash_handler.build_name(s) for s in pipeline_specs]
-            )
-        except (SpackError, HTTPError, URLError, TimeoutError) as err:
-            tty.warn(f"Problem populating buildgroup: {err}")
+        options.cdash_handler.populate_buildgroup(
+            [options.cdash_handler.build_name(s) for s in pipeline_specs]
+        )
     elif cdash_config:
         # warn only if there was actually a CDash configuration.
         tty.warn("Unable to populate buildgroup without CDash credentials")

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -321,23 +321,21 @@ class URLFetchStrategy(FetchStrategy):
 
         request = urllib.request.Request(url, headers={"User-Agent": web_util.SPACK_USER_AGENT})
 
+        if os.path.lexists(save_file):
+            os.remove(save_file)
+
         try:
             response = web_util.urlopen(request)
-        except (TimeoutError, urllib.error.URLError) as e:
+            tty.msg(f"Fetching {url}")
+            with open(save_file, "wb") as f:
+                shutil.copyfileobj(response, f)
+        except OSError as e:
             # clean up archive on failure.
             if self.archive_file:
                 os.remove(self.archive_file)
             if os.path.lexists(save_file):
                 os.remove(save_file)
             raise FailedDownloadError(e) from e
-
-        tty.msg(f"Fetching {url}")
-
-        if os.path.lexists(save_file):
-            os.remove(save_file)
-
-        with open(save_file, "wb") as f:
-            shutil.copyfileobj(response, f)
 
         # Save the redirected URL for error messages. Sometimes we're redirected to an arbitrary
         # mirror that is broken, leading to spurious download failures. In that case it's helpful
@@ -535,23 +533,22 @@ class OCIRegistryFetchStrategy(URLFetchStrategy):
     @_needs_stage
     def fetch(self):
         file = self.stage.save_filename
-        tty.msg(f"Fetching {self.url}")
+
+        if os.path.lexists(file):
+            os.remove(file)
 
         try:
             response = self._urlopen(self.url)
-        except (TimeoutError, urllib.error.URLError) as e:
+            tty.msg(f"Fetching {self.url}")
+            with open(file, "wb") as f:
+                shutil.copyfileobj(response, f)
+        except OSError as e:
             # clean up archive on failure.
             if self.archive_file:
                 os.remove(self.archive_file)
             if os.path.lexists(file):
                 os.remove(file)
             raise FailedDownloadError(e) from e
-
-        if os.path.lexists(file):
-            os.remove(file)
-
-        with open(file, "wb") as f:
-            shutil.copyfileobj(response, f)
 
 
 class VCSFetchStrategy(FetchStrategy):

--- a/lib/spack/spack/test/oci/mock_registry.py
+++ b/lib/spack/spack/test/oci/mock_registry.py
@@ -4,7 +4,6 @@
 
 
 import base64
-import email.message
 import hashlib
 import io
 import json
@@ -19,49 +18,7 @@ from urllib.request import Request
 import spack.oci.oci
 from spack.oci.image import Digest
 from spack.oci.opener import OCIAuthHandler
-
-
-class MockHTTPResponse(io.IOBase):
-    """This is a mock HTTP response, which implements part of http.client.HTTPResponse"""
-
-    def __init__(self, status, reason, headers=None, body=None):
-        self.msg = None
-        self.version = 11
-        self.url = None
-        self.headers = email.message.EmailMessage()
-        self.status = status
-        self.code = status
-        self.reason = reason
-        self.debuglevel = 0
-        self._body = body
-
-        if headers is not None:
-            for key, value in headers.items():
-                self.headers[key] = value
-
-    @classmethod
-    def with_json(cls, status, reason, headers=None, body=None):
-        """Create a mock HTTP response with JSON string as body"""
-        body = io.BytesIO(json.dumps(body).encode("utf-8"))
-        return cls(status, reason, headers, body)
-
-    def read(self, *args, **kwargs):
-        return self._body.read(*args, **kwargs)
-
-    def getheader(self, name, default=None):
-        self.headers.get(name, default)
-
-    def getheaders(self):
-        return self.headers.items()
-
-    def fileno(self):
-        return 0
-
-    def getcode(self):
-        return self.status
-
-    def info(self):
-        return self.headers
+from spack.test.conftest import MockHTTPResponse
 
 
 class MiddlewareError(Exception):

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -32,6 +32,7 @@ from spack.oci.opener import (
     get_bearer_challenge,
     parse_www_authenticate,
 )
+from spack.test.conftest import MockHTTPResponse
 from spack.test.oci.mock_registry import (
     DummyServer,
     DummyServerUrllibHandler,
@@ -39,7 +40,6 @@ from spack.test.oci.mock_registry import (
     InMemoryOCIRegistryWithAuth,
     MiddlewareError,
     MockBearerTokenServer,
-    MockHTTPResponse,
     create_opener,
 )
 

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -354,21 +354,6 @@ def test_url_missing_curl(mutable_config, missing_curl, monkeypatch):
         web_util.url_exists("https://example.com/")
 
 
-def test_url_fetch_text_urllib_bad_returncode(mutable_config, monkeypatch):
-    class response:
-        def getcode(self):
-            return 404
-
-    def _read_from_url(*args, **kwargs):
-        return None, None, response()
-
-    monkeypatch.setattr(web_util, "read_from_url", _read_from_url)
-    mutable_config.set("config:url_fetch_method", "urllib")
-
-    with pytest.raises(spack.error.FetchError, match="failed with error code"):
-        web_util.fetch_url_text("https://example.com/")
-
-
 def test_url_fetch_text_urllib_web_error(mutable_config, monkeypatch):
     def _raise_web_error(*args, **kwargs):
         raise web_util.SpackWebError("bad url")
@@ -376,5 +361,5 @@ def test_url_fetch_text_urllib_web_error(mutable_config, monkeypatch):
     monkeypatch.setattr(web_util, "read_from_url", _raise_web_error)
     mutable_config.set("config:url_fetch_method", "urllib")
 
-    with pytest.raises(spack.error.FetchError, match="fetch failed to verify"):
+    with pytest.raises(spack.error.FetchError, match="fetch failed"):
         web_util.fetch_url_text("https://example.com/")

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -209,7 +209,7 @@ def read_from_url(url, accept_content_type=None):
 
     try:
         response = urlopen(request)
-    except (TimeoutError, URLError) as e:
+    except OSError as e:
         raise SpackWebError(f"Download of {url.geturl()} failed: {e.__class__.__name__}: {e}")
 
     if accept_content_type:
@@ -227,7 +227,7 @@ def read_from_url(url, accept_content_type=None):
             tty.debug(msg)
             return None, None, None
 
-    return response.geturl(), response.headers, response
+    return response.url, response.headers, response
 
 
 def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=None):
@@ -405,12 +405,6 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
         try:
             _, _, response = read_from_url(url)
 
-            returncode = response.getcode()
-            if returncode and returncode != 200:
-                raise spack.error.FetchError(
-                    "Urllib failed with error code {0}".format(returncode)
-                )
-
             output = codecs.getreader("utf-8")(response).read()
             if output:
                 with working_dir(dest_dir, create=True):
@@ -419,8 +413,8 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
 
                 return path
 
-        except SpackWebError as err:
-            raise spack.error.FetchError("Urllib fetch failed to verify url: {0}".format(str(err)))
+        except (SpackWebError, OSError, ValueError) as err:
+            raise spack.error.FetchError(f"Urllib fetch failed: {err}")
 
     return None
 
@@ -464,7 +458,7 @@ def url_exists(url, curl=None):
             timeout=spack.config.get("config:connect_timeout", 10),
         )
         return True
-    except (TimeoutError, URLError) as e:
+    except OSError as e:
         tty.debug(f"Failure reading {url}: {e}")
         return False
 
@@ -746,7 +740,7 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
                 subcalls.append(abs_link)
                 _visited.add(abs_link)
 
-    except (TimeoutError, URLError) as e:
+    except OSError as e:
         tty.debug(f"[SPIDER] Unable to read: {url}")
         tty.debug(str(e), level=2)
         if isinstance(e, URLError) and isinstance(e.reason, ssl.SSLError):


### PR DESCRIPTION
Closes #48706

I think this is a bit too big to backport.

* Backward compat with Python 3.9 for `socket.timeout`
* Forward compat with Python [unknown] as HTTPResponse.geturl is deprecated
* Catch timeout etc from `.read()`
* Some minor simplifications: `json.load(...)` takes file object in binary mode.
* Fix CDash code which does error handling wrong: non-2XX responses raise.