### PR TITLE
setup-env.fish: fix version checking for completions

### DIFF
--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -788,8 +788,7 @@ end
 #
 set -l fish_version (string split '.' $FISH_VERSION)
 if test $fish_version[1] -gt 3
-    or test $fish_version[1] -eq 3
-    and test $fish_version[2] -ge 2
+    or begin ; test $fish_version[1] -eq 3 and test $fish_version[2] -ge 2 ; end
 
     source $sp_share_dir/spack-completion.fish
 end


### PR DESCRIPTION
I'm currently using` fish 4.0b1`, and the current version checking throws an error. It seems that the last condition, `and test $fish_version[2] -ge 2,` is always evaluated. This patch fixes the version checking code. 