### PR TITLE
Adding ability for repo paths from a manifest file to be expanded when creating an environment.

### DIFF
--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -5,9 +5,13 @@ import os
 
 import pytest
 
+import spack.config
+import spack.environment as ev
 import spack.main
+from spack.main import SpackCommand
 
 repo = spack.main.SpackCommand("repo")
+env = SpackCommand("env")
 
 
 def test_help_option():
@@ -33,3 +37,33 @@ def test_create_add_list_remove(mutable_config, tmpdir):
     repo("remove", "--scope=site", str(tmpdir))
     output = repo("list", "--scope=site", output=str)
     assert "mockrepo" not in output
+
+
+def test_env_repo_path_vars_substitution(
+    tmpdir, install_mockery, mutable_mock_env_path, monkeypatch
+):
+    """Test Spack correctly substitues repo paths with environment variables when creating an
+    environment from a manifest file."""
+    # store the repo path in an environment variable that will be used in the environment
+    testrepo = "/somepath"
+    monkeypatch.setenv("CUSTOM_REPO_PATH", testrepo)
+
+    # setup environment from spack.yaml
+    envdir = tmpdir.mkdir("env")
+    with envdir.as_cwd():
+        with open("spack.yaml", "w", encoding="utf-8") as f:
+            f.write(
+                """\
+spack:
+  specs: []
+
+  repos:
+    - $CUSTOM_REPO_PATH
+"""
+            )
+        # creating env from manifest file
+        env("create", "test", "./spack.yaml")
+        # check that repo path was correctly substituted with the environment variable
+        with ev.read("test") as newenv:
+            repos_specs = spack.config.get("repos", default={}, scope=newenv.scope_name)
+            assert testrepo in repos_specs

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -44,8 +44,14 @@ def test_env_repo_path_vars_substitution(
 ):
     """Test Spack correctly substitues repo paths with environment variables when creating an
     environment from a manifest file."""
+<<<<<<< HEAD
 
     monkeypatch.setenv("CUSTOM_REPO_PATH", ".")
+=======
+    # store the repo path in an environment variable that will be used in the environment
+    testrepo = "/somepath"
+    monkeypatch.setenv("CUSTOM_REPO_PATH", testrepo)
+>>>>>>> 6c6c453b (Adding ability for repo paths from a manifest file to be expanded when creating an environment.)
 
     # setup environment from spack.yaml
     envdir = tmpdir.mkdir("env")
@@ -63,7 +69,13 @@ spack:
         # creating env from manifest file
         env("create", "test", "./spack.yaml")
         # check that repo path was correctly substituted with the environment variable
+<<<<<<< HEAD
         current_dir = os.getcwd()
         with ev.read("test") as newenv:
             repos_specs = spack.config.get("repos", default={}, scope=newenv.scope_name)
             assert current_dir in repos_specs
+=======
+        with ev.read("test") as newenv:
+            repos_specs = spack.config.get("repos", default={}, scope=newenv.scope_name)
+            assert testrepo in repos_specs
+>>>>>>> 6c6c453b (Adding ability for repo paths from a manifest file to be expanded when creating an environment.)

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -44,9 +44,8 @@ def test_env_repo_path_vars_substitution(
 ):
     """Test Spack correctly substitues repo paths with environment variables when creating an
     environment from a manifest file."""
-    # store the repo path in an environment variable that will be used in the environment
-    testrepo = "/somepath"
-    monkeypatch.setenv("CUSTOM_REPO_PATH", testrepo)
+
+    monkeypatch.setenv("CUSTOM_REPO_PATH", ".")
 
     # setup environment from spack.yaml
     envdir = tmpdir.mkdir("env")
@@ -64,6 +63,7 @@ spack:
         # creating env from manifest file
         env("create", "test", "./spack.yaml")
         # check that repo path was correctly substituted with the environment variable
+        current_dir = os.getcwd()
         with ev.read("test") as newenv:
             repos_specs = spack.config.get("repos", default={}, scope=newenv.scope_name)
-            assert testrepo in repos_specs
+            assert current_dir in repos_specs

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -44,14 +44,8 @@ def test_env_repo_path_vars_substitution(
 ):
     """Test Spack correctly substitues repo paths with environment variables when creating an
     environment from a manifest file."""
-<<<<<<< HEAD
 
     monkeypatch.setenv("CUSTOM_REPO_PATH", ".")
-=======
-    # store the repo path in an environment variable that will be used in the environment
-    testrepo = "/somepath"
-    monkeypatch.setenv("CUSTOM_REPO_PATH", testrepo)
->>>>>>> 6c6c453b (Adding ability for repo paths from a manifest file to be expanded when creating an environment.)
 
     # setup environment from spack.yaml
     envdir = tmpdir.mkdir("env")
@@ -69,13 +63,7 @@ spack:
         # creating env from manifest file
         env("create", "test", "./spack.yaml")
         # check that repo path was correctly substituted with the environment variable
-<<<<<<< HEAD
         current_dir = os.getcwd()
         with ev.read("test") as newenv:
             repos_specs = spack.config.get("repos", default={}, scope=newenv.scope_name)
             assert current_dir in repos_specs
-=======
-        with ev.read("test") as newenv:
-            repos_specs = spack.config.get("repos", default={}, scope=newenv.scope_name)
-            assert testrepo in repos_specs
->>>>>>> 6c6c453b (Adding ability for repo paths from a manifest file to be expanded when creating an environment.)


### PR DESCRIPTION
Adding ability for repo paths from a manifest file to be expanded when creating an environment.

A unit test was added to check that an environment variable will be expanded. Also, a possible bug was fixed in the expansion of develop paths where if an environment variable was in the path that then produced an absolute path the path would not be extended.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
