### PR TITLE
kubectl: add v1.30.0 -> v1.32.3

### DIFF
--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -11,17 +11,77 @@ class Kubectl(GoPackage):
     """
 
     homepage = "https://kubernetes.io"
-    url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.27.0.tar.gz"
+    url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.32.2.tar.gz"
 
     maintainers("alecbcs")
 
     license("Apache-2.0")
 
-    version("1.32.0", sha256="3793859c53f09ebc92e013ea858b8916cc19d7fe288ec95882dada4e5a075d08")
-    version("1.31.1", sha256="83094915698a9c24f93d1ffda3f17804a4024d3b65eabf681e77a62b35137208")
-    version("1.31.0", sha256="6679eb90815cc4c3bef6c1b93f7a8451bf3f40d003f45ab57fdc9f8c4e8d4b4f")
-    version("1.27.1", sha256="3a3f7c6b8cf1d9f03aa67ba2f04669772b1205b89826859f1636062d5f8bec3f")
-    version("1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323")
+    version("1.32.2", sha256="d2a917570d7c9d7247e60b58bffa13c4a4dfcc63c195f2deedbf6224b9fb4993")
+    version("1.31.6", sha256="4fbe4f949494d5f21e247b59313d85ecf4bd042dc1f3113430b023b1945248d0")
+    version("1.30.10", sha256="556fa1f93d46184f839253f7507170a518cac74a7e632272aed466d105e8d159")
+
+    with default_args(deprecated=True):
+        version(
+            "1.32.1", sha256="9724c849c524c2e69a0a0da4f1a3b0335d7d544eeaa9fc22cb5b87d7c0c52c9d"
+        )
+        version(
+            "1.32.0", sha256="3793859c53f09ebc92e013ea858b8916cc19d7fe288ec95882dada4e5a075d08"
+        )
+        version(
+            "1.31.5", sha256="7648c290f46bfc45cb8a24dc94e39cdea333bbe39223ab1cc253ebf9e2e0c3cb"
+        )
+        version(
+            "1.31.4", sha256="ff3a2e9cae3b4734be4a6cdfeb933830c63219eaeda05cc4e59b7559fcde52b0"
+        )
+        version(
+            "1.31.3", sha256="a58bf0797989acc9530a23164d529d5df5e4068e2fce9738cbe6f11f823ccf20"
+        )
+        version(
+            "1.31.2", sha256="05007001f41176b388fcb01d6dc35e454db35a4e65b114db42b2b7340be8aed3"
+        )
+        version(
+            "1.31.1", sha256="83094915698a9c24f93d1ffda3f17804a4024d3b65eabf681e77a62b35137208"
+        )
+        version(
+            "1.31.0", sha256="6679eb90815cc4c3bef6c1b93f7a8451bf3f40d003f45ab57fdc9f8c4e8d4b4f"
+        )
+        version(
+            "1.30.9", sha256="d703f03da3e1dadd3d4e8a1ef6dcaa572600c64d2193e802172cd9b9360c00e6"
+        )
+        version(
+            "1.30.8", sha256="d33a93d74ae29d31a44384920039160c66eebacfb7ff83ceec9104577e3bd1e9"
+        )
+        version(
+            "1.30.7", sha256="e11936d2a0e1ef2c10d3358ecca3bf7615a3664be8b337adb3e636342bff9750"
+        )
+        version(
+            "1.30.6", sha256="8ef8826088ab531e9162ae7e0c3e4f197f807a69b5f1903324cf6f2df84083e9"
+        )
+        version(
+            "1.30.5", sha256="e0c24a726a9a24180c9c51292d3a4ec9e1583537112661cf9504f92ed99e7aac"
+        )
+        version(
+            "1.30.4", sha256="9f0fb73016b1ca9dee9fc8e5f072ec60822b1ec6457634b1a0085760d9bc2e97"
+        )
+        version(
+            "1.30.3", sha256="2e57ccaa4d3a8fb9dd0527af61702d6f193ff2f4c3b2fb35362bbf5fed6ce674"
+        )
+        version(
+            "1.30.2", sha256="a4ac165376708bce1634e0f1a2156c1cb1c4390fa574bacca3382b889f0d7b28"
+        )
+        version(
+            "1.30.1", sha256="0b0bae91594fc8f8cc2ae3443f24b95660e6c5f5761bc2dc76cb7ef1c6047d9f"
+        )
+        version(
+            "1.30.0", sha256="16385d1e4af6d3ede885b5c5d617ad06cc2a7a28e40a380fb04c521c9e7fb957"
+        )
+        version(
+            "1.27.1", sha256="3a3f7c6b8cf1d9f03aa67ba2f04669772b1205b89826859f1636062d5f8bec3f"
+        )
+        version(
+            "1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323"
+        )
 
     depends_on("bash", type="build")
     depends_on("go@1.22:", type="build", when="@1.30:")

--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -94,3 +94,32 @@ class Kubectl(GoPackage):
     depends_on("go", type="build")
 
     build_directory = "cmd/kubectl"
+
+    # Required to correctly set the version
+    # Method discovered by following the trail below
+    #
+    # 1. https://github.com/kubernetes/kubernetes/blob/v1.32.2/Makefile#L1
+    # 2. https://github.com/kubernetes/kubernetes/blob/v1.32.2/build/root/Makefile#L97
+    # 3. https://github.com/kubernetes/kubernetes/blob/v1.32.2/hack/make-rules/build.sh#L25
+    # 4. https://github.com/kubernetes/kubernetes/blob/v1.32.2/hack/lib/init.sh#L61
+    # 5. https://github.com/kubernetes/kubernetes/blob/v1.32.2/hack/lib/version.sh#L151-L183
+    @property
+    def build_args(self):
+        kube_ldflags = [
+            f"-X 'k8s.io/client-go/pkg/version.gitVersion=v{self.version}'",
+            f"-X 'k8s.io/client-go/pkg/version.gitMajor={self.version.up_to(1)}'",
+            f"-X 'k8s.io/client-go/pkg/version.gitMinor={str(self.version).split('.')[1]}'",
+            f"-X 'k8s.io/component-base/version.gitVersion=v{self.version}'",
+            f"-X 'k8s.io/component-base/version.gitMajor={self.version.up_to(1)}'",
+            f"-X 'k8s.io/component-base/version.gitMinor={str(self.version).split('.')[1]}'",
+        ]
+
+        args = super().build_args
+
+        if "-ldflags" in args:
+            ldflags_index = args.index("-ldflags") + 1
+            args[ldflags_index] = args[ldflags_index] + " " + " ".join(kube_ldflags)
+        else:
+            args.extend(["-ldflags", " ".join(kube_ldflags)])
+
+        return args

--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -38,12 +38,13 @@ class Kubectl(GoPackage):
             "1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323"
         )
 
-    depends_on("bash", type="build")
-    depends_on("go@1.23:", type="build", when="@1.32:")
-    depends_on("go@1.22:", type="build", when="@1.30:")
-    depends_on("go@1.21:", type="build", when="@1.29:")
-    depends_on("go@1.20:", type="build", when="@1.27:")
-    depends_on("go", type="build")
+    with default_args(type="build"):
+        depends_on("bash")
+
+        depends_on("go@1.23:", when="@1.32:")
+        depends_on("go@1.22:", when="@1.30:")
+        depends_on("go@1.21:", when="@1.29:")
+        depends_on("go@1.20:", when="@1.27:")
 
     build_directory = "cmd/kubectl"
 

--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -5,7 +5,7 @@
 from spack.package import *
 
 
-class Kubectl(Package):
+class Kubectl(GoPackage):
     """
     Kubectl is a command-line interface for Kubernetes clusters.
     """
@@ -86,22 +86,11 @@ class Kubectl(Package):
             "1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323"
         )
 
-    depends_on("c", type="build")
     depends_on("bash", type="build")
-    depends_on("gmake", type="build")
-
     depends_on("go@1.23:", type="build", when="@1.32:")
     depends_on("go@1.22:", type="build", when="@1.30:")
     depends_on("go@1.21:", type="build", when="@1.29:")
     depends_on("go@1.20:", type="build", when="@1.27:")
     depends_on("go", type="build")
 
-    phases = ["build", "install"]
-
-    def build(self, spec, prefix):
-        components = ["cmd/kubectl"]
-
-        make(f"WHAT={' '.join(components)}")
-
-    def install(self, spec, prefix):
-        install_tree("_output/bin", prefix.bin)
+    build_directory = "cmd/kubectl"

--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -17,16 +17,22 @@ class Kubectl(GoPackage):
 
     license("Apache-2.0")
 
-    version("1.32.2", sha256="d2a917570d7c9d7247e60b58bffa13c4a4dfcc63c195f2deedbf6224b9fb4993")
-    version("1.31.6", sha256="4fbe4f949494d5f21e247b59313d85ecf4bd042dc1f3113430b023b1945248d0")
-    version("1.30.10", sha256="556fa1f93d46184f839253f7507170a518cac74a7e632272aed466d105e8d159")
+    version("1.32.3", sha256="b1ed5abe78a626804aadc49ecb8ade6fd33b27ab8c23d43cd59dc86f6462ac09")
+    version("1.31.7", sha256="92005ebd010a8d4fe3a532444c4645840e0af486062611a4d9c8d862414c3f56")
+    version("1.30.11", sha256="f30e4082b6a554d4a2bfedd8b2308a5e6012287e15bec94f72987f717bab4133")
 
     with default_args(deprecated=True):
+        version(
+            "1.32.2", sha256="d2a917570d7c9d7247e60b58bffa13c4a4dfcc63c195f2deedbf6224b9fb4993"
+        )
         version(
             "1.32.1", sha256="9724c849c524c2e69a0a0da4f1a3b0335d7d544eeaa9fc22cb5b87d7c0c52c9d"
         )
         version(
             "1.32.0", sha256="3793859c53f09ebc92e013ea858b8916cc19d7fe288ec95882dada4e5a075d08"
+        )
+        version(
+            "1.31.6", sha256="4fbe4f949494d5f21e247b59313d85ecf4bd042dc1f3113430b023b1945248d0"
         )
         version(
             "1.31.5", sha256="7648c290f46bfc45cb8a24dc94e39cdea333bbe39223ab1cc253ebf9e2e0c3cb"
@@ -45,6 +51,9 @@ class Kubectl(GoPackage):
         )
         version(
             "1.31.0", sha256="6679eb90815cc4c3bef6c1b93f7a8451bf3f40d003f45ab57fdc9f8c4e8d4b4f"
+        )
+        version(
+            "1.30.10", sha256="556fa1f93d46184f839253f7507170a518cac74a7e632272aed466d105e8d159"
         )
         version(
             "1.30.9", sha256="d703f03da3e1dadd3d4e8a1ef6dcaa572600c64d2193e802172cd9b9360c00e6"

--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -5,7 +5,7 @@
 from spack.package import *
 
 
-class Kubectl(GoPackage):
+class Kubectl(Package):
     """
     Kubectl is a command-line interface for Kubernetes clusters.
     """
@@ -77,14 +77,31 @@ class Kubectl(GoPackage):
             "1.30.0", sha256="16385d1e4af6d3ede885b5c5d617ad06cc2a7a28e40a380fb04c521c9e7fb957"
         )
         version(
+            "1.27.2", sha256="c6fcfddd38f877ce49c49318973496f9a16672e83a29874a921242950cd1c5d2"
+        )
+        version(
             "1.27.1", sha256="3a3f7c6b8cf1d9f03aa67ba2f04669772b1205b89826859f1636062d5f8bec3f"
         )
         version(
             "1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323"
         )
 
+    depends_on("c", type="build")
     depends_on("bash", type="build")
-    depends_on("go@1.22:", type="build", when="@1.30:")
-    depends_on("go@1.23:", type="build", when="@1.32:")
+    depends_on("gmake", type="build")
 
-    build_directory = "cmd/kubectl"
+    depends_on("go@1.23:", type="build", when="@1.32:")
+    depends_on("go@1.22:", type="build", when="@1.30:")
+    depends_on("go@1.21:", type="build", when="@1.29:")
+    depends_on("go@1.20:", type="build", when="@1.27:")
+    depends_on("go", type="build")
+
+    phases = ["build", "install"]
+
+    def build(self, spec, prefix):
+        components = ["cmd/kubectl"]
+
+        make(f"WHAT={' '.join(components)}")
+
+    def install(self, spec, prefix):
+        install_tree("_output/bin", prefix.bin)

--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -23,70 +23,13 @@ class Kubectl(GoPackage):
 
     with default_args(deprecated=True):
         version(
-            "1.32.2", sha256="d2a917570d7c9d7247e60b58bffa13c4a4dfcc63c195f2deedbf6224b9fb4993"
-        )
-        version(
-            "1.32.1", sha256="9724c849c524c2e69a0a0da4f1a3b0335d7d544eeaa9fc22cb5b87d7c0c52c9d"
-        )
-        version(
             "1.32.0", sha256="3793859c53f09ebc92e013ea858b8916cc19d7fe288ec95882dada4e5a075d08"
-        )
-        version(
-            "1.31.6", sha256="4fbe4f949494d5f21e247b59313d85ecf4bd042dc1f3113430b023b1945248d0"
-        )
-        version(
-            "1.31.5", sha256="7648c290f46bfc45cb8a24dc94e39cdea333bbe39223ab1cc253ebf9e2e0c3cb"
-        )
-        version(
-            "1.31.4", sha256="ff3a2e9cae3b4734be4a6cdfeb933830c63219eaeda05cc4e59b7559fcde52b0"
-        )
-        version(
-            "1.31.3", sha256="a58bf0797989acc9530a23164d529d5df5e4068e2fce9738cbe6f11f823ccf20"
-        )
-        version(
-            "1.31.2", sha256="05007001f41176b388fcb01d6dc35e454db35a4e65b114db42b2b7340be8aed3"
         )
         version(
             "1.31.1", sha256="83094915698a9c24f93d1ffda3f17804a4024d3b65eabf681e77a62b35137208"
         )
         version(
             "1.31.0", sha256="6679eb90815cc4c3bef6c1b93f7a8451bf3f40d003f45ab57fdc9f8c4e8d4b4f"
-        )
-        version(
-            "1.30.10", sha256="556fa1f93d46184f839253f7507170a518cac74a7e632272aed466d105e8d159"
-        )
-        version(
-            "1.30.9", sha256="d703f03da3e1dadd3d4e8a1ef6dcaa572600c64d2193e802172cd9b9360c00e6"
-        )
-        version(
-            "1.30.8", sha256="d33a93d74ae29d31a44384920039160c66eebacfb7ff83ceec9104577e3bd1e9"
-        )
-        version(
-            "1.30.7", sha256="e11936d2a0e1ef2c10d3358ecca3bf7615a3664be8b337adb3e636342bff9750"
-        )
-        version(
-            "1.30.6", sha256="8ef8826088ab531e9162ae7e0c3e4f197f807a69b5f1903324cf6f2df84083e9"
-        )
-        version(
-            "1.30.5", sha256="e0c24a726a9a24180c9c51292d3a4ec9e1583537112661cf9504f92ed99e7aac"
-        )
-        version(
-            "1.30.4", sha256="9f0fb73016b1ca9dee9fc8e5f072ec60822b1ec6457634b1a0085760d9bc2e97"
-        )
-        version(
-            "1.30.3", sha256="2e57ccaa4d3a8fb9dd0527af61702d6f193ff2f4c3b2fb35362bbf5fed6ce674"
-        )
-        version(
-            "1.30.2", sha256="a4ac165376708bce1634e0f1a2156c1cb1c4390fa574bacca3382b889f0d7b28"
-        )
-        version(
-            "1.30.1", sha256="0b0bae91594fc8f8cc2ae3443f24b95660e6c5f5761bc2dc76cb7ef1c6047d9f"
-        )
-        version(
-            "1.30.0", sha256="16385d1e4af6d3ede885b5c5d617ad06cc2a7a28e40a380fb04c521c9e7fb957"
-        )
-        version(
-            "1.27.2", sha256="c6fcfddd38f877ce49c49318973496f9a16672e83a29874a921242950cd1c5d2"
         )
         version(
             "1.27.1", sha256="3a3f7c6b8cf1d9f03aa67ba2f04669772b1205b89826859f1636062d5f8bec3f"


### PR DESCRIPTION
Added all versions currently supported upstream: last three minor versions. Check [https://kubernetes.io/releases/](https://kubernetes.io/releases/) for details.

Only did a some basic checks for the added versions, but don't see how the newer versions would be broken.

Checks done:
- compiled correctly
- run a few basic commands
- check correct Go version dependency (based on `go.mod` upstream)

Would appreciate feedback on my usage of `deprecated=True`. Especially for the existing 1.27.x versions. Still kind of new to Spack, so this might not be the desired way to do things.