### PR TITLE
style: fix `not in` and `is not`

### DIFF
--- a/lib/spack/spack/container/__init__.py
+++ b/lib/spack/spack/container/__init__.py
@@ -57,7 +57,7 @@ def validate(configuration_file):
     # Set the default value of the concretization strategy to unify and
     # warn if the user explicitly set another value
     env_dict.setdefault("concretizer", {"unify": True})
-    if not env_dict["concretizer"]["unify"] is True:
+    if env_dict["concretizer"]["unify"] is not True:
         warnings.warn(
             '"concretizer:unify" is not set to "true", which means the '
             "generated image may contain different variants of the same "

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -814,7 +814,7 @@ class BuildRequest:
         # Include build dependencies if pkg is going to be built from sources, or
         # if build deps are explicitly requested.
         if include_build_deps or not (
-            cache_only or pkg.spec.installed and not pkg.spec.dag_hash() in self.overwrite
+            cache_only or pkg.spec.installed and pkg.spec.dag_hash() not in self.overwrite
         ):
             depflag |= dt.BUILD
         if self.run_tests(pkg):

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -64,7 +64,7 @@ class Mirror:
     @staticmethod
     def from_url(url: str):
         """Create an anonymous mirror by URL. This method validates the URL."""
-        if not urllib.parse.urlparse(url).scheme in supported_url_schemes:
+        if urllib.parse.urlparse(url).scheme not in supported_url_schemes:
             raise ValueError(
                 f'"{url}" is not a valid mirror URL. '
                 f"Scheme must be one of {supported_url_schemes}."

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -182,7 +182,7 @@ def test_requirement_adds_version_satisfies(
 
     # Sanity check: early version of T does not include U
     s0 = spack.concretize.concretize_one("t@2.0")
-    assert not ("u" in s0)
+    assert "u" not in s0
 
     conf_str = """\
 packages:

--- a/var/spack/repos/builtin/packages/ace/package.py
+++ b/var/spack/repos/builtin/packages/ace/package.py
@@ -32,7 +32,7 @@ class Ace(MakefilePackage):
         # Dictionary mapping: compiler-name : ACE config-label
         supported = {"intel": "_icc", "gcc": ""}
 
-        if not (self.compiler.name in supported):
+        if self.compiler.name not in supported:
             raise Exception(
                 "compiler " + self.compiler.name + " not supported in ace spack-package"
             )

--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -360,7 +360,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
             args.append("-DAMReX_GPU_BACKEND=SYCL")
             # SYCL GPU backend only supported with Intel's oneAPI or DPC++ compilers
             sycl_compatible_compilers = ["icpx"]
-            if not (os.path.basename(self.compiler.cxx) in sycl_compatible_compilers):
+            if os.path.basename(self.compiler.cxx) not in sycl_compatible_compilers:
                 raise InstallError(
                     "AMReX's SYCL GPU Backend requires the oneAPI CXX (icpx) compiler."
                 )

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -276,7 +276,7 @@ class Charmpp(Package):
     #            build-target=LIBS backend={0}'.format(b))
 
     def install(self, spec, prefix):
-        if not ("backend=mpi" in self.spec) or not ("backend=netlrts" in self.spec):
+        if "backend=mpi" not in self.spec or "backend=netlrts" not in self.spec:
             if self.spec.satisfies("+pthreads"):
                 raise InstallError(
                     "The pthreads option is only available on the Netlrts and MPI network layers."

--- a/var/spack/repos/builtin/packages/dav-sdk/package.py
+++ b/var/spack/repos/builtin/packages/dav-sdk/package.py
@@ -30,7 +30,7 @@ def dav_sdk_depends_on(spec, when=None, propagate=None):
     # Map the propagated variants to the dependency variant.  Some packages may need
     # overrides to propagate a dependency as something else, e.g., {"visit": "libsim"}.
     # Most call-sites will just use a list.
-    if not type(propagate) is dict:
+    if type(propagate) is not dict:
         propagate = dict([(v, v) for v in propagate])
 
     # Determine the base variant

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -30,7 +30,7 @@ def dav_sdk_depends_on(spec, when=None, propagate=None):
     # Map the propagated variants to the dependency variant.  Some packages may need
     # overrides to propagate a dependency as something else, e.g., {"visit": "libsim"}.
     # Most call-sites will just use a list.
-    if not type(propagate) is dict:
+    if type(propagate) is not dict:
         propagate = dict([(v, v) for v in propagate])
 
     # Determine the base variant

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -226,7 +226,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
         if self.spec.satisfies("+sycl"):
             sycl_compatible_compilers = ["icpx"]
-            if not (os.path.basename(self.compiler.cxx) in sycl_compatible_compilers):
+            if os.path.basename(self.compiler.cxx) not in sycl_compatible_compilers:
                 raise InstallError("ginkgo +sycl requires icpx compiler.")
         return args
 

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -322,7 +322,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         if spec.satisfies("+sycl"):
             configure_args.append("--with-sycl")
             sycl_compatible_compilers = ["icpx"]
-            if not (os.path.basename(self.compiler.cxx) in sycl_compatible_compilers):
+            if os.path.basename(self.compiler.cxx) not in sycl_compatible_compilers:
                 raise InstallError(
                     "Hypre's SYCL GPU Backend requires the oneAPI CXX (icpx) compiler."
                 )

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -582,7 +582,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         if "+sycl" in spec:
             sycl_compatible_compilers = ["icpx"]
-            if not (os.path.basename(self.compiler.cxx) in sycl_compatible_compilers):
+            if os.path.basename(self.compiler.cxx) not in sycl_compatible_compilers:
                 raise InstallError("PETSc's SYCL GPU Backend requires oneAPI CXX (icpx) compiler.")
             options.append("--with-sycl=1")
             options.append("--with-syclc=" + self.compiler.cxx)


### PR DESCRIPTION
These are some changes that `ruff check --fix` would make that the current `spack style` also agrees with.  Make the changes now so that the `ruff` change is less disruptive.

See #48823
