### PR TITLE
geomodel: add v6.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -17,6 +17,7 @@ class Geomodel(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.8.0", sha256="4dfd5a932955ee2618a880bb210aed9ce7087cfadd31f23f92e5ff009c8384eb")
     version("6.7.0", sha256="bfa69062ba191d0844d7099b28c0d6c3c0f87e726dacfaa21dba7a6f593d34bf")
     version("6.6.0", sha256="3cefeaa409177d45d3fa63e069b6496ca062991b0d7d71275b1748487659e91b")
     version("6.5.0", sha256="8a2f71493e54ea4d393f4c0075f3ca13df132f172c891825f3ab949cda052c5f")


### PR DESCRIPTION
This commit adds version 6.8.0 of GeoModel. As far as I can tell from the change notes, there are no changes required to the build configuration or dependencies.