### PR TITLE
RepoSplit/core: flag core uses of builtin

### DIFF
--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -146,6 +146,7 @@ class ClingoBootstrapConcretizer:
 
     def _external_spec(self, initial_spec) -> "spack.spec.Spec":
         # TODO/RepoSplit: How should the built-in repository be handled?
+        # TODO/RepoSplit: What is the new namespace for the new package repo?
         initial_spec.namespace = "builtin"
         initial_spec.compiler = self.host_compiler.spec
         initial_spec.architecture = self.host_architecture

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -145,8 +145,7 @@ class ClingoBootstrapConcretizer:
         return self._external_spec(result)
 
     def _external_spec(self, initial_spec) -> "spack.spec.Spec":
-        # TODO/RepoSplit: How should the built-in repository be handled?
-        # TODO/RepoSplit: What is the new namespace for the new package repo?
+        # TODO/RepoSplit: Convert to namespace of new or bootstrap pkg repo
         initial_spec.namespace = "builtin"
         initial_spec.compiler = self.host_compiler.spec
         initial_spec.architecture = self.host_architecture

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -145,6 +145,7 @@ class ClingoBootstrapConcretizer:
         return self._external_spec(result)
 
     def _external_spec(self, initial_spec) -> "spack.spec.Spec":
+        # TODO/RepoSplit: How should the built-in repository be handled?
         initial_spec.namespace = "builtin"
         initial_spec.compiler = self.host_compiler.spec
         initial_spec.architecture = self.host_architecture

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -952,8 +952,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             namespace = getattr(cls, "namespace", None)
             if namespace:
                 fullnames.append("%s.%s" % (namespace, cls.name))
-            # TODO/RepoSplit: Will the inability to inherit from other repos
-            # TODO/RepoSplit:   still apply when package repository split off?
+            # TODO/RepoSplit: Convert to the new package repo namespace
             if namespace == "builtin":
                 # builtin packages cannot inherit from other repos
                 break

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -952,7 +952,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             namespace = getattr(cls, "namespace", None)
             if namespace:
                 fullnames.append("%s.%s" % (namespace, cls.name))
-            # TODO/RepoSplit: Is this still relevant post-split?
+            # TODO/RepoSplit: Will the inability to inherit from other repos
+            # TODO/RepoSplit:   still apply when package repository split off?
             if namespace == "builtin":
                 # builtin packages cannot inherit from other repos
                 break

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -952,6 +952,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             namespace = getattr(cls, "namespace", None)
             if namespace:
                 fullnames.append("%s.%s" % (namespace, cls.name))
+            # TODO/RepoSplit: Is this still relevant post-split?
             if namespace == "builtin":
                 # builtin packages cannot inherit from other repos
                 break

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -57,6 +57,7 @@ var_path = os.path.join(prefix, "var", "spack")
 
 # read-only things in $spack/var/spack
 repos_path = os.path.join(var_path, "repos")
+# TODO/RepoSplit: How will builtin packages repo be handled?
 packages_path = os.path.join(repos_path, "builtin")
 mock_packages_path = os.path.join(repos_path, "builtin.mock")
 

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -57,7 +57,7 @@ var_path = os.path.join(prefix, "var", "spack")
 
 # read-only things in $spack/var/spack
 repos_path = os.path.join(var_path, "repos")
-# TODO/RepoSplit: How will builtin packages repo be handled?
+# TODO/RepoSplit: How will builtin packages moved to new package repo be handled?
 packages_path = os.path.join(repos_path, "builtin")
 mock_packages_path = os.path.join(repos_path, "builtin.mock")
 

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -57,7 +57,7 @@ var_path = os.path.join(prefix, "var", "spack")
 
 # read-only things in $spack/var/spack
 repos_path = os.path.join(var_path, "repos")
-# TODO/RepoSplit: How will builtin packages moved to new package repo be handled?
+# TODO/RepoSplit: Convert to the new package repository path and namespace
 packages_path = os.path.join(repos_path, "builtin")
 mock_packages_path = os.path.join(repos_path, "builtin.mock")
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -50,6 +50,7 @@ import spack.util.spack_yaml as syaml
 ROOT_PYTHON_NAMESPACE = "spack.pkg"
 
 
+# TODO/RepoSplit: Changed from builtin to builtin.mock
 def python_package_for_repo(namespace):
     """Returns the full namespace of a repository, given its relative one
 
@@ -63,6 +64,7 @@ def python_package_for_repo(namespace):
     return "{0}.{1}".format(ROOT_PYTHON_NAMESPACE, namespace)
 
 
+# TODO/RepoSplit: Changed from builtin to builtin.mock
 def namespace_from_fullname(fullname):
     """Return the repository namespace only for the full module name.
 
@@ -181,7 +183,8 @@ def packages_path():
     try:
         return PATH.get_repo("builtin.mock").packages_path
     except UnknownNamespaceError:
-        # TODO/RepoSplit: How will this be handled post-repo split?
+        # TODO/RepoSplit: Will this still be relevant for new package repo?
+        # TODO/RepoSplit: If so, what will the namespace of that repo be?
         return PATH.get_repo("builtin").packages_path
 
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -50,7 +50,6 @@ import spack.util.spack_yaml as syaml
 ROOT_PYTHON_NAMESPACE = "spack.pkg"
 
 
-# TODO/RepoSplit: Changed from builtin to builtin.mock
 def python_package_for_repo(namespace):
     """Returns the full namespace of a repository, given its relative one
 
@@ -64,7 +63,6 @@ def python_package_for_repo(namespace):
     return "{0}.{1}".format(ROOT_PYTHON_NAMESPACE, namespace)
 
 
-# TODO/RepoSplit: Changed from builtin to builtin.mock
 def namespace_from_fullname(fullname):
     """Return the repository namespace only for the full module name.
 
@@ -183,8 +181,7 @@ def packages_path():
     try:
         return PATH.get_repo("builtin.mock").packages_path
     except UnknownNamespaceError:
-        # TODO/RepoSplit: Will this still be relevant for new package repo?
-        # TODO/RepoSplit: If so, what will the namespace of that repo be?
+        # TODO/RepoSplit: Convert to the new package repository namespace
         return PATH.get_repo("builtin").packages_path
 
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -55,7 +55,7 @@ def python_package_for_repo(namespace):
 
     For instance:
 
-        python_package_for_repo('builtin') == 'spack.pkg.builtin'
+        python_package_for_repo('builtin.mock') == 'spack.pkg.builtin.mock'
 
     Args:
         namespace (str): repo namespace
@@ -68,7 +68,7 @@ def namespace_from_fullname(fullname):
 
     For instance:
 
-        namespace_from_fullname('spack.pkg.builtin.hdf5') == 'builtin'
+        namespace_from_fullname('spack.pkg.builtin.mock.hdf5') == 'builtin.mock'
 
     Args:
         fullname (str): full name for the Python module
@@ -181,6 +181,7 @@ def packages_path():
     try:
         return PATH.get_repo("builtin.mock").packages_path
     except UnknownNamespaceError:
+        # TODO/RepoSplit: How will this be handled post-repo split?
         return PATH.get_repo("builtin").packages_path
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2258,6 +2258,7 @@ class Spec:
 
         self._dup(self.lookup_hash())
 
+    # TODO/RepoSplit: does the repository split affect the namespace in the docstring?
     def to_node_dict(self, hash=ht.dag_hash):
         """Create a dictionary representing the state of this Spec.
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2258,8 +2258,6 @@ class Spec:
 
         self._dup(self.lookup_hash())
 
-    # TODO/RepoSplit: Replace the docstring namespace to new package repo to
-    # TODO/RepoSplit:   avoid confusion since no longer "built in".
     def to_node_dict(self, hash=ht.dag_hash):
         """Create a dictionary representing the state of this Spec.
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2258,7 +2258,8 @@ class Spec:
 
         self._dup(self.lookup_hash())
 
-    # TODO/RepoSplit: does the repository split affect the namespace in the docstring?
+    # TODO/RepoSplit: Replace the docstring namespace to new package repo to
+    # TODO/RepoSplit:   avoid confusion since no longer "built in".
     def to_node_dict(self, hash=ht.dag_hash):
         """Create a dictionary representing the state of this Spec.
 


### PR DESCRIPTION
This PR simply flags for consideration occurrences of use of the builtin repository.