### PR TITLE
Windows: add env name to prompts

### DIFF
--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -57,11 +57,17 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
         if view:
             cmds += "$Env:SPACK_ENV_VIEW='%s'\n" % view
         if prompt:
-            cmds += """function global:prompt {\n
+            cmds += """@"
+function prompt {\n
+}"""
+            
+            """function prompt {\n
     $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf
-    $spack_prompt = "[{prompt}] PS $pth>"
-    if(!$Env:SPACK_OLD_PROMPT) {$Env:SPACK_OLD_PROMPT=$spack_prompt}
+    $spack_prompt = "[womp] PS $pth>"
+    if(!"$Env:SPACK_OLD_PROMPT") {$Env:SPACK_OLD_PROMPT=$spack_prompt}
     $spack_prompt}\n""".format(prompt=prompt)
+    """@"function prompt {$pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf}; "[womp] PS $pth>""@"""
+
     else:
         bash_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=True)
         zsh_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=False, zsh=True)

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -49,8 +49,9 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
             cmds += 'set "SPACK_ENV_VIEW=%s"\n' % view
         if prompt:
             # we're going to need to start a new prompt from the env... UGH
-            # cmds += f'IF NOT DEFINED OLD_SPACK_PROMPT SET "OLD_SPACK_PROMPT=%PROMPT%"'
-            cmds += f'set "PROMPT=[{prompt}] $P$G"\n'
+            old_prompt = os.environ.get("PROMPT")
+            cmds += f'set "SPACK_OLD_PROMPT={old_prompt}"\n'
+            cmds += f'set "PROMPT={prompt} $P$G"\n'
     elif shell == "pwsh":
         cmds += "$Env:SPACK_ENV='%s'\n" % env.path
         if view:
@@ -115,7 +116,9 @@ def deactivate_header(shell):
         cmds += 'set "SPACK_ENV="\n'
         cmds += 'set "SPACK_ENV_VIEW="\n'
         # TODO: despacktivate
-        # cmds += 'IF %SPACK_OLD_PROMPT!="" set "PROMPT=%SPACK_OLD_PROMPT"'
+        old_prompt = os.environ.get("SPACK_OLD_PROMPT")
+        if old_prompt:
+            cmds += f'set "PROMPT={old_prompt}"\n'
     elif shell == "pwsh":
         cmds += "Set-Item -Path Env:SPACK_ENV\n"
         cmds += "Set-Item -Path Env:SPACK_ENV_VIEW\n"

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -48,7 +48,6 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
         if view:
             cmds += 'set "SPACK_ENV_VIEW=%s"\n' % view
         if prompt:
-            # we're going to need to start a new prompt from the env... UGH
             old_prompt = os.environ.get("PROMPT")
             cmds += f'set "SPACK_OLD_PROMPT={old_prompt}"\n'
             cmds += f'set "PROMPT={prompt} $P$G"\n'
@@ -58,8 +57,10 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
             cmds += "$Env:SPACK_ENV_VIEW='%s'\n" % view
         if prompt:
             cmds += (
-                'function global:prompt { $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") {$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; "%s PS $pth>"}\n'
-                % prompt
+                'function global:prompt { $pth = $(Convert-Path $(Get-Location))'
+                ' | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") '
+                '{$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; '
+                '"%s PS $pth>"}\n' % prompt
             )
     else:
         bash_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=True)
@@ -121,7 +122,12 @@ def deactivate_header(shell):
     elif shell == "pwsh":
         cmds += "Set-Item -Path Env:SPACK_ENV\n"
         cmds += "Set-Item -Path Env:SPACK_ENV_VIEW\n"
-        cmds += 'function global:prompt { $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf; $spack_prompt = "[spack] $pth >"; if("$Env:SPACK_OLD_PROMPT") {$spack_prompt=$Env:SPACK_OLD_PROMPT}; $spack_prompt}\n'
+        cmds += (
+            'function global:prompt { $pth = $(Convert-Path $(Get-Location))'
+            ' | Split-Path -leaf; $spack_prompt = "[spack] $pth >"; '
+            'if("$Env:SPACK_OLD_PROMPT") {$spack_prompt=$Env:SPACK_OLD_PROMPT};'
+            ' $spack_prompt}\n'
+        )
     else:
         cmds += "if [ ! -z ${SPACK_ENV+x} ]; then\n"
         cmds += "unset SPACK_ENV; export SPACK_ENV;\n"

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -57,17 +57,7 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
         if view:
             cmds += "$Env:SPACK_ENV_VIEW='%s'\n" % view
         if prompt:
-            cmds += """@"
-function prompt {\n
-}"""
-            
-            """function prompt {\n
-    $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf
-    $spack_prompt = "[womp] PS $pth>"
-    if(!"$Env:SPACK_OLD_PROMPT") {$Env:SPACK_OLD_PROMPT=$spack_prompt}
-    $spack_prompt}\n""".format(prompt=prompt)
-    """@"function prompt {$pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf}; "[womp] PS $pth>""@"""
-
+            cmds += 'function global:prompt { $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") {$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; "%s PS $pth>"}\n' % prompt
     else:
         bash_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=True)
         zsh_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=False, zsh=True)
@@ -128,10 +118,7 @@ def deactivate_header(shell):
     elif shell == "pwsh":
         cmds += "Set-Item -Path Env:SPACK_ENV\n"
         cmds += "Set-Item -Path Env:SPACK_ENV_VIEW\n"
-        cmds += """function global:prompt { 
-    $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf
-    "[spack] PS $pth>"
-}\n"""
+        cmds += 'function global:prompt { $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf; $spack_prompt = "[spack] $pth >"; if("$Env:SPACK_OLD_PROMPT") {$spack_prompt=$Env:SPACK_OLD_PROMPT}; $spack_prompt}\n'
     else:
         cmds += "if [ ! -z ${SPACK_ENV+x} ]; then\n"
         cmds += "unset SPACK_ENV; export SPACK_ENV;\n"

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -57,7 +57,10 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
         if view:
             cmds += "$Env:SPACK_ENV_VIEW='%s'\n" % view
         if prompt:
-            cmds += 'function global:prompt { $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") {$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; "%s PS $pth>"}\n' % prompt
+            cmds += (
+                'function global:prompt { $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") {$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; "%s PS $pth>"}\n'
+                % prompt
+            )
     else:
         bash_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=True)
         zsh_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=False, zsh=True)

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -57,7 +57,7 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
             cmds += "$Env:SPACK_ENV_VIEW='%s'\n" % view
         if prompt:
             cmds += (
-                'function global:prompt { $pth = $(Convert-Path $(Get-Location))'
+                "function global:prompt { $pth = $(Convert-Path $(Get-Location))"
                 ' | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") '
                 '{$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; '
                 '"%s PS $pth>"}\n' % prompt
@@ -123,10 +123,10 @@ def deactivate_header(shell):
         cmds += "Set-Item -Path Env:SPACK_ENV\n"
         cmds += "Set-Item -Path Env:SPACK_ENV_VIEW\n"
         cmds += (
-            'function global:prompt { $pth = $(Convert-Path $(Get-Location))'
+            "function global:prompt { $pth = $(Convert-Path $(Get-Location))"
             ' | Split-Path -leaf; $spack_prompt = "[spack] $pth >"; '
             'if("$Env:SPACK_OLD_PROMPT") {$spack_prompt=$Env:SPACK_OLD_PROMPT};'
-            ' $spack_prompt}\n'
+            " $spack_prompt}\n"
         )
     else:
         cmds += "if [ ! -z ${SPACK_ENV+x} ]; then\n"

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -48,7 +48,9 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
         if view:
             cmds += 'set "SPACK_ENV_VIEW=%s"\n' % view
         if prompt:
-            old_prompt = os.environ.get("PROMPT")
+            old_prompt = os.environ.get("SPACK_OLD_PROMPT")
+            if not old_prompt:
+                old_prompt = os.environ.get("PROMPT")
             cmds += f'set "SPACK_OLD_PROMPT={old_prompt}"\n'
             cmds += f'set "PROMPT={prompt} $P$G"\n'
     elif shell == "pwsh":
@@ -119,6 +121,7 @@ def deactivate_header(shell):
         old_prompt = os.environ.get("SPACK_OLD_PROMPT")
         if old_prompt:
             cmds += f'set "PROMPT={old_prompt}"\n'
+            cmds += 'set "SPACK_OLD_PROMPT="\n'
     elif shell == "pwsh":
         cmds += "Set-Item -Path Env:SPACK_ENV\n"
         cmds += "Set-Item -Path Env:SPACK_ENV_VIEW\n"


### PR DESCRIPTION
Finally adds `-p|--prompt` support to the `env activate` commands for Windows shells, `CMD` and `powershell`|`pwsh`.

User requested feature, for more context see the `spack-on-windows` slack channel in the spack slack