### PR TITLE
gocryptfs: add v2.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/gocryptfs/package.py
+++ b/var/spack/repos/builtin/packages/gocryptfs/package.py
@@ -17,9 +17,13 @@ class Gocryptfs(GoPackage):
 
     license("MIT", checked_by="snehring")
 
+    version("2.5.1", sha256="b2e69d382caef598ffa1071b8d5f6e9df30d38fe2f9e9b0bee0d2e7436654f6d")
     version("2.4.0", sha256="26a93456588506f4078f192b70e7816b6a4042a14b748b28a50d2b6c9b10e2ec")
 
     depends_on("c", type="build")  # generated
+
+    depends_on("go@1.16:", type="build")
+    depends_on("go@1.19:", type="build", when="@2.5:")
 
     depends_on("openssl")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
This PR adds `gocryptfs`, v2.5.1 ([diff](https://github.com/rfjakob/gocryptfs/compare/v2.4.0...v2.5.1)), which bumps the minimum go version.

Test build (I think we should add apptainer to one of the cloud pipelines):
```
==> Installing gocryptfs-2.5.1-45azqn47h7cufmjwgvlmasst4lzwk4s6 [9/9]
==> No binary for gocryptfs-2.5.1-45azqn47h7cufmjwgvlmasst4lzwk4s6 found: installing from source
==> Fetching https://github.com/rfjakob/gocryptfs/releases/download/v2.5.1/gocryptfs_v2.5.1_src.tar.gz
==> No patches needed for gocryptfs
==> gocryptfs: Executing phase: 'build'
==> gocryptfs: Executing phase: 'install'
==> gocryptfs: Successfully installed gocryptfs-2.5.1-45azqn47h7cufmjwgvlmasst4lzwk4s6
  Stage: 1.25s.  Build: 40.31s.  Install: 0.01s.  Post-install: 0.44s.  Total: 42.39s
[+] /opt/software/linux-ubuntu25.04-skylake/gcc-14.2.0/gocryptfs-2.5.1-45azqn47h7cufmjwgvlmasst4lzwk4s6
```