### PR TITLE
paraview: add patch for Intel Classic compilers

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -359,6 +359,11 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     # intel oneapi doesn't compile some code in catalyst
     patch("catalyst-etc_oneapi_fix.patch", when="@5.10.0:5.10.1%oneapi")
 
+    # Classic Intel compilers don't compile some code in vtkFFT.txx
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11928
+    # Applying it for every compiler is fine.
+    patch("vtk-fft-icc.patch", when="@5.12.0:5.13.2")
+
     # Patch for paraview 5.8: ^hdf5@1.13.2:
     # Even with ~hdf5, hdf5 is part of the dependency tree due to netcdf-c
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9690

--- a/var/spack/repos/builtin/packages/paraview/vtk-fft-icc.patch
+++ b/var/spack/repos/builtin/packages/paraview/vtk-fft-icc.patch
@@ -1,0 +1,13 @@
+diff --git a/VTK/Common/Math/vtkFFT.txx b/VTK/Common/Math/vtkFFT.txx
+index 043812a2f32..8c8410aeee9 100644
+--- a/VTK/Common/Math/vtkFFT.txx
++++ b/VTK/Common/Math/vtkFFT.txx
+@@ -327,6 +327,6 @@ vtkSmartPointer<vtkFFT::vtkScalarNumberArray> vtkFFT::Csd(vtkScalarNumberArray*
+   vtkSMPTools::Fill(averageRange.begin(), averageRange.end(), 0.0);
+ 
+   auto resRange = vtk::DataArrayTupleRange(result);
+-  using ConstTupleRef = decltype(resRange)::ConstTupleReferenceType;
++  using ConstTupleRef = typename decltype(resRange)::ConstTupleReferenceType;
+   for (unsigned int i = 0; i < shape[0]; ++i)
+   {
+     auto begin = resRange.cbegin() + i * shape[1];


### PR DESCRIPTION
ParaView 5.12.0 through 5.13.2 do not compile. See https://gitlab.kitware.com/vtk/vtk/-/issues/19620.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
