### PR TITLE
binutils: add debuginfod variant + update deps

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -89,8 +89,8 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
         deprecated=True,
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("plugins", default=True, description="enable plugins, needed for gold linker")
     # When you build ld.gold you automatically get ld, even when you add the
@@ -124,6 +124,12 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
         description="Enable debug section compression by default in ld, gas, gold.",
         when="@2.26:",
     )
+    variant(
+        "debuginfod",
+        default=False,
+        description="Enable debuginfod HTTP server support for readelf and objdump",
+        when="@2.34:",
+    )
 
     patch("cr16.patch", when="@:2.29.1")
     patch("update_symbol-2.26.patch", when="@2.26")
@@ -134,12 +140,15 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     patch("gold-gcc4.patch", when="@2.42 %gcc@:4.8.5")
 
     # compression libs for debug symbols.
-    # pkg-config is used to find zstd in gas/configure
-    depends_on("pkgconfig", type="build")
     depends_on("zstd@1.4.0:", when="@2.40:")
     depends_on("zlib-api")
 
+    depends_on("elfutils+debuginfod", when="+debuginfod")
+
+    # pkg-config is used to locate zstd, libdebuginfod
+    depends_on("pkgconfig", type="build")
     depends_on("diffutils", type="build")
+
     depends_on("gettext", when="+nls")
 
     # PGO runs tests, which requires `runtest` from dejagnu
@@ -280,17 +289,18 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
             "--enable-targets={}".format(targets),
             "--with-sysroot=/",
             "--with-system-zlib",
+            *self.enable_or_disable("gas"),
+            *self.enable_or_disable("gold"),
+            *self.enable_or_disable("gprofng"),
+            *self.enable_or_disable("install-libiberty", variant="libiberty"),
+            *self.enable_or_disable("interwork"),
+            *self.enable_or_disable("ld"),
+            *self.enable_or_disable("libs"),
+            *self.enable_or_disable("lto"),
+            *self.enable_or_disable("nls"),
+            *self.enable_or_disable("plugins"),
+            *self.with_or_without("debuginfod"),
         ]
-        args += self.enable_or_disable("gas")
-        args += self.enable_or_disable("gold")
-        args += self.enable_or_disable("gprofng")
-        args += self.enable_or_disable("install-libiberty", variant="libiberty")
-        args += self.enable_or_disable("interwork")
-        args += self.enable_or_disable("ld")
-        args += self.enable_or_disable("libs")
-        args += self.enable_or_disable("lto")
-        args += self.enable_or_disable("nls")
-        args += self.enable_or_disable("plugins")
         if self.spec.satisfies("+pgo"):
             args.append("--enable-pgo-build=lto")
         else:

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -91,6 +91,11 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     conflicts("%gcc@7.2.0:", when="@0.163")
 
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=32684 elfutils on aarch64 requires
+    # linux-headers 5.0 or higher, which is a dependency of glibc we don't model. So this is a more
+    # strict constraint than necessary.
+    conflicts("@0.192 arch=aarch64:")
+
     provides("elf@1")
 
     # libarchive with iconv doesn't configure (still broken as of libarchive@3.7.1)

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -83,8 +83,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     # debuginfod has extra dependencies
     with when("+debuginfod"), default_args(type="link"):
-        # NB: Waiting on an elfutils patch before we can use libmicrohttpd@0.9.51
-        depends_on("libmicrohttpd@0.9.33:0.9.50")
+        depends_on("libmicrohttpd@0.9.33:")
         depends_on("libarchive@3.1.2:")
         depends_on("sqlite@3.7.17:")
         depends_on("curl@7.29.0:")

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -26,6 +26,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     license("GPL-3.0-or-later AND ( GPL-2.0-or-later OR LGPL-3.0-or-later )")
 
+    version("0.192", sha256="616099beae24aba11f9b63d86ca6cc8d566d968b802391334c91df54eab416b4")
     version("0.191", sha256="df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871")
     version("0.190", sha256="8e00a3a9b5f04bc1dc273ae86281d2d26ed412020b391ffcc23198f10231d692")
     version("0.189", sha256="39bd8f1a338e2b7cd4abc3ff11a0eddc6e690f69578a57478d8179b4148708c8")
@@ -49,8 +50,8 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     version("0.168", sha256="b88d07893ba1373c7dd69a7855974706d05377766568a7d9002706d5de72c276")
     version("0.163", sha256="7c774f1eef329309f3b05e730bdac50013155d437518a2ec0e24871d312f2e23")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # Native language support from libintl.
     variant("nls", default=True, description="Enable Native Language Support.")
@@ -81,11 +82,13 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     depends_on("pkgconfig@0.9.0:", type=("build", "link"))
 
     # debuginfod has extra dependencies
-    # NB: Waiting on an elfutils patch before we can use libmicrohttpd@0.9.51
-    depends_on("libmicrohttpd@0.9.33:0.9.50", type="link", when="+debuginfod")
-    depends_on("libarchive@3.1.2:", type="link", when="+debuginfod")
-    depends_on("sqlite@3.7.17:", type="link", when="+debuginfod")
-    depends_on("curl@7.29.0:", type="link", when="+debuginfod")
+    with when("+debuginfod"), default_args(type="link"):
+        # NB: Waiting on an elfutils patch before we can use libmicrohttpd@0.9.51
+        depends_on("libmicrohttpd@0.9.33:0.9.50")
+        depends_on("libarchive@3.1.2:")
+        depends_on("sqlite@3.7.17:")
+        depends_on("curl@7.29.0:")
+        depends_on("json-c@0.11:", when="@0.192:")
 
     conflicts("%gcc@7.2.0:", when="@0.163")
 
@@ -154,6 +157,10 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
             args.append("--disable-debuginfod")
             if spec.satisfies("@0.181:"):
                 args.append("--disable-libdebuginfod")
+
+        if spec.satisfies("@0.192:"):
+            # only relevant for rhel/fedora, disabled cause it requires a dependency on rpm.
+            args.append("--disable-debuginfod-ima-verification")
 
         return args
 

--- a/var/spack/repos/builtin/packages/json-c/package.py
+++ b/var/spack/repos/builtin/packages/json-c/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import cmake
 from spack.package import *
 
 
@@ -13,47 +14,38 @@ class JsonC(CMakePackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("0.18", sha256="876ab046479166b869afc6896d288183bbc0e5843f141200c677b3e8dfb11724")
     version("0.16", sha256="8e45ac8f96ec7791eaf3bb7ee50e9c2100bbbc87b8d0f1d030c5ba8a0288d96b")
     version("0.15", sha256="b8d80a1ddb718b3ba7492916237bbf86609e9709fb007e7f7d4322f02341a4c6")
     version("0.14", sha256="b377de08c9b23ca3b37d9a9828107dff1de5ce208ff4ebb35005a794f30c6870")
-    version("0.13.1", sha256="b87e608d4d3f7bfdd36ef78d56d53c74e66ab278d318b71e6002a369d36f4873")
-    version("0.12.1", sha256="2a136451a7932d80b7d197b10441e26e39428d67b1443ec43bbba824705e1123")
-    version("0.12", sha256="000c01b2b3f82dcb4261751eb71f1b084404fb7d6a282f06074d3c17078b9f3f")
-    version("0.11", sha256="28dfc65145dc0d4df1dfe7701ac173c4e5f9347176c8983edbfac9149494448c")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    with default_args(deprecated=True):
+        version(
+            "0.13.1", sha256="b87e608d4d3f7bfdd36ef78d56d53c74e66ab278d318b71e6002a369d36f4873"
+        )
+        version(
+            "0.12.1", sha256="2a136451a7932d80b7d197b10441e26e39428d67b1443ec43bbba824705e1123"
+        )
+        version("0.12", sha256="000c01b2b3f82dcb4261751eb71f1b084404fb7d6a282f06074d3c17078b9f3f")
+        version("0.11", sha256="28dfc65145dc0d4df1dfe7701ac173c4e5f9347176c8983edbfac9149494448c")
+
+    depends_on("c", type="build")
 
     build_system(
         conditional("cmake", when="@0.14:"),
-        conditional("autotools", when="@:0.13.1"),
+        conditional("autotools", when="@:0.13"),
         default="cmake",
     )
 
     depends_on("autoconf", when="build_system=autotools", type="build")
+    depends_on("cmake@3.9:", when="@0.17: build_system=cmake", type="build")
 
-    parallel = False
+    @property
+    def parallel(self):
+        # autotools issue with make -j: https://github.com/json-c/json-c/issues/75
+        return not self.spec.satisfies("build_system=autotools")
 
-    @when("@0.12:0.12.1 %gcc@7:")
-    def patch(self):
-        filter_file(
-            "-Wextra",
-            "-Wextra -Wno-error=implicit-fallthrough " "-Wno-error=unused-but-set-variable",
-            "Makefile.in",
-        )
 
-    @when("%cce@11.0.3:")
-    def patch(self):
-        filter_file("-Werror", "", "CMakeLists.txt")
-
-    def flag_handler(self, name, flags):
-        if name == "cflags":
-            if self.spec.satisfies("%oneapi"):
-                flags.append("-Wno-error=implicit-function-declaration")
-        return (flags, None, None)
-
-    @run_after("install")
-    def darwin_fix(self):
-        # The shared library is not installed correctly on Darwin; fix this
-        if "platform=darwin" in self.spec:
-            fix_darwin_install_name(self.prefix.lib)
+class CMakeBuilder(cmake.CMakeBuilder):
+    def cmake_args(self):
+        return [self.define("DISABLE_WERROR", True)]

--- a/var/spack/repos/builtin/packages/libmicrohttpd/package.py
+++ b/var/spack/repos/builtin/packages/libmicrohttpd/package.py
@@ -17,6 +17,8 @@ class Libmicrohttpd(AutotoolsPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("1.0.1", sha256="a89e09fc9b4de34dde19f4fcb4faaa1ce10299b9908db1132bbfa1de47882b94")
+    version("0.9.77", sha256="9e7023a151120060d2806a6ea4c13ca9933ece4eacfc5c9464d20edddb76b0a0")
     version("0.9.76", sha256="f0b1547b5a42a6c0f724e8e1c1cb5ce9c4c35fb495e7d780b9930d35011ceb4c")
     version("0.9.75", sha256="9278907a6f571b391aab9644fd646a5108ed97311ec66f6359cebbedb0a4e3bb")
     version("0.9.74", sha256="42035d0261373324bfb434018f4ab892514b10253d1af232e41b4cc2c11e650b")
@@ -26,7 +28,7 @@ class Libmicrohttpd(AutotoolsPackage):
     version("0.9.70", sha256="90d0a3d396f96f9bc41eb0f7e8187796049285fabef82604acd4879590977307")
     version("0.9.50", sha256="d1b6385068abded29b6470e383287aa7705de05ae3c08ad0bf5747ac4dc6ebd7")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     variant("https", default=False, description="HTTPS support with GnuTLS")
 


### PR DESCRIPTION
Closes #38160.

- `binutils`: add `~debuginfod` by default (`+debuginfod` adds a huge amount of dependencies, complicating compiler bootstrapping)
- `json-c`: deprecate versions with `build_system=autotools`.
- `elfutils`: add new version, add `json-c` dep, remove incorrect forward compat bound with `libmicrohttpd` (I think both upperbounds were wrong: `@:0.9.51` was probably the result of misreading the build log, and `@:0.9.70` seems to be unnecessary also with the latest elfutils at that time, which works fine with libmicrohttpd@1.)
- `libmicrohttpd`: bump versions