### PR TITLE
emacs: improve gui variant to cover both linux and macos

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -9,17 +9,22 @@ from spack.package import *
 
 
 class Emacs(AutotoolsPackage, GNUMirrorPackage):
-    """The Emacs programmable text editor."""
+    """Emacs is an extensible, customizable, free/libre text editor.
+    At its core is an interpreter for Emacs Lisp, a dialect of the Lisp
+    programming language with extensions to support text editing."""
 
     homepage = "https://www.gnu.org/software/emacs"
-    git = "https://git.savannah.gnu.org/git/emacs.git"
     gnu_mirror_path = "emacs/emacs-24.5.tar.gz"
-    list_url = " https://ftpmirror.gnu.org/emacs/"
+    git = "https://git.savannah.gnu.org/git/emacs.git"
+    list_url = "https://ftpmirror.gnu.org/emacs/"
     list_depth = 0
 
     maintainers("alecbcs")
 
     license("GPL-3.0-or-later", checked_by="wdconinc")
+
+    sanity_check_is_file = ["bin/emacs"]
+    sanity_check_is_dir = ["share/emacs"]
 
     version("master", branch="master")
     version("29.4", sha256="1adb1b9a2c6cdb316609b3e86b0ba1ceb523f8de540cfdda2aec95b6a5343abf")
@@ -38,35 +43,50 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     version("25.1", sha256="763344b90db4d40e9fe90c5d14748a9dbd201ce544e2cf0835ab48a0aa4a1c67")
     version("24.5", sha256="2737a6622fb2d9982e9c47fb6f2fb297bda42674e09db40fc9bcc0db4297c3b6")
 
-    variant("gui", default=False, description="Enable GUI build on Mac")
-    variant("json", default=False, when="@27:", description="Build with json support")
-    variant("native", default=False, when="@28:", description="enable native compilation of elisp")
-    variant("tls", default=True, description="Build Emacs with gnutls")
-    variant("treesitter", default=False, when="@29:", description="Build with tree-sitter support")
-    variant("X", default=False, description="Enable an X toolkit")
+    variant(
+        "gui",
+        default="none",
+        values=("none", "x11", "cocoa"),
+        description="GUI support (none=terminal only, x11=X11, cocoa=macOS)",
+    )
     variant(
         "toolkit",
         default="gtk",
         values=("gtk", "athena"),
-        description="Select an X toolkit (gtk, athena)",
+        description="X11 toolkit when gui=x11 (gtk, athena)",
+        when="gui=x11",
     )
+    variant("json", default=False, when="@27:", description="Build with json support")
+    variant("native", default=False, when="@28:", description="Enable native compilation of elisp")
+    variant("tls", default=True, description="Build with gnutls support")
+    variant("treesitter", default=False, when="@29:", description="Build with tree-sitter support")
 
+    # Build dependencies
     depends_on("c", type="build")
+
     depends_on("pkgconfig", type="build")
     depends_on("gzip", type="build")
     depends_on("texinfo", type="build", when="@29.4:")
+    depends_on("m4", type="build", when="@master:")
+    depends_on("autoconf", type="build", when="@master:")
+    depends_on("automake", type="build", when="@master:")
+    depends_on("libtool", type="build", when="@master:")
 
+    # Required dependencies
     depends_on("ncurses")
     depends_on("pcre")
     depends_on("zlib-api")
     depends_on("libxml2")
     depends_on("jpeg")
-    depends_on("gnutls", when="+tls")
-    depends_on("tree-sitter", when="+treesitter")
-    depends_on("gcc@11: +strip languages=jit", when="+native")
-    depends_on("jansson@2.7:", when="+json")
 
-    with when("+X"):
+    # Optional dependencies
+    depends_on("gnutls", type="link", when="+tls")
+    depends_on("tree-sitter", type="link", when="+treesitter")
+    depends_on("gcc@11: +strip languages=jit", type="link", when="+native")
+    depends_on("jansson@2.7:", type="link", when="+json")
+
+    # GUI dependencies
+    with when("gui=x11"):
         depends_on("libtiff")
         depends_on("libpng")
         depends_on("libxpm")
@@ -75,64 +95,46 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
         depends_on("libxaw", when="toolkit=athena")
         depends_on("gtkplus", when="toolkit=gtk")
 
-    # the following dependencies are required when building from a git ref
-    # so that we can run reconfigure to generate a ./configure script
-    depends_on("m4", type="build", when="@master:")
-    depends_on("autoconf", type="build", when="@master:")
-    depends_on("automake", type="build", when="@master:")
-    depends_on("libtool", type="build", when="@master:")
-
+    # Platform-specific conflicts
+    conflicts("gui=cocoa", when="platform=linux", msg="Use gui=x11 for Linux GUI support")
+    conflicts("gui=cocoa", when="platform=cray", msg="Use gui=x11 for Linux/Cray GUI support")
+    conflicts("gui=x11", when="platform=darwin", msg="Use gui=cocoa for macOS GUI support")
     conflicts("@:26.3", when="platform=darwin os=catalina")
 
-    @when("platform=darwin")
-    def setup_build_environment(self, env):
-        # on macOS, emacs' config does search hard enough for ncurses'
-        # termlib `-ltinfo` lib, which results in linker errors
-        if "+termlib" in self.spec["ncurses"]:
-            env.append_flags("LDFLAGS", "-ltinfo")
-
     def configure_args(self):
-        spec = self.spec
+        args = []
 
-        toolkit = spec.variants["toolkit"].value
-        if spec.satisfies("+X"):
-            args = ["--with-x", "--with-x-toolkit={0}".format(toolkit)]
+        gui = self.spec.variants["gui"].value
+        if gui == "x11":
+            toolkit = self.spec.variants["toolkit"].value
+            args.extend(["--with-x", f"--with-x-toolkit={toolkit}"])
+        elif gui == "cocoa":
+            args.append("--without-x")
+            args.append("--disable-ns-self-contained")
         else:
-            args = ["--without-x"]
-
-        if sys.platform == "darwin":
-            if spec.satisfies("+gui"):
-                # Do not build the self-contained "nextstep/Emacs.app"
-                args.append("--disable-ns-self-contained")
-            else:
-                # Do not build "nextstep/Emacs.app" at all
+            args.append("--without-x")
+            if sys.platform == "darwin":
                 args.append("--without-ns")
 
-        args += self.with_or_without("native-compilation", variant="native")
-        args += self.with_or_without("gnutls", variant="tls")
-        args += self.with_or_without("tree-sitter", variant="treesitter")
-        args += self.with_or_without("json")
+        args.extend(self.with_or_without("native-compilation", variant="native"))
+        args.extend(self.with_or_without("gnutls", variant="tls"))
+        args.extend(self.with_or_without("tree-sitter", variant="treesitter"))
+        args.extend(self.with_or_without("json"))
 
         return args
 
-    @run_after("install")
+    @when("platform=darwin")
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("^ncurses+termlib"):
+            env.append_flags("LDFLAGS", "-ltinfo")
+
+    @run_after("install", when="gui=cocoa")
     def move_macos_app(self):
-        """Move the Emacs.app build on MacOS to <prefix>/Applications.
+        """Move the Emacs.app build on macOS to <prefix>/Applications.
         From there users can move it or link it in ~/Applications."""
-        if sys.platform == "darwin" and "+gui" in self.spec:
-            apps_dir = join_path(self.prefix, "Applications")
-            mkdir(apps_dir)
-            move("nextstep/Emacs.app", apps_dir)
-
-    def run_version_check(self, bin):
-        """Runs and checks output of the installed binary."""
-        exe_path = join_path(self.prefix.bin, bin)
-        if not os.path.exists(exe_path):
-            raise SkipTest(f"{exe_path} is not installed")
-
-        exe = which(exe_path)
-        out = exe("--version", output=str.split, error=str.split)
-        assert str(self.spec.version) in out
+        apps_dir = join_path(self.prefix, "Applications")
+        mkdir(apps_dir)
+        move("nextstep/Emacs.app", apps_dir)
 
     def test_ctags(self):
         """check ctags version"""
@@ -153,3 +155,13 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     def test_etags(self):
         """check etags version"""
         self.run_version_check("etags")
+
+    def run_version_check(self, bin):
+        """Runs and checks output of the installed binary."""
+        exe_path = join_path(self.prefix.bin, bin)
+        if not os.path.exists(exe_path):
+            raise SkipTest(f"{exe_path} is not installed")
+
+        exe = which(exe_path)
+        out = exe("--version", output=str.split, error=str.split)
+        assert str(self.spec.version) in out

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -67,6 +67,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     depends_on("pkgconfig", type="build")
     depends_on("gzip", type="build")
     depends_on("texinfo", type="build", when="@29.4:")
+
     depends_on("m4", type="build", when="@master:")
     depends_on("autoconf", type="build", when="@master:")
     depends_on("automake", type="build", when="@master:")
@@ -80,10 +81,10 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     depends_on("jpeg")
 
     # Optional dependencies
-    depends_on("gnutls", type="link", when="+tls")
-    depends_on("tree-sitter", type="link", when="+treesitter")
-    depends_on("gcc@11: +strip languages=jit", type="link", when="+native")
-    depends_on("jansson@2.7:", type="link", when="+json")
+    depends_on("gnutls", when="+tls")
+    depends_on("tree-sitter", when="+treesitter")
+    depends_on("gcc@11: +strip languages=jit", when="+native")
+    depends_on("jansson@2.7:", when="+json")
 
     # GUI dependencies
     with when("gui=x11"):


### PR DESCRIPTION
Improve the `gui=` variant to be multi-valued to cover both linux and macos.
