### PR TITLE
sherpa: support cxxstd=20 when=@3:

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -83,7 +83,7 @@ spack:
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet ~root # pythia8 and root circularly depend
   - rivet hepmc=3
   - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
-  - sherpa +analysis ~blackhat +gzip +hepmc3 +hepmc3root +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
+  - sherpa +analysis ~blackhat +gzip +hepmc3 +hepmc3root +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo cxxstd=20
   - tauola +hepmc3 +lhapdf cxxstd=20
   - thepeg hepmc=3 ~rivet
   - vecgeom +gdml +geant4 +root

--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -39,7 +39,7 @@ class Sherpa(CMakePackage, AutotoolsPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    _cxxstd_values = ("11", "14", "17")
+    _cxxstd_values = (conditional("11", "14", "17", when="@:"), conditional("20", when="@3:"))
     variant(
         "cxxstd",
         default="11",
@@ -114,7 +114,8 @@ class Sherpa(CMakePackage, AutotoolsPackage):
     filter_compiler_wrappers("share/SHERPA-MC/makelibs")
 
     for std in _cxxstd_values:
-        depends_on("root cxxstd=" + std, when="+root cxxstd=" + std)
+        for v in std:
+            depends_on(f"root cxxstd={v.value}", when=f"+root cxxstd={v.value}")
 
     def patch(self):
         filter_file(


### PR DESCRIPTION
Sherpa has supported C++20 for a while (https://gitlab.com/sherpa-team/sherpa/-/commits/master?search=C%2B%2B20). This PR let's spack build with `cxxstd=20`. Other `cxxstd` values are also turned into conditionals to make the handling of ROOT dependency easier.

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
[+]  jjukmgc sherpa@3.0.1+analysis~blackhat~cms+gzip+hepmc3~hepmc3root+ipo+lhapdf+lhole+mpi+openloops+pythia+python~recola+rivet+root~ufo build_system=cmake build_type=Release cxxstd=20 generator=make libs=shared,static
==> 1 installed package
```