### PR TITLE
heppdt: add dependency on C

### DIFF
--- a/var/spack/repos/builtin/packages/heppdt/package.py
+++ b/var/spack/repos/builtin/packages/heppdt/package.py
@@ -30,8 +30,9 @@ class Heppdt(AutotoolsPackage):
         preferred=True,
     )
 
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     def patch(self):
         # fix csh redirect in /bin/sh script


### PR DESCRIPTION
Extracted from #45189 

It seems having just a C++ compiler causes issues in configuration, that are reflected at build time in a linker error.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
