### PR TITLE
Petsc: add in  hipblas dependency on hipblas-common

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -721,7 +721,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 hip_ipkgs.extend(["rocrand"])
             else:
                 hip_lpkgs.extend(["rocrand"])
-            if spec.satisfies("^hipblas@6.3.0:"):
+            if spec.satisfies("^hipblas-common"):
                 hip_ipkgs.extend(["hipblas-common"])
             hip_inc = ""
             hip_lib = ""

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -356,6 +356,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     with when("+rocm"):
         depends_on("rocm-core")
         depends_on("hipblas")
+        depends_on("hipblas-common", when="^hipblas@6.3.0:")
         depends_on("hipsparse")
         depends_on("hipsolver")
         depends_on("rocsparse")


### PR DESCRIPTION
Fix rocm include flags logic to check if `hipblas-common` is in the `spec`. This fix is needed when `hipblas` is declared as an external package, in which case `hipblas-common` is not present in the `spec`.

