### PR TITLE
harfbuzz: add v10.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -23,6 +23,7 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("10.2.0", sha256="620e3468faec2ea8685d32c46a58469b850ef63040b3565cde05959825b48227")
     version("10.1.0", sha256="6ce3520f2d089a33cef0fc48321334b8e0b72141f6a763719aaaecd2779ecb82")
     version("10.0.1", sha256="b2cb13bd351904cb9038f907dc0dee0ae07127061242fe3556b2795c4e9748fc")
     version("10.0.0", sha256="c2dfe016ad833a5043ecc6579043f04e8e6d50064e02ad449bb466e6431e3e04")


### PR DESCRIPTION
This PR adds `harfbuzz`, v10.2.0 ([diff](https://github.com/harfbuzz/harfbuzz/compare/10.1.0...10.2.0)); no build system or dependency changes. [Tested in CI](https://cache.spack.io/package/develop/harfbuzz/specs/).