### PR TITLE
gcc: remove --with-ld=ld-classic

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -800,11 +800,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
                     "--with-as=" + binutils.join("as"),
                 ]
             )
-        elif spec.satisfies("%apple-clang@15:"):
-            # https://github.com/iains/gcc-darwin-arm64/issues/117
-            # https://github.com/iains/gcc-12-branch/issues/22
-            # https://github.com/iains/gcc-13-branch/issues/8
-            options.append("--with-ld=/Library/Developer/CommandLineTools/usr/bin/ld-classic")
 
         # enable_bootstrap
         if spec.satisfies("+bootstrap"):


### PR DESCRIPTION
This was unfortunately missed in #47843.
