### PR TITLE
py-torchgeo: correct pyvista dep

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -125,7 +125,7 @@ class PyTorchgeo(PythonPackage):
         depends_on("py-pycocotools@2.0.5:", when="@0.5:")
         depends_on("py-pycocotools@2:")
         depends_on("py-pyvista@0.34.2:", when="@0.5:0.6")
-        depends_on("py-pyvista@0.20:", when="@0.4:")
+        depends_on("py-pyvista@0.20:", when="@0.4")
         depends_on("py-scikit-image@0.19:", when="@0.6:")
         depends_on("py-scikit-image@0.18:", when="@0.4:")
         depends_on("py-scipy@1.7.2:", when="@0.6:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Made a mistake in my last PR, this dep was still being added, which prevented use of Python 3.12+.