### PR TITLE
xz: Work around ASM declaration issue with NVHPC

### DIFF
--- a/var/spack/repos/builtin/packages/xz/nvhpc.patch
+++ b/var/spack/repos/builtin/packages/xz/nvhpc.patch
@@ -1,0 +1,12 @@
+diff -Naru xz.pristine/src/liblzma/common/common.h xz.new/src/liblzma/common/common.h
+--- xz.pristine/src/liblzma/common/common.h	2025-02-11 21:03:10.322612833 +0000
++++ xz.new/src/liblzma/common/common.h	2025-02-11 21:02:56.135613226 +0000
+@@ -93,7 +93,7 @@
+ 					LZMA_API(type) intname
+ #	else
+ #		define LZMA_SYMVER_API(extnamever, type, intname) \
+-			__asm__(".symver " #intname "," extnamever); \
++			__asm__(".symver " #intname "," extnamever "\n"); \
+ 			extern LZMA_API(type) intname
+ #	endif
+ #endif

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -61,6 +61,12 @@ class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
     # prior to 5.2.3, build system is for MinGW only, not currently supported by Spack
     conflicts("platform=windows", when="@:5.2.3")
 
+    patch(
+        "nvhpc.patch",
+        when="@5.2.10: %nvhpc",
+        sha256="32228638c462651ec7dedab706d05aa352995f064ace2dee915f31c75cc995c0",
+    )
+
     build_system(conditional("msbuild", when="platform=windows"), "autotools", default="autotools")
 
     def flag_handler(self, name, flags):


### PR DESCRIPTION
This commit works around an issue described below that xz encounters during compilation with nvhpc.

https://forums.developer.nvidia.com/t/problem-in-inline-assembly-when-using-multiple-asm-declarations/210952

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
