### PR TITLE
bash: add autotools dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -23,6 +23,10 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("c", type="build")  # generated
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("ncurses")
     depends_on("readline@8.2:", when="@5.2:")
     depends_on("readline@5.0:")


### PR DESCRIPTION
Discovered on a minimal system installation without autotools. Bash calls `autoconf` during configuration.