### PR TITLE
nwchem: add master

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/oneapi2025.patch
+++ b/var/spack/repos/builtin/packages/nwchem/oneapi2025.patch
@@ -1,0 +1,36 @@
+diff -ruN spack-src/src/config/makefile.h spack-src-patched/src/config/makefile.h
+--- spack-src/src/config/makefile.h	2024-08-28 02:30:22.000000000 +0000
++++ spack-src-patched/src/config/makefile.h	2025-02-07 16:03:07.315882016 +0000
+@@ -2364,15 +2364,14 @@
+ 		    _GOTAVX2 := $(shell cat /proc/cpuinfo | grep fma | tail -n 1 | awk ' /fma/  {print "Y"}')
+ 		    _GOTAVX512F := $(shell cat /proc/cpuinfo | grep avx512f | tail -n 1 | awk ' /avx512f/  {print "Y"}')
+                 endif
+-		_IFCE := $(shell ifort -V  2>&1 |head -1 |awk ' /64/ {print "Y";exit};')
+-		_IFCV7 := $(shell ifort -v  2>&1|grep "Version "|head -n 1|awk ' /7./  {print "Y";exit}')
+-		_IFCV11 := $(shell ifort -logo  2>&1|grep "Version "|head -n 1|sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 11) {print "Y";exit}}')
+-		_IFCV12 := $(shell ifort -logo  2>&1|grep "Version "|head -n 1|sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 12) {print "Y";exit}}')
+-		_IFCV14 := $(shell ifort -logo  2>&1|grep "Version "|head -n 1|sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 14) {print "Y";exit}}')
+-		_IFCV15ORNEWER := $(shell ifort -logo  2>&1|grep "Version "|head -n 1 | sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 15) {print "Y";exit}}')
+-	       _IFCV17 := $(shell ifort -logo  2>&1|grep "Version "|head -n 1 | sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 17) {print "Y";exit}}')
+-	       _IFCV18 := $(shell ifort -logo  2>&1|grep "Version "|head -n 1 | sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 18) {print "Y";exit}}')
+-
++                _IFCE := $(shell $(FC) -V  2>&1 |head -1 |awk ' /64/ {print "Y";exit};')
++		_IFCV7 := $(shell $(FC) -v  2>&1|grep "Version "|head -n 1|awk ' /7./  {print "Y";exit}')
++		_IFCV11 := $(shell $(FC) -logo  2>&1|grep "Version "|head -n 1|sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 11) {print "Y";exit}}')
++		_IFCV12 := $(shell $(FC) -logo  2>&1|grep "Version "|head -n 1|sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 12) {print "Y";exit}}')
++		_IFCV14 := $(shell $(FC) -logo  2>&1|grep "Version "|head -n 1|sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 14) {print "Y";exit}}')
++		_IFCV15ORNEWER := $(shell $(FC) -logo  2>&1|grep "Version "|head -n 1 | sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 15) {print "Y";exit}}')
++	        _IFCV17 := $(shell $(FC) -logo  2>&1|grep "Version "|head -n 1 | sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 17) {print "Y";exit}}')
++	        _IFCV18 := $(shell $(FC) -logo  2>&1|grep "Version "|head -n 1 | sed 's/.*Version \([0-9][0-9]\).*/\1/' | awk '{if ($$1 >= 18) {print "Y";exit}}')
+ #               Intel EM64T is required
+                 ifneq ($(_IFCE),Y)
+                     defineFCE:
+@@ -2406,7 +2405,7 @@
+ #               CPP=fpp -P
+ #
+                 ifeq ($(_IFCV15ORNEWER), Y)
+-		 IFORTVER := $(shell ifort -v 2>&1|cut -d " " -f 3)
++                 IFORTVER := $(shell $(FC) -v 2>&1|cut -d " " -f 3)
+ #                ifeq ($(IFORTVER),2021.7.0)
+ #                   $(info     )
+ #                   $(info     ifort 2021.7.0 not validated)

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -72,6 +72,9 @@ class Nwchem(Package):
         "elpa", default=False, description="Enable optimised diagonalisation routines from ELPA"
     )
 
+    # https://github.com/nwchemgit/nwchem/pull/1034
+    patch("oneapi2025.patch", when="@7.2.3 %oneapi@2025:")
+
     # This patch is for the modification of the build system (e.g. compiler flags) and
     # Fortran syntax to enable the compilation with Fujitsu compilers. The modification
     # will be merged to the next release of NWChem (see https://github.com/nwchemgit/nwchem/issues/347

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -13,10 +13,13 @@ class Nwchem(Package):
 
     homepage = "https://nwchemgit.github.io"
     url = "https://github.com/nwchemgit/nwchem/releases/download/v7.2.0-release/nwchem-7.2.0-release.revision-d0d141fd-srconly.2023-03-10.tar.bz2"
+    git = "https://github.com/nwchemgit/nwchem.git"
 
     tags = ["ecp", "ecp-apps"]
 
     maintainers("jeffhammond")
+
+    version("master", branch="master")
 
     version(
         "7.2.3",


### PR DESCRIPTION
as latest release was on Aug 28, 2024 some necessary changes were include after it and are waiting for new release

adding master branch will allow to build nwchem in local environment during tests of pre-release 2025.x oneapi compilers

necessary change to be included in new release:
https://github.com/nwchemgit/nwchem/pull/1034
