### PR TITLE
fcgi: add v2.4.3, v2.4.4

### DIFF
--- a/var/spack/repos/builtin/packages/fcgi/package.py
+++ b/var/spack/repos/builtin/packages/fcgi/package.py
@@ -14,12 +14,10 @@ class Fcgi(AutotoolsPackage):
     homepage = "https://fastcgi-archives.github.io/"
     url = "https://github.com/FastCGI-Archives/fcgi2/archive/refs/tags/2.4.2.tar.gz"
 
-    depends_on("autoconf", type="build")
-    depends_on("automake", type="build")
-    depends_on("libtool", type="build")
-
     license("OML")
 
+    version("2.4.4", sha256="c0e0d9cc7d1e456d7278c974e2826f593ef5ca555783eba81e7e9c1a07ae0ecc")
+    version("2.4.3", sha256="5273bc54c28215d81b9bd78f937a9bcdd4fe94e41ccd8d7c991aa8a01b50b70e")
     version("2.4.2", sha256="1fe83501edfc3a7ec96bb1e69db3fd5ea1730135bd73ab152186fd0b437013bc")
     version(
         "2.4.1-SNAP-0910052249",
@@ -27,7 +25,10 @@ class Fcgi(AutotoolsPackage):
         url="https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz",
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
 
     parallel = False


### PR DESCRIPTION
This PR adds `fcgi`, v2.4.3 and v2.4.4 ([diff](https://github.com/FastCGI-Archives/fcgi2/compare/2.4.2...2.4.4)). No changes to the `configure.ac` beyond just adding a way to disable examples (not adapted here). [Tested in CI](https://cache.spack.io/package/develop/fcgi/specs/).