### PR TITLE
R: Explicitly depend on `gettext`

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -96,6 +96,7 @@ class R(AutotoolsPackage):
     depends_on("zlib-api")
     depends_on("zlib@1.2.5:", when="^[virtuals=zlib-api] zlib")
     depends_on("texinfo", type="build")
+    depends_on("gettext")
 
     with when("+X"):
         depends_on("cairo+X+gobject+pdf")
@@ -196,6 +197,8 @@ class R(AutotoolsPackage):
             "ac_cv_path_TEX=",
             "ac_cv_path_TEXI2DVI=",
         ]
+
+        config_args.append("--with-libintl-prefix={0}".format(spec["gettext"].prefix))
 
         if "+X" in spec:
             config_args.append("--with-cairo")


### PR DESCRIPTION
R [depends on `gettext` ](https://cran.r-project.org/doc/manuals/r-patched/R-admin.html#Useful-libraries-and-programs-1) however this package was missing as a depends. Although the above help suggests an internal `gettext` would be used, `ldd`/`libtree` on linux shows the build using spack's `gettext`.

This PR explicitly adds `gettexxt` as a dependency. 

On macos, R linked against a system framework for `libintl`. Because the `gettext` `libintl` path is saved to the Makeconfig, which is used by installing R packages, dependent libraries wouldn't correctly build, e.g., 

```
ld: library 'intl' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
 Using spack's `gettext` also resolves this problem.

