### PR TITLE
Remove variable from cmake.py

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -466,7 +466,7 @@ class CMakeBuilder(BuilderWithDefaults):
             primary_generator = _extract_primary_generator(self.generator)
             configure_artifact = "Makefile"
             if primary_generator == "Ninja":
-               configure_artifact = "ninja.build"
+                configure_artifact = "ninja.build"
 
             if os.path.isfile(os.path.join(self.build_directory, configure_artifact)):
                 return

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -461,18 +461,14 @@ class CMakeBuilder(BuilderWithDefaults):
         if spec.is_develop:
             # skip cmake phase if it is an incremental develop build
 
-            def _configure_artifact():
-                """
-                Determine the files that will re-run CMake that are generated from a successful
-                configure step based on state
-                """
-                primary_generator = _extract_primary_generator(self.generator)
-                if primary_generator == "Unix Makefiles":
-                    return "Makefile"
-                elif primary_generator == "Ninja":
-                    return "ninja.build"
+            # Determine the files that will re-run CMake that are generated from a successful
+            # configure step based on state
+            primary_generator = _extract_primary_generator(self.generator)
+            configure_artifact = "Makefile":
+            if primary_generator == "Ninja":
+               configure_artifact = "ninja.build"
 
-            if os.path.isfile(os.path.join(self.build_directory, _configure_artifact())):
+            if os.path.isfile(os.path.join(self.build_directory, configure_artifact)):
                 return
 
         options = self.std_cmake_args

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -464,7 +464,7 @@ class CMakeBuilder(BuilderWithDefaults):
             # Determine the files that will re-run CMake that are generated from a successful
             # configure step based on state
             primary_generator = _extract_primary_generator(self.generator)
-            configure_artifact = "Makefile":
+            configure_artifact = "Makefile"
             if primary_generator == "Ninja":
                configure_artifact = "ninja.build"
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -458,19 +458,24 @@ class CMakeBuilder(BuilderWithDefaults):
     ) -> None:
         """Runs ``cmake`` in the build directory"""
 
-        # skip cmake phase if it is an incremental develop build
-        # These are the files that will re-run CMake that are generated from a successful
-        # configure step
-        primary_generator = _extract_primary_generator(self.generator)
-        if primary_generator == "Unix Makefiles":
-            configure_artifact = "Makefile"
-        elif primary_generator == "Ninja":
-            configure_artifact = "ninja.build"
+        if spec.is_develop:
+            # skip cmake phase if it is an incremental develop build
+            
+            def _configure_artifact():
+                """
+                Determine the files that will re-run CMake that are generated from a successful
+                configure step based on state
+                """
+                primary_generator = _extract_primary_generator(self.generator)
+                if primary_generator == "Unix Makefiles":
+                    return "Makefile"
+                elif primary_generator == "Ninja":
+                    return "ninja.build"
 
-        if spec.is_develop and os.path.isfile(
-            os.path.join(self.build_directory, configure_artifact)
-        ):
-            return
+            if os.path.isfile(
+                os.path.join(self.build_directory, _configure_artifact())
+            ):
+                return
 
         options = self.std_cmake_args
         options += self.cmake_args()

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -460,7 +460,7 @@ class CMakeBuilder(BuilderWithDefaults):
 
         if spec.is_develop:
             # skip cmake phase if it is an incremental develop build
-            
+
             def _configure_artifact():
                 """
                 Determine the files that will re-run CMake that are generated from a successful
@@ -472,9 +472,7 @@ class CMakeBuilder(BuilderWithDefaults):
                 elif primary_generator == "Ninja":
                     return "ninja.build"
 
-            if os.path.isfile(
-                os.path.join(self.build_directory, _configure_artifact())
-            ):
+            if os.path.isfile(os.path.join(self.build_directory, _configure_artifact())):
                 return
 
         options = self.std_cmake_args


### PR DESCRIPTION
#48775 left a dangling variable that was not caught in CI but by the eyes of @haampie. Restructure variable to local method.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
