### PR TITLE
Revert "Honor `cmake_prefix_paths` property if available"

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1234,10 +1234,6 @@ class SetupContext:
             if os.path.isdir(bin_dir):
                 env.prepend_path("PATH", bin_dir)
 
-        for cp_dir in spack.build_systems.cmake.get_cmake_prefix_path(dep.package):
-            env.append_path("CMAKE_PREFIX_PATH", cp_dir)
-        env.prune_duplicate_paths("CMAKE_PREFIX_PATH")
-
 
 def _setup_pkg_and_run(
     serialized_pkg: "spack.subprocess_context.PackageInstallContext",

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -52,8 +52,7 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages
         mpileaks_spec = spack.concretize.concretize_one("mpileaks")
 
         # Ensure our reference variable is clean.
-        hello_world_paths = [os.path.normpath(p) for p in ("/hello", "/world")]
-        os.environ["CMAKE_PREFIX_PATH"] = os.pathsep.join(hello_world_paths)
+        os.environ["CMAKE_PREFIX_PATH"] = "/hello" + os.pathsep + "/world"
 
         shell_out = load(shell, "mpileaks")
 
@@ -70,7 +69,7 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages
         paths_shell = extract_value(shell_out, "CMAKE_PREFIX_PATH")
 
         # We should've prepended new paths, and keep old ones.
-        assert paths_shell[-2:] == hello_world_paths
+        assert paths_shell[-2:] == ["/hello", "/world"]
 
         # All but the last two paths are added by spack load; lookup what packages they're from.
         pkgs = [prefix_to_pkg(p) for p in paths_shell[:-2]]


### PR DESCRIPTION
Reverts spack/spack#42569

* The order is wrong (append_path).
* Putting this in `_make_runnable` while `CMAKE_PREFIX_PATH` is also modified in `_make_buildtime_detectable` is not consistent.
* `prune_duplicate_paths` shouldn't be called in a loop.