### PR TITLE
typst: add v0.13.0

### DIFF
--- a/var/spack/repos/builtin/packages/typst/package.py
+++ b/var/spack/repos/builtin/packages/typst/package.py
@@ -18,8 +18,8 @@ class Typst(CargoPackage):
 
     license("Apache-2.0", checked_by="upsj")
 
-    version("0.12.0", commit="737895d769188f6fc154523e67a9102bc24c872e", tag="v0.12.0")
     version("0.13.0", commit="8dce676dcd691f75696719e0480cd619829846a9", tag="v0.13.0")
+    version("0.12.0", commit="737895d769188f6fc154523e67a9102bc24c872e", tag="v0.12.0")
 
     depends_on("rust@1.81.0:")
     depends_on("openssl")

--- a/var/spack/repos/builtin/packages/typst/package.py
+++ b/var/spack/repos/builtin/packages/typst/package.py
@@ -25,13 +25,10 @@ class Typst(CargoPackage):
     depends_on("openssl")
     depends_on("pkgconfig", type="build")
 
+    build_directory = "crates/typst-cli"
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)
         match = re.search(r"typst ([0-9.]+)", output)
         return match.group(1) if match else None
-
-    def build(self, spec, prefix):
-        # The cargopackage installer doesn't allow for an option to install from a subdir
-        # see: https://github.com/rust-lang/cargo/issues/7599
-        cargo("install", "--root", "out", "--path", "crates/typst-cli")

--- a/var/spack/repos/builtin/packages/typst/package.py
+++ b/var/spack/repos/builtin/packages/typst/package.py
@@ -19,6 +19,7 @@ class Typst(CargoPackage):
     license("Apache-2.0", checked_by="upsj")
 
     version("0.12.0", commit="737895d769188f6fc154523e67a9102bc24c872e", tag="v0.12.0")
+    version("0.13.0", commit="8dce676dcd691f75696719e0480cd619829846a9", tag="v0.13.0")
 
     depends_on("rust@1.81.0:")
     depends_on("openssl")

--- a/var/spack/repos/builtin/packages/typst/package.py
+++ b/var/spack/repos/builtin/packages/typst/package.py
@@ -21,7 +21,7 @@ class Typst(CargoPackage):
     version("0.13.0", commit="8dce676dcd691f75696719e0480cd619829846a9", tag="v0.13.0")
     version("0.12.0", commit="737895d769188f6fc154523e67a9102bc24c872e", tag="v0.12.0")
 
-    depends_on("rust@1.81.0:")
+    depends_on("rust@1.80:", type="build")
     depends_on("openssl")
     depends_on("pkgconfig", type="build")
 


### PR DESCRIPTION
**Changelog:**
https://github.com/typst/typst/releases/tag/v0.13.0

Description updated by @alecbcs.