### PR TITLE
spack.repo <-> spack.package_base circularity

### DIFF
--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -11,7 +11,7 @@ import spack.error
 import spack.multimethod
 import spack.package_base
 import spack.phase_callbacks
-import spack.repo
+import spack.repo_utils
 import spack.spec
 import spack.util.environment
 
@@ -59,7 +59,7 @@ class _PhaseAdapter:
 def get_builder_class(pkg, name: str) -> Optional[Type["Builder"]]:
     """Return the builder class if a package module defines it."""
     cls = getattr(pkg.module, name, None)
-    if cls and cls.__module__.startswith(spack.repo.ROOT_PYTHON_NAMESPACE):
+    if cls and cls.__module__.startswith(spack.repo_utils.ROOT_PYTHON_NAMESPACE):
         return cls
     return None
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -8,6 +8,7 @@ import sys
 import llnl.util.tty as tty
 
 import spack.config
+import spack.error
 import spack.repo
 import spack.util.path
 from spack.cmd.common import arguments
@@ -129,7 +130,7 @@ def repo_remove(args):
                 spack.config.set("repos", repos, args.scope)
                 tty.msg("Removed repository %s with namespace '%s'." % (repo.root, repo.namespace))
                 return
-        except spack.repo.RepoError:
+        except spack.error.RepoError:
             continue
 
     tty.die("No repository with path or namespace: %s" % namespace_or_path)
@@ -142,7 +143,7 @@ def repo_list(args):
     for r in roots:
         try:
             repos.append(spack.repo.from_path(r))
-        except spack.repo.RepoError:
+        except spack.error.RepoError:
             continue
 
     if sys.stdout.isatty():

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -14,7 +14,7 @@ import llnl.util.tty.color as color
 from llnl.util.filesystem import working_dir
 
 import spack.paths
-import spack.repo
+import spack.repo_utils
 import spack.util.git
 from spack.util.executable import Executable, which
 
@@ -369,7 +369,7 @@ def run_black(black_cmd, file_list, args):
 def _module_part(root: str, expr: str):
     parts = expr.split(".")
     # spack.pkg is for repositories, don't try to resolve it here.
-    if ".".join(parts[:2]) == spack.repo.ROOT_PYTHON_NAMESPACE:
+    if ".".join(parts[:2]) == spack.repo_utils.ROOT_PYTHON_NAMESPACE:
         return None
     while parts:
         f1 = os.path.join(root, "lib", "spack", *parts) + ".py"

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Type, Uni
 import llnl.util.lang
 
 import spack.error
-import spack.repo
+import spack.repo_utils
 import spack.spec
 
 #: Names of possible directives. This list is mostly populated using the @directive decorator.
@@ -65,7 +65,7 @@ class DirectiveMeta(type):
         # The instance is being initialized: if it is a package we must ensure
         # that the directives are called to set it up.
 
-        if cls.__module__.startswith(spack.repo.ROOT_PYTHON_NAMESPACE):
+        if cls.__module__.startswith(spack.repo_utils.ROOT_PYTHON_NAMESPACE):
             # Ensure the presence of the dictionaries associated with the directives.
             # All dictionaries are defaultdicts that create lists for missing keys.
             for d in DirectiveMeta._directive_dict_names:

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -202,3 +202,11 @@ class MirrorError(SpackError):
 
     def __init__(self, msg, long_msg=None):
         super().__init__(msg, long_msg)
+
+
+class RepoError(SpackError):
+    """Superclass for repository-related errors."""
+
+
+class UnknownEntityError(RepoError):
+    """Raised when we encounter a package spack doesn't have."""

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -560,7 +560,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
             try:
                 source_repo = spack.repo.from_path(source_repo_root)
                 source_pkg_dir = source_repo.dirname_for_package_name(node.name)
-            except spack.repo.RepoError as err:
+            except spack.error.RepoError as err:
                 tty.debug(f"Failed to create source repo for {node.name}: {str(err)}")
                 source_pkg_dir = None
                 tty.warn(f"Warning: Couldn't copy in provenance for {node.name}")

--- a/lib/spack/spack/repo_utils.py
+++ b/lib/spack/spack/repo_utils.py
@@ -1,0 +1,36 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#: Package modules are imported as spack.pkg.<repo-namespace>.<pkg-name>
+ROOT_PYTHON_NAMESPACE = "spack.pkg"
+
+
+def namespace_from_fullname(fullname):
+    """Return the repository namespace only for the full module name.
+
+    For instance:
+
+        namespace_from_fullname('spack.pkg.builtin.hdf5') == 'builtin'
+
+    Args:
+        fullname (str): full name for the Python module
+    """
+    namespace, dot, module = fullname.rpartition(".")
+    prefix_and_dot = "{0}.".format(ROOT_PYTHON_NAMESPACE)
+    if namespace.startswith(prefix_and_dot):
+        namespace = namespace[len(prefix_and_dot) :]
+    return namespace
+
+
+def python_package_for_repo(namespace):
+    """Returns the full namespace of a repository, given its relative one
+
+    For instance:
+
+        python_package_for_repo('builtin') == 'spack.pkg.builtin'
+
+    Args:
+        namespace (str): repo namespace
+    """
+    return "{0}.{1}".format(ROOT_PYTHON_NAMESPACE, namespace)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3814,7 +3814,7 @@ def _is_reusable(spec: spack.spec.Spec, packages, local: bool) -> bool:
 
     try:
         provided = spack.repo.PATH.get(spec).provided_virtual_names()
-    except spack.repo.RepoError:
+    except spack.error.RepoError:
         provided = []
 
     for name in {spec.name, *provided}:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3342,7 +3342,7 @@ class Spec:
                     # Here we might get an abstract spec
                     pkg_cls = spack.repo.PATH.get_pkg_class(non_virtual_spec.fullname)
                     pkg = pkg_cls(non_virtual_spec)
-                except spack.repo.UnknownEntityError:
+                except spack.error.UnknownEntityError:
                     # If we can't get package info on this spec, don't treat
                     # it as a provider of this vdep.
                     return False
@@ -3447,7 +3447,7 @@ class Spec:
                     # Here we might get an abstract spec
                     pkg_cls = spack.repo.PATH.get_pkg_class(self.fullname)
                     pkg = pkg_cls(self)
-                except spack.repo.UnknownEntityError:
+                except spack.error.UnknownEntityError:
                     # If we can't get package info on this spec, don't treat
                     # it as a provider of this vdep.
                     return False

--- a/lib/spack/spack/version/git_ref_lookup.py
+++ b/lib/spack/spack/version/git_ref_lookup.py
@@ -10,6 +10,7 @@ from typing import Dict, Optional, Tuple
 from llnl.util.filesystem import mkdirp, working_dir
 
 import spack.caches
+import spack.error
 import spack.fetch_strategy
 import spack.paths
 import spack.repo
@@ -78,7 +79,7 @@ class GitRefLookup(AbstractRefLookup):
             try:
                 pkg = spack.repo.PATH.get_pkg_class(self.pkg_name)
                 pkg.git
-            except (spack.repo.RepoError, AttributeError) as e:
+            except (spack.error.RepoError, AttributeError) as e:
                 raise VersionLookupError(f"Couldn't get the git repo for {self.pkg_name}") from e
             self._pkg = pkg
         return self._pkg


### PR DESCRIPTION
The hope is `spack.repo` can add typehints for `spack.package_base.PackageBase`

Actually needs #48729 to get rid of `spack.package` importing `spack.repo` for the package dependency graph.

Current situation is basically

```
spack.repo imports spack.package_base, spack.spec
spack.package_base imports spack.spec
spack.spec imports spack.repo
```

so rather non-trivial...