### PR TITLE
virtualgl: add v3.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/virtualgl/package.py
+++ b/var/spack/repos/builtin/packages/virtualgl/package.py
@@ -12,15 +12,39 @@ class Virtualgl(CMakePackage):
     3D application in real time."""
 
     homepage = "https://www.virtualgl.org/Main/HomePage"
-    url = "https://downloads.sourceforge.net/project/virtualgl/2.5.2/VirtualGL-2.5.2.tar.gz"
+    url = "https://github.com/VirtualGL/virtualgl/archive/refs/tags/3.1.2.tar.gz"
 
     license("LGPL-2.1-or-later")
 
-    version("2.5.2", sha256="4f43387678b289a24139c5b7c3699740ca555a9f10011c979e51aa4df2b93238")
+    version("3.1.2", sha256="1e7f1e37e173af972ac34cdd207e856f613da44f474d19b85fe4795b0a16df38")
+    version("2.5.2", sha256="e6105f579f25a77a4a190a80f9b239a9f70e007e5e9f4a5a69c9e7cce168d166")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     # This package will only work with libjpeg-turbo, not other jpeg providers
     depends_on("libjpeg-turbo")
+    depends_on("libxtst")
+    depends_on("libxext")
+    depends_on("libx11")
+    depends_on("gl")
     depends_on("glu")
+    depends_on("libxcb", when="@3:")
+    depends_on("xcb-util-keysyms", when="@3:")
+    depends_on("opencl-headers", when="@3:", type="build")
+    depends_on("opencl-icd-loader", when="@3:")
+    depends_on("egl", when="@3:")
+
+    @when("@3:")
+    def patch(self):
+        with working_dir("server"):
+            filter_file(
+                r"string\(REGEX REPLACE.*XCB_XCB_LIB.*\)",
+                f"set(XCB_XCB_LIB {join_path(self.spec['libxcb'].prefix.lib, 'libxcb.so')})",
+                "CMakeLists.txt",
+            )
+            filter_file(
+                r"string\(REGEX REPLACE.*XCB_GLX_LIB.*\)",
+                f"set(XCB_GLX_LIB {join_path(self.spec['libxcb'].prefix.lib, 'libxcb-glx.so')})",
+                "CMakeLists.txt",
+            )


### PR DESCRIPTION
Version bump.

They changed to hosting on github. 

EGL and a couple things are required for some of the newer features
