### PR TITLE
cppgsl: add v4.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/cppgsl/package.py
+++ b/var/spack/repos/builtin/packages/cppgsl/package.py
@@ -15,6 +15,7 @@ class Cppgsl(CMakePackage):
     license("MIT")
 
     version("main", branch="main")
+    version("4.1.0", sha256="0a227fc9c8e0bf25115f401b9a46c2a68cd28f299d24ab195284eb3f1d7794bd")
     version("4.0.0", sha256="f0e32cb10654fea91ad56bde89170d78cfbf4363ee0b01d8f097de2ba49f6ce9")
     version("3.1.0", sha256="d3234d7f94cea4389e3ca70619b82e8fb4c2f33bb3a070799f1e18eef500a083")
     version("2.1.0", sha256="ef73814657b073e1be86c8f7353718771bf4149b482b6cb54f99e79b23ff899d")
@@ -32,6 +33,7 @@ class Cppgsl(CMakePackage):
     )
 
     depends_on("cmake@3.1.3:", type="build")
+    depends_on("cmake@3.14:", type="build", when="@4.1:")
 
     def cmake_args(self):
         return [


### PR DESCRIPTION
This PR adds `cppgsl`, v4.1.0 ([diff](https://github.com/microsoft/GSL/compare/v4.0.0...v4.1.0)); requires higher cmake version. [Tested in CI](https://cache.spack.io/package/develop/cppgsl/specs/).