### PR TITLE
ci: print spec in each rebuild job

### DIFF
--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -582,6 +582,7 @@ class SpackCIConfig:
                     "script": [
                         "cd {env_dir}",
                         "spack env activate --without-view .",
+                        "spack spec /$SPACK_JOB_SPEC_DAG_HASH",
                         "spack ci rebuild",
                     ]
                 }

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -339,6 +339,7 @@ spack:
             "spack -d ci rebuild",
             "cd ENV",
             "spack env activate --without-view .",
+            "spack spec /$SPACK_JOB_SPEC_DAG_HASH",
             "spack ci rebuild",
         ]
         assert ci_obj["after_script"] == ["rm -rf /some/path/spack"]


### PR DESCRIPTION
Suggestion from @white238 and @balos1 that seemed worth including in the default.

Provides an option for the user to visually confirm the spec for a particular CI rebuild.
