### PR TITLE
packages: remove useless trailing commas

### DIFF
--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -150,7 +150,7 @@ class Elemental(CMakePackage):
                     ),
                     "-DCUSTOM_BLAS_SUFFIX:BOOL=TRUE",
                 ]
-            ),
+            )
             if spec.satisfies("+scalapack"):
                 args.extend(
                     [
@@ -159,7 +159,7 @@ class Elemental(CMakePackage):
                         ),
                         "-DCUSTOM_LAPACK_SUFFIX:BOOL=TRUE",
                     ]
-                ),
+                )
         else:
             math_libs = spec["lapack"].libs + spec["blas"].libs
 

--- a/var/spack/repos/builtin/packages/embree/package.py
+++ b/var/spack/repos/builtin/packages/embree/package.py
@@ -80,7 +80,7 @@ class Embree(CMakePackage):
             avx512_suffix = ""
             if spec.satisfies("@:3.12"):
                 avx512_suffix = "SKX"
-            args.append(self.define("EMBREE_ISA_AVX512" + avx512_suffix, True)),
+            args.append(self.define("EMBREE_ISA_AVX512" + avx512_suffix, True))
             if spec.satisfies("%gcc@:7"):
                 # remove unsupported -mprefer-vector-width=256, otherwise copied
                 # from common/cmake/gnu.cmake

--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -173,7 +173,7 @@ class FoamExtend(Package):
         if minimal:
             # pre-build or minimal environment
             tty.info("foam-extend minimal env {0}".format(self.prefix))
-            env.set("FOAM_INST_DIR", os.path.dirname(self.projectdir)),
+            env.set("FOAM_INST_DIR", os.path.dirname(self.projectdir))
             env.set("FOAM_PROJECT_DIR", self.projectdir)
             env.set("WM_PROJECT_DIR", self.projectdir)
             for d in ["wmake", self.archbin]:  # bin added automatically

--- a/var/spack/repos/builtin/packages/gurobi/package.py
+++ b/var/spack/repos/builtin/packages/gurobi/package.py
@@ -53,7 +53,7 @@ class Gurobi(Package):
     def setup_run_environment(self, env):
         env.set("GUROBI_HOME", self.prefix)
         env.set("GRB_LICENSE_FILE", join_path(self.prefix, "gurobi.lic"))
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib),
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
 
     def install(self, spec, prefix):
         install_tree("linux64", prefix)

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -667,12 +667,12 @@ class Hip(CMakePackage):
         if self.spec.satisfies("@5.6.0:"):
             args.append(self.define("ROCCLR_PATH", self.stage.source_path + "/clr/rocclr"))
             args.append(self.define("AMD_OPENCL_PATH", self.stage.source_path + "/clr/opencl"))
-            args.append(self.define("CLR_BUILD_HIP", True)),
-            args.append(self.define("CLR_BUILD_OCL", False)),
+            args.append(self.define("CLR_BUILD_HIP", True))
+            args.append(self.define("CLR_BUILD_OCL", False))
         if self.spec.satisfies("@5.6:5.7"):
-            args.append(self.define("HIPCC_BIN_DIR", self.stage.source_path + "/hipcc/bin")),
+            args.append(self.define("HIPCC_BIN_DIR", self.stage.source_path + "/hipcc/bin"))
         if self.spec.satisfies("@6.0:"):
-            args.append(self.define("HIPCC_BIN_DIR", self.spec["hipcc"].prefix.bin)),
+            args.append(self.define("HIPCC_BIN_DIR", self.spec["hipcc"].prefix.bin))
         return args
 
     test_src_dir_old = "samples"

--- a/var/spack/repos/builtin/packages/openradioss-engine/package.py
+++ b/var/spack/repos/builtin/packages/openradioss-engine/package.py
@@ -110,10 +110,10 @@ class OpenradiossEngine(CMakePackage):
         )
         install_tree(
             join_path(self.stage.source_path, "hm_cfg_files"), join_path(prefix, "hm_cfg_files")
-        ),
+        )
         install_tree(
             join_path(self.stage.source_path, "extlib", "h3d"), join_path(prefix, "extlib", "h3d")
-        ),
+        )
         install_tree(
             join_path(self.stage.source_path, "extlib", "hm_reader"),
             join_path(prefix, "extlib", "hm_reader"),

--- a/var/spack/repos/builtin/packages/openradioss-starter/package.py
+++ b/var/spack/repos/builtin/packages/openradioss-starter/package.py
@@ -96,10 +96,10 @@ class OpenradiossStarter(CMakePackage):
         )
         install_tree(
             join_path(self.stage.source_path, "hm_cfg_files"), join_path(prefix, "hm_cfg_files")
-        ),
+        )
         install_tree(
             join_path(self.stage.source_path, "extlib", "h3d"), join_path(prefix, "extlib", "h3d")
-        ),
+        )
         install_tree(
             join_path(self.stage.source_path, "extlib", "hm_reader"),
             join_path(prefix, "extlib", "hm_reader"),

--- a/var/spack/repos/builtin/packages/rocm-opencl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl/package.py
@@ -210,7 +210,7 @@ class RocmOpencl(CMakePackage):
             env.set("LDFLAGS", "-fuse-ld=lld")
 
     def setup_run_environment(self, env):
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib),
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
         env.set("OCL_ICD_VENDORS", self.prefix.vendors + "/")
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -599,8 +599,8 @@ class RocmOpenmpExtras(Package):
                 "-DNUMACTL_DIR={0}".format(numactl_prefix),
             ]
         if self.spec.satisfies("@:6.2"):
-            "-DHSAKMT_LIB={0}/lib".format(hsakmt_prefix),
-            "-DHSAKMT_LIB64={0}/lib64".format(hsakmt_prefix),
+            "-DHSAKMT_LIB={0}/lib".format(hsakmt_prefix)
+            "-DHSAKMT_LIB64={0}/lib64".format(hsakmt_prefix)
 
         components["openmp"] = ["../rocm-openmp-extras/llvm-project/openmp"]
         components["openmp"] += openmp_common_args

--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -154,8 +154,8 @@ class RocmValidationSuite(CMakePackage):
             self.define("UT_INC", self.spec["googletest"].prefix.include),
         ]
         if self.spec.satisfies("@6.2.1:"):
-            args.append(self.define("HIPRAND_DIR", self.spec["hiprand"].prefix)),
-            args.append(self.define("ROCRAND_DIR", self.spec["rocrand"].prefix)),
+            args.append(self.define("HIPRAND_DIR", self.spec["hiprand"].prefix))
+            args.append(self.define("ROCRAND_DIR", self.spec["rocrand"].prefix))
         libloc = self.spec["googletest"].prefix.lib64
         if not os.path.isdir(libloc):
             libloc = self.spec["googletest"].prefix.lib


### PR DESCRIPTION
Some stray commas will result in two statements being interpreted (harmlessly, but still undesirably) as tuples. 
Remove them.
