### PR TITLE
add --last as well as --first to `spack load`

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -281,6 +281,7 @@ def disambiguate_spec(
     local: bool = False,
     installed: Union[bool, InstallRecordStatus] = True,
     first: bool = False,
+    last: bool = False,
 ) -> spack.spec.Spec:
     """Given a spec, figure out which installed package it refers to.
 
@@ -292,7 +293,7 @@ def disambiguate_spec(
         first: returns the first matching spec, even if more than one match is found
     """
     hashes = env.all_hashes() if env else None
-    return disambiguate_spec_from_hashes(spec, hashes, local, installed, first)
+    return disambiguate_spec_from_hashes(spec, hashes, local, installed, first, last)
 
 
 def disambiguate_spec_from_hashes(
@@ -301,6 +302,7 @@ def disambiguate_spec_from_hashes(
     local: bool = False,
     installed: Union[bool, InstallRecordStatus] = True,
     first: bool = False,
+    last: bool = False,
 ) -> spack.spec.Spec:
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 
@@ -320,6 +322,8 @@ def disambiguate_spec_from_hashes(
 
     elif first:
         return matching_specs[0]
+    elif last:
+        return matching_specs[-1]
 
     ensure_single_spec_or_die(spec, matching_specs)
 

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -65,6 +65,13 @@ def setup_parser(subparser):
         dest="load_first",
         help="load the first match if multiple packages match the spec",
     )
+    subparser.add_argument(
+        "--last",
+        action="store_true",
+        default=False,
+        dest="load_last",
+        help="load the last match if multiple packages match the spec",
+    )
 
     subparser.add_argument(
         "--list",
@@ -86,7 +93,7 @@ def load(parser, args):
 
     constraint_specs = spack.cmd.parse_specs(args.constraint)
     specs = [
-        spack.cmd.disambiguate_spec(spec, env, first=args.load_first) for spec in constraint_specs
+        spack.cmd.disambiguate_spec(spec, env, first=args.load_first, last=args.load_last) for spec in constraint_specs
     ]
 
     if not args.shell:

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -81,6 +81,13 @@ def setup_parser(subparser):
         dest="find_first",
         help="use the first match if multiple packages match the spec",
     )
+    subparser.add_argument(
+        "--last",
+        action="store_true",
+        default=False,
+        dest="find_last",
+        help="use the last match if multiple packages match the spec",
+    )
 
     arguments.add_common_arguments(subparser, ["spec"])
 
@@ -127,7 +134,7 @@ def location(parser, args):
     # install_dir command matches against installed specs.
     if args.install_dir:
         env = ev.active_environment()
-        spec = spack.cmd.disambiguate_spec(specs[0], env, first=args.find_first)
+        spec = spack.cmd.disambiguate_spec(specs[0], env, first=args.find_first, last=args.find_last)
         print(spec.prefix)
         return
 

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -138,6 +138,19 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     # Using --first should avoid the error condition
     load(shell, "--first", "libelf")
 
+def test_load_last(install_mockery, mock_fetch, mock_archive, mock_packages):
+    """Test with and without the --last option"""
+    shell = "--bat" if sys.platform == "win32" else "--sh"
+    install("libelf@0.8.12")
+    install("libelf@0.8.13")
+
+    # Now there are two versions of libelf, which should cause an error
+    out = load(shell, "libelf", fail_on_error=False)
+    assert "matches multiple packages" in out
+    assert "Use a more specific spec" in out
+
+    # Using --last should avoid the error condition
+    load(shell, "--last", "libelf")
 
 def test_load_fails_no_shell(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test that spack load prints an error message without a shell."""

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -41,6 +41,14 @@ def test_location_first(install_mockery, mock_fetch, mock_archive, mock_packages
     # This would normally return an error without --first
     assert location("--first", "--install-dir", "libelf")
 
+def test_location_last(install_mockery, mock_fetch, mock_archive, mock_packages):
+    """Test with and without the --last option"""
+    install = SpackCommand("install")
+    install("libelf@0.8.12")
+    install("libelf@0.8.13")
+    # This would normally return an error without --last
+    assert location("--last", "--install-dir", "libelf")
+
 
 def test_location_build_dir(mock_spec):
     """Tests spack location --build-dir."""


### PR DESCRIPTION
This pull adds --last as well as --first to `spack load`, `spack location` etc.

`spack load --first` is a good way to get some version of a package, but it generally gets you the oldest, most out of
date version you have installed.   This pull adds --last, which is basically the same, but takes the last one in the list
rather than the first, which generally gets you the newest/highest version rather than the oldest; if you have multiple
platforms installed, you may need `os=default_os` with it to not get another platform. 