### PR TITLE
spec.py: fix virtual reconstruction for old specs

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4856,7 +4856,7 @@ def reconstruct_virtuals_on_edges(spec):
                 if any(node.satisfies(x) for x in when_deps):
                     possible_virtuals[key].add(name)
         except Exception as e:
-            warnings.warn(f"cannot reconstruct virtual dependencies on package {node.name}: {e}")
+            warnings.warn(f"cannot reconstruct virtual dependencies on {node.name}: {e}")
             continue
 
     for edge in spec.traverse_edges():
@@ -4864,7 +4864,12 @@ def reconstruct_virtuals_on_edges(spec):
             continue
 
         key = edge.parent.dag_hash()
-        provided_virtuals = {x.name for x in edge.spec.package.virtuals_provided}
+        try:
+            provided_virtuals = {x.name for x in edge.spec.package.virtuals_provided}
+        except Exception as e:
+            warnings.warn(f"cannot reconstruct virtual dependencies on {edge.parent.name}: {e}")
+            continue
+
         virtuals_to_add = possible_virtuals[key] & provided_virtuals
         if not virtuals_to_add:
             continue

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4849,17 +4849,19 @@ def reconstruct_virtuals_on_edges(spec):
     for node in spec.traverse():
         key = node.dag_hash()
         try:
-            for name, when_deps in node.package.dependencies_by_name(when=True).items():
-                if not spack.repo.PATH.is_virtual(name):
-                    continue
-
-                if any(node.satisfies(x) for x in when_deps):
-                    possible_virtuals[key].add(name)
+            node_pkg = node.package
         except Exception as e:
             warnings.warn(f"cannot reconstruct virtual dependencies on {node.name}: {e}")
             continue
 
-    for edge in spec.traverse_edges():
+        for name, when_deps in node_pkg.dependencies_by_name(when=True).items():
+            if not spack.repo.PATH.is_virtual(name):
+                continue
+
+            if any(node.satisfies(x) for x in when_deps):
+                possible_virtuals[key].add(name)
+
+    for edge in spec.traverse_edges(cover="edges"):
         if edge.parent is None:
             continue
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4885,10 +4885,8 @@ def reconstruct_virtuals_on_edges(spec):
             continue
 
         virtuals_to_add = virtuals_needed[parent_key] & virtuals_provided[child_key]
-        if not virtuals_to_add:
-            continue
-
-        edge.update_virtuals(virtuals_to_add)
+        if virtuals_to_add:
+            edge.update_virtuals(virtuals_to_add)
 
 
 class SpecfileReaderBase:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4859,12 +4859,12 @@ def reconstruct_virtuals_on_edges(spec):
                 )
                 continue
 
-            for name, when_deps in parent_pkg.dependencies_by_name(when=True).items():
-                if not spack.repo.PATH.is_virtual(name):
-                    continue
-
-                if any(edge.parent.satisfies(x) for x in when_deps):
-                    virtuals_needed[parent_key].add(name)
+            virtuals_needed[parent_key] = {
+                name
+                for name, when_deps in parent_pkg.dependencies_by_name(when=True).items()
+                if spack.repo.PATH.is_virtual(name)
+                and any(edge.parent.satisfies(x) for x in when_deps)
+            }
 
         if not virtuals_needed[parent_key]:
             continue

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -427,6 +427,9 @@ def test_load_json_specfiles(specfile, expected_hash, reader_cls):
     openmpi_edges = s2.edges_to_dependencies(name="openmpi")
     assert len(openmpi_edges) == 1
 
+    # Check that virtuals have been reconstructed
+    assert "mpi" in openmpi_edges[0].virtuals
+
     # The virtuals attribute must be a tuple, when read from a
     # JSON or YAML file, not a list
     for edge in s2.traverse_edges():


### PR DESCRIPTION
This function was not tested properly, and stopped working when we started keying all metadata by when specs.

Modifications:
- [x] Add a check that virtuals are reconstructed when reading old specs
- [x] Improve virtual reconstruction to account for when conditions

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
