### PR TITLE
fms: add 2025.01, 2024.03

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -18,6 +18,8 @@ class Fms(CMakePackage):
     license("LGPL-3.0-or-later")
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett", "rem1776", "climbfuji")
+    version("2025.01", sha256="19997ef5468a06c60c1e7af3a56ab7f8a33da814a30827293ca34df5bd888d6f")
+    version("2024.03", sha256="4c1e6bdfafcfec19a4a1c08770c313ab3135d47ec8319f6b07f24d2589caf44d")
     version("2024.02", sha256="47e5740bb066f5eb032e1de163eb762c7258880a2932f4cc4e34e769e0cc2b0e")
     version(
         "2024.01.01", sha256="41c8686bad2b1aed76275e35cbe1af855f7dfce9b6d8907744ea2e8174758f6a"
@@ -62,6 +64,13 @@ class Fms(CMakePackage):
         "https://github.com/NOAA-GFDL/FMS/commit/c9bba516ba1115d4a7660fba92f9d67cf3fd32ad.patch?full_index=1",
         sha256="07d5b68838bba61ee547bd4cd7c12d81228c91a80a966b8693694fa236d0ac30",
         when="@2023.03",
+    )
+
+    variant(
+        "portable_kinds",
+        description="Use iso_c_binding variable kinds",
+        when="@2025.01:",
+        default=False,
     )
 
     variant("shared", description="Build shared libraries", when="@2024.02:", default=False)
@@ -131,6 +140,7 @@ class Fms(CMakePackage):
             self.define_from_variant("OPENMP"),
             self.define_from_variant("ENABLE_QUAD_PRECISION", "quad_precision"),
             self.define_from_variant("SHARED_LIBS", "shared"),
+            self.define_from_variant("PORTABLE_KINDS", "portable_kinds"),
             self.define_from_variant("WITH_YAML", "yaml"),
             self.define_from_variant("CONSTANTS"),
             self.define_from_variant("LARGEFILE", "large_file"),


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds FMS 2025.01 and 2024.03. 

It also adds a new `portable_kinds` variant which enables the `-DPORTABLE_KINDS=ON` CMake option to allow use of...portable kinds (see https://github.com/NOAA-GFDL/FMS/pull/1572). This is only available from 2025.01 on.