### PR TITLE
abinit: fix typo resulting in bare tuple and ignored option

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -179,7 +179,7 @@ class Abinit(AutotoolsPackage):
             if spec.satisfies("@:8"):
                 oapp("--with-dft-flavor=atompaw+libxc")
             else:
-                "--without-wannier90",
+                oapp("--without-wannier90")
 
         if spec.satisfies("+mpi"):
             oapp(f"CC={spec['mpi'].mpicc}")


### PR DESCRIPTION
Someone apparently left `"--without-wannier",` lying around after a refactor.

Update it so that it's actually added as an option when needed.
