### PR TITLE
Fix setup.fish syntax

### DIFF
--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -788,7 +788,7 @@ end
 #
 set -l fish_version (string split '.' $FISH_VERSION)
 if test $fish_version[1] -gt 3
-    ; or begin ; test $fish_version[1] -eq 3 ; and test $fish_version[2] -ge 2 ; end
+    or begin ; test $fish_version[1] -eq 3 ; and test $fish_version[2] -ge 2 ; end
 
     source $sp_share_dir/spack-completion.fish
 end

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -788,7 +788,7 @@ end
 #
 set -l fish_version (string split '.' $FISH_VERSION)
 if test $fish_version[1] -gt 3
-    or begin ; test $fish_version[1] -eq 3 and test $fish_version[2] -ge 2 ; end
+    ; or begin ; test $fish_version[1] -eq 3 ; and test $fish_version[2] -ge 2 ; end
 
     source $sp_share_dir/spack-completion.fish
 end


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
PR #48806 introduced an invalid fish syntax (https://fishshell.com/docs/current/cmds/and.html), at least with fish 3.7.1.