### PR TITLE
cgns: patch for include path for 4.5

### DIFF
--- a/var/spack/repos/builtin/packages/cgns/cgns-4.5-tk-private.patch
+++ b/var/spack/repos/builtin/packages/cgns/cgns-4.5-tk-private.patch
@@ -1,0 +1,13 @@
+diff --git a/src/cgnstools/tkogl/tkogl.c b/src/cgnstools/tkogl/tkogl.c
+index 506599d..71b4fb8 100644
+--- a/src/cgnstools/tkogl/tkogl.c
++++ b/src/cgnstools/tkogl/tkogl.c
+@@ -25,7 +25,7 @@
+ #if ! defined(__WIN32__) && ! defined(_WIN32)
+ /* For TkWmAddToColormapWindows. */
+ #define _TKPORT /* Typical installations cannot find tkPort.h. */
+-#include <tk-private/generic/tkInt.h>
++#include <tkInt.h>
+ #endif
+
+ #ifndef CONST

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -77,7 +77,7 @@ class Cgns(CMakePackage):
     # copied from https://github.com/CGNS/CGNS/pull/757
     # (adjusted an include from tk-private/generic/tkInt.h to tkInt.h)
     patch("gcc14.patch", when="@:4.4.0 %gcc@14:")
-    # "wrong" include for spack (tk-private) from the patch above made its way into the official version
+    # "wrong" include for spack (tk-private) from the patch above made it into the official version
     patch("cgns-4.5-tk-private.patch", when="@4.5.0")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -77,6 +77,8 @@ class Cgns(CMakePackage):
     # copied from https://github.com/CGNS/CGNS/pull/757
     # (adjusted an include from tk-private/generic/tkInt.h to tkInt.h)
     patch("gcc14.patch", when="@:4.4.0 %gcc@14:")
+    # "wrong" include for spack (tk-private) from the patch above made its way into the official version
+    patch("cgns-4.5-tk-private.patch", when="@4.5.0")
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Based on the patch from here: https://github.com/spack/spack/pull/44562

This patch was merged into cgns 4.5 but with a slightly different include path:
We seem to need `#include <tkInt.h>` instead of `#include <tk-private/generic/tkInt.h>`.