### PR TITLE
root: add v6.34.04

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -35,6 +35,7 @@ class Root(CMakePackage):
     version("develop", branch="master")
 
     # Production version
+    version("6.34.04", sha256="e320c5373a8e87bb29b7280954ca8355ad8c4295cf49235606f0c8b200acb374")
     version("6.34.02", sha256="166bec562e420e177aaf3133fa3fb09f82ecddabe8a2e1906345bad442513f94")
     version("6.34.00", sha256="f3b00f3db953829c849029c39d7660a956468af247efd946e89072101796ab03")
     version("6.32.08", sha256="29ad4945a72dff1a009c326a65b6fa5ee2478498823251d3cef86a2cbeb77b27")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -441,11 +441,14 @@ class Root(CMakePackage):
     conflicts("%intel")
 
     # ROOT <6.08 was incompatible with the GCC 5+ ABI
-    conflicts("%gcc@5.0.0:", when="@:6.07")
+    conflicts("%gcc@5:", when="@:6.07")
 
     # The version of Clang featured in ROOT <6.12 fails to build with
     # GCC 9.2.1, which we can safely extrapolate to the GCC 9 series.
-    conflicts("%gcc@9.0.0:", when="@:6.11")
+    conflicts("%gcc@9:", when="@:6.11")
+
+    # GCC 15 support was added in 6.34.04
+    conflicts("%gcc@15:", when="@:6.34.02")
 
     # See https://github.com/root-project/root/issues/9297
     conflicts("target=ppc64le:", when="@:6.24")


### PR DESCRIPTION
This PR adds `root`, v6.34.04 ([release notes](https://root.cern/doc/v634/release-notes.html#release-6.34.04)).

- [x] conflict with gcc-15 for older versions