### PR TITLE
celeritas: prevent 0.5.0 with geant4@11.3

### DIFF
--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -72,6 +72,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("nlohmann-json")
     depends_on("geant4@10.5:", when="@0.4.2: +geant4")
     depends_on("geant4@10.5:11.1", when="@0.3.1:0.4.1 +geant4")
+    depends_on("geant4@:11.2", when="@:0.5.0 +geant4")
     depends_on("hepmc3", when="+hepmc3")
     depends_on("root", when="+root")
     depends_on("swig@4.1:", when="+swig")


### PR DESCRIPTION
This PR ensures that `celeritas` up to 0.5.0 will depend on geant4 up to at most 11.2, due to https://github.com/celeritas-project/celeritas/pull/1484.