### PR TITLE
davix: add v0.8.8, v0.8.9, v0.8.10

### DIFF
--- a/var/spack/repos/builtin/packages/davix/package.py
+++ b/var/spack/repos/builtin/packages/davix/package.py
@@ -82,6 +82,7 @@ class Davix(CMakePackage):
         return [
             self.define_from_variant("CMAKE_CXX_STANDARD", variant="cxxstd"),
             self.define_from_variant("ENABLE_THIRD_PARTY_COPY", variant="thirdparty"),
+            self.define("DAVIX_TESTS", self.run_tests),
             # Disable the use of embedded packages; use Spack to fetch them instead
             self.define("EMBEDDED_LIBCURL", False),
             self.define("EMBEDDED_RAPIDJSON", False),

--- a/var/spack/repos/builtin/packages/davix/package.py
+++ b/var/spack/repos/builtin/packages/davix/package.py
@@ -15,6 +15,9 @@ class Davix(CMakePackage):
 
     license("LGPL-2.1-or-later")
 
+    version("0.8.10", sha256="66aa9adadee6ff2bae14caba731597ba7a7cd158763d9d80a9cfe395afc17403")
+    version("0.8.9", sha256="0dc7e3702500fc4a88e037ababf096e8c1cad2532c34e08add043d4dc84283f6")
+    version("0.8.8", sha256="7ff139babf39030dd9984ad5ff8cd5da1ced2963f53f04efc387101840ff3458")
     version("0.8.7", sha256="78c24e14edd7e4e560392d67147ec8658c2aa0d3640415bdf6bc513afcf695e6")
     version("0.8.6", sha256="7383b6f6595c77a9dc8c03c5483c67dc32bd6d23751e956cf9c174768e7eeb5b")
     version("0.8.5", sha256="f9ce21bcc2ed248f7825059d17577876616258c35177d74fad8f854a818a87f9")
@@ -64,7 +67,7 @@ class Davix(CMakePackage):
     depends_on("libxml2")
     depends_on("uuid")
     depends_on("openssl")
-    depends_on("curl")
+    depends_on("curl", when="@0.8.1:")
     depends_on("rapidjson", when="@0.8.7:")
 
     variant("thirdparty", default=False, description="Build vendored libraries")
@@ -76,5 +79,6 @@ class Davix(CMakePackage):
             self.define_from_variant("ENABLE_THIRD_PARTY_COPY", variant="thirdparty"),
             # Disable the use of embedded packages; use Spack to fetch them instead
             self.define("EMBEDDED_LIBCURL", False),
+            self.define("EMBEDDED_RAPIDJSON", False),
             self.define("CMAKE_MACOSX_RPATH", self.spec.satisfies("platform=darwin")),
         ]

--- a/var/spack/repos/builtin/packages/davix/package.py
+++ b/var/spack/repos/builtin/packages/davix/package.py
@@ -70,6 +70,8 @@ class Davix(CMakePackage):
     depends_on("curl", when="@0.8.1:")
     depends_on("rapidjson", when="@0.8.7:")
 
+    depends_on("googletest", type="test", when="@0.8.8:")
+
     variant("thirdparty", default=False, description="Build vendored libraries")
     depends_on("gsoap", when="+thirdparty")
 

--- a/var/spack/repos/builtin/packages/davix/package.py
+++ b/var/spack/repos/builtin/packages/davix/package.py
@@ -73,6 +73,9 @@ class Davix(CMakePackage):
     variant("thirdparty", default=False, description="Build vendored libraries")
     depends_on("gsoap", when="+thirdparty")
 
+    def url_for_version(self, v):
+        return f"https://github.com/cern-fts/davix/releases/download/R_{v.underscored}/davix-{v}.tar.gz"
+
     def cmake_args(self):
         return [
             self.define_from_variant("CMAKE_CXX_STANDARD", variant="cxxstd"),


### PR DESCRIPTION
This PR adds `davix`, v0.8.8, v0.8.9, v0.8.10 ([diff](https://github.com/cern-fts/davix/compare/R_0_8_7...R_0_8_10)). No build system or dependency changes. As of 0.8.8 there is [now](https://github.com/cern-fts/davix/commit/d6df7e0483e954107e74e638183e6ad79f09ec80) a way to prefer external rapidjson. The external curl was [fixed](https://github.com/cern-fts/davix/commit/78c00e1e558510d42f928b5c584e085a8df7ff88) in 0.8.1 only. Latest version will be tested in CI.