### PR TITLE
isa-l: add v2.31.1

### DIFF
--- a/var/spack/repos/builtin/packages/isa-l/package.py
+++ b/var/spack/repos/builtin/packages/isa-l/package.py
@@ -30,6 +30,7 @@ class IsaL(AutotoolsPackage):
     version("master", branch="master")
 
     # Current
+    version("2.31.1", sha256="e1d5573a4019738243b568ab1e1422e6ab7557c5cae33cc8686944d327ad6bb4")
     version("2.30.0", sha256="bcf592c04fdfa19e723d2adf53d3e0f4efd5b956bb618fed54a1108d76a6eb56")
     version("2.29.0", sha256="832d9747ef3f0c8c05d39e3d7fd6ee5299a844e1ee7382fc8c8b52a268f36eda")
     version("2.28.0", sha256="589202efdcfe437b1786750ec81bf93055e3b88a4bdf909d3b519f2a7134034b")


### PR DESCRIPTION
This PR adds `isa-l`, v2.31.1 ([diff](https://github.com/intel/isa-l/compare/v2.30.0...v2.31.1)); no build system or dependency changes. [Tested in CI](https://cache.spack.io/package/develop/isa-l/specs/).