### PR TITLE
vtk: fix gcc compat

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -87,6 +87,10 @@ class Vtk(CMakePackage):
 
     conflicts("%gcc@13", when="@9.2")
 
+    # VTK 8 vendors a heavily outdated version of CMake's GenerateExportHeader module, which
+    # has a bogus version check for GCC/Intel version to early exit. This drops the early exit.
+    patch("vtk-bogus-compiler-check.patch", when="@7.1:8")
+
     # Based on PyPI wheel availability
     with when("+python"), default_args(type=("build", "link", "run")):
         depends_on("python@:3.13")

--- a/var/spack/repos/builtin/packages/vtk/vtk-bogus-compiler-check.patch
+++ b/var/spack/repos/builtin/packages/vtk/vtk-bogus-compiler-check.patch
@@ -1,0 +1,28 @@
+From a444764fa92b8c4d5b49914ad9c8d8a9a4efafec Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <me@harmenstoppels.nl>
+Date: Mon, 27 Jan 2025 19:10:22 +0100
+Subject: [PATCH] VTKGenerateExportHeader.cmake: remove faulty compiler version
+ check
+
+---
+ CMake/VTKGenerateExportHeader.cmake | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/CMake/VTKGenerateExportHeader.cmake b/CMake/VTKGenerateExportHeader.cmake
+index 9a7a76386e..59d0bf7ebf 100644
+--- a/CMake/VTKGenerateExportHeader.cmake
++++ b/CMake/VTKGenerateExportHeader.cmake
+@@ -204,9 +204,7 @@ macro(_vtk_test_compiler_hidden_visibility)
+   # Exclude XL here because it misinterprets -fvisibility=hidden even though
+   # the check_cxx_compiler_flag passes
+   # http://www.cdash.org/CDash/testDetails.php?test=109109951&build=1419259
+-  if(NOT GCC_TOO_OLD
+-      AND NOT _INTEL_TOO_OLD
+-      AND NOT WIN32
++  if(NOT WIN32
+       AND NOT CYGWIN
+       AND NOT CMAKE_CXX_COMPILER_ID MATCHES "XL"
+       AND NOT CMAKE_CXX_COMPILER_ID MATCHES "PGI"
+-- 
+2.43.0
+


### PR DESCRIPTION
I've wasted too much time on this, but it should fix the broken CI state on `develop` in Spack.

VTK vendors a completely outdated and broken version of CMake's GenerateExportHeader, picked from CMake between v2.8.6 - v2.8.8. It has a completely bogus version check here https://github.com/Kitware/VTK/blob/e3de2c35c9f44fd6d16ad4c6b6527de7c4f677c7/CMake/VTKGenerateExportHeader.cmake#L173-L189, resulting in `GCC_TOO_OLD` for my GCC `11.4.0` and early exit, ultimately resulting in hiding public symbols in shared libraries, causing linking errors during the build.

The bug is basically that

```
if(_gcc_version VERSION_LESS "4.2")
```

is compared, but `_gcc_version` is a full string from `gcc --version` output:

```
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

which is always true.

