### PR TITLE
vtk: fix 9.4.1 concretization

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -295,6 +295,9 @@ class Seacas(CMakePackage):
     )
     conflicts("+shared", when="platform=windows")
     conflicts("+x11", when="platform=windows")
+
+    conflicts("@2024-06-27 platform=windows")
+
     # Remove use of variable in array assignment (triggers c2057 on MSVC)
     # See https://github.com/sandialabs/seacas/issues/438
     patch(


### PR DESCRIPTION
Currently `spack install vtk@9.4.1` fails to concretize due to:

```
    depends_on("seacas@2022-10-14", when="@9.2:")
    depends_on("seacas@2024-04-03:", when="@9.4:")
```
This correct this by setting a upper version boundary for `depends_on("seacas@2022-10-14", when="@9.2:9.3")`.

Other issues addressed that were required for 9.4.1 to build:
- Build VTK with c++17 (new seacas requires this).
- Patch VTK so that it does not search for SEACASIoss_INCLUDE_DIRS (new seacas correctly use targets, thus this is not needed).
- In seacas conflicts: `platform=windows` when `@2024-06-27` since seacas fails to build in that context: https://gitlab.spack.io/spack/spack/-/jobs/15089070