### PR TITLE
cp2k: fine graining control of the GPU modules 

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -122,7 +122,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "pw_gpu",
         default=True,
-        description="Enable FFT calculations on GPU (off by default for now)",
+        description="Enable FFT calculations on GPU",
         when="@2025.2: +cuda",
     )
     variant("grid_gpu", default=True, description="Enable grid GPU backend", when="@2025.2:")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -126,7 +126,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         when="@2025.2: +cuda",
     )
     variant("grid_gpu", default=True, description="Enable grid GPU backend", when="@2025.2:")
-    variant("dbm_gpu", default=True, description="Eanble DBM gpu backend", when="@2025.2:")
+    variant("dbm_gpu", default=True, description="Enable DBM GPU backend", when="@2025.2:")
     variant(
         "pw_gpu",
         default=False,

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -119,7 +119,26 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant("dftd4", when="@2024.2:", default=False, description="Enable DFT-D4 support")
     variant("mpi_f08", default=False, description="Use MPI F08 module")
     variant("smeagol", default=False, description="Enable libsmeagol support", when="@2025.2:")
-
+    variant(
+        "pw_gpu",
+        default=True,
+        description="Enable FFT calculations on GPU (off by default for now)",
+        when="@2025.2: +cuda",
+    )
+    variant("grid_gpu", default=True, description="Enable grid gpu backend", when="@2025.2:")
+    variant("dbm_gpu", default=True, description="Eanble DBM gpu backend", when="@2025.2:")
+    variant(
+        "pw_gpu",
+        default=False,
+        description="Enable FFT calculations on GPU",
+        when="@2025.2: +rocm",
+    )
+    variant(
+        "hip_backend",
+        default=False,
+        description="Enable HIP backend on Nvidia GPU",
+        when="@2025.2:+cuda",
+    )
     variant(
         "enable_regtests",
         default=False,
@@ -147,6 +166,11 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
             when="@:7",  # req in CP2K v8+
             description="Use CUBLAS for general matrix operations in DBCSR",
         )
+
+    depends_on("hipcc", when="+hip_backend+cuda")
+    depends_on("hip+cuda", when="+hip_backend+cuda")
+    depends_on("hipfft+cuda", when="+hip_backend+cuda")
+    depends_on("hipblas+cuda", when="+hip_backend+cuda")
 
     HFX_LMAX_RANGE = range(4, 8)
 
@@ -983,10 +1007,15 @@ class CMakeBuilder(cmake.CMakeBuilder):
                 raise InstallError("CP2K supports only one cuda_arch at a time.")
             else:
                 gpu_ver = GPU_MAP[spec.variants["cuda_arch"].value[0]]
-                args += [
-                    self.define("CP2K_USE_ACCEL", "CUDA"),
-                    self.define("CP2K_WITH_GPU", gpu_ver),
-                ]
+                if spec.satisfies("+hip_backend"):
+                    args += [
+                        self.define("CP2K_USE_ACCEL", "HIP"),
+                        self.define("CMAKE_HIP_PLATFORM=nvidia"),
+                    ]
+                else:
+                    args += [self.define("CP2K_USE_ACCEL", "CUDA")]
+
+                args += [self.define("CP2K_WITH_GPU", gpu_ver)]
 
         if spec.satisfies("+rocm"):
             if len(spec.variants["amdgpu_target"].value) > 1:
@@ -1018,6 +1047,9 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("CP2K_USE_DFTD4", "dftd4"),
             self.define_from_variant("CP2K_USE_MPI_F08", "mpi_f08"),
             self.define_from_variant("CP2K_USE_LIBSMEAGOL", "smeagol"),
+            self.define_from_variant("CP2K_ENABLE_GRID_GPU", "grid_gpu"),
+            self.define_from_variant("CP2K_ENABLE_DBM_GPU", "dbm_gpu"),
+            self.define_from_variant("CP2K_ENABLE_PW_GPU", "pw_gpu"),
         ]
 
         # we force the use elpa openmp threading support. might need to be revisited though
@@ -1027,6 +1059,9 @@ class CMakeBuilder(cmake.CMakeBuilder):
                 ("+elpa +openmp" in spec) or ("^elpa +openmp" in spec),
             )
         ]
+
+        if spec.satisfies("+hip_backend"):
+            args += [self.define_from_variant("-DCMAKE_HIP_PLATFORM=nvidia")]
 
         if "spla" in spec and (spec.satisfies("+cuda") or spec.satisfies("+rocm")):
             args += ["-DCP2K_USE_SPLA_GEMM_OFFLOADING=ON"]

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -1061,7 +1061,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
         ]
 
         if spec.satisfies("+hip_backend"):
-            args += [self.define_from_variant("-DCMAKE_HIP_PLATFORM=nvidia")]
+            args += [self.define("CMAKE_HIP_PLATFORM", "nvidia")]
 
         if "spla" in spec and (spec.satisfies("+cuda") or spec.satisfies("+rocm")):
             args += ["-DCP2K_USE_SPLA_GEMM_OFFLOADING=ON"]

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -137,7 +137,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         "hip_backend",
         default=False,
         description="Enable HIP backend on Nvidia GPU",
-        when="@2025.2:+cuda",
+        when="@2025.2: +cuda",
     )
     variant(
         "enable_regtests",

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -1010,7 +1010,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
                 if spec.satisfies("+hip_backend"):
                     args += [
                         self.define("CP2K_USE_ACCEL", "HIP"),
-                        self.define("CMAKE_HIP_PLATFORM=nvidia"),
+                        self.define("CMAKE_HIP_PLATFORM", "nvidia"),
                     ]
                 else:
                     args += [self.define("CP2K_USE_ACCEL", "CUDA")]

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -125,7 +125,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         description="Enable FFT calculations on GPU (off by default for now)",
         when="@2025.2: +cuda",
     )
-    variant("grid_gpu", default=True, description="Enable grid gpu backend", when="@2025.2:")
+    variant("grid_gpu", default=True, description="Enable grid GPU backend", when="@2025.2:")
     variant("dbm_gpu", default=True, description="Eanble DBM gpu backend", when="@2025.2:")
     variant(
         "pw_gpu",

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -167,10 +167,11 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
             description="Use CUBLAS for general matrix operations in DBCSR",
         )
 
-    depends_on("hipcc", when="+hip_backend+cuda")
-    depends_on("hip+cuda", when="+hip_backend+cuda")
-    depends_on("hipfft+cuda", when="+hip_backend+cuda")
-    depends_on("hipblas+cuda", when="+hip_backend+cuda")
+    with when("+hip_backend+cuda"):
+        depends_on("hipcc")
+        depends_on("hip+cuda")
+        depends_on("hipfft+cuda")
+        depends_on("hipblas+cuda")
 
     HFX_LMAX_RANGE = range(4, 8)
 

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -120,10 +120,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     variant("mpi_f08", default=False, description="Use MPI F08 module")
     variant("smeagol", default=False, description="Enable libsmeagol support", when="@2025.2:")
     variant(
-        "pw_gpu",
-        default=True,
-        description="Enable FFT calculations on GPU",
-        when="@2025.2: +cuda",
+        "pw_gpu", default=True, description="Enable FFT calculations on GPU", when="@2025.2: +cuda"
     )
     variant("grid_gpu", default=True, description="Enable grid GPU backend", when="@2025.2:")
     variant("dbm_gpu", default=True, description="Enable DBM GPU backend", when="@2025.2:")
@@ -134,7 +131,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         when="@2025.2: +rocm",
     )
     variant(
-        "hip_backend",
+        "hip_backend_cuda",
         default=False,
         description="Enable HIP backend on Nvidia GPU",
         when="@2025.2: +cuda",
@@ -167,7 +164,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
             description="Use CUBLAS for general matrix operations in DBCSR",
         )
 
-    with when("+hip_backend+cuda"):
+    with when("+hip_backend_cuda"):
         depends_on("hipcc")
         depends_on("hip+cuda")
         depends_on("hipfft+cuda")
@@ -1008,7 +1005,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
                 raise InstallError("CP2K supports only one cuda_arch at a time.")
             else:
                 gpu_ver = GPU_MAP[spec.variants["cuda_arch"].value[0]]
-                if spec.satisfies("+hip_backend"):
+                if spec.satisfies("+hip_backend_cuda"):
                     args += [
                         self.define("CP2K_USE_ACCEL", "HIP"),
                         self.define("CMAKE_HIP_PLATFORM", "nvidia"),
@@ -1060,9 +1057,6 @@ class CMakeBuilder(cmake.CMakeBuilder):
                 ("+elpa +openmp" in spec) or ("^elpa +openmp" in spec),
             )
         ]
-
-        if spec.satisfies("+hip_backend"):
-            args += [self.define("CMAKE_HIP_PLATFORM", "nvidia")]
 
         if "spla" in spec and (spec.satisfies("+cuda") or spec.satisfies("+rocm")):
             args += ["-DCP2K_USE_SPLA_GEMM_OFFLOADING=ON"]


### PR DESCRIPTION
This PR add 
- four variants that control support of cp2k modules supporting GPU. They are all ON by default for nvidia hardware. GRID and DBM are ON for rocm, PW is off for now because of issue when multiple MPI share the same GPU.
- the possibility to use the hip backend for grid on nvidia hardware.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
