### PR TITLE
package_hash.py: move metadata_attrs inline out of package_base

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -710,19 +710,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: Do not include @ here in order not to unnecessarily ping the users.
     maintainers: List[str] = []
 
-    #: List of attributes to be excluded from a package's hash.
-    metadata_attrs = [
-        "homepage",
-        "url",
-        "urls",
-        "list_url",
-        "extendable",
-        "parallel",
-        "make_jobs",
-        "maintainers",
-        "tags",
-    ]
-
     #: Set to ``True`` to indicate the stand-alone test requires a compiler.
     #: It is used to ensure a compiler and build dependencies like 'cmake'
     #: are available to build a custom test code.

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -8,7 +8,6 @@ from typing import Optional
 import spack.directives_meta
 import spack.error
 import spack.fetch_strategy
-import spack.package_base
 import spack.repo
 import spack.spec
 import spack.util.hash
@@ -61,10 +60,18 @@ class RemoveDirectives(ast.NodeTransformer):
     """
 
     def __init__(self, spec):
-        # list of URL attributes and metadata attributes
-        # these will be removed from packages.
-        self.metadata_attrs = [s.url_attr for s in spack.fetch_strategy.all_strategies]
-        self.metadata_attrs += spack.package_base.PackageBase.metadata_attrs
+        #: List of attributes to be excluded from a package's hash.
+        self.metadata_attrs = [s.url_attr for s in spack.fetch_strategy.all_strategies] + [
+            "homepage",
+            "url",
+            "urls",
+            "list_url",
+            "extendable",
+            "parallel",
+            "make_jobs",
+            "maintainers",
+            "tags",
+        ]
 
         self.spec = spec
         self.in_classdef = False  # used to avoid nested classdefs


### PR DESCRIPTION
It does not look like `metadata_attrs` was ever overridden by a derived class, so might as well make it static and avoid the circular import.