### PR TITLE
crtm-fix: 3.1.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -17,7 +17,7 @@ class CrtmFix(Package):
         "BenjaminTJohnson", "edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "climbfuji"
     )
 
-    version("3.1.1.2", sha256="46777d5c573e2208fe638744f625bf1f9a4a7e2241cca1ce4cd4acee6339b9ab")
+    version("3.1.1.2", sha256="c2e289f690d82a3aa82d2239cbb567cd514fa0f476a8b498ceba11670685ca66")
     version(
         "2.4.0.1_emc", sha256="6e4005b780435c8e280d6bfa23808d8f12609dfd72f77717d046d4795cac0457"
     )

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -53,6 +53,7 @@ class CrtmFix(Package):
         fix_files = []
         for d in endian_dirs:
             fix_files = fix_files + find(".", "*/{}/*".format(d))
+        fix_files = [f for f in fix_files if "/fix/test_data/" not in f]
 
         # Big_Endian amsua_metop-c.SpcCoeff.bin is incorrect
         # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be.

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -17,6 +17,7 @@ class CrtmFix(Package):
         "BenjaminTJohnson", "edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "climbfuji"
     )
 
+    version("3.1.1.2", sha256="46777d5c573e2208fe638744f625bf1f9a4a7e2241cca1ce4cd4acee6339b9ab")
     version(
         "2.4.0.1_emc", sha256="6e4005b780435c8e280d6bfa23808d8f12609dfd72f77717d046d4795cac0457"
     )

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -27,6 +27,7 @@ class CrtmFix(Package):
     variant("big_endian", default=True, description="Install big_endian fix files")
     variant("little_endian", default=False, description="Install little endian fix files")
     variant("netcdf", default=True, description="Install netcdf fix files")
+    variant("testfiles", default=False, description="Install test files", when="@3:")
 
     conflicts("+big_endian", when="+little_endian", msg="big_endian and little_endian conflict")
 
@@ -52,8 +53,11 @@ class CrtmFix(Package):
 
         fix_files = []
         for d in endian_dirs:
-            fix_files = fix_files + find(".", "*/{}/*".format(d))
-        fix_files = [f for f in fix_files if "/fix/test_data/" not in f]
+            fix_files = fix_files + find(".", "*/{}/*".format(d), recursive=False)
+            fix_files = fix_files + find(".", "*/*/{}/*".format(d), recursive=False)
+        if self.spec.satisfies("~testfiles"):
+            fix_files = [f for f in fix_files if "/fix/test_data/" not in f]
+        fix_files = [f for f in fix_files if os.path.isfile(f)]
 
         # Big_Endian amsua_metop-c.SpcCoeff.bin is incorrect
         # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be.


### PR DESCRIPTION
This PR adds 3.1.1.2 to crtm-fix.

Tested updated installation logic with 3.1.1.2 and 2.4.0.1_emc.