### PR TITLE
nvpl-scalapack: new package

### DIFF
--- a/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
@@ -6,15 +6,19 @@ from spack.package import *
 
 
 class NvplScalapack(Package):
-    """FIXME: Put a proper description of your package here."""
+    """NVPL ScaLAPACK (NVIDIA Performance Libraries ScaLAPACK)."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "https://www.example.com"
-    url = "https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_scalapack/" "linux-sbsa/nvpl_scalapack-linux-sbsa-0.0.0-archive.tar.xz"
+    homepage = "https://docs.nvidia.com/nvpl/latest/scalapack/index.html"
+    url = (
+        "https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_scalapack/"
+        "linux-sbsa/nvpl_scalapack-linux-sbsa-0.2.1-archive.tar.xz"
+    )
 
     maintainers("RMeli")
 
-    version("0.2.1", sha256="6655898327ed36afd0242719075447058c3c89640b5b9bbfeb5af4dd5c101174")
+    version("0.2.1", sha256="dada4d1ecf044d90609b9e62750b383d11be9b22c87e109414bcc07dce3c83c9")
+
+    provides("scalapack")
 
     variant("ilp64", default=False, description="Force 64-bit Fortran native integers")
 
@@ -24,12 +28,16 @@ class NvplScalapack(Package):
     depends_on("nvpl-lapack ~ilp64", when="~ilp64")
     depends_on("mpi")
 
-    provides("scalapack")
-
     requires("target=armv8.2a:", msg="Any CPU with Arm-v8.2a+ microarch")
 
     conflicts("%gcc@:7")
     conflicts("%clang@:13")
+
+    def url_for_version(self, version):
+        """Spack can't detect the verion in the URL above"""
+        url = "https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_scalapack/linux-sbsa/nvpl_scalapack-linux-sbsa-{0}-archive.tar.xz"
+        print(url, url.format(version))
+        return url.format(version)
 
     @property
     def scalapack_headers(self):
@@ -39,12 +47,12 @@ class NvplScalapack(Package):
     def scalapack_libs(self):
         spec = self.spec
 
-        if spec.satisfies("+ilp64"):
-            int_type = "ilp64"
-        else:
-            int_type = "lp64"
+        int_type = "ilp64" if spec.satisfies("+ilp64") else "lp64"
 
-        if any(spec.satisfies(mpi_library) for mpi_library in ["^mpich", "^cray-mpich", "^mvapich", "^mvapich2"]):
+        if any(
+            spec.satisfies(mpi_library)
+            for mpi_library in ["^mpich", "^cray-mpich", "^mvapich", "^mvapich2"]
+        ):
             mpi_type = "mpich"
         elif spec.satisfies("^openmpi"):
             mpi_type = "openmpi" + spec["openmpi"].version.up_to(1)

--- a/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
@@ -1,0 +1,61 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class NvplScalapack(Package):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://www.example.com"
+    url = "https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_scalapack/" "linux-sbsa/nvpl_scalapack-linux-sbsa-0.0.0-archive.tar.xz"
+
+    maintainers("RMeli")
+
+    version("0.2.1", sha256="6655898327ed36afd0242719075447058c3c89640b5b9bbfeb5af4dd5c101174")
+
+    variant("ilp64", default=False, description="Force 64-bit Fortran native integers")
+
+    depends_on("nvpl-blas +ilp64", when="+ilp64")
+    depends_on("nvpl-blas ~ilp64", when="~ilp64")
+    depends_on("nvpl-lapack +ilp64", when="+ilp64")
+    depends_on("nvpl-lapack ~ilp64", when="~ilp64")
+    depends_on("mpi")
+
+    provides("scalapack")
+
+    requires("target=armv8.2a:", msg="Any CPU with Arm-v8.2a+ microarch")
+
+    requires("mpi_family=mpich", when="^mpich")
+    requires("mpi_family=mpich", when="^cray-mpich")
+    requires("mpi_family=openmpi", when="^openmpi")
+
+    conflicts("%gcc@:7")
+    conflicts("%clang@:13")
+
+    @property
+    def scalapack_headers(self):
+        return find_all_headers(self.spec.prefix.include)
+
+    @property
+    def scalapack_libs(self):
+        spec = self.spec
+
+        if spec.satisfies("+ilp64"):
+            int_type = "ilp64"
+        else:
+            int_type = "lp64"
+
+        if any(spec.satisfies(mpi_library) for mpi_library in ["^mpich", "^cray-mpich", "^mvapich", "^mvapich2"]):
+            mpi_type = "mpich"
+        elif spec.satisfies("^openmpi"):
+            mpi_type = "openmpi" + spec["openmpi"].version.up_to(1)
+
+        name = [f"libnvpl_blacs_{int_type}_{mpi_type}", f"libnvpl_scalapack_{int_type}"]
+
+        return find_libraries(name, spec.prefix.lib, shared=True, recursive=True)
+
+    def install(self, spec, prefix):
+        install_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
@@ -28,10 +28,6 @@ class NvplScalapack(Package):
 
     requires("target=armv8.2a:", msg="Any CPU with Arm-v8.2a+ microarch")
 
-    requires("mpi_family=mpich", when="^mpich")
-    requires("mpi_family=mpich", when="^cray-mpich")
-    requires("mpi_family=openmpi", when="^openmpi")
-
     conflicts("%gcc@:7")
     conflicts("%clang@:13")
 

--- a/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
@@ -34,9 +34,8 @@ class NvplScalapack(Package):
     conflicts("%clang@:13")
 
     def url_for_version(self, version):
-        """Spack can't detect the verion in the URL above"""
+        """Spack can't detect the version in the URL above"""
         url = "https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_scalapack/linux-sbsa/nvpl_scalapack-linux-sbsa-{0}-archive.tar.xz"
-        print(url, url.format(version))
         return url.format(version)
 
     @property
@@ -50,11 +49,11 @@ class NvplScalapack(Package):
         int_type = "ilp64" if spec.satisfies("+ilp64") else "lp64"
 
         if any(
-            spec.satisfies(mpi_library)
-            for mpi_library in ["^mpich", "^cray-mpich", "^mvapich", "^mvapich2"]
+            spec.satisfies(f"^[virtuals=mpi] {mpi_library}")
+            for mpi_library in ["mpich", "cray-mpich", "mvapich", "mvapich2"]
         ):
             mpi_type = "mpich"
-        elif spec.satisfies("^openmpi"):
+        elif spec.satisfies("^[virtuals=mpi] openmpi"):
             mpi_type = "openmpi" + spec["openmpi"].version.up_to(1)
 
         name = [f"libnvpl_blacs_{int_type}_{mpi_type}", f"libnvpl_scalapack_{int_type}"]

--- a/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-scalapack/package.py
@@ -55,6 +55,11 @@ class NvplScalapack(Package):
             mpi_type = "mpich"
         elif spec.satisfies("^[virtuals=mpi] openmpi"):
             mpi_type = "openmpi" + spec["openmpi"].version.up_to(1)
+        else:
+            raise InstallError(
+                f"Unsupported MPI library {spec['mpi']}.\n"
+                "Add support to the Spack package, if needed."
+            )
 
         name = [f"libnvpl_blacs_{int_type}_{mpi_type}", f"libnvpl_scalapack_{int_type}"]
 


### PR DESCRIPTION
Add [Nvidia NVPL ScaLAPACK](https://docs.nvidia.com/nvpl/latest/scalapack/index.html).

I'm aware of the discussion in https://github.com/spack/spack/issues/48733 and of PR https://github.com/spack/spack/issues/48733 trying to unify the NVPL packages, but since they seem to have stalled this PR adds the `nvpl-scalapack` package.

As it is the case for other maintainers in https://github.com/spack/spack/issues/48733, I'd be happy to keep maintaining this package if Nvidia will keep providing separate packages.