### PR TITLE
openblas: .libs() uses self.libraries attribute

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -322,7 +322,7 @@ class Openblas(CMakePackage, MakefilePackage):
         spec = self.spec
 
         # Look for openblas{symbol_suffix}
-        name = ["libopenblas", "openblas"]
+        name = self.libraries
         search_shared = bool(spec.variants["shared"].value)
         suffix = spec.variants["symbol_suffix"].value
         if suffix != "none":


### PR DESCRIPTION
Currently this is hardcoded to the same value as listed in the class definition. If one ever overrides this attribute, such as:

```
packages:
  openblas:
    package_attributes:
      libraries = [ 'libopenblaso64', ]
```

this patch will make sure that override also in the `spec['openblas'].libs()` call. (Which happens in `hypre`, likely others).

( see
https://spack.readthedocs.io/en/latest/packages_yaml.html#assigning-package-attributes )

Thanks to @becker33 for debugging help in Slack

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
