### PR TITLE
spec.py: fix hash change due to None vs {}

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1527,9 +1527,8 @@ class Spec:
         self._external_path = external_path
         self.external_modules = Spec._format_module_list(external_modules)
 
-        # This attribute is used to store custom information for
-        # external specs. None signal that it was not set yet.
-        self.extra_attributes = None
+        # This attribute is used to store custom information for external specs.
+        self.extra_attributes: dict = {}
 
         # This attribute holds the original build copy of the spec if it is
         # deployed differently than it was built. None signals that the spec
@@ -2351,15 +2350,10 @@ class Spec:
             )
 
         if self.external:
-            if self.extra_attributes:
-                extra_attributes = syaml.sorted_dict(self.extra_attributes)
-            else:
-                extra_attributes = None
-
             d["external"] = {
                 "path": self.external_path,
                 "module": self.external_modules,
-                "extra_attributes": extra_attributes,
+                "extra_attributes": syaml.sorted_dict(self.extra_attributes),
             }
 
         if not self._concrete:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2352,7 +2352,7 @@ class Spec:
         if self.external:
             d["external"] = {
                 "path": self.external_path,
-                "module": self.external_modules,
+                "module": self.external_modules or None,
                 "extra_attributes": syaml.sorted_dict(self.extra_attributes),
             }
 


### PR DESCRIPTION
Currently `Spec.extra_attributes` has type `Optional[dict]`, but `None` and `{}` hash differently for DAG hash. That should not happen. #48615 made an accidental change in DAG hash as a consequence.

`Spec.external_modules` is `Optional[list]`, but the `None` value is used by default instead of empty list.