### PR TITLE
spack.spec.SpecBuildInterface: spack.repo dep

### DIFF
--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -209,7 +209,7 @@ class LmodConfiguration(BaseConfiguration):
         # All the other tokens in the hierarchy must be virtual dependencies
         for x in self.hierarchy_tokens:
             if self.spec.package.provides(x):
-                provides[x] = self.spec[x]
+                provides[x] = self.spec
         return provides
 
     @property

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1337,14 +1337,20 @@ class SpecBuildInterface(lang.ObjectWrapper):
         "command", default_handler=_command_default_handler, _indirect=True
     )
 
-    def __init__(self, spec: "Spec", name: str, query_parameters: List[str], _parent: "Spec"):
+    def __init__(
+        self,
+        spec: "Spec",
+        name: str,
+        query_parameters: List[str],
+        _parent: "Spec",
+        is_virtual: bool,
+    ):
         super().__init__(spec)
         # Adding new attributes goes after super() call since the ObjectWrapper
         # resets __dict__ to behave like the passed object
         original_spec = getattr(spec, "wrapped_obj", spec)
         self.wrapped_obj = original_spec
-        self.token = original_spec, name, query_parameters, _parent
-        is_virtual = spack.repo.PATH.is_virtual(name)
+        self.token = original_spec, name, query_parameters, _parent, is_virtual
         self.last_query = QueryState(
             name=name, extra_parameters=query_parameters, isvirtual=is_virtual
         )
@@ -3756,21 +3762,16 @@ class Spec:
         # Consider runtime dependencies and direct build/test deps before transitive dependencies,
         # and prefer matches closest to the root.
         try:
-            child: Spec = next(
-                e.spec
-                for e in itertools.chain(
-                    (e for e in order() if e.spec.name == name or name in e.virtuals),
-                    # for historical reasons
-                    (e for e in order() if e.spec.concrete and e.spec.package.provides(name)),
-                )
-            )
+            edge = next((e for e in order() if e.spec.name == name or name in e.virtuals))
         except StopIteration:
             raise KeyError(f"No spec with name {name} in {self}")
 
         if self._concrete:
-            return SpecBuildInterface(child, name, query_parameters, _parent=self)
+            return SpecBuildInterface(
+                edge.spec, name, query_parameters, _parent=self, is_virtual=name in edge.virtuals
+            )
 
-        return child
+        return edge.spec
 
     def __contains__(self, spec):
         """True if this spec or some dependency satisfies the spec.

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1243,7 +1243,7 @@ class TestConcretize:
     def test_conditional_provides_or_depends_on(self):
         # Check that we can concretize correctly a spec that can either
         # provide a virtual or depend on it based on the value of a variant
-        s = spack.concretize.concretize_one("conditional-provider +disable-v1")
+        s = spack.concretize.concretize_one("v1-consumer ^conditional-provider +disable-v1")
         assert "v1-provider" in s
         assert s["v1"].name == "v1-provider"
         assert s["v2"].name == "conditional-provider"

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -259,7 +259,7 @@ mpileaks:
     def test_external_mpi(self):
         # make sure this doesn't give us an external first.
         spec = spack.concretize.concretize_one("mpi")
-        assert not spec["mpi"].external
+        assert not spec.external and spec.package.provides("mpi")
 
         # load config
         conf = syaml.load_config(
@@ -293,7 +293,7 @@ mpich:
         monkeypatch.setattr(spack.util.module_cmd, "module", mock_module)
 
         spec = spack.concretize.concretize_one("mpi")
-        assert not spec["mpi"].external
+        assert not spec.external and spec.package.provides("mpi")
 
         # load config
         conf = syaml.load_config(


### PR DESCRIPTION
PR 1 / n of disentangling `spack.package_base`, `spack.spec`, `spack.repo`.

In this PR: remove `spack.repo.PATH.is_virtual` call from `SpecBuildInterface`.

This PR is effectively a breaking change extracted from #45189, which removes support for `spec["mpi"]` if `spec` itself is `openmpi` / `mpich` that _could_ provide `mpi`; from the `Spec` instance we don't have any parent it provides it to, hence it's a `KeyError`.

I'm not a big fan of it because this looks weird:

```python
spec = spec.concretize.concretize_one("mpi")
spec["mpi"]  # KeyError
```

but arguably it's sensible that `__getitem__` applies to children. In fact it's required for #45189 because `compiler_spec["c"]`  should refer to compiler used to build this compiler, instead of to itself (for instance `gcc@14 %gcc@13` -> `gcc_14["c"] == gcc_13`).