### PR TITLE
cairo: add new version and update build system

### DIFF
--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -44,7 +44,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
     variant("X", default=False, description="Build with X11 support")
     variant("gobject", default=False, description="Enable cairo's gobject functions feature")
 
-    with when("@:1.17.6"):
+    with when("build_system=autotools"):
         variant("png", default=False, description="Enable cairo's PNG functions feature")
         variant("svg", default=False, description="Enable cairo's SVG functions feature")
         variant("pic", default=True, description="Enable position-independent code (PIC)")
@@ -61,10 +61,16 @@ class Cairo(AutotoolsPackage, MesonPackage):
         variant("shared", default=True, description="Build shared libraries")
         conflicts("+shared~pic")
 
+        depends_on("automake", type="build")
+        depends_on("autoconf", type="build")
+        depends_on("libtool", type="build")
+        depends_on("m4", type="build")
+        depends_on("which", type="build")
+
     # meson is the only build system from now
     # these names follow those listed here
     # https://gitlab.freedesktop.org/cairo/cairo/-/blob/1.18.2/meson_options.txt
-    with when("@1.17.8:"):
+    with when("build_system=meson"):
         variant("dwrite", default=False, description="Microsoft Windows DWrite font backend")
 
         # doesn't exist @1.17.8: but kept as compatibility
@@ -132,7 +138,9 @@ class Cairo(AutotoolsPackage, MesonPackage):
         requires("+svg", when="+png")
         requires("~png", when="~svg", msg="+svg implies +png now")
 
-    # meson also needs this for auto discovery of depends
+        depends_on("meson@1.3.0:", type="build")
+
+    # both autotools and meson need this for auto discovery of depends
     depends_on("pkgconfig", type="build")
 
     # lzo is not strictly required, but cannot be disabled and may be pulled in accidentally
@@ -141,28 +149,19 @@ class Cairo(AutotoolsPackage, MesonPackage):
     depends_on("lzo", when="@1.17.6: build_system=meson")
 
     with when("@:1.17.6"):
-        depends_on("automake", type="build")
-        depends_on("autoconf", type="build")
-        depends_on("libtool", type="build")
-
-        depends_on("m4", type="build")
-
         depends_on("pixman@0.36.0:", when="@1.17.2:")
-        depends_on("freetype build_system=autotools", when="+ft")
-        depends_on("fontconfig@2.10.91:", when="+fc")  # Require newer version of fontconfig.
+        depends_on("freetype", when="+ft")
+        depends_on("fontconfig@2.10.91:", when="+fc")
         depends_on("libpng", when="+png")
         depends_on("glib")
-        depends_on("which", type="build")
 
     with when("@1.17.8:"):
-        depends_on("meson@1.3.0:")
+        depends_on("binutils", when="+symbol-lookup")
         depends_on("freetype@2.13.0:", when="+ft")
         depends_on("libpng@1.4.0:", when="+png")
-
         depends_on("glib@2.14:", when="+gobject")
         depends_on("pixman@0.40.0:")
         depends_on("fontconfig@2.13.0:", when="+fc")
-        depends_on("binutils", when="+symbol-lookup")
 
     with when("+X"):
         depends_on("libx11")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -149,6 +149,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
     # https://github.com/microsoft/vcpkg/pull/38313
     depends_on("lzo", when="@1.17.6: build_system=meson")
 
+    # versions that use (the old) autotools build
     with when("@:1.17.6"):
         depends_on("pixman@0.36.0:", when="@1.17.2:")
         depends_on("freetype", when="+ft")
@@ -156,6 +157,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
         depends_on("libpng", when="+png")
         depends_on("glib")
 
+    # versions that use (the new) meson build
     with when("@1.17.8:"):
         depends_on("binutils", when="+symbol-lookup")
         depends_on("freetype@2.13.0:", when="+ft")
@@ -164,6 +166,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
         depends_on("pixman@0.40.0:")
         depends_on("fontconfig@2.13.0:", when="+fc")
 
+    # needed for both meson and autotools builds
     with when("+X"):
         depends_on("libx11")
         depends_on("libxext")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -114,6 +114,11 @@ class Cairo(AutotoolsPackage, MesonPackage):
 
     # meson also needs this for auto discovery of depends
     depends_on("pkgconfig", type="build")
+    
+    # lzo is not strictly required, but cannot be disabled and may be pulled in accidentally
+    # https://github.com/mesonbuild/meson/issues/8224
+    # https://github.com/microsoft/vcpkg/pull/38313
+    depends_on("lzo", when="@1.17.6: build_system=meson")
 
     with when("@:1.17.6"):
         depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -114,7 +114,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
 
     # meson also needs this for auto discovery of depends
     depends_on("pkgconfig", type="build")
-    
+
     # lzo is not strictly required, but cannot be disabled and may be pulled in accidentally
     # https://github.com/mesonbuild/meson/issues/8224
     # https://github.com/microsoft/vcpkg/pull/38313

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -43,11 +43,11 @@ class Cairo(AutotoolsPackage, MesonPackage):
 
     variant("X", default=False, description="Build with X11 support")
     variant("gobject", default=False, description="Enable cairo's gobject functions feature")
+    variant("shared", default=True, description="Build shared libraries")
 
     with when("@:1.17.6"):
         variant("png", default=False, description="Enable cairo's PNG functions feature")
         variant("svg", default=False, description="Enable cairo's SVG functions feature")
-        variant("shared", default=True, description="Build shared libraries")
         variant("pic", default=True, description="Enable position-independent code (PIC)")
         variant("pdf", default=False, description="Enable cairo's PDF surface backend feature")
         variant("ft", default=False, description="Enable cairo's FreeType font backend feature")
@@ -201,6 +201,8 @@ class MesonBuilder(meson.MesonBuilder):
         args.append(self.enable_or_disable("glib", variant="gobject"))
         args.append(self.enable_or_disable("spectre"))
         args.append(self.enable_or_disable("symbol-lookup"))
+
+        args.append(self.enable_or_disable("shared"))
 
         return args
 

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -161,7 +161,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
     # patch from https://gitlab.freedesktop.org/cairo/cairo/issues/346
     patch("fontconfig.patch", when="@1.16.0:1.17.2")
     # Don't regenerate docs to avoid a dependency on gtk-doc
-    patch("disable-gtk-docs.patch", when="@:1.17.4^autoconf@2.70:")
+    patch("disable-gtk-docs.patch", when="build_system=autotools ^autoconf@2.70:")
 
 
 class MesonBuilder(meson.MesonBuilder):

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -44,7 +44,6 @@ class Cairo(AutotoolsPackage, MesonPackage):
     variant("X", default=False, description="Build with X11 support")
     variant("gobject", default=False, description="Enable cairo's gobject functions feature")
 
-
     with when("@:1.17.6"):
         variant("png", default=False, description="Enable cairo's PNG functions feature")
         variant("svg", default=False, description="Enable cairo's SVG functions feature")
@@ -67,33 +66,25 @@ class Cairo(AutotoolsPackage, MesonPackage):
         variant("dwrite", default=False, description="Microsoft Windows DWrite font backend")
 
         # doesn't exist @1.17.8: but kept as compatibility
-        variant(
-            "pdf",
-            default=False,
-            description="+pdf implies +zlib now. ~pdf does nothing",
-        )
+        variant("pdf", default=False, description="+pdf implies +zlib now. ~pdf does nothing")
         # svg is combined into png now, kept seperate for compatibility
-        variant(
-            "svg",
-            default=False,
-            description="+svg implies +png now. ~svg does nothing",
-        )
+        variant("svg", default=False, description="+svg implies +png now. ~svg does nothing")
 
         # meson seems to have assumptions about what is enabled/disabled
-        # these four compile best if +variant in unison, otherwise various errors happen if these aren't in sync
-        # easier to have a sane default. conflicts below try to protect known incompatibilities 
+        # these four compile best if +variant in unison, otherwise various errors happen
+        # if these aren't in sync. It is  easier to have a sane default. conflicts below
+        # to try to protect known incompatibilities
         variant("png", default=True, description="Enable cairo's PNG and SVG functions feature.")
         variant("ft", default=True, description="Enable cairo's FreeType font backend feature.")
         variant("fc", default=True, description="Enable cairo's Fontconfig font backend feature.")
         variant(
             "zlib",
             default=True,
-            description="Enable cairo's script, ps, pdf, xml functions feature. +ft,+fc, +zlib, +png must be in sync.",
+            description="Enable cairo's script, ps, pdf, xml functions feature.",
         )
 
         variant("quartz", default=False, description="Enable cairo's Quartz functions feature")
         variant("tee", default=False, description="Enable cairo's tee functions feature")
-
 
         # not in spack
         variant(
@@ -148,7 +139,6 @@ class Cairo(AutotoolsPackage, MesonPackage):
         depends_on("fontconfig@2.13.0:", when="+fc")
         depends_on("binutils", when="+symbol-lookup")
 
-
     with when("+X"):
         depends_on("libx11")
         depends_on("libxext")
@@ -165,7 +155,6 @@ class Cairo(AutotoolsPackage, MesonPackage):
     patch("fontconfig.patch", when="@1.16.0:1.17.2")
     # Don't regenerate docs to avoid a dependency on gtk-doc
     patch("disable-gtk-docs.patch", when="@:1.17.4^autoconf@2.70:")
-
 
 
 class MesonBuilder(meson.MesonBuilder):

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -42,9 +42,6 @@ class Cairo(AutotoolsPackage, MesonPackage):
         default="meson",
     )
 
-    requires("build_system=meson", when="@1.18.0:")
-    requires("build_system=autotools", when="@:1.17.4")
-
     variant("X", default=False, description="Build with X11 support")
     variant("gobject", default=False, description="Enable cairo's gobject functions feature")
 

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -35,15 +35,20 @@ class Cairo(AutotoolsPackage, MesonPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    # 1.17.4 is the last autotools based version. From 1.18.0 onward it is meson only
     build_system(
-        conditional("meson", when="@1.17.6:"),
+        conditional("meson", when="@1.18.0:"),
         conditional("autotools", when="@:1.17.4"),
         default="meson",
     )
 
+    requires("build_system=meson", when="@1.18.0:")
+    requires("build_system=autotools", when="@:1.17.4")
+
     variant("X", default=False, description="Build with X11 support")
     variant("gobject", default=False, description="Enable cairo's gobject functions feature")
 
+    # variants and build system depends for the autotools builds
     with when("build_system=autotools"):
         variant("png", default=False, description="Enable cairo's PNG functions feature")
         variant("svg", default=False, description="Enable cairo's SVG functions feature")
@@ -67,7 +72,8 @@ class Cairo(AutotoolsPackage, MesonPackage):
         depends_on("m4", type="build")
         depends_on("which", type="build")
 
-    # meson is the only build system from now
+
+    # variants and build system depends for the autotools builds
     # these names follow those listed here
     # https://gitlab.freedesktop.org/cairo/cairo/-/blob/1.18.2/meson_options.txt
     with when("build_system=meson"):
@@ -144,21 +150,18 @@ class Cairo(AutotoolsPackage, MesonPackage):
     # both autotools and meson need this for auto discovery of depends
     depends_on("pkgconfig", type="build")
 
-    # lzo is not strictly required, but cannot be disabled and may be pulled in accidentally
-    # https://github.com/mesonbuild/meson/issues/8224
-    # https://github.com/microsoft/vcpkg/pull/38313
-    depends_on("lzo", when="@1.17.6: build_system=meson")
-
+    # non build system specific depends
     # versions that use (the old) autotools build
-    with when("@:1.17.6"):
+    with when("@:1.17.4"):
         depends_on("pixman@0.36.0:", when="@1.17.2:")
         depends_on("freetype", when="+ft")
         depends_on("fontconfig@2.10.91:", when="+fc")
         depends_on("libpng", when="+png")
         depends_on("glib")
 
+    # non build system specific depends
     # versions that use (the new) meson build
-    with when("@1.17.8:"):
+    with when("@1.18.0:"):
         depends_on("binutils", when="+symbol-lookup")
         depends_on("freetype@2.13.0:", when="+ft")
         depends_on("libpng@1.4.0:", when="+png")
@@ -166,7 +169,12 @@ class Cairo(AutotoolsPackage, MesonPackage):
         depends_on("pixman@0.40.0:")
         depends_on("fontconfig@2.13.0:", when="+fc")
 
-    # needed for both meson and autotools builds
+        # lzo is not strictly required, but cannot be disabled and may be pulled in accidentally
+        # https://github.com/mesonbuild/meson/issues/8224
+        # https://github.com/microsoft/vcpkg/pull/38313
+        depends_on("lzo")
+
+    # needed for both meson and autotools builds when including X
     with when("+X"):
         depends_on("libx11")
         depends_on("libxext")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -68,9 +68,19 @@ class Cairo(AutotoolsPackage, MesonPackage):
         variant("dwrite", default=False, description="Microsoft Windows DWrite font backend")
 
         # doesn't exist @1.17.8: but kept as compatibility
-        variant("pdf", default=False, description="+pdf implies +zlib now")
+        variant(
+            "pdf",
+            default=False,
+            description="""+pdf is combined into +zlib now, kept seperate for compatibility.
+              +pdf implies +zlib now. Please use the updated variants""",
+        )
         # svg is combined into png now, kept seperate for compatibility
-        variant("svg", default=False, description="+svg implies +png now")
+        variant(
+            "svg",
+            default=False,
+            description="""+svg is combined into +png now, kept seperate for compatibility.
+              +svg implies +png now. Please use the updated variants""",
+        )
 
         # meson seems to have assumptions about what is enabled/disabled
         # these four compile best if +variant in unison, otherwise various errors happen
@@ -109,20 +119,18 @@ class Cairo(AutotoolsPackage, MesonPackage):
 
         # meson seems to have assumptions about what is enabled/disabled
         # so this protects against incompatible combinations
-        # conflicts("~zlib+png")
-        requires("+zlib", when="+png", msg="+png requires +zlib")
-        requires("+ft", when="+fc", msg="+fc requires +ft")
-        requires("+fc", when="+ft", msg="+fc requires +ft")
-        requires("+zlib", when="+fc+ft", msg="+fc+ft requires +zlib")
-        requires("+png", when="+ft+fc+zlib", msg="+ft+fc+zlib requires +png")
+        conflicts("~zlib+png", msg="+png requires +zlib")
+        conflicts("~ft+fc", msg="+fc requires +ft")
+        conflicts("+ft~fc", msg="+ft requires +fc")
+        conflicts("+ft+fc~zlib", msg="+fc+ft requires +zlib")
+        conflicts("+fc+ft~png+zlib", msg="+ft+fc+zlib requires +png")
 
         # +pdf implies zlib now
         requires("+zlib", when="+pdf")
+        requires("~zlib", when="~pdf", msg="+pdf implies +zlib now")
         # +svg implies png now
         requires("+svg", when="+png")
-
-        requires("~zlib", when="~pdf", msg="+pdf implies +zlib now")
-        requires("~png", when="~png", msg="+svg implies +png now")
+        requires("~png", when="~svg", msg="+svg implies +png now")
 
     # meson also needs this for auto discovery of depends
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -72,7 +72,6 @@ class Cairo(AutotoolsPackage, MesonPackage):
         depends_on("m4", type="build")
         depends_on("which", type="build")
 
-
     # variants and build system depends for the autotools builds
     # these names follow those listed here
     # https://gitlab.freedesktop.org/cairo/cairo/-/blob/1.18.2/meson_options.txt

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -43,7 +43,6 @@ class Cairo(AutotoolsPackage, MesonPackage):
 
     variant("X", default=False, description="Build with X11 support")
     variant("gobject", default=False, description="Enable cairo's gobject functions feature")
-    variant("shared", default=True, description="Build shared libraries")
 
     with when("@:1.17.6"):
         variant("png", default=False, description="Enable cairo's PNG functions feature")
@@ -57,6 +56,9 @@ class Cairo(AutotoolsPackage, MesonPackage):
         conflicts("+png", when="platform=darwin")
         conflicts("+svg", when="platform=darwin")
 
+        # meson build already defines these and maps them to args
+        # variant("shared", default=True, description="Build shared libraries")
+        variant("shared", default=True, description="Build shared libraries")
         conflicts("+shared~pic")
 
     # meson is the only build system from now
@@ -201,8 +203,6 @@ class MesonBuilder(meson.MesonBuilder):
         args.append(self.enable_or_disable("glib", variant="gobject"))
         args.append(self.enable_or_disable("spectre"))
         args.append(self.enable_or_disable("symbol-lookup"))
-
-        args.append(self.enable_or_disable("shared"))
 
         return args
 

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import autotools, meson
 from spack.package import *
 
 
-class Cairo(AutotoolsPackage):
+class Cairo(AutotoolsPackage, MesonPackage):
     """Cairo is a 2D graphics library with support for multiple output
     devices."""
 
@@ -14,6 +15,7 @@ class Cairo(AutotoolsPackage):
 
     license("LGPL-2.1-or-later OR MPL-1.1", checked_by="tgamblin")
 
+    version("1.18.2", sha256="a62b9bb42425e844cc3d6ddde043ff39dbabedd1542eba57a2eb79f85889d45a")
     version("1.18.0", sha256="243a0736b978a33dee29f9cca7521733b78a65b5418206fef7bd1c3d4cf10b64")
     version(
         "1.17.4",
@@ -25,11 +27,7 @@ class Cairo(AutotoolsPackage):
         sha256="6b70d4655e2a47a22b101c666f4b29ba746eda4aa8a0f7255b32b2e9408801df",
         url="https://cairographics.org/snapshots/cairo-1.17.2.tar.xz",
     )  # Snapshot
-    version(
-        "1.16.0",
-        sha256="5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331",
-        preferred=True,
-    )
+    version("1.16.0", sha256="5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331")
     version("1.14.12", sha256="8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16")
     version("1.14.8", sha256="d1f2d98ae9a4111564f6de4e013d639cf77155baf2556582295a0f00a9bc5e20")
     version("1.14.0", sha256="2cf5f81432e77ea4359af9dcd0f4faf37d015934501391c311bfd2d19a0134b7")
@@ -37,43 +35,191 @@ class Cairo(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    build_system(
+        conditional("meson", when="@1.17.6:"),
+        conditional("autotools", when="@:1.17.4"),
+        default="meson",
+    )
+
     variant("X", default=False, description="Build with X11 support")
-    variant("pdf", default=False, description="Enable cairo's PDF surface backend feature")
     variant("gobject", default=False, description="Enable cairo's gobject functions feature")
-    variant("ft", default=False, description="Enable cairo's FreeType font backend feature")
-    variant("fc", default=False, description="Enable cairo's Fontconfig font backend feature")
-    variant("png", default=False, description="Enable cairo's PNG functions feature")
-    variant("svg", default=False, description="Enable cairo's SVG functions feature")
-    variant("shared", default=True, description="Build shared libraries")
-    variant("pic", default=True, description="Enable position-independent code (PIC)")
 
-    depends_on("libx11", when="+X")
-    depends_on("libxext", when="+X")
-    depends_on("libxrender", when="+X")
-    depends_on("libxcb", when="+X")
-    depends_on("python", when="+X", type="build")
-    depends_on("libpng", when="+png")
-    depends_on("glib")
-    depends_on("pixman@0.36.0:", when="@1.17.2:")
-    depends_on("pixman")
-    depends_on("automake", type="build")
-    depends_on("autoconf", type="build")
-    depends_on("libtool", type="build")
-    depends_on("m4", type="build")
-    depends_on("freetype build_system=autotools", when="+ft")
+
+    with when("@:1.17.6"):
+        variant("png", default=False, description="Enable cairo's PNG functions feature")
+        variant("svg", default=False, description="Enable cairo's SVG functions feature")
+        variant("shared", default=True, description="Build shared libraries")
+        variant("pic", default=True, description="Enable position-independent code (PIC)")
+        variant("pdf", default=False, description="Enable cairo's PDF surface backend feature")
+        variant("ft", default=False, description="Enable cairo's FreeType font backend feature")
+        variant("fc", default=False, description="Enable cairo's Fontconfig font backend feature")
+
+        # seems to be an older cairo limitation as cairo@1.18.2 seems to build fine against libpng
+        conflicts("+png", when="platform=darwin")
+        conflicts("+svg", when="platform=darwin")
+
+        conflicts("+shared~pic")
+
+    # meson is the only build system from now
+    # these names follow those listed here
+    # https://gitlab.freedesktop.org/cairo/cairo/-/blob/1.18.2/meson_options.txt
+    with when("@1.17.8:"):
+        variant("dwrite", default=False, description="Microsoft Windows DWrite font backend")
+
+        # doesn't exist @1.17.8: but kept as compatibility
+        variant(
+            "pdf",
+            default=False,
+            description="+pdf implies +zlib now. ~pdf does nothing",
+        )
+        # svg is combined into png now, kept seperate for compatibility
+        variant(
+            "svg",
+            default=False,
+            description="+svg implies +png now. ~svg does nothing",
+        )
+
+        # meson seems to have assumptions about what is enabled/disabled
+        # these four compile best if +variant in unison, otherwise various errors happen if these aren't in sync
+        # easier to have a sane default. conflicts below try to protect known incompatibilities 
+        variant("png", default=True, description="Enable cairo's PNG and SVG functions feature.")
+        variant("ft", default=True, description="Enable cairo's FreeType font backend feature.")
+        variant("fc", default=True, description="Enable cairo's Fontconfig font backend feature.")
+        variant(
+            "zlib",
+            default=True,
+            description="Enable cairo's script, ps, pdf, xml functions feature. +ft,+fc, +zlib, +png must be in sync.",
+        )
+
+        variant("quartz", default=False, description="Enable cairo's Quartz functions feature")
+        variant("tee", default=False, description="Enable cairo's tee functions feature")
+
+
+        # not in spack
+        variant(
+            "spectre",
+            default=False,
+            description="Not available. Enable cairo's spectre functions feature",
+        )
+
+        # (bfd might be too old) with binutils 2.43.1 on macos
+        #  so not sure how this is supposed to work
+        variant(
+            "symbol-lookup",
+            default=False,
+            description="Not available. Enable cairo's symbol lookup functions feature",
+        )
+
+        # not currently supported variants
+        conflicts("+spectre", msg="Not currently supported")
+        conflicts("+symbol-lookup", msg="Not currently supported")
+
+        # these must be unified now
+        # conflicts("+png~svg", msg="+png implies +svg")
+        # conflicts("~png+svg", msg="~png implies ~svg")
+
+        # these must be unified now
+        conflicts("~pdf+zlib", msg="+zlib implies +pdf")
+        conflicts("+pdf~zlib", msg="+pdf implies +zlib")
+
+        # meson seems to have assumptions about what is enabled/disabled
+        # so this protects against incompatible combinations
+        conflicts("~zlib+png", msg="+png requires +zlib")
+        conflicts("~ft+fc", msg="+fc requires +ft")
+        conflicts("+ft+fc~zlib", msg="+fc+ft requires +zlib")
+        conflicts("+fc+ft~png+zlib", msg="+ft+fc+zlib requires +png")
+
+    # meson also needs this for auto discovery of depends
     depends_on("pkgconfig", type="build")
-    depends_on("fontconfig@2.10.91:", when="+fc")  # Require newer version of fontconfig.
-    depends_on("which", type="build")
 
-    conflicts("+png", when="platform=darwin")
-    conflicts("+svg", when="platform=darwin")
-    conflicts("+shared~pic")
+    with when("@:1.17.6"):
+        depends_on("automake", type="build")
+        depends_on("autoconf", type="build")
+        depends_on("libtool", type="build")
+
+        depends_on("m4", type="build")
+
+        depends_on("pixman@0.36.0:", when="@1.17.2:")
+        depends_on("freetype build_system=autotools", when="+ft")
+        depends_on("fontconfig@2.10.91:", when="+fc")  # Require newer version of fontconfig.
+        depends_on("libpng", when="+png")
+        depends_on("glib")
+        depends_on("which", type="build")
+
+    with when("@1.17.8:"):
+        depends_on("meson@1.3.0:")
+        depends_on("freetype@2.13.0:", when="+ft")
+        depends_on("libpng@1.4.0:", when="+png")
+
+        depends_on("glib@2.14:", when="+gobject")
+        depends_on("pixman@0.40.0:")
+        depends_on("fontconfig@2.13.0:", when="+fc")
+        depends_on("binutils", when="+symbol-lookup")
+
+
+    with when("+X"):
+        depends_on("libx11")
+        depends_on("libxext")
+
+        depends_on("libxrender")
+        depends_on("libxrender@0.6:", when="@1.17.8:")
+
+        depends_on("libxcb")
+        depends_on("libxcb@1.6:", when="@1.17.8:")
+
+        depends_on("python", type="build")
 
     # patch from https://gitlab.freedesktop.org/cairo/cairo/issues/346
     patch("fontconfig.patch", when="@1.16.0:1.17.2")
     # Don't regenerate docs to avoid a dependency on gtk-doc
-    patch("disable-gtk-docs.patch", when="^autoconf@2.70:")
+    patch("disable-gtk-docs.patch", when="@:1.17.6^autoconf@2.70:")
 
+
+
+class MesonBuilder(meson.MesonBuilder):
+    def enable_or_disable(self, feature_name, variant=None):
+        if variant is None:
+            variant = feature_name
+        return (
+            f"-D{feature_name}=enabled"
+            if self.spec.satisfies(f"+{variant}")
+            else f"-D{feature_name}=disabled"
+        )
+
+    def meson_args(self):
+        args = []
+
+        args.append(self.enable_or_disable("dwrite"))
+        args.append(self.enable_or_disable("fontconfig", variant="ft"))
+        args.append(self.enable_or_disable("freetype", variant="fc"))
+
+        # +svg implies png now
+        if self.spec.satisfies("+svg"):
+            self.spec.variants["png"].value = True
+
+        args.append(self.enable_or_disable("png"))
+
+        args.append(self.enable_or_disable("quartz"))
+        args.append(self.enable_or_disable("tee"))
+        args.append(self.enable_or_disable("xcb"))
+
+        args.append(self.enable_or_disable("xlib", variant="X"))
+        args.append(self.enable_or_disable("xlib-xcb", variant="X"))
+
+        # +pdf implies zlib now
+        if self.spec.satisfies("+pdf"):
+            self.spec.variants["zlib"].value = True
+
+        args.append(self.enable_or_disable("zlib"))
+
+        args.append(self.enable_or_disable("glib", variant="gobject"))
+        args.append(self.enable_or_disable("spectre"))
+        args.append(self.enable_or_disable("symbol-lookup"))
+
+        return args
+
+
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def autoreconf(self, spec, prefix):
         # Regenerate, directing the script *not* to call configure before Spack
         # does

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -114,14 +114,6 @@ class Cairo(AutotoolsPackage, MesonPackage):
         conflicts("+spectre", msg="Not currently supported")
         conflicts("+symbol-lookup", msg="Not currently supported")
 
-        # these must be unified now
-        # conflicts("+png~svg", msg="+png implies +svg")
-        # conflicts("~png+svg", msg="~png implies ~svg")
-
-        # these must be unified now
-        conflicts("~pdf+zlib", msg="+zlib implies +pdf")
-        conflicts("+pdf~zlib", msg="+pdf implies +zlib")
-
         # meson seems to have assumptions about what is enabled/disabled
         # so this protects against incompatible combinations
         conflicts("~zlib+png", msg="+png requires +zlib")
@@ -172,7 +164,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
     # patch from https://gitlab.freedesktop.org/cairo/cairo/issues/346
     patch("fontconfig.patch", when="@1.16.0:1.17.2")
     # Don't regenerate docs to avoid a dependency on gtk-doc
-    patch("disable-gtk-docs.patch", when="@:1.17.6^autoconf@2.70:")
+    patch("disable-gtk-docs.patch", when="@:1.17.4^autoconf@2.70:")
 
 
 

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -138,6 +138,7 @@ class Cairo(AutotoolsPackage, MesonPackage):
         requires("+svg", when="+png")
         requires("~png", when="~svg", msg="+svg implies +png now")
 
+        # https://gitlab.freedesktop.org/cairo/cairo/-/blob/1.18.2/meson.build?ref_type=tags#L2
         depends_on("meson@1.3.0:", type="build")
 
     # both autotools and meson need this for auto discovery of depends

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -54,7 +54,7 @@ class Pango(MesonPackage):
     depends_on("harfbuzz")
     depends_on("harfbuzz+coretext", when="platform=darwin")
     depends_on("cairo+ft+fc")
-    # quartz needed even when ~X 
+    # quartz needed even when ~X
     depends_on("cairo+quartz", when="^cairo@1.17.8: platform=darwin")
     depends_on("cairo~X", when="~X")
     depends_on("cairo+X", when="+X")

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -54,6 +54,7 @@ class Pango(MesonPackage):
     depends_on("harfbuzz")
     depends_on("harfbuzz+coretext", when="platform=darwin")
     depends_on("cairo+ft+fc")
+    depends_on("cairo+quartz", when="^cairo@1.17.8:")
     depends_on("cairo~X", when="~X")
     depends_on("cairo+X", when="+X")
     depends_on("libxft", when="+X")

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -54,8 +54,8 @@ class Pango(MesonPackage):
     depends_on("harfbuzz")
     depends_on("harfbuzz+coretext", when="platform=darwin")
     depends_on("cairo+ft+fc")
-    # quartz needed even when ~X
-    depends_on("cairo+quartz", when="^cairo@1.17.8: platform=darwin")
+    # quartz needed even when ~X on the new cairo versions
+    requires("^cairo+quartz", when="^cairo@1.17.8: platform=darwin")
     depends_on("cairo~X", when="~X")
     depends_on("cairo+X", when="+X")
     depends_on("libxft", when="+X")

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -54,7 +54,8 @@ class Pango(MesonPackage):
     depends_on("harfbuzz")
     depends_on("harfbuzz+coretext", when="platform=darwin")
     depends_on("cairo+ft+fc")
-    depends_on("cairo+quartz", when="^cairo@1.17.8:")
+    # quartz needed even when ~X 
+    depends_on("cairo+quartz", when="^cairo@1.17.8: platform=darwin")
     depends_on("cairo~X", when="~X")
     depends_on("cairo+X", when="+X")
     depends_on("libxft", when="+X")


### PR DESCRIPTION
Post `cairo@1.17.7:`, cairo requires the meson build system. As a result, the `@1.18` version doesn't build.

This is a pretty significant update to 
- add `@1.18:`
- add meson build system
- unify the new meson variants with existing variant names
- remove `"1.16.0",` from being a preferred version, as there is no reason why it needs to be. It also doesn't build on macos.

There are clearly some assumptions about what meson variants are enabled together, so this tries to protect against incompatible variant options I found in testing.

I couldn't get the new `symbol-lookup` variant to work on macos. Maybe this is a linux specific thing? It is currently `False` by default and conflicts on `+symbol-lookup` such that this can be fixed in the future.

`svg` and `pdf` are now legacy variants. However, many packages still use these variants. The problem is that the new variants `png` and `zlib` combine `+png = +png+svg` and `+zlib=ps, pdf, ...`. I have made the decision that `+svg and +pdf` can turn on the meta variants, but cannot disable them.
