### PR TITLE
py-xesmf: add v0.8.8

### DIFF
--- a/var/spack/repos/builtin/packages/py-xesmf/package.py
+++ b/var/spack/repos/builtin/packages/py-xesmf/package.py
@@ -13,6 +13,7 @@ class PyXesmf(PythonPackage):
 
     license("MIT")
 
+    version("0.8.8", sha256="8588f83007ce7011379991f516be3691df6fb30486741f0e1c33aa962056ea33")
     version("0.8.4", sha256="c5a2c4b3e8dbbc9fccd5772a940f9067d68e824215ef87ba222b06718c4eeb56")
 
     with default_args(type="build"):
@@ -21,9 +22,9 @@ class PyXesmf(PythonPackage):
 
     with default_args(type=("build", "run")):
         depends_on("py-cf-xarray@0.5.1:")
-        # TODO: add optional dependency
-        # https://github.com/esmf-org/esmf/tree/develop/src/addon/esmpy
-        # depends_on("py-esmpy@8:")
+
+        # esmf +python is only handled correctly in spack for 8.4+
+        depends_on("esmf@8.4.0: +python")
         depends_on("py-numba@0.55.2:")
         depends_on("py-numpy@1.16:")
         depends_on("py-shapely")


### PR DESCRIPTION
Add new version of xesmf and fix how `esmf +python` is used in light of https://github.com/spack/spack/pull/45504

I also don't think `esmf` is correctly listed as an optional given xesmf is:
>Powerful: It uses [ESMF](https://earthsystemmodeling.org/)/[ESMPy](http://earthsystemmodeling.org/esmpy/) as backend and can regrid between general curvilinear grids with all [ESMF regridding algorithms](https://earthsystemmodeling.org/regrid/#regridding-methods), such as bilinear, conservative and nearest neighbour.

and that`esmf` shows up commented in https://github.com/pangeo-data/xESMF/blob/master/requirements.txt
```
# We cannot list this  here b/c it is not on PyPI.
#esmpy>=8.0.0
```