### PR TITLE
update pyproject.toml for `ruff format`

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# flake8: noqa: F401
+# flake8: noqa: F401, E402
 """spack.package defines the public API for Spack packages, by re-exporting useful symbols from
 other modules. Packages should import this module, instead of importing from spack.* directly
 to ensure forward compatibility with future versions of Spack."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,21 @@ features = [
   "ci",
 ]
 
+[tool.ruff]
+# smallest version ruff seems to support
+line-length = 99
+target-version = "py37"
+include = ["pyproject.toml", "lib/spack/**/*.py", "var/spack/repos/**/*.py", "bin/spack"]
+exclude = ["lib/spack/external"]
+extend-exclude = ["*.pyi"]
+
+[tool.ruff.lint]
+ignore = ["E731", "E203"]
+
+[tool.ruff.lint.per-file-ignores]
+"var/spack/repos/*/package.py" = ["F403", "F405", "F821"]
+"*-ci-package.py" = ["F403", "F405", "F821"]
+
 [tool.black]
 line-length = 99
 target-version = ['py36', 'py37', 'py38', 'py39', 'py310']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name="spack"
 description="The spack package manager"
+requires-python=">=3.6"
 dependencies=[
   "clingo",
   "setuptools",
@@ -68,15 +69,19 @@ features = [
 ]
 
 [tool.ruff]
-# smallest version ruff seems to support
 line-length = 99
-target-version = "py37"
-include = ["pyproject.toml", "lib/spack/**/*.py", "var/spack/repos/**/*.py", "bin/spack"]
-exclude = ["lib/spack/external"]
-extend-exclude = ["*.pyi"]
+extend-include = ["pyproject.toml", "lib/spack/**/*.py", "var/spack/repos/**/*.py", "bin/spack"]
+extend-exclude = ["lib/spack/external", "*.pyi"]
+
+[tool.ruff.format]
+skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
+extend-select = ["I"]
 ignore = ["E731", "E203"]
+
+[tool.ruff.lint.isort]
+split-on-trailing-comma = false
 
 [tool.ruff.lint.per-file-ignores]
 "var/spack/repos/*/package.py" = ["F403", "F405", "F821"]
@@ -84,7 +89,6 @@ ignore = ["E731", "E203"]
 
 [tool.black]
 line-length = 99
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 include = '(lib/spack|var/spack/repos)/.*\.pyi?$|bin/spack$'
 extend-exclude = 'lib/spack/external'
 skip_magic_trailing_comma = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,21 @@ ignore = ["E731", "E203"]
 
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "archspec",
+    "llnl",
+    "spack",
+    "first-party",
+    "local-folder",
+]
+
+[tool.ruff.lint.isort.sections]
+spack = ["spack"]
+archspec = ["archspec"]
+llnl = ["llnl"]
 
 [tool.ruff.lint.per-file-ignores]
 "var/spack/repos/*/package.py" = ["F403", "F405", "F811", "F821"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ features = [
 
 [tool.ruff]
 line-length = 99
-extend-include = ["pyproject.toml", "lib/spack/**/*.py", "var/spack/repos/**/*.py", "bin/spack"]
+extend-include = ["bin/spack"]
 extend-exclude = ["lib/spack/external", "*.pyi"]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ ignore = ["E731", "E203"]
 split-on-trailing-comma = false
 
 [tool.ruff.lint.per-file-ignores]
-"var/spack/repos/*/package.py" = ["F403", "F405", "F821"]
+"var/spack/repos/*/package.py" = ["F403", "F405", "F811", "F821"]
 "*-ci-package.py" = ["F403", "F405", "F821"]
 
 [tool.black]


### PR DESCRIPTION
Add ruff configuration to `pyproject.toml`.

This allows `ruff format` in the Spack repository to format all the files we care about, with our line length of 99, the exceptions we already put in place, and excluding things we don't auto-format, like vendored dependencies.

Right now it'll reformat 175 or so files, but only slightly, in places where `ruff` differs from `black`. For the most part I like the ruff format decisions better than `black`, but none of the changes seem too severe.

This does not change `spack style` -- I figure that can come later but this at least will let people start playing with `ruff`.
