### PR TITLE
apptainer/singularity/singularityCE: variant suid default False

### DIFF
--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 
 
 class SingularityBase(MakefilePackage):
-    variant("suid", default=True, description="install SUID binary")
+    variant("suid", default=False, description="install SUID binary")
     variant("network", default=True, description="install network plugins")
 
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
This PR changes the default `suid` setting for `apptainer`, `singularity`, and `singularityCE` to false.