### PR TITLE
r-packages: add missing gettext dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/r-data-table/package.py
+++ b/var/spack/repos/builtin/packages/r-data-table/package.py
@@ -41,7 +41,7 @@ class RDataTable(RPackage):
 
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("zlib-api")
-    depends_on("llvm-openmp", when="platform=darwin %apple-clang" , type=("build", "run")
+    depends_on("llvm-openmp", when="platform=darwin %apple-clang" , type=("build", "run"))
 
     # gettext linkage is passed in from libR, however data-table looks for libintl.h directly
     depends_on("gettext")

--- a/var/spack/repos/builtin/packages/r-data-table/package.py
+++ b/var/spack/repos/builtin/packages/r-data-table/package.py
@@ -41,7 +41,7 @@ class RDataTable(RPackage):
 
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("zlib-api")
-    depends_on("llvm-openmp", when="platform=darwin %apple-clang" , type=("build", "run"))
+    depends_on("llvm-openmp", when="platform=darwin %apple-clang", type=("build", "run"))
 
     # gettext linkage is passed in from libR, however data-table looks for libintl.h directly
     depends_on("gettext")

--- a/var/spack/repos/builtin/packages/r-data-table/package.py
+++ b/var/spack/repos/builtin/packages/r-data-table/package.py
@@ -41,3 +41,7 @@ class RDataTable(RPackage):
 
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("zlib-api")
+    depends_on("llvm-openmp", when="platform=darwin %apple-clang" , type=("build", "run")
+
+    # gettext linkage is passed in from libR, however data-table looks for libintl.h directly
+    depends_on("gettext")

--- a/var/spack/repos/builtin/packages/r-matrix/package.py
+++ b/var/spack/repos/builtin/packages/r-matrix/package.py
@@ -37,3 +37,5 @@ class RMatrix(RPackage):
     depends_on("r@3.5.0:", type=("build", "run"), when="@1.3-3:")
     depends_on("r@4.4.0:", type=("build", "run"), when="@1.7-0:")
     depends_on("r-lattice", type=("build", "run"))
+    # looks for libintl.h directly
+    depends_on("gettext")

--- a/var/spack/repos/builtin/packages/r-mgcv/package.py
+++ b/var/spack/repos/builtin/packages/r-mgcv/package.py
@@ -41,3 +41,4 @@ class RMgcv(RPackage):
     depends_on("r@3.6.0:", type=("build", "run"), when="@1.8.34:")
     depends_on("r-nlme@3.1-64:", type=("build", "run"))
     depends_on("r-matrix", type=("build", "run"))
+    depends_on("gettext")

--- a/var/spack/repos/builtin/packages/r-nlme/package.py
+++ b/var/spack/repos/builtin/packages/r-nlme/package.py
@@ -34,3 +34,6 @@ class RNlme(RPackage):
     depends_on("r@3.4.0:", type=("build", "run"), when="@3.1-135.5:")
     depends_on("r@3.6.0:", type=("build", "run"), when="@3.1-165:")
     depends_on("r-lattice", type=("build", "run"))
+
+    # looks for libintl.h directly
+    depends_on("gettext")


### PR DESCRIPTION
Adds missing `gettext` dependency to packages that explicitly look for `libintl.h`.
Also fixes the openmp compilation on macos for `r-data-table`
