### PR TITLE
dla-future-fortran: add v0.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/dla-future-fortran/package.py
+++ b/var/spack/repos/builtin/packages/dla-future-fortran/package.py
@@ -20,6 +20,7 @@ class DlaFutureFortran(CMakePackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
+    version("0.3.0", sha256="404ce0d2d3df9317764450158901fd6cb2198b37f5687e9616519100ad6e9ece")
     version("0.2.0", sha256="7fd3e1779c111b35f0d2701a024398b4f6e8dea4af523b6c8617d28c0b7ae61a")
     version("0.1.0", sha256="9fd8a105cbb2f3e1daf8a49910f98fce68ca0b954773dba98a91464cf2e7c1da")
 
@@ -36,6 +37,7 @@ class DlaFutureFortran(CMakePackage):
 
     depends_on("dla-future@0.4.1:0.5 +scalapack", when="@0.1.0")
     depends_on("dla-future@0.6.0: +scalapack", when="@0.2.0:")
+    depends_on("dla-future@0.7.3: +scalapack", when="@0.3:")
     depends_on("dla-future +shared", when="+shared")
 
     depends_on("mpi", when="+test")


### PR DESCRIPTION
https://github.com/eth-cscs/DLA-Future-Fortran/releases/tag/v0.3.0