### PR TITLE
Fix installing `rust@nightly`

### DIFF
--- a/lib/spack/spack/version/common.py
+++ b/lib/spack/spack/version/common.py
@@ -10,7 +10,7 @@ import spack.error
 COMMIT_VERSION = re.compile(r"^[a-f0-9]{40}$")
 
 # Infinity-like versions. The order in the list implies the comparison rules
-infinity_versions = ["stable", "trunk", "head", "master", "main", "develop"]
+infinity_versions = ["stable", "nightly", "trunk", "head", "master", "main", "develop"]
 
 iv_min_len = min(len(s) for s in infinity_versions)
 


### PR DESCRIPTION
Installing `rust@nightly` fails because the package file declares a conflict of rust versions older than `:1.64` with `gcc>=13`. However, because `nightly` is alphanumerically smaller than any actual version number, `nightly` is incorrectly detected to have a conflict with `gcc>=13` as well. Setting the conflict to `0.0:1.64` instead solves this.

CC @alecbcs

Before this PR:

```
$ spack install -n rust@nightly       
==> Error: failed to concretize `rust@nightly` for the following reasons:
     1. rust: Rust<1.64 not compatible with GCC>=13
     2. rust: Rust<1.64 not compatible with GCC>=13
        required because conflict constraint @:1.63 
          required because rust@nightly requested explicitly 
        required because conflict is triggered when %gcc@13: 
          required because rust@nightly requested explicitly 
```

After this PR:

```
$ spack install -n rust@nightly
...
==> rust: Executing phase: 'configure'
==> rust: Executing phase: 'build'
==> rust: Executing phase: 'install'
==> rust: Successfully installed rust-nightly-2yfhvq662jgmv5pe5mxdx3xa5n4iqnln
  Stage: 2m 7.17s.  Configure: 0.16s.  Build: 29m 52.87s.  Install: 4m 59.88s.  Post-install: 8.44s.  Total: 37m 9.30s

```