### PR TITLE
spec.py: use json.dumps directly to avoid hash breakage

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -52,6 +52,7 @@ import collections.abc
 import enum
 import io
 import itertools
+import json
 import os
 import pathlib
 import platform
@@ -2128,7 +2129,9 @@ class Spec:
         if hash.override is not None:
             return hash.override(self)
         node_dict = self.to_node_dict(hash=hash)
-        json_text = sjson.dump(node_dict)
+        json_text = json.dumps(
+            node_dict, ensure_ascii=True, indent=None, separators=(",", ":"), sort_keys=False
+        )
         # This implements "frankenhashes", preserving the last 7 characters of the
         # original hash when splicing so that we can avoid relocation issues
         out = spack.util.hash.b32_hash(json_text)


### PR DESCRIPTION
Apparently we had a hash breakage long ago in #39457, because it was not realized that `Spec.spec_hash` uses the same code path. Prevent these issues going forward by using `json` directly, and fixing default arguments inline. That should also be forward compatible would Python ever change defaults (like outputting utf-8 instead of ascii)