### PR TITLE
ICU4C: Ensure no doubly quoted args

### DIFF
--- a/var/spack/repos/builtin/packages/icu4c/ICU4C_NMAKE_NO_DOUBLE_QUOTE_VARS.patch
+++ b/var/spack/repos/builtin/packages/icu4c/ICU4C_NMAKE_NO_DOUBLE_QUOTE_VARS.patch
@@ -1,0 +1,13 @@
+diff --git a/source/test/testdata/testdata.mak b/source/test/testdata/testdata.mak
+index 2809efd..02f5b79 100644
+--- a/source/test/testdata/testdata.mak
++++ b/source/test/testdata/testdata.mak
+@@ -25,7 +25,7 @@ ALL : "$(TESTDATAOUT)\testdata.dat"
+ 
+ # old_e_testtypes.res is the same, but icuswapped to big-endian EBCDIC
+ 
+-TESTDATATMP="$(TESTDATAOUT)\testdata"
++TESTDATATMP=$(TESTDATAOUT)\testdata
+ 
+ CREATE_DIRS :
+ 	@if not exist "$(TESTDATAOUT)\$(NULL)" mkdir "$(TESTDATAOUT)"

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -53,6 +53,9 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
         depends_on("automake", type="build")
         depends_on("libtool", type="build")
 
+    with when("build_system=msbuild"):
+        patch("ICU4C_NMAKE_NO_DOUBLE_QUOTE_VARS.patch")
+
     conflicts(
         "%intel@:16",
         when="@60.1:",

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -54,7 +54,7 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
         depends_on("libtool", type="build")
 
     with when("build_system=msbuild"):
-        patch("ICU4C_NMAKE_NO_DOUBLE_QUOTE_VARS.patch")
+        patch("ICU4C_NMAKE_NO_DOUBLE_QUOTE_VARS.patch", when="@64.1:")
 
     conflicts(
         "%intel@:16",


### PR DESCRIPTION
ICU4C's NMAKE seems to over-quote to the degree that it  passes paths like ""<path>"" which confuses the Python command line in subprocesses the build starts

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
