### PR TITLE
`Spec.virtual` -> `spack.repo.PATH.is_virtual`

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -1010,7 +1010,7 @@ def _issues_in_depends_on_directive(pkgs, error_cls):
             for dep_name, dep in deps_by_name.items():
 
                 def check_virtual_with_variants(spec, msg):
-                    if not spec.virtual or not spec.variants:
+                    if not spack.repo.PATH.is_virtual(spec.name) or not spec.variants:
                         return
                     error = error_cls(
                         f"{pkg_name}: {msg}",

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2529,10 +2529,10 @@ def install_root_node(
         allow_missing: when true, allows installing a node with missing dependencies
     """
     # Early termination
-    if spec.external or spec.virtual:
-        warnings.warn("Skipping external or virtual package {0}".format(spec.format()))
+    if spec.external or not spec.concrete:
+        warnings.warn("Skipping external or abstract spec {0}".format(spec.format()))
         return
-    elif spec.concrete and spec.installed and not force:
+    elif spec.installed and not force:
         warnings.warn("Package for spec {0} already installed.".format(spec.format()))
         return
 

--- a/lib/spack/spack/cmd/providers.py
+++ b/lib/spack/spack/cmd/providers.py
@@ -41,7 +41,11 @@ def providers(parser, args):
     specs = spack.cmd.parse_specs(args.virtual_package)
 
     # Check prerequisites
-    non_virtual = [str(s) for s in specs if not s.virtual or s.name not in valid_virtuals]
+    non_virtual = [
+        str(s)
+        for s in specs
+        if not spack.repo.PATH.is_virtual(s.name) or s.name not in valid_virtuals
+    ]
     if non_virtual:
         msg = "non-virtual specs cannot be part of the query "
         msg += "[{0}]\n".format(", ".join(non_virtual))

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -220,7 +220,7 @@ def concretize_one(spec: Union[str, Spec], tests: TestsType = False) -> Spec:
     opt, i, answer = min(result.answers)
     name = spec.name
     # TODO: Consolidate this code with similar code in solve.py
-    if spec.virtual:
+    if spack.repo.PATH.is_virtual(spec.name):
         providers = [s.name for s in answer.values() if s.package.provides(name)]
         name = providers[0]
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -41,6 +41,8 @@ from typing import (
     Union,
 )
 
+import spack.repo
+
 try:
     import uuid
 
@@ -1556,7 +1558,12 @@ class Database:
         # If we did fine something, the query spec can't be virtual b/c we matched an actual
         # package installation, so skip the virtual check entirely. If we *didn't* find anything,
         # check all the deferred specs *if* the query is virtual.
-        if not results and query_spec is not None and deferred and query_spec.virtual:
+        if (
+            not results
+            and query_spec is not None
+            and deferred
+            and spack.repo.PATH.is_virtual(query_spec.name)
+        ):
             results = [spec for spec in deferred if spec.satisfies(query_spec)]
 
         return results

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -406,8 +406,8 @@ def fixup_macos_rpaths(spec):
     entries which makes it harder to adjust with ``install_name_tool
     -delete_rpath``.
     """
-    if spec.external or spec.virtual:
-        tty.warn("external or virtual package cannot be fixed up: {0!s}".format(spec))
+    if spec.external or not spec.concrete:
+        tty.warn("external/abstract spec cannot be fixed up: {0!s}".format(spec))
         return False
 
     if "platform=darwin" not in spec:

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -381,7 +381,9 @@ class Counter:
             self.all_types = dt.LINK | dt.RUN | dt.BUILD
 
         self._possible_dependencies: Set[str] = set()
-        self._possible_virtuals: Set[str] = set(x.name for x in specs if x.virtual)
+        self._possible_virtuals: Set[str] = {
+            x.name for x in specs if spack.repo.PATH.is_virtual(x.name)
+        }
 
     def possible_dependencies(self) -> Set[str]:
         """Returns the list of possible dependencies"""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1909,6 +1909,12 @@ class Spec:
 
     @property
     def virtual(self):
+        warnings.warn(
+            "`Spec.virtual` is deprecated and will be removed in version 1.0.0. Use "
+            "`spack.repo.PATH.is_virtual(spec.name)` instead.",
+            category=spack.error.SpackAPIWarning,
+            stacklevel=2,
+        )
         return spack.repo.PATH.is_virtual(self.name)
 
     @property
@@ -3084,7 +3090,7 @@ class Spec:
         # FIXME: raise just the first one encountered
         for spec in self.traverse():
             # raise an UnknownPackageError if the spec's package isn't real.
-            if (not spec.virtual) and spec.name:
+            if spec.name and not spack.repo.PATH.is_virtual(spec.name):
                 spack.repo.PATH.get_pkg_class(spec.fullname)
 
             # validate compiler in addition to the package name.
@@ -3093,7 +3099,7 @@ class Spec:
                     raise UnsupportedCompilerError(spec.compiler.name)
 
             # Ensure correctness of variants (if the spec is not virtual)
-            if not spec.virtual:
+            if not spack.repo.PATH.is_virtual(spec.name):
                 Spec.ensure_valid_variants(spec)
                 substitute_abstract_variants(spec)
 
@@ -3328,7 +3334,9 @@ class Spec:
 
         # If the names are different, we need to consider virtuals
         if self.name != other.name and self.name and other.name:
-            if self.virtual and other.virtual:
+            self_virtual = spack.repo.PATH.is_virtual(self.name)
+            other_virtual = spack.repo.PATH.is_virtual(other.name)
+            if self_virtual and other_virtual:
                 # Two virtual specs intersect only if there are providers for both
                 lhs = spack.repo.PATH.providers_for(str(self))
                 rhs = spack.repo.PATH.providers_for(str(other))
@@ -3336,8 +3344,8 @@ class Spec:
                 return bool(intersection)
 
             # A provider can satisfy a virtual dependency.
-            elif self.virtual or other.virtual:
-                virtual_spec, non_virtual_spec = (self, other) if self.virtual else (other, self)
+            elif self_virtual or other_virtual:
+                virtual_spec, non_virtual_spec = (self, other) if self_virtual else (other, self)
                 try:
                     # Here we might get an abstract spec
                     pkg_cls = spack.repo.PATH.get_pkg_class(non_virtual_spec.fullname)
@@ -3442,7 +3450,9 @@ class Spec:
         # If the names are different, we need to consider virtuals
         if self.name != other.name and self.name and other.name:
             # A concrete provider can satisfy a virtual dependency.
-            if not self.virtual and other.virtual:
+            if not spack.repo.PATH.is_virtual(self.name) and spack.repo.PATH.is_virtual(
+                other.name
+            ):
                 try:
                     # Here we might get an abstract spec
                     pkg_cls = spack.repo.PATH.get_pkg_class(self.fullname)
@@ -3510,7 +3520,7 @@ class Spec:
         lhs_edges: Dict[str, Set[DependencySpec]] = collections.defaultdict(set)
         for rhs_edge in other.traverse_edges(root=False, cover="edges"):
             # If we are checking for ^mpi we need to verify if there is any edge
-            if rhs_edge.spec.virtual:
+            if spack.repo.PATH.is_virtual(rhs_edge.spec.name):
                 rhs_edge.update_virtuals(virtuals=(rhs_edge.spec.name,))
 
             if not rhs_edge.virtuals:
@@ -3556,7 +3566,7 @@ class Spec:
 
     def virtual_dependencies(self):
         """Return list of any virtual deps in this spec."""
-        return [spec for spec in self.traverse() if spec.virtual]
+        return [spec for spec in self.traverse() if spack.repo.PATH.is_virtual(spec.name)]
 
     @property  # type: ignore[misc] # decorated prop not supported in mypy
     def patches(self):
@@ -4844,7 +4854,9 @@ def reconstruct_virtuals_on_edges(spec):
     possible_virtuals = set()
     for node in spec.traverse():
         try:
-            possible_virtuals.update({x for x in node.package.dependencies if Spec(x).virtual})
+            possible_virtuals.update(
+                {x for x in node.package.dependencies if spack.repo.PATH.is_virtual(x)}
+            )
         except Exception as e:
             warnings.warn(f"cannot reconstruct virtual dependencies on package {node.name}: {e}")
             continue


### PR DESCRIPTION
PR 3 / n of disentangling `spack.package_base`, `spack.spec`, `spack.repo`.

In this PR: deprecate `Spec.virtual` and inline it on every call site. This is similar to `Spec.concretize` deprecation; a specific repo should be asked whether a spec is virtual, instead of the spec asking a global repo.

This makes indirect dependencies on globals explicit (e.g. in solver/input_analysis.py which tries to avoid globals).