### PR TITLE
py-pip: mark Python 3.12+ support

### DIFF
--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -45,11 +45,16 @@ class PyPip(Package, PythonExtension):
     version("9.0.1", sha256="690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0")
 
     extends("python")
-    depends_on("python@3.8:", when="@24.1:", type=("build", "run"))
-    depends_on("python@3.7:", when="@22:", type=("build", "run"))
 
-    # Uses collections.MutableMapping
-    depends_on("python@:3.9", when="@:19.1", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("python@3.8:", when="@24.1:")
+        depends_on("python@3.7:", when="@22:")
+
+        # Uses pkgutil.ImpImporter
+        depends_on("python@:3.11", when="@:23.1.1")
+
+        # Uses collections.MutableMapping
+        depends_on("python@:3.9", when="@:19.1")
 
     resource(
         name="pip-bootstrap",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Noticed this because packages that still use `--install-option` require ancient versions of pip.