### PR TITLE
CachedCMakePackage: Improve finding mpiexec for non-slurm machines

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -189,14 +189,18 @@ class CachedCMakeBuilder(CMakeBuilder):
 
     def get_scheduler(self) -> Optional[Scheduler]:
         spec = self.pkg.spec
+
+        # Check for Spectrum-mpi, which always uses LSF or LSF MPI variant
         if spec.satisfies("^spectrum-mpi") or spec["mpi"].satisfies("schedulers=lsf"):
             return self.Scheduler.LSF
 
+        # Check for Slurm MPI variants
         slurm_checks = ["+slurm", "schedulers=slurm", "process_managers=slurm"]
         if any(spec["mpi"].satisfies(variant) for variant in slurm_checks):
             return self.Scheduler.SLURM
 
         # TODO improve this when MPI implementations support flux
+        # Do this check last to avoid using a flux wrapper present next to Slurm/ LSF schedulers
         if which_string("flux") is not None:
             return self.Scheduler.FLUX
 

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -11,9 +11,9 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 import spack.phase_callbacks
+import spack.spec
 import spack.util.prefix
 from spack.directives import depends_on
-from spack.spec import Spec
 from spack.util.executable import which_string
 
 from .cmake import CMakeBuilder, CMakePackage
@@ -377,7 +377,7 @@ class CachedCMakeBuilder(CMakeBuilder):
         return []
 
     def initconfig(
-        self, pkg: "CachedCMakePackage", spec: Spec, prefix: spack.util.prefix.Prefix
+        self, pkg: "CachedCMakePackage", spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         cache_entries = (
             self.std_initconfig_entries()

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -8,7 +8,6 @@ import socket
 from os.path import join as pjoin
 
 from spack.package import *
-from spack.util.executable import which_string
 
 
 def get_spec_path(spec, package_name, path_replacements={}, use_bin=False):
@@ -452,19 +451,6 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_MPI", True))
             if spec["mpi"].name == "spectrum-mpi":
                 entries.append(cmake_cache_string("BLT_MPI_COMMAND_APPEND", "mpibind"))
-
-            # Replace /usr/bin/srun path with srun flux wrapper path on TOSS 4
-            # TODO: Remove this logic by adding `using_flux` case in
-            #  spack/lib/spack/spack/build_systems/cached_cmake.py:196 and remove hard-coded
-            #  path to srun in same file.
-            if "toss_4" in self._get_sys_type(spec):
-                srun_wrapper = which_string("srun")
-                mpi_exec_index = [
-                    index for index, entry in enumerate(entries) if "MPIEXEC_EXECUTABLE" in entry
-                ]
-                if mpi_exec_index:
-                    del entries[mpi_exec_index[0]]
-                entries.append(cmake_cache_path("MPIEXEC_EXECUTABLE", srun_wrapper))
         else:
             entries.append(cmake_cache_option("ENABLE_MPI", False))
 


### PR DESCRIPTION
Resolves https://github.com/spack/spack/issues/42298 by using `which(srun)` to determine srun path, which also works for machines with flux (and wrappers) instead of slurm.

I have tested this with the Quandary CI where I encountered the issue and this fix works on Ruby (slurm), Tioga (flux with slurm wrappers), and Lassen (LSF with srun). Let me know if you can think of other tests that would be useful!