### PR TITLE
Bug fixes for fckit (disable finalization of DDTs) and ectrans (disable use of Fortran contiguous keyword)

### DIFF
--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -77,7 +77,7 @@ class Ectrans(CMakePackage):
             # Turn off use of contiguous keyword in Fortran because a number
             # of compilers have issues with it, and the hardcoded list of "bad"
             # compilers in ectrans is incomplete and isn't kept up to date
-            # TODO ADD LINK TO ECTRANS ISSUE HERE
+            # https://github.com/JCSDA/spack-stack/issues/1522
             "-DECTRANS_HAVE_CONTIGUOUS_ISSUE",
         ]
         return args

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -74,5 +74,10 @@ class Ectrans(CMakePackage):
             self.define_from_variant("ENABLE_FFTW", "fftw"),
             self.define_from_variant("ENABLE_MKL", "mkl"),
             self.define_from_variant("ENABLE_TRANSI", "transi"),
+            # Turn off use of contiguous keyword in Fortran because a number
+            # of compilers have issues with it, and the hardcoded list of "bad"
+            # compilers in ectrans is incomplete and isn't kept up to date
+            # TODO ADD LINK TO ECTRANS ISSUE HERE
+            "-DECTRANS_HAVE_CONTIGUOUS_ISSUE",
         ]
         return args

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -78,6 +78,6 @@ class Ectrans(CMakePackage):
             # of compilers have issues with it, and the hardcoded list of "bad"
             # compilers in ectrans is incomplete and isn't kept up to date
             # https://github.com/JCSDA/spack-stack/issues/1522
-            "-DECTRANS_HAVE_CONTIGUOUS_ISSUE",
+            "-DECTRANS_HAVE_CONTIGUOUS_ISSUE=ON",
         ]
         return args

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -63,7 +63,8 @@ class Fckit(CMakePackage):
 
         # Turn off finalization of derived data types (DDTs) because it is
         # flaky and we can't rely on fckit to auto-detect if the compiler
-        # supports the feature or not. TODO ADD LINK TO FCKIT ISSUE HERE
+        # supports the feature or not.
+        # https://github.com/JCSDA/spack-stack/issues/1521
         args.append("-DENABLE_FINAL=OFF")
 
         if (

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -50,17 +50,6 @@ class Fckit(CMakePackage):
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant("shared", default=True, description="Build shared libraries")
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
-    variant(
-        "finalize_ddts",
-        default="auto",
-        description="Enable / disable automatic finalization of derived types",
-        values=("auto", "no", "yes"),
-    )
-
-    # fckit fails to auto-detect/switch off finalization
-    # of derived types for latest Intel compilers. If set
-    # to auto, turn off in cmake_args. If set to yes, abort.
-    conflicts("%intel@2021.8:", when="finalize_ddts=yes")
 
     def cmake_args(self):
         args = [
@@ -72,11 +61,10 @@ class Fckit(CMakePackage):
         if self.spec.satisfies("~shared"):
             args.append("-DBUILD_SHARED_LIBS=OFF")
 
-        if "finalize_ddts=auto" not in self.spec:
-            args.append(self.define_from_variant("ENABLE_FINAL", "finalize_ddts"))
-        elif "finalize_ddts=auto" in self.spec and self.spec.satisfies("%intel@2021.8:"):
-            # See comment above (conflicts for finalize_ddts)
-            args.append("-DENABLE_FINAL=OFF")
+        # Turn off finalization of derived data types (DDTs) because it is
+        # flaky and we can't rely on fckit to auto-detect if the compiler
+        # supports the feature or not. TODO ADD LINK TO FCKIT ISSUE HERE
+        args.append("-DENABLE_FINAL=OFF")
 
         if (
             self.spec.satisfies("%intel")


### PR DESCRIPTION
## Description

1. **fckit** The auto-detection of compiler support for finalization of derived data types is unreliable and has caused issues with new and old compilers alike, see https://github.com/JCSDA/spack-stack/issues/1521. We brought this issue up to the `fckit` developers a while ago, and they more or less said that adding this feature wasn't the greatest idea. The solution is to simply turn off the feature altogether in the `cmake` step.
2. **ectrans** The package maintains a list of "bad" compilers that do not support the Fortran `contiguous` keyword correctly. The list is incomplete and out of date, see https://github.com/JCSDA/spack-stack/issues/1522. Maintaining such a list of compilers is bound to fail, and the expected performance benefits of using `contiguous` are minimal. Therefore, turn off the use of `contiguous` altogether in the `cmake` step.

Tested by JCSDA developers as part of https://github.com/JCSDA/spack-stack/issues/1522