### PR TITLE
vtk: relax seacas dependency

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -207,10 +207,9 @@ class Vtk(CMakePackage):
         depends_on("seacas+mpi", when="+mpi")
         depends_on("seacas~mpi", when="~mpi")
         depends_on("seacas@2021-05-12:2022-10-14", when="@9.1")
-        # vtk@9.2: need Ioss::Utils::get_debug_stream() which only 2022-10-14 provides,
-        # and to be safe against other issues, make them build with this version only:
-        depends_on("seacas@2022-10-14", when="@9.2:9.3")
-        depends_on("seacas@2024-06-27", when="@9.4:")
+        # vtk@9.2: need Ioss::Utils::get_debug_stream() which 2022-10-14 and later provide
+        depends_on("seacas@2022-10-14:", when="@9.2:9.3")
+        depends_on("seacas@2024-06-27:", when="@9.4:")
 
     depends_on("nlohmann-json", when="@9.2:")
 


### PR DESCRIPTION
As discussed in https://github.com/spack/spack/pull/49224#issuecomment-2689003005 and following, the version-pinned dependency on `seacas` in `vtk` appears stricter than necessary. This results in newer `seacas` versions not getting built in CI.

This PR opens the range of `seacas` versions accepted by `vtk`:
- `vtk@9.2:9.3`: the version pinning was originally applied in https://github.com/spack/spack/pull/39896/commits/fef69c7b9450717a249bf345f9ec8d7eee2491ed but [per `seacas` maintainer](https://github.com/spack/spack/pull/49224#issuecomment-2689107869) that is incorrect.
- `vtk@9.4`: the version pinning was originally applied in https://github.com/spack/spack/pull/48946/commits/27c8edc575033df4e60be640cf852bdb7efc4f9b, which changed the dependency from open-ended to pinned, possibly due to the comment on the version pinning of `vtk@9.2:9.3`.