### PR TITLE
ci: add codecov token secret to coverage upload job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,3 +33,4 @@ jobs:
       with:
         verbose: true
         fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov needs to see the token secret when uploading, so we have to add this line to the workflow YAML:

```yaml
  with:
    token: ${{ secrets.CODECOV_TOKEN }}
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
