### PR TITLE
h5hut: Remove H5_USE_110_API for newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -50,7 +50,7 @@ class H5hut(AutotoolsPackage):
         build_system_flags = []
         if (
             name == "cflags"
-            and self.spec.satisfies("@:2")
+            and self.spec.satisfies("@:1")
             and self.spec["hdf5"].satisfies("@1.12:")
         ):
             build_system_flags = ["-DH5_USE_110_API"]

--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -13,6 +13,7 @@ class H5hut(AutotoolsPackage):
     homepage = "https://amas.psi.ch/H5hut/"
     url = "https://amas.web.psi.ch/Downloads/H5hut/H5hut-2.0.0rc3.tar.gz"
     git = "https://gitlab.psi.ch/H5hut/src.git"
+    maintainers("biddisco")
 
     version("2.0.0rc3", sha256="1ca9a9478a99e1811ecbca3c02cc49258050d339ffb1a170006eab4ab2a01790")
 
@@ -47,8 +48,12 @@ class H5hut(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         build_system_flags = []
-        if name == "cflags" and self.spec.satisfies("@:2") and self.spec["hdf5"].satisfies("@1.12:"):
-          build_system_flags = ["-DH5_USE_110_API"]
+        if (
+            name == "cflags"
+            and self.spec.satisfies("@:2")
+            and self.spec["hdf5"].satisfies("@1.12:")
+        ):
+            build_system_flags = ["-DH5_USE_110_API"]
         return flags, None, build_system_flags
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -47,8 +47,8 @@ class H5hut(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         build_system_flags = []
-        if name == "cflags" and self.spec["hdf5"].satisfies("@1.12:"):
-            build_system_flags = ["-DH5_USE_110_API"]
+        if name == "cflags" and self.spec.satisfies("@:2") and self.spec["hdf5"].satisfies("@1.12:"):
+          build_system_flags = ["-DH5_USE_110_API"]
         return flags, None, build_system_flags
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -11,12 +11,11 @@ class H5hut(AutotoolsPackage):
     High-Performance I/O Library for Particle-based Simulations."""
 
     homepage = "https://amas.psi.ch/H5hut/"
-    url = "https://amas.web.psi.ch/Downloads/H5hut/H5hut-2.0.0rc3.tar.gz"
+    url = "https://amas.web.psi.ch/Downloads/H5hut/H5hut-2.0.0rc7.tar.gz"
     git = "https://gitlab.psi.ch/H5hut/src.git"
     maintainers("biddisco")
 
-    version("2.0.0rc3", sha256="1ca9a9478a99e1811ecbca3c02cc49258050d339ffb1a170006eab4ab2a01790")
-
+    version("2.0.0rc7", sha256="bc058c4817c356b7b7acfe386c586923103b90bdfa83575db3a91754767e6fab")
     version("master", branch="master")
 
     depends_on("c", type="build")  # generated

--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -11,7 +11,7 @@ class H5hut(AutotoolsPackage):
     High-Performance I/O Library for Particle-based Simulations."""
 
     homepage = "https://amas.psi.ch/H5hut/"
-    url = "https://amas.web.psi.ch/Downloads/H5hut/H5hut-2.0.0rc7.tar.gz"
+    url = "https://amas.web.psi.ch/Downloads/H5hut/H5hut-0.0.0.tar.gz"
     git = "https://gitlab.psi.ch/H5hut/src.git"
     maintainers("biddisco")
 


### PR DESCRIPTION
The use of `H5_USE_110_API` flag causes build failures when the master or @2.x branches are used as they have addressed the hdf5 API changes and do not need the flag
 
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
