### PR TITLE
Add explicit path to zlib library to link to

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -62,6 +62,9 @@ class CMakeBuilder(CMakeBuilder):
             self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
+        zlib_lib = self.spec["zlib-api"].libs
+        if zlib_lib:
+            args.append(self.define("ZLIB_LIBRARY", zlib_lib[0]))
         if self.spec.satisfies("platform=darwin target=aarch64:"):
             args.append("-DPNG_ARM_NEON=off")
         return args


### PR DESCRIPTION
CMake's find zlib looks for zlib before zdll. On Windows zlib is the static lib, and zdll the import library. LibPNG only links to shared zlib, but recieves zlib on Windows, resulting in a search for non import mangled symbols, which results in a linker failure. The directly provides the correct library to the libpng CMake
