### PR TITLE
cargo: avoid need to use super().build_args with std_build_args

### DIFF
--- a/lib/spack/spack/build_systems/cargo.py
+++ b/lib/spack/spack/build_systems/cargo.py
@@ -71,9 +71,15 @@ class CargoBuilder(BuilderWithDefaults):
         return self.pkg.stage.source_path
 
     @property
+    def std_build_args(self):
+        """Standard arguments for ``cargo build`` provided as a property for
+        convenience of package writers."""
+        return ["-j", str(self.pkg.module.make_jobs)]
+
+    @property
     def build_args(self):
         """Arguments for ``cargo build``."""
-        return ["-j", str(self.pkg.module.make_jobs)]
+        return []
 
     @property
     def check_args(self):
@@ -88,7 +94,7 @@ class CargoBuilder(BuilderWithDefaults):
     ) -> None:
         """Runs ``cargo install`` in the source directory"""
         with fs.working_dir(self.build_directory):
-            pkg.module.cargo("install", "--root", "out", "--path", ".", *self.build_args)
+            pkg.module.cargo("install", "--root", "out", "--path", ".", *self.std_build_args, *self.build_args)
 
     def install(
         self, pkg: CargoPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix

--- a/lib/spack/spack/build_systems/cargo.py
+++ b/lib/spack/spack/build_systems/cargo.py
@@ -94,7 +94,9 @@ class CargoBuilder(BuilderWithDefaults):
     ) -> None:
         """Runs ``cargo install`` in the source directory"""
         with fs.working_dir(self.build_directory):
-            pkg.module.cargo("install", "--root", "out", "--path", ".", *self.std_build_args, *self.build_args)
+            pkg.module.cargo(
+                "install", "--root", "out", "--path", ".", *self.std_build_args, *self.build_args
+            )
 
     def install(
         self, pkg: CargoPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix

--- a/var/spack/repos/builtin/packages/jujutsu/package.py
+++ b/var/spack/repos/builtin/packages/jujutsu/package.py
@@ -32,4 +32,4 @@ class CargoBuilder(spack.build_systems.cargo.CargoBuilder):
 
     @property
     def build_args(self):
-        return super().build_args + ["--bin", "jj", "jj-cli"]
+        return ["--bin", "jj", "jj-cli"]


### PR DESCRIPTION
The CMake build system [already has](https://github.com/spack/spack/blob/develop/lib/spack/spack/build_systems/cmake.py) a separate `std_cmake_args` and `cmake_args` (which defaults to empty). The Cargo build system can benefit from something similar to avoid having to use `super().build_args + my_args` as in https://github.com/spack/spack/pull/48231#discussion_r1957480565.

This PR moves the default `-j{make_jobs}` arguments into `std_build_args`, and defines a default-empty `build_args` for packagers to define/override.

Note: Once #48231 is merged, I'll rebase this and remove the `super()` use in `jujutsu`.