### PR TITLE
sw4: fix build options

### DIFF
--- a/var/spack/repos/builtin/packages/sw4/package.py
+++ b/var/spack/repos/builtin/packages/sw4/package.py
@@ -35,7 +35,7 @@ class Sw4(MakefilePackage):
     depends_on("lapack")
     depends_on("python")
     depends_on("proj@9:", when="+proj")
-    depends_on("hdf5@1.12: +mpi", when="+hdf5")
+    depends_on("hdf5@1.14: +mpi", when="+hdf5")
     depends_on("py-h5py", when="+hdf5")
     depends_on("zfp", when="+zfp")
     depends_on("h5z-zfp@develop", when="+zfp")

--- a/var/spack/repos/builtin/packages/sw4/package.py
+++ b/var/spack/repos/builtin/packages/sw4/package.py
@@ -8,59 +8,66 @@ from spack.package import *
 
 
 class Sw4(MakefilePackage):
-    """This package builds SW4 with MPI, OpenMP, HDF5, FFTW, PROJ, and ZFP."""
+    """SW4 implements substantial capabilities for 3-D seismic modeling."""
 
     homepage = "https://github.com/geodynamics/sw4"
     git = "https://github.com/geodynamics/sw4.git"
 
     maintainers("houjun", "andersp")
 
+    license("GPL-2.0-or-later")
+
     version("master", branch="master")
     version("developer", branch="developer")
     version("3.0", tag="v3.0", commit="13e6d431976f7fc49124c997bf87353aa7afd35e")
 
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    variant("openmp", default=True, description="Build with OpenMP")
+    variant("proj", default=True, description="Build with PROJ")
+    variant("hdf5", default=True, description="Build with HDF5")
+    variant("zfp", default=False, when="+hdf5", description="Build with ZFP")
+    variant("fftw", default=True, description="Build with FFTW")
+    variant("debug", default=False, description="Build with debugging symbols")
 
-    variant("openmp", default=True, description="build with OpenMP")
-    variant("hdf5", default=True, description="build with HDF5")
-    variant("proj", default=True, description="build with proj")
-    variant("zfp", default=False, description="build with ZFP")
-    variant("fftw", default=True, description="build with FFTW")
-
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
     depends_on("mpi")
     depends_on("blas")
     depends_on("lapack")
-    depends_on("proj", when="+proj")
-    depends_on("hdf5+mpi", when="+hdf5")
-    depends_on("fftw@3.0: +mpi", when="+fftw")
+    depends_on("python")
+    depends_on("proj@9:", when="+proj")
+    depends_on("hdf5@1.12: +mpi", when="+hdf5")
+    depends_on("py-h5py", when="+hdf5")
     depends_on("zfp", when="+zfp")
     depends_on("h5z-zfp@develop", when="+zfp")
-    depends_on("python")
-    depends_on("py-h5py")
+    depends_on("fftw@3: +mpi", when="+fftw")
     depends_on("llvm-openmp", when="%apple-clang +openmp")
 
     def edit(self, spec, prefix):
         os.environ["CXX"] = spec["mpi"].mpicxx
         os.environ["FC"] = spec["mpi"].mpifc
-        os.environ["proj"] = "yes"
-        os.environ["openmp"] = "yes"
-        os.environ["hdf5"] = "yes"
-        os.environ["zfp"] = "yes"
-        os.environ["fftw"] = "yes"
-        os.environ["SW4ROOT"] = spec["proj"].prefix
-        os.environ["HDF5ROOT"] = spec["hdf5"].prefix
-        os.environ["H5ZROOT"] = spec["h5z-zfp"].prefix
-        os.environ["ZFPROOT"] = spec["zfp"].prefix
-        os.environ["FFTWHOME"] = spec["fftw"].prefix
+        # openmp is enabled by default
+        if spec.satisfies("~openmp"):
+            os.environ["openmp"] = "no"
+        if spec.satisfies("+proj"):
+            os.environ["proj"] = "yes"
+            os.environ["SW4ROOT"] = spec["proj"].prefix
+        if spec.satisfies("+hdf5"):
+            os.environ["hdf5"] = "yes"
+            os.environ["HDF5ROOT"] = spec["hdf5"].prefix
+        if spec.satisfies("+zfp"):
+            os.environ["zfp"] = "yes"
+            os.environ["ZFPROOT"] = spec["zfp"].prefix
+            os.environ["H5ZROOT"] = spec["h5z-zfp"].prefix
+        if spec.satisfies("+fftw"):
+            os.environ["fftw"] = "yes"
+            os.environ["FFTWHOME"] = spec["fftw"].prefix
+        if spec.satisfies("+debug"):
+            os.environ["debug"] = "yes"
         os.environ["EXTRA_LINK_FLAGS"] = "-lstdc++ -lm -ldl "
         os.environ["EXTRA_LINK_FLAGS"] += spec["blas"].libs.ld_flags + " "
-        os.environ["EXTRA_LINK_FLAGS"] += spec["blas"].libs.ld_flags + " "
-
-        if "+openmp" in spec:
-            if spec.satisfies("%apple-clang"):
-                os.environ["EXTRA_LINK_FLAGS"] += spec["llvm-openmp"].libs.ld_flags + " "
-
+        os.environ["EXTRA_LINK_FLAGS"] += spec["lapack"].libs.ld_flags + " "
+        if spec.satisfies("%apple-clang +openmp"):
+            os.environ["EXTRA_LINK_FLAGS"] += spec["llvm-openmp"].libs.ld_flags + " "
         # From spack/trilinos
         if spec.satisfies("%gcc") or spec.satisfies("%clang") or spec.satisfies("%apple-clang"):
             fc = Executable(self.compiler.fc)
@@ -73,5 +80,12 @@ class Sw4(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
-        install("optimize_mp/sw4", prefix.bin)
+        if spec.satisfies("+openmp~debug"):
+            install("optimize_mp/sw4", prefix.bin)
+        elif spec.satisfies("+openmp+debug"):
+            install("debug_mp/sw4", prefix.bin)
+        elif spec.satisfies("~openmp~debug"):
+            install("optimize/sw4", prefix.bin)
+        elif spec.satisfies("~openmp+debug"):
+            install("debug/sw4", prefix.bin)
         install_tree("pytest", prefix.test)

--- a/var/spack/repos/builtin/packages/sw4/package.py
+++ b/var/spack/repos/builtin/packages/sw4/package.py
@@ -78,9 +78,9 @@ class Sw4(MakefilePackage):
             libgfortran = fc("--print-file-name", "libgfortran." + dso_suffix, output=str).strip()
             if libgfortran == "libgfortran." + dso_suffix:
                 libgfortran = fc("--print-file-name", "libgfortran.a", output=str).strip()
-            env.append_flags("EXTRA_LINK_FLAGS", "-L{0} -lgfortran".format(
-                os.path.dirname(libgfortran)
-            ))
+            env.append_flags(
+                "EXTRA_LINK_FLAGS", "-L{0} -lgfortran".format(os.path.dirname(libgfortran))
+            )
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)

--- a/var/spack/repos/builtin/packages/sw4/package.py
+++ b/var/spack/repos/builtin/packages/sw4/package.py
@@ -63,11 +63,11 @@ class Sw4(MakefilePackage):
             env.set("FFTWHOME", self.spec["fftw"].prefix)
         if self.spec.satisfies("+debug"):
             env.set("debug", "yes")
-        os.environ["EXTRA_LINK_FLAGS"] = "-lstdc++ -lm -ldl "
-        os.environ["EXTRA_LINK_FLAGS"] += self.spec["blas"].libs.ld_flags + " "
-        os.environ["EXTRA_LINK_FLAGS"] += self.spec["lapack"].libs.ld_flags + " "
+        env.set("EXTRA_LINK_FLAGS", "-lstdc++ -lm -ldl")
+        env.append_flags("EXTRA_LINK_FLAGS", self.spec["blas"].libs.ld_flags)
+        env.append_flags("EXTRA_LINK_FLAGS", self.spec["lapack"].libs.ld_flags)
         if self.spec.satisfies("%apple-clang +openmp"):
-            os.environ["EXTRA_LINK_FLAGS"] += self.spec["llvm-openmp"].libs.ld_flags + " "
+            env.append_flags("EXTRA_LINK_FLAGS", self.spec["llvm-openmp"].libs.ld_flags)
         # From spack/trilinos
         if (
             self.spec.satisfies("%gcc")
@@ -78,9 +78,9 @@ class Sw4(MakefilePackage):
             libgfortran = fc("--print-file-name", "libgfortran." + dso_suffix, output=str).strip()
             if libgfortran == "libgfortran." + dso_suffix:
                 libgfortran = fc("--print-file-name", "libgfortran.a", output=str).strip()
-            os.environ["EXTRA_LINK_FLAGS"] += " -L{0} -lgfortran ".format(
+            env.append_flags("EXTRA_LINK_FLAGS", "-L{0} -lgfortran".format(
                 os.path.dirname(libgfortran)
-            )
+            ))
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)

--- a/var/spack/repos/builtin/packages/sw4/package.py
+++ b/var/spack/repos/builtin/packages/sw4/package.py
@@ -42,34 +42,38 @@ class Sw4(MakefilePackage):
     depends_on("fftw@3: +mpi", when="+fftw")
     depends_on("llvm-openmp", when="%apple-clang +openmp")
 
-    def edit(self, spec, prefix):
-        os.environ["CXX"] = spec["mpi"].mpicxx
-        os.environ["FC"] = spec["mpi"].mpifc
+    def setup_build_environment(self, env):
+        env.set("CXX", self.spec["mpi"].mpicxx)
+        env.set("FC", self.spec["mpi"].mpifc)
         # openmp is enabled by default
-        if spec.satisfies("~openmp"):
-            os.environ["openmp"] = "no"
-        if spec.satisfies("+proj"):
-            os.environ["proj"] = "yes"
-            os.environ["SW4ROOT"] = spec["proj"].prefix
-        if spec.satisfies("+hdf5"):
-            os.environ["hdf5"] = "yes"
-            os.environ["HDF5ROOT"] = spec["hdf5"].prefix
-        if spec.satisfies("+zfp"):
-            os.environ["zfp"] = "yes"
-            os.environ["ZFPROOT"] = spec["zfp"].prefix
-            os.environ["H5ZROOT"] = spec["h5z-zfp"].prefix
-        if spec.satisfies("+fftw"):
-            os.environ["fftw"] = "yes"
-            os.environ["FFTWHOME"] = spec["fftw"].prefix
-        if spec.satisfies("+debug"):
-            os.environ["debug"] = "yes"
+        if self.spec.satisfies("~openmp"):
+            env.set("openmp", "no")
+        if self.spec.satisfies("+proj"):
+            env.set("proj", "yes")
+            env.set("SW4ROOT", self.spec["proj"].prefix)
+        if self.spec.satisfies("+hdf5"):
+            env.set("hdf5", "yes")
+            env.set("HDF5ROOT", self.spec["hdf5"].prefix)
+        if self.spec.satisfies("+zfp"):
+            env.set("zfp", "yes")
+            env.set("ZFPROOT", self.spec["zfp"].prefix)
+            env.set("H5ZROOT", self.spec["h5z-zfp"].prefix)
+        if self.spec.satisfies("+fftw"):
+            env.set("fftw", "yes")
+            env.set("FFTWHOME", self.spec["fftw"].prefix)
+        if self.spec.satisfies("+debug"):
+            env.set("debug", "yes")
         os.environ["EXTRA_LINK_FLAGS"] = "-lstdc++ -lm -ldl "
-        os.environ["EXTRA_LINK_FLAGS"] += spec["blas"].libs.ld_flags + " "
-        os.environ["EXTRA_LINK_FLAGS"] += spec["lapack"].libs.ld_flags + " "
-        if spec.satisfies("%apple-clang +openmp"):
-            os.environ["EXTRA_LINK_FLAGS"] += spec["llvm-openmp"].libs.ld_flags + " "
+        os.environ["EXTRA_LINK_FLAGS"] += self.spec["blas"].libs.ld_flags + " "
+        os.environ["EXTRA_LINK_FLAGS"] += self.spec["lapack"].libs.ld_flags + " "
+        if self.spec.satisfies("%apple-clang +openmp"):
+            os.environ["EXTRA_LINK_FLAGS"] += self.spec["llvm-openmp"].libs.ld_flags + " "
         # From spack/trilinos
-        if spec.satisfies("%gcc") or spec.satisfies("%clang") or spec.satisfies("%apple-clang"):
+        if (
+            self.spec.satisfies("%gcc")
+            or self.spec.satisfies("%clang")
+            or self.spec.satisfies("%apple-clang")
+        ):
             fc = Executable(self.compiler.fc)
             libgfortran = fc("--print-file-name", "libgfortran." + dso_suffix, output=str).strip()
             if libgfortran == "libgfortran." + dso_suffix:


### PR DESCRIPTION
Some changes to the sw4 package:

- Fixing the build options so that they are enabled/disabled based on the variants that are enabled/disabled
- Adding a debug variant for building with debugging symbols
- Adding the prefix for lapack libraries (there was a duplicate for blas libraries)
- Adding dependency version constraints based on recommendations in the installation guide
- Restricting the zfp variant to show only when the hdf5 variant is enabled, because the zfp build option requires hdf5
- Adding license information