### PR TITLE
dcap: depends_on libxcrypt

### DIFF
--- a/var/spack/repos/builtin/packages/dcap/package.py
+++ b/var/spack/repos/builtin/packages/dcap/package.py
@@ -25,6 +25,7 @@ class Dcap(AutotoolsPackage):
     depends_on("m4", type="build")
 
     depends_on("openssl")
+    depends_on("libxcrypt")
     depends_on("zlib-api")
 
     variant("plugins", default=True, description="Build plugins")


### PR DESCRIPTION
This PR adds to `dcap` a dependency on `libxcrypt`, which is [linked against](https://github.com/dCache/dcap/blob/a1321a6ffba4e0924a21b78ca71ec92d8bc2b21c/plugins/telnet/Makefile.am#L11) in the telnet plugin, and then [reported](https://gitlab.spack.io/spack/spack/-/jobs/14971282#L631) in CI. Tested in CI.