### PR TITLE
gnutls: add v3.8.9

### DIFF
--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -17,7 +17,7 @@ class Gnutls(AutotoolsPackage):
 
     homepage = "https://www.gnutls.org"
     url = "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.19.tar.xz"
-    git = "https://gitlab.com/gnutls/gnutls/"
+    git = "https://gitlab.com/gnutls/gnutls.git"
     list_depth = 2
 
     maintainers("alecbcs")

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -18,11 +18,13 @@ class Gnutls(AutotoolsPackage):
     homepage = "https://www.gnutls.org"
     url = "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.19.tar.xz"
     list_depth = 2
+    git = "https://gitlab.com/gnutls/gnutls/"
 
     maintainers("alecbcs")
 
     license("LGPL-2.1-or-later")
 
+    version("3.8.9", sha256="69e113d802d1670c4d5ac1b99040b1f2d5c7c05daec5003813c049b5184820ed")
     version("3.8.8", sha256="ac4f020e583880b51380ed226e59033244bc536cad2623f2e26f5afa2939d8fb")
     version("3.8.4", sha256="2bea4e154794f3f00180fa2a5c51fe8b005ac7a31cd58bd44cdfa7f36ebc3a9b")
     version("3.8.3", sha256="f74fc5954b27d4ec6dfbb11dea987888b5b124289a3703afcada0ee520f4173e")

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -17,8 +17,8 @@ class Gnutls(AutotoolsPackage):
 
     homepage = "https://www.gnutls.org"
     url = "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.19.tar.xz"
-    list_depth = 2
     git = "https://gitlab.com/gnutls/gnutls/"
+    list_depth = 2
 
     maintainers("alecbcs")
 


### PR DESCRIPTION
This PR adds `gnutls`, v3.8.9 ([diff](https://gitlab.com/gnutls/gnutls/-/compare/3.8.8...3.8.9?from_project_id=179611)). No build system or dependency changes. Latest version will be tested in CI.