### PR TITLE
Backports 0.22.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-# v0.22.4 (2025-02-18)
+# v0.22.5 (2025-02-21)
 
 ## Bugfixes
 - Continue to mark non-roots as implicitly installed on partial env installs (#47183)
+
+## Notes
+- v0.22.4 is skipped to do an error in the release process
 
 # v0.22.3 (2024-11-18)
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "0.22.4"
+__version__ = "0.22.5"
 spack_version = __version__
 
 


### PR DESCRIPTION
Re-release of the bugfixes originally released as v0.22.4 due to a release process error.
