### PR TITLE
spec.py: ensure spec.extra_attributes is {} if it null in json

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4908,7 +4908,7 @@ class SpecfileReaderBase:
                 spec.external_modules = node["external"]["module"]
                 if spec.external_modules is False:
                     spec.external_modules = None
-                spec.extra_attributes = node["external"].get("extra_attributes", {})
+                spec.extra_attributes = node["external"].get("extra_attributes") or {}
 
         # specs read in are concrete unless marked abstract
         if node.get("concrete", True):


### PR DESCRIPTION
`.get(...) or {}` captures both missing `extra_attributes` and `"extra_attributes": null`