### PR TITLE
util/tty/colify: make COLIFY_SIZE case-insensitive

### DIFF
--- a/lib/spack/spack/llnl/util/tty/colify.py
+++ b/lib/spack/spack/llnl/util/tty/colify.py
@@ -138,7 +138,7 @@ def colify(
     env_size = os.environ.get("COLIFY_SIZE")
     if env_size:
         try:
-            console_cols = int(env_size.partition("x")[2])
+            console_cols = int(env_size.lower().partition("x")[2])
             tty = True
         except ValueError:
             pass


### PR DESCRIPTION
Unless there is a convention I'm unfamiliar with, it seems like this should work in a case-insensitive manner.
