### PR TITLE
ci: avoid py-mpi4py tests on darwin

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/darwin/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/darwin/ci.yaml
@@ -2,6 +2,7 @@ ci:
   broken-tests-packages:
   - mpich
   - openmpi
+  - py-mpi4py
   pipeline-gen:
   - build-job-remove:
       tags: [spack]


### PR DESCRIPTION
It seems like the `py-mpi4py` tests may be hung, as in this [job](https://gitlab.spack.io/spack/spack/-/jobs/15394955), the package built in 46 seconds, but the job is still sitting there 6 hrs later.

Add `py-mpi4py` to the list of broken tests for any darwin stacks.