### PR TITLE
`spack compiler find`: `flang-new` in newer LLVM versions

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -26,7 +26,6 @@ paths:
       echo "Target: x86_64-unknown-linux-gnu"
       echo "Thread model: posix"
       echo "InstalledDir: /path/to/spack/install/llvm/bin"
-      echo "Configuration file: /path/to/spack/install/llvm/bin/clang.cfg"
   - executables:
     - "bin/flang-new"
     script: |
@@ -34,7 +33,6 @@ paths:
       echo "Target: x86_64-unknown-linux-gnu"
       echo "Thread model: posix"
       echo "InstalledDir: /path/to/spack/install/llvm/bin"
-      echo "Configuration file: /path/to/spack/install/llvm/bin/flang.cfg"
   platforms: ["darwin", "linux"]
   results:
   - spec: 'llvm@19.1.6 +flang+clang~lld~lldb'
@@ -50,22 +48,20 @@ paths:
     - "bin/clang"
     - "bin/clang++"
     script: |
-      echo "clang version 20.0.0 (I made this up)"
+      echo "clang version 20.1.0-rc1 (https://github.com/llvm/llvm-project af7f483a9d801252247b6c72e3763c1f55c5a506)"
       echo "Target: x86_64-unknown-linux-gnu"
       echo "Thread model: posix"
-      echo "InstalledDir: /path/to/spack/install/llvm/bin"
-      echo "Configuration file: /path/to/spack/install/llvm/bin/clang.cfg"
+      echo "InstalledDir: /tmp/clang/LLVM-20.1.0-rc1-Linux-X64/bin"
   - executables:
     - "bin/flang"
     script: |
-      echo "flang version 20.0.0 (I made this up)"
+      echo "flang version 20.1.0-rc1 (https://github.com/llvm/llvm-project af7f483a9d801252247b6c72e3763c1f55c5a506)"
       echo "Target: x86_64-unknown-linux-gnu"
       echo "Thread model: posix"
-      echo "InstalledDir: /path/to/spack/install/llvm/bin"
-      echo "Configuration file: /path/to/spack/install/llvm/bin/flang.cfg"
+      echo "InstalledDir: /tmp/clang/LLVM-20.1.0-rc1-Linux-X64/bin"
   platforms: ["darwin", "linux"]
   results:
-  - spec: 'llvm@20.0.0 +flang+clang~lld~lldb'
+  - spec: 'llvm@20.1.0 +flang+clang~lld~lldb'
     extra_attributes:
       compilers:
         c: ".*/bin/clang"

--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -44,6 +44,34 @@ paths:
         cxx: ".*/bin/clang[+][+]"
         fortran: ".*/bin/flang-new"
 
+# flang: like previous test, but the fortran compiler is called "flang" vs. "flang-new"
+- layout:
+  - executables:
+    - "bin/clang"
+    - "bin/clang++"
+    script: |
+      echo "clang version 20.0.0 (I made this up)"
+      echo "Target: x86_64-unknown-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /path/to/spack/install/llvm/bin"
+      echo "Configuration file: /path/to/spack/install/llvm/bin/clang.cfg"
+  - executables:
+    - "bin/flang"
+    script: |
+      echo "flang version 20.0.0 (I made this up)"
+      echo "Target: x86_64-unknown-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /path/to/spack/install/llvm/bin"
+      echo "Configuration file: /path/to/spack/install/llvm/bin/flang.cfg"
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'llvm@20.0.0 +flang+clang~lld~lldb'
+    extra_attributes:
+      compilers:
+        c: ".*/bin/clang"
+        cxx: ".*/bin/clang[+][+]"
+        fortran: ".*/bin/flang"
+
 # `~` and other weird characters in the version string
 - layout:
   - executables:

--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -16,6 +16,26 @@ paths:
         c: ".*/bin/clang-3.9$"
         cxx: ".*/bin/clang[+][+]-3.9$"
 
+- layout:
+  - executables:
+    - "bin/clang"
+    - "bin/clang++"
+    - "bin/flang-new"
+    script: |
+      echo "flang-new version 19.1.6 (https://github.com/spack/spack.git 8d3a733b7798b6e33c371518b6dec298c3ebd8b1)"
+      echo "Target: x86_64-unknown-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /path/to/spack/install/llvm/bin"
+      echo "Configuration file: /path/to/spack/install/llvm/bin/flang.cfg"
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'llvm@19.1.6 +flang+clang~lld~lldb'
+    extra_attributes:
+      compilers:
+        c: ".*/bin/clang"
+        cxx: ".*/bin/clang[+][+]"
+        fortran: ".*/bin/flang-new"
+
 # `~` and other weird characters in the version string
 - layout:
   - executables:

--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -16,6 +16,7 @@ paths:
         c: ".*/bin/clang-3.9$"
         cxx: ".*/bin/clang[+][+]-3.9$"
 
+# flang-new detection: flang-new generates slightly-different output than clang
 - layout:
   - executables:
     - "bin/clang"

--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -20,6 +20,13 @@ paths:
   - executables:
     - "bin/clang"
     - "bin/clang++"
+    script: |
+      echo "clang version 19.1.6 (https://github.com/spack/spack.git 8d3a733b7798b6e33c371518b6dec298c3ebd8b1)"
+      echo "Target: x86_64-unknown-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /path/to/spack/install/llvm/bin"
+      echo "Configuration file: /path/to/spack/install/llvm/bin/clang.cfg"
+  - executables:
     - "bin/flang-new"
     script: |
       echo "flang-new version 19.1.6 (https://github.com/spack/spack.git 8d3a733b7798b6e33c371518b6dec298c3ebd8b1)"

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -740,7 +740,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
             string=True,
         )
 
-    clang_and_friends = "(clang|flang|flang-new)"
+    clang_and_friends = "(?:clang|flang|flang-new)"
 
     compiler_version_regex = (
         # Normal clang compiler versions are left as-is

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -740,19 +740,21 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
             string=True,
         )
 
+    clang_and_friends = "(clang|flang|flang-new)"
+
     compiler_version_regex = (
         # Normal clang compiler versions are left as-is
-        r"clang version ([^ )\n]+)-svn[~.\w\d-]*|"
+        rf"{clang_and_friends} version ([^ )\n]+)-svn[~.\w\d-]*|"
         # Don't include hyphenated patch numbers in the version
         # (see https://github.com/spack/spack/pull/14365 for details)
-        r"clang version ([^ )\n]+?)-[~.\w\d-]*|"
-        r"clang version ([^ )\n]+)|"
+        rf"{clang_and_friends} version ([^ )\n]+?)-[~.\w\d-]*|"
+        rf"{clang_and_friends} version ([^ )\n]+)|"
         # LLDB
         r"lldb version ([^ )\n]+)|"
         # LLD
         r"LLD ([^ )\n]+) \(compatible with GNU linkers\)"
     )
-    fortran_names = ["flang"]
+    fortran_names = ["flang", "flang-new"]
 
     @property
     def supported_languages(self):


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/48253

With this I can `spack install llvm@19.1.6+flang`, or more specifically

```
llvm@19.1.6+clang~cuda+flang+gold~ipo+libomptarget~libomptarget_debug~link_llvm_dylib+lld+lldb+llvm_dylib+lua~mlir+offload+polly~python~split_dwarf~z3~zstd build_system=cmake build_type=Release compiler-rt=runtime generator=ninja libcxx=runtime libunwind=runtime openmp=runtime shlib_symbol_version=none targets=all version_suffix=none
```

And then I can ``spack compiler add `spack location -i llvm`/bin ``

Newer llvm calls it's Fortran compiler `flang-new` vs. `flang`, and `exec flang-new --version` yields

```
/<spack-llvm-install-prefix>/bin/flang-new --version
flang-new version 19.1.6 (https://github.com/spack/spack.git 8d3a733b7798b6e33c371518b6dec298c3ebd8b1)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /<spack-llvm-install-prefix>/bin
Configuration file: /<spack-llvm-install-prefix>/bin/flang.cfg
```

The regexes in the `llvm` package didn't account for that