### PR TITLE
Fix OSError when running multiple spack install

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -246,7 +246,7 @@ class LockableStagingDir:
         if not self._lock:
             sha1 = hashlib.sha1(self.name.encode("utf-8")).digest()
             lock_id = prefix_bits(sha1, bit_length(sys.maxsize))
-            stage_lock_path = os.path.join(get_stage_root(), ".lock")
+            stage_lock_path = os.path.join(get_stage_root(), f"{os.getpid()}.lock")
             self._lock = spack.util.lock.Lock(
                 stage_lock_path, start=lock_id, length=1, desc=self.name
             )


### PR DESCRIPTION
There are scenarios where we might run more than 1 `spack install` on a many core machine, one for each envs, targets, or subset of packages to make full use of all cores to complete the install quickly.

This workaround the bug when running multiple instances
- when one `spack install` completed all build stage, `${spack_stage}/.lock` will be deleted.
- subsequent `spack install` will get OS Error trying to unlock a non-existent `${spack_stage}/.lock`.
- It works by making use of `pid` to distinguish each instance's lock
- new lock path is `${spack_stage}/${os.getpid()}.lock`

