### PR TITLE
icu4c: add v75.1, v76.1

### DIFF
--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -19,6 +19,8 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
 
     license("Unicode-TOU")
 
+    version("76.1", sha256="dfacb46bfe4747410472ce3e1144bf28a102feeaa4e3875bac9b4c6cf30f4f3e")
+    version("75.1", sha256="cb968df3e4d2e87e8b11c49a5d01c787bd13b9545280fc6642f826527618caef")
     version("74.2", sha256="68db082212a96d6f53e35d60f47d38b962e9f9d207a74cfac78029ae8ff5e08c")
     version("67.1", sha256="94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc")
     version("66.1", sha256="52a3f2209ab95559c1cf0a14f24338001f389615bf00e2585ef3dbc43ecf0a2e")
@@ -40,7 +42,7 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
             variant(
                 "cxxstd",
                 default="11",
-                values=("11", "14", "17"),
+                values=(conditional("11", "14", when="@:74"), "17"),
                 multi=False,
                 description="Use the specified C++ standard when building",
             )


### PR DESCRIPTION
This PR adds `icu4c`, v75.1 and v76.1 ([diff](https://github.com/unicode-org/icu/compare/release-74-2...release-76-1) (warning: very long)). These versions require c++17 string_view. [Tested in CI](https://cache.spack.io/package/develop/icu4c/specs/).