### PR TITLE
Bug Fix: Better incremental check for CMake

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -461,9 +461,10 @@ class CMakeBuilder(BuilderWithDefaults):
         # skip cmake phase if it is an incremental develop build
         # These are the files that will re-run CMake that are generated from a successful
         # configure step
-        if self.generator == "Unix Makefiles":
+        primary_generator = _extract_primary_generator(self.generator)
+        if primary_generator == "Unix Makefiles":
             configure_artifact = "Makefile"
-        elif self.generator == "Ninja":
+        elif primary_generator == "Ninja":
             configure_artifact = "ninja.build"
 
         if spec.is_develop and os.path.isfile(

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -461,9 +461,13 @@ class CMakeBuilder(BuilderWithDefaults):
         # skip cmake phase if it is an incremental develop build
         # These are the files that will re-run CMake that are generated from a successful
         # configure step
-        if spec.is_develop and (
-            os.path.isfile(os.path.join(self.build_directory, "Makefile"))
-            or os.path.isfile(os.path.join(self.build_directory, "ninja.build"))
+        if self.generator == "Unix Makefiles":
+           configure_artifact = "Makefile" 
+        elif self.generator == "Ninja":
+           configure_artifact = "ninja.build" 
+
+        if spec.is_develop and os.path.isfile(
+            os.path.join(self.build_directory, configure_artifact)
         ):
             return
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -462,8 +462,8 @@ class CMakeBuilder(BuilderWithDefaults):
         # These are the files that will re-run CMake that are generated from a successful
         # configure step
         if spec.is_develop and (
-            os.path.isfile(os.path.join(self.build_directory, "Makefile") or
-            os.path.isfile(os.path.join(self.build_directory, "ninja.build")
+            os.path.isfile(os.path.join(self.build_directory, "Makefile"))
+            or os.path.isfile(os.path.join(self.build_directory, "ninja.build"))
         ):
             return
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -459,8 +459,11 @@ class CMakeBuilder(BuilderWithDefaults):
         """Runs ``cmake`` in the build directory"""
 
         # skip cmake phase if it is an incremental develop build
-        if spec.is_develop and os.path.isfile(
-            os.path.join(self.build_directory, "CMakeCache.txt")
+        # These are the files that will re-run CMake that are generated from a successful
+        # configure step
+        if spec.is_develop and (
+            os.path.isfile(os.path.join(self.build_directory, "Makefile") or
+            os.path.isfile(os.path.join(self.build_directory, "ninja.build")
         ):
             return
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -462,9 +462,9 @@ class CMakeBuilder(BuilderWithDefaults):
         # These are the files that will re-run CMake that are generated from a successful
         # configure step
         if self.generator == "Unix Makefiles":
-           configure_artifact = "Makefile" 
+            configure_artifact = "Makefile"
         elif self.generator == "Ninja":
-           configure_artifact = "ninja.build" 
+            configure_artifact = "ninja.build"
 
         if spec.is_develop and os.path.isfile(
             os.path.join(self.build_directory, configure_artifact)


### PR DESCRIPTION
Provide a more robust check that CMake successfully configured the project before attempting to skip configure for development cycles

Resolves: #48770 
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
