### PR TITLE
spec.py: remove VariantMap.concrete

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4615,17 +4615,6 @@ class VariantMap(lang.HashableMap):
 
         return changed
 
-    @property
-    def concrete(self):
-        """Returns True if the spec is concrete in terms of variants.
-
-        Returns:
-            bool: True or False
-        """
-        return self.spec._concrete or all(
-            v in self for v in spack.repo.PATH.get_pkg_class(self.spec.fullname).variant_names()
-        )
-
     def copy(self) -> "VariantMap":
         clone = VariantMap(self.spec)
         for name, variant in self.items():

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -685,22 +685,6 @@ class TestVariantMapTest:
         c["shared"] = BoolValuedVariant("shared", True)
         assert str(c) == "+shared feebar=foo foo=bar,baz foobar=fee"
 
-    def test_concrete(self, mock_packages, config) -> None:
-        spec = Spec("pkg-a")
-        assert not VariantMap(spec).concrete
-
-        # concrete if associated spec is concrete
-        spec = spack.concretize.concretize_one(spec)
-        assert VariantMap(spec).concrete
-
-        # concrete if all variants are present (even if spec not concrete)
-        spec._mark_concrete(False)
-        assert spec.variants.concrete
-
-        # remove a variant to test the condition
-        del spec.variants["foo"]
-        assert not spec.variants.concrete
-
 
 def test_disjoint_set_initialization_errors():
     # Constructing from non-disjoint sets should raise an exception


### PR DESCRIPTION
`VariantMap.concrete` is unused, and would be incorrect if it were used
due to conditional variants.

Just let the `Spec` dictate what is concrete and what is not.