### PR TITLE
Fix file modify check in develop mode

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1472,7 +1472,7 @@ def set_executable(path):
 def recursive_mtime_greater_than(path: str, time: float) -> bool:
     """Returns true if any file or dir recursively under `path` has mtime greater than `time`."""
     # use bfs order to increase likelihood of early return
-    queue: Deque[str] = collections.deque(path)
+    queue: Deque[str] = collections.deque([path])
 
     if os.stat(path).st_mtime > time:
         return True


### PR DESCRIPTION
Fix for issue https://github.com/spack/spack/issues/48699#issuecomment-2613591321, following up on fix in https://github.com/spack/spack/pull/48718.

This fix initializes deque with single element `path` instead of character array.

@psakievich @haampie 