### PR TITLE
libseccomp: add v2.5.5, v2.5.6, v2.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/libseccomp/package.py
+++ b/var/spack/repos/builtin/packages/libseccomp/package.py
@@ -13,6 +13,9 @@ class Libseccomp(AutotoolsPackage, PythonExtension):
 
     license("LGPL-2.1-or-later")
 
+    version("2.6.0", sha256="83b6085232d1588c379dc9b9cae47bb37407cf262e6e74993c61ba72d2a784dc")
+    version("2.5.6", sha256="04c37d72965dce218a0c94519b056e1775cf786b5260ee2b7992956c4ee38633")
+    version("2.5.5", sha256="248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375")
     version("2.5.4", sha256="d82902400405cf0068574ef3dc1fe5f5926207543ba1ae6f8e7a1576351dcbdb")
     version("2.5.3", sha256="59065c8733364725e9721ba48c3a99bbc52af921daf48df4b1e012fbc7b10a76")
     version("2.3.3", sha256="7fc28f4294cc72e61c529bedf97e705c3acf9c479a8f1a3028d4cd2ca9f3b155")
@@ -27,7 +30,8 @@ class Libseccomp(AutotoolsPackage, PythonExtension):
         extends("python")
         depends_on("py-cython", type="build")
         # https://github.com/seccomp/libseccomp/commit/afbde6ddaec7c58c3b281d43b0b287269ffca9bd
-        depends_on("python@:3.11", type=("run", "link", "build"), when="@:2.5.5")
+        depends_on("python@:3.11", type=("run", "link", "build"), when="@:2.5")
+        depends_on("py-setuptools", type="build", when="@2.6:")
 
     def configure_args(self):
         return self.enable_or_disable("python", variant="python")


### PR DESCRIPTION
This PR adds `libseccomp`, v2.5.5, v2.5.6, and v2.6.0. As of v2.6.0, the change from distutils to setuptools that has already been added as a comment in #47876 is active.

Test build:
```
==> Installing libseccomp-2.6.0-qdsghl7evtuopol4eo7bfaxjkfx64jy2 [29/29]
==> No binary for libseccomp-2.6.0-qdsghl7evtuopol4eo7bfaxjkfx64jy2 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/83/83b6085232d1588c379dc9b9cae47bb37407cf262e6e74993c61ba72d2a784dc.tar.gz
==> No patches needed for libseccomp
==> libseccomp: Executing phase: 'autoreconf'
==> libseccomp: Executing phase: 'configure'
==> libseccomp: Executing phase: 'build'
==> libseccomp: Executing phase: 'install'
==> libseccomp: Successfully installed libseccomp-2.6.0-qdsghl7evtuopol4eo7bfaxjkfx64jy2
  Stage: 0.08s.  Autoreconf: 0.00s.  Configure: 7.81s.  Build: 36.92s.  Install: 6.32s.  Post-install: 0.56s.  Total: 51.99s
[+] /opt/software/linux-ubuntu25.04-skylake/gcc-14.2.0/libseccomp-2.6.0-qdsghl7evtuopol4eo7bfaxjkfx64jy2
```