### PR TITLE
libx*: add new versions of X packages

### DIFF
--- a/var/spack/repos/builtin/packages/libxau/package.py
+++ b/var/spack/repos/builtin/packages/libxau/package.py
@@ -5,7 +5,7 @@
 from spack.package import *
 
 
-class Libxau(AutotoolsPackage, XorgPackage):
+class Libxau(AutotoolsPackage, MesonPackage, XorgPackage):
     """The libXau package contains a library implementing the X11
     Authorization Protocol. This is useful for restricting client
     access to the display."""
@@ -17,6 +17,9 @@ class Libxau(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    build_system("autotools", conditional("meson", when="@1.0.12:"), default="autotools")
+
+    version("1.0.12", sha256="2402dd938da4d0a332349ab3d3586606175e19cb32cb9fe013c19f1dc922dcee")
     version("1.0.11", sha256="3a321aaceb803577a4776a5efe78836eb095a9e44bbc7a465d29463e1a14f189")
     version("1.0.10", sha256="51a54da42475d4572a0b59979ec107c27dacf6c687c2b7b04e5cf989a7c7e60c")
     version("1.0.9", sha256="1f123d8304b082ad63a9e89376400a3b1d4c29e67e3ea07b3f659cccca690eea")

--- a/var/spack/repos/builtin/packages/libxcursor/package.py
+++ b/var/spack/repos/builtin/packages/libxcursor/package.py
@@ -15,6 +15,7 @@ class Libxcursor(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.2.3", sha256="74e72da27e61cc2cfd2e267c14f500ea47775850048ee0b00362a55c9b60ee9b")
     version("1.2.2", sha256="98c3a30a3f85274c167d1ac5419d681ce41f14e27bfa5fe3003c8172cd8af104")
     version("1.2.1", sha256="77f96b9ad0a3c422cfa826afabaf1e02b9bfbfc8908c5fa1a45094faad074b98")
     version("1.1.14", sha256="be0954faf274969ffa6d95b9606b9c0cfee28c13b6fc014f15606a0c8b05c17b")

--- a/var/spack/repos/builtin/packages/libxfont2/package.py
+++ b/var/spack/repos/builtin/packages/libxfont2/package.py
@@ -18,6 +18,8 @@ class Libxfont2(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("2.0.7", sha256="90b331c2fd2d0420767c4652e007d054c97a3f03a88c55e3b986bd3acfd7e338")
     version("2.0.6", sha256="a944df7b6837c8fa2067f6a5fc25d89b0acc4011cd0bc085106a03557fb502fc")
     version("2.0.1", sha256="381b6b385a69343df48a082523c856aed9042fbbc8ee0a6342fb502e4321230a")

--- a/var/spack/repos/builtin/packages/libxfont2/package.py
+++ b/var/spack/repos/builtin/packages/libxfont2/package.py
@@ -18,6 +18,7 @@ class Libxfont2(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("2.0.7", sha256="90b331c2fd2d0420767c4652e007d054c97a3f03a88c55e3b986bd3acfd7e338")
     version("2.0.6", sha256="a944df7b6837c8fa2067f6a5fc25d89b0acc4011cd0bc085106a03557fb502fc")
     version("2.0.1", sha256="381b6b385a69343df48a082523c856aed9042fbbc8ee0a6342fb502e4321230a")
 

--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -17,6 +17,7 @@ class Libxshmfence(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.3.3", sha256="d4a4df096aba96fea02c029ee3a44e11a47eb7f7213c1a729be83e85ec3fde10")
     version("1.3.2", sha256="870df257bc40b126d91b5a8f1da6ca8a524555268c50b59c0acd1a27f361606f")
     version("1.3.1", sha256="1129f95147f7bfe6052988a087f1b7cb7122283d2c47a7dbf7135ce0df69b4f8")
     version("1.3", sha256="b884300d26a14961a076fbebc762a39831cb75f92bed5ccf9836345b459220c7")

--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -17,6 +17,8 @@ class Libxshmfence(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.3.3", sha256="d4a4df096aba96fea02c029ee3a44e11a47eb7f7213c1a729be83e85ec3fde10")
     version("1.3.2", sha256="870df257bc40b126d91b5a8f1da6ca8a524555268c50b59c0acd1a27f361606f")
     version("1.3.1", sha256="1129f95147f7bfe6052988a087f1b7cb7122283d2c47a7dbf7135ce0df69b4f8")

--- a/var/spack/repos/builtin/packages/libxt/package.py
+++ b/var/spack/repos/builtin/packages/libxt/package.py
@@ -15,6 +15,7 @@ class Libxt(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.3.1", sha256="cf2212189869adb94ffd58c7d9a545a369b83d2274930bfbe148da354030b355")
     version("1.3.0", sha256="de4a80c4cc7785b9620e572de71026805f68e85a2bf16c386009ef0e50be3f77")
     version("1.2.1", sha256="6da1bfa9dd0ed87430a5ce95b129485086394df308998ebe34d98e378e3dfb33")
     version("1.2.0", sha256="d4bee88898fc5e1dc470e361430c72fbc529b9cdbbb6c0ed3affea3a39f97d8d")

--- a/var/spack/repos/builtin/packages/libxtst/package.py
+++ b/var/spack/repos/builtin/packages/libxtst/package.py
@@ -24,6 +24,7 @@ class Libxtst(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.2.5", sha256="244ba6e1c5ffa44f1ba251affdfa984d55d99c94bb925a342657e5e7aaf6d39c")
     version("1.2.4", sha256="01366506aeb033f6dffca5326af85f670746b0cabbfd092aabefb046cf48c445")
     version("1.2.3", sha256="a0c83acce02d4923018c744662cb28eb0dbbc33b4adc027726879ccf68fbc2c2")
     version("1.2.2", sha256="221838960c7b9058cd6795c1c3ee8e25bae1c68106be314bc3036a4f26be0e6c")

--- a/var/spack/repos/builtin/packages/libxv/package.py
+++ b/var/spack/repos/builtin/packages/libxv/package.py
@@ -16,6 +16,7 @@ class Libxv(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.0.13", sha256="9a0c31392b8968a4f29a0ad9c51e7ce225bcec3c4cbab9f2a241f921776b2991")
     version("1.0.12", sha256="ce706619a970a580a0e35e9b5c98bdd2af243ac6494c65f44608a89a86100126")
     version("1.0.11", sha256="c4112532889b210e21cf05f46f0f2f8354ff7e1b58061e12d7a76c95c0d47bb1")
     version("1.0.10", sha256="89a664928b625558268de81c633e300948b3752b0593453d7815f8775bab5293")

--- a/var/spack/repos/builtin/packages/libxxf86vm/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86vm/package.py
@@ -15,6 +15,7 @@ class Libxxf86vm(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.1.6", sha256="d2b4b1ec4eb833efca9981f19ed1078a8a73eed0bb3ca5563b64527ae8021e52")
     version("1.1.5", sha256="f3f1c29fef8accb0adbd854900c03c6c42f1804f2bc1e4f3ad7b2e1f3b878128")
     version("1.1.4", sha256="5108553c378a25688dcb57dca383664c36e293d60b1505815f67980ba9318a99")
 

--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -28,6 +28,7 @@ class WaylandProtocols(MesonPackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("1.40", sha256="0d783e6c1fff096d37c4e0fd1f3f14f63c4fdc5c1cf8ec07db2a349ffd56a1d3")
     version("1.39", sha256="42c16435dfc83f320ff727b6d446bb0d4feb361dc11796a2c5d3c0fb6532a517")
     version("1.38", sha256="a6069948458a1d86cea2b33a9735e67d7524118c32c388d75efb881a9e9d2cd9")
     version("1.37", sha256="c3b215084eb4cf318415533554c2c2714e58ed75847d7c3a8e50923215ffbbf3")

--- a/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
@@ -18,6 +18,7 @@ class XcbUtilCursor(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("0.1.5", sha256="0caf99b0d60970f81ce41c7ba694e5eaaf833227bb2cbcdb2f6dc9666a663c57")
     version("0.1.4", sha256="28dcfe90bcab7b3561abe0dd58eb6832aa9cc77cfe42fcdfa4ebe20d605231fb")
     version(
         "0.1.3",

--- a/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
@@ -18,6 +18,8 @@ class XcbUtilCursor(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("0.1.5", sha256="0caf99b0d60970f81ce41c7ba694e5eaaf833227bb2cbcdb2f6dc9666a663c57")
     version("0.1.4", sha256="28dcfe90bcab7b3561abe0dd58eb6832aa9cc77cfe42fcdfa4ebe20d605231fb")
     version(


### PR DESCRIPTION
This PR updates various X and freedesktop.org packages. Besides `libxau` which now is also a meson package, there are no changes. Some of these (libs) are tested in CI, but some are not (wayland-protocols, xcb-util-cursor).