### PR TITLE
qemacs: add v6.4.1, fix +doc

### DIFF
--- a/var/spack/repos/builtin/packages/qemacs/package.py
+++ b/var/spack/repos/builtin/packages/qemacs/package.py
@@ -15,6 +15,7 @@ class Qemacs(MakefilePackage):
     maintainers("Buldram")
 
     version("master", branch="master")
+    version("6.4.1", commit="43b5851958ee13fe0b96cf92b5cfc0aaa085d740")
     version("6.3.3", commit="e3c5bfd457614773508feefdc12dbc60073030ed")
     version("6.3.2", commit="0e90c181078f3d85d0d44d985d541184223668e1")
     version("6.3.1", commit="288eeb450e534a39adb337396aa9ffcdc629f94e")
@@ -24,18 +25,17 @@ class Qemacs(MakefilePackage):
 
     depends_on("which", type="build")
 
-    variant("docs", default=False, description="Build documentation")
+    variant("doc", default=True, description="Install documentation")
     variant("plugins", default=False, description="Enable plugin support")
     variant("X", default=False, description="Build with X11 support")
     variant("png", default=True, when="+X", description="Build with PNG support")
     variant("xshm", default=True, when="+X", description="Build with XShm support")
     variant("xv", default=True, when="+X", description="Build with X Video support")
 
-    conflicts("+docs", when="platform=freebsd")
     conflicts("+plugins", when="platform=freebsd")
     conflicts("+plugins", when="platform=darwin")
+    conflicts("+plugins", when="platform=windows")
 
-    depends_on("texi2html", type="build", when="+docs")
     depends_on("libx11", type="link", when="+X")
     depends_on("libxcb", type="link", when="+X")
     depends_on("libxau", type="link", when="+X")
@@ -57,3 +57,17 @@ class Qemacs(MakefilePackage):
             "--disable-ffmpeg",  # Currently broken
             "--disable-xrender",  # Currently broken
         )
+
+        if spec.satisfies("~doc"):
+            filter_file(
+                "$(INSTALL) -m 755 -d $(DESTDIR)$(mandir)/man1", "", "Makefile", string=True
+            )
+            filter_file(
+                "$(INSTALL) -m 644 qe.1 $(DESTDIR)$(mandir)/man1", "", "Makefile", string=True
+            )
+
+    @run_after("install", when="+doc")
+    def install_docs(self):
+        doc_dir = self.prefix.share.join("qe")
+        install("config.eg", doc_dir)
+        install("qe-doc.html", doc_dir)


### PR DESCRIPTION
Adds version 6.4.1 and fixes the qemacs doc variant so that it controls installing documentation.
Removes texi2html dependency as it's only necessary for building docs and already built docs are included.