### PR TITLE
Fix a few minor issues in tests

### DIFF
--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -36,6 +36,7 @@ import spack.main
 import spack.mirrors.mirror
 import spack.oci.image
 import spack.paths
+import spack.repo
 import spack.spec
 import spack.store
 import spack.util.gpg
@@ -94,7 +95,7 @@ def config_directory(tmp_path_factory):
 
 
 @pytest.fixture(scope="function")
-def default_config(tmp_path, config_directory, monkeypatch, install_mockery):
+def default_config(tmp_path, config_directory, mock_repo_path, install_mockery):
     # This fixture depends on install_mockery to ensure
     # there is a clear order of initialization. The substitution of the
     # config scopes here is done on top of the substitution that comes with
@@ -109,7 +110,6 @@ def default_config(tmp_path, config_directory, monkeypatch, install_mockery):
     ]
 
     with spack.config.use_configuration(*scopes):
-        spack.config.CONFIG.set("repos", [spack.paths.mock_packages_path])
         njobs = spack.config.get("config:build_jobs")
         if not njobs:
             spack.config.set("config:build_jobs", 4, scope="user")
@@ -130,8 +130,8 @@ def default_config(tmp_path, config_directory, monkeypatch, install_mockery):
         timeout = spack.config.get("config:connect_timeout")
         if not timeout:
             spack.config.set("config:connect_timeout", 10, scope="user")
-
-        yield spack.config.CONFIG
+        with spack.repo.use_repositories(mock_repo_path):
+            yield spack.config.CONFIG
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -14,7 +14,7 @@ import spack.repo
 
 
 @pytest.fixture()
-def builder_test_repository():
+def builder_test_repository(config):
     builder_test_path = os.path.join(spack.paths.repos_path, "builder.test")
     with spack.repo.use_repositories(builder_test_path) as mock_repo:
         yield mock_repo

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -720,7 +720,7 @@ class TestConcretize:
         assert spec.satisfies("^second-dependency-foo-bar-fee +fee")
         assert not spec.satisfies("parent-foo-bar +fee")
 
-    def test_no_matching_compiler_specs(self, mock_low_high_config):
+    def test_no_matching_compiler_specs(self):
         # only relevant when not building compilers as needed
         with spack.concretize.enable_compiler_existence_check():
             s = Spec("pkg-a %gcc@=0.0.0")


### PR DESCRIPTION
Extracted from #48729

* test_no_matching_compiler_specs: does not need mock_low_high_config, since mutable_config is already used at class level
* bindist.py: setup a configuration that doesn't super-impose builtin.mock over builtin
* builder.py: use a mock configuration for the tests

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
