### PR TITLE
Tesseract v5.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/leptonica/package.py
+++ b/var/spack/repos/builtin/packages/leptonica/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -14,6 +16,7 @@ class Leptonica(CMakePackage):
 
     license("custom")
 
+    version("1.85.0", sha256="c01376bce0379d4ea4bc2ec5d5cbddaa49e2f06f88242619ab8c059e21adf233")
     version("1.84.1", sha256="ecd7a868403b3963c4e33623595d77f2c87667e2cfdd9b370f87729192061bef")
     version("1.83.1", sha256="4289d0a4224b614010072253531c0455a33a4d7c7a0017fe7825ed382290c0da")
     version("1.81.0", sha256="70ebc04ff8b9684205bd1d01843c635a8521255b74813bf7cce9a33368f7952c")
@@ -36,3 +39,9 @@ class Leptonica(CMakePackage):
         args = [self.define("BUILD_SHARED_LIBS", "ON")]
 
         return args
+
+    @run_after("install")
+    def pkgconfig_fixup(self):
+        with working_dir(self.prefix.lib.pkgconfig):
+            if not os.path.exists("lept.pc"):
+                symlink(f"lept_{self.spec.variants['build_type'].value}.pc", "lept.pc")

--- a/var/spack/repos/builtin/packages/tesseract/package.py
+++ b/var/spack/repos/builtin/packages/tesseract/package.py
@@ -13,33 +13,36 @@ class Tesseract(AutotoolsPackage):
 
     license("Apache-2.0")
 
+    version("5.5.0", sha256="f2fb34ca035b6d087a42875a35a7a5c4155fa9979c6132365b1e5a28ebc3fc11")
     version("4.1.1", sha256="2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb")
     version("4.1.0", sha256="5c5ed5f1a76888dc57a83704f24ae02f8319849f5c4cf19d254296978a1a1961")
     version("4.0.0", sha256="a1f5422ca49a32e5f35c54dee5112b11b99928fc9f4ee6695cdc6768d69f61dd")
 
+    variant("doc", default=False, description="Build with documentation.")
+
     depends_on("cxx", type="build")  # generated
 
     # do not fetch the jar files from Makefile
-    patch("java_Makefile.patch")
+    patch("java_Makefile.patch", when="@:4.1.1")
 
     jars = ["piccolo2d-core-3.0.1", "piccolo2d-extras-3.0.1", "jaxb-api-2.3.1"]
     resource(
         name=jars[0],
-        url="https://search.maven.org/remotecontent?filepath=org/piccolo2d/piccolo2d-core/3.0.1/piccolo2d-core-3.0.1.jar",
+        url="https://repo1.maven.org/maven2/org/piccolo2d/piccolo2d-core/3.0.1/piccolo2d-core-3.0.1.jar",
         sha256="9acad723136ddb996e96f5d488b9b046753a1d4c60ea639d5e3f9701deaf60ad",
         placement=jars[0],
         expand=False,
     )
     resource(
         name=jars[1],
-        url="https://search.maven.org/remotecontent?filepath=org/piccolo2d/piccolo2d-extras/3.0.1/piccolo2d-extras-3.0.1.jar",
+        url="https://repo1.maven.org/maven2/org/piccolo2d/piccolo2d-extras/3.0.1/piccolo2d-extras-3.0.1.jar",
         sha256="ba45f343e9ebc06c9b4ce165c8bb539b11cbf59e93d1df48489ab173f74375a8",
         placement=jars[1],
         expand=False,
     )
     resource(
         name=jars[2],
-        url="https://search.maven.org/remotecontent?filepath=javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
+        url="https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
         sha256="88b955a0df57880a26a74708bc34f74dcaf8ebf4e78843a28b50eae945732b06",
         placement=jars[2],
         expand=False,
@@ -49,11 +52,11 @@ class Tesseract(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("doxygen", type="build")
-    depends_on("asciidoc", type="build")
-    depends_on("libxslt", type="build")
+    depends_on("doxygen", type="build", when="+doc")
+    depends_on("asciidoc", type="build", when="+doc")
+    depends_on("libxslt", type="build", when="+doc")
     depends_on("pkgconfig", type="build")
-    depends_on("leptonica")
+    depends_on("leptonica@1.74:")
     depends_on("libarchive")
     depends_on("curl")
     depends_on("icu4c")
@@ -65,8 +68,16 @@ class Tesseract(AutotoolsPackage):
         autogen = Executable(join_path(".", "autogen.sh"))
         autogen()
 
+    def configure_args(self):
+        return self.enable_or_disable("doc")
+
     def setup_run_environment(self, env):
         env.set("SCROLLVIEW_PATH", prefix.share.tessdata)
+
+    @when("@5.5.0:")
+    def patch(self):
+        with working_dir("java"):
+            filter_file(r"^.*curl.*$", "", "Makefile.am")
 
     @run_after("install")
     def training(self):


### PR DESCRIPTION
Updating tesseract and leptonica.

the cmake build of leptonica seems to annoyingly append ```_<CMAKE_BUILD_TYPE>``` to the pkgconf file generated. So I've added in a method to link lept.pc to that if lept.pc isn't generated. Which seems to be the current behavior for their cmake build (this was breaking tesseract's build).

replaced the tesseract resource fetch urls with what their build process fetches from now. Also made building the docs optional (it wasn't working for me).