### PR TITLE
fuse: Fix int64 type build error on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/libfuse/int64type.patch
+++ b/var/spack/repos/builtin/packages/libfuse/int64type.patch
@@ -1,0 +1,13 @@
+diff --git a/include/fuse_kernel.h b/include/fuse_kernel.h
+index c632b58fbcf4..560f0c0ea1e7 100644
+--- a/include/fuse_kernel.h
++++ b/include/fuse_kernel.h
+@@ -88,7 +88,7 @@
+ #ifndef _LINUX_FUSE_H
+ #define _LINUX_FUSE_H
+ 
+-#include <sys/types.h>
++#include <linux/types.h>
+ #define __u64 uint64_t
+ #define __s64 int64_t
+ #define __u32 uint32_t

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -94,7 +94,11 @@ class Libfuse(MesonPackage):
         sha256="94d5c6d9785471147506851b023cb111ef2081d1c0e695728037bbf4f64ce30a",
         when="@:2",
     )
-
+    patch(
+        "int64type.patch",
+        sha256="ef552aa73c9308bf080cc50f432add397b3fdf1a541b25af911ed48e4df6e458",
+        when="@:2 target=aarch64:",
+    )
     executables = ["^fusermount3?$"]
 
     @classmethod


### PR DESCRIPTION
I didn't realize that #47846 exists already and had this fix on my system. It seems like it might be a simpler solution to the problem that libfuse@2.9.9 (in particular) doesn't build on aarch64 systems. I did not test it exhaustively. 
