### PR TITLE
py-natsort: add new variant +icu and dependent package

### DIFF
--- a/var/spack/repos/builtin/packages/py-natsort/package.py
+++ b/var/spack/repos/builtin/packages/py-natsort/package.py
@@ -38,6 +38,6 @@ class PyNatsort(PythonPackage):
 
     depends_on("py-setuptools", type=("build"))
 
-    variant("icu", default=False, description="Use icu for locale sorting")
+    variant("icu", default=False, when="@5.0.3:", description="Use icu for locale sorting")
 
     depends_on("py-pyicu", type=("build", "run"), when="+icu")

--- a/var/spack/repos/builtin/packages/py-natsort/package.py
+++ b/var/spack/repos/builtin/packages/py-natsort/package.py
@@ -37,3 +37,7 @@ class PyNatsort(PythonPackage):
     version("4.0.1", sha256="1c1d29150938ca71f0943363a06765dbb2cea01f9c4d760ba880cc65f39baba0")
 
     depends_on("py-setuptools", type=("build"))
+
+    variant("icu", default=False, description="Use icu for locale sorting")
+
+    depends_on("py-pyicu", type=("build", "run"), when="+icu")

--- a/var/spack/repos/builtin/packages/py-pyicu/package.py
+++ b/var/spack/repos/builtin/packages/py-pyicu/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyicu(PythonPackage):
+    """Python extension wrapping the ICU C++ API"""
+
+    homepage = "https://gitlab.pyicu.org/main/pyicu"
+    pypi = "PyICU/PyICU-2.14.tar.gz"
+
+    maintainers("Chrismarsh")
+
+    license("MIT", checked_by="Chrismarsh")
+
+    version("2.14", sha256="acc7eb92bd5c554ed577249c6978450a4feda0aa6f01470152b3a7b382a02132")
+
+    depends_on("cxx", type="build")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("pkgconfig", type="build")
+
+    depends_on("icu4c@:76")

--- a/var/spack/repos/builtin/packages/py-pyicu/package.py
+++ b/var/spack/repos/builtin/packages/py-pyicu/package.py
@@ -22,4 +22,4 @@ class PyPyicu(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("pkgconfig", type="build")
 
-    depends_on("icu4c@:76")
+    depends_on("icu4c@:76")  # ICU_MAX_MAJOR_VERSION in setup.py


### PR DESCRIPTION
Add new variant `+icu` to `py-natsort`. This allows using `icu4c` for locale sorting. This PR also adds the new `py-pyicu` package required for this variant.

