### PR TITLE
[WIP] disable compiler mismatch for link deps

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1403,6 +1403,14 @@ compiler_mismatch(PackageNode, DependencyNode)
      not attr("node_compiler_set", DependencyNode, _),
      not compiler_match(PackageNode, DependencyNode).
 
+:- not allow_mismatch(1),
+  attr("depends_on", ParentNode, node(ID, DepName), "link"),
+  not compiler_mismatch_allowed(DepName),
+  not compiler_match(ParentNode, node(ID, DepName)).
+
+#defined allow_mismatch/1.
+#defined compiler_mismatch_allowed/1.
+
 compiler_mismatch_required(PackageNode, DependencyNode)
   :- depends_on(PackageNode, DependencyNode),
      attr("node_compiler_set", DependencyNode, _),


### PR DESCRIPTION
This not necessarily intended to be merged (in light of compilers-as-deps work), but I want to be able to influence concretization behavior at this level (including after that merges).

Currently the changes in this PR disable compiler mixing unconditionally for any X -> Y where Y is a link dependency,. The idea is that I could hook in config processing into the asp.py such that the added logic is only enabled if the user does

```
packages:
  dissallow_compiler_mismatch: True
```

I assume users might want to adjust this for individual packages like:

```
packages:
  compiler_mismatch_allowed: [mpich]
  dissallow_compiler_mismatch: True
```

In #45189, I think that would look like deriving `node_compiler` properties within `concretize.lp` (e.g. `node_compiler(...) :- depends_on(node(), x); is_compiler(x).`)

To emphasize, this isn't something that I think should be handled with weighting, I want to be able to easily concretize matrices of specs that include a compiler vector while disabling mixing in most cases, e.g.:

```
spack:
  specs:
  - matrix:
    - ["%clang", "%gcc"]
    - [umpire+mpi]
  view: true
  concretizer:
    unify: when_possible
  packages:
    mpi:
      buildable: false
    mpich:
      externals:
      - spec: mpich@=4.0.3%gcc
        prefix: /usr/
      - spec: mpich@=4.0.3%clang
        prefix: /usr/
```