### PR TITLE
log.py: remove setenv calls

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2436,11 +2436,7 @@ class BuildProcessInstaller:
                     # DEBUGGING TIP - to debug this section, insert an IPython
                     # embed here, and run the sections below without log capture
                     log_contextmanager = log_output(
-                        log_file,
-                        self.echo,
-                        True,
-                        env=self.unmodified_env,
-                        filter_fn=self.filter_fn,
+                        log_file, self.echo, True, filter_fn=self.filter_fn
                     )
 
                     with log_contextmanager as logger:


### PR DESCRIPTION
`setenv` is called unconditionally in `log_output` but should be redundant since logging is not affected by environment variables (it should be locale independent, otherwise it's a bug)

Calling setenv can be unsafe, so remove.
