### PR TITLE
dd4hep: add v1.31

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -25,6 +25,7 @@ class Dd4hep(CMakePackage):
     license("LGPL-3.0-or-later")
 
     version("master", branch="master")
+    version("1.31", sha256="9c06a1b4462fc1b51161404889c74b37350162d0b0ac2154db27e3f102670bd1")
     version("1.30", sha256="02de46151e945eff58cffd84b4b86d35051f4436608199c3efb4d2e1183889fe")
     version("1.29", sha256="435d25a7ef093d8bf660f288b5a89b98556b4c1c293c55b93bf641fb4cba77e9")
     version("1.28", sha256="b28d671eda0154073873a044a384486e66f1f200065deca99537aa84f07328ad")
@@ -118,13 +119,16 @@ class Dd4hep(CMakePackage):
     depends_on("tbb", when="+tbb")
     depends_on("intel-tbb@:2020.3", when="+tbb @:1.23")
     depends_on("lcio", when="+lcio")
-    depends_on("edm4hep", when="+edm4hep")
-    depends_on("podio", when="+edm4hep")
-    depends_on("podio@:0.16.03", when="@:1.23 +edm4hep")
-    depends_on("podio@0.16:", when="@1.24: +edm4hep")
-    depends_on("podio@0.16.3:", when="@1.26: +edm4hep")
-    depends_on("podio@:0", when="@:1.29 +edm4hep")
     depends_on("py-pytest", type=("build", "test"))
+    with when("+edm4hep"):
+        depends_on("edm4hep")
+        depends_on("edm4hep@0.10.5:", when="@1.31:")
+        depends_on("podio")
+        depends_on("podio@:0.16.03", when="@:1.23")
+        depends_on("podio@:0", when="@:1.29")
+        depends_on("podio@0.16:", when="@1.24:")
+        depends_on("podio@0.16.3:", when="@1.26:")
+        depends_on("podio@0.16.7:", when="@1.31:")
 
     # See https://github.com/AIDASoft/DD4hep/pull/771 and https://github.com/AIDASoft/DD4hep/pull/876
     conflicts(


### PR DESCRIPTION
This PR adds `dd4hep`, v1.31 ([diff](https://github.com/AIDASoft/DD4hep/compare/v01-30...v01-31)). This version requires some newer edm4hep and podio minimum versions. To be tested in gitlab CI.