### PR TITLE
Compiler: migrate platform support filter to new compiler packages

### DIFF
--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -23,6 +23,7 @@ import spack.platforms
 import spack.repo
 import spack.spec
 from spack.operating_systems import windows_os
+from spack.platforms import PlatformSupport
 from spack.util.environment import get_path
 
 #: Tag used to identify packages providing a compiler
@@ -104,15 +105,15 @@ def supported_compilers() -> List[str]:
     return sorted(spack.repo.PATH.packages_with_tags(COMPILER_TAG))
 
 
-def is_supported_compiler_class_for_platform(cls_str: str, platform: "spack.platforms.Platform") -> bool:
-    supported_platform_for_compiler_attr = getattr(spack.repo.PATH.get_pkg_class(cls_str), "is_supported_on_platform", None)
+def is_supported_compiler_class_for_platform(cls_str: str, platform: PlatformSupport) -> bool:
+    supported_platform_for_compiler_attr = getattr(spack.repo.PATH.get_pkg_class(cls_str), "supported_platform", None)
     if supported_platform_for_compiler_attr:
-        return supported_platform_for_compiler_attr(platform)
+        return platform in supported_platform_for_compiler_attr
     return False
 
 
 def is_supported_compiler_class_for_host_platform(cls_str: str) ->bool:
-    host_plat = spack.platforms.real_host()
+    host_plat = spack.platforms.real_host().platform_support
     return is_supported_compiler_class_for_platform(cls_str, host_plat)
 
 

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -71,7 +71,13 @@ def find_compilers(
     default_paths = fs.search_paths_for_executables(*path_hints)
     if sys.platform == "win32":
         default_paths.extend(windows_os.WindowsOs().compiler_search_paths)
-    compiler_pkgs = spack.repo.PATH.packages_with_tags(COMPILER_TAG, full=True)
+
+    compiler_pkgs = list(
+        filter(
+            is_supported_compiler_class_for_host_platform,
+            spack.repo.PATH.packages_with_tags(COMPILER_TAG, full=True),
+        )
+    )
 
     detected_packages = spack.detection.by_path(
         compiler_pkgs, path_hints=default_paths, max_workers=max_workers
@@ -96,6 +102,18 @@ def select_new_compilers(
 def supported_compilers() -> List[str]:
     """Returns all the currently supported compiler packages"""
     return sorted(spack.repo.PATH.packages_with_tags(COMPILER_TAG))
+
+
+def is_supported_compiler_class_for_platform(cls_str: str, platform: "spack.platforms.Platform") -> bool:
+    supported_platform_for_compiler_attr = getattr(spack.repo.PATH.get_pkg_class(cls_str), "is_supported_on_platform", None)
+    if supported_platform_for_compiler_attr:
+        return supported_platform_for_compiler_attr(platform)
+    return False
+
+
+def is_supported_compiler_class_for_host_platform(cls_str: str) ->bool:
+    host_plat = spack.platforms.real_host()
+    return is_supported_compiler_class_for_platform(cls_str, host_plat)
 
 
 def all_compilers(scope: Optional[str] = None, init_config: bool = True) -> List[spack.spec.Spec]:

--- a/lib/spack/spack/platforms/__init__.py
+++ b/lib/spack/spack/platforms/__init__.py
@@ -5,7 +5,7 @@ import contextlib
 from typing import Callable
 
 from ._functions import _host, by_name, platforms, reset
-from ._platform import Platform
+from ._platform import Platform, PlatformSupport
 from .darwin import Darwin
 from .freebsd import FreeBSD
 from .linux import Linux
@@ -14,6 +14,7 @@ from .windows import Windows
 
 __all__ = [
     "Platform",
+    "PlatformSupport",
     "Darwin",
     "Linux",
     "FreeBSD",

--- a/lib/spack/spack/platforms/_platform.py
+++ b/lib/spack/spack/platforms/_platform.py
@@ -1,12 +1,19 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from enum import Flag, auto
 import warnings
 from typing import Optional
 
 import spack.vendor.archspec.cpu
 
 import spack.llnl.util.lang
+
+class PlatformSupport(Flag):
+    WINDOWS = auto()
+    LINUX = auto()
+    DARWIN = auto()
+    FREEBSD = auto()
 
 
 @spack.llnl.util.lang.lazy_lexicographic_ordering
@@ -31,6 +38,8 @@ class Platform:
     reserved_targets = ["default_target", "frontend", "fe", "backend", "be"]
     reserved_oss = ["default_os", "frontend", "fe", "backend", "be"]
     deprecated_names = ["frontend", "fe", "backend", "be"]
+
+    platform_support: PlatformSupport
 
     def __init__(self, name):
         self.targets = {}

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -7,13 +7,15 @@ import platform as py_platform
 from spack.operating_systems.mac_os import MacOs
 from spack.version import Version
 
-from ._platform import Platform
+from ._platform import Platform, PlatformSupport
 
 
 class Darwin(Platform):
     priority = 89
 
     binary_formats = ["macho"]
+
+    platform_support = PlatformSupport.DARWIN
 
     def __init__(self):
         super().__init__("darwin")

--- a/lib/spack/spack/platforms/freebsd.py
+++ b/lib/spack/spack/platforms/freebsd.py
@@ -5,11 +5,13 @@ import platform
 
 from spack.operating_systems.freebsd import FreeBSDOs
 
-from ._platform import Platform
+from ._platform import Platform, PlatformSupport
 
 
 class FreeBSD(Platform):
     priority = 102
+
+    platform_support = PlatformSupport.FREEBSD
 
     def __init__(self):
         super().__init__("freebsd")

--- a/lib/spack/spack/platforms/linux.py
+++ b/lib/spack/spack/platforms/linux.py
@@ -5,12 +5,13 @@ import platform
 
 from spack.operating_systems.linux_distro import LinuxDistro
 
-from ._platform import Platform
+from ._platform import Platform, PlatformSupport
 
 
 class Linux(Platform):
     priority = 90
-
+    platform_support = PlatformSupport.LINUX
+    
     def __init__(self):
         super().__init__("linux")
         linux_dist = LinuxDistro()

--- a/lib/spack/spack/platforms/windows.py
+++ b/lib/spack/spack/platforms/windows.py
@@ -6,12 +6,13 @@ import platform
 
 from spack.operating_systems.windows_os import WindowsOs
 
-from ._platform import Platform
+from ._platform import Platform, PlatformSupport
 
 
 class Windows(Platform):
     priority = 101
-
+    platform_support = PlatformSupport.WINDOWS
+    
     def __init__(self):
         super().__init__("windows")
         windows_os = WindowsOs()

--- a/var/spack/repos/spack_repo/builtin/build_systems/compiler.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/compiler.py
@@ -1,0 +1,261 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import itertools
+import os
+import pathlib
+import re
+import sys
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+from llnl.util.lang import classproperty, memoized
+
+import spack.compilers.error
+from spack.package import Executable, PackageBase, ProcessError, Spec, tty, which_string
+from spack.platforms import PlatformSupport
+
+# Local "type" for type hints
+Path = Union[str, pathlib.Path]
+
+
+class CompilerPackage(PackageBase):
+    """A Package mixin for all common logic for packages that implement compilers"""
+
+    # TODO: how do these play nicely with other tags
+    tags: Sequence[str] = ["compiler"]
+
+    #: Optional suffix regexes for searching for this type of compiler.
+    #: Suffixes are used by some frameworks, e.g. macports uses an '-mp-X.Y'
+    #: version suffix for gcc.
+    compiler_suffixes: List[str] = [r"-.*"]
+
+    #: Optional prefix regexes for searching for this compiler
+    compiler_prefixes: List[str] = []
+
+    #: Compiler argument(s) that produces version information
+    #: If multiple arguments, the earlier arguments must produce errors when invalid
+    compiler_version_argument: Union[str, Tuple[str, ...]] = "-dumpversion"
+
+    #: Regex used to extract version from compiler's output
+    compiler_version_regex: str = "(.*)"
+
+    #: Static definition of languages supported by this class
+    compiler_languages: Sequence[str] = ["c", "cxx", "fortran"]
+
+    #: Relative path to compiler wrappers
+    compiler_wrapper_link_paths: Dict[str, str] = {}
+
+    #: Optimization flags
+    opt_flags: Sequence[str] = []
+    #: Flags for generating debug information
+    debug_flags: Sequence[str] = []
+
+    # Support everything but Windows by default
+    supported_platform = PlatformSupport.LINUX | PlatformSupport.DARWIN | PlatformSupport.FREEBSD
+
+    def __init__(self, spec: Spec):
+        super().__init__(spec)
+        msg = f"Supported languages for {spec} are not a subset of possible supported languages"
+        msg += f"    supports: {self.supported_languages}, valid values: {self.compiler_languages}"
+        assert set(self.supported_languages) <= set(self.compiler_languages), msg
+
+    @property
+    def supported_languages(self) -> Sequence[str]:
+        """Dynamic definition of languages supported by this package"""
+        return self.compiler_languages
+
+    @classproperty
+    def compiler_names(cls) -> Sequence[str]:
+        """Construct list of compiler names from per-language names"""
+        names = []
+        for language in cls.compiler_languages:
+            names.extend(getattr(cls, f"{language}_names"))
+        return names
+
+    @classproperty
+    def executables(cls) -> Sequence[str]:
+        """Construct executables for external detection from names, prefixes, and suffixes."""
+        regexp_fmt = r"^({0}){1}({2})$"
+        prefixes = [""] + cls.compiler_prefixes
+        suffixes = [""] + cls.compiler_suffixes
+        if sys.platform == "win32":
+            ext = r"\.(?:exe|bat)"
+            suffixes += [suf + ext for suf in suffixes]
+        return [
+            regexp_fmt.format(prefix, re.escape(name), suffix)
+            for prefix, name, suffix in itertools.product(prefixes, cls.compiler_names, suffixes)
+        ]
+
+    @classmethod
+    def determine_version(cls, exe: Path) -> str:
+        version_argument = cls.compiler_version_argument
+        if isinstance(version_argument, str):
+            version_argument = (version_argument,)
+
+        for va in version_argument:
+            try:
+                output = compiler_output(exe, version_argument=va)
+                match = re.search(cls.compiler_version_regex, output)
+                if match:
+                    return ".".join(match.groups())
+            except ProcessError:
+                pass
+            except Exception as e:
+                tty.debug(
+                    f"[{__file__}] Cannot detect a valid version for the executable "
+                    f"{str(exe)}, for package '{cls.name}': {e}"
+                )
+        return ""
+
+    @classmethod
+    def compiler_bindir(cls, prefix: Path) -> Path:
+        """Overridable method for the location of the compiler bindir within the prefix"""
+        return os.path.join(prefix, "bin")
+
+    @classmethod
+    def determine_compiler_paths(cls, exes: Sequence[Path]) -> Dict[str, Path]:
+        """Compute the paths to compiler executables associated with this package
+
+        This is a helper method for ``determine_variants`` to compute the ``extra_attributes``
+        to include with each spec object."""
+        # There are often at least two copies (not symlinks) of each compiler executable in the
+        # same directory: one with a canonical name, e.g. "gfortran", and another one with the
+        # target prefix, e.g. "x86_64-pc-linux-gnu-gfortran". There also might be a copy of "gcc"
+        # with the version suffix, e.g. "x86_64-pc-linux-gnu-gcc-6.3.0". To ensure the consistency
+        # of values in the "paths" dictionary (i.e. we prefer all of them to reference copies
+        # with canonical names if possible), we iterate over the executables in the reversed sorted
+        # order:
+        # First pass over languages identifies exes that are perfect matches for canonical names
+        # Second pass checks for names with prefix/suffix
+        # Second pass is sorted by language name length because longer named languages
+        # e.g. cxx can often contain the names of shorter named languages
+        # e.g. c (e.g. clang/clang++)
+        paths = {}
+        exes = sorted(exes, reverse=True)
+        languages = {
+            lang: getattr(cls, f"{lang}_names")
+            for lang in sorted(cls.compiler_languages, key=len, reverse=True)
+        }
+        for exe in exes:
+            for lang, names in languages.items():
+                if os.path.basename(exe) in names:
+                    paths[lang] = exe
+                    break
+            else:
+                for lang, names in languages.items():
+                    if any(name in os.path.basename(exe) for name in names):
+                        paths[lang] = exe
+                        break
+
+        return paths
+
+    @classmethod
+    def determine_variants(cls, exes: Sequence[Path], version_str: str) -> Tuple:
+        # path determination is separated so it can be reused in subclasses
+        return "", {"compilers": cls.determine_compiler_paths(exes=exes)}
+
+    #: Returns the argument needed to set the RPATH, or None if it does not exist
+    rpath_arg: Optional[str] = "-Wl,-rpath,"
+    #: Flag that needs to be used to pass an argument to the linker
+    linker_arg: str = "-Wl,"
+    #: Flag used to produce Position Independent Code
+    pic_flag: str = "-fPIC"
+    #: Flag used to get verbose output
+    verbose_flags: str = "-v"
+    #: Flag to activate OpenMP support
+    openmp_flag: str = "-fopenmp"
+
+    implicit_rpath_libs: List[str] = []
+
+    def standard_flag(self, *, language: str, standard: str) -> str:
+        """Returns the flag used to enforce a given standard for a language"""
+        if language not in self.supported_languages:
+            raise spack.compilers.error.UnsupportedCompilerFlag(
+                f"{self.spec} does not provide the '{language}' language"
+            )
+        try:
+            return self._standard_flag(language=language, standard=standard)
+        except (KeyError, RuntimeError) as e:
+            raise spack.compilers.error.UnsupportedCompilerFlag(
+                f"{self.spec} does not provide the '{language}' standard {standard}"
+            ) from e
+
+    def _standard_flag(self, *, language: str, standard: str) -> str:
+        raise NotImplementedError("Must be implemented by derived classes")
+
+    def archspec_name(self) -> str:
+        """Name that archspec uses to refer to this compiler"""
+        return self.spec.name
+
+    @property
+    def cc(self) -> Optional[str]:
+        assert self.spec.concrete, "cannot retrieve C compiler, spec is not concrete"
+        if self.spec.external:
+            return self.spec.extra_attributes.get("compilers", {}).get("c", None)
+        return self._cc_path()
+
+    def _cc_path(self) -> Optional[str]:
+        """Returns the path to the C compiler, if the package was installed by Spack"""
+        return None
+
+    @property
+    def cxx(self) -> Optional[str]:
+        assert self.spec.concrete, "cannot retrieve C++ compiler, spec is not concrete"
+        if self.spec.external:
+            return self.spec.extra_attributes.get("compilers", {}).get("cxx", None)
+        return self._cxx_path()
+
+    def _cxx_path(self) -> Optional[str]:
+        """Returns the path to the C++ compiler, if the package was installed by Spack"""
+        return None
+
+    @property
+    def fortran(self):
+        assert self.spec.concrete, "cannot retrieve Fortran compiler, spec is not concrete"
+        if self.spec.external:
+            return self.spec.extra_attributes.get("compilers", {}).get("fortran", None)
+        return self._fortran_path()
+
+    def _fortran_path(self) -> Optional[str]:
+        """Returns the path to the Fortran compiler, if the package was installed by Spack"""
+        return None
+
+
+@memoized
+def _compiler_output(
+    compiler_path: Path, *, version_argument: str, ignore_errors: Tuple[int, ...] = ()
+) -> str:
+    """Returns the output from the compiler invoked with the given version argument.
+
+    Args:
+        compiler_path: path of the compiler to be invoked
+        version_argument: the argument used to extract version information
+    """
+    compiler = Executable(compiler_path)
+    if not version_argument:
+        return compiler(
+            output=str, error=str, ignore_errors=ignore_errors, timeout=120, fail_on_error=True
+        )
+    return compiler(
+        version_argument,
+        output=str,
+        error=str,
+        ignore_errors=ignore_errors,
+        timeout=120,
+        fail_on_error=True,
+    )
+
+
+def compiler_output(
+    compiler_path: Path, *, version_argument: str, ignore_errors: Tuple[int, ...] = ()
+) -> str:
+    """Wrapper for _get_compiler_version_output()."""
+    # This ensures that we memoize compiler output by *absolute path*,
+    # not just executable name. If we don't do this, and the path changes
+    # (e.g., during testing), we can get incorrect results.
+    if not os.path.isabs(compiler_path):
+        compiler_path = which_string(str(compiler_path), required=True)
+
+    return _compiler_output(
+        compiler_path, version_argument=version_argument, ignore_errors=ignore_errors
+    )

--- a/var/spack/repos/spack_repo/builtin/packages/apple_clang/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/apple_clang/package.py
@@ -1,0 +1,83 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
+from spack_repo.builtin.build_systems.bundle import BundlePackage
+from spack_repo.builtin.build_systems.compiler import CompilerPackage
+from spack_repo.builtin.packages.llvm.package import LlvmDetection
+
+from spack.package import *
+
+
+class AppleClang(BundlePackage, LlvmDetection, CompilerPackage):
+    """Apple's Clang compiler"""
+
+    homepage = "https://developer.apple.com/videos/developer-tools/compiler-and-llvm"
+    has_code = False
+
+    maintainers("alalazo")
+
+    compiler_languages = ["c", "cxx"]
+    compiler_version_regex = r"^Apple (?:LLVM|clang) version ([^ )]+)"
+
+    openmp_flag = "-Xpreprocessor -fopenmp"
+
+    compiler_wrapper_link_paths = {
+        "c": os.path.join("clang", "clang"),
+        "cxx": os.path.join("clang", "clang++"),
+    }
+
+    implicit_rpath_libs = ["libclang"]
+    
+    # apple-clang is Darwin only
+    is_supported_on_platform = lambda x: isinstance(x, Darwin)
+    provides("c", "cxx")
+
+    requires("platform=darwin")
+
+    @classmethod
+    def validate_detected_spec(cls, spec, extra_attributes):
+        msg = f'the extra attribute "compilers" must be set for the detected spec "{spec}"'
+        assert "compilers" in extra_attributes, msg
+        compilers = extra_attributes["compilers"]
+        for key in ("c", "cxx"):
+            msg = f"{key} compiler not found for {spec}"
+            assert key in compilers, msg
+
+    @property
+    def cc(self):
+        msg = "apple-clang is expected to be an external spec"
+        assert self.spec.concrete and self.spec.external, msg
+        return self.spec.extra_attributes["compilers"].get("c", None)
+
+    @property
+    def cxx(self):
+        msg = "apple-clang is expected to be an external spec"
+        assert self.spec.concrete and self.spec.external, msg
+        return self.spec.extra_attributes["compilers"].get("cxx", None)
+
+    def _standard_flag(self, *, language, standard):
+        flags = {
+            "cxx": {
+                "11": [("@4.0:", "-std=c++11")],
+                "14": [("@6.1:", "-std=c++14")],
+                "17": [("@6.1:10.0", "-std=c++1z"), ("@10.1:", "-std=c++17")],
+                "20": [("@10.0:13.0", "-std=c++2a"), ("@13.1:", "-std=c++20")],
+                "23": [("@13.0:", "-std=c++2b")],
+            },
+            "c": {
+                "99": [("@4.0:", "-std=c99")],
+                "11": [("@4.0:", "-std=c11")],
+                "17": [("@11.1:", "-std=c17")],
+                "23": [("@11.1:", "-std=c2x")],
+            },
+        }
+        for condition, flag in flags[language][standard]:
+            if self.spec.satisfies(condition):
+                return flag
+        else:
+            raise RuntimeError(
+                f"{self.spec} does not support the '{standard}' standard "
+                f"for the '{language}' language"
+            )

--- a/var/spack/repos/spack_repo/builtin/packages/apple_clang/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/apple_clang/package.py
@@ -4,7 +4,7 @@
 import os
 
 from spack_repo.builtin.build_systems.bundle import BundlePackage
-from spack_repo.builtin.build_systems.compiler import CompilerPackage
+from spack_repo.builtin.build_systems.compiler import CompilerPackage, PlatformSupport
 from spack_repo.builtin.packages.llvm.package import LlvmDetection
 
 from spack.package import *
@@ -31,7 +31,8 @@ class AppleClang(BundlePackage, LlvmDetection, CompilerPackage):
     implicit_rpath_libs = ["libclang"]
     
     # apple-clang is Darwin only
-    is_supported_on_platform = lambda x: isinstance(x, Darwin)
+    supported_platform = PlatformSupport.DARWIN
+
     provides("c", "cxx")
 
     requires("platform=darwin")

--- a/var/spack/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gcc/package.py
@@ -595,9 +595,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
     compiler_languages = ["c", "cxx", "fortran", "d", "go"]
 
-    # gcc works everywhere but Windows
-    is_supported_on_platform = lambda x: not isinstance(x, spack.platforms.Windows)
-
     @property
     def supported_languages(self):
         # This weirdness is because it could be called on an abstract spec

--- a/var/spack/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1,0 +1,1257 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import glob
+import os
+import sys
+
+from spack_repo.builtin.build_systems import compiler
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems.compiler import CompilerPackage
+from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage
+
+from llnl.util.symlink import readlink
+
+import spack.platforms
+import spack.repo
+import spack.util.libc
+from spack.operating_systems.mac_os import macos_sdk_path, macos_version
+from spack.package import *
+
+
+class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
+    """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
+    Fortran, Ada, and Go, as well as libraries for these languages."""
+
+    homepage = "https://gcc.gnu.org"
+    gnu_mirror_path = "gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
+    git = "git://gcc.gnu.org/git/gcc.git"
+    list_url = "https://ftp.gnu.org/gnu/gcc/"
+    list_depth = 1
+    keep_werror = "all"
+
+    maintainers("michaelkuhn", "alalazo")
+
+    license("GPL-2.0-or-later AND LGPL-2.1-or-later")
+
+    provides("c", "cxx", when="languages=c,c++")
+    provides("c", when="languages=c")
+    provides("cxx", when="languages=c++")
+    provides("fortran", when="languages=fortran")
+
+    version("master", branch="master")
+
+    # Latest stable
+    version("15.1.0", sha256="e2b09ec21660f01fecffb715e0120265216943f038d0e48a9868713e54f06cea")
+
+    # Previous stable series releases
+
+    # Final releases of previous versions
+    version("14.3.0", sha256="e0dc77297625631ac8e50fa92fffefe899a4eb702592da5c32ef04e2293aca3a")
+    version("13.3.0", sha256="0845e9621c9543a13f484e94584a49ffc0129970e9914624235fc1d061a0c083")
+    version("12.4.0", sha256="704f652604ccbccb14bdabf3478c9511c89788b12cb3bbffded37341916a9175")
+    version("11.5.0", sha256="a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478")
+    version("10.5.0", sha256="25109543fdf46f397c347b5d8b7a2c7e5694a5a51cce4b9c6e1ea8a71ca307c1")
+    version("9.5.0", sha256="27769f64ef1d4cd5e2be8682c0c93f9887983e6cfd1a927ce5a0a2915a95cf8f")
+    version("8.5.0", sha256="d308841a511bb830a6100397b0042db24ce11f642dab6ea6ee44842e5325ed50")
+    version("7.5.0", sha256="b81946e7f01f90528a1f7352ab08cc602b9ccc05d4e44da4bd501c5a189ee661")
+    version("6.5.0", sha256="7ef1796ce497e89479183702635b14bb7a46b53249209a5e0f999bebf4740945")
+    version("5.5.0", sha256="530cea139d82fe542b358961130c69cfde8b3d14556370b65823d2f91f0ced87")
+    version("4.9.4", sha256="6c11d292cd01b294f9f84c9a59c230d80e9e4a47e5c6355f046bb36d4f358092")
+    version("4.8.5", sha256="22fb1e7e0f68a63cee631d85b20461d1ea6bda162f03096350e38c8d427ecf23")
+    version("4.7.4", sha256="92e61c6dc3a0a449e62d72a38185fda550168a86702dea07125ebd3ec3996282")
+    version("4.6.4", sha256="35af16afa0b67af9b8eb15cafb76d2bc5f568540552522f5dc2c88dd45d977e8")
+    version("4.5.4", sha256="eef3f0456db8c3d992cbb51d5d32558190bc14f3bc19383dd93acc27acc6befc")
+
+    # Deprecated older non-final releases
+    with default_args(deprecated=True):
+        version(
+            "14.2.0", sha256="a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9"
+        )
+        version(
+            "14.1.0", sha256="e283c654987afe3de9d8080bc0bd79534b5ca0d681a73a11ff2b5d3767426840"
+        )
+
+        version(
+            "13.2.0", sha256="e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da"
+        )
+        version(
+            "13.1.0", sha256="61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86"
+        )
+
+        version(
+            "12.3.0", sha256="949a5d4f99e786421a93b532b22ffab5578de7321369975b91aec97adfda8c3b"
+        )
+        version(
+            "12.2.0", sha256="e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff"
+        )
+        version(
+            "12.1.0", sha256="62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b"
+        )
+
+        version(
+            "11.4.0", sha256="3f2db222b007e8a4a23cd5ba56726ef08e8b1f1eb2055ee72c1402cea73a8dd9"
+        )
+        version(
+            "11.3.0", sha256="b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39"
+        )
+        version(
+            "11.2.0", sha256="d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
+        )
+        version(
+            "11.1.0", sha256="4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf"
+        )
+
+        version(
+            "10.4.0", sha256="c9297d5bcd7cb43f3dfc2fed5389e948c9312fd962ef6a4ce455cff963ebe4f1"
+        )
+        version(
+            "10.3.0", sha256="64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344"
+        )
+        version(
+            "10.2.0", sha256="b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c"
+        )
+        version(
+            "10.1.0", sha256="b6898a23844b656f1b68691c5c012036c2e694ac4b53a8918d4712ad876e7ea2"
+        )
+
+        version("9.4.0", sha256="c95da32f440378d7751dd95533186f7fc05ceb4fb65eb5b85234e6299eb9838e")
+        version("9.3.0", sha256="71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1")
+        version("9.2.0", sha256="ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206")
+        version("9.1.0", sha256="79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0")
+
+        version("8.4.0", sha256="e30a6e52d10e1f27ed55104ad233c30bd1e99cfb5ff98ab022dc941edd1b2dd4")
+        version("8.3.0", sha256="64baadfe6cc0f4947a84cb12d7f0dfaf45bb58b7e92461639596c21e02d97d2c")
+        version("8.2.0", sha256="196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080")
+        version("8.1.0", sha256="1d1866f992626e61349a1ccd0b8d5253816222cdc13390dcfaa74b093aa2b153")
+
+        version("7.4.0", sha256="eddde28d04f334aec1604456e536416549e9b1aa137fc69204e65eb0c009fe51")
+        version("7.3.0", sha256="832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c")
+        version("7.2.0", sha256="1cf7adf8ff4b5aa49041c8734bbcf1ad18cc4c94d0029aae0f4e48841088479a")
+        version("7.1.0", sha256="8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17")
+
+        version("6.4.0", sha256="850bf21eafdfe5cd5f6827148184c08c4a0852a37ccf36ce69855334d2c914d4")
+        version("6.3.0", sha256="f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f")
+        version("6.2.0", sha256="9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5")
+        version("6.1.0", sha256="09c4c85cabebb971b1de732a0219609f93fc0af5f86f6e437fd8d7f832f1a351")
+
+        version("5.4.0", sha256="608df76dec2d34de6558249d8af4cbee21eceddbcb580d666f7a5a583ca3303a")
+        version("5.3.0", sha256="b84f5592e9218b73dbae612b5253035a7b34a9a1f7688d2e1bfaaf7267d5c4db")
+        version("5.2.0", sha256="5f835b04b5f7dd4f4d2dc96190ec1621b8d89f2dc6f638f9f8bc1b1014ba8cad")
+        version("5.1.0", sha256="b7dafdf89cbb0e20333dbf5b5349319ae06e3d1a30bf3515b5488f7e89dca5ad")
+
+        version("4.9.3", sha256="2332b2a5a321b57508b9031354a8503af6fdfb868b8c1748d33028d100a8b67e")
+        version("4.9.2", sha256="2020c98295856aa13fda0f2f3a4794490757fc24bcca918d52cc8b4917b972dd")
+        version("4.9.1", sha256="d334781a124ada6f38e63b545e2a3b8c2183049515a1abab6d513f109f1d717e")
+        version("4.8.4", sha256="4a80aa23798b8e9b5793494b8c976b39b8d9aa2e53cd5ed5534aff662a7f8695")
+
+    # We specifically do not add 'all' variant here because:
+    # (i) Ada, D, Go, Jit, and Objective-C++ are not default languages.
+    # In that respect, the name 'all' is rather misleading.
+    # (ii) Languages other than c,c++,fortran are prone to configure bug in GCC
+    # For example, 'java' appears to ignore custom location of zlib
+    # (iii) meaning of 'all' changes with GCC version, i.e. 'java' is not part
+    # of gcc7. Correctly specifying conflicts() and depends_on() in such a
+    # case is a PITA.
+    #
+    # Also note that some languages get enabled by the configure scripts even if not listed in the
+    # arguments. For example, c++ is enabled when the bootstrapping is enabled and lto is enabled
+    # when the link time optimization support is enabled.
+    variant(
+        "languages",
+        default="c,c++,fortran",
+        values=(
+            "ada",
+            "brig",
+            "c",
+            "c++",
+            "d",
+            "fortran",
+            "go",
+            "java",
+            "jit",
+            "lto",
+            "objc",
+            "obj-c++",
+        ),
+        multi=True,
+        description="Compilers and runtime libraries to build",
+    )
+    variant("binutils", default=False, description="Build via binutils")
+    variant("mold", default=False, description="Use mold as the linker by default", when="@12:")
+    variant(
+        "piclibs", default=False, description="Build PIC versions of libgfortran.a and libstdc++.a"
+    )
+    variant("strip", default=False, description="Strip executables to reduce installation size")
+    variant("nvptx", default=False, description="Target nvptx offloading to NVIDIA GPUs")
+    variant("bootstrap", default=True, description="Enable 3-stage bootstrap")
+    variant(
+        "graphite", default=False, description="Enable Graphite loop optimizations (requires ISL)"
+    )
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
+        description="CMake-like build type. "
+        "Debug: -O0 -g; Release: -O3; "
+        "RelWithDebInfo: -O2 -g; MinSizeRel: -Os",
+    )
+    variant(
+        "profiled", default=False, description="Use Profile Guided Optimization", when="+bootstrap"
+    )
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("flex", type="build", when="@master")
+
+    # https://gcc.gnu.org/install/prerequisites.html
+    depends_on("gmp@4.3.2:")
+    # mawk is not sufficient for go support
+    depends_on("gawk@3.1.5:", type="build")
+    depends_on("texinfo@4.7:", type="build")
+    depends_on("libtool", type="build")
+    # dependencies required for git versions
+    depends_on("m4@1.4.6:", when="@master", type="build")
+    depends_on("automake@1.15.1:", when="@master", type="build")
+    depends_on("autoconf@2.69:", when="@master", type="build")
+
+    depends_on("gmake@3.80:", type="build")
+    depends_on("perl@5", type="build")
+
+    # GCC 7.3 does not compile with newer releases on some platforms, see
+    #   https://github.com/spack/spack/issues/6902#issuecomment-433030376
+    depends_on("mpfr@2.4.2:3.1.6", when="@:9.9")
+    depends_on("mpfr@3.1.0:", when="@10:")
+    depends_on("mpc@1.0.1:", when="@4.5:")
+    # Already released GCC versions do not support any newer version of ISL
+    #   GCC 5.4 https://github.com/spack/spack/issues/6902#issuecomment-433072097
+    #   GCC 7.3 https://github.com/spack/spack/issues/6902#issuecomment-433030376
+    #   GCC 9+  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86724
+    with when("+graphite"):
+        depends_on("isl@0.14", when="@5.0:5.2")
+        depends_on("isl@0.15", when="@5.3:5.9")
+        depends_on("isl@0.15:0.18", when="@6:8.9")
+        depends_on("isl@0.15:0.20", when="@9:9.9")
+        depends_on("isl@0.15:", when="@10:")
+
+    depends_on("zlib-api", when="@6:")
+    depends_on("zstd", when="@10:")
+    depends_on("diffutils", type="build")
+    depends_on("iconv", when="platform=darwin")
+    depends_on("gnat", when="languages=ada")
+    depends_on(
+        "binutils+gas+ld+plugins~libiberty", when="+binutils", type=("build", "link", "run")
+    )
+    depends_on("mold", when="+mold")
+    depends_on("zip", type="build", when="languages=java")
+
+    # The server is sometimes a bit slow to respond
+    timeout = {"timeout": 60}
+
+    # TODO: integrate these libraries.
+    # depends_on('ppl')
+    # depends_on('cloog')
+
+    # https://gcc.gnu.org/install/test.html
+    depends_on("dejagnu@1.4.4", type="test")
+    depends_on("expect", type="test")
+    depends_on("tcl", type="test")
+    depends_on("autogen@5.5.4:", type="test")
+    depends_on("guile@1.4.1:", type="test")
+
+    # See https://go.dev/doc/install/gccgo#Releases
+    with when("languages=go"):
+        provides("go-or-gccgo-bootstrap@:1.0", when="@4.7.1:")
+        provides("go-or-gccgo-bootstrap@:1.2", when="@4.9:")
+        provides("go-or-gccgo-bootstrap@:1.4", when="@5:")
+        provides("go-or-gccgo-bootstrap@:1.6.1", when="@6:")
+        provides("go-or-gccgo-bootstrap@:1.8.1", when="@7:")
+        provides("go-or-gccgo-bootstrap@:1.10.1", when="@8:")
+        provides("go-or-gccgo-bootstrap@:1.12.2", when="@9:")
+        provides("go-or-gccgo-bootstrap@:1.14.6", when="@10:")
+        provides("go-or-gccgo-bootstrap@1.16.3:1.16.5", when="@11:")
+
+        provides("golang@:1.0", when="@4.7.1:")
+        provides("golang@:1.2", when="@4.9:")
+        provides("golang@:1.4", when="@5:")
+        provides("golang@:1.6.1", when="@6:")
+        provides("golang@:1.8.1", when="@7:")
+        provides("golang@:1.10.1", when="@8:")
+        provides("golang@:1.12.2", when="@9:")
+        provides("golang@:1.14.6", when="@10:")
+        provides("golang@1.16.3:1.16.5", when="@11:")
+
+        # GCC 4.7.1 added full support for the Go 1.x programming language.
+        conflicts("@:4.7.0")
+
+        # Go is not supported on macOS
+        conflicts("platform=darwin", msg="GCC cannot build Go support on MacOS")
+
+    # For a list of valid languages for a specific release,
+    # run the following command in the GCC source directory:
+    #    $ grep ^language= gcc/*/config-lang.in
+    # See https://gcc.gnu.org/install/configure.html
+
+    # Support for processing BRIG 1.0 files was added in GCC 7
+    # BRIG is a binary format for HSAIL:
+    # (Heterogeneous System Architecture Intermediate Language).
+    # See https://gcc.gnu.org/gcc-7/changes.html
+    conflicts("languages=brig", when="@:6")
+
+    # BRIG does not seem to be supported on macOS
+    conflicts("languages=brig", when="platform=darwin")
+
+    # GCC 4.8 added a 'c' language. I'm sure C was always built,
+    # but this is the first version that accepts 'c' as a valid language.
+    conflicts("languages=c", when="@:4.7")
+
+    # The GCC Java frontend and associated libjava runtime library
+    # have been removed from GCC as of GCC 7.
+    # See https://gcc.gnu.org/gcc-7/changes.html
+    conflicts("languages=java", when="@7:")
+
+    # GCC 5 added the ability to build GCC as a Just-In-Time compiler.
+    # See https://gcc.gnu.org/gcc-5/changes.html
+    conflicts("languages=jit", when="@:4")
+
+    with when("languages=d"):
+        # The very first version of GDC that became part of GCC already supported version 2.076 of
+        # the language and runtime.
+        # See https://wiki.dlang.org/GDC#Status
+        provides("D@2")
+
+        # Support for the D programming language has been added to GCC 9.
+        # See https://gcc.gnu.org/gcc-9/changes.html#d
+        conflicts("@:8", msg="support for D has been added in GCC 9.1")
+
+        # Versions of GDC prior to 12 can be built with an ISO C++11 compiler. Starting version 12,
+        # the D frontend requires a working GDC. Moreover, it is strongly recommended to use an
+        # older version of GDC to build GDC.
+        # See https://gcc.gnu.org/install/prerequisites.html#GDC-prerequisite
+        with when("@12:"):
+            # All versions starting 12 have to be built GCC:
+            requires("%gcc")
+
+            # And it has to be GCC older than the version we build:
+            vv = ["11", "12.1.0", "12.2.0"]
+            for prev_v, curr_v in zip(vv, vv[1:]):
+                conflicts(
+                    "%gcc@{0}:".format(curr_v),
+                    when="@{0}".format(curr_v),
+                    msg="'gcc@{0} languages=d' requires '%gcc@:{1}' "
+                    "with the D language support".format(curr_v, prev_v),
+                )
+
+            # In principle, it is possible to have GDC even with GCC 5.
+            # See https://github.com/D-Programming-GDC/gdc
+            # We, however, require at least the oldest version that officially supports GDC. It is
+            # also a good opportunity to tell the users that they need a working GDC:
+            conflicts(
+                "%gcc@:8",
+                msg="'gcc@12: languages=d' requires '%gcc@9:' with the D language support",
+            )
+
+    with when("+nvptx"):
+        depends_on("cuda")
+        resource(
+            name="newlib",
+            url="ftp://sourceware.org/pub/newlib/newlib-3.0.0.20180831.tar.gz",
+            sha256="3ad3664f227357df15ff34e954bfd9f501009a647667cd307bf0658aefd6eb5b",
+            destination="newlibsource",
+            fetch_options=timeout,
+        )
+
+        nvptx_tools_ver = "2023-09-13"
+        depends_on("nvptx-tools@" + nvptx_tools_ver, type="build")
+
+        # NVPTX offloading supported in 7 and later by limited languages
+        conflicts("@:6", msg="NVPTX only supported in gcc 7 and above")
+        conflicts("languages=ada")
+        conflicts("languages=brig")
+        conflicts("languages=go")
+        conflicts("languages=java")
+        conflicts("languages=jit")
+        conflicts("languages=objc")
+        conflicts("languages=obj-c++")
+        conflicts("languages=d")
+        # NVPTX build disables bootstrap
+        conflicts("+bootstrap")
+
+    # Binutils can't build ld on macOS
+    conflicts("+binutils", when="platform=darwin")
+
+    # Bootstrap comparison failure:
+    #   see https://github.com/spack/spack/issues/23296
+    #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
+    #   on XCode 12.5
+    conflicts("+bootstrap", when="@:11.1 %apple-clang@12.0.5")
+
+    requires(
+        "@11.3:",
+        when="target=aarch64: platform=darwin",
+        msg="Only GCC 11.3+ support aarch64-darwin",
+    )
+
+    # Newer binutils than RHEL's is required to run `as` on some instructions
+    # generated by new GCC (see https://github.com/spack/spack/issues/12235)
+    conflicts("~binutils", when="@7: os=rhel6", msg="New GCC cannot use system assembler on RHEL6")
+    # Ditto for RHEL7/8: OpenBLAS uses flags which the RHEL system-binutils don't have:
+    # https://github.com/xianyi/OpenBLAS/issues/3805#issuecomment-1319878852
+    conflicts(
+        "~binutils", when="@10: os=rhel7", msg="gcc: Add +binutils - preinstalled as might be old"
+    )
+    conflicts(
+        "~binutils", when="@10: os=rhel8", msg="gcc: Add +binutils - preinstalled as might be old"
+    )
+
+    # GCC 11 requires GCC 4.8 or later (https://gcc.gnu.org/gcc-11/changes.html)
+    conflicts("%gcc@:4.7", when="@11:")
+
+    # https://github.com/iains/gcc-12-branch/issues/6
+    conflicts("@:12", when="%apple-clang@14:14.0")
+
+    if sys.platform == "darwin":
+        # Fix parallel build on APFS filesystem
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
+        if macos_version() >= Version("10.13"):
+            patch("darwin/apfs.patch", when="@5.5.0,6.1:6.4,7.1:7.3")
+            # from homebrew via macports
+            # https://trac.macports.org/ticket/56502#no1
+            # see also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83531
+            patch("darwin/headers-10.13-fix.patch", when="@5.5.0")
+        if macos_version() >= Version("10.14"):
+            # Fix system headers for Mojave SDK:
+            # https://github.com/Homebrew/homebrew-core/pull/39041
+            patch(
+                "https://raw.githubusercontent.com/Homebrew/formula-patches/b8b8e65e/gcc/8.3.0-xcode-bug-_Atomic-fix.patch",
+                sha256="33ee92bf678586357ee8ab9d2faddf807e671ad37b97afdd102d5d153d03ca84",
+                when="@6:8.3",
+            )
+        if macos_version() >= Version("10.15"):
+            # Fix system headers for Catalina SDK
+            # (otherwise __OSX_AVAILABLE_STARTING ends up undefined)
+            patch(
+                "https://raw.githubusercontent.com/Homebrew/formula-patches/b8b8e65e/gcc/9.2.0-catalina.patch",
+                sha256="0b8d14a7f3c6a2f0d2498526e86e088926671b5da50a554ffa6b7f73ac4f132b",
+                when="@9.2.0",
+            )
+
+            # See https://raw.githubusercontent.com/Homebrew/homebrew-core/3b7db4457ac64a31e3bbffc54b04c4bd824a4a4a/Formula/gcc.rb
+            patch(
+                "https://github.com/iains/gcc-darwin-arm64/commit/20f61faaed3b335d792e38892d826054d2ac9f15.patch?full_index=1",
+                sha256="c0605179a856ca046d093c13cea4d2e024809ec2ad4bf3708543fc3d2e60504b",
+                when="@11.2.0",
+            )
+
+        # aarch64-darwin support from Iain Sandoe's branch
+        patch(
+            "https://github.com/iains/gcc-14-branch/compare/04696df09633baf97cdbbdd6e9929b9d472161d3..a495b2dded281beeafec91074e4e82a5a3df8104.patch?full_index=1",
+            sha256="838cf070bec5468340018bf003f714f6340c562b878f3244303d2b7ba9949ccd",
+            when="@14.2.0 target=aarch64:",
+        )
+        patch(
+            "https://github.com/iains/gcc-14-branch/compare/cd0059a1976303638cea95f216de129334fc04d1..gcc-14.1-darwin-r1.patch?full_index=1",
+            sha256="159cc2a1077ad5d9a3cca87880cd977b8202d8fb464a6ec7b53804475d21a682",
+            when="@14.1.0 target=aarch64:",
+        )
+
+        patch(
+            "https://github.com/iains/gcc-13-branch/compare/b71f1de6e9cf7181a288c0f39f9b1ef6580cf5c8..7808d253bf53c6c6ce63f04a66601b595e2bae08.patch?full_index=1",
+            sha256="e7d4415e66ba09dd65b102a842e62e6f9ba6b41da878e08235e59a3fc53058eb",
+            when="@13.3.0 target=aarch64:",
+        )
+        patch(
+            "https://github.com/iains/gcc-13-branch/compare/c891d8dc23e1a46ad9f3e757d09e57b500d40044..gcc-13.2-darwin-r0.patch?full_index=1",
+            sha256="6a49d1074d7dd2e3b76e61613a0f143c668ed648fb8d9d48ed76a6b127815c88",
+            when="@13.2.0 target=aarch64:",
+        )
+        patch(
+            "https://github.com/iains/gcc-13-branch/compare/cc035c5d8672f87dc8c2756d9f8367903aa72d93..gcc-13.1-darwin-r0.patch?full_index=1",
+            sha256="36d2c04d487edb6792b48dedae6936f8b864b6f969bd3fd03763e072d471c022",
+            when="@13.1.0 target=aarch64:",
+        )
+
+        patch(
+            "https://github.com/iains/gcc-12-branch/compare/2bada4bc59bed4be34fab463bdb3c3ebfd2b41bb..99533d94172ed7a24c0e54c4ea97e6ae2260409e.patch?full_index=1",
+            sha256="4f59c671b34cc24b57eaa528592a5188f18716cd3cd63c4601fbbda92d397ce2",
+            when="@12.4.0 target=aarch64:",
+        )
+        patch(
+            "https://github.com/iains/gcc-12-branch/compare/8fc1a49c9312b05d925b7d21f1d2145d70818151..gcc-12.3-darwin-r0.patch?full_index=1",
+            sha256="1ebac2010eb9ced33cf46a8d8378193671ed6830f262219aa3428de5bc9fd668",
+            when="@12.3.0 target=aarch64:",
+        )
+        patch(
+            "https://github.com/iains/gcc-12-branch/compare/2ee5e4300186a92ad73f1a1a64cb918dc76c8d67..gcc-12.2-darwin-r0.patch?full_index=1",
+            sha256="16d5203ddb97cd43d6c1e9c34e0f681154aed1d127f2324b2a50006b92960cfd",
+            when="@12.2.0 target=aarch64:",
+        )
+        patch(
+            "https://github.com/iains/gcc-12-branch/compare/1ea978e3066ac565a1ec28a96a4d61eaf38e2726..gcc-12.1-darwin-r1.patch?full_index=1",
+            sha256="b0a811e33c3451ebd1882eac4e2b4b32ce0b60cfa0b8ccf8c5fda7b24327c820",
+            when="@12.1.0 target=aarch64:",
+        )
+
+        patch(
+            "https://github.com/iains/gcc-11-branch/compare/5cc4c42a0d4de08715c2eef8715ad5b2e92a23b6..gcc-11.5-darwin-r0.patch?full_index=1",
+            sha256="6c92190a9acabd6be13bd42ca675f59f44be050a7121214abeaea99d898db30c",
+            when="@11.5.0 target=aarch64:",
+        )
+        patch(
+            "https://github.com/iains/gcc-11-branch/compare/ff4bf326d03e750a8d4905ea49425fe7d15a04b8..gcc-11.4-darwin-r0.patch?full_index=1",
+            sha256="05810e5cdb052c06490f7d987c66a13d47ae7bd2eb285a3a881ad4aa6dd0d13f",
+            when="@11.4.0 target=aarch64:",
+        )
+        patch(
+            "https://github.com/iains/gcc-11-branch/compare/2d280e7eafc086e9df85f50ed1a6526d6a3a204d..gcc-11.3-darwin-r2.patch?full_index=1",
+            sha256="a8097c232dfb21b0e02f3d99e3c3e47443db3982dafbb584938ac1a9a4afd33d",
+            when="@11.3.0 target=aarch64:",
+        )
+
+        conflicts("+bootstrap", when="@11.3.0,13.1: target=aarch64:")
+
+        # Use -headerpad_max_install_names in the build,
+        # otherwise updated load commands won't fit in the Mach-O header.
+        # This is needed because `gcc` avoids the superenv shim.
+        patch("darwin/gcc-7.1.0-headerpad.patch", when="@5:11.2")
+        patch("darwin/gcc-6.1.0-jit.patch", when="@5:7")
+        patch("darwin/gcc-4.9.patch1", when="@4.9.0:4.9.3")
+        patch("darwin/gcc-4.9.patch2", when="@4.9.0:4.9.3")
+
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92061
+        patch("darwin/clang13.patch", when="@:11.1 %apple-clang@13")
+
+    patch("piclibs.patch", when="+piclibs")
+    patch("gcc-backport.patch", when="@4.7:4.9.3,5:5.3")
+
+    # Backport libsanitizer patch for glibc >= 2.31 and 5.3.0 <= gcc <= 9.2.0
+    # https://bugs.gentoo.org/708346
+    patch("glibc-2.31-libsanitizer-1.patch", when="@7.1.0:7.5.0,8.1.0:8.3.0,9.0.0:9.2.0")
+    patch("glibc-2.31-libsanitizer-1-gcc-6.patch", when="@5.3.0:5.5.0,6.1.0:6.5.0")
+    patch("glibc-2.31-libsanitizer-2.patch", when="@8.1.0:8.3.0,9.0.0:9.2.0")
+    patch("glibc-2.31-libsanitizer-2-gcc-6.patch", when="@5.3.0:5.5.0,6.1.0:6.5.0")
+    patch("glibc-2.31-libsanitizer-2-gcc-7.patch", when="@7.1.0:7.5.0")
+    patch(
+        "patch-2b40941d23b1570cdd90083b58fa0f66aa58c86e.patch",
+        when="@6.5.0,7.4.0:7.5.0,8.2.0:9.3.0",
+    )
+    patch("patch-745dae5923aba02982563481d75a21595df22ff8.patch", when="@10.1.0:10.3.0,11.1.0")
+
+    # Backport libsanitizer patch for glibc >= 2.36
+    # https://reviews.llvm.org/D129471
+    patch("glibc-2.36-libsanitizer-gcc-5-9.patch", when="@5:9")
+    patch("glibc-2.36-libsanitizer-gcc-10-12.patch", when="@10:10.4,11:11.3,12.1.0")
+
+    # Older versions do not compile with newer versions of glibc
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81712
+    patch("ucontext_t.patch", when="@4.9,5.1:5.4,6.1:6.4,7.1")
+    patch("ucontext_t-java.patch", when="@4.9,5.1:5.4,6.1:6.4 languages=java")
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81066
+    patch("stack_t-4.9.patch", when="@4.9")
+    patch("stack_t.patch", when="@5.1:5.4,6.1:6.4,7.1")
+    # https://bugs.busybox.net/show_bug.cgi?id=10061
+    patch("signal.patch", when="@4.9,5.1:5.4")
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85835
+    patch("sys_ustat.h.patch", when="@5.0:6.4,7.0:7.3,8.1")
+    patch("sys_ustat-4.9.patch", when="@4.9")
+
+    # this patch removes cylades support from gcc-5 and allows gcc-5 to be built
+    # with newer glibc versions.
+    patch("glibc-2.31-libsanitizer-3-gcc-5.patch", when="@5.3.0:5.5.0")
+
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95005
+    patch("zstd.patch", when="@10")
+
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100102
+    patch("patch-fc930b3010bd0de899a3da3209eab20664ddb703.patch", when="@10.1:10.3")
+    patch("patch-f1feb74046e0feb0596b93bbb822fae02940a90e.patch", when="@11.1")
+
+    # libstdc++: Fix inconsistent noexcept-specific for valarray begin/end
+    patch(
+        "https://github.com/gcc-mirror/gcc/commit/423cd47cfc9640ba3d6811b780e8a0b94b704dcb.patch?full_index=1",
+        sha256="0d136226eb07bc43f1b15284f48bd252e3748a0426b5d7ac9084ebc406e15490",
+        when="@9.5.0:10.4.0,11.1.0:11.2.0",
+    )
+
+    # patch ICE on aarch64 in tree-vect-slp, cf: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111478
+    # patch taken from releases/gcc-12 branch
+    patch(
+        "https://github.com/gcc-mirror/gcc/commit/9d033155254ac6df5f47ab32896dbf336f991589.patch?full_index=1",
+        sha256="8b76fe575ef095b48ac45e8b56544c331663f840ce4b63abdb61510bf3647597",
+        when="@12.3.0 target=aarch64:",
+    )
+    # patch taken from releases/gcc-13 branch
+    patch(
+        "https://github.com/gcc-mirror/gcc/commit/7c67939ec384425a3d7383dfb4fb39aa7e9ad20a.patch?full_index=1",
+        sha256="f0826d7a9c9808af40f3434918f24ad942f1c6a6daec73f11cf52c544cf5fc01",
+        when="@13.2.0 target=aarch64:",
+    )
+
+    # see https://gcc.gnu.org/gcc-11/changes.html 11.5 Caveats
+    patch("patch-5522dec054cb940fe83661b96249aa12c54c1d77.patch", when="@11.5.0 target=aarch64:")
+
+    build_directory = "spack-build"
+
+    compiler_languages = ["c", "cxx", "fortran", "d", "go"]
+
+    # gcc works everywhere but Windows
+    is_supported_on_platform = lambda x: not isinstance(x, spack.platforms.Windows)
+
+    @property
+    def supported_languages(self):
+        # This weirdness is because it could be called on an abstract spec
+        if "languages" not in self.spec.variants:
+            return self.compiler_languages
+        variant_value = {"cxx": "c++"}
+        return [
+            x
+            for x in self.compiler_languages
+            if self.spec.satisfies(f"languages={variant_value.get(x, x)}")
+        ]
+
+    c_names = ["gcc"]
+    cxx_names = ["g++"]
+    fortran_names = ["gfortran"]
+    d_names = ["gdc"]
+    go_names = ["gccgo"]
+    compiler_suffixes = [r"-mp-\d+(?:\.\d+)?", r"-\d+(?:\.\d+)?", r"\d\d"]
+    compiler_version_regex = r"([0-9.]+)"
+    compiler_version_argument = ("-dumpfullversion", "-dumpversion")
+
+    compiler_wrapper_link_paths = {
+        "c": os.path.join("gcc", "gcc"),
+        "cxx": os.path.join("gcc", "g++"),
+        "fortran": os.path.join("gcc", "gfortran"),
+    }
+
+    debug_flags = ["-g", "-gstabs+", "-gstabs", "-gxcoff+", "-gxcoff", "-gvms"]
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-Os", "-Ofast", "-Og"]
+
+    implicit_rpath_libs = ["libgcc", "libgfortran"]
+    stdcxx_libs = ("-lstdc++",)
+
+    def _standard_flag(self, *, language, standard):
+        flags = {
+            "cxx": {
+                "98": [("@6:", "-std=c++98"), ("@:5", "")],
+                "11": [("@4.3:4.6", "-std=c++0x"), ("@4.7:", "-std=c++11")],
+                "14": [("@4.8", "-std=c++1y"), ("@4.9:", "-std=c++14")],
+                "17": [("@5", "-std=c++1z"), ("@6:", "-std=c++17")],
+                "20": [("@8:10", "-std=c++2a"), ("@11:", "-std=c++20")],
+                "23": [("@11:13", "-std=c++2b"), ("@14:", "-std=c++23")],
+            },
+            "c": {"99": [("@4.5:", "-std=c99")], "11": [("@4.7:", "-std=c11")]},
+        }
+        for condition, flag in flags[language][standard]:
+            if self.spec.satisfies(condition):
+                return flag
+
+        else:
+            raise RuntimeError(
+                f"{self.spec} does not support the '{standard}' standard "
+                f"for the '{language}' language"
+            )
+
+    @classmethod
+    def filter_detected_exes(cls, prefix, exes_in_prefix):
+        # Apple's gcc is actually apple clang, so skip it.
+        if str(spack.platforms.host()) == "darwin":
+            not_apple_clang = []
+            for exe in exes_in_prefix:
+                try:
+                    output = compiler.compiler_output(exe, version_argument="--version")
+                except Exception:
+                    output = ""
+                if "clang version" in output:
+                    continue
+                not_apple_clang.append(exe)
+            return not_apple_clang
+
+        return exes_in_prefix
+
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        compilers = cls.determine_compiler_paths(exes=exes)
+
+        languages = set()
+        translation = {"cxx": "c++"}
+        for lang, _ in compilers.items():
+            languages.add(translation.get(lang, lang))
+        variant_str = "languages:={0}".format(",".join(languages))
+        return variant_str, {"compilers": compilers}
+
+    @classmethod
+    def validate_detected_spec(cls, spec, extra_attributes):
+        # For GCC 'compilers' is a mandatory attribute
+        msg = f'the extra attribute "compilers" must be set for the detected spec "{spec}"'
+        assert "compilers" in extra_attributes, msg
+
+        compilers = extra_attributes["compilers"]
+        for constraint, key in {
+            "languages=c": "c",
+            "languages=c++": "cxx",
+            "languages=d": "d",
+            "languages=fortran": "fortran",
+        }.items():
+            if spec.satisfies(constraint):
+                msg = "{0} not in {1}"
+                assert key in compilers, msg.format(key, spec)
+
+    def _cc_path(self):
+        if self.spec.satisfies("languages=c"):
+            return str(self.spec.prefix.bin.gcc)
+        return None
+
+    def _cxx_path(self):
+        if self.spec.satisfies("languages=c++"):
+            return os.path.join(self.spec.prefix.bin, "g++")
+        return None
+
+    def _fortran_path(self):
+        if self.spec.satisfies("languages=fortran"):
+            return str(self.spec.prefix.bin.gfortran)
+        return None
+
+    def url_for_version(self, version):
+        # This function will be called when trying to fetch from url, before
+        # mirrors are tried. It takes care of modifying the suffix of gnu
+        # mirror path so that Spack will also look for the correct file in
+        # the mirrors
+        if (version < Version("6.4.0") and version != Version("5.5.0")) or version == Version(
+            "7.1.0"
+        ):
+            self.gnu_mirror_path = self.gnu_mirror_path.replace("xz", "bz2")
+        return super().url_for_version(version)
+
+    def patch(self):
+        spec = self.spec
+        prefix = self.spec.prefix
+
+        # Fix a standard header file for OS X Yosemite that
+        # is GCC incompatible by replacing non-GCC compliant macros
+        if "yosemite" in spec.architecture:
+            if os.path.isfile("/usr/include/dispatch/object.h"):
+                new_dispatch_dir = join_path(prefix, "include", "dispatch")
+                mkdirp(new_dispatch_dir)
+                new_header = join_path(new_dispatch_dir, "object.h")
+                install("/usr/include/dispatch/object.h", new_header)
+                filter_file(
+                    r"typedef void \(\^dispatch_block_t\)\(void\)",
+                    "typedef void* dispatch_block_t",
+                    new_header,
+                )
+
+        # Use installed libz
+        if self.version >= Version("6"):
+            filter_file(
+                "@zlibdir@", "-L{0}".format(spec["zlib-api"].prefix.lib), "gcc/Makefile.in"
+            )
+            filter_file(
+                "@zlibinc@", "-I{0}".format(spec["zlib-api"].prefix.include), "gcc/Makefile.in"
+            )
+
+        if spec.satisfies("+nvptx"):
+            # backport of 383400a6078d upstream to allow support of cuda@11:
+            filter_file(
+                '#define ASM_SPEC "%{misa=*:-m %*}"',
+                '#define ASM_SPEC "%{misa=*:-m %*; :-m sm_35}"',
+                "gcc/config/nvptx/nvptx.h",
+                string=True,
+            )
+            filter_file(
+                "Target RejectNegative ToLower Joined "
+                "Enum(ptx_isa) Var(ptx_isa_option) Init(PTX_ISA_SM30)",
+                "Target RejectNegative ToLower Joined "
+                "Enum(ptx_isa) Var(ptx_isa_option) Init(PTX_ISA_SM35)",
+                "gcc/config/nvptx/nvptx.opt",
+                string=True,
+            )
+        self.build_optimization_config()
+
+    def get_common_target_flags(self, spec):
+        """Get the right (but pessimistic) architecture specific flags supported by
+        both host gcc and to-be-built gcc. For example: gcc@7 %gcc@12 target=znver3
+        should pick -march=znver1, since that's what gcc@7 supports."""
+        microarchitectures = [spec.target] + spec.target.ancestors
+        for uarch in microarchitectures:
+            try:
+                return uarch.optimization_flags("gcc", str(spec.version))
+            except ValueError:
+                pass
+        # no arch specific flags in common, unlikely to happen.
+        return ""
+
+    def build_optimization_config(self):
+        """Write a config/spack.mk file with sensible optimization flags, taking into
+        account bootstrapping subtleties."""
+        build_type_flags = {
+            "Debug": "-O0 -g",
+            "Release": "-O3",
+            "RelWithDebInfo": "-O2 -g",
+            "MinSizeRel": "-Os",
+        }
+
+        # Generic optimization flags.
+        flags = build_type_flags[self.spec.variants["build_type"].value]
+
+        # Pessimistic target specific flags. For example, when building
+        # gcc@11 %gcc@7 on znver3, Spack will fix the target to znver1 during
+        # concretization, so we'll stick to that. The other way around however can
+        # result in compilation errors, when gcc@7 is built with gcc@11, and znver3
+        # is taken as a the target, which gcc@7 doesn't support.
+        # Note we're not adding this for aarch64 because of
+        # https://github.com/spack/spack/issues/31184
+        if "+bootstrap %gcc" in self.spec and self.spec.target.family != "aarch64":
+            flags += " " + self.get_common_target_flags(self.spec)
+
+        if self.spec.satisfies("+bootstrap"):
+            variables = ["BOOT_CFLAGS", "CFLAGS_FOR_TARGET", "CXXFLAGS_FOR_TARGET"]
+        else:
+            variables = ["CFLAGS", "CXXFLAGS"]
+
+        # Redefine a few variables without losing other defaults:
+        # BOOT_CFLAGS = $(filter-out -O% -g%, $(BOOT_CFLAGS)) -O3
+        # This makes sure that build_type=Release is really -O3, not -O3 -g.
+        fmt_string = "{} := $(filter-out -O% -g%, $({})) {}\n"
+        with open("config/spack.mk", "w") as f:
+            for var in variables:
+                f.write(fmt_string.format(var, var, flags))
+            # Improve the build time for stage 2 a bit by enabling -O1 in stage 1.
+            # Note: this is ignored under ~bootstrap.
+            f.write("STAGE1_CFLAGS += -O1\n")
+
+    # https://gcc.gnu.org/install/configure.html
+    def configure_args(self):
+        spec = self.spec
+
+        # Generic options to compile GCC
+        options = [
+            # Distributor options
+            "--with-pkgversion=Spack GCC",
+            "--with-bugurl=https://github.com/spack/spack/issues",
+            # Xcode 10 dropped 32-bit support
+            "--disable-multilib",
+            "--enable-languages={0}".format(",".join(spec.variants["languages"].value)),
+            # Drop gettext dependency
+            "--disable-nls",
+        ]
+
+        # Avoid excessive realpath/stat calls for every system header
+        # by making -fno-canonical-system-headers the default.
+        if self.version >= Version("4.8.0"):
+            options.append("--disable-canonical-system-headers")
+
+        # Use installed libz
+        if self.version >= Version("6"):
+            options.append("--with-system-zlib")
+
+        if self.version >= Version("10"):
+            options.append("--with-zstd-include={0}".format(spec["zstd"].headers.directories[0]))
+            options.append("--with-zstd-lib={0}".format(spec["zstd"].libs.directories[0]))
+
+        # Enabling language "jit" requires --enable-host-shared.
+        if spec.satisfies("languages=jit"):
+            options.append("--enable-host-shared")
+
+        # enable_bootstrap
+        if spec.satisfies("+bootstrap"):
+            options.extend(["--enable-bootstrap"])
+        else:
+            options.extend(["--disable-bootstrap"])
+
+        # Configure include and lib directories explicitly for these
+        # dependencies since the short GCC option assumes that libraries
+        # are installed in "/lib" which might not be true on all OS
+        # (see #10842)
+        #
+        # More info at: https://gcc.gnu.org/install/configure.html
+        for dep_str in ("mpfr", "gmp", "mpc", "isl"):
+            if dep_str not in spec:
+                options.append("--without-{0}".format(dep_str))
+                continue
+
+            dep_spec = spec[dep_str]
+            include_dir = dep_spec.headers.directories[0]
+            lib_dir = dep_spec.libs.directories[0]
+            options.extend(
+                [
+                    "--with-{0}-include={1}".format(dep_str, include_dir),
+                    "--with-{0}-lib={1}".format(dep_str, lib_dir),
+                ]
+            )
+
+        # nvptx-none offloading for host compiler
+        if spec.satisfies("+nvptx"):
+            options.extend(
+                [
+                    "--enable-offload-targets=nvptx-none",
+                    "--with-cuda-driver-include={0}".format(spec["cuda"].prefix.include),
+                    "--with-cuda-driver-lib={0}".format(spec["cuda"].libs.directories[0]),
+                    "--disable-bootstrap",
+                    "--disable-multilib",
+                ]
+            )
+
+        if sys.platform == "darwin":
+            options.extend(
+                [
+                    "--with-native-system-header-dir=/usr/include",
+                    "--with-sysroot={0}".format(macos_sdk_path()),
+                    "--with-libiconv-prefix={0}".format(spec["iconv"].prefix),
+                ]
+            )
+
+        # enable appropriate bootstrapping flags
+        stage1_ldflags = str(self.rpath_args)
+        boot_ldflags = stage1_ldflags + " -static-libstdc++ -static-libgcc"
+        options.append("--with-stage1-ldflags=" + stage1_ldflags)
+        options.append("--with-boot-ldflags=" + boot_ldflags)
+        options.append("--with-build-config=spack")
+
+        if spec.satisfies("languages=d"):
+            # Phobos is the standard library for the D Programming Language. The documentation says
+            # that on some targets, 'libphobos' is not enabled by default, but compiles and works
+            # if '--enable-libphobos' is used. Specifics are documented for affected targets.
+            # See https://gcc.gnu.org/install/prerequisites.html#GDC-prerequisite
+            # Unfortunately, it is unclear where exactly the aforementioned specifics are
+            # documented but GDC seems to be unusable without the library, therefore we enable it
+            # explicitly:
+            options.append("--enable-libphobos")
+            if spec.satisfies("@12:"):
+                options.append("GDC={0}".format(self.detect_gdc()))
+
+        return options
+
+    # Copy nvptx-tools into the GCC install prefix
+    def copy_nvptx_tools(self):
+        nvptx_tools_bin_path = self.spec["nvptx-tools"].prefix.bin
+        gcc_bin_path = self.prefix.bin
+        mkdirp(gcc_bin_path)
+        copy_list = ["as", "ld", "nm", "run", "run-single"]
+        for file in copy_list:
+            fullname = f"nvptx-none-{file}"
+            copy(join_path(nvptx_tools_bin_path, fullname), join_path(gcc_bin_path, fullname))
+        link_list = ["ar", "ranlib"]
+        for file in link_list:
+            fullname = f"nvptx-none-{file}"
+            orig_target = readlink(join_path(nvptx_tools_bin_path, fullname))
+            symlink(orig_target, join_path(gcc_bin_path, fullname))
+        util_dir_path = join_path(self.prefix, "nvptx-none", "bin")
+        mkdirp(util_dir_path)
+        util_list = ["ar", "as", "ld", "nm", "ranlib"]
+        for file in util_list:
+            rel_target = join_path("..", "..", "bin", f"nvptx-none-{file}")
+            dest_link = join_path(util_dir_path, file)
+            symlink(rel_target, dest_link)
+
+    # run configure/make/make(install) for the nvptx-none target
+    # before running the host compiler phases
+    @run_before("configure")
+    def nvptx_install(self):
+        spec = self.spec
+        prefix = self.prefix
+
+        if not spec.satisfies("+nvptx"):
+            return
+
+        # config.guess returns the host triple, e.g. "x86_64-pc-linux-gnu"
+        guess = Executable("./config.guess")
+        targetguess = guess(output=str).rstrip("\n")
+
+        options = getattr(self, "configure_flag_args", [])
+        options += ["--prefix={0}".format(prefix)]
+
+        options += [
+            "--with-cuda-driver-include={0}".format(spec["cuda"].prefix.include),
+            "--with-cuda-driver-lib={0}".format(spec["cuda"].libs.directories[0]),
+        ]
+
+        self.copy_nvptx_tools()
+
+        pattern = join_path(self.stage.source_path, "newlibsource", "*")
+        files = glob.glob(pattern)
+
+        if files:
+            symlink(join_path(files[0], "newlib"), "newlib")
+
+        # self.build_directory = 'spack-build-nvptx'
+        with working_dir("spack-build-nvptx", create=True):
+            options = [
+                "--prefix={0}".format(prefix),
+                "--enable-languages={0}".format(",".join(spec.variants["languages"].value)),
+                "--with-mpfr={0}".format(spec["mpfr"].prefix),
+                "--with-gmp={0}".format(spec["gmp"].prefix),
+                "--target=nvptx-none",
+                "--with-build-time-tools={0}".format(join_path(prefix, "nvptx-none", "bin")),
+                "--enable-as-accelerator-for={0}".format(targetguess),
+                "--disable-sjlj-exceptions",
+                "--enable-newlib-io-long-long",
+            ]
+
+            configure = Executable("../configure")
+            configure(*options)
+            make()
+            make("install")
+
+    @property
+    def build_targets(self):
+        if self.spec.satisfies("+profiled"):
+            return ["profiledbootstrap"]
+        return []
+
+    @property
+    def install_targets(self):
+        if self.spec.satisfies("+strip"):
+            return ["install-strip"]
+        return ["install"]
+
+    @property
+    def spec_dir(self):
+        # e.g. lib/gcc/x86_64-unknown-linux-gnu/4.9.2
+        spec_dir = glob.glob(f"{self.prefix.lib}/gcc/*/*")
+        return spec_dir[0] if spec_dir else None
+
+    @run_after("install")
+    def write_specs_file(self):
+        """(1) inject an rpath to its runtime library dir, (2) add a default programs search path
+        to <binutils>/bin."""
+        if not self.spec_dir:
+            tty.warn(f"Could not install specs for {self.spec.format('{name}{@version}')}.")
+            return
+
+        # Find which directories have shared libraries
+        for dir in ["lib64", "lib"]:
+            libdir = join_path(self.prefix, dir)
+            if glob.glob(join_path(libdir, "libgcc_s.*")):
+                rpath_dir = libdir
+                break
+        else:
+            tty.warn("No dynamic libraries found in lib/lib64")
+            rpath_dir = None
+
+        specs_file = join_path(self.spec_dir, "specs")
+        with open(specs_file, "w") as f:
+            # can't extend the builtins without dumping them first
+            f.write(self.command("-dumpspecs", output=str, error=os.devnull).strip())
+
+            f.write("\n\n# Generated by Spack\n\n")
+
+            # rpath
+            if rpath_dir:
+                f.write(f"*link_libgcc:\n+ -rpath {rpath_dir}\n\n")
+
+            # programs search path
+            if self.spec.satisfies("+binutils"):
+                f.write(f"*self_spec:\n+ -B{self.spec['binutils'].prefix.bin}\n\n")
+
+            # set -fuse-ld=mold as the default linker when +mold
+            if self.spec.satisfies("+mold"):
+                f.write(
+                    f"*self_spec:\n+ -B{self.spec['mold'].prefix.bin} "
+                    "%{!fuse-ld*:-fuse-ld=mold}\n\n"
+                )
+
+        set_install_permissions(specs_file)
+        tty.info(f"Wrote new spec file to {specs_file}")
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        if self.cc and self.spec.satisfies("languages=c"):
+            env.set("CC", self.cc)
+
+        if self.cxx and self.spec.satisfies("languages=c++"):
+            env.set("CXX", self.cxx)
+
+        if self.fortran and self.spec.satisfies("languages=fortran"):
+            env.set("FC", self.fortran)
+            env.set("F77", self.fortran)
+
+    def detect_gdc(self):
+        """Detect and return the path to GDC that belongs to the same instance of GCC that is used
+        by self.compiler.
+
+        If the path cannot be detected, raise InstallError with recommendations for the users on
+        how to circumvent the problem.
+
+        Should be use only if self.spec.satisfies("@12: languages=d")
+        """
+        # Detect GCC package in the directory of the GCC compiler
+        # or in the $PATH if self.compiler.cc is not an absolute path:
+        from spack.detection import by_path
+
+        compiler_dir = os.path.dirname(self.compiler.cc)
+        detected_packages = by_path(
+            [self.name], path_hints=([compiler_dir] if os.path.isdir(compiler_dir) else None)
+        )
+
+        # We consider only packages that satisfy the following constraint:
+        required_spec = Spec("languages=c,c++,d")
+        candidate_specs = [
+            p.spec
+            for p in filter(
+                lambda p: p.spec.satisfies(required_spec), detected_packages.get(self.name, ())
+            )
+        ]
+
+        if candidate_specs:
+            # We now need to filter specs that match the compiler version:
+            compiler_spec = Spec(repr(self.compiler.spec))
+
+            # First, try to filter specs that satisfy the compiler spec:
+            new_candidate_specs = list(
+                filter(lambda s: s.satisfies(compiler_spec), candidate_specs)
+            )
+
+            # The compiler version might be more specific than what we can detect. For example, the
+            # user might have "gcc@10.2.1-sys" as the compiler spec in compilers.yaml. In that
+            # case, we end up with an empty list of candidates. To circumvent the problem, we try
+            # to filter specs that are satisfied by the compiler spec:
+            if not new_candidate_specs:
+                new_candidate_specs = list(
+                    filter(lambda s: compiler_spec.satisfies(s), candidate_specs)
+                )
+
+            candidate_specs = new_candidate_specs
+
+        error_nl = "\n    "  # see SpackError.__str__()
+
+        if not candidate_specs:
+            raise InstallError(
+                "Cannot detect GDC",
+                long_msg="Starting version 12, the D frontend requires a working GDC."
+                "{0}You can install it with Spack by running:"
+                "{0}{0}spack install gcc@9:11 languages=c,c++,d"
+                "{0}{0}Once that has finished, you will need to add it to your compilers.yaml file"
+                "{0}and use it to install this spec (i.e. {1} ...).".format(
+                    error_nl, self.spec.format("{name}{@version} {variants.languages}")
+                ),
+            )
+        elif len(candidate_specs) == 0:
+            return candidate_specs[0].extra_attributes["compilers"]["d"]
+        else:
+            # It is rather unlikely to end up here but let us try to resolve the ambiguity:
+            candidate_gdc = candidate_specs[0].extra_attributes["compilers"]["d"]
+            if all(
+                candidate_gdc == s.extra_attributes["compilers"]["d"] for s in candidate_specs[1:]
+            ):
+                # It does not matter which one we take if they are all the same:
+                return candidate_gdc
+            else:
+                raise InstallError(
+                    "Cannot resolve ambiguity when detecting GDC that belongs to "
+                    "%{0}".format(self.compiler.spec),
+                    long_msg="The candidates are:{0}{0}{1}{0}".format(
+                        error_nl,
+                        error_nl.join(
+                            "{0} (cc: {1})".format(
+                                s.extra_attributes["compilers"]["d"],
+                                s.extra_attributes["compilers"]["c"],
+                            )
+                            for s in candidate_specs
+                        ),
+                    ),
+                )
+
+    @classmethod
+    def runtime_constraints(cls, *, spec, pkg):
+        """Callback function to inject runtime-related rules into the solver.
+
+        Rule-injection is obtained through method calls of the ``pkg`` argument.
+
+        Documentation for this function is temporary. When the API will be in its final state,
+        we'll document the behavior at https://spack.readthedocs.io/en/latest/
+
+        Args:
+            spec: spec that will inject runtime dependencies
+            pkg: object used to forward information to the solver
+        """
+        for language in ("c", "cxx", "fortran"):
+            pkg("*").depends_on(
+                f"gcc-runtime@{spec.version}:",
+                when=f"%[deptypes=build virtuals={language}] {spec.name}@{spec.versions}",
+                type="link",
+                description=f"Inject gcc-runtime when gcc is used as a {language} compiler",
+            )
+
+        gfortran_str = "libgfortran@5"
+        if spec.satisfies("gcc@:6"):
+            gfortran_str = "libgfortran@3"
+        elif spec.satisfies("gcc@7"):
+            gfortran_str = "libgfortran@4"
+
+        for fortran_virtual in ("fortran-rt", gfortran_str):
+            pkg("*").depends_on(
+                fortran_virtual,
+                when=f"%[deptypes=build virtuals=fortran] {spec.name}@{spec.versions}",
+                type="link",
+                description=f"Add a dependency on '{gfortran_str}' for nodes compiled with "
+                f"{spec} and using the 'fortran' language",
+            )
+        # The version of gcc-runtime is the same as the %gcc used to "compile" it
+        pkg("gcc-runtime").requires(
+            f"@{spec.versions}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
+        )
+
+        # If a node used %gcc@X.Y its dependencies must use gcc-runtime@:X.Y
+        # (technically @:X is broader than ... <= @=X but this should work in practice)
+        pkg("*").propagate(
+            f"gcc@:{spec.version}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
+        )
+
+    def _post_buildcache_install_hook(self):
+        if not self.spec.satisfies("platform=linux"):
+            return
+
+        # Setting up the runtime environment shouldn't be necessary here.
+        relocation_args = []
+        gcc = self.command
+        specs_file = os.path.join(self.spec_dir, "specs")
+        dryrun = gcc("test.c", "-###", output=os.devnull, error=str).strip()
+        if not dryrun:
+            tty.warn(f"Cannot relocate {specs_file}, compiler might not be working properly")
+            return
+        dynamic_linker = spack.util.libc.parse_dynamic_linker(dryrun)
+        if not dynamic_linker:
+            tty.warn(f"Cannot relocate {specs_file}, compiler might not be working properly")
+            return
+
+        libc = spack.util.libc.libc_from_dynamic_linker(dynamic_linker)
+
+        # We search for crt1.o ourselves because `gcc -print-prile-name=crt1.o` can give a rather
+        # convoluted relative path from a different prefix.
+        startfile_prefix = spack.util.libc.startfile_prefix(libc.external_path, dynamic_linker)
+
+        gcc_can_locate = lambda p: os.path.isabs(
+            gcc(f"-print-file-name={p}", output=str, error=os.devnull).strip()
+        )
+
+        if not gcc_can_locate("crt1.o"):
+            relocation_args.append(f"-B{startfile_prefix}")
+
+        # libc headers may also be in a multiarch subdir.
+        header_dir = spack.util.libc.libc_include_dir_from_startfile_prefix(
+            libc.external_path, startfile_prefix
+        )
+        if header_dir and all(
+            os.path.exists(os.path.join(header_dir, h))
+            for h in spack.repo.PATH.get_pkg_class(libc.fullname).representative_headers
+        ):
+            relocation_args.append(f"-idirafter {header_dir}")
+        else:
+            tty.warn(
+                f"Cannot relocate {specs_file} include directories, "
+                f"compiler might not be working properly"
+            )
+
+        # Delete current spec files.
+        try:
+            os.unlink(specs_file)
+        except OSError:
+            pass
+
+        # Write a new one and append flags for libc
+        self.write_specs_file()
+
+        if relocation_args:
+            with open(specs_file, "a") as f:
+                f.write(f"*self_spec:\n+ {' '.join(relocation_args)}\n\n")

--- a/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 
 from spack_repo.builtin.build_systems import compiler
-from spack_repo.builtin.build_systems.compiler import CompilerPackage
+from spack_repo.builtin.build_systems.compiler import CompilerPackage, PlatformSupport
 from spack_repo.builtin.build_systems.generic import Package
 
 import spack.platforms
@@ -47,7 +47,7 @@ class Msvc(Package, CompilerPackage):
 
     compiler_version_argument = ""
     compiler_version_regex = r"([1-9][0-9]*\.[0-9]*\.[0-9]*)"
-    is_supported_on_platform = lambda x: isinstance(x, Windows)
+    supported_platform = PlatformSupport.WINDOWS
 
     # Due to the challenges of supporting compiler wrappers
     # in Windows, we leave these blank, and dynamically compute

--- a/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
@@ -1,0 +1,364 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os.path
+import re
+import subprocess
+
+from spack_repo.builtin.build_systems import compiler
+from spack_repo.builtin.build_systems.compiler import CompilerPackage
+from spack_repo.builtin.build_systems.generic import Package
+
+import spack.platforms
+from spack.package import *
+
+FC_PATH: Dict[str, str] = dict()
+
+
+def get_latest_valid_fortran_pth():
+    """Assign maximum available fortran compiler version"""
+    # TODO (johnwparent): validate compatibility w/ try compiler
+    # functionality when added
+    sort_fn = lambda fc_ver: Version(fc_ver)
+    sort_fc_ver = sorted(list(FC_PATH.keys()), key=sort_fn)
+    return FC_PATH[sort_fc_ver[-1]] if sort_fc_ver else None
+
+
+class Msvc(Package, CompilerPackage):
+    """
+    Microsoft Visual C++ is a compiler for the C, C++, C++/CLI and C++/CX programming languages.
+    """
+
+    homepage = "https://visualstudio.microsoft.com/vs/features/cplusplus/"
+    has_code = False
+
+    has_code = False
+
+    def install(self, spec, prefix):
+        raise InstallError(
+            "MSVC compilers are not installable with Spack, but can be "
+            "detected on a system where they are externally installed"
+        )
+
+    compiler_languages = ["c", "cxx", "fortran"]
+    c_names = ["cl"]
+    cxx_names = ["cl"]
+    fortran_names = ["ifx", "ifort"]
+
+    compiler_version_argument = ""
+    compiler_version_regex = r"([1-9][0-9]*\.[0-9]*\.[0-9]*)"
+    is_supported_on_platform = lambda x: isinstance(x, Windows)
+
+    # Due to the challenges of supporting compiler wrappers
+    # in Windows, we leave these blank, and dynamically compute
+    # based on proper versions of MSVC from there
+    # pending acceptance of #28117 for full support using
+    # compiler wrappers
+    compiler_wrapper_link_paths = {"c": "", "cxx": "", "fortran": ""}
+
+    provides("c", "cxx", "fortran")
+    requires("platform=windows", msg="MSVC is only supported on Windows")
+
+    @classmethod
+    def determine_version(cls, exe):
+        # MSVC compiler does not have a proper version argument
+        # Errors out and prints version info with no args
+        is_ifx = "ifx.exe" in str(exe)
+        match = re.search(
+            cls.compiler_version_regex,
+            compiler.compiler_output(exe, version_argument=None, ignore_errors=1),
+        )
+        if match:
+            if is_ifx:
+                FC_PATH[match.group(1)] = str(exe)
+            return match.group(1)
+
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        # MSVC uses same executable for both languages
+        spec, extras = super().determine_variants(exes, version_str)
+        extras["compilers"]["c"] = extras["compilers"]["cxx"]
+        # This depends on oneapi being processed before msvc
+        # which is guarunteed from detection behavior.
+        # Processing oneAPI tracks oneAPI installations within
+        # this module, which are then used to populate compatible
+        # MSVC version's fortran compiler spots
+
+        # TODO: remove this once #45189 lands
+        # TODO: interrogate intel and msvc for compatibility after
+        # #45189 lands
+        fortran_compiler = get_latest_valid_fortran_pth()
+        if fortran_compiler is not None:
+            extras["compilers"]["fortran"] = fortran_compiler
+        return spec, extras
+
+    def setup_dependent_package(self, module, dependent_spec):
+        """Populates dependent module with tooling available from VS"""
+        # We want these to resolve to the paths set by MSVC's VCVARs
+        # so no paths
+        module.nmake = Executable("nmake")
+        module.msbuild = Executable("msbuild")
+
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        self.init_msvc()
+        # Set the build environment variables for spack. Just using
+        # subprocess.call() doesn't work since that operates in its own
+        # environment which is destroyed (along with the adjusted variables)
+        # once the process terminates. So go the long way around: examine
+        # output, sort into dictionary, use that to make the build
+        # environment.
+
+        # vcvars can target specific sdk versions, force it to pick up concretized sdk
+        # version, if needed by spec
+        if dependent_spec.name != "win-sdk" and "win-sdk" in dependent_spec:
+            self.vcvars_call.sdk_ver = dependent_spec["win-sdk"].version.string
+
+        out = self.msvc_compiler_environment()
+        int_env = dict(
+            (key, value)
+            for key, _, value in (line.partition("=") for line in out.splitlines())
+            if key and value
+        )
+
+        for env_var in int_env:
+            if os.pathsep not in int_env[env_var]:
+                env.set(env_var, int_env[env_var])
+            else:
+                env.set_path(env_var, int_env[env_var].split(os.pathsep))
+
+        if self.cc:
+            env.set("CC", self.cc)
+        if self.cxx:
+            env.set("CXX", self.cxx)
+        if self.fortran:
+            env.set("FC", self.fortran)
+            env.set("F77", self.fortran)
+
+    def init_msvc(self):
+        # To use the MSVC compilers, VCVARS must be invoked
+        # VCVARS is located at a fixed location, referencable
+        # idiomatically by the following relative path from the
+        # compiler.
+        # Spack first finds the compilers via VSWHERE
+        # and stores their path, but their respective VCVARS
+        # file must be invoked before useage.
+        env_cmds = []
+        compiler_root = os.path.join(os.path.dirname(self.cc), "../../../../../..")
+        vcvars_script_path = os.path.join(compiler_root, "Auxiliary", "Build", "vcvars64.bat")
+        # get current platform architecture and format for vcvars argument
+        arch = spack.platforms.real_host().default.lower()
+        arch = arch.replace("-", "_")
+        if self.spec.satisfies("target=x86_64:"):
+            arch = "amd64"
+
+        msvc_version = Version(re.search(Msvc.compiler_version_regex, self.cc).group(1))
+        self.vcvars_call = VCVarsInvocation(vcvars_script_path, arch, msvc_version)
+        env_cmds.append(self.vcvars_call)
+
+        def get_oneapi_root(pth: str):
+            """From within a prefix known to be a oneAPI path
+            determine the oneAPI root path from arbitrary point
+            under root
+
+            Args:
+                pth: path prefixed within oneAPI root
+            """
+            if not pth:
+                return ""
+            while os.path.basename(pth) and os.path.basename(pth) != "oneAPI":
+                pth = os.path.dirname(pth)
+            return pth
+
+        if self.fortran:
+            # If this found, it sets all the vars
+            oneapi_root = get_oneapi_root(self.fortran)
+            if not oneapi_root:
+                raise RuntimeError(f"Non-oneAPI Fortran compiler {self.fortran} assigned to MSVC")
+            oneapi_root_setvars = os.path.join(oneapi_root, "setvars.bat")
+            # some oneAPI exes return a version more precise than their
+            # install paths specify, so we determine path from
+            # the install path rather than the fc executable itself
+            numver = r"\d+\.\d+(?:\.\d+)?"
+            pattern = f"((?:{numver})|(?:latest))"
+            version_from_path = re.search(pattern, self.fortran).group(1)
+            oneapi_version_setvars = os.path.join(
+                oneapi_root, "compiler", version_from_path, "env", "vars.bat"
+            )
+            env_cmds.extend(
+                [VarsInvocation(oneapi_version_setvars), VarsInvocation(oneapi_root_setvars)]
+            )
+        self.msvc_compiler_environment = CmdCall(*env_cmds)
+
+    def _standard_flag(self, *, language: str, standard: str) -> str:
+        flags = {
+            "cxx": {
+                "11": "/std:c++11",
+                "14": "/std:c++14",
+                "17": "/std:c++17",
+                "20": "/std:c++20",
+            },
+            "c": {"11": "/std:c11", "17": "/std:c17"},
+        }
+        return flags[language][standard]
+
+    @property
+    def short_msvc_version(self):
+        """This is the shorthand VCToolset version of form
+        MSVC<short-ver>
+        """
+        return "MSVC" + self.vc_toolset_ver
+
+    @property
+    def vc_toolset_ver(self):
+        """
+        The toolset version is the version of the combined set of cl and link
+        This typically relates directly to VS version i.e. VS 2022 is v143
+        VS 19 is v142, etc.
+        This value is defined by the first three digits of the major + minor
+        version of the VS toolset (143 for 14.3x.bbbbb). Traditionally the
+        minor version has remained a static two digit number for a VS release
+        series, however, as of VS22, this is no longer true, both
+        14.4x.bbbbb and 14.3x.bbbbb are considered valid VS22 VC toolset
+        versions due to a change in toolset minor version sentiment.
+
+        This is *NOT* the full version, for that see
+        Msvc.msvc_version or MSVC.platform_toolset_ver for the
+        raw platform toolset version
+
+        """
+        ver = self.msvc_version[:2].joined.string[:3]
+        return ver
+
+    @property
+    def msvc_version(self):
+        """This is the VCToolset version *NOT* the actual version of the cl compiler"""
+        return Version(re.search(Msvc.compiler_version_regex, self.cc).group(1))
+
+    @property
+    def vs_root(self):
+        # The MSVC install root is located at a fix level above the compiler
+        # and is referenceable idiomatically via the pattern below
+        # this should be consistent accross versions
+        return os.path.abspath(os.path.join(self.cc, "../../../../../../../.."))
+
+    @property
+    def platform_toolset_ver(self):
+        """
+        This is the platform toolset version of current MSVC compiler
+        i.e. 142. The platform toolset is the targeted MSVC library/compiler
+        versions by compilation (this is different from the VC Toolset)
+
+
+        This is different from the VC toolset version as established
+        by `short_msvc_version`, but typically are represented by the same
+        three digit value
+        """
+        # Typically VS toolset version and platform toolset versions match
+        # VS22 introduces the first divergence of VS toolset version
+        # (144 for "recent" releases) and platform toolset version (143)
+        # so it needs additional handling until MS releases v144
+        # (assuming v144 is also for VS22)
+        # or adds better support for detection
+        # TODO: (johnwparent) Update this logic for the next platform toolset
+        # or VC toolset version update
+        toolset_ver = self.vc_toolset_ver
+        vs22_toolset = Version(toolset_ver) > Version("142")
+        return toolset_ver if not vs22_toolset else "143"
+
+
+class CmdCall:
+    """Compose a call to `cmd` for an ordered series of cmd commands/scripts"""
+
+    def __init__(self, *cmds):
+        if not cmds:
+            raise RuntimeError(
+                """Attempting to run commands from CMD without specifying commands.
+                Please add commands to be run."""
+            )
+        self._cmds = cmds
+
+    def __call__(self):
+        out = subprocess.check_output(self.cmd_line, stderr=subprocess.STDOUT)  # novermin
+        return out.decode("utf-16le", errors="replace")  # novermin
+
+    @property
+    def cmd_line(self):
+        base_call = "cmd /u /c "
+        commands = " && ".join([x.command_str() for x in self._cmds])
+        # If multiple commands are being invoked by a single subshell
+        # they must be encapsulated by a double quote. Always double
+        # quote to be sure of proper handling
+        # cmd will properly resolve nested double quotes as needed
+        #
+        # `set`` writes out the active env to the subshell stdout,
+        # and in this context we are always trying to obtain env
+        # state so it should always be appended
+        return base_call + f'"{commands} && set"'
+
+
+class VarsInvocation:
+    def __init__(self, script):
+        self._script = script
+
+    def command_str(self):
+        return f'"{self._script}"'
+
+    @property
+    def script(self):
+        return self._script
+
+
+class VCVarsInvocation(VarsInvocation):
+    def __init__(self, script, arch, msvc_version):
+        super(VCVarsInvocation, self).__init__(script)
+        self._arch = arch
+        self._msvc_version = msvc_version
+
+    @property
+    def sdk_ver(self):
+        """Accessor for Windows SDK version property
+
+        Note: This property may not be set by
+        the calling context and as such this property will
+        return an empty string
+
+        This property will ONLY be set if the SDK package
+        is a dependency somewhere in the Spack DAG of the package
+        for which we are constructing an MSVC compiler env.
+        Otherwise this property should be unset to allow the VCVARS
+        script to use its internal heuristics to determine appropriate
+        SDK version
+        """
+        if getattr(self, "_sdk_ver", None):
+            return self._sdk_ver + ".0"
+        return ""
+
+    @sdk_ver.setter
+    def sdk_ver(self, val):
+        self._sdk_ver = val
+
+    @property
+    def arch(self):
+        return self._arch
+
+    @property
+    def vcvars_ver(self):
+        return f"-vcvars_ver={self._msvc_version}"
+
+    def command_str(self):
+        script = super(VCVarsInvocation, self).command_str()
+        return f"{script} {self.arch} {self.sdk_ver} {self.vcvars_ver}"
+
+
+FC_PATH = {}
+
+
+def get_valid_fortran_pth():
+    """Assign maximum available fortran compiler version"""
+    # TODO (johnwparent): validate compatibility w/ try compiler
+    # functionality when added
+    sort_fn = lambda fc_ver: Version(fc_ver)
+    sort_fc_ver = sorted(list(FC_PATH.keys()), key=sort_fn)
+    return FC_PATH[sort_fc_ver[-1]] if sort_fc_ver else None


### PR DESCRIPTION
Previous iterations of compiler detection filtered the compilers by supported platform. Spack recently migrated compiler detection but neglected to migrate this filtering as well.
This filtering was required to resolve bugs on Windows and Linux where detection attempts for compilers that were incompatible with the given host platform caused Spack to hang or crash.

Current mechanism to determine platform support for a compiler is a bit cludgey at the moment, will likely refactor before a final merge.

Resolves https://github.com/spack/spack/issues/39622 again.