### PR TITLE
docs/Conflicts and requirements: elaborate on specs and provide link for more when arg examples

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2799,7 +2799,7 @@ Adding the following to a package:
     )
 
 expresses the fact that the current package *cannot be built* with the Intel
-compiler when we are trying to install a version "<=1.2". 
+compiler when we are trying to install a version "<=1.2".
 
 If the ``when`` argument is omitted then conflict will always be active.
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2775,8 +2775,17 @@ Conflicts and requirements
 --------------------------
 
 Sometimes packages have known bugs, or limitations, that would prevent them
-from building e.g. against other dependencies or with certain compilers. Spack
-makes it possible to express such constraints with the ``conflicts`` directive.
+from building a spec e.g. against other dependencies or with certain compilers.
+Spack makes it possible to express such constraints with the ``conflicts`` directive.
+
+The directive supports the optional ``when`` clause, which means the conflict
+applies only to the spec indicated by the value of the clause's argument. The
+syntax and spec options for the argument are consistent with those of other
+directives.
+
+An optional custom error message can be added via the ``msg=`` parameter, and
+will be printed by Spack in case the conflict cannot be avoided and leads to a
+concretization error.
 
 Adding the following to a package:
 
@@ -2789,13 +2798,15 @@ Adding the following to a package:
              "please use a newer release."
     )
 
-we express the fact that the current package *cannot be built* with the Intel
-compiler when we are trying to install a version "<=1.2".
+expresses the fact that the current package *cannot be built* with the Intel
+compiler when we are trying to install a version "<=1.2". 
 
-The ``when`` argument can be omitted, in which case the conflict will always be active.
+If the ``when`` argument is omitted then conflict will always be active.
 
-An optional custom error message can be added via the ``msg=`` parameter, and will be printed
-by Spack in case the conflict cannot be avoided and leads to a concretization error.
+.. note::
+
+    More examples of conflicts using the ``when`` clause can be found in
+    :ref:`group_when_spec`.
 
 Sometimes, packages allow only very specific choices and they can't use the rest. In those cases
 the ``requires`` directive can be used:
@@ -2809,8 +2820,8 @@ the ``requires`` directive can be used:
     )
 
 In the example above, our package can only be built with Apple-Clang on Darwin.
-The ``requires`` directive is effectively the opposite of the ``conflicts`` directive, and takes
-the same optional ``when`` and ``msg`` arguments.
+The ``requires`` directive is effectively the opposite of the ``conflicts`` 
+directive, and takes the same optional ``when`` and ``msg`` arguments.
 
 If a package needs to express more complex requirements, involving more than a single spec,
 that can also be done using the ``requires`` directive. To express that a package can be built

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2781,7 +2781,8 @@ Spack makes it possible to express such constraints with the ``conflicts`` direc
 The directive supports the optional ``when`` clause, which means the conflict
 applies only to the spec indicated by the value of the clause's argument. The
 syntax and spec options for the argument are consistent with those of other
-directives.
+directives and can include constraints on the compiler, version, variants,
+architecture, dependencies, etc. of the spec.
 
 An optional custom error message can be added via the ``msg=`` parameter, and
 will be printed by Spack in case the conflict cannot be avoided and leads to a
@@ -2801,12 +2802,24 @@ Adding the following to a package:
 expresses the fact that the current package *cannot be built* with the Intel
 compiler when we are trying to install a version "<=1.2".
 
-If the ``when`` argument is omitted then conflict will always be active.
+A conflict with the ``when`` argument omitted means the conflict is always
+active for specs matching the first argument. For example,
 
-.. note::
+.. code-block:: python
 
-    More examples of conflicts using the ``when`` clause can be found in
-    :ref:`group_when_spec`.
+    conflicts("+cuda+rocm", msg="Cannot build with both +cuda and +rocm"))
+
+means the package cannot be installed when both variants are enabled.
+
+Similarly,
+
+.. code-block:: python
+
+    for os in ["ventura", "monterey", "bigsur"]:
+        conflicts(f"platform=darwin os={os}", msg=f"{os} is not supported")
+
+expresses that the package cannot be built on a Mac running Ventura, Monterey,
+or Big Sur.
 
 Sometimes, packages allow only very specific choices and they can't use the rest. In those cases
 the ``requires`` directive can be used:


### PR DESCRIPTION
Questions about what specs are supported in conflicts args keep coming up so expand the main section in the docs to elaborate on args and provide a link to the "common" `when=` cases.

Post-1e018c3 version can be seen at https://spack--48773.org.readthedocs.build/en/48773/packaging_guide.html#conflicts-and-requirements.