### PR TITLE
CP2K: Add GRPP support

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -1055,7 +1055,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("CP2K_ENABLE_GRID_GPU", "grid_gpu"),
             self.define_from_variant("CP2K_ENABLE_DBM_GPU", "dbm_gpu"),
             self.define_from_variant("CP2K_ENABLE_PW_GPU", "pw_gpu"),
-            self.defile_from_variant("CP2K_USE_GRPP", "grpp"),
+            self.define_from_variant("CP2K_USE_GRPP", "grpp"),
         ]
 
         # we force the use elpa openmp threading support. might need to be revisited though

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -144,6 +144,8 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         " conventional location. This option is only relevant when regtests need to be run.",
     )
 
+    variant("grpp", default=False, description="Enable GRPP psuedo potentials", when="@2025.2:")
+
     with when("+cuda"):
         variant(
             "cuda_arch_35_k20x",
@@ -1048,6 +1050,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("CP2K_ENABLE_GRID_GPU", "grid_gpu"),
             self.define_from_variant("CP2K_ENABLE_DBM_GPU", "dbm_gpu"),
             self.define_from_variant("CP2K_ENABLE_PW_GPU", "pw_gpu"),
+            self.defile_from_variant("CP2K_USE_GRPP", "grpp"),
         ]
 
         # we force the use elpa openmp threading support. might need to be revisited though

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -144,7 +144,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         " conventional location. This option is only relevant when regtests need to be run.",
     )
 
-    variant("grpp", default=False, description="Enable GRPP psuedo potentials", when="@2025.2:")
+    variant("grpp", default=False, description="Enable GRPP psuedo potentials", when="@2025.2: build_system=cmake")
 
     with when("+cuda"):
         variant(

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -144,7 +144,12 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         " conventional location. This option is only relevant when regtests need to be run.",
     )
 
-    variant("grpp", default=False, description="Enable GRPP psuedo potentials", when="@2025.2: build_system=cmake")
+    variant(
+        "grpp",
+        default=False,
+        description="Enable GRPP psuedo potentials",
+        when="@2025.2: build_system=cmake",
+    )
 
     with when("+cuda"):
         variant(


### PR DESCRIPTION
It only add a variant to CP2K. The code is integrated in CP2K code, so no external dependency needed.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
