### PR TITLE
fjcontrib: add v1.055, v1.056, and v1.100 with patch

### DIFF
--- a/var/spack/repos/builtin/packages/fjcontrib/configure-1.100.patch
+++ b/var/spack/repos/builtin/packages/fjcontrib/configure-1.100.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 879d44f..b4bab5f 100755
+--- a/configure
++++ b/configure
+@@ -352,7 +352,7 @@ else
+     #dynlibopt="-shared"
+     # the following more elaborate set of options requested by Alexander Puck Neuwirth
+     # for compatibility with gentoo, cf. https://github.com/fjcontrib/fjcontrib/issues/4
+-    dynlibopt="-shared -Wl,--as-needed -Wl,-soname,fastjetcontribfragile.so.0"
++    dynlibopt="-shared -Wl,--as-needed -Wl,-soname,libfastjetcontribfragile.so"
+     dynlibext="so"
+     dynlibpostproc="" # some dummy command needed
+ fi

--- a/var/spack/repos/builtin/packages/fjcontrib/package.py
+++ b/var/spack/repos/builtin/packages/fjcontrib/package.py
@@ -15,6 +15,9 @@ class Fjcontrib(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.100", sha256="52ad945d9195c40f347958dc04041e41c7130e845ebdf0c13f1bbdd5b6d2429b")
+    version("1.056", sha256="fc31544424dece0d0676ea2433ad1e96fd9db82920bc7a7ef6294ce94e659d6e")
+    version("1.055", sha256="d9aa46560fdfd85082f202a5a9ce64768fe0c598660f013206a8c9c17ecd0f36")
     version("1.054", sha256="1ef922d4c45863e5fe7a3b64dc441703db6b1c2cc92d4160125dc629b05ac331")
     version("1.052", sha256="bde63c28cbdf992bedea4ddedfc3cd52c9fec241a767cc455dd4ad10e8210c39")
     version("1.051", sha256="76a2ec612c768db3eb6bbaf686d02b05ddb64dde477d185e20df563b52308473")
@@ -66,6 +69,9 @@ class Fjcontrib(AutotoolsPackage):
     version("1.000", sha256="95fa36ae48f03cb941d632b0a537995fb7148a6bd028c4978fab8b7b04332c3b")
     version("0.001", sha256="51f24ad55e28fb1f9d698270602e5077c920fcf58d8ccfd274efbe829d7dd821")
     version("0.000", sha256="9486b11201e6b6e181b8a3abecd929403ae9aa67de0eb8b7353fb82ab4b89f41")
+
+    # fix incorrect soname in 1.100
+    patch("configure-1.100.patch", when="@1.100")
 
     depends_on("cxx", type="build")  # generated
 


### PR DESCRIPTION
This PR adds 'fjcontrib`, v1.055, v1.056, and v1.100 ([diff](https://github.com/fjcontrib/fjcontrib/compare/1.054...1.100)). No build system or dependency changes, but a patch is needed for 1.100 to fix an incorrect soname (only affects that version, and is fixed in main branch). Build will be tested in CI.