### PR TITLE
libx11: add v1.8.11; libxrender: add v0.9.12

### DIFF
--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -16,6 +16,7 @@ class Libx11(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.8.11", sha256="17a37d1597354a1d8040196f1cdac54240c78c0bd1a1a95e97cc23215cf0b734")
     version("1.8.10", sha256="b7a1a90d881bb7b94df5cf31509e6b03f15c0972d3ac25ab0441f5fbc789650f")
     version("1.8.9", sha256="57ca5f07d263788ad661a86f4139412e8b699662e6b60c20f1f028c25a935e48")
     version("1.8.8", sha256="26997a2bc48c03df7d670f8a4ee961d1d6b039bf947475e5fec6b7635b4efe72")

--- a/var/spack/repos/builtin/packages/libxrender/package.py
+++ b/var/spack/repos/builtin/packages/libxrender/package.py
@@ -15,6 +15,7 @@ class Libxrender(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("0.9.12", sha256="0fff64125819c02d1102b6236f3d7d861a07b5216d8eea336c3811d31494ecf7")
     version("0.9.11", sha256="6aec3ca02e4273a8cbabf811ff22106f641438eb194a12c0ae93c7e08474b667")
     version("0.9.10", sha256="770527cce42500790433df84ec3521e8bf095dfe5079454a92236494ab296adf")
     version("0.9.9", sha256="beeac64ff8d225f775019eb7c688782dee9f4cc7b412a65538f8dde7be4e90fe")
@@ -22,6 +23,8 @@ class Libxrender(AutotoolsPackage, XorgPackage):
     depends_on("c", type="build")
 
     depends_on("libx11@1.6:")
+    # https://gitlab.freedesktop.org/xorg/lib/libxrender/-/merge_requests/14
+    conflicts("^libx11@1.8.11:", when="@:0.9.11", msg="libxrender@0.9.12: requires libx11@1.8.11:")
 
     depends_on("renderproto@0.9:", type=("build", "link"))
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
This adds `libx11`, v1.8.11 ([diff](https://gitlab.freedesktop.org/xorg/lib/libx11/-/compare/libX11-1.8.10...libX11-1.8.11)); no build system or dependency changes. [Tested in CI](https://cache.spack.io/package/develop/libx11/specs/).

This adds `libxrender`, v0.9.12 ([diff](https://gitlab.freedesktop.org/xorg/lib/libxrender/-/compare/libXrender-0.9.11...libXrender-0.9.12)); no build system or dependency changes. [Tested in CI](https://cache.spack.io/package/develop/libxrender/specs/). Conflict added since missing semicolons after macro expansion with newer libx11.