### PR TITLE
import os.path -> os

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -25,7 +25,6 @@ exit 1
 # The code above runs this file with our preferred python interpreter.
 
 import os
-import os.path
 import sys
 
 min_python3 = (3, 6)

--- a/lib/spack/llnl/url.py
+++ b/lib/spack/llnl/url.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """URL primitives that just require Python standard library."""
 import itertools
-import os.path
+import os
 import re
 from typing import Optional, Set, Tuple
 from urllib.parse import urlsplit, urlunsplit

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -5,7 +5,7 @@
 import fnmatch
 import glob
 import importlib
-import os.path
+import os
 import re
 import sys
 import sysconfig

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -4,7 +4,7 @@
 """Manage configuration swapping for bootstrapping purposes"""
 
 import contextlib
-import os.path
+import os
 import sys
 from typing import Any, Dict, Generator, MutableSequence, Sequence
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -25,7 +25,6 @@ import copy
 import functools
 import json
 import os
-import os.path
 import sys
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Tuple

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import os.path
 import stat
 import subprocess
 from typing import Callable, List, Optional, Set, Tuple, Union

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 import shutil
 import sys
 import tempfile

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -4,7 +4,7 @@
 
 
 import argparse
-import os.path
+import os
 import textwrap
 
 from llnl.util.lang import stable_partition

--- a/lib/spack/spack/cmd/containerize.py
+++ b/lib/spack/spack/cmd/containerize.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import os.path
 
 import llnl.util.tty
 

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -5,7 +5,7 @@
 """Implementation details of the ``spack module`` command."""
 
 import collections
-import os.path
+import os
 import shutil
 import sys
 

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 import shutil
 
 import llnl.util.tty as tty

--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -5,7 +5,7 @@
 import argparse
 import collections
 import io
-import os.path
+import os
 import re
 import sys
 

--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Manages the details on the images used in the various stages."""
 import json
-import os.path
+import os
 import shlex
 import sys
 

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -15,7 +15,6 @@ detection mechanisms.
 import glob
 import itertools
 import os
-import os.path
 import pathlib
 import re
 import sys

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -7,7 +7,6 @@ and running executables.
 import collections
 import concurrent.futures
 import os
-import os.path
 import re
 import sys
 import traceback

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -32,7 +32,7 @@ The available directives are:
 """
 import collections
 import collections.abc
-import os.path
+import os
 import re
 from typing import Any, Callable, List, Optional, Tuple, Type, Union
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -25,7 +25,6 @@ import copy
 import functools
 import http.client
 import os
-import os.path
 import re
 import shutil
 import urllib.error

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -14,7 +14,6 @@ import inspect
 import io
 import operator
 import os
-import os.path
 import pstats
 import re
 import shlex

--- a/lib/spack/spack/mirrors/layout.py
+++ b/lib/spack/spack/mirrors/layout.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import os.path
 from typing import Optional
 
 import llnl.url

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import os.path
 import traceback
 
 import llnl.util.tty as tty

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -31,7 +31,7 @@ import contextlib
 import copy
 import datetime
 import inspect
-import os.path
+import os
 import re
 import string
 from typing import List, Optional

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -4,7 +4,7 @@
 
 import collections
 import itertools
-import os.path
+import os
 from typing import Dict, List, Optional, Tuple
 
 import llnl.util.filesystem as fs

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -5,7 +5,7 @@
 """This module implements the classes necessary to generate Tcl
 non-hierarchical modules.
 """
-import os.path
+import os
 from typing import Dict, Optional, Tuple
 
 import spack.config

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -4,7 +4,6 @@
 
 import hashlib
 import os
-import os.path
 import pathlib
 import sys
 from typing import Any, Dict, Optional, Tuple, Type, Union

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 
 def slingshot_network():

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -14,7 +14,6 @@ import importlib.util
 import inspect
 import itertools
 import os
-import os.path
 import random
 import re
 import shutil

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
 import hashlib
-import os.path
+import os
 import platform
 import posixpath
 import re

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 import spack.tengine
 

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import os.path
 
 import pytest
 

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 import pytest
 

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 import sys
 
 import pytest

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import os.path
 import platform
 
 import pytest

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import os.path
 import sys
 
 import pytest

--- a/lib/spack/spack/test/cmd/license.py
+++ b/lib/spack/spack/test/cmd/license.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 import re
 
 import pytest

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 import sys
 from textwrap import dedent
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 import re
 
 import pytest

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 import pytest
 

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 import sys
 
 import pytest

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -10,7 +10,6 @@ import inspect
 import itertools
 import json
 import os
-import os.path
 import pathlib
 import re
 import shutil

--- a/lib/spack/spack/test/container/images.py
+++ b/lib/spack/spack/test/container/images.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 import pytest
 

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -6,7 +6,6 @@
 This test verifies that the Spack directory layout works properly.
 """
 import os
-import os.path
 from pathlib import Path
 
 import pytest

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import fnmatch
-import os.path
+import os
 import sys
 
 import pytest

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 import re
 import sys
 from datetime import datetime, timedelta
@@ -23,7 +23,7 @@ def now():
 def module_path(tmpdir):
     m = tmpdir.join("foo.py")
     content = """
-import os.path
+import os
 
 value = 1
 path = os.path.join('/usr', 'bin')

--- a/lib/spack/spack/test/schema.py
+++ b/lib/spack/spack/test/schema.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import json
-import os.path
+import os
 
 import jsonschema
 import pytest

--- a/lib/spack/spack/test/util/util_url.py
+++ b/lib/spack/spack/test/util/util_url.py
@@ -4,7 +4,6 @@
 
 """Test Spack's URL handling utility functions."""
 import os
-import os.path
 import urllib.parse
 
 import pytest

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -7,7 +7,6 @@ import contextlib
 import inspect
 import json
 import os
-import os.path
 import pickle
 import re
 import shlex

--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import os.path
 import re
 import shlex
 import sys

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -7,7 +7,6 @@ import email.message
 import errno
 import json
 import os
-import os.path
 import re
 import shutil
 import ssl

--- a/var/spack/repos/builtin.mock/packages/extension1/package.py
+++ b/var/spack/repos/builtin.mock/packages/extension1/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin.mock/packages/extension2/package.py
+++ b/var/spack/repos/builtin.mock/packages/extension2/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin.mock/packages/libtool-deletion/package.py
+++ b/var/spack/repos/builtin.mock/packages/libtool-deletion/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 import spack.build_systems.autotools
 from spack.package import *

--- a/var/spack/repos/builtin.mock/packages/perl-extension/package.py
+++ b/var/spack/repos/builtin.mock/packages/perl-extension/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin.mock/packages/py-extension1/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension1/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin.mock/packages/py-extension2/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension2/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin.mock/packages/view-not-ignored/package.py
+++ b/var/spack/repos/builtin.mock/packages/view-not-ignored/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/ampliconnoise/package.py
+++ b/var/spack/repos/builtin/packages/ampliconnoise/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/aperture-photometry/package.py
+++ b/var/spack/repos/builtin/packages/aperture-photometry/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/asio/package.py
+++ b/var/spack/repos/builtin/packages/asio/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/astral/package.py
+++ b/var/spack/repos/builtin/packages/astral/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/beagle/package.py
+++ b/var/spack/repos/builtin/packages/beagle/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/bref3/package.py
+++ b/var/spack/repos/builtin/packages/bref3/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import copy
 import os
-import os.path
 import sys
 
 import spack.util.environment

--- a/var/spack/repos/builtin/packages/cromwell-womtool/package.py
+++ b/var/spack/repos/builtin/packages/cromwell-womtool/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/cromwell/package.py
+++ b/var/spack/repos/builtin/packages/cromwell/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import glob
-import os.path
+import os
 
 from spack.package import *
 from spack.util.environment import is_system_path

--- a/var/spack/repos/builtin/packages/elsi/package.py
+++ b/var/spack/repos/builtin/packages/elsi/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/express/package.py
+++ b/var/spack/repos/builtin/packages/express/package.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import glob
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import os.path
 
 import llnl.util.lang
 

--- a/var/spack/repos/builtin/packages/fftx/package.py
+++ b/var/spack/repos/builtin/packages/fftx/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/gatk/package.py
+++ b/var/spack/repos/builtin/packages/gatk/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 import spack.build_systems.autotools
 import spack.build_systems.meson

--- a/var/spack/repos/builtin/packages/globalarrays/package.py
+++ b/var/spack/repos/builtin/packages/globalarrays/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/grackle/package.py
+++ b/var/spack/repos/builtin/packages/grackle/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.hooks.sbang import filter_shebang
 from spack.package import *

--- a/var/spack/repos/builtin/packages/haploview/package.py
+++ b/var/spack/repos/builtin/packages/haploview/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import os.path
 import platform
 
 from spack.package import *

--- a/var/spack/repos/builtin/packages/jmol/package.py
+++ b/var/spack/repos/builtin/packages/jmol/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/jq/package.py
+++ b/var/spack/repos/builtin/packages/jq/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 import sys
 
 from spack.package import *

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 
 import llnl.util.lang as lang
 

--- a/var/spack/repos/builtin/packages/linux-perf/package.py
+++ b/var/spack/repos/builtin/packages/linux-perf/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 import re
 import shutil
 from textwrap import dedent

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import os.path
 import re
 import sys
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import os.path
 import re
 import sys
 

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 import re
 import sys
 

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 import re
 import shutil
 import sys

--- a/var/spack/repos/builtin/packages/oommf/package.py
+++ b/var/spack/repos/builtin/packages/oommf/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/pgdspider/package.py
+++ b/var/spack/repos/builtin/packages/pgdspider/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/picard/package.py
+++ b/var/spack/repos/builtin/packages/picard/package.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import glob
-import os.path
+import os
 import re
 
 from spack.package import *

--- a/var/spack/repos/builtin/packages/pilon/package.py
+++ b/var/spack/repos/builtin/packages/pilon/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import collections
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/qorts/package.py
+++ b/var/spack/repos/builtin/packages/qorts/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/rna-seqc/package.py
+++ b/var/spack/repos/builtin/packages/rna-seqc/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/snpeff/package.py
+++ b/var/spack/repos/builtin/packages/snpeff/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/trimmomatic/package.py
+++ b/var/spack/repos/builtin/packages/trimmomatic/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/varscan/package.py
+++ b/var/spack/repos/builtin/packages/varscan/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/wannier90/package.py
+++ b/var/spack/repos/builtin/packages/wannier90/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
+import os
 
 from spack.package import *
 


### PR DESCRIPTION
From `help(os.path)`:

> Instead of importing this module directly, import os and refer to this module as os.path.

