### PR TITLE
nccl: Bump c++ standard to c++14 when gcc 14 is used

### DIFF
--- a/var/spack/repos/builtin/packages/nccl/gcc14.patch
+++ b/var/spack/repos/builtin/packages/nccl/gcc14.patch
@@ -1,0 +1,11 @@
+--- nccl/makefiles/common.mk	2024-09-17 08:41:17.000000000 +0200
++++ nccl-2.23.4-1/makefiles/common.mk	2025-03-02 10:08:06.216965856 +0100
+@@ -65,7 +65,7 @@
+ # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)
+ # 512 : 120, 640 : 96, 768 : 80, 1024 : 60
+ # We would not have to set this if we used __launch_bounds__, but this only works on kernels, not on functions.
+-NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) -std=c++11 --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all
++NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) -std=c++14 --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all
+ # Use addprefix so that we can specify more than one path
+ NVLDFLAGS  := -L${CUDA_LIB} -lcudart -lrt
+ 

--- a/var/spack/repos/builtin/packages/nccl/package.py
+++ b/var/spack/repos/builtin/packages/nccl/package.py
@@ -62,7 +62,7 @@ class Nccl(MakefilePackage, CudaPackage):
 
     # https://github.com/NVIDIA/nccl/issues/244
     patch("so_reuseport.patch", when="@2.3.7-1:2.4.8-1")
-
+    patch("gcc14.patch", when="%gcc@14")
     conflicts("~cuda", msg="NCCL requires CUDA")
     conflicts(
         "cuda_arch=none",


### PR DESCRIPTION
NCCL does compile properly when CUDA 12.8 and gcc@14 are combined due to the c++ standard. Bumping the standard c++14 solves the issue. The patch is only applied when `gcc@14` is part of the spec. 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
