### PR TITLE
prometheus: improve dependency specs

### DIFF
--- a/var/spack/repos/builtin/packages/prometheus/package.py
+++ b/var/spack/repos/builtin/packages/prometheus/package.py
@@ -35,7 +35,6 @@ class Prometheus(MakefilePackage):
     depends_on("npm", type="build", when="@2.30.0:")
     depends_on("yarn@1", type="build", when="@:2.29.2")
 
-
     def build(self, spec, prefix):
         make("build", parallel=False)
 

--- a/var/spack/repos/builtin/packages/prometheus/package.py
+++ b/var/spack/repos/builtin/packages/prometheus/package.py
@@ -10,7 +10,7 @@ class Prometheus(MakefilePackage):
     systems and service monitoring system."""
 
     homepage = "https://prometheus.io/"
-    url = "https://github.com/prometheus/prometheus/archive/v2.19.2.tar.gz"
+    url = "https://github.com/prometheus/prometheus/archive/v2.55.1.tar.gz"
 
     license("Apache-2.0")
 
@@ -23,10 +23,18 @@ class Prometheus(MakefilePackage):
 
     depends_on("c", type="build")  # generated
 
-    depends_on("go", type="build")
+    depends_on("go@1.17:", type="build", when="@2.37.0:")
+    depends_on("go@1.16:", type="build", when="@2.33.0:")
+    depends_on("go@1.14:", type="build", when="@2.23.0:")
+    depends_on("go@1.13:", type="build", when="@2.17.0:")
+
+    depends_on("node-js@16:", type="build", when="@2.31.0")
     depends_on("node-js@11.10.1:", type="build")
-    depends_on("yarn", type="build")
-    depends_on("npm", type="build", when="@2.55.1:")
+
+    depends_on("npm@7:", type="build", when="@2.31.0:")
+    depends_on("npm", type="build", when="@2.30.0:")
+    depends_on("yarn@1", type="build", when="@:2.29.2")
+
 
     def build(self, spec, prefix):
         make("build", parallel=False)

--- a/var/spack/repos/builtin/packages/prometheus/package.py
+++ b/var/spack/repos/builtin/packages/prometheus/package.py
@@ -10,16 +10,16 @@ class Prometheus(MakefilePackage):
     systems and service monitoring system."""
 
     homepage = "https://prometheus.io/"
-    url = "https://github.com/prometheus/prometheus/archive/v2.55.1.tar.gz"
+    url = "https://github.com/prometheus/prometheus/archive/refs/tags/v2.55.1.tar.gz"
 
     license("Apache-2.0")
 
     version("2.55.1", sha256="f48251f5c89eea6d3b43814499d558bacc4829265419ee69be49c5af98f79573")
-    version("2.19.2", sha256="d4e84cae2fed6761bb8a80fcc69b6e0e9f274d19dffc0f38fb5845f11da1bbc3")
-    version("2.19.1", sha256="b72b9b6bdbae246dcc29ef354d429425eb3c0a6e1596fc8b29b502578a4ce045")
-    version("2.18.2", sha256="a26c106c97d81506e3a20699145c11ea2cce936427a0e96eb2fd0dc7cd1945ba")
-    version("2.17.1", sha256="d0b53411ea0295c608634ca7ef1d43fa0f5559e7ad50705bf4d64d052e33ddaf")
-    version("2.17.0", sha256="b5e508f1c747aaf50dd90a48e5e2a3117fec2e9702d0b1c7f97408b87a073009")
+    version("2.19.2", sha256="f77017846259d01f281ded0d70af834e06ee489d325c9c84de0e68c7d505b42b")
+    version("2.19.1", sha256="c5bdfb3653b82c1d26e5e14feadf644692289fae42a48e2567629aa2c4a02fc4")
+    version("2.18.2", sha256="01b4d55aae0a43c9eecb5a660648e45e74ea20f9d4558ff6533058f2050aabd1")
+    version("2.17.1", sha256="443590c1896cf5096b75d4a30e45381c84a5d17712dc714109ea8cf418b275ac")
+    version("2.17.0", sha256="c94b13677003838d795c082b95878903d43cd21ab148996d39f1900f00370c97")
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/prometheus/package.py
+++ b/var/spack/repos/builtin/packages/prometheus/package.py
@@ -28,7 +28,7 @@ class Prometheus(MakefilePackage):
     depends_on("go@1.14:", type="build", when="@2.23.0:")
     depends_on("go@1.13:", type="build", when="@2.17.0:")
 
-    depends_on("node-js@16:", type="build", when="@2.31.0")
+    depends_on("node-js@16:", type="build", when="@2.31.0:")
     depends_on("node-js@11.10.1:", type="build")
 
     depends_on("npm@7:", type="build", when="@2.31.0:")


### PR DESCRIPTION
Improved dependency specs so I can later safely introduce `yarn` with versions greater than 1.

Dependency information is based on https://github.com/prometheus/prometheus/tree/main?tab=readme-ov-file#building-from-source.