### PR TITLE
seacas: add v2025-02-27

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -35,6 +35,9 @@ class Seacas(CMakePackage):
     # ###################### Versions ##########################
     version("master", branch="master")
     version(
+        "2025-02-27", sha256="3906fedf17e0a5f1c6f941cb94b56134f41abe4da89f4ec25766fc33b327f521"
+    )
+    version(
         "2024-08-15", sha256="c85130b0dac5ab9a08dcb53c8ccff478122d72b08bd41d99c0adfddc5eb18a52"
     )
     version(


### PR DESCRIPTION
This release contains modifications to most of the SEACAS applications to support ChangeSets to some degree. 

See https://github.com/SandiaLabs/seacas/wiki/Dynamic_Topology for information about Change Sets

See https://github.com/SandiaLabs/seacas/wiki/Supporting-Change-Sets for information about how the various seacas applications are supporting the use or creation of change sets.

The release also includes various other small changes including formatting, portability, intallation, TPL version updates, and spelling.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
