### PR TITLE
libmd: add v1.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/libmd/package.py
+++ b/var/spack/repos/builtin/packages/libmd/package.py
@@ -11,10 +11,11 @@ class Libmd(AutotoolsPackage):
     macOS, Solaris) libraries and lacking on others like GNU systems."""
 
     homepage = "https://www.hadrons.org/software/libmd/"
-    url = "https://archive.hadrons.org/software/libmd/libmd-1.0.3.tar.xz"
+    url = "https://archive.hadrons.org/software/libmd/libmd-1.1.0.tar.xz"
 
     maintainers("haampie")
 
+    version("1.1.0", sha256="1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332")
     version("1.0.4", sha256="f51c921042e34beddeded4b75557656559cf5b1f2448033b4c1eec11c07e530f")
     version("1.0.3", sha256="5a02097f95cc250a3f1001865e4dbba5f1d15554120f95693c0541923c52af4a")
     version("1.0.2", sha256="dc66b8278f82e7e1bf774fbd4bc83a0348e8f27afa185b2c2779cfcb3da25013")


### PR DESCRIPTION
Release notes can be read at https://archive.hadrons.org/software/libmd/libmd-1.1.0.announce