### PR TITLE
builtin: remove redundant imports

### DIFF
--- a/var/spack/repos/builtin/packages/additivefoam/package.py
+++ b/var/spack/repos/builtin/packages/additivefoam/package.py
@@ -9,7 +9,6 @@ import llnl.util.tty as tty
 
 import spack.pkg.builtin.openfoam as openfoam
 from spack.package import *
-from spack.version import Version
 
 
 class Additivefoam(Package):

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import warnings
 
-import spack.main
 from spack.package import *
 
 
@@ -147,7 +147,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
                 git = which("git")
                 git("describe", "--long", "--always", output="version.git")
             except ProcessError:
-                spack.main.send_warning_to_tty("Omitting version stamp due to git error")
+                warnings.warn("Omitting version stamp due to git error")
 
         # The GASNet-EX library has a highly multi-dimensional configure space,
         # to accomodate the varying behavioral requirements of each client runtime.

--- a/var/spack/repos/builtin/packages/gem5/package.py
+++ b/var/spack/repos/builtin/packages/gem5/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import spack.config
 from spack.package import *
 
 
@@ -64,7 +63,7 @@ class Gem5(SConsPackage):
     def build_args(self, spec, prefix):
         args = []
         args.append("build/ALL/gem5.opt")
-        args.append(f"-j{spack.config.determine_number_of_jobs(parallel=True)}")
+        args.append(f"-j{determine_number_of_jobs(parallel=True)}")
         args.append("--ignore-style")
 
         return args

--- a/var/spack/repos/builtin/packages/genie/package.py
+++ b/var/spack/repos/builtin/packages/genie/package.py
@@ -6,7 +6,6 @@
 import os
 
 from spack.package import *
-from spack.version import Version
 
 
 class Genie(Package):

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.filesystem as fs
-
 import spack.build_systems.cmake
 from spack.package import *
 
@@ -660,7 +658,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         not be intended with ``--test``.
         """
         if self.pkg.run_tests:
-            with fs.working_dir(self.build_directory):
+            with working_dir(self.build_directory):
                 make("tests")
 
     def check(self):
@@ -669,7 +667,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         Override the standard CMakeBuilder behavior. GROMACS has both `test`
         and `check` targets, but we are only interested in the latter.
         """
-        with fs.working_dir(self.build_directory):
+        with working_dir(self.build_directory):
             if self.generator == "Unix Makefiles":
                 make("check")
             elif self.generator == "Ninja":

--- a/var/spack/repos/builtin/packages/hpx-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/hpx-kokkos/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.filesystem as fs
-
 from spack.package import *
 
 
@@ -95,7 +93,7 @@ class HpxKokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     def check(self):
         if self.run_tests:
-            with fs.working_dir(self.build_directory):
+            with working_dir(self.build_directory):
                 cmake("--build", ".", "--target", "tests")
                 cmake("--build", ".", "--target", "benchmarks")
                 ctest("--output-on-failure")

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -6,7 +6,6 @@ import glob
 import os
 
 from spack.package import *
-from spack.version import ver
 
 
 def get_best_target(microarch, compiler_name, compiler_version):

--- a/var/spack/repos/builtin/packages/meme/package.py
+++ b/var/spack/repos/builtin/packages/meme/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.version import Version
 
 
 class Meme(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/mmg/package.py
+++ b/var/spack/repos/builtin/packages/mmg/package.py
@@ -6,7 +6,6 @@ import os
 
 import spack.build_systems.cmake
 from spack.package import *
-from spack.util.executable import which
 
 
 class Mmg(CMakePackage):

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.filesystem as fs
-
 from spack.package import *
 
 
@@ -167,7 +165,7 @@ class Nektar(CMakePackage):
         super(Nektar, self).install(spec, prefix)
         if "+python" in spec:
             python = which("python")
-            with fs.working_dir(self.build_directory):
+            with working_dir(self.build_directory):
                 python("setup.py", "install", "--prefix", prefix)
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.version
 from spack.package import *
 
 
@@ -63,7 +62,7 @@ class NinjaFortran(Package):
         split_ver = str(ver).split(".")
         url_version = ".".join(split_ver[:3]) + "." + split_ver[4]
 
-        if version < spack.version.Version("1.8.2.1"):
+        if version < Version("1.8.2.1"):
             url = "https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.tar.gz"
         else:
             url = (

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -4,7 +4,6 @@
 
 import os
 
-import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 from spack.package import *
@@ -370,7 +369,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
         with working_dir("example-recipe", create=True):
             print("Current working directory (in example-recipe)")
-            fs.copy(join_path(os.path.dirname(__file__), "test", "recipe.inp"), "inp")
+            copy(join_path(os.path.dirname(__file__), "test", "recipe.inp"), "inp")
             exe = which(self.spec.prefix.bin.octopus)
             out = exe(output=str.split, error=str.split)
             check_outputs(expected, out)
@@ -399,7 +398,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
         with working_dir("example-he", create=True):
             print("Current working directory (in example-he)")
-            fs.copy(join_path(os.path.dirname(__file__), "test", "he.inp"), "inp")
+            copy(join_path(os.path.dirname(__file__), "test", "he.inp"), "inp")
             exe = which(self.spec.prefix.bin.octopus)
             out = exe(output=str.split, error=str.split)
             check_outputs(expected, out)

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -10,7 +10,6 @@ import sys
 import llnl.util.tty as tty
 
 import spack.compilers
-import spack.version
 from spack.package import *
 
 
@@ -736,7 +735,7 @@ with '-Wl,-commons,use_dylibs' and without
                 variants.append("+atomics")
 
             # java
-            if version in spack.version.ver("1.7.4:"):
+            if version in ver("1.7.4:"):
                 match = re.search(r"\bJava bindings: (\S+)", output)
                 if match and is_enabled(match.group(1)):
                     variants.append("+java")
@@ -754,7 +753,7 @@ with '-Wl,-commons,use_dylibs' and without
                 variants.append("~static")
 
             # sqlite
-            if version in spack.version.ver("1.7.3:1"):
+            if version in ver("1.7.3:1"):
                 if re.search(r"\bMCA db: sqlite", output):
                     variants.append("+sqlite3")
                 else:
@@ -765,7 +764,7 @@ with '-Wl,-commons,use_dylibs' and without
                 variants.append("+vt")
 
             # thread_multiple
-            if version in spack.version.ver("1.5.4:2"):
+            if version in ver("1.5.4:2"):
                 match = re.search(r"MPI_THREAD_MULTIPLE: (\S+?),?", output)
                 if match and is_enabled(match.group(1)):
                     variants.append("+thread_multiple")
@@ -782,7 +781,7 @@ with '-Wl,-commons,use_dylibs' and without
                 variants.append("~cuda")
 
             # wrapper-rpath
-            if version in spack.version.ver("1.7.4:"):
+            if version in ver("1.7.4:"):
                 match = re.search(r"\bWrapper compiler rpath: (\S+)", output)
                 if match and is_enabled(match.group(1)):
                     variants.append("+wrapper-rpath")
@@ -790,7 +789,7 @@ with '-Wl,-commons,use_dylibs' and without
                     variants.append("~wrapper-rpath")
 
             # cxx
-            if version in spack.version.ver(":4"):
+            if version in ver(":4"):
                 match = re.search(r"\bC\+\+ bindings: (\S+)", output)
                 if match and match.group(1) == "yes":
                     variants.append("+cxx")
@@ -798,7 +797,7 @@ with '-Wl,-commons,use_dylibs' and without
                     variants.append("~cxx")
 
             # cxx_exceptions
-            if version in spack.version.ver(":4"):
+            if version in ver(":4"):
                 match = re.search(r"\bC\+\+ exceptions: (\S+)", output)
                 if match and match.group(1) == "yes":
                     variants.append("+cxx_exceptions")
@@ -806,7 +805,7 @@ with '-Wl,-commons,use_dylibs' and without
                     variants.append("~cxx_exceptions")
 
             # singularity
-            if version in spack.version.ver(":4"):
+            if version in ver(":4"):
                 if re.search(r"--with-singularity", output):
                     variants.append("+singularity")
 
@@ -822,7 +821,7 @@ with '-Wl,-commons,use_dylibs' and without
                 variants.append("~memchecker")
 
             # pmi
-            if version in spack.version.ver("1.5.5:4"):
+            if version in ver("1.5.5:4"):
                 if re.search(r"\bMCA (?:ess|prrte): pmi", output):
                     variants.append("+pmi")
                 else:

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -6,8 +6,6 @@ import glob
 import os
 import sys
 
-import llnl.util.filesystem as fs
-
 import spack.util.environment
 from spack.package import *
 
@@ -211,7 +209,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
                 join_path(self.prefix.lib, "libpapi.so"),
                 join_path(self.prefix.lib, "libpapi.dylib"),
             )
-            fs.fix_darwin_install_name(self.prefix.lib)
+            fix_darwin_install_name(self.prefix.lib)
 
     test_src_dir = "src/smoke_tests"
     test_requires_compiler = True

--- a/var/spack/repos/builtin/packages/py-pythran/package.py
+++ b/var/spack/repos/builtin/packages/py-pythran/package.py
@@ -4,8 +4,6 @@
 
 import sys
 
-import llnl.util.filesystem as fs
-
 from spack.package import *
 
 
@@ -88,7 +86,7 @@ class PyPythran(PythonPackage):
         # Pythran is mainly meant to be used as a compiler, so return no headers to
         # avoid issue https://github.com/spack/spack/issues/33237 This can be refined
         # later to allow using pythran also as a library.
-        return fs.HeaderList([])
+        return HeaderList([])
 
     def patch(self):
         # Compiler is used at run-time to determine name of OpenMP library to search for

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -5,8 +5,6 @@
 import os
 import shutil
 
-import llnl.util.filesystem as fs
-
 from spack.package import *
 
 
@@ -36,7 +34,7 @@ class PythonVenv(Package):
             # Replace the VIRTUAL_ENV variable in the activate scripts after copying
             if name.lower().startswith("activate"):
                 shutil.copy(src, dst)
-                fs.filter_file(
+                filter_file(
                     self.spec.prefix,
                     os.path.abspath(view.get_projection_for_spec(self.spec)),
                     dst,

--- a/var/spack/repos/builtin/packages/singularity-eos/package.py
+++ b/var/spack/repos/builtin/packages/singularity-eos/package.py
@@ -5,7 +5,6 @@
 import os
 
 import spack
-import spack.version
 from spack.package import *
 
 
@@ -118,7 +117,7 @@ class SingularityEos(CMakePackage, CudaPackage):
     depends_on("kokkos +wrapper+cuda_lambda", when="+cuda+kokkos")
 
     # fix for older spacks
-    if spack.version.Version(spack.spack_version) >= spack.version.Version("0.17"):
+    if Version(spack.spack_version) >= Version("0.17"):
         depends_on("kokkos-kernels ~shared", when="+kokkos-kernels")
 
     for _flag in list(CudaPackage.cuda_arch_values):

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -5,8 +5,6 @@
 import os
 import sys
 
-from llnl.util.filesystem import find_first
-
 import spack.build_systems.autotools
 import spack.build_systems.nmake
 from spack.package import *

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-from llnl.util.filesystem import find_first
-
 from spack.package import *
 
 


### PR DESCRIPTION
Part of #47480 

Remove redundant imports of Spack internals if it's public API already re-exported from `spack.package`.

This improves backward/forward compat with Spack when the Spack package repo is split from this git repo.