### PR TITLE
spack.package: re-export EnvironmentModifications / Prefix

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -136,7 +136,6 @@ from spack.package_completions import (
 from spack.phase_callbacks import run_after, run_before
 from spack.spec import Spec
 
-# These props will be overridden when the build env is set up.
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable, ProcessError, which, which_string
 from spack.util.filesystem import fix_darwin_install_name

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -135,7 +135,6 @@ from spack.package_completions import (
 )
 from spack.phase_callbacks import run_after, run_before
 from spack.spec import Spec
-
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable, ProcessError, which, which_string
 from spack.util.filesystem import fix_darwin_install_name

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -49,7 +49,6 @@ from llnl.util.filesystem import (
 )
 from llnl.util.symlink import symlink
 
-# These props will be overridden when the build env is set up.
 from spack.build_environment import MakeExecutable
 from spack.build_systems.aspell_dict import AspellDictPackage
 from spack.build_systems.autotools import AutotoolsPackage
@@ -136,6 +135,9 @@ from spack.package_completions import (
 )
 from spack.phase_callbacks import run_after, run_before
 from spack.spec import Spec
+
+# These props will be overridden when the build env is set up.
+from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable, ProcessError, which, which_string
 from spack.util.filesystem import fix_darwin_install_name
 from spack.variant import any_combination_of, auto_or_any_combination_of, disjoint_sets

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -140,6 +140,7 @@ from spack.spec import Spec
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable, ProcessError, which, which_string
 from spack.util.filesystem import fix_darwin_install_name
+from spack.util.prefix import Prefix
 from spack.variant import any_combination_of, auto_or_any_combination_of, disjoint_sets
 from spack.version import Version, ver
 

--- a/var/spack/repos/builtin/packages/anaconda3/package.py
+++ b/var/spack/repos/builtin/packages/anaconda3/package.py
@@ -6,7 +6,6 @@ import platform
 from os.path import split
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Anaconda3(Package):

--- a/var/spack/repos/builtin/packages/aocl-da/package.py
+++ b/var/spack/repos/builtin/packages/aocl-da/package.py
@@ -5,7 +5,6 @@
 import os
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class AoclDa(CMakePackage):

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -8,7 +8,6 @@ import spack.paths
 import spack.user_environment
 from spack.package import *
 from spack.pkg.builtin.clingo import Clingo
-from spack.util.environment import EnvironmentModifications
 
 
 class ClingoBootstrap(Clingo):

--- a/var/spack/repos/builtin/packages/conda4aarch64/package.py
+++ b/var/spack/repos/builtin/packages/conda4aarch64/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Conda4aarch64(Package):

--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -41,7 +41,6 @@ from spack.pkg.builtin.openfoam import (
     rewrite_environ_files,
     write_environ,
 )
-from spack.util.environment import EnvironmentModifications
 
 
 class FoamExtend(Package):

--- a/var/spack/repos/builtin/packages/freesurfer/package.py
+++ b/var/spack/repos/builtin/packages/freesurfer/package.py
@@ -6,7 +6,6 @@ import glob
 import os
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Freesurfer(Package):

--- a/var/spack/repos/builtin/packages/fsl/package.py
+++ b/var/spack/repos/builtin/packages/fsl/package.py
@@ -7,7 +7,6 @@ import os
 
 import spack.util.environment
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Fsl(Package, CudaPackage):

--- a/var/spack/repos/builtin/packages/heasoft/package.py
+++ b/var/spack/repos/builtin/packages/heasoft/package.py
@@ -7,7 +7,6 @@ import os
 import llnl.util.tty as tty
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Heasoft(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -8,7 +8,6 @@ import re
 import spack.build_environment
 from spack.hooks.sbang import filter_shebang
 from spack.package import *
-from spack.util.prefix import Prefix
 
 
 class Hip(CMakePackage):

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -7,7 +7,6 @@ import platform
 
 from spack.build_environment import dso_suffix
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 versions = [
     {

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -6,7 +6,6 @@ import os
 import re
 
 from spack.package import *
-from spack.util.prefix import Prefix
 
 
 class Jdk(Package):

--- a/var/spack/repos/builtin/packages/miniconda2/package.py
+++ b/var/spack/repos/builtin/packages/miniconda2/package.py
@@ -5,7 +5,6 @@
 from os.path import split
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Miniconda2(Package):

--- a/var/spack/repos/builtin/packages/miniconda3/package.py
+++ b/var/spack/repos/builtin/packages/miniconda3/package.py
@@ -6,7 +6,6 @@ import platform
 from os.path import split
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 _versions = {
     "24.7.1": {

--- a/var/spack/repos/builtin/packages/miniforge3/package.py
+++ b/var/spack/repos/builtin/packages/miniforge3/package.py
@@ -6,7 +6,6 @@ import platform
 from os.path import split
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 _versions = {
     "24.3.0-0": {

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -7,7 +7,6 @@
 import platform
 
 from spack.package import *
-from spack.util.prefix import Prefix
 
 # FIXME Remove hack for polymorphic versions
 # This package uses a ugly hack to be able to dispatch, given the same

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -48,7 +48,6 @@ from spack.pkg.builtin.openfoam import (
     rewrite_environ_files,
     write_environ,
 )
-from spack.util.environment import EnvironmentModifications
 
 
 class OpenfoamOrg(Package):

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -47,7 +47,6 @@ import llnl.util.tty as tty
 
 from spack.package import *
 from spack.pkg.builtin.boost import Boost
-from spack.util.environment import EnvironmentModifications
 
 # Not the nice way of doing things, but is a start for refactoring
 __all__ = [

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -7,7 +7,6 @@ import platform
 import re
 
 from spack.package import *
-from spack.util.prefix import Prefix
 
 # If you need to add a new version, please be aware that:
 #  - versions in the following dict are automatically added to the package

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -18,7 +18,6 @@ from llnl.util.lang import dedupe
 import spack.paths
 from spack.build_environment import dso_suffix, stat_suffix
 from spack.package import *
-from spack.util.prefix import Prefix
 
 
 def make_pyvenv_cfg(python_spec: Spec, venv_prefix: str) -> str:

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -6,7 +6,6 @@
 import os
 import sys
 
-import spack.util.environment
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *
 from spack.util.environment import is_system_path
@@ -848,9 +847,7 @@ class Root(CMakePackage):
         if "+rpath" not in self.spec:
             env.prepend_path(self.root_library_path, self.prefix.lib.root)
 
-    def setup_dependent_build_environment(
-        self, env: spack.util.environment.EnvironmentModifications, dependent_spec
-    ):
+    def setup_dependent_build_environment(self, env: EnvironmentModifications, dependent_spec):
         env.set("ROOTSYS", self.prefix)
         env.set("ROOT_VERSION", "v{0}".format(self.version.up_to(1)))
         env.prepend_path("PYTHONPATH", self.prefix.lib.root)
@@ -863,9 +860,7 @@ class Root(CMakePackage):
             # Newer deployment targets cause fatal errors in rootcling
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 
-    def setup_dependent_run_environment(
-        self, env: spack.util.environment.EnvironmentModifications, dependent_spec
-    ):
+    def setup_dependent_run_environment(self, env: EnvironmentModifications, dependent_spec):
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
         # For dependents that build dictionaries, ROOT needs to know where the
         # dictionaries have been installed.  This can be facilitated by


### PR DESCRIPTION
`EnvironmentModifications` and `Prefix` are both names that are essentially already part of the package API, because they're typed in phase functions like `def build(self, spec, prefix: Prefix)` and `def setup_run_environment(self, env: EnvironmentModifications)`.

Since they're also used in some packages directly, let's export them as public API.