### PR TITLE
Do not attempt to invoke parallel `nmake`

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -186,7 +186,8 @@ class MakeExecutable(Executable):
         output: Union[Optional[TextIO], str] = ...,
         error: Union[Optional[TextIO], str] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     @overload
     def __call__(
@@ -205,7 +206,8 @@ class MakeExecutable(Executable):
         output: Union[Type[str], Callable] = ...,
         error: Union[Optional[TextIO], str, Type[str], Callable] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
-    ) -> str: ...
+    ) -> str:
+        ...
 
     @overload
     def __call__(
@@ -224,7 +226,8 @@ class MakeExecutable(Executable):
         output: Union[Optional[TextIO], str, Type[str], Callable] = ...,
         error: Union[Type[str], Callable] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
-    ) -> str: ...
+    ) -> str:
+        ...
 
     def __call__(
         self,

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -577,11 +577,13 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
     # TODO: johnwparent: add package or builder support to define these build tools
     # for now there is no entrypoint for builders to define these on their
     # own
+    # TODO: johnwparent: Once compilers as nodes lands, make the three
+    # tools below DeprecatedExecutable
     if sys.platform == "win32":
-        module.nmake = Executable("nmake")
-        module.msbuild = Executable("msbuild")
+        module.nmake = MakeExecutable("nmake", jobs=1)
+        module.msbuild = MakeExecutable("msbuild", jobs=1)
         # analog to configure for win32
-        module.cscript = Executable("cscript")
+        module.cscript = MakeExecutable("cscript", jobs=1)
 
     # Find the configure script in the archive path
     # Don't use which for this; we want to find it in the current dir.

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -580,10 +580,10 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
     # TODO: johnwparent: Once compilers as nodes lands, make the three
     # tools below DeprecatedExecutable
     if sys.platform == "win32":
-        module.nmake = Executable("nmake", jobs=1)
-        module.msbuild = Executable("msbuild", jobs=1)
+        module.nmake = Executable("nmake")
+        module.msbuild = Executable("msbuild")
         # analog to configure for win32
-        module.cscript = MakeExecutable("cscript", jobs=1)
+        module.cscript = Executable("cscript")
 
     # Find the configure script in the archive path
     # Don't use which for this; we want to find it in the current dir.

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -574,14 +574,10 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
     module.make = DeprecatedExecutable(pkg.name, "make", "gmake")
     module.gmake = DeprecatedExecutable(pkg.name, "gmake", "gmake")
     module.ninja = DeprecatedExecutable(pkg.name, "ninja", "ninja")
-    # TODO: johnwparent: add package or builder support to define these build tools
-    # for now there is no entrypoint for builders to define these on their
-    # own
-    # TODO: johnwparent: Once compilers as nodes lands, make the three
-    # tools below DeprecatedExecutable
+
     if sys.platform == "win32":
-        module.nmake = Executable("nmake")
-        module.msbuild = Executable("msbuild")
+        module.nmake = DeprecatedExecutable(pkg.name, "nmake", "msvc")
+        module.msbuild = DeprecatedExecutable(pkg.name, "msbuild", "msvc")
         # analog to configure for win32
         module.cscript = Executable("cscript")
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -186,8 +186,7 @@ class MakeExecutable(Executable):
         output: Union[Optional[TextIO], str] = ...,
         error: Union[Optional[TextIO], str] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @overload
     def __call__(
@@ -206,8 +205,7 @@ class MakeExecutable(Executable):
         output: Union[Type[str], Callable] = ...,
         error: Union[Optional[TextIO], str, Type[str], Callable] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
-    ) -> str:
-        ...
+    ) -> str: ...
 
     @overload
     def __call__(
@@ -226,8 +224,7 @@ class MakeExecutable(Executable):
         output: Union[Optional[TextIO], str, Type[str], Callable] = ...,
         error: Union[Type[str], Callable] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
-    ) -> str:
-        ...
+    ) -> str: ...
 
     def __call__(
         self,

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -580,8 +580,8 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
     # TODO: johnwparent: Once compilers as nodes lands, make the three
     # tools below DeprecatedExecutable
     if sys.platform == "win32":
-        module.nmake = MakeExecutable("nmake", jobs=1)
-        module.msbuild = MakeExecutable("msbuild", jobs=1)
+        module.nmake = Executable("nmake", jobs=1)
+        module.msbuild = Executable("msbuild", jobs=1)
         # analog to configure for win32
         module.cscript = MakeExecutable("cscript", jobs=1)
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -162,6 +162,7 @@ pwd = getcwd
 configure: Executable
 make_jobs: int
 make: MakeExecutable
+nmake: MakeExecutable
 ninja: MakeExecutable
 python_include: str
 python_platlib: str

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -162,7 +162,7 @@ pwd = getcwd
 configure: Executable
 make_jobs: int
 make: MakeExecutable
-nmake: MakeExecutable
+nmake: Executable
 ninja: MakeExecutable
 python_include: str
 python_platlib: str

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -131,7 +131,6 @@ class Bzip2(Package, SourcewarePackage):
         # Build the static library and everything else
         if self.spec.satisfies("platform=windows"):
             # Build step
-            nmake = Executable("nmake.exe")
             nmake("-f", "makefile.msc")
             # Install step
             mkdirp(self.prefix.include)

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -94,8 +94,8 @@ class Msvc(Package, CompilerPackage):
         """Populates dependent module with tooling available from VS"""
         # We want these to resolve to the paths set by MSVC's VCVARs
         # so no paths
-        module.nmake = MakeExecutable("nmake", jobs=1)
-        module.msbuild = MakeExecutable("msbuild", jobs=1)
+        module.nmake = Executable("nmake")
+        module.msbuild = Executable("msbuild")
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.init_msvc()

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -89,7 +89,7 @@ class Msvc(Package, CompilerPackage):
         if fortran_compiler is not None:
             extras["compilers"]["fortran"] = fortran_compiler
         return spec, extras
-    
+
     def setup_dependent_package(self, module, dependent_spec):
         """Populates dependent module with tooling available from VS"""
         # We want these to resolve to the paths set by MSVC's VCVARs

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -89,6 +89,13 @@ class Msvc(Package, CompilerPackage):
         if fortran_compiler is not None:
             extras["compilers"]["fortran"] = fortran_compiler
         return spec, extras
+    
+    def setup_dependent_package(self, module, dependent_spec):
+        """Populates dependent module with tooling available from VS"""
+        # We want these to resolve to the paths set by MSVC's VCVARs
+        # so no paths
+        module.nmake = MakeExecutable("nmake", jobs=1)
+        module.msbuild = MakeExecutable("msbuild", jobs=1)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.init_msvc()

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -95,4 +95,4 @@ class NetcdfCxx4(CMakePackage):
 
     def check(self):
         with working_dir(self.build_directory):
-            make("test", parallel=False)
+            ctest()

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -189,18 +189,20 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
 
         if spec.satisfies("platform=windows"):
             host_make = nmake
+            make_args = {}
         else:
             host_make = make
+            make_args = {"parallel": False}
 
         host_make()
 
         if self.run_tests:
-            host_make("test", parallel=False)  # 'VERBOSE=1'
+            host_make("test", **make_args)  # 'VERBOSE=1'
 
         install_tgt = "install" if self.spec.satisfies("+docs") else "install_sw"
 
         # See https://github.com/openssl/openssl/issues/7466#issuecomment-432148137
-        host_make(install_tgt, parallel=False)
+        host_make(install_tgt, *make_args)
 
     @run_after("install")
     def link_system_certs(self):

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -202,7 +202,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
         install_tgt = "install" if self.spec.satisfies("+docs") else "install_sw"
 
         # See https://github.com/openssl/openssl/issues/7466#issuecomment-432148137
-        host_make(install_tgt, *make_args)
+        host_make(install_tgt, **make_args)
 
     @run_after("install")
     def link_system_certs(self):

--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -49,4 +49,4 @@ class Pegtl(CMakePackage):
     @on_package_attributes(run_tests=True)
     def check(self):
         with working_dir(self.build_directory):
-            make("test", parallel=False)
+            ctest()


### PR DESCRIPTION
Adds a setup method to the msvc compiler class to effect this once compilers as nodes lands

Fixes a build error for OpenSSL on Windows (and any other package that accidentally invokes `nmake` with the `parallel` flag)

Refactors any useage of make to drive ctest in CMake packages ported to Windows


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
