### PR TITLE
hep: rivet: require hepmc=3

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -19,6 +19,8 @@ spack:
       require: +geant4 +hepmc3 +root +shared cxxstd=20
     hip:
       require: '@5.7.1 +rocm'
+    rivet:
+      require: hepmc=3
     root:
       require: +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
       # note: root cxxstd=20 not concretizable within sherpa
@@ -93,7 +95,7 @@ spack:
   - py-uproot +lz4 +xrootd +zstd
   - py-vector
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet ~root # pythia8 and root circularly depend
-  - rivet hepmc=3
+  - rivet
   - root ~cuda
   - sherpa +analysis ~blackhat +gzip +hepmc3 +hepmc3root +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo cxxstd=20
   - tauola +hepmc3 +lhapdf cxxstd=20


### PR DESCRIPTION
This PR ensures that the HEP cloud pipeline always uses `rivet` with `hepmc=3` instead of defaulting to `hepmc=2` and falling back to the older version 3 of rivet.