### PR TITLE
VTK: Fixes for 9.4

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -492,6 +492,16 @@ class Vtk(CMakePackage):
             if "%intel" in spec and spec.version >= Version("8.2"):
                 cmake_args.append("-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF")
 
+        # @9.4+ requires c++17
+        if spec.satisfies("@9.4:"):
+             cmake_args.extend(
+                [
+                    "-DCMAKE_CXX_STANDARD=17",
+                    "-DCMAKE_CXX_STANDARD_REQUIRED=ON",
+                    "-DCMAKE_CXX_EXTENSIONS=OFF"
+                ]
+            )
+
         # -no-ipo prevents an internal compiler error from multi-file
         # optimization (https://github.com/spack/spack/issues/20471)
         if "%intel" in spec:
@@ -515,7 +525,7 @@ class Vtk(CMakePackage):
         # CMake Error at CMake/vtkModule.cmake:5552 (message):
         # The variable `SEACASIoss_INCLUDE_DIRS` was expected to have been available,
         # but was not defined:
-        with when("^seacas@2023-05-30:"):
+        if spec.satisfies("^seacas@2023-05-30:"):
             cmake_args.extend(
                 [
                     "-DSEACASIoss_INCLUDE_DIRS="+self.spec['seacas'].prefix.include

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -260,6 +260,13 @@ class Vtk(CMakePackage):
                 env.append_flags("CFLAGS", "-DH5_USE_18_API")
                 env.append_flags("CXXFLAGS", "-DH5_USE_18_API")
 
+    def flag_handler(self, name, flags):
+        # The new seacas version for 9.4: requires c++ 17, so hard override the cmake files
+        # TODO: Probably better to patch the vtk cmake file
+        if self.spec.satisfies("@9.4:") and name == "cxxflags":
+            flags.append("-std=c++17")
+        return (flags, None, None)
+
     def cmake_args(self):
         spec = self.spec
 
@@ -491,16 +498,6 @@ class Vtk(CMakePackage):
             # A bug in tao pegtl causes build failures with intel compilers
             if "%intel" in spec and spec.version >= Version("8.2"):
                 cmake_args.append("-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF")
-
-        # @9.4+ requires c++17
-        if spec.satisfies("@9.4:"):
-             cmake_args.extend(
-                [
-                    "-DCMAKE_CXX_STANDARD=17",
-                    "-DCMAKE_CXX_STANDARD_REQUIRED=ON",
-                    "-DCMAKE_CXX_EXTENSIONS=OFF"
-                ]
-            )
 
         # -no-ipo prevents an internal compiler error from multi-file
         # optimization (https://github.com/spack/spack/issues/20471)

--- a/var/spack/repos/builtin/packages/vtk/vtk94-appleclang-int128.patch
+++ b/var/spack/repos/builtin/packages/vtk/vtk94-appleclang-int128.patch
@@ -1,0 +1,34 @@
+--- a/ThirdParty/fmt/vtkfmt/vtkfmt/core.h
++++ b/ThirdParty/fmt/vtkfmt/vtkfmt/core.h
+@@ -354,11 +354,15 @@
+ #endif
+
+ #ifdef FMT_USE_INT128
+-// Do nothing.
++using int128_opt = __int128;  // An optional native 128-bit integer.
++using uint128_opt = __uint128_t;
++template <typename T> inline auto convert_for_visit(T value) -> T {
++  return value;
++}
+ #elif defined(__SIZEOF_INT128__) && !defined(__NVCC__) && \
+     !(FMT_CLANG_VERSION && FMT_MSC_VERSION)
+ #  define FMT_USE_INT128 1
+-using int128_opt = __int128_t;  // An optional native 128-bit integer.
++using int128_opt = __int128;  // An optional native 128-bit integer.
+ using uint128_opt = __uint128_t;
+ template <typename T> inline auto convert_for_visit(T value) -> T {
+   return value;
+
+--- a/IO/IOSS/vtkIOSSUtilities.cxx
++++ b/IO/IOSS/vtkIOSSUtilities.cxx
+@@ -301,8 +301,8 @@
+   }
+
+   // Check for Transient 2D data that should be 3D for WarpByVector/Glyphs
+-  if (entity->type() == vtkioss_Ioss::NODEBLOCK &&
+-    field.get_role() == vtkioss_Ioss::Field::RoleType::TRANSIENT && // Nodal / Elem Variables
++  if (entity->type() == Ioss::EntityType::NODEBLOCK &&
++    field.get_role() == Ioss::Field::RoleType::TRANSIENT && // Nodal / Elem Variables
+     entity->get_property("component_degree").get_int() == 2 &&      // dimension 2 mesh nodeblock
+     field.raw_storage()->component_count() == 2)                    // 2D Vector
+   {


### PR DESCRIPTION
- Fixes a conflicting pin for seacas version with `vtk@9.2:`
- Seacas no longer sets `SEACASIoss_INCLUDE_DIRS`, so VTK con't compile against anything newer than `seacas@2023-05-30`. Add a manually specified variable to allow for more recent seacas versions.
- There are a bunch of issues compiling with VTK 9.4 (testing on the apple-clang@16 compiler but they are likely on other compilers too). This includes a preliminary patch to address some of these issues

Reported in issue 
https://github.com/spack/spack-packages/issues/1439

I can't get past the last issue:
```
  >> 7856    Undefined symbols for architecture arm64:
     7857      "vtkfmt::v11::vformat(vtkfmt::v11::basic_string_view<char>, vtkfmt::v11::basic_format_args<vtkfmt::v11::basic_format_context<vtkfmt::v11::appender, char>>)", referenced from:
     7858          vtkIOSSWriter::WriteData() in vtkIOSSWriter.cxx.o
     7859    ld: symbol(s) not found for architecture arm64
```
and would appreciate any help