### PR TITLE
go: add v1.24.0

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -31,6 +31,17 @@ class GoBootstrap(Package):
     # should update these binary releases on a yearly schedule as
     # bootstrapping requirements are modified by new releases of go.
     go_releases = {
+        "1.22.12": {
+            "darwin": {
+                "amd64": "e7bbe07e96f0bd3df04225090fe1e7852ed33af37c43a23e16edbbb3b90a5b7c",
+                "arm64": "416c35218edb9d20990b5d8fc87be655d8b39926f15524ea35c66ee70273050d",
+            },
+            "linux": {
+                "amd64": "4fa4f869b0f7fc6bb1eb2660e74657fbf04cdd290b5aef905585c86051b34d43",
+                "arm64": "fd017e647ec28525e86ae8203236e0653242722a7436929b1f775744e26278e7",
+                "ppc64le": "9573d30003b0796717a99d9e2e96c48fddd4fc0f29d840f212c503b03d7de112",
+            },
+        },
         "1.20.6": {
             "darwin": {
                 "amd64": "98a09c085b4c385abae7d35b9155195d5e584d14988347ac7f18e4cbe3b5ef3d",

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -38,44 +38,44 @@ class Go(Package):
 
     license("BSD-3-Clause")
 
+    version("1.24.0", sha256="d14120614acb29d12bcab72bd689f257eb4be9e0b6f88a8fb7e41ac65f8556e5")
     version("1.23.6", sha256="039c5b04e65279daceee8a6f71e70bd05cf5b801782b6f77c6e19e2ed0511222")
     version("1.23.5", sha256="a6f3f4bbd3e6bdd626f79b668f212fbb5649daf75084fb79b678a0ae4d97423b")
     version("1.23.4", sha256="ad345ac421e90814293a9699cca19dd5238251c3f687980bbcae28495b263531")
     version("1.23.3", sha256="8d6a77332487557c6afa2421131b50f83db4ae3c579c3bc72e670ee1f6968599")
     version("1.23.2", sha256="36930162a93df417d90bd22c6e14daff4705baac2b02418edda671cdfa9cd07f")
     version("1.23.1", sha256="6ee44e298379d146a5e5aa6b1c5b5d5f5d0a3365eabdd70741e6e21340ec3b0d")
-    version("1.22.8", sha256="df12c23ebf19dea0f4bf46a22cbeda4a3eca6f474f318390ce774974278440b8")
-    version("1.22.7", sha256="66432d87d85e0cfac3edffe637d5930fc4ddf5793313fe11e4a0f333023c879f")
-    version("1.22.6", sha256="9e48d99d519882579917d8189c17e98c373ce25abaebb98772e2927088992a51")
-    version("1.22.4", sha256="fed720678e728a7ca30ba8d1ded1caafe27d16028fab0232b8ba8e22008fb784")
 
-    # https://nvd.nist.gov/vuln/detail/CVE-2024-24790
-    # https://nvd.nist.gov/vuln/detail/CVE-2024-24789
-    version(
-        "1.22.2",
-        sha256="374ea82b289ec738e968267cac59c7d5ff180f9492250254784b2044e90df5a9",
-        deprecated=True,
-    )
-    version(
-        "1.22.1",
-        sha256="79c9b91d7f109515a25fc3ecdaad125d67e6bdb54f6d4d98580f46799caea321",
-        deprecated=True,
-    )
-    version(
-        "1.22.0",
-        sha256="4d196c3d41a0d6c1dfc64d04e3cc1f608b0c436bd87b7060ce3e23234e1f4d5c",
-        deprecated=True,
-    )
-    version(
-        "1.21.6",
-        sha256="124926a62e45f78daabbaedb9c011d97633186a33c238ffc1e25320c02046248",
-        deprecated=True,
-    )
-    version(
-        "1.21.5",
-        sha256="285cbbdf4b6e6e62ed58f370f3f6d8c30825d6e56c5853c66d3c23bcdb09db19",
-        deprecated=True,
-    )
+    with default_args(deprecated=True):
+        version(
+            "1.22.8", sha256="df12c23ebf19dea0f4bf46a22cbeda4a3eca6f474f318390ce774974278440b8"
+        )
+        version(
+            "1.22.7", sha256="66432d87d85e0cfac3edffe637d5930fc4ddf5793313fe11e4a0f333023c879f"
+        )
+        version(
+            "1.22.6", sha256="9e48d99d519882579917d8189c17e98c373ce25abaebb98772e2927088992a51"
+        )
+        version(
+            "1.22.4", sha256="fed720678e728a7ca30ba8d1ded1caafe27d16028fab0232b8ba8e22008fb784"
+        )
+        # https://nvd.nist.gov/vuln/detail/CVE-2024-24790
+        # https://nvd.nist.gov/vuln/detail/CVE-2024-24789
+        version(
+            "1.22.2", sha256="374ea82b289ec738e968267cac59c7d5ff180f9492250254784b2044e90df5a9"
+        )
+        version(
+            "1.22.1", sha256="79c9b91d7f109515a25fc3ecdaad125d67e6bdb54f6d4d98580f46799caea321"
+        )
+        version(
+            "1.22.0", sha256="4d196c3d41a0d6c1dfc64d04e3cc1f608b0c436bd87b7060ce3e23234e1f4d5c"
+        )
+        version(
+            "1.21.6", sha256="124926a62e45f78daabbaedb9c011d97633186a33c238ffc1e25320c02046248"
+        )
+        version(
+            "1.21.5", sha256="285cbbdf4b6e6e62ed58f370f3f6d8c30825d6e56c5853c66d3c23bcdb09db19"
+        )
 
     provides("golang")
 
@@ -85,6 +85,7 @@ class Go(Package):
     depends_on("go-or-gccgo-bootstrap", type="build")
     depends_on("go-or-gccgo-bootstrap@1.17.13:", type="build", when="@1.20:")
     depends_on("go-or-gccgo-bootstrap@1.20.6:", type="build", when="@1.22:")
+    depends_on("go-or-gccgo-bootstrap@1.22.6:", type="build", when="@1.24:")
 
     phases = ["build", "install"]
 

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -45,20 +45,13 @@ class Go(Package):
     version("1.23.3", sha256="8d6a77332487557c6afa2421131b50f83db4ae3c579c3bc72e670ee1f6968599")
     version("1.23.2", sha256="36930162a93df417d90bd22c6e14daff4705baac2b02418edda671cdfa9cd07f")
     version("1.23.1", sha256="6ee44e298379d146a5e5aa6b1c5b5d5f5d0a3365eabdd70741e6e21340ec3b0d")
+    version("1.22.8", sha256="df12c23ebf19dea0f4bf46a22cbeda4a3eca6f474f318390ce774974278440b8")
+    version("1.22.7", sha256="66432d87d85e0cfac3edffe637d5930fc4ddf5793313fe11e4a0f333023c879f")
+    version("1.22.6", sha256="9e48d99d519882579917d8189c17e98c373ce25abaebb98772e2927088992a51")
+    version("1.22.4", sha256="fed720678e728a7ca30ba8d1ded1caafe27d16028fab0232b8ba8e22008fb784")
 
+    # Deprecated versions due to CVEs
     with default_args(deprecated=True):
-        version(
-            "1.22.8", sha256="df12c23ebf19dea0f4bf46a22cbeda4a3eca6f474f318390ce774974278440b8"
-        )
-        version(
-            "1.22.7", sha256="66432d87d85e0cfac3edffe637d5930fc4ddf5793313fe11e4a0f333023c879f"
-        )
-        version(
-            "1.22.6", sha256="9e48d99d519882579917d8189c17e98c373ce25abaebb98772e2927088992a51"
-        )
-        version(
-            "1.22.4", sha256="fed720678e728a7ca30ba8d1ded1caafe27d16028fab0232b8ba8e22008fb784"
-        )
         # https://nvd.nist.gov/vuln/detail/CVE-2024-24790
         # https://nvd.nist.gov/vuln/detail/CVE-2024-24789
         version(
@@ -80,12 +73,13 @@ class Go(Package):
     provides("golang")
 
     depends_on("bash", type="build")
-    depends_on("sed", type="build")
     depends_on("grep", type="build")
-    depends_on("go-or-gccgo-bootstrap", type="build")
-    depends_on("go-or-gccgo-bootstrap@1.17.13:", type="build", when="@1.20:")
-    depends_on("go-or-gccgo-bootstrap@1.20.6:", type="build", when="@1.22:")
+    depends_on("sed", type="build")
+
     depends_on("go-or-gccgo-bootstrap@1.22.6:", type="build", when="@1.24:")
+    depends_on("go-or-gccgo-bootstrap@1.20.6:", type="build", when="@1.22:")
+    depends_on("go-or-gccgo-bootstrap@1.17.13:", type="build", when="@1.20:")
+    depends_on("go-or-gccgo-bootstrap", type="build")
 
     phases = ["build", "install"]
 
@@ -99,7 +93,6 @@ class Go(Package):
         return match.group(1) if match else None
 
     def setup_build_environment(self, env):
-        env.set("GOROOT_FINAL", self.spec.prefix.go)
         # We need to set CC/CXX_FOR_TARGET, otherwise cgo will use the
         # internal Spack wrappers and fail.
         env.set("CC_FOR_TARGET", self.compiler.cc)


### PR DESCRIPTION
Add go-bootstrap version 1.22.12 for `go@1.24.0`: https://go.dev/doc/go1.24#bootstrap.