### PR TITLE
spack.package: wrap llnl.util.tty

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -13,6 +13,17 @@ from shutil import move, rmtree
 # import most common types used in packages
 from typing import Dict, List, Optional
 
+
+class tty:
+    import llnl.util.tty as __tty
+
+    debug = __tty.debug
+    error = __tty.error
+    info = __tty.info
+    msg = __tty.msg
+    warn = __tty.warn
+
+
 from llnl.util.filesystem import (
     FileFilter,
     FileList,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -15,13 +15,13 @@ from typing import Dict, List, Optional
 
 
 class tty:
-    import llnl.util.tty as __tty
+    import llnl.util.tty as _tty
 
-    debug = __tty.debug
-    error = __tty.error
-    info = __tty.info
-    msg = __tty.msg
-    warn = __tty.warn
+    debug = _tty.debug
+    error = _tty.error
+    info = _tty.info
+    msg = _tty.msg
+    warn = _tty.warn
 
 
 from llnl.util.filesystem import (

--- a/var/spack/repos/builtin/packages/additivefoam/package.py
+++ b/var/spack/repos/builtin/packages/additivefoam/package.py
@@ -5,8 +5,6 @@
 import inspect
 import os
 
-import llnl.util.tty as tty
-
 import spack.pkg.builtin.openfoam as openfoam
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from llnl.util import tty
 
 from spack.package import *
 from spack.pkg.builtin.llvm import LlvmDetection

--- a/var/spack/repos/builtin/packages/apcomp/package.py
+++ b/var/spack/repos/builtin/packages/apcomp/package.py
@@ -6,8 +6,6 @@
 import os
 import socket
 
-import llnl.util.tty as tty
-
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/arkouda/package.py
+++ b/var/spack/repos/builtin/packages/arkouda/package.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.util.environment import set_env
 

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -9,8 +9,6 @@ import socket
 import sys
 from os import environ as env
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -5,8 +5,6 @@
 import glob
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.pkg.builtin.boost import Boost
 

--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.package_test import compare_output
 from spack.pkg.builtin.boost import Boost

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -8,8 +8,6 @@ import shutil
 import socket
 from os import environ as env
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -7,8 +7,6 @@ import platform
 import re
 from glob import glob
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 # FIXME Remove hack for polymorphic versions
@@ -741,7 +739,7 @@ class Cuda(Package):
                 os.remove("/tmp/cuda-installer.log")
             except OSError:
                 if spec.satisfies("@10.1:"):
-                    tty.die(
+                    raise InstallError(
                         "The cuda installer will segfault due to the "
                         "presence of /tmp/cuda-installer.log "
                         "please remove the file and try again "

--- a/var/spack/repos/builtin/packages/dray/package.py
+++ b/var/spack/repos/builtin/packages/dray/package.py
@@ -5,8 +5,6 @@
 import os
 import socket
 
-import llnl.util.tty as tty
-
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/fasta/package.py
+++ b/var/spack/repos/builtin/packages/fasta/package.py
@@ -41,7 +41,7 @@ class Fasta(MakefilePackage):
         elif self.spec.satisfies("platform=linux target=x86_64:"):
             name = "Makefile.linux64_sse2"
         else:
-            tty.die(
+            raise InstallError(
                 """Unsupported platform/target, must be
 Darwin (assumes 64-bit)
 Linux x86_64

--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -32,8 +32,6 @@ import glob
 import os
 import re
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.pkg.builtin.openfoam import (
     OpenfoamArch,

--- a/var/spack/repos/builtin/packages/freeipmi/package.py
+++ b/var/spack/repos/builtin/packages/freeipmi/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/gaussian-view/package.py
+++ b/var/spack/repos/builtin/packages/gaussian-view/package.py
@@ -5,8 +5,6 @@
 
 import os
 
-import llnl.util.tty as tty
-
 import spack.tengine
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/gcc-runtime/package.py
+++ b/var/spack/repos/builtin/packages/gcc-runtime/package.py
@@ -8,8 +8,6 @@ import re
 
 from macholib import MachO, mach_o
 
-from llnl.util import tty
-
 from spack.package import *
 from spack.util.elf import delete_needed_from_elf, parse_elf
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -7,7 +7,6 @@ import sys
 
 import archspec.cpu
 
-import llnl.util.tty as tty
 from llnl.util.symlink import readlink
 
 import spack.compiler

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -8,7 +8,6 @@ import shutil
 import sys
 
 import llnl.util.lang
-import llnl.util.tty as tty
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/heasoft/package.py
+++ b/var/spack/repos/builtin/packages/heasoft/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.util.environment import EnvironmentModifications
 

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -6,8 +6,6 @@ import configparser
 import os
 import tempfile
 
-import llnl.util.tty as tty
-
 import spack.build_systems.autotools
 import spack.build_systems.meson
 from spack.package import *

--- a/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
-from llnl.util import tty
-
 from spack.package import *
 from spack.pkg.builtin.gcc_runtime import get_elf_libraries
 

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import re
 
-import llnl.util.tty as tty
-
 import spack.compiler
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -4,8 +4,6 @@
 
 import subprocess
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libsodium/package.py
+++ b/var/spack/repos/builtin/packages/libsodium/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -5,8 +5,6 @@
 import glob
 import os
 
-import llnl.util.tty as tty
-
 import spack.tengine
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/linux-perf/package.py
+++ b/var/spack/repos/builtin/packages/linux-perf/package.py
@@ -7,8 +7,6 @@ import re
 import shutil
 from textwrap import dedent
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -5,8 +5,6 @@ import os
 import re
 import sys
 
-import llnl.util.tty as tty
-
 from spack.build_systems.cmake import get_cmake_prefix_path
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -5,7 +5,6 @@ import os
 import re
 import sys
 
-import llnl.util.tty as tty
 from llnl.util.lang import classproperty
 
 import spack.compilers

--- a/var/spack/repos/builtin/packages/mercurial/package.py
+++ b/var/spack/repos/builtin/packages/mercurial/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from llnl.util import tty
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -6,8 +6,6 @@ import os
 import platform
 import sys
 
-import llnl.util.tty as tty
-
 from spack.build_environment import optimization_flags
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 
@@ -192,7 +190,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         else:
             # To be foolproof, fail with a proper error message
             # if neither FFTW nor MKL are in the dependency tree.
-            tty.die(
+            raise InstallError(
                 'Unsupported "fftw-api" provider, '
                 "currently only FFTW and MKL are supported.\n"
                 "Please report this issue on Spack's repository."

--- a/var/spack/repos/builtin/packages/of-precice/package.py
+++ b/var/spack/repos/builtin/packages/of-precice/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.pkg.builtin.openfoam import add_extra_files
 

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -38,8 +38,6 @@ import glob
 import os
 import re
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.pkg.builtin.openfoam import (
     OpenfoamArch,

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -43,8 +43,6 @@ import glob
 import os
 import re
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.pkg.builtin.boost import Boost
 from spack.util.environment import EnvironmentModifications

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -7,8 +7,6 @@ import os
 import re
 import sys
 
-import llnl.util.tty as tty
-
 import spack.compilers
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/openpbs/package.py
+++ b/var/spack/repos/builtin/packages/openpbs/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -5,8 +5,6 @@
 import os
 import re
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/oras/package.py
+++ b/var/spack/repos/builtin/packages/oras/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
 
 from spack.package import *
 
@@ -43,6 +42,6 @@ class Oras(Package):
 
         oras = find("bin", "oras")
         if not oras:
-            tty.die("Oras executable missing in bin.")
+            raise InstallError("Oras executable missing in bin.")
         tty.debug("Found oras executable %s to move into install bin" % oras[0])
         install(oras[0], prefix.bin)

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #
-import llnl.util.tty as tty
+
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
 
 import spack.hooks.sbang as sbang
 from spack.package import *

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -12,7 +12,6 @@ import sys
 from shutil import copy
 from typing import Dict, List
 
-import llnl.util.tty as tty
 from llnl.util.lang import dedupe
 
 import spack.paths

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -8,8 +8,6 @@ import shutil
 import sys
 import tempfile
 
-import llnl.util.tty as tty
-
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -6,8 +6,6 @@ import os
 import platform
 import sys
 
-import llnl.util.tty as tty
-
 from spack.operating_systems.linux_distro import kernel_version
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *

--- a/var/spack/repos/builtin/packages/rpm/package.py
+++ b/var/spack/repos/builtin/packages/rpm/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/sarus/package.py
+++ b/var/spack/repos/builtin/packages/sarus/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -5,8 +5,6 @@
 import os
 import shutil
 
-import llnl.util.tty as tty
-
 import spack.tengine
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.util.environment import set_env
 

--- a/var/spack/repos/builtin/packages/swiftsim/package.py
+++ b/var/spack/repos/builtin/packages/swiftsim/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -8,8 +8,6 @@ import socket
 import sys
 from os import environ as env
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -10,8 +10,6 @@ from os.path import basename
 from pathlib import Path
 from subprocess import PIPE, Popen
 
-from llnl.util import tty
-
 from spack.package import *
 
 if sys.platform != "win32":

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -259,7 +259,7 @@ class Xrootd(CMakePackage):
         else:
             # The user has selected a (new?) legal value that we've
             # forgotten to deal with here.
-            tty.die(
+            raise InstallError(
                 "INTERNAL ERROR: cannot accommodate unexpected variant ",
                 "cxxstd={0}".format(self.spec.variants["cxxstd"].value),
             )


### PR DESCRIPTION
Many packages import `llnl.util.tty` which is an internal module.

This PR exposes

```python
class tty:
    info = llnl.util.tty.info
    ...
```

in `spack.package` instead.

`tty.die` is excluded, packages can already `raise InstallError`.