### PR TITLE
Spec.satisfies, Spec.intersects: drop spack.repo

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -8,6 +8,7 @@ import sys
 import llnl.util.tty as tty
 
 import spack.config
+import spack.error
 import spack.repo
 import spack.util.path
 from spack.cmd.common import arguments
@@ -129,7 +130,7 @@ def repo_remove(args):
                 spack.config.set("repos", repos, args.scope)
                 tty.msg("Removed repository %s with namespace '%s'." % (repo.root, repo.namespace))
                 return
-        except spack.repo.RepoError:
+        except spack.error.RepoError:
             continue
 
     tty.die("No repository with path or namespace: %s" % namespace_or_path)
@@ -142,7 +143,7 @@ def repo_list(args):
     for r in roots:
         try:
             repos.append(spack.repo.from_path(r))
-        except spack.repo.RepoError:
+        except spack.error.RepoError:
             continue
 
     if sys.stdout.isatty():

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -202,3 +202,11 @@ class MirrorError(SpackError):
 
     def __init__(self, msg, long_msg=None):
         super().__init__(msg, long_msg)
+
+
+class RepoError(SpackError):
+    """Superclass for repository-related errors."""
+
+
+class UnknownEntityError(RepoError):
+    """Raised when we encounter a package spack doesn't have."""

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -560,7 +560,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
             try:
                 source_repo = spack.repo.from_path(source_repo_root)
                 source_pkg_dir = source_repo.dirname_for_package_name(node.name)
-            except spack.repo.RepoError as err:
+            except spack.error.RepoError as err:
                 tty.debug(f"Failed to create source repo for {node.name}: {str(err)}")
                 source_pkg_dir = None
                 tty.warn(f"Warning: Couldn't copy in provenance for {node.name}")

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2109,7 +2109,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         # Try to get the package for the spec
         try:
             pkg = spec.package
-        except spack.repo.UnknownEntityError:
+        except spack.error.UnknownEntityError:
             pkg = None
 
         # Pre-uninstall hook runs first.

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -663,7 +663,7 @@ class RepoPath:
                     repo = Repo(repo, cache=cache, overrides=overrides)
                 repo.finder(self)
                 self.put_last(repo)
-            except RepoError as e:
+            except spack.error.RepoError as e:
                 tty.warn(
                     f"Failed to initialize repository: '{repo}'.",
                     e.message,
@@ -1241,7 +1241,7 @@ class Repo:
             raise UnknownPackageError(fullname)
         except Exception as e:
             msg = f"cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
-            raise RepoError(msg) from e
+            raise spack.error.RepoError(msg) from e
 
         cls = getattr(module, class_name)
         if not isinstance(cls, type):
@@ -1501,27 +1501,19 @@ class MockRepositoryBuilder:
         return os.path.join(self.root, "packages", name, "package.py")
 
 
-class RepoError(spack.error.SpackError):
-    """Superclass for repository-related errors."""
-
-
-class NoRepoConfiguredError(RepoError):
+class NoRepoConfiguredError(spack.error.RepoError):
     """Raised when there are no repositories configured."""
 
 
-class InvalidNamespaceError(RepoError):
+class InvalidNamespaceError(spack.error.RepoError):
     """Raised when an invalid namespace is encountered."""
 
 
-class BadRepoError(RepoError):
+class BadRepoError(spack.error.RepoError):
     """Raised when repo layout is invalid."""
 
 
-class UnknownEntityError(RepoError):
-    """Raised when we encounter a package spack doesn't have."""
-
-
-class UnknownPackageError(UnknownEntityError):
+class UnknownPackageError(spack.error.UnknownEntityError):
     """Raised when we encounter a package spack doesn't have."""
 
     def __init__(self, name, repo=None):
@@ -1558,7 +1550,7 @@ class UnknownPackageError(UnknownEntityError):
         self.name = name
 
 
-class UnknownNamespaceError(UnknownEntityError):
+class UnknownNamespaceError(spack.error.UnknownEntityError):
     """Raised when we encounter an unknown namespace"""
 
     def __init__(self, namespace, name=None):
@@ -1568,7 +1560,7 @@ class UnknownNamespaceError(UnknownEntityError):
         super().__init__(msg, long_msg)
 
 
-class FailedConstructorError(RepoError):
+class FailedConstructorError(spack.error.RepoError):
     """Raised when a package's class constructor fails."""
 
     def __init__(self, name, exc_type, exc_obj, exc_tb):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3831,7 +3831,7 @@ def _is_reusable(spec: spack.spec.Spec, packages, local: bool) -> bool:
 
     try:
         provided = spack.repo.PATH.get(spec).provided_virtual_names()
-    except spack.repo.RepoError:
+    except spack.error.RepoError:
         provided = []
 
     for name in {spec.name, *provided}:

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -457,7 +457,7 @@ def test_dump_packages_deps_errs(install_mockery, tmpdir, monkeypatch, capsys):
 
     def _repoerr(repo, name):
         if name == "cmake":
-            raise spack.repo.RepoError(repo_err_msg)
+            raise spack.error.RepoError(repo_err_msg)
         else:
             return orig_dirname(repo, name)
 
@@ -476,7 +476,7 @@ def test_dump_packages_deps_errs(install_mockery, tmpdir, monkeypatch, capsys):
     # Now try the error path, which requires the mock directory structure
     # above
     monkeypatch.setattr(spack.repo.Repo, "dirname_for_package_name", _repoerr)
-    with pytest.raises(spack.repo.RepoError, match=repo_err_msg):
+    with pytest.raises(spack.error.RepoError, match=repo_err_msg):
         inst.dump_packages(spec, path)
 
     out = str(capsys.readouterr()[1])

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -472,9 +472,6 @@ class TestSpecSemantics:
             ("mpileaks^mpich@2.0^callpath@1.7", "^mpich@1:3^callpath@1.4:1.6"),
             ("mpileaks^mpich@4.0^callpath@1.7", "^mpich@1:3^callpath@1.4:1.6"),
             ("mpileaks^mpi@3", "^mpi@1.2:1.6"),
-            ("mpileaks^mpi@3:", "^mpich2@1.4"),
-            ("mpileaks^mpi@3:", "^mpich2"),
-            ("mpileaks^mpi@3:", "^mpich@1.0"),
             ("mpich~foo", "mpich+foo"),
             ("mpich+foo", "mpich~foo"),
             ("mpich foo=True", "mpich foo=False"),
@@ -705,9 +702,9 @@ class TestSpecSemantics:
             assert copy[s.name].satisfies(s)
 
     def test_intersects_virtual(self):
-        assert Spec("mpich").intersects(Spec("mpi"))
-        assert Spec("mpich2").intersects(Spec("mpi"))
-        assert Spec("zmpi").intersects(Spec("mpi"))
+        assert spack.concretize.concretize_one("mpich").intersects("mpi")
+        assert spack.concretize.concretize_one("mpich2").intersects("mpi")
+        assert spack.concretize.concretize_one("zmpi").intersects("mpi")
 
     def test_intersects_virtual_providers(self):
         """Tests that we can always intersect virtual providers from abstract specs.
@@ -1829,9 +1826,6 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         (Spec, "cppflags=-foo", "cflags=-foo", (True, False, False)),
         # Versions
         (Spec, "@0.94h", "@:0.94i", (True, True, False)),
-        # Different virtuals intersect if there is at least package providing both
-        (Spec, "mpi", "lapack", (True, False, False)),
-        (Spec, "mpi", "pkgconfig", (False, False, False)),
         # Intersection among target ranges for different architectures
         (Spec, "target=x86_64:", "target=ppc64le:", (False, False, False)),
         (Spec, "target=x86_64:", "target=:power9", (False, False, False)),

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -11,6 +11,7 @@ import pytest
 import spack.binary_distribution
 import spack.cmd
 import spack.concretize
+import spack.error
 import spack.platforms.test
 import spack.repo
 import spack.spec
@@ -1139,7 +1140,7 @@ def test_parse_filename_missing_slash_as_spec(specfile_for, tmpdir, filename):
 
     # Check that if we concretize this spec, we get a good error
     # message that mentions we might've meant a file.
-    with pytest.raises(spack.repo.UnknownEntityError) as exc_info:
+    with pytest.raises(spack.error.UnknownEntityError) as exc_info:
         spack.concretize.concretize_one(spec)
     assert exc_info.value.long_message
     assert (

--- a/lib/spack/spack/version/git_ref_lookup.py
+++ b/lib/spack/spack/version/git_ref_lookup.py
@@ -10,6 +10,7 @@ from typing import Dict, Optional, Tuple
 from llnl.util.filesystem import mkdirp, working_dir
 
 import spack.caches
+import spack.error
 import spack.fetch_strategy
 import spack.paths
 import spack.repo
@@ -78,7 +79,7 @@ class GitRefLookup(AbstractRefLookup):
             try:
                 pkg = spack.repo.PATH.get_pkg_class(self.pkg_name)
                 pkg.git
-            except (spack.repo.RepoError, AttributeError) as e:
+            except (spack.error.RepoError, AttributeError) as e:
                 raise VersionLookupError(f"Couldn't get the git repo for {self.pkg_name}") from e
             self._pkg = pkg
         return self._pkg


### PR DESCRIPTION
> [!CAUTION]
> Edit: this requires a bit more thought regarding virtuals.

PR 6 / n of disentangling `spack.package_base`, `spack.spec`, `spack.repo`.

Currently `Spec.satisfies` and `Spec.intersects` are stateful both for concrete
and abstract specs, even after our changes where concrete specs list virtuals
as edge attributes.

Virtuals on edges basically provide too little information:

1. They don't specify what version of the virtual is provided, so you
   cannot know the return value of `s.satisfies("^mpi@3:")` without
   looking in the current state of the package.
2. It's not all about edges: `spack.concretize_one("mpi").satisfies("mpi")` is
   expected to be true (difference is *can* provide versus *provides*).

This commit tries to reduce the statefulness by only letting satisfies
and intersects access `spec.package`, instead of looking up the package.
The idea is that it reduces the surface area with `spack.repo`, as in
principle `spec.package` can be set upon construction.

The commit is breaking for abstract specs. The idea is you cannot answer
queries about abstract specs unless you associate a repo.