### PR TITLE
Spec.package_class -> spack.repo.PATH.get_pkg_class

### DIFF
--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -125,7 +125,7 @@ def develop(parser, args):
     version = spec.versions.concrete_range_as_version
     if not version:
         # look up the maximum version so infintiy versions are preferred for develop
-        version = max(spec.package_class.versions.keys())
+        version = max(spack.repo.PATH.get_pkg_class(spec.fullname).versions.keys())
         tty.msg(f"Defaulting to highest version: {spec.name}@{version}")
     spec.versions = spack.version.VersionList([version])
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -545,7 +545,7 @@ class IncludeFilter:
         package does not explicitly forbid redistributing source."""
         if self.private:
             return True
-        elif x.package_class.redistribute_source(x):
+        elif spack.repo.PATH.get_pkg_class(x.fullname).redistribute_source(x):
             return True
         else:
             tty.debug(

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -252,7 +252,9 @@ def test_list(args):
     hashes = env.all_hashes() if env else None
 
     specs = spack.store.STORE.db.query(hashes=hashes)
-    specs = list(filter(lambda s: has_test_and_tags(s.package_class), specs))
+    specs = list(
+        filter(lambda s: has_test_and_tags(spack.repo.PATH.get_pkg_class(s.fullname)), specs)
+    )
 
     spack.cmd.display_specs(specs, long=True)
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -566,7 +566,7 @@ def copy_test_files(pkg: Pb, test_spec: spack.spec.Spec):
 
     # copy test data into test stage data dir
     try:
-        pkg_cls = test_spec.package_class
+        pkg_cls = spack.repo.PATH.get_pkg_class(test_spec.fullname)
     except spack.repo.UnknownPackageError:
         tty.debug(f"{test_spec.name}: skipping test data copy since no package class found")
         return
@@ -623,7 +623,7 @@ def test_functions(
         vpkgs = virtuals(pkg)
         for vname in vpkgs:
             try:
-                classes.append((Spec(vname)).package_class)
+                classes.append(spack.repo.PATH.get_pkg_class(vname))
             except spack.repo.UnknownPackageError:
                 tty.debug(f"{vname}: virtual does not appear to have a package file")
 
@@ -668,7 +668,7 @@ def process_test_parts(pkg: Pb, test_specs: List[spack.spec.Spec], verbose: bool
 
             # grab test functions associated with the spec, which may be virtual
             try:
-                tests = test_functions(spec.package_class)
+                tests = test_functions(spack.repo.PATH.get_pkg_class(spec.fullname))
             except spack.repo.UnknownPackageError:
                 # Some virtuals don't have a package so we don't want to report
                 # them as not having tests when that isn't appropriate.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3489,7 +3489,7 @@ class SpecBuilder:
         self._specs[node].extra_attributes = spec_info.get("extra_attributes", {})
 
         # If this is an extension, update the dependencies to include the extendee
-        package = self._specs[node].package_class(self._specs[node])
+        package = spack.repo.PATH.get_pkg_class(self._specs[node].fullname)(self._specs[node])
         extendee_spec = package.extendee_spec
 
         if extendee_spec:

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -206,7 +206,7 @@ def test_repo(_create_test_repo, monkeypatch, mock_stage):
 )
 def test_redistribute_directive(test_repo, spec_str, distribute_src, distribute_bin):
     spec = spack.spec.Spec(spec_str)
-    assert spec.package_class.redistribute_source(spec) == distribute_src
+    assert spack.repo.PATH.get_pkg_class(spec.fullname).redistribute_source(spec) == distribute_src
     concretized_spec = spack.concretize.concretize_one(spec)
     assert concretized_spec.package.redistribute_binary == distribute_bin
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -11,6 +11,7 @@ from llnl.util.symlink import readlink
 
 import spack.compiler
 import spack.platforms
+import spack.repo
 import spack.util.libc
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
 from spack.package import *
@@ -1217,7 +1218,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         )
         if header_dir and all(
             os.path.exists(os.path.join(header_dir, h))
-            for h in libc.package_class.representative_headers
+            for h in spack.repo.PATH.get_pkg_class(libc.fullname).representative_headers
         ):
             relocation_args.append(f"-idirafter {header_dir}")
         else:


### PR DESCRIPTION
PR 2 / n of disentangling `spack.package_base`, `spack.spec`, `spack.repo`.

In this PR: deprecate `Spec.package_class` and inline it on every call site (similar to `Spec.concretize` deprecation)

Since `spack.spec` calls `package_class` a couple times, not much is gained yet.