### PR TITLE
amrex: add v25.03

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -25,6 +25,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause")
 
     version("develop", branch="development")
+    version("25.03", sha256="7a2dc60d01619afdcbce0ff624a3c1a5a605e28dd8721c0fbec638076228cab0")
     version("25.02", sha256="2680a5a9afba04e211cd48d27799c5a25abbb36c6c3d2b6c13cd4757c7176b23")
     version("25.01", sha256="29eb35cf67d66b0fd0654282454c210abfadf27fcff8478b256e3196f237c74f")
     version("24.12", sha256="ca4b41ac73fabb9cf3600b530c9823eb3625f337d9b7b9699c1089e81c67fc67")
@@ -137,7 +138,8 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
     )
     variant("eb", default=True, description="Build Embedded Boundary classes", when="@24.10:")
     variant("eb", default=False, description="Build Embedded Boundary classes", when="@:24.09")
-    variant("fft", default=False, description="Build FFT support", when="@24.11:")
+    variant("fft", default=True, description="Build FFT support", when="@25.03:")
+    variant("fft", default=False, description="Build FFT support", when="@24.11:25.02")
     variant("fortran", default=False, description="Build Fortran API")
     variant("linear_solvers", default=True, description="Build linear solvers")
     variant("amrdata", default=False, description="Build data services")


### PR DESCRIPTION
Starting from amrex-25.03, FFT is enabled by default in spack build.
