### PR TITLE
llvm: fix llvm@15 %apple-clang@16

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -730,6 +730,19 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
 
     patch("sanitizer-platform-limits-posix-xdr-macos.patch", when="@10:14 platform=darwin")
 
+    # https://github.com/spack/spack/issues/48865
+    patch(
+        "https://github.com/llvm/llvm-project/commit/f4be5ed6a3fef0b2b0c60b29e1c0638926638d28.patch?full_index=1",
+        sha256="51740996bbc01a5049fa859134ad44ffc9514da212cc7d9a445c8d16d6cc867e",
+        when="@15",
+    )
+    # https://github.com/spack/spack/issues/48865
+    patch(
+        "https://github.com/llvm/llvm-project/commit/73e15b5edb4fa4a77e68c299a6e3b21e610d351f.patch?full_index=1",
+        sha256="b540ef6e3728d7881d95775a163314fac6e2f9207f5d5e8b79c8c73c73ba4dc3",
+        when="@15",
+    )
+
     @when("@14:17")
     def patch(self):
         # https://github.com/llvm/llvm-project/pull/69458

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -740,7 +740,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     patch(
         "https://github.com/llvm/llvm-project/commit/73e15b5edb4fa4a77e68c299a6e3b21e610d351f.patch?full_index=1",
         sha256="b540ef6e3728d7881d95775a163314fac6e2f9207f5d5e8b79c8c73c73ba4dc3",
-        when="@15",
+        when="@15:16",
     )
 
     @when("@14:17")


### PR DESCRIPTION
* add missing `<cstdio>` include to fix lldb build
* add patch so `#if __is_target_environment(<something unknown>)` is false. This `#if` is used in newer versions of XCode's TargetConditionals.h.

Tested it and t works, but still running into various linker warnings due to the new linker on macOS. That's https://github.com/llvm/llvm-project/issues/109549. One solution is `-fuse-ld=lld`. Not going to attempt to fix that as part of this PR.