### PR TITLE
acts dependencies: new versions as of 2025/02/17

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -40,6 +40,7 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("39.1.0", commit="09225b0d0bba24d57a696e347e3027b39404bb75", submodules=True)
     version("39.0.0", commit="b055202e2fbdd509bc186eb4782714bc46f38f3f", submodules=True)
     version("38.2.0", commit="9cb8f4494656553fd9b85955938b79b2fac4c9b0", submodules=True)
     version("38.1.0", commit="8a20c88808f10bf4fcdfd7c6e077f23614c3ab90", submodules=True)

--- a/var/spack/repos/builtin/packages/covfie/package.py
+++ b/var/spack/repos/builtin/packages/covfie/package.py
@@ -19,6 +19,8 @@ class Covfie(CMakePackage, CudaPackage):
 
     maintainers("stephenswat")
 
+    version("0.12.1", sha256="c33d7707ee30ab5fa8df686a780600343760701023ac0b23355627e1f2f044de")
+    version("0.12.0", sha256="e35e94075a40e89c4691ff373e3061577295d583a2546c682b2d652d9fce7828")
     version("0.11.0", sha256="39fcd0f218d3b4f3aacc6af497a8cda8767511efae7a72b47781f10fd4340f4f")
     version("0.10.0", sha256="d44142b302ffc193ad2229f1d2cc6d8d720dd9da8c37989ada4f23018f86c964")
 

--- a/var/spack/repos/builtin/packages/detray/package.py
+++ b/var/spack/repos/builtin/packages/detray/package.py
@@ -19,6 +19,7 @@ class Detray(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.88.1", sha256="89134c86c6857cb3a821181e3bb0565ebb726dd8b1245678db1681483d792cf9")
     version("0.88.0", sha256="bda15501c9c96af961e24ce243982f62051c535b9fe458fb28336a19b54eb47d")
     version("0.87.0", sha256="2d4a76432dd6ddbfc00b88b5d482072e471fefc264b60748bb1f9a123963576e")
     version("0.86.0", sha256="98350c94e8a2395b8712b7102fd449536857e8158b38a96cc913c79b70301170")


### PR DESCRIPTION
This commit adds detray v0.88.1, covfie v0.12.0 and v0.12.1, as well as ACTS v37.1.0.