### PR TITLE
ccache: set base_dir

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -960,9 +960,6 @@ if [ -n "$SPACK_CCACHE_BINARY" ]; then
     case "$lang_flags" in
         C|CXX)  # ccache only supports C languages
             prepend full_command_list "${SPACK_CCACHE_BINARY}"
-            # workaround for stage being a temp folder
-            # see #3761#issuecomment-294352232
-            export CCACHE_NOHASHDIR=yes
             ;;
     esac
 fi

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -610,9 +610,11 @@ def set_wrapper_variables(pkg, env):
     if spack.config.get("config:ccache"):
         # Enable ccache in the compiler wrapper
         env.set(SPACK_CCACHE_BINARY, spack.util.executable.which_string("ccache", required=True))
+        env.set("CCACHE_NOHASHDIR", "")
+        env.set("CCACHE_BASEDIR", os.path.realpath(spack.stage.get_stage_root()))
     else:
         # Avoid cache pollution if a build system forces `ccache <compiler wrapper invocation>`.
-        env.set("CCACHE_DISABLE", "1")
+        env.set("CCACHE_DISABLE", "")
 
     # Gather information about various types of dependencies
     rpath_hashes = set(s.dag_hash() for s in get_rpath_deps(pkg))


### PR DESCRIPTION
On macOS I get exactly 0 direct hits from ccache, because of `-I<abs path>/include -c <abs path>/example.c`. The issue is extra annoying because of the `/private/var` vs `/var` symlinked dirs, so I added `realpath`.

Due to Spack's unfortunate choice of `spack-build-<short hash>/` for the build dir, I think this PR is still mostly useless across two builds with different dag hash.

For whatever reason, I'm not getting any preprocessed cache hits either. So, WIP.