### PR TITLE
petsc: fix can provide vs provides issue

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -610,14 +610,14 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         if "+exodusii+fortran" in spec and "+fortran" in spec:
             options.append("--with-exodusii-fortran-bindings")
 
+        direct_dependencies = {
+            *(spec.name for spec in spec.dependencies()),
+            *(virtual for edge in spec.edges_to_dependencies() for virtual in edge.virtuals),
+        }
         # tuple format (spacklibname, petsclibname, useinc, uselib)
         # default: 'gmp', => ('gmp', 'gmp', True, True)
         # any other combination needs a full tuple
         # if not (useinc || uselib): usedir - i.e (False, False)
-        direct_dependencies = []
-        for dep in spec.dependencies():
-            direct_dependencies.append(dep.name)
-            direct_dependencies.extend(set(vspec.name for vspec in dep.package.virtuals_provided))
         for library in (
             ("cuda", "cuda", False, False),
             ("hip", "hip", True, False),


### PR DESCRIPTION
Depending on a package that _can_ provide a virtual is not the same as depending on a virtual provided by that package.

Specifically for petsc: `scalapack` can be provided by `cray-libsci`, which is a dependency of `petsc` probably for `blas`, but `petsc` just doesn't depend on `scalapack`.

So, instead of working at the package level, look only at the concrete spec.

We should add better API for this in another PR.