### PR TITLE
xtl: add v0.7.7

### DIFF
--- a/var/spack/repos/builtin/packages/xtl/package.py
+++ b/var/spack/repos/builtin/packages/xtl/package.py
@@ -17,6 +17,7 @@ class Xtl(CMakePackage):
     license("BSD-3-Clause")
 
     version("develop", branch="master")
+    version("0.7.7", sha256="44fb99fbf5e56af5c43619fc8c29aa58e5fad18f3ba6e7d9c55c111b62df1fbb")
     version("0.7.4", sha256="3c88be0e696b64150c4de7a70f9f09c00a335186b0b0b409771ef9f56bca7d9a")
     version("0.7.2", sha256="95c221bdc6eaba592878090916383e5b9390a076828552256693d5d97f78357c")
     version("0.6.4", sha256="5db5087c37daab3e1d35337782f79972aaaf19218a0de786a0515f247244e390")


### PR DESCRIPTION
	-	Add latest version of xtl
	-	hash tested with spack install xtl@0.7.7

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
