### PR TITLE
schema.py: validate spec only on additional keys

### DIFF
--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -39,7 +39,7 @@ module_file_configuration = {
         "load": array_of_strings,
         "suffixes": {
             "type": "object",
-            "validate_spec": True,
+            "additionalKeysAreSpecs": True,
             "additionalProperties": {"type": "string"},  # key
         },
         "environment": spack.schema.environment.definition,
@@ -64,7 +64,7 @@ common_props = {
 tcl_configuration = {
     "type": "object",
     "default": {},
-    "validate_spec": True,
+    "additionalKeysAreSpecs": True,
     "properties": {**common_props},
     "additionalProperties": module_file_configuration,
 }
@@ -72,7 +72,7 @@ tcl_configuration = {
 lmod_configuration = {
     "type": "object",
     "default": {},
-    "validate_spec": True,
+    "additionalKeysAreSpecs": True,
     "properties": {
         **common_props,
         "core_compilers": array_of_strings,
@@ -80,7 +80,7 @@ lmod_configuration = {
         "core_specs": array_of_strings,
         "filter_hierarchy_specs": {
             "type": "object",
-            "validate_spec": True,
+            "additionalKeysAreSpecs": True,
             "additionalProperties": array_of_strings,
         },
     },

--- a/lib/spack/spack/test/schema.py
+++ b/lib/spack/spack/test/schema.py
@@ -17,7 +17,7 @@ import spack.util.spack_yaml as syaml
 def validate_spec_schema():
     return {
         "type": "object",
-        "validate_spec": True,
+        "additionalKeysAreSpecs": True,
         "patternProperties": {r"\w[\w-]*": {"type": "string"}},
     }
 
@@ -34,7 +34,7 @@ def module_suffixes_schema():
                         "type": "object",
                         "properties": {
                             "suffixes": {
-                                "validate_spec": True,
+                                "additionalKeysAreSpecs": True,
                                 "patternProperties": {r"\w[\w-]*": {"type": "string"}},
                             }
                         },


### PR DESCRIPTION
Currently we validate all keys as specs, but it's meant to validate only additional keys in all cases.