### PR TITLE
berkeleygw: add -o flag to tar extraction

### DIFF
--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -118,7 +118,7 @@ class Berkeleygw(MakefilePackage):
     def edit(self, spec, prefix):
         # archive is a tar file, despite the .gz expension
         tar = which("tar")
-        tar("-x", "-f", self.stage.archive_file, "--strip-components=1")
+        tar("-x", "-o", "-f", self.stage.archive_file, "--strip-components=1")
 
         # get generic arch.mk template
         if spec.satisfies("+mpi"):


### PR DESCRIPTION
The berkeleygw tarball has some really weird UID/GID set on the contained files and tar attempts to preserve those upon extraction.  This can fail on some systems and the build will crash with messages like this

    Cannot change ownership to uid 823814, gid 81313: Invalid argument

To prevent that, tar has a flag `-o` which will discard the ownership of the files inside the archive and instead use the UID/GID of the calling process. GNU tar also knows this flag under the name `--no-same-owner`, which is more descriptive, but this is probably not portable.[^1][^2]

[^1]: https://www.gnu.org/software/tar/manual/html_node/Option-Summary.html#g_t_002d_002dno_002dsame_002downer
[^2]: https://man.freebsd.org/cgi/man.cgi?tar(1)#:~:text=%2Do%20%20%20%20%20%20(x%20mode)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
