### PR TITLE
libgcrypt: fix enforced -O0

### DIFF
--- a/var/spack/repos/builtin/packages/libgcrypt/o_flag_munging-1.10.patch
+++ b/var/spack/repos/builtin/packages/libgcrypt/o_flag_munging-1.10.patch
@@ -1,0 +1,39 @@
+From 7cea256ef1a6017e722bdfd5b7381fa90580d55a Mon Sep 17 00:00:00 2001
+From: "simit.ghane" <simit.ghane@lge.com>
+Date: Tue, 7 May 2024 14:09:03 +0530
+Subject: [PATCH] fix o_flag_munging
+
+---
+ cipher/Makefile.am | 2 +-
+ random/Makefile.am | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cipher/Makefile.am b/cipher/Makefile.am
+index c3d642b2..04bf25e9 100644
+--- a/cipher/Makefile.am
++++ b/cipher/Makefile.am
+@@ -153,7 +153,7 @@ gost-s-box: gost-s-box.c
+ 
+ 
+ if ENABLE_O_FLAG_MUNGING
+-o_flag_munging = sed -e 's/-O\([2-9sgz][2-9sgz]*\)/-O1/' -e 's/-Ofast/-O1/g'
++o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]*\)/ -O1 /g' -e 's/[[:blank:]]-Ofast/ -O1 /g'
+ else
+ o_flag_munging = cat
+ endif
+diff --git a/random/Makefile.am b/random/Makefile.am
+index 0c935a05..a42e4306 100644
+--- a/random/Makefile.am
++++ b/random/Makefile.am
+@@ -56,7 +56,7 @@ jitterentropy-base.c jitterentropy.h jitterentropy-base-user.h
+ 
+ # The rndjent module needs to be compiled without optimization.  */
+ if ENABLE_O_FLAG_MUNGING
+-o_flag_munging = sed -e 's/-O\([1-9sgz][1-9sgz]*\)/-O0/g' -e 's/-Ofast/-O0/g'
++o_flag_munging = sed -e 's/[[:blank:]]-O\([1-9sgz][1-9sgz]*\)/ -O0 /g' -e 's/[[:blank:]]-Ofast/ -O0 /g'
+ else
+ o_flag_munging = cat
+ endif
+-- 
+2.43.0
+

--- a/var/spack/repos/builtin/packages/libgcrypt/o_flag_munging-1.11.patch
+++ b/var/spack/repos/builtin/packages/libgcrypt/o_flag_munging-1.11.patch
@@ -1,0 +1,50 @@
+From 9c11f1e12a6ddbd49b5fd38c94e6a004f8da6e29 Mon Sep 17 00:00:00 2001
+From: "simit.ghane" <simit.ghane@lge.com>
+Date: Tue, 11 Jun 2024 07:22:28 +0530
+Subject: [PATCH] random:cipher: handle substitution in sed command
+
+* cipher/Makefile.am (o_flag_munging): Add 'g' flag for first sed
+expression.
+* random/Makefile.am (o_flag_munging): Likewise.
+--
+
+It was there earlier and accidentally removed from
+Makefile.am of cipher and random
+
+Signed-off-by: simit.ghane <simit.ghane@lge.com>
+[jk: add changelog to commit message]
+Signed-off-by: Jussi Kivilinna <jussi.kivilinna@iki.fi>
+---
+ cipher/Makefile.am | 2 +-
+ random/Makefile.am | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cipher/Makefile.am b/cipher/Makefile.am
+index ea9014cc..149c9f21 100644
+--- a/cipher/Makefile.am
++++ b/cipher/Makefile.am
+@@ -169,7 +169,7 @@ gost-s-box$(EXEEXT_FOR_BUILD): gost-s-box.c
+ 
+ 
+ if ENABLE_O_FLAG_MUNGING
+-o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]*\)/ -O1 /' -e 's/[[:blank:]]-Ofast/ -O1 /g'
++o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]*\)/ -O1 /g' -e 's/[[:blank:]]-Ofast/ -O1 /g'
+ else
+ o_flag_munging = cat
+ endif
+diff --git a/random/Makefile.am b/random/Makefile.am
+index c7100ef8..a42e4306 100644
+--- a/random/Makefile.am
++++ b/random/Makefile.am
+@@ -56,7 +56,7 @@ jitterentropy-base.c jitterentropy.h jitterentropy-base-user.h
+ 
+ # The rndjent module needs to be compiled without optimization.  */
+ if ENABLE_O_FLAG_MUNGING
+-o_flag_munging = sed -e 's/[[:blank:]]-O\([1-9sgz][1-9sgz]*\)/ -O0 /' -e 's/[[:blank:]]-Ofast/ -O0 /g'
++o_flag_munging = sed -e 's/[[:blank:]]-O\([1-9sgz][1-9sgz]*\)/ -O0 /g' -e 's/[[:blank:]]-Ofast/ -O0 /g'
+ else
+ o_flag_munging = cat
+ endif
+-- 
+2.43.0
+

--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -49,6 +49,8 @@ class Libgcrypt(AutotoolsPackage):
         # We should not inject optimization flags through the wrapper, because
         # the jitter entropy code should never be compiled with optimization
         # flags, and the build system ensures that
+        if name.lower() == "cflags":
+            flags.append("-O0")
         return (None, flags, None)
 
     # 1.10.2 fails on macOS when trying to use the Linux getrandom() call

--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -17,26 +17,26 @@ class Libgcrypt(AutotoolsPackage):
 
     version("1.11.0", sha256="09120c9867ce7f2081d6aaa1775386b98c2f2f246135761aae47d81f58685b9c")
     version("1.10.3", sha256="8b0870897ac5ac67ded568dcfadf45969cfa8a6beb0fd60af2a9eadc2a3272aa")
-    version("1.10.2", sha256="3b9c02a004b68c256add99701de00b383accccf37177e0d6c58289664cce0c03")
-    version("1.10.1", sha256="ef14ae546b0084cd84259f61a55e07a38c3b53afc0f546bffcef2f01baffe9de")
-    version("1.10.0", sha256="6a00f5c05caa4c4acc120c46b63857da0d4ff61dc4b4b03933fa8d46013fae81")
 
-    # End of life: 2024-03-31
     with default_args(deprecated=True):
-        version("1.9.4", sha256="ea849c83a72454e3ed4267697e8ca03390aee972ab421e7df69dfe42b65caaf7")
-        version("1.9.3", sha256="97ebe4f94e2f7e35b752194ce15a0f3c66324e0ff6af26659bbfb5ff2ec328fd")
-        version("1.9.2", sha256="b2c10d091513b271e47177274607b1ffba3d95b188bbfa8797f948aec9053c5a")
-        version("1.9.1", sha256="c5a67a8b9b2bd370fb415ed1ee31c7172e5683076493cf4a3678a0fbdf0265d9")
+        version(
+            "1.10.2", sha256="3b9c02a004b68c256add99701de00b383accccf37177e0d6c58289664cce0c03"
+        )
+        version(
+            "1.10.1", sha256="ef14ae546b0084cd84259f61a55e07a38c3b53afc0f546bffcef2f01baffe9de"
+        )
+        version(
+            "1.10.0", sha256="6a00f5c05caa4c4acc120c46b63857da0d4ff61dc4b4b03933fa8d46013fae81"
+        )
+        # End of life: 2024-12-31 (LTS)
+        version("1.8.9", sha256="2bda4790aa5f0895d3407cf7bf6bd7727fd992f25a45a63d92fef10767fa3769")
+        version("1.8.7", sha256="03b70f028299561b7034b8966d7dd77ef16ed139c43440925fe8782561974748")
+        version("1.8.6", sha256="0cba2700617b99fc33864a0c16b1fa7fdf9781d9ed3509f5d767178e5fd7b975")
+        version("1.8.5", sha256="3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3")
+        version("1.8.4", sha256="f638143a0672628fde0cad745e9b14deb85dffb175709cacc1f4fe24b93f2227")
+        version("1.8.1", sha256="7a2875f8b1ae0301732e878c0cca2c9664ff09ef71408f085c50e332656a78b3")
 
-    # End of life: 2024-12-31 (LTS)
-    version("1.8.9", sha256="2bda4790aa5f0895d3407cf7bf6bd7727fd992f25a45a63d92fef10767fa3769")
-    version("1.8.7", sha256="03b70f028299561b7034b8966d7dd77ef16ed139c43440925fe8782561974748")
-    version("1.8.6", sha256="0cba2700617b99fc33864a0c16b1fa7fdf9781d9ed3509f5d767178e5fd7b975")
-    version("1.8.5", sha256="3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3")
-    version("1.8.4", sha256="f638143a0672628fde0cad745e9b14deb85dffb175709cacc1f4fe24b93f2227")
-    version("1.8.1", sha256="7a2875f8b1ae0301732e878c0cca2c9664ff09ef71408f085c50e332656a78b3")
-
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("libgpg-error@1.25:")
     depends_on("libgpg-error@1.27:", when="@1.9:")
@@ -59,6 +59,9 @@ class Libgcrypt(AutotoolsPackage):
 
     # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commit;h=b42116d6067a5233f72e5598032d4b396bb8eaac
     patch("conditional_avx512.patch", when="@1.11.0")
+
+    patch("o_flag_munging-1.10.patch", when="@1.10")
+    patch("o_flag_munging-1.11.patch", when="@1.11")
 
     def check(self):
         # Without this hack, `make check` fails on macOS when SIP is enabled

--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -49,8 +49,6 @@ class Libgcrypt(AutotoolsPackage):
         # We should not inject optimization flags through the wrapper, because
         # the jitter entropy code should never be compiled with optimization
         # flags, and the build system ensures that
-        if name.lower() == "cflags":
-            flags.append("-O0")
         return (None, flags, None)
 
     # 1.10.2 fails on macOS when trying to use the Linux getrandom() call


### PR DESCRIPTION
Supersedes #48855 to which I cannot push.

This deprecates versions of libgcrypt so I don't have to patch everything.

It condenses

https://github.com/gpg/libgcrypt/commit/7edf1abb9a0d892a80cbf7ab42f64b2720671ee9
https://github.com/gpg/libgcrypt/commit/b99952adc6ee611641709610d2e4dc90ba9acf37
https://github.com/gpg/libgcrypt/commit/5afadba008918d651afefb842ae123cc18454c74
https://github.com/gpg/libgcrypt/commit/e96df0c82e086bf348753d2d0fa37fa6191b4b14

into two patches for 1.10 and 1.11