### PR TITLE
Put in maintainers for Kokkos Tools Spack package 

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-tools/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-tools/package.py
@@ -10,7 +10,7 @@ class KokkosTools(CMakePackage):
 
     homepage = "https://github.com/kokkos/kokkos-tools/"
     git = "https://github.com/kokkos/kokkos-tools.git"
-    maintainers = ("jennfshr" , "vlkale", "rbberger") 
+    maintainers = ("jennfshr", "vlkale", "rbberger") 
     license("Apache-2.0 WITH LLVM-exception")
 
     version("develop", branch="develop")

--- a/var/spack/repos/builtin/packages/kokkos-tools/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-tools/package.py
@@ -10,7 +10,7 @@ class KokkosTools(CMakePackage):
 
     homepage = "https://github.com/kokkos/kokkos-tools/"
     git = "https://github.com/kokkos/kokkos-tools.git"
-    maintainers = ("jennfshr", "vlkale", "rbberger") 
+    maintainers = ("jennfshr", "vlkale", "rbberger")
     license("Apache-2.0 WITH LLVM-exception")
 
     version("develop", branch="develop")

--- a/var/spack/repos/builtin/packages/kokkos-tools/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-tools/package.py
@@ -10,7 +10,7 @@ class KokkosTools(CMakePackage):
 
     homepage = "https://github.com/kokkos/kokkos-tools/"
     git = "https://github.com/kokkos/kokkos-tools.git"
-    maintainers = ("jennfshr", "vlkale", "rbberger")
+    maintainers("jennfshr", "vlkale", "rbberger")
     license("Apache-2.0 WITH LLVM-exception")
 
     version("develop", branch="develop")

--- a/var/spack/repos/builtin/packages/kokkos-tools/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-tools/package.py
@@ -10,7 +10,7 @@ class KokkosTools(CMakePackage):
 
     homepage = "https://github.com/kokkos/kokkos-tools/"
     git = "https://github.com/kokkos/kokkos-tools.git"
-
+    maintainers = ("jennfshr" , "vlkale", "rbberger") 
     license("Apache-2.0 WITH LLVM-exception")
 
     version("develop", branch="develop")


### PR DESCRIPTION
This PR adds the current list of maintainers to the Kokkos Tools Spack package, which was not put in when it was developed and then merged. See the Spack PR for the Kokkos Tools package in #45382 for context of the package's development. 