### PR TITLE
reuse: allow filtering by namespace

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -34,6 +34,7 @@ an object, with the following keys:
 
 1. ``roots``: if ``true`` root specs are reused, if ``false`` only dependencies of root specs are reused
 2. ``from``: list of sources from which reused specs are taken
+3. ``namespaces``: list of namespaces from which to reuse specs, or the string ``"any"``.
 
 Each source in ``from`` is itself an object:
 
@@ -56,6 +57,7 @@ For instance, the following configuration:
    concretizer:
      reuse:
        roots: true
+       namespaces: [builtin]
        from:
        - type: local
          include:
@@ -63,7 +65,8 @@ For instance, the following configuration:
          - "%clang"
 
 tells the concretizer to reuse all specs compiled with either ``gcc`` or ``clang``, that are installed
-in the local store. Any spec from remote buildcaches is disregarded.
+in the local store. Any spec from remote buildcaches is disregarded. Any spec from a namespace other than
+Spack's builtin repo is disregarded.
 
 To reduce the boilerplate in configuration files, default values for the ``include`` and
 ``exclude`` options can be pushed up one level:

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -25,6 +25,12 @@ properties: Dict[str, Any] = {
                             "roots": {"type": "boolean"},
                             "include": LIST_OF_SPECS,
                             "exclude": LIST_OF_SPECS,
+                            "namespaces": {
+                                "oneOf": [
+                                    {"type": "string", "enum": ["any"]},
+                                    {"type": "array", "items": {"type": "string"}},
+                                ]
+                            },
                             "from": {
                                 "type": "array",
                                 "items": {

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3986,6 +3986,7 @@ class ReusableSpecsSelector:
         self.configuration = configuration
         self.store = spack.store.create(configuration)
         self.reuse_strategy = ReuseStrategy.ROOTS
+        self.reuse_namespaces = "any"
 
         reuse_yaml = self.configuration.get("concretizer:reuse", False)
         self.reuse_sources = []
@@ -4016,6 +4017,7 @@ class ReusableSpecsSelector:
                 self.reuse_strategy = ReuseStrategy.ROOTS
             else:
                 self.reuse_strategy = ReuseStrategy.DEPENDENCIES
+            self.reuse_namespaces = reuse_yaml.get("namespaces", "any")
             default_include = reuse_yaml.get("include", [])
             default_exclude = reuse_yaml.get("exclude", [])
             default_sources = [{"type": "local"}, {"type": "buildcache"}]
@@ -4082,6 +4084,9 @@ class ReusableSpecsSelector:
         # If we only want to reuse dependencies, remove the root specs
         if self.reuse_strategy == ReuseStrategy.DEPENDENCIES:
             result = [spec for spec in result if not any(root in spec for root in specs)]
+
+        if self.reuse_namespaces != "any":
+            result = [spec for spec in result if spec.namespace in self.reuse_namespaces]
 
         return result
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1466,7 +1466,7 @@ class TestConcretize:
 
         reuse = spack.concretize.concretize_one("libelf")
         assert reuse.installed
-        assert reuse.satisfies("@0.8.13")
+        assert reuse.satisfies("@0.8.13")  # version installed in mutable_database
 
         spack.config.set("concretizer:reuse", {"namespaces": []})
         noreuse = spack.concretize.concretize_one("libelf")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1483,6 +1483,12 @@ class TestConcretize:
         assert noreuse.installed
         assert noreuse.satisfies("@0.8.13")
 
+        # Expected behavior same as second concretization
+        spack.config.set("concretizer:reuse", {"namespaces": ["foobar"]})
+        noreuse = spack.concretize.concretize_one("libelf")
+        assert noreuse.installed
+        assert noreuse.satisfies("@0.8.13")
+
     def test_reuse_with_flags(self, mutable_database, mutable_config):
         spack.config.set("concretizer:reuse", True)
         spec = spack.concretize.concretize_one("pkg-a cflags=-g cxxflags=-g")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1460,6 +1460,19 @@ class TestConcretize:
         new2 = spack.concretize.concretize_one("conditional-variant-pkg +two_whens")
         assert new2.satisfies("@2 +two_whens +version_based")
 
+    def test_reuse_by_namespace(self, mutable_database, mock_packages):
+        spack.config.set("concretizer:reuse", True)
+        spack.config.set("packages:libelf", {"version": ["0.8.10"]})
+
+        reuse = spack.concretize.concretize_one("libelf")
+        assert reuse.installed
+        assert reuse.satisfies("@0.8.13")
+
+        spack.config.set("concretizer:reuse", {"namespaces": []})
+        noreuse = spack.concretize.concretize_one("libelf")
+        assert not noreuse.installed
+        assert noreuse.satisfies("@0.8.10")
+
     def test_reuse_with_flags(self, mutable_database, mutable_config):
         spack.config.set("concretizer:reuse", True)
         spec = spack.concretize.concretize_one("pkg-a cflags=-g cxxflags=-g")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1486,8 +1486,8 @@ class TestConcretize:
         # Expected behavior same as second concretization
         spack.config.set("concretizer:reuse", {"namespaces": ["foobar"]})
         noreuse = spack.concretize.concretize_one("libelf")
-        assert noreuse.installed
-        assert noreuse.satisfies("@0.8.13")
+        assert not noreuse.installed
+        assert noreuse.satisfies("@0.8.10")
 
     def test_reuse_with_flags(self, mutable_database, mutable_config):
         spack.config.set("concretizer:reuse", True)


### PR DESCRIPTION
Allow reuse filtering by namespace

Feature request was for a workflow to reuse all packages from builtin repo, but not reuse packages from local proprietary repo to always test the latest versions of the local packages.

Edited to add:

Default is to reuse from any namespace, and can be explicitly configured with the string `any`. If a list of namespaces is provided, reuse will ignore any spec from a namespace that is not listed. The example below is from the new docs:

```
@@ -56,14 +57,16 @@ For instance, the following configuration:
   concretizer:
     reuse:
       roots: true
       namespaces: [builtin]
       from:
       - type: local
         include:
         - "%gcc"
         - "%clang"
```
> tells the concretizer to reuse all specs compiled with either ``gcc`` or ``clang``, that are installed in the local store. Any spec from remote buildcaches is disregarded. Any spec from a namespace other than Spack's builtin repo is disregarded.