### PR TITLE
e4s oneapi ci stack: mpi: require intel-oneapi-mpi

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -38,9 +38,12 @@ spack:
     xz:
       variants: +pic
     mpi:
-      require: 'mpich@4: target=x86_64_v3'
-    mpich:
-      require: '~wrapperrpath ~hwloc target=x86_64_v3'
+      require: intel-oneapi-mpi
+    intel-oneapi-mpi:
+      buildable: false
+      externals:
+      - spec: intel-oneapi-mpi@2021.13.1
+        prefix: /opt/intel/oneapi
     unzip:
       require: '%gcc target=x86_64_v3'
     binutils:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -131,7 +131,7 @@ spack:
   - nccmp
   - nco
   - netlib-scalapack
-  - nrm
+  - nrm ^py-scipy cflags="-Wno-error=incompatible-function-pointer-types"
   - nwchem
   - omega-h
   - openfoam

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -131,7 +131,7 @@ spack:
   - nccmp
   - nco
   - netlib-scalapack
-  - nrm ^py-scipy cflags="-Wno-error=incompatible-function-pointer-types"
+  - nrm ^py-scipy cflags="-Wno-error=incompatible-function-pointer-types" # py-scipy@1.8.1 fails without cflags here
   - nwchem
   - omega-h
   - openfoam


### PR DESCRIPTION
E4S OneAPI CI Stack - require `intel-oneapi-mpi` as the MPI provider.

FYI @PiotrSacharuk @rscohn2 -- I may have to iterate on this PR a bit in the event there are some packages that have an issue with this.