### PR TITLE
vecmem: fix SYCL compiler specification

### DIFF
--- a/var/spack/repos/builtin/packages/vecmem/package.py
+++ b/var/spack/repos/builtin/packages/vecmem/package.py
@@ -67,6 +67,11 @@ class Vecmem(CMakePackage, CudaPackage):
     depends_on("hip", when="+hip")
     depends_on("sycl", when="+sycl")
 
+    # NOTE: this package uses a non-standard "SYCLCXX" environment variable which we can
+    # set easily only by requiring the OneAPI compiler, as this is automatically capable
+    # of compiling SYCL code.
+    requires("%oneapi", when="+sycl")
+
     # FIXME: due to #29447, googletest is not available to cmake when building with --test,
     # and we can choose between always depending on googletest, or using FetchContent
     # depends_on("googletest", type="test")


### PR DESCRIPTION
This commit adds an additional requirement to the vecmem package, requiring the OneAPI compiler iff the `sycl` variant is turned on. This allows us to correctly set the non-standard `SYCLCXX` environment variable.