### PR TITLE
apr-util: add missing libxcrypt

### DIFF
--- a/var/spack/repos/builtin/packages/apr-util/package.py
+++ b/var/spack/repos/builtin/packages/apr-util/package.py
@@ -36,6 +36,7 @@ class AprUtil(AutotoolsPackage):
     depends_on("sqlite", when="+sqlite")
     depends_on("unixodbc", when="+odbc")
     depends_on("pkgconfig", type="build", when="+crypto ^openssl~shared")
+    depends_on("libxcrypt", when="platform=linux")
 
     @property
     def libs(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
