### PR TITLE
slurm-drmaa: remove patch on main

### DIFF
--- a/var/spack/repos/builtin/packages/slurm-drmaa/package.py
+++ b/var/spack/repos/builtin/packages/slurm-drmaa/package.py
@@ -27,13 +27,6 @@ class SlurmDrmaa(AutotoolsPackage):
 
     depends_on("c", type="build")  # generated
 
-    # Remove this patch when it is merged into main:
-    patch(
-        "https://github.com/natefoo/slurm-drmaa/pull/62.patch?full_index=1",
-        sha256="ec8d2963c731f7054f7d3c130232e731bc92366280100e108d93a3685fddfca7",
-        when="@main",
-    )
-
     depends_on("autoconf", type="build", when="@main")
     depends_on("automake", type="build", when="@main")
     depends_on("libtool", type="build", when="@main")


### PR DESCRIPTION
Patch got merged: https://github.com/natefoo/slurm-drmaa/pull/62

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
