### PR TITLE
lua-lpeg inheritance fix

### DIFF
--- a/var/spack/repos/builtin/packages/lua-lpeg/package.py
+++ b/var/spack/repos/builtin/packages/lua-lpeg/package.py
@@ -42,7 +42,8 @@ class LuaBuilder(spack.build_systems.lua.LuaBuilder):
     # * replaces `-bundle` from the default flags with `-shared`
     @when("platform=darwin")
     def generate_luarocks_config(self, pkg, spec, prefix):
-        path = super().generate_luarocks_config(pkg, spec, prefix)
+        super().generate_luarocks_config(pkg, spec, prefix)
+        path = self._luarocks_config_path()
 
         with open(path, "a") as cfg:
             cfg.write(


### PR DESCRIPTION
The parent class function doesn't return the path to the config file. So `lua-lpeg` fails to build on darwin. This is one potential fix, or we can add the return back to base builder.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
