### PR TITLE
rust: add v1.85.0, drop beta

### DIFF
--- a/var/spack/repos/builtin/packages/rust-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/rust-bootstrap/package.py
@@ -22,6 +22,17 @@ class RustBootstrap(Package):
     # should update these binary releases as bootstrapping requirements are
     # modified by new releases of Rust.
     rust_releases = {
+        "1.85.0": {
+            "darwin": {
+                "x86_64": "69a36d239e38cc08c6366d1d85071847406645346c6f2d2e0dfaf64b58050d3d",
+                "aarch64": "3ff45cefaf9a002069902acf3a6332113b76b530bb31803fe5cfd30f7ef8ba03",
+            },
+            "linux": {
+                "x86_64": "be4ba7b777100c851ab268e95f70f405d28d7813ba60a9bdcf4e88c88acf8602",
+                "aarch64": "0306c30bee00469fbec4b07bb04ea0308c096454354c3dc96a92b729f1c2acd1",
+                "powerpc64le": "d0761bf0e1786a46dddfe60cc9397b899f680b86e6aebd7ca16b2a70a9dd631b",
+            },
+        },
         "1.82.0": {
             "darwin": {
                 "x86_64": "b1a289cabc523f259f65116a41374ac159d72fbbf6c373bd5e545c8e835ceb6a",
@@ -134,7 +145,6 @@ class RustBootstrap(Package):
     # Pre-release versions of the bootstrap compiler.
     # Note: These versions are unchecksumed since they will change
     # periodically as new versions are released.
-    version("beta")
     version("nightly")
 
     # Stable releases of the bootstrap compiler.

--- a/var/spack/repos/builtin/packages/rust-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/rust-bootstrap/package.py
@@ -66,6 +66,17 @@ class RustBootstrap(Package):
                 "powerpc64le": "c5aedb12c552daa18072e386697205fb7b91cef1e8791fe6fb74834723851388",
             },
         },
+        "1.76.0": {
+            "darwin": {
+                "x86_64": "7bdbe085695df8e46389115e99eda7beed37a9494f6b961b45554c658e53b8e7",
+                "aarch64": "17496f15c3cb6ff73d5c36f5b54cc110f1ac31fa09521a7991c0d7ddd890dceb",
+            },
+            "linux": {
+                "x86_64": "9d589d2036b503cc45ecc94992d616fb3deec074deb36cacc2f5c212408f7399",
+                "aarch64": "2e8313421e8fb673efdf356cdfdd4bc16516f2610d4f6faa01327983104c05a0",
+                "powerpc64le": "44b3494675284d26b04747a824dc974e32fd8fd46fc0aa06a7c8ebe851332d2c",
+            },
+        },
         "1.75.0": {
             "darwin": {
                 "x86_64": "ad066e4dec7ae5948c4e7afe68e250c336a5ab3d655570bb119b3eba9cf22851",

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -30,11 +30,11 @@ class Rust(Package):
     #
     #     $ spack install -n rust@pre-release-version
     #
-    version("beta")
     version("master", branch="master", submodules=True)
     version("nightly")
 
     # Stable versions.
+    version("1.85.0", sha256="2f4f3142ffb7c8402139cfa0796e24baaac8b9fd3f96b2deec3b94b4045c6a8a")
     version("1.83.0", sha256="722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e")
     version("1.81.0", sha256="872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7")
     version("1.78.0", sha256="ff544823a5cb27f2738128577f1e7e00ee8f4c83f2a348781ae4fc355e91d5a9")
@@ -46,9 +46,6 @@ class Rust(Package):
     version("1.65.0", sha256="5828bb67f677eabf8c384020582b0ce7af884e1c84389484f7f8d00dd82c0038")
     version("1.60.0", sha256="20ca826d1cf674daf8e22c4f8c4b9743af07973211c839b85839742314c838b7")
 
-    depends_on("c", type="build")
-    depends_on("cxx", type="build")
-
     variant(
         "dev",
         default=False,
@@ -58,6 +55,9 @@ class Rust(Package):
     variant("src", default=True, description="Include standard library source files.")
 
     # Core dependencies
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("curl+nghttp2")
     depends_on("libgit2")
     depends_on("libssh2")
@@ -76,24 +76,22 @@ class Rust(Package):
     # Compiling Rust requires a previous version of Rust.
     # The easiest way to bootstrap a Rust environment is to
     # download the binary distribution of the compiler and build with that.
-    depends_on("rust-bootstrap", type="build")
 
     # Pre-release version dependencies
-    depends_on("rust-bootstrap@beta", type="build", when="@beta")
     depends_on("rust-bootstrap@nightly", type="build", when="@master")
     depends_on("rust-bootstrap@nightly", type="build", when="@nightly")
 
     # Stable version dependencies
-    depends_on("rust-bootstrap", type="build")
-    depends_on("rust-bootstrap@1.59:1.60", type="build", when="@1.60")
-    depends_on("rust-bootstrap@1.64:1.65", type="build", when="@1.65")
-    depends_on("rust-bootstrap@1.69:1.70", type="build", when="@1.70")
-    depends_on("rust-bootstrap@1.72:1.73", type="build", when="@1.73")
-    depends_on("rust-bootstrap@1.73:1.74", type="build", when="@1.74")
-    depends_on("rust-bootstrap@1.74:1.75", type="build", when="@1.75")
-    depends_on("rust-bootstrap@1.77:1.78", type="build", when="@1.78")
-    depends_on("rust-bootstrap@1.80:1.81", type="build", when="@1.81")
+    depends_on("rust-bootstrap@1.84:1.85", type="build", when="@1.85")
     depends_on("rust-bootstrap@1.82:1.83", type="build", when="@1.83")
+    depends_on("rust-bootstrap@1.80:1.81", type="build", when="@1.81")
+    depends_on("rust-bootstrap@1.77:1.78", type="build", when="@1.78")
+    depends_on("rust-bootstrap@1.74:1.75", type="build", when="@1.75")
+    depends_on("rust-bootstrap@1.73:1.74", type="build", when="@1.74")
+    depends_on("rust-bootstrap@1.72:1.73", type="build", when="@1.73")
+    depends_on("rust-bootstrap@1.69:1.70", type="build", when="@1.70")
+    depends_on("rust-bootstrap@1.64:1.65", type="build", when="@1.65")
+    depends_on("rust-bootstrap@1.59:1.60", type="build", when="@1.60")
 
     # src/llvm-project/llvm/cmake/modules/CheckCompilerVersion.cmake
     conflicts("%gcc@:7.3", when="@1.73:", msg="Host GCC version must be at least 7.4")

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -86,6 +86,7 @@ class Rust(Package):
     depends_on("rust-bootstrap@1.82:1.83", type="build", when="@1.83")
     depends_on("rust-bootstrap@1.80:1.81", type="build", when="@1.81")
     depends_on("rust-bootstrap@1.77:1.78", type="build", when="@1.78")
+    depends_on("rust-bootstrap@1.75:1.76", type="build", when="@1.76")
     depends_on("rust-bootstrap@1.74:1.75", type="build", when="@1.75")
     depends_on("rust-bootstrap@1.73:1.74", type="build", when="@1.74")
     depends_on("rust-bootstrap@1.72:1.73", type="build", when="@1.73")
@@ -183,6 +184,9 @@ class Rust(Package):
         # Disable bootstrap LLVM download.
         opts.append("llvm.download-ci-llvm=false")
 
+        # Use vendored resources to perform offline build.
+        opts.append("build.vendor=true")
+
         # Convert opts to '--set key=value' format.
         flags = [flag for opt in opts for flag in ("--set", opt)]
 
@@ -198,9 +202,6 @@ class Rust(Package):
 
         # Compile tools into flag for configure.
         flags.append(f"--tools={','.join(tools)}")
-
-        # Use vendored resources to perform offline build.
-        flags.append("--enable-vendor")
 
         configure(*flags)
 


### PR DESCRIPTION
Add v1.85.0 to rust, add requred rust-bootstrap version, and remove `rust@beta`.
