### PR TITLE
[WIP] Spack generated modules `$PATH`: spack-built / external / path

### DIFF
--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -33,7 +33,7 @@ def prefix_inspections(platform):
         return inspections
 
     inspections = {
-        "bin": ["PATH"],
+        "bin": ["SPACK_PATH"],
         "man": ["MANPATH"],
         "share/man": ["MANPATH"],
         "share/aclocal": ["ACLOCAL_PATH"],

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -33,7 +33,7 @@ def prefix_inspections(platform):
         return inspections
 
     inspections = {
-        "bin": ["SPACK_PATH"],
+        "bin": ["PATH"],
         "man": ["MANPATH"],
         "share/man": ["MANPATH"],
         "share/aclocal": ["ACLOCAL_PATH"],

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -57,8 +57,6 @@ set decompose_after {}
 set decompose_found 0
 set decompose_split_sentinel "spack-sentinel"
 
-module set-path SPACK_PATH $decompose_before
-
 foreach dir $decompose_path {
     if {!$decompose_found && [string match $decompose_split_sentinel $dir]} {
         set decompose_found 1
@@ -71,6 +69,8 @@ foreach dir $decompose_path {
 
 set decompose_before_path [join $decompose_before ":"]
 set decompose_after_path [join $decompose_after ":"]
+
+set-path PATH $decompose_before_path
 
 {% block environment %}
 {% for command_name, cmd in environment_modifications %}
@@ -105,8 +105,8 @@ append-path MANPATH {{ '{' }}{{ '}' }}
 {% endif %}
 {% endblock %}
 
-set combined_path [join [list $decompose_before_path $decompose_split_sentinel $decompose_after_path] ":"]
-module set-path PATH $combined_path
+set combined_path [join [list $decompose_split_sentinel $decompose_after_path] ":"]
+append-path PATH $combined_path
 
 {% block footer %}
 {# In case the module needs to be extended with custom Tcl code #}

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -58,14 +58,18 @@ set decompose_found 0
 set decompose_split_sentinel "spack-sentinel"
 
 foreach dir $decompose_path {
+    ## puts "<----- $dir"
     if {!$decompose_found && [string match $decompose_split_sentinel $dir]} {
         set decompose_found 1
     } elseif {$decompose_found} {
-        lappend $decompose_after $dir
+        lappend decompose_after $dir
     } else {
-        lappend $decompose_before $dir
+        lappend decompose_before $dir
     }
 }
+
+##puts "<------- $decompose_after"
+##puts "<------- $decompose_before"
 
 if {!$decompose_found} {
     set decompose_after $decompose_before
@@ -74,6 +78,11 @@ if {!$decompose_found} {
 
 set decompose_before_path [join $decompose_before ":"]
 set decompose_after_path [join $decompose_after ":"]
+
+##set x [getenv PATH]
+##puts "<------- $x"
+##puts "<------- $decompose_after"
+##puts "<------- $decompose_before"
 
 setenv PATH $decompose_before_path
 

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -51,7 +51,7 @@ conflict {{ name }}
 {% endfor %}
 {% endblock %}
 
-set decompose_path [split [module-info getenv PATH] ":"]
+set decompose_path [split [getenv PATH] ":"]
 set decompose_before {}
 set decompose_after {}
 set decompose_found 0
@@ -67,10 +67,15 @@ foreach dir $decompose_path {
     }
 }
 
+if {!$decompose_found} {
+    set decompose_after $decompose_before
+    set decompose_before {}
+}
+
 set decompose_before_path [join $decompose_before ":"]
 set decompose_after_path [join $decompose_after ":"]
 
-set-path PATH $decompose_before_path
+setenv PATH $decompose_before_path
 
 {% block environment %}
 {% for command_name, cmd in environment_modifications %}

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -58,7 +58,6 @@ set decompose_found 0
 set decompose_split_sentinel "spack-sentinel"
 
 foreach dir $decompose_path {
-    ## puts "<----- $dir"
     if {!$decompose_found && [string match $decompose_split_sentinel $dir]} {
         set decompose_found 1
     } elseif {$decompose_found} {
@@ -68,9 +67,6 @@ foreach dir $decompose_path {
     }
 }
 
-##puts "<------- $decompose_after"
-##puts "<------- $decompose_before"
-
 if {!$decompose_found} {
     set decompose_after $decompose_before
     set decompose_before {}
@@ -78,11 +74,6 @@ if {!$decompose_found} {
 
 set decompose_before_path [join $decompose_before ":"]
 set decompose_after_path [join $decompose_after ":"]
-
-##set x [getenv PATH]
-##puts "<------- $x"
-##puts "<------- $decompose_after"
-##puts "<------- $decompose_before"
 
 setenv PATH $decompose_before_path
 


### PR DESCRIPTION
See https://github.com/spack/spack/issues/39046

This is an incomplete mechanism in tcl modules to order path modifications such that spack built prefixes come first, followed by externals, followed by system paths.

This update the tcl module to insert a "spack-sentinel" string into the `$PATH`, and then use that for each module load. If externals were added with `append` vs. prepend, the updated template would achieve this ordering

(right now, it's all still prepends though, so successive invocations of `module load` for spack modules can still end up prepending path - the PR in it's current state was just to experiment with doing the PATH manipulations in tcl)