### PR TITLE
unifyfs: Apply workaround for oneAPI compiler for problem with build

### DIFF
--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -112,10 +112,12 @@ class Unifyfs(AutotoolsPackage):
         if self.spec.satisfies("%oneapi"):
             env.append_flags("CFLAGS", "-Wno-unused-function")
 
-    @when("%cce@11.0.3:")
     def patch(self):
-        filter_file("-Werror", "", "client/src/Makefile.in")
-        filter_file("-Werror", "", "client/src/Makefile.am")
+        if self.spec.satisfies("%cce@11.0.3:"):
+            filter_file("-Werror", "", "client/src/Makefile.in")
+            filter_file("-Werror", "", "client/src/Makefile.am")
+        if self.spec.satisfies("@2.0 %oneapi@2025:"):
+            filter_file("static int asprintf", "int asprintf", "examples/src/testutil.c")
 
     @when("@develop")
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
there is no upstream change for it, provided change helps with building with oneAPI compiler. I am open for other suggestions
