### PR TITLE
concretize.lp: don't warn about deprecation when external

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -265,6 +265,7 @@ error(100, "Cannot select a single version for virtual '{0}'", Virtual)
 % If we select a deprecated version, mark the package as deprecated
 attr("deprecated", node(ID, Package), Version) :-
      attr("version", node(ID, Package), Version),
+     not external(node(ID, Package)),
      pkg_fact(Package, deprecated_version(Version)).
 
 error(100, "Package '{0}' needs the deprecated version '{1}', and this is not allowed", Package, Version)


### PR DESCRIPTION
When using external openssl / git etc, there's no point in warning it's deprecated.

* More often than not, security fixes are backported by the distro without changing the version number.
* Sometimes we deprecate patch versions to cleanup package.py and improve solve times (e.g. llvm), it doesn't mean it's bad to use an older system version.