### PR TITLE
openmpi: fix for gcc14 compile error in 4.1.8 and 5.0.7

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/fix-type-mismatch-error.patch
+++ b/var/spack/repos/builtin/packages/openmpi/fix-type-mismatch-error.patch
@@ -1,0 +1,32 @@
+From b7eea5bf8e7f6b2f494ab922ec5e98247c37a1e9 Mon Sep 17 00:00:00 2001
+From: Tomislav Janjusic <tomislavj@nvidia.com>
+Date: Tue, 18 Feb 2025 12:25:27 -0600
+Subject: [PATCH] Fix type mismatch error
+
+Signed-off-by: Tomislav Janjusic <tomislavj@nvidia.com>
+---
+ oshmem/mca/sshmem/base/sshmem_base_open.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/oshmem/mca/sshmem/base/sshmem_base_open.c b/oshmem/mca/sshmem/base/sshmem_base_open.c
+index 1f0d1eb761e..2694120e1cf 100644
+--- a/oshmem/mca/sshmem/base/sshmem_base_open.c
++++ b/oshmem/mca/sshmem/base/sshmem_base_open.c
+@@ -31,7 +31,7 @@
+  * globals
+  */
+ 
+-void *mca_sshmem_base_start_address = UINTPTR_MAX;
++void *mca_sshmem_base_start_address = (void *)UINTPTR_MAX;
+ 
+ char * mca_sshmem_base_backing_file_dir = NULL;
+ 
+@@ -49,7 +49,7 @@ mca_sshmem_base_register (mca_base_register_flag_t flags)
+                                  "base",
+                                  "start_address",
+                                  "Specify base address for shared memory region",
+-                                 MCA_BASE_VAR_TYPE_UNSIGNED_LONG_LONG,
++                                 MCA_BASE_VAR_TYPE_UNSIGNED_LONG,
+                                  NULL,
+                                  0,
+                                  MCA_BASE_VAR_FLAG_SETTABLE,

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -410,6 +410,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     patch("configure.patch", when="@1.10.1")
     patch("fix_multidef_pmi_class.patch", when="@2.0.0:2.0.1")
     patch("fix-ucx-1.7.0-api-instability.patch", when="@4.0.0:4.0.2")
+    patch("fix-type-mismatch-error.patch", when="@4.1.8,5.0.7")
 
     # Vader Bug: https://github.com/open-mpi/ompi/issues/5375
     # Haven't release fix for 2.1.x


### PR DESCRIPTION
Patch for openmpi from https://github.com/open-mpi/ompi/pull/13105

Fixes builds with some compilers (GCC14 and Intel 2025), see https://github.com/open-mpi/ompi/issues/13103