### PR TITLE
gmake: fix def libs/headers

### DIFF
--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -102,4 +102,8 @@ class Gmake(Package, GNUMirrorPackage):
 
     @property
     def libs(self):
-        return []
+        return LibraryList([])
+
+    @property
+    def headers(self):
+        return HeaderList([])


### PR DESCRIPTION
follow-up to #48995, apparently ✅ ✅ ✅ ✅ was not enough.