### PR TITLE
Add py-zarr 3

### DIFF
--- a/var/spack/repos/builtin/packages/py-donfig/package.py
+++ b/var/spack/repos/builtin/packages/py-donfig/package.py
@@ -1,0 +1,24 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyDonfig(PythonPackage):
+    """Donfig is a python library making package and script configuration easy"""
+
+    homepage = "https://donfig.readthedocs.io/en/latest/"
+    pypi = "donfig/donfig-0.8.1.post1.tar.gz"
+
+    maintainers("Chrismarsh")
+
+    license("MIT", checked_by="Chrismarsh")
+
+    version(
+        "0.8.1.post1", sha256="3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52"
+    )
+
+    depends_on("py-setuptools@62.6:", type="build")
+    depends_on("py-versioneer@0.28: +toml")
+    depends_on("py-pyyaml", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-numcodecs/package.py
+++ b/var/spack/repos/builtin/packages/py-numcodecs/package.py
@@ -23,6 +23,11 @@ class PyNumcodecs(PythonPackage):
 
     version("main", branch="main", submodules=True)
     version("master", branch="main", submodules=True, deprecated=True)
+    version(
+        "0.15.0",
+        sha256="52fb0c20d99845ef600eb3f8c8ad3e22fe2cb4f2a53394d331210af7cc3375ca",
+        preferred=True,
+    )
     version("0.13.0", sha256="ba4fac7036ea5a078c7afe1d4dffeb9685080d42f19c9c16b12dad866703aa2e")
     version("0.12.1", sha256="05d91a433733e7eef268d7e80ec226a0232da244289614a8f3826901aec1098e")
     version("0.12.0", sha256="6388e5f4e94d18a7165fbd1c9d3637673b74157cff8bc644005f9e2a4c717d6e")
@@ -49,7 +54,7 @@ class PyNumcodecs(PythonPackage):
     depends_on("py-entrypoints", when="@0.10.1:0.11", type=("build", "run"))
     depends_on("py-msgpack", type=("build", "run"), when="+msgpack")
 
-    patch("apple-clang-12.patch", when="%apple-clang@12:")
+    patch("apple-clang-12.patch", when="%apple-clang@12: @:0.13")
 
     # TODO: this package should really depend on blosc, zstd, lz4, zlib, but right now it vendors
     # those libraries without any way to use the system versions.

--- a/var/spack/repos/builtin/packages/py-zarr/package.py
+++ b/var/spack/repos/builtin/packages/py-zarr/package.py
@@ -14,6 +14,7 @@ class PyZarr(PythonPackage):
 
     license("MIT")
 
+    version("3.0.1", sha256="033859c5603dc9c29e53af494ede24b42f1b761d2bb625466990a3b8a9afb792")
     version("2.17.0", sha256="6390a2b8af31babaab4c963efc45bf1da7f9500c9aafac193f84cf019a7c66b0")
     version("2.10.2", sha256="5c6ae914ab9215631bb95c09e76b9b9b4fffa70fec0c7bca26b68387d858ebe2")
     version("2.6.1", sha256="fa7eac1e4ff47ff82d09c42bb4679e18e8a05a73ee81ce59cee6a441a210b2fd")
@@ -21,21 +22,33 @@ class PyZarr(PythonPackage):
     version("2.4.0", sha256="53aa21b989a47ddc5e916eaff6115b824c0864444b1c6f3aaf4f6cf9a51ed608")
     version("2.3.2", sha256="c62d0158fb287151c978904935a177b3d2d318dea3057cfbeac8541915dfa105")
 
-    depends_on("python@3.9:", type=("build", "run"), when="@2.17:")
-    depends_on("python@3.7:3", type=("build", "run"), when="@2.10")
-    depends_on("py-setuptools@64:", type="build", when="@2.17:")
-    depends_on("py-setuptools@38.6.0:", type="build", when="@2.4.0:")
-    depends_on("py-setuptools@18.0:", type="build")
-    depends_on("py-setuptools-scm@1.5.5:", type="build")
-    depends_on("py-asciitree", type=("build", "run"))
-    depends_on("py-numpy@1.21.1:", type=("build", "run"), when="@2.17:")
-    depends_on("py-numpy@1.7:", type=("build", "run"))
-    # https://github.com/zarr-developers/zarr-python/issues/1818
-    depends_on("py-numpy@:1", when="@:2.17", type=("build", "run"))
-    depends_on("py-fasteners", type=("build", "run"))
-    depends_on("py-numcodecs@0.10:", type=("build", "run"), when="@2.17:")
-    depends_on("py-numcodecs@0.6.4:", type=("build", "run"), when="@2.4.0:")
-    depends_on("py-numcodecs@0.6.2:", type=("build", "run"))
+    with when("@:2"):
+        depends_on("python@3.9:", type=("build", "run"), when="@2.17:")
+        depends_on("python@3.7:3", type=("build", "run"), when="@2.10")
+        depends_on("py-setuptools@64:", type="build", when="@2.17:")
+        depends_on("py-setuptools@38.6.0:", type="build", when="@2.4.0:")
+        depends_on("py-setuptools@18.0:", type="build")
+        depends_on("py-setuptools-scm@1.5.5:", type="build")
 
-    # Historical dependencies
-    depends_on("py-msgpack", type=("build", "run"), when="@:2.3.2")
+        depends_on("py-asciitree", type=("build", "run"))
+        depends_on("py-numpy@1.21.1:", type=("build", "run"), when="@2.17:")
+        depends_on("py-numpy@1.7:", type=("build", "run"))
+        # https://github.com/zarr-developers/zarr-python/issues/1818
+        depends_on("py-numpy@:1", when="@:2.17", type=("build", "run"))
+        depends_on("py-fasteners", type=("build", "run"))
+        depends_on("py-numcodecs@0.10:", type=("build", "run"), when="@2.17:")
+        depends_on("py-numcodecs@0.6.4:", type=("build", "run"), when="@2.4.0:")
+        depends_on("py-numcodecs@0.6.2:", type=("build", "run"))
+
+        # Historical dependencies
+        depends_on("py-msgpack", type=("build", "run"), when="@:2.3.2")
+
+    with when("@3:"):
+        depends_on("python@3.11:", type=("build", "run"))
+        depends_on("py-hatchling", type="build")
+        depends_on("py-hatch-vcs", type="build")
+        depends_on("py-packaging@:22.0", type=("build", "run"))
+        depends_on("py-numpy@0.14:", type=("build", "run"))
+        depends_on("py-numcodecs@0.14:", type=("build", "run"))
+        depends_on("py-typing-extensions@4.9:", type=("build", "run"))
+        depends_on("py-donfig@0.8:", type=("build", "run"))


### PR DESCRIPTION
- Add `py-zarr@3`
- Add new required for `py-zarr@3` package `py-donfig`
- bug fix `py-numcodecs` patch range as the patch no longer applies post `@13` and does not apply to `main`
- add new version of `py-numcodecs` and set it is as the prefered so that `@main` is not installed by default
