### PR TITLE
gcc: fix package.py for gcc@:9

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -818,7 +818,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if self.version >= Version("6"):
             options.append("--with-system-zlib")
 
-        if spec.satisfies("^zstd"):
+        if self.version >= Version("10") and spec.satisfies("^zstd"):
             options.append("--with-zstd-include={0}".format(spec["zstd"].headers.directories[0]))
             options.append("--with-zstd-lib={0}".format(spec["zstd"].libs.directories[0]))
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -818,7 +818,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if self.version >= Version("6"):
             options.append("--with-system-zlib")
 
-        if self.version >= Version("10") and spec.satisfies("^zstd"):
+        if self.version >= Version("10"):
             options.append("--with-zstd-include={0}".format(spec["zstd"].headers.directories[0]))
             options.append("--with-zstd-lib={0}".format(spec["zstd"].libs.directories[0]))
 


### PR DESCRIPTION
Fix error for gcc <= 9 which doesn't depend on zstd - this currently generates an error of the form:
```
==> Installing gcc-8.5.0-2axclqcfsccrsduafixmmebwbm6binbr [86/89]
==> No binary for gcc-8.5.0-2axclqcfsccrsduafixmmebwbm6binbr found: installing from source
==> Using cached archive: /scratch/spack-25.1pre/var/spack/cache/_source-cache/archive/d3/d308841a511bb830a6100397b0042db24ce11f642dab6ea6ee44842e5325ed50.tar.xz
==> Applied patch /scratch/spack-25.1pre/var/spack/repos/builtin/packages/gcc/patch-2b40941d23b1570cdd90083b58fa0f66aa58c86e.patch
==> Applied patch /scratch/spack-25.1pre/var/spack/repos/builtin/packages/gcc/glibc-2.36-libsanitizer-gcc-5-9.patch
==> Ran patch() for gcc
==> gcc: Executing phase: 'autoreconf'
==> gcc: Executing phase: 'configure'
==> Error: KeyError: 'No spec with name zstd in gcc@8.5.0/2axclqcfsccrsduafixmmebwbm6binbr'

/scratch/spack-25.1pre/var/spack/repos/builtin/packages/gcc/package.py:819, in configure_args:
        816            options.append("--with-system-zlib")
        817
        818        if spec.satisfies("^zstd"):
  >>    819            options.append("--with-zstd-include={0}".format(spec["zstd"].headers.directories[0]))
        820            options.append("--with-zstd-lib={0}".format(spec["zstd"].libs.directories[0]))
        821
        822        # Enabling language "jit" requires --enable-host-shared.

See build log for details:
  /tmp/f_jkessx/spack-stage/spack-stage-gcc-8.5.0-2axclqcfsccrsduafixmmebwbm6binbr/spack-build-out.txt
```
