### PR TITLE
g4vg/vecgeom: add version1.0.2 and patch cuda build failures

### DIFF
--- a/var/spack/repos/builtin/packages/g4vg/package.py
+++ b/var/spack/repos/builtin/packages/g4vg/package.py
@@ -18,6 +18,7 @@ class G4vg(CMakePackage):
 
     version("develop", branch="main", get_full_repo=True)
 
+    version("1.0.2", sha256="daeb9263f2741c4a1073eb26f2e9fc10e89207c1ed3425da70db934069ff4160")
     version("1.0.1", sha256="add7ce4bc37889cac2101323a997cea8574b18da6cbeffdab44a2b714d134e99")
 
     variant("debug", default=False, description="Enable runtime debug assertions")

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -97,17 +97,11 @@ class Vecgeom(CMakePackage, CudaPackage):
 
     conflicts("+cuda", when="@:1.1.5")
 
-    # Fix missing CMAKE_CUDA_STANDARD
+    # Fix empty -Xcompiler= with nvcc
     patch(
-        "https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/7094dd180ef694f2abb7463cafcedfb8b8ed30a1.diff",
-        sha256="34f1a6899616e40bce33d80a38a9b409f819cbaab07b2e3be7f4ec4bedb52b29",
-        when="@1.1.7 +cuda",
-    )
-    # Fix installed target properties to not propagate flags to nvcc
-    patch(
-        "https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/ac398bd109dd9175e4a898cd4b62571a3cc88252.diff",
-        sha256="a9ba136d3ed4282ec950069da2199f22beadea27d89a4264d8773ba329e253df",
-        when="@1.1.18 +cuda ^cuda@:11.4",
+        "https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/0bf9b675ab70eb5cb9409ff73c1152fd1326dbf4.diff",
+        sha256="f172b0a9ee1de4931b106d8500d1a60d5688c9bce324cf12ca107ec866a16c56",
+        when="@1.2.7:1.2.10 +cuda ^cuda@:11",
     )
 
     def std_when(values):


### PR DESCRIPTION
- Remove patches from deleted versions of vecgeom
- Add patch for CUDA 11
- Add g4vg 1.0.2