### PR TITLE
spack debug create-db-tarball: remove after test failures

### DIFF
--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -2,50 +2,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import platform
-
-import pytest
 
 import spack
 import spack.platforms
 import spack.spec
-from spack.database import INDEX_JSON_FILE
 from spack.main import SpackCommand
-from spack.util.executable import which
 
 debug = SpackCommand("debug")
-
-
-@pytest.mark.db
-def test_create_db_tarball(tmpdir, database):
-    with tmpdir.as_cwd():
-        debug("create-db-tarball")
-
-        # get the first non-dotfile to avoid coverage files in the directory
-        files = os.listdir(os.getcwd())
-        tarball_name = next(
-            f for f in files if not f.startswith(".") and not f.startswith("tests")
-        )
-
-        # debug command made an archive
-        assert os.path.exists(tarball_name)
-
-        # print contents of archive
-        tar = which("tar")
-        contents = tar("tzf", tarball_name, output=str)
-
-        # DB file is included
-        assert INDEX_JSON_FILE in contents
-
-        # specfiles from all installs are included
-        for spec in database.query():
-            # externals won't have a specfile
-            if spec.external:
-                continue
-
-            spec_suffix = "%s/.spack/spec.json" % spec.dag_hash()
-            assert spec_suffix in contents
 
 
 def test_report():

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -929,12 +929,8 @@ _spack_debug() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create-db-tarball report"
+        SPACK_COMPREPLY="report"
     fi
-}
-
-_spack_debug_create_db_tarball() {
-    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_debug_report() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1317,15 +1317,9 @@ complete -c spack -n '__fish_spack_using_command create' -s b -l batch -d 'don'"
 
 # spack debug
 set -g __fish_spack_optspecs_spack_debug h/help
-complete -c spack -n '__fish_spack_using_command_pos 0 debug' -f -a create-db-tarball -d 'create a tarball of Spack'"'"'s installation metadata'
 complete -c spack -n '__fish_spack_using_command_pos 0 debug' -f -a report -d 'print information useful for bug reports'
 complete -c spack -n '__fish_spack_using_command debug' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command debug' -s h -l help -d 'show this help message and exit'
-
-# spack debug create-db-tarball
-set -g __fish_spack_optspecs_spack_debug_create_db_tarball h/help
-complete -c spack -n '__fish_spack_using_command debug create-db-tarball' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command debug create-db-tarball' -s h -l help -d 'show this help message and exit'
 
 # spack debug report
 set -g __fish_spack_optspecs_spack_debug_report h/help


### PR DESCRIPTION
```spack debug create-db-tarball``` is causing test failures. Fixing it is trivial, but after skimming through the implementation, it relies on default projections for `glob` and on specific GNU `tar` features instead of using tarfile.

I think it's better to remove than to fix, given I've never seen anybody use this. Reverting is easy.