### PR TITLE
mapl: fix too strict oneapi conflict

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -252,9 +252,11 @@ class Mapl(CMakePackage):
     conflicts("%gcc@13:", when="@:2.44")
 
     # MAPL can use ifx only from MAPL 2.51 onwards and only supports
-    # ifx 2025.0 and newer due to bugs in ifx
-    conflicts("%oneapi@:2024")
-    conflicts("%oneapi", when="@:2.50")
+    # ifx 2025.0 and newer due to bugs in ifx.
+    conflicts("%oneapi@2025:", when="@:2.50")
+    # NOTE there is a further check on oneapi in the cmake_args below
+    # that is hard to conflict since we don't know the fortran compiler
+    # at this point
 
     variant("flap", default=False, description="Build with FLAP support", when="@:2.39")
     variant("pflogger", default=True, description="Build with pFlogger support")
@@ -387,6 +389,14 @@ class Mapl(CMakePackage):
                 fflags.append("-fallow-argument-mismatch")
         if fflags:
             args.append(self.define("CMAKE_Fortran_FLAGS", " ".join(fflags)))
+
+        # If oneapi is used and it gets past the conflict above, we might be
+        # using ifx or ifort. If we are using ifx and the MAPL version is 2.50 or older
+        # we need to raise an error
+
+        if self.spec.satisfies("@:2.50 %oneapi"):
+            if self.spec["fortran"].name == "ifx":
+                raise InstallError("MAPL versions 2.50 and older do not support ifx")
 
         # Scripts often need to know the MPI stack used to setup the environment.
         # Normally, we can autodetect this, but building with Spack does not

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -390,11 +390,11 @@ class Mapl(CMakePackage):
         if fflags:
             args.append(self.define("CMAKE_Fortran_FLAGS", " ".join(fflags)))
 
-        # If oneapi is used and it gets past the conflict above, we might be
+        # If oneapi@:2024 is used and it gets past the conflict above, we might be
         # using ifx or ifort. If we are using ifx and the MAPL version is 2.50 or older
         # we need to raise an error
 
-        if self.spec.satisfies("%oneapi@:2025"):
+        if self.spec.satisfies("@:2.50 %oneapi@:2024"):
             # We now need to get which Fortran compiler is used here but there
             # isn't an easy way like:
             #   if self.spec["fortran"].name == "ifx":

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -400,7 +400,9 @@ class Mapl(CMakePackage):
             #   if self.spec["fortran"].name == "ifx":
             # yet (see https://github.com/spack/spack/pull/45189)
             # So we need to parse the output of $FC --version
-            output = spack.compiler.get_compiler_version_output(self.compiler.fc, "--version")
+            output = spack.compiler.get_compiler_version_output(
+                self.compiler.fc, "-diag-disable=10448 --version", ignore_errors=True
+            )
             if "ifx" in output:
                 raise InstallError("MAPL versions 2.50 and older do not support ifx")
 

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -394,8 +394,14 @@ class Mapl(CMakePackage):
         # using ifx or ifort. If we are using ifx and the MAPL version is 2.50 or older
         # we need to raise an error
 
-        if self.spec.satisfies("@:2.50 %oneapi"):
-            if self.spec["fortran"].name == "ifx":
+        if self.spec.satisfies("%oneapi@:2025"):
+            # We now need to get which Fortran compiler is used here but there
+            # isn't an easy way like:
+            #   if self.spec["fortran"].name == "ifx":
+            # yet (see https://github.com/spack/spack/pull/45189)
+            # So we need to parse the output of $FC --version
+            output = spack.compiler.get_compiler_version_output(self.compiler.fc, "--version")
+            if "ifx" in output:
                 raise InstallError("MAPL versions 2.50 and older do not support ifx")
 
         # Scripts often need to know the MPI stack used to setup the environment.


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Thanks to @climbfuji, it was pointed out that our protections of MAPL against `ifx` was hurting when `ifort` was provided by oneAPI 2024. This PR fixes those issues.