### PR TITLE
Build Cache View Package Index

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -378,7 +378,7 @@ class BinaryCacheIndex:
         on disk under ``_index_cache_root``)."""
         self._init_local_index_cache()
         configured_mirrors = [
-            MirrorURLAndVersion(m.fetch_url, layout_version)
+            MirrorURLAndVersion(m.fetch_url, m.fetch_view, layout_version)
             for layout_version in SUPPORTED_LAYOUT_VERSIONS
             for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
         ]
@@ -699,27 +699,49 @@ def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str):
     cache_class.maybe_push_layout_json(cache_prefix)
 
 
-def _read_specs_and_push_index(
+def _read_specs_from_list(
     file_list: List[str],
-    read_method: Callable,
-    cache_prefix: str,
-    db: BuildCacheDatabase,
-    temp_dir: str,
+    read_method: Callable[[str], str],
+    filter_fn: Callable[[str], bool] = lambda f: True,
+) -> Iterable[spack.spec.Spec]:
+    """Convert a list of specs file paths with read function to a Iterator of specs
+
+    Args:
+        file_list: List of spec files
+        read_method: Method read the spec file contents to a string
+
+    Return:
+        Yields concrete specs created from read spec files
+    """
+    for file in file_list:
+        if not filter_fn(file):
+            continue
+
+        contents = read_method(file)
+        # Need full spec.json name or this gets confused with index.json.
+        if file.endswith(".json.sig"):
+            specfile_json = spack.spec.Spec.extract_json_from_clearsig(contents)
+            yield spack.spec.Spec.from_dict(specfile_json)
+        elif file.endswith(".json"):
+            yield spack.spec.Spec.from_json(contents)
+        else:
+            continue
+
+
+def _read_specs_and_push_index(
+    spec_list: Iterable[spack.spec.Spec], cache_prefix: str, db: BuildCacheDatabase, temp_dir: str
 ):
     """Read listed specs, generate the index, and push it to the mirror.
 
     Args:
-        file_list: List of urls or file paths pointing at spec files to read
-        read_method: A function taking a single argument, either a url or a file path,
-            and which reads the spec file at that location, and returns the spec.
+        spec_list: Iterable set of specs to add to database that exist in the cache
         cache_prefix: prefix of the build cache on s3 where index should be pushed.
         db: A spack database used for adding specs and then writing the index.
         temp_dir: Location to write index.json and hash for pushing
     """
-    for file in file_list:
-        fetched_spec = spack.spec.Spec.from_dict(read_method(file))
-        db.add(fetched_spec)
-        db.mark(fetched_spec, "in_buildcache", True)
+    for spec in spec_list:
+        db.add(spec)
+        db.mark(spec, "in_buildcache", True)
 
     _push_index(db, temp_dir, cache_prefix)
 
@@ -810,7 +832,7 @@ def _specs_from_cache_fallback(url: str, tmpspecsdir: str):
     return file_list, read_fn
 
 
-def _spec_files_from_cache(url: str, tmpspecsdir: str):
+def _spec_files_from_cache(url: str, tmpspecsdir: str) -> Tuple[List[str], Callable[[str], str]]:
     """Get a list of all the spec files in the mirror and a function to
     read them.
 
@@ -852,6 +874,7 @@ def _url_generate_package_index(url: str, tmpdir: str):
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
         try:
             file_list, read_fn = _spec_files_from_cache(url, tmpspecsdir)
+            spec_list = _read_specs_from_list(file_list, read_fn)
         except ListMirrorSpecsError as e:
             raise GenerateIndexError(f"Unable to generate package index: {e}") from e
 
@@ -861,11 +884,71 @@ def _url_generate_package_index(url: str, tmpdir: str):
         db._write()
 
         try:
-            _read_specs_and_push_index(file_list, read_fn, url, db, str(db.database_directory))
+            _read_specs_and_push_index(spec_list, url, db, str(db.database_directory))
         except Exception as e:
             raise GenerateIndexError(
                 f"Encountered problem pushing package index to {url}: {e}"
             ) from e
+
+
+def _url_generate_view_package_index(
+    url: str, view: str, append: bool, specs: List[spack.spec.Spec], tmpdir: str
+):
+    """Create or replace the build cache index on the given mirror.  The
+    buildcache index contains an entry for each binary package under the
+    cache_prefix.
+
+    Args:
+        url: Base url of binary mirror.
+        view: name of the view to generate the index for.
+
+    Return:
+        None
+    """
+    cache_url = url_util.join(url, build_cache_relative_path())
+    try:
+        file_list, read_fn = _spec_files_from_cache(cache_url)
+
+        # Compute the names of all of the spec files associated with the
+        # list of specs to include in the view index.
+        spec_files = [tarball_name(s, ".spec.json.sig") for s in specs]
+        spec_files += [tarball_name(s, ".spec.json") for s in specs]
+
+        # Only add specs that exist in both the cache and the search specs
+        spec_filter = lambda f: any([s in f for s in spec_files])
+
+        spec_list = _read_specs_from_list(file_list, read_fn, spec_filter)
+    except ListMirrorSpecsError as e:
+        raise GenerateIndexError(f"Unable to generate view package index: {e}") from e
+
+    tty.debug(f"Retrieving spec descriptor files from {url} to build index")
+
+    db = BuildCacheDatabase(tmpdir)
+    db._write()
+
+    view_url = build_cache_view_prefix(url, view)
+    # Load the current state of the index for append
+    if append:
+        tty.warn(
+            "Appending to a package index does not currently support "
+            "proper locking. This may result in missing specs in the "
+            "index if run asynchronously."
+        )
+        _, _, index_file = web_util.read_from_url(
+            url_util.join(view_url, spack_db.INDEX_JSON_FILE)
+        )
+        tmp_index_file = os.path.join(tmpdir, "tmpindex.json")
+        with open(tmp_index_file, "w", encoding="utf-8") as fp:
+            fp.write(index_file.read().decode())
+
+        db._read_from_file(tmp_index_file)
+
+    try:
+        _read_specs_and_push_index(spec_list, view_url, db, str(db.database_directory))
+    except Exception as e:
+        raise GenerateIndexError(
+            f"Encountered problem pushing view package index to {view_url}: {e}"
+        ) from e
 
 
 def generate_key_index(mirror_url: str, tmpdir: str) -> None:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -243,9 +243,6 @@ class BinaryCacheIndex:
                 self._specs_already_associated.add(cached_index_hash)
 
     def _associate_built_specs_with_mirror(self, cache_key, url_and_version: MirrorURLAndVersion):
-        mirror_url = url_and_version.url
-        layout_version = url_and_version.version
-
         with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
             db = BuildCacheDatabase(tmpdir)
 
@@ -257,7 +254,7 @@ class BinaryCacheIndex:
             except spack_db.InvalidDatabaseVersionError as e:
                 tty.warn(
                     "you need a newer Spack version to read the buildcache index "
-                    f"for the following v{layout_version} mirror: '{mirror_url}'. "
+                    f"for the following v{url_and_version.version} mirror: '{url_and_version:short}'. "
                     f"{e.database_version_message}"
                 )
                 return
@@ -278,10 +275,7 @@ class BinaryCacheIndex:
                     # A binary mirror can only have one spec per DAG hash, so
                     # if we already have an entry under this DAG hash for this
                     # mirror url/layout version, we're done.
-                    if (
-                        entry.url_and_version.url == mirror_url
-                        and entry.url_and_version.version == layout_version
-                    ):
+                    if entry.url_and_version == url_and_version:
                         break
                 else:
                     self._mirrors_for_spec[dag_hash].append(
@@ -518,6 +512,7 @@ class BinaryCacheIndex:
             FetchIndexError
         """
         mirror_url = url_and_version.url
+        mirror_view = url_and_version.view
         layout_version = url_and_version.version
 
         # TODO: get rid of this request, handle 404 better
@@ -525,7 +520,7 @@ class BinaryCacheIndex:
 
         if scheme != "oci":
             cache_class = get_url_buildcache_class(layout_version=layout_version)
-            if not web_util.url_exists(cache_class.get_index_url(mirror_url)):
+            if not web_util.url_exists(cache_class.get_index_url(mirror_url, mirror_view)):
                 return False
 
         fetcher: IndexFetcher = get_index_fetcher(scheme, url_and_version, cache_entry)
@@ -1913,7 +1908,12 @@ def download_tarball(
 
     try_next = []
     for try_layout in SUPPORTED_LAYOUT_VERSIONS:
-        try_next.extend([MirrorURLAndVersion(i.fetch_url, try_layout) for i in configured_mirrors])
+        try_next.extend(
+            [
+                MirrorURLAndVersion(i.fetch_url, try_layout, i.fetch_view)
+                for i in configured_mirrors
+            ]
+        )
     urls_and_versions = try_first + [uv for uv in try_next if uv not in try_first]
 
     # TODO: turn `mirrors_for_spec` into a list of Mirror instances, instead of doing that here.
@@ -2377,7 +2377,10 @@ def try_direct_fetch(spec, mirrors=None):
             fetched_spec._mark_concrete()
 
             found_specs.append(
-                MirrorForSpec(MirrorURLAndVersion(mirror.fetch_url, layout_version), fetched_spec)
+                MirrorForSpec(
+                    MirrorURLAndVersion(mirror.fetch_url, layout_version, mirror.fetch_view),
+                    fetched_spec,
+                )
             )
 
     return found_specs
@@ -2627,6 +2630,9 @@ def check_specs_against_mirrors(mirrors, specs, output_file=None):
     """Check all the given specs against buildcaches on the given mirrors and
     determine if any of the specs need to be rebuilt.  Specs need to be rebuilt
     when their hash doesn't exist in the mirror.
+
+    Note: This method does not consider filtering by views. If a spec exists in
+          in binary mirror it is reported as found.
 
     Arguments:
         mirrors (dict): Mirrors to check against
@@ -2970,13 +2976,14 @@ class DefaultIndexFetcher(IndexFetcher):
     def __init__(self, url_and_version: MirrorURLAndVersion, local_hash, urlopen=web_util.urlopen):
         self.url = url_and_version.url
         self.layout_version = url_and_version.version
+        self.view = url_and_version.view
         self.local_hash = local_hash
         self.urlopen = urlopen
         self.headers = {"User-Agent": web_util.SPACK_USER_AGENT}
 
     def conditional_fetch(self) -> FetchIndexResult:
         cache_class = get_url_buildcache_class(layout_version=self.layout_version)
-        url_index_manifest = cache_class.get_index_url(self.url)
+        url_index_manifest = cache_class.get_index_url(self.url, self.view)
 
         try:
             response = self.urlopen(
@@ -3027,13 +3034,14 @@ class EtagIndexFetcher(IndexFetcher):
     def __init__(self, url_and_version: MirrorURLAndVersion, etag, urlopen=web_util.urlopen):
         self.url = url_and_version.url
         self.layout_version = url_and_version.version
+        self.view = url_and_version.view
         self.etag = etag
         self.urlopen = urlopen
 
     def conditional_fetch(self) -> FetchIndexResult:
         # Do a conditional fetch of the index manifest (i.e. using If-None-Match header)
         cache_class = get_url_buildcache_class(layout_version=self.layout_version)
-        manifest_url = cache_class.get_index_url(self.url)
+        manifest_url = cache_class.get_index_url(self.url, self.view)
         headers = {"User-Agent": web_util.SPACK_USER_AGENT, "If-None-Match": f'"{self.etag}"'}
 
         try:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -269,6 +269,20 @@ def setup_parser(subparser: argparse.ArgumentParser):
         "mirror", type=arguments.mirror_name_or_url, help="destination mirror name, path, or URL"
     )
     update_index.add_argument(
+        "--append",
+        default=False,
+        action="store_true",
+        help="append the current environment or specified specs to the current index",
+    )
+    # Add ways to specify which specs to update the view index with
+    update_index_specs_group = update_index.add_mutually_exclusive_group(required=False)
+    update_index_specs_group.add_argument(
+        "--envfile", action="store", help="manifest or lock file (ends with ‘.json’ or ‘.lock’)"
+    )
+    update_index_specs_group.add_argument(
+        "--specfile", action="append", help="Spack spec file of spec to include in index"
+    )
+    update_index.add_argument(
         "-k",
         "--keys",
         default=False,
@@ -737,7 +751,11 @@ def manifest_copy(
         copy_buildcache_entry(src_cache_entry, destination_url)
 
 
-def update_index(mirror: spack.mirrors.mirror.Mirror, update_keys=False):
+def update_index_fn(args):
+    """update a buildcache index"""
+
+    mirror = args.mirror
+
     # Special case OCI images for now.
     try:
         image_ref = spack.oci.oci.image_from_mirror(mirror)
@@ -753,11 +771,40 @@ def update_index(mirror: spack.mirrors.mirror.Mirror, update_keys=False):
 
     # Otherwise, assume a normal mirror.
     url = mirror.push_url
+    active_env = ev.active_environment()
 
-    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
-        bindist._url_generate_package_index(url, tmpdir)
+    if mirror.push_view and not (args.specfile or args.envfile or active_env):
+        raise spack.error.SpackError(
+            "Updating a view package index in a binary mirror without specifying an "
+            "environment or specfile is reduntant to the top level mirror index"
+        )
 
-    if update_keys:
+    if mirror.push_view and active_env and not (args.specfile or args.envfile):
+        tty.info("Collecting specs for view index from active" f" environment {active_env.name}")
+
+    if mirror.push_view:
+        # This mirror is pushing a specific view index
+        if args.specfile:
+            view_specs = [spack.spec.Spec.from_specfile(f) for f in args.specfile]
+        else:
+            if args.envfile and os.path.isfile(args.envfile):
+                env = ev.environment_from_name_or_dir(os.path.dirname(args.envfile))
+            elif active_env:
+                env = active_env
+            if env:
+                env = ev.environment_from_name_or_dir(os.path.dirname(args.envfile))
+                view_specs = env.all_concretized_user_specs()
+
+        with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
+            bindist._url_generate_view_package_index(
+                url, mirror.push_view, args.append, view_specs, tmpdir
+            )
+    else:
+        with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
+            bindist._url_generate_package_index(url, tmpdir)
+
+    # Push keys
+    if args.keys:
         try:
             with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
                 bindist.generate_key_index(url, tmpdir)
@@ -765,11 +812,6 @@ def update_index(mirror: spack.mirrors.mirror.Mirror, update_keys=False):
             # Do not error out if listing keys went wrong. This usually means that the _gpg path
             # does not exist. TODO: distinguish between this and other errors.
             tty.warn(f"did not update the key index: {e}")
-
-
-def update_index_fn(args):
-    """update a buildcache index"""
-    return update_index(args.mirror, update_keys=args.keys)
 
 
 def migrate_fn(args):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -117,6 +117,7 @@ def setup_parser(subparser):
         action="store_true",
         help=("set mirror to push automatically after installation"),
     )
+    add_parser.add_argument("--view", default=None, help="specify the binary mirror view name.")
     add_parser_signed = add_parser.add_mutually_exclusive_group(required=False)
     add_parser_signed.add_argument(
         "--unsigned",
@@ -315,6 +316,7 @@ def mirror_add(args):
         or args.oci_password
         or args.oci_username_variable
         or args.oci_password_variable
+        or args.view
         or args.autopush
         or args.signed is not None
     ):
@@ -365,6 +367,10 @@ def mirror_add(args):
             connection["autopush"] = args.autopush
         if args.signed is not None:
             connection["signed"] = args.signed
+        if args.view is not None:
+            if args.type and not ("binary" in args.type):
+                tty.warn("Adding a view name to non-binary mirrors has no effect")
+            connection["view"] = args.view
         mirror = spack.mirrors.mirror.Mirror(connection, name=args.name)
     else:
         mirror = spack.mirrors.mirror.Mirror(args.url, name=args.name)

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -34,6 +34,7 @@ connection = {
             },
         ]
     },
+    "view": {"type": ["string", "null"]},
     "profile": {"type": ["string", "null"]},
     "endpoint_url": {"type": ["string", "null"]},
     "access_token": {"type": ["string", "null"]},  # deprecated

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -252,11 +252,17 @@ class URLBuildcacheEntry:
         return rematch.group(1)
 
     @classmethod
-    def get_index_url(cls, mirror_url: str):
+    def get_index_url(cls, mirror_url: str, view: Optional[str] = None):
+        index_name = cls.BUILDCACHE_INDEX_FILE
+        if view:
+            # Convert "/-." to "_"
+            clean_view_name = view.replace("/", "_")
+            clean_view_name = clean_view_name.replace("-", "_")
+            clean_view_name = clean_view_name.replace(".", "_")
+            index_name = f"{clean_view_name}.{index_name}"
+
         return url_util.join(
-            mirror_url,
-            *cls.get_relative_path_components(BuildcacheComponent.INDEX),
-            cls.BUILDCACHE_INDEX_FILE,
+            mirror_url, *cls.get_relative_path_components(BuildcacheComponent.INDEX), index_name
         )
 
     @classmethod
@@ -1173,28 +1179,62 @@ class MirrorURLAndVersion:
     track of downloaded/processed buildcache index files from remote mirrors
     in some layout version."""
 
+    _formats_with_view = {
+        "full": "{m.view}@{m.url}__v{m.version}",
+        "short": "{m.view}@{m.url}",
+        "url": "{m.url}",
+    }
+
+    _formats_wo_view = {"full": "{m.url}__v{m.version}", "short": "{m.url}", "url": "{m.url}"}
+
     url: str
     version: int
+    view: Optional[str]
 
-    def __init__(self, url: str, version: int):
+    def __init__(self, url: str, version: int, view: Optional[str] = None):
         self.url = url
         self.version = version
+        self.view = view
+
+    def __format__(self, fmt):
+        fmt = fmt or "short"
+
+        if self.view:
+            fstr = self._formats_with_view.get(fmt, "")
+        else:
+            fstr = self._formats_wo_view.get(fmt, "")
+
+        return fstr.format(m=self)
 
     def __str__(self):
-        return f"{self.url}__v{self.version}"
+        return self.__format__("full")
 
     def __eq__(self, other):
         if isinstance(other, MirrorURLAndVersion):
-            return self.url == other.url and self.version == other.version
+            return (
+                self.url == other.url and self.version == other.version and self.view == other.view
+            )
+
         return False
 
     def __hash__(self):
-        return hash((self.url, self.version))
+        return hash((self.url, self.version, self.view))
 
     @classmethod
     def from_string(cls, s: str):
-        parts = s.split("__v")
-        return cls(parts[0], int(parts[1]))
+        """Parse from formatted string
+        Args:
+            s (str): Formatted string of form <url>__v<version>[@<view>]
+        """
+        url, vv = s.split("__v")
+        vv_parts = vv.split("@")
+        if len(vv_parts) == 2:
+            version, view = vv_parts
+        else:
+            view = None
+            (version,) = vv_parts
+
+        return cls(url, int(version), view)
 
 
 class MirrorForSpec:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -636,7 +636,7 @@ _spack_buildcache_sync() {
 _spack_buildcache_update_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -k --keys"
+        SPACK_COMPREPLY="-h --help --append --envfile --specfile -k --keys"
     else
         _mirrors
     fi
@@ -645,7 +645,7 @@ _spack_buildcache_update_index() {
 _spack_buildcache_rebuild_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -k --keys"
+        SPACK_COMPREPLY="-h --help --append --envfile --specfile -k --keys"
     else
         _mirrors
     fi
@@ -1468,7 +1468,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret --s3-access-key-secret-variable --s3-access-token --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password --oci-password-variable"
+        SPACK_COMPREPLY="-h --help --scope --type --autopush --view --unsigned --signed --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret --s3-access-key-secret-variable --s3-access-token --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password --oci-password-variable"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -847,18 +847,30 @@ complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-gl
 complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-glob -r -d 'a quoted glob pattern identifying CI rebuild manifest files'
 
 # spack buildcache update-index
-set -g __fish_spack_optspecs_spack_buildcache_update_index h/help k/keys
+set -g __fish_spack_optspecs_spack_buildcache_update_index h/help append envfile= specfile= k/keys
 
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l append -f -a append
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l append -d 'append the current environment or specified specs to the current index'
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l envfile -r -f -a envfile
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l envfile -r -d 'manifest or lock file (ends with ‘.json’ or ‘.lock’)'
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l specfile -r -f -a specfile
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l specfile -r -d 'Spack spec file of spec to include in index'
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
 
 # spack buildcache rebuild-index
-set -g __fish_spack_optspecs_spack_buildcache_rebuild_index h/help k/keys
+set -g __fish_spack_optspecs_spack_buildcache_rebuild_index h/help append envfile= specfile= k/keys
 
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l append -f -a append
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l append -d 'append the current environment or specified specs to the current index'
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l envfile -r -f -a envfile
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l envfile -r -d 'manifest or lock file (ends with ‘.json’ or ‘.lock’)'
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l specfile -r -f -a specfile
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l specfile -r -d 'Spack spec file of spec to include in index'
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
 
@@ -2314,7 +2326,7 @@ complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -
 complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -r -d 'find mirror to destroy by url'
 
 # spack mirror add
-set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret= s3-access-key-secret-variable= s3-access-token= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password= oci-password-variable=
+set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush view= unsigned signed s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret= s3-access-key-secret-variable= s3-access-token= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
@@ -2324,6 +2336,8 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -f -a 'b
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -d 'specify the mirror type: for both binary and source use `--type binary --type source` (default)'
 complete -c spack -n '__fish_spack_using_command mirror add' -l autopush -f -a autopush
 complete -c spack -n '__fish_spack_using_command mirror add' -l autopush -d 'set mirror to push automatically after installation'
+complete -c spack -n '__fish_spack_using_command mirror add' -l view -r -f -a view
+complete -c spack -n '__fish_spack_using_command mirror add' -l view -r -d 'specify the binary mirror view name.'
 complete -c spack -n '__fish_spack_using_command mirror add' -l unsigned -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror add' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror add' -l signed -f -a signed


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add the ability to create build cache view package indices.

This feature is independent of the changes in #48713 and implements the feature described in #45629.