### PR TITLE
python 3.12 package fixes

### DIFF
--- a/var/spack/repos/builtin/packages/c-blosc/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc/package.py
@@ -16,6 +16,7 @@ class CBlosc(CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("1.21.6", sha256="9fcd60301aae28f97f1301b735f966cc19e7c49b6b4321b839b4579a0c156f38")
     version("1.21.5", sha256="32e61961bbf81ffea6ff30e9d70fca36c86178afd3e3cfa13376adec8c687509")
     version("1.21.4", sha256="e72bd03827b8564bbb3dc3ea0d0e689b4863871ce3861d946f2efd7a186ecf3e")
     version("1.21.2", sha256="e5b4ddb4403cbbad7aab6e9ff55762ef298729c8a793c6147160c771959ea2aa")

--- a/var/spack/repos/builtin/packages/py-blosc/package.py
+++ b/var/spack/repos/builtin/packages/py-blosc/package.py
@@ -14,14 +14,34 @@ class PyBlosc(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.11.2", sha256="8a0eb2daabb23415c3be3b9473176c75fa150cdb91b2ef42a77f492dad92cb2a")
     version("1.9.1", sha256="ffc884439a12409aa4e8945e21dc920d6bc21807357c51d24c7f0a27ae4f79b9")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("python@3.6:", type=("build", "run"))
+    # the vendored cpuinfo in 1.9.1 doesn't work with ptyhon@3.7:
+    # https://github.com/Blosc/python-blosc/issues/225
+    depends_on("python@3.6", type=("build", "run"), when="@1.9.1")
+
+    depends_on("python@3.9:", type=("build", "run"), when="@1.11.2:")
+
     depends_on("py-setuptools", type="build")
     depends_on("py-scikit-build", type="build")
+    depends_on("py-scikit-build@0.11.1:", type="build", when="@1.11.2:")
+    depends_on("py-py-cpuinfo", type="build", when="@1.11.2:")
+    depends_on("py-versioneer", type="build", when="@1.11.2:")
     depends_on("cmake@3.11:", type="build")
+    depends_on("cmake@3.14:", type="build", when="@1.11.2:")
     depends_on("ninja", type="build")
-    # depends_on('c-blosc')  # shipped internally
+
+    depends_on("py-numpy@1.16:", type=("build", "run"), when="@1.11.2:")
+
+    # c-blosc is internally vendored but 1.11.2 doesn't correctly ship the
+    # c-blosc in the tarball https://github.com/Blosc/python-blosc/issues/337
+    # so use the c-blosc version as specified in
+    # https://github.com/Blosc/python-blosc/releases/tag/v1.11.2
+    depends_on("c-blosc@1.21.6", type=("build", "run"), when="@1.11.2 ^python@3.12:")
+
+    def setup_build_environment(self, env):
+        env.set("USE_SYSTEM_BLOSC", 1)

--- a/var/spack/repos/builtin/packages/py-blosc/package.py
+++ b/var/spack/repos/builtin/packages/py-blosc/package.py
@@ -44,5 +44,5 @@ class PyBlosc(PythonPackage):
     depends_on("c-blosc@1.21.6", type=("build", "run"), when="@1.11.2 ^python@3.12:")
 
     def setup_build_environment(self, env):
-        if self.spec.satisfies("@1.11.2 ^python@3.12:"): 
+        if self.spec.satisfies("@1.11.2 ^python@3.12:"):
             env.set("USE_SYSTEM_BLOSC", 1)

--- a/var/spack/repos/builtin/packages/py-blosc/package.py
+++ b/var/spack/repos/builtin/packages/py-blosc/package.py
@@ -44,4 +44,5 @@ class PyBlosc(PythonPackage):
     depends_on("c-blosc@1.21.6", type=("build", "run"), when="@1.11.2 ^python@3.12:")
 
     def setup_build_environment(self, env):
-        env.set("USE_SYSTEM_BLOSC", 1)
+        if self.spec.satisfies("@1.11.2 ^python@3.12:"): 
+            env.set("USE_SYSTEM_BLOSC", 1)

--- a/var/spack/repos/builtin/packages/py-blosc/package.py
+++ b/var/spack/repos/builtin/packages/py-blosc/package.py
@@ -20,10 +20,7 @@ class PyBlosc(PythonPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    # the vendored cpuinfo in 1.9.1 doesn't work with ptyhon@3.7:
-    # https://github.com/Blosc/python-blosc/issues/225
-    depends_on("python@3.6", type=("build", "run"), when="@1.9.1")
-
+    depends_on("python@3.7:", type=("build", "run"), when="@1.9:1.10")
     depends_on("python@3.9:", type=("build", "run"), when="@1.11.2:")
 
     depends_on("py-setuptools", type="build")
@@ -39,10 +36,10 @@ class PyBlosc(PythonPackage):
 
     # c-blosc is internally vendored but 1.11.2 doesn't correctly ship the
     # c-blosc in the tarball https://github.com/Blosc/python-blosc/issues/337
-    # so use the c-blosc version as specified in
+    # so use the exact c-blosc version as specified in
     # https://github.com/Blosc/python-blosc/releases/tag/v1.11.2
     depends_on("c-blosc@1.21.6", type=("build", "run"), when="@1.11.2 ^python@3.12:")
 
     def setup_build_environment(self, env):
-        if self.spec.satisfies("@1.11.2 ^python@3.12:"):
+        if self.spec.satisfies("^c-blosc"):
             env.set("USE_SYSTEM_BLOSC", 1)

--- a/var/spack/repos/builtin/packages/py-cf-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-cf-xarray/package.py
@@ -13,9 +13,11 @@ class PyCfXarray(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.10.0", sha256="7b45319fc315175854c9e701a84ebb795eb4b2764a2d05bd2d9d3ea87d004d18")
     version("0.9.0", sha256="01213bdc5ed4d41eeb5da179d99076f49a905b1995daef2a0c7ec402b148675c")
 
     depends_on("python@3.9:", type=("build", "run"))
+    depends_on("python@3.10:", type=("build", "run"), when="@0.9.5:")
     depends_on("py-setuptools@45:", type="build")
     depends_on("py-setuptools-scm@6.2:+toml", type="build")
     depends_on("py-xarray@2022.03:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-cftime/package.py
+++ b/var/spack/repos/builtin/packages/py-cftime/package.py
@@ -13,8 +13,17 @@ class PyCftime(PythonPackage):
     homepage = "https://unidata.github.io/cftime/"
     url = "https://github.com/Unidata/cftime/archive/refs/tags/v1.0.3.4rel.tar.gz"
 
+    version("1.6.4", sha256="38970aa0d0ed9ed6b1d90f2cff2301b7299ae62d38e39a540400ab00edb4d2ce")
     version("1.0.3.4", sha256="f261ff8c65ceef4799784cd999b256d608c177d4c90b083553aceec3b6c23fd3")
 
-    depends_on("py-setuptools@18.0:", type="build")
-    depends_on("py-cython@0.19:", type="build")
-    depends_on("py-numpy", type=("build", "run"))
+    with when("@1.0.3.4"):
+        depends_on("py-setuptools@18.0:", type="build")
+        depends_on("py-cython@0.19:", type="build")
+        depends_on("py-numpy", type=("build", "run"))
+
+    with when("@1.6.4:"):
+        depends_on("py-setuptools@41.2:", type="build")
+        depends_on("py-cython@0.29.20:", type="build")
+        depends_on("py-numpy@1.26.0:", type=("build", "run"))
+
+    requires("@1.6.4:", when="^python@3.12:")

--- a/var/spack/repos/builtin/packages/py-cftime/package.py
+++ b/var/spack/repos/builtin/packages/py-cftime/package.py
@@ -16,14 +16,13 @@ class PyCftime(PythonPackage):
     version("1.6.4", sha256="38970aa0d0ed9ed6b1d90f2cff2301b7299ae62d38e39a540400ab00edb4d2ce")
     version("1.0.3.4", sha256="f261ff8c65ceef4799784cd999b256d608c177d4c90b083553aceec3b6c23fd3")
 
-    with when("@1.0.3.4"):
-        depends_on("py-setuptools@18.0:", type="build")
-        depends_on("py-cython@0.19:", type="build")
-        depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-setuptools@18.0:", type="build", when="@1.0.3.4")
+    depends_on("py-setuptools@41.2:", type="build", when="@1.6.4:")
 
-    with when("@1.6.4:"):
-        depends_on("py-setuptools@41.2:", type="build")
-        depends_on("py-cython@0.29.20:", type="build")
-        depends_on("py-numpy@1.26.0:", type=("build", "run"))
+    depends_on("py-cython@0.19:", type="build", when="@1.0.3.4")
+    depends_on("py-cython@0.29.20:", type="build", when="@1.6.4:")
+
+    depends_on("py-numpy", type=("build", "run"), when="@1.0.3.4")
+    depends_on("py-numpy@1.26.0:", type=("build", "run"), when="@1.6.4:")
 
     requires("@1.6.4:", when="^python@3.12:")

--- a/var/spack/repos/builtin/packages/py-cftime/package.py
+++ b/var/spack/repos/builtin/packages/py-cftime/package.py
@@ -16,13 +16,15 @@ class PyCftime(PythonPackage):
     version("1.6.4", sha256="38970aa0d0ed9ed6b1d90f2cff2301b7299ae62d38e39a540400ab00edb4d2ce")
     version("1.0.3.4", sha256="f261ff8c65ceef4799784cd999b256d608c177d4c90b083553aceec3b6c23fd3")
 
+    # https://github.com/Unidata/cftime/blob/v1.6.3rel/Changelog#L7
+    depends_on("python@:3.11", when="@:1.6.2")
+
     depends_on("py-setuptools@18.0:", type="build", when="@1.0.3.4")
     depends_on("py-setuptools@41.2:", type="build", when="@1.6.4:")
 
     depends_on("py-cython@0.19:", type="build", when="@1.0.3.4")
     depends_on("py-cython@0.29.20:", type="build", when="@1.6.4:")
 
-    depends_on("py-numpy", type=("build", "run"), when="@1.0.3.4")
+    # https://github.com/Unidata/cftime/blob/v1.6.4rel/Changelog#L6
+    depends_on("py-numpy@:1.26.4", type=("build", "run"), when="@1.0.3.4")
     depends_on("py-numpy@1.26.0:", type=("build", "run"), when="@1.6.4:")
-
-    requires("@1.6.4:", when="^python@3.12:")

--- a/var/spack/repos/builtin/packages/py-nc-time-axis/package.py
+++ b/var/spack/repos/builtin/packages/py-nc-time-axis/package.py
@@ -13,10 +13,19 @@ class PyNcTimeAxis(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.4.1", sha256="72d80f492f34bbf59490838d8cb3d92f14e88900b0ee35498b2b33c82795eb81")
     version("1.1.0", sha256="ea9d4f7f9e9189c96f7d320235ac6c4be7f63dc5aa256b3ee5d5cca5845e6e26")
 
+    depends_on("python@3.7:", when="@1.4.1:")
+    depends_on("python@3.7:3.11", when="@1.1.0")
+
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@42:", type="build", when="@1.4.1:")
+    depends_on("py-setuptools-scm@6.0: +toml", type="build", when="@1.4.1:")
     depends_on("py-cftime", type=("build", "run"))
+    depends_on("py-cftime@1.5:", type="build", when="@1.4.1:")
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
-    depends_on("py-six", type=("build", "run"))
+    depends_on("py-six", type=("build", "run"), when="@1.1.0")
+
+    requires("@1.4.1:", when="^python@3.12:")

--- a/var/spack/repos/builtin/packages/py-nc-time-axis/package.py
+++ b/var/spack/repos/builtin/packages/py-nc-time-axis/package.py
@@ -27,5 +27,3 @@ class PyNcTimeAxis(PythonPackage):
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-six", type=("build", "run"), when="@1.1.0")
-
-    requires("@1.4.1:", when="^python@3.12:")

--- a/var/spack/repos/builtin/packages/py-numpy-groupies/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy-groupies/package.py
@@ -23,10 +23,11 @@ class PyNumpyGroupies(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.11.2", sha256="2fda978c4d28d2f1633a63972f425d0a7f2f12a75505d215b41b6de712e2ec4b")
     version("0.9.20", sha256="923a382d6bc6876384b58a9c0503b05b9d36a660f329695c2d33e4f93fcbbe3d")
 
-    depends_on("python@3.7:", type=("build", "run"))
-
+    depends_on("python@3.7:3.11", type=("build", "run"), when="@0.9.20")
+    depends_on("python@3.9:", type=("build", "run"), when="@0.11.2:")
     depends_on("py-setuptools", type="build")
-
+    depends_on("py-setuptools-scm", type="build", when="@0.11.2:")
     depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-numpy-groupies/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy-groupies/package.py
@@ -26,8 +26,12 @@ class PyNumpyGroupies(PythonPackage):
     version("0.11.2", sha256="2fda978c4d28d2f1633a63972f425d0a7f2f12a75505d215b41b6de712e2ec4b")
     version("0.9.20", sha256="923a382d6bc6876384b58a9c0503b05b9d36a660f329695c2d33e4f93fcbbe3d")
 
-    depends_on("python@3.7:3.11", type=("build", "run"), when="@0.9.20")
+    # ptyhon 3.12 added in 0.11.2
+    # https://github.com/ml31415/numpy-groupies/commit/cf42fd58b46e72abddd27c3ed15c8c094e0b6211
+    depends_on("python@3.7:3.11", type=("build", "run"), when="@:0.11.1")
     depends_on("python@3.9:", type=("build", "run"), when="@0.11.2:")
+
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools-scm", type="build", when="@0.11.2:")
+
     depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-numpy-groupies/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy-groupies/package.py
@@ -28,7 +28,8 @@ class PyNumpyGroupies(PythonPackage):
 
     # ptyhon 3.12 added in 0.11.2
     # https://github.com/ml31415/numpy-groupies/commit/cf42fd58b46e72abddd27c3ed15c8c094e0b6211
-    depends_on("python@3.7:3.11", type=("build", "run"), when="@:0.11.1")
+    depends_on("python@3.9:", type=("build", "run"), when="@0.10:")
+    depends_on("python@:3.11", type=("build", "run"), when="@:0.11.1")
     depends_on("python@3.9:", type=("build", "run"), when="@0.11.2:")
 
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-partd/package.py
+++ b/var/spack/repos/builtin/packages/py-partd/package.py
@@ -20,11 +20,16 @@ class PyPartd(PythonPackage):
     version("0.3.10", sha256="33722a228ebcd1fa6f44b1631bdd4cff056376f89eb826d7d880b35b637bcfba")
     version("0.3.8", sha256="67291f1c4827cde3e0148b3be5d69af64b6d6169feb9ba88f0a6cfe77089400f")
 
-    depends_on("python@3.5:", type=("build", "run"), when="@1.1.0:")
-    depends_on("python@3.7:", type=("build", "run"), when="@1.4.0:")
+    # python 3.12+ requires 1.4.2
+    # https://github.com/dask/partd/issues/68
+    depends_on("python@3.5:3.11", type=("build", "run"), when="@1.1.0:")
+    depends_on("python@3.7:3.11", type=("build", "run"), when="@1.4.0:")
     depends_on("python@3.9:", type=("build", "run"), when="@1.4.2:")
+
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@61.2:", type="build", when="@1.4.2:")
+
     depends_on("py-versioneer@0.29 +toml", type="build", when="@1.4.2:")
     depends_on("py-locket", type=("build", "run"))
     depends_on("py-toolz", type=("build", "run"))
+

--- a/var/spack/repos/builtin/packages/py-partd/package.py
+++ b/var/spack/repos/builtin/packages/py-partd/package.py
@@ -22,8 +22,8 @@ class PyPartd(PythonPackage):
 
     # python 3.12+ requires 1.4.2
     # https://github.com/dask/partd/issues/68
-    depends_on("python@3.5:3.11", type=("build", "run"), when="@1.1.0:")
-    depends_on("python@3.7:3.11", type=("build", "run"), when="@1.4.0:")
+    depends_on("python@3.5:3.11", type=("build", "run"), when="@1.1.0:1.3.9")
+    depends_on("python@3.7:3.11", type=("build", "run"), when="@1.4.0:1.4.1")
     depends_on("python@3.9:", type=("build", "run"), when="@1.4.2:")
 
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-partd/package.py
+++ b/var/spack/repos/builtin/packages/py-partd/package.py
@@ -17,12 +17,19 @@ class PyPartd(PythonPackage):
     version("1.4.1", sha256="56c25dd49e6fea5727e731203c466c6e092f308d8f0024e199d02f6aa2167f67")
     version("1.4.0", sha256="aa0ff35dbbcc807ae374db56332f4c1b39b46f67bf2975f5151e0b4186aed0d5")
     version("1.1.0", sha256="6e258bf0810701407ad1410d63d1a15cfd7b773fd9efe555dac6bb82cc8832b0")
-    version("0.3.10", sha256="33722a228ebcd1fa6f44b1631bdd4cff056376f89eb826d7d880b35b637bcfba")
-    version("0.3.8", sha256="67291f1c4827cde3e0148b3be5d69af64b6d6169feb9ba88f0a6cfe77089400f")
+
+    # very old versions, should remove later
+    with default_args(deprecated=True):
+        version(
+            "0.3.10", sha256="33722a228ebcd1fa6f44b1631bdd4cff056376f89eb826d7d880b35b637bcfba"
+        )
+        version("0.3.8", sha256="67291f1c4827cde3e0148b3be5d69af64b6d6169feb9ba88f0a6cfe77089400f")
+
+    variant("complete", default=False, description="Complete install")
 
     # python 3.12+ requires 1.4.2
     # https://github.com/dask/partd/issues/68
-    depends_on("python@3.5:3.11", type=("build", "run"), when="@1.1.0:1.3.9")
+    depends_on("python@3.5:3.11", type=("build", "run"), when="@1.1:1.3")
     depends_on("python@3.7:3.11", type=("build", "run"), when="@1.4.0:1.4.1")
     depends_on("python@3.9:", type=("build", "run"), when="@1.4.2:")
 
@@ -30,6 +37,14 @@ class PyPartd(PythonPackage):
     depends_on("py-setuptools@61.2:", type="build", when="@1.4.2:")
 
     depends_on("py-versioneer@0.29 +toml", type="build", when="@1.4.2:")
+
     depends_on("py-locket", type=("build", "run"))
     depends_on("py-toolz", type=("build", "run"))
 
+    with when("+complete"):
+        depends_on("py-numpy@1.9.0:", type=("build", "run"), when="@1.1.0:")
+        depends_on("py-numpy@1.20.0:", type=("build", "run"), when="@1.4.2:")
+        depends_on("py-pandas@0.19.0:", type=("build", "run"), when="@1.1.0:")
+        depends_on("py-pandas@1.3:", type=("build", "run"), when="@1.4.2:")
+        depends_on("py-pyzmq", type=("build", "run"), when="@1.1.0:")
+        depends_on("py-blosc", type=("build", "run"), when="@1.1.0:")

--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -17,8 +17,6 @@ class PyScikitBuild(PythonPackage):
     homepage = "https://scikit-build.readthedocs.io/en/latest/"
     pypi = "scikit-build/scikit_build-0.17.6.tar.gz"
 
-    maintainers("coreyjadams")
-
     license("MIT")
 
     version("0.18.1", sha256="a4152ac5a084d499c28a7797be0628d8366c336e2fb0e1a063eb32e55efcb8e7")

--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -31,6 +31,7 @@ class PyScikitBuild(PythonPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
+    depends_on("python@3.7:", when="@0.17.6:")
     # 0.18.1 fixes disutils for python 3.12+
     # https://github.com/scikit-build/scikit-build/commit/77451ffb1b43e3908edfc813f22c9559421c1372
     depends_on("python@:3.11", when="@:0.17.6")
@@ -50,7 +51,8 @@ class PyScikitBuild(PythonPackage):
     depends_on("py-wheel@0.29:", type=("build", "run"))
 
     # https://github.com/scikit-build/scikit-build/releases/tag/0.18.0
-    depends_on("cmake@3.5:", type=("build", "run"), when="@0.18")
+    # https://github.com/scikit-build/scikit-build/blob/0.18.1/skbuild/constants.py#L52
+    depends_on("cmake@3.5:", type=("build", "run"), when="@0.18:")
 
     # Historical dependencies
     depends_on("py-setuptools-scm+toml", when="@0.15", type="build")

--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -31,6 +31,10 @@ class PyScikitBuild(PythonPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
+    # 0.18.1 fixes disutils for python 3.12+
+    # https://github.com/scikit-build/scikit-build/commit/77451ffb1b43e3908edfc813f22c9559421c1372
+    depends_on("python@:3.11", when="@:0.17.6")
+
     depends_on("py-hatchling", when="@0.17:", type="build")
     depends_on("py-hatch-fancy-pypi-readme", when="@0.17:", type="build")
     depends_on("py-hatch-vcs", when="@0.17:", type="build")
@@ -50,10 +54,6 @@ class PyScikitBuild(PythonPackage):
 
     # Historical dependencies
     depends_on("py-setuptools-scm+toml", when="@0.15", type="build")
-
-    # fixes disutils for python 3.12+
-    # https://github.com/scikit-build/scikit-build/commit/77451ffb1b43e3908edfc813f22c9559421c1372
-    requires("@0.18:", when="^python@3.12:")
 
     def url_for_version(self, version):
         url = (

--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -21,6 +21,7 @@ class PyScikitBuild(PythonPackage):
 
     license("MIT")
 
+    version("0.18.1", sha256="a4152ac5a084d499c28a7797be0628d8366c336e2fb0e1a063eb32e55efcb8e7")
     version("0.17.6", sha256="b51a51a36b37c42650994b5047912f59b22e3210b23e321f287611f9ef6e5c9d")
     version("0.15.0", sha256="e723cd0f3489a042370b9ea988bbb9cfd7725e8b25b20ca1c7981821fcf65fb9")
     version("0.12.0", sha256="f851382c469bcd9a8c98b1878bcfdd13b68556279d2fd9a329be41956ae5a7fe")
@@ -35,15 +36,24 @@ class PyScikitBuild(PythonPackage):
     depends_on("py-hatch-vcs", when="@0.17:", type="build")
     depends_on("py-distro", when="@0.11:", type=("build", "run"))
     depends_on("py-packaging", type=("build", "run"))
-    depends_on("py-setuptools@42:", when="@0.15:", type=("build", "run"))
+
     depends_on("py-setuptools@28:", type=("build", "run"))
+    depends_on("py-setuptools@42:", type=("build", "run"), when="@0.15:")
+
     depends_on("py-tomli", when="@0.17: ^python@:3.10", type=("build", "run"))
     depends_on("py-typing-extensions@3.7:", when="@0.17: ^python@:3.7", type=("build", "run"))
     depends_on("py-wheel@0.32:", when="@0.17:", type=("build", "run"))
     depends_on("py-wheel@0.29:", type=("build", "run"))
 
+    # https://github.com/scikit-build/scikit-build/releases/tag/0.18.0
+    depends_on("cmake@3.5:", type=("build", "run"), when="@0.18")
+
     # Historical dependencies
     depends_on("py-setuptools-scm+toml", when="@0.15", type="build")
+
+    # fixes disutils for python 3.12+
+    # https://github.com/scikit-build/scikit-build/commit/77451ffb1b43e3908edfc813f22c9559421c1372
+    requires("@0.18:", when="^python@3.12:")
 
     def url_for_version(self, version):
         url = (


### PR DESCRIPTION
A set of small fixes and new version additions to support these libraries building with `python@3.12:`. Submitting as a bundle due to some interdependencies. 

- `py-cftime`
- `py-nc-time-axis`
- `py-numpy-groupies`
- `py-partd`