### PR TITLE
py-nanobind: add v2.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-nanobind/package.py
+++ b/var/spack/repos/builtin/packages/py-nanobind/package.py
@@ -17,11 +17,14 @@ class PyNanobind(PythonPackage):
     url = "https://github.com/wjakob/nanobind/archive/refs/tags/v1.2.0.tar.gz"
     git = "https://github.com/wjakob/nanobind.git"
 
-    maintainers("chrisrichardson", "garth-wells", "ma595")
+    maintainers("chrisrichardson", "garth-wells")
 
     license("BSD-3-Clause")
 
     version("master", branch="master", submodules=True)
+    version(
+        "2.5.0", tag="v2.5.0", commit="4ccbe6e005fc017652312305f280742da49d3dd5", submodules=True
+    )
     version(
         "2.4.0", tag="v2.4.0", commit="0f9ce749b257fdfe701edb3cf6f7027ba029434a", submodules=True
     )


### PR DESCRIPTION
Also removes inactive maintainer.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
