### PR TITLE
vtk-m: CMAKE_CXX_COMPILER is not a BOOL

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -238,7 +238,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
                 os.environ["TBB_ROOT"] = spec["tbb"].prefix
 
             if "+kokkos" in spec and "+rocm" in spec and spec.satisfies("^kokkos@4:"):
-                options.append(f"-DCMAKE_CXX_COMPILER:BOOL={spec['hip'].prefix.bin.hipcc}")
+                options.append(f"-DCMAKE_CXX_COMPILER:FILEPATH={spec['hip'].prefix.bin.hipcc}")
 
             # Support for relocatable code
             if "~shared" in spec and "+fpic" in spec:


### PR DESCRIPTION
Stumbled upon this. Defining `CMAKE_CXX_COMPILER:BOOL` is incorrect, and should be `FILEPATH` type.