### PR TITLE
sherpa: +hepmc3root only when +root

### DIFF
--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -53,7 +53,7 @@ class Sherpa(CMakePackage, AutotoolsPackage):
     variant("python", default=False, description="Enable Python API")
     variant("hepmc2", default=True, when="@:2", description="Enable HepMC (version 2.x) support")
     variant("hepmc3", default=True, description="Enable HepMC (version 3.x) support")
-    variant("hepmc3root", default=False, description="Enable HepMC (version 3.1+) ROOT support")
+    variant("hepmc3root", default=False, description="Enable HepMC (version 3.1+) ROOT support", when="+root")
     variant("rivet", default=False, description="Enable Rivet support")
     variant("fastjet", default=True, when="@:2", description="Enable FASTJET")
     variant("openloops", default=False, description="Enable OpenLoops")

--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -53,7 +53,12 @@ class Sherpa(CMakePackage, AutotoolsPackage):
     variant("python", default=False, description="Enable Python API")
     variant("hepmc2", default=True, when="@:2", description="Enable HepMC (version 2.x) support")
     variant("hepmc3", default=True, description="Enable HepMC (version 3.x) support")
-    variant("hepmc3root", default=False, description="Enable HepMC (version 3.1+) ROOT support", when="+root")
+    variant(
+        "hepmc3root",
+        default=False,
+        description="Enable HepMC (version 3.1+) ROOT support",
+        when="+root",
+    )
     variant("rivet", default=False, description="Enable Rivet support")
     variant("fastjet", default=True, when="@:2", description="Enable FASTJET")
     variant("openloops", default=False, description="Enable OpenLoops")


### PR DESCRIPTION
Sherpa fails to build with `+hepmc3root ~root` because the HepMC3 CMake config assumes that the `ROOT::Tree` target is already available.
```
  >> 256    CMake Error at /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/hepmc3-3.3.0-iejffq3ywyifmmyxkxjfnp6exhqcwqlm/share/HepMC3/cmake/HepMC3rootIOTargets.cmake:61 (set_target_properties):
     257      The link interface of target "HepMC3::rootIO" contains:
     258
     259        ROOT::Tree
     260
     261      but the target was not found.  Possible reasons include:
     262
```

This PR ensures that `+hepmc3root` can only be set when `+root`.