### PR TITLE
Fix slow gmake linking issue

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -125,9 +125,9 @@ class Cmake(Package):
     patch("mr-9623.patch", when="@3.22.0:3.30")
 
     depends_on("ninja", when="platform=windows")
-    depends_on("gmake", when="platform=linux")
-    depends_on("gmake", when="platform=darwin")
-    depends_on("gmake", when="platform=freebsd")
+    depends_on("gmake", type=("build", "run"), when="platform=linux")
+    depends_on("gmake", type=("build", "run"), when="platform=darwin")
+    depends_on("gmake", type=("build", "run"), when="platform=freebsd")
 
     depends_on("qt", when="+qtgui")
     # Qt depends on libmng, which is a CMake package;

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -99,3 +99,7 @@ class Gmake(Package, GNUMirrorPackage):
             self.spec.prefix.bin.make,
             jobs=determine_number_of_jobs(parallel=dspec.package.parallel),
         )
+
+    @property
+    def libs(self):
+        return []

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -335,8 +335,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     patch("revert-3.18.0-ver-format-for-dealii.patch", when="@3.18.0")
 
     depends_on("diffutils", type="build")
-    # not listed as a "build" dependency - so that slepc build gets the same dependency
-    depends_on("gmake")
+    depends_on("gmake", type="build")
 
     # Virtual dependencies
     # Git repository needs sowing to build Fortran interface


### PR DESCRIPTION
This PR resolves an issue with an externally configured `gmake` package in a very large directory, where running `spack install` it would take longer than an hour because of the scanning for (non-existent) libraries for `gmake`.

- Since `gmake` has no libraries, have `gmake::libs` return empty list
- Do not link against `gmake` in `petsc` or `cmake` packages

Issue discussed on slack general channel and fix suggested by @becker33, thanks!