### PR TITLE
libdrm: add v2.4.124

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -20,6 +20,7 @@ class Libdrm(AutotoolsPackage, MesonPackage):
 
     license("MIT")
 
+    version("2.4.124", sha256="ac36293f61ca4aafaf4b16a2a7afff312aa4f5c37c9fbd797de9e3c0863ca379")
     version("2.4.123", sha256="a2b98567a149a74b0f50e91e825f9c0315d86e7be9b74394dae8b298caadb79e")
     version("2.4.122", sha256="d9f5079b777dffca9300ccc56b10a93588cdfbc9dde2fae111940dfb6292f251")
     version("2.4.121", sha256="909084a505d7638887f590b70791b3bbd9069c710c948f5d1f1ce6d080cdfcab")


### PR DESCRIPTION
This PR adds `libdrm`, v2.4.124 ([diff](https://gitlab.freedesktop.org/mesa/drm/-/compare/libdrm-2.4.123...libdrm-2.4.124)); no build system or dependency changes. [Tested in CI](https://cache.spack.io/package/develop/libdrm/specs/).