### PR TITLE
index: avoid quadratic complexity through bulk update

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -485,7 +485,7 @@ class Indexer(metaclass=abc.ABCMeta):
         """Read this index from a provided file object."""
 
     @abc.abstractmethod
-    def update(self, pkg_fullname):
+    def update(self, pkgs_fullname: Set[str]):
         """Update the index in memory with information about a package."""
 
     @abc.abstractmethod
@@ -502,8 +502,8 @@ class TagIndexer(Indexer):
     def read(self, stream):
         self.index = spack.tag.TagIndex.from_json(stream)
 
-    def update(self, pkg_fullname):
-        self.index.update_package(pkg_fullname.split(".")[-1], self.repository)
+    def update(self, pkgs_fullname: Set[str]):
+        self.index.update_packages({p.split(".")[-1] for p in pkgs_fullname}, self.repository)
 
     def write(self, stream):
         self.index.to_json(stream)
@@ -518,15 +518,15 @@ class ProviderIndexer(Indexer):
     def read(self, stream):
         self.index = spack.provider_index.ProviderIndex.from_json(stream, self.repository)
 
-    def update(self, pkg_fullname):
-        name = pkg_fullname.split(".")[-1]
+    def update(self, pkgs_fullname: Set[str]):
         is_virtual = (
-            not self.repository.exists(name) or self.repository.get_pkg_class(name).virtual
+            lambda name: not self.repository.exists(name)
+            or self.repository.get_pkg_class(name).virtual
         )
-        if is_virtual:
-            return
-        self.index.remove_provider(pkg_fullname)
-        self.index.update(pkg_fullname)
+        non_virtual_pkgs_fullname = {p for p in pkgs_fullname if not is_virtual(p.split(".")[-1])}
+        non_virtual_pkgs_names = {p.split(".")[-1] for p in non_virtual_pkgs_fullname}
+        self.index.remove_providers(non_virtual_pkgs_names)
+        self.index.update_packages(non_virtual_pkgs_fullname)
 
     def write(self, stream):
         self.index.to_json(stream)
@@ -551,8 +551,8 @@ class PatchIndexer(Indexer):
     def write(self, stream):
         self.index.to_json(stream)
 
-    def update(self, pkg_fullname):
-        self.index.update_package(pkg_fullname)
+    def update(self, pkgs_fullname: Set[str]):
+        self.index.update_packages(pkgs_fullname)
 
 
 class RepoIndex:
@@ -644,9 +644,7 @@ class RepoIndex:
                 if new_index_mtime != index_mtime:
                     needs_update = self.checker.modified_since(new_index_mtime)
 
-                for pkg_name in needs_update:
-                    indexer.update(f"{self.namespace}.{pkg_name}")
-
+                indexer.update({f"{self.namespace}.{pkg_name}" for pkg_name in needs_update})
                 indexer.write(new)
 
         return indexer.index

--- a/lib/spack/spack/test/provider_index.py
+++ b/lib/spack/spack/test/provider_index.py
@@ -72,3 +72,15 @@ def test_copy(mock_packages):
     p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
     q = p.copy()
     assert p == q
+
+
+def test_remove_providers(mock_packages):
+    """Test removing providers from the index."""
+    p = ProviderIndex(specs=["mpich"], repository=spack.repo.PATH)
+    # Check that mpich is a provider for mpi
+    providers = p.providers_for("mpi")
+    assert any(spec.name == "mpich" for spec in providers)
+    p.remove_providers({"mpich"})
+    # After removal, mpich should no longer be a provider for mpi
+    providers = p.providers_for("mpi")
+    assert not any(spec.name == "mpich" for spec in providers)

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -146,7 +146,6 @@ def test_tag_no_tags(mock_packages):
 def test_tag_update_package(mock_packages):
     mock_index = mock_packages.tag_index
     index = spack.tag.TagIndex()
-    for name in spack.repo.all_package_names():
-        index.update_package(name, repo=mock_packages)
+    index.update_packages(set(spack.repo.all_package_names()), repo=mock_packages)
 
     ensure_tags_results_equal(mock_index.tags, index.tags)


### PR DESCRIPTION
Optimizes provider index creation for bulk updates, relevant on first
use. Previously, updating the index with N packages involved iterating
through the entire index for each package to remove stale entries,
resulting in O(N * IndexSize) complexity.

This change splits the update process into two steps:

1. Bulk removal of stale entries for all updated packages.
2. Bulk insertion of new entries.

This reduces the complexity of full index generation from quadratic to linear.