### PR TITLE
hep: static_analysis: true

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -4,6 +4,7 @@ spack:
   concretizer:
     reuse: false
     unify: when_possible
+    static_analysis: true
 
   packages:
     all:


### PR DESCRIPTION
This PR enables static analysis in the HEP stack. Not sure that this is noticeably faster in CI, but supposedly it doesn't hurt?