### PR TITLE
libgcrypt: adding explicit -O0 override in flag_handler

### DIFF
--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -49,6 +49,8 @@ class Libgcrypt(AutotoolsPackage):
         # We should not inject optimization flags through the wrapper, because
         # the jitter entropy code should never be compiled with optimization
         # flags, and the build system ensures that
+        if name.lower() == "cflags":
+            flags.append("-O0")
         return (None, flags, None)
 
     # 1.10.2 fails on macOS when trying to use the Linux getrandom() call


### PR DESCRIPTION
You can't specify optimizations for libgcrypt, it says as such in the recipe and the build system will error out if one is specified. 

Some people (like myself) may define cflags for specs that will result in errors for libgcrypt. I can pretty easily update the spec I was trying to install to specify ```^libgcrypt cflags=-O0``` but less experienced spack users might not know how to handle it. 

I debated altering the flag_handler to search cflags for an instance of ```-O[a-zA-Z1-9]+``` or similar and removing it, but that seemed like more effort than the problem really calls for. Easier to just tack a ```-O0``` on the end of cflags which'll override any earlier ```-O``` args
