### PR TITLE
`spack config change`: use default modify scope if no scope contains key

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -350,9 +350,12 @@ def _config_change(config_path, match_spec_str=None):
                 if spack.config.get(key_path, scope=scope):
                     ideal_scope_to_modify = scope
                     break
+            # If we find our key in a specific scope, that's the one we want
+            # to modify. Otherwise we use the default write scope.
+            write_scope = ideal_scope_to_modify or spack.config.default_modify_scope()
 
             update_path = f"{key_path}:[{str(spec)}]"
-            spack.config.add(update_path, scope=ideal_scope_to_modify)
+            spack.config.add(update_path, scope=write_scope)
     else:
         raise ValueError("'config change' can currently only change 'require' sections")
 


### PR DESCRIPTION
This extracts a small piece of https://github.com/spack/spack/pull/48704 that fixes an annoyance with `spack config change`:

If you use `spack config change` to modify a `require:` section that did not exist before, Spack was inserting the merged configuration into the highest modification scope (which for example would clutter the environment's `spack.yaml` with a bunch of configuration details from the defaults).