### PR TITLE
openfoam: add v2406, v2412, fix minor link deps

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -265,6 +265,8 @@ class Openfoam(Package):
 
     version("develop", branch="develop", submodules="True")
     version("master", branch="master", submodules="True")
+    version("2412", sha256="c353930105c39b75dac7fa7cfbfc346390caa633a868130fd8c9816ef5f732cd")
+    version("2406", sha256="8d1450fb89eec1e7cecc55c3bb7bc486ccbf63d069379d1d5d7518fa16a4686a")
     version("2312", sha256="f113183a4d027c93939212af8967053c5f8fe76fb62e5848cb11bbcf8e829552")
     version("2306", sha256="d7fba773658c0f06ad17f90199565f32e9bf502b7bb03077503642064e1f5344")
     version(
@@ -379,6 +381,9 @@ class Openfoam(Package):
     depends_on("flex@:2.6.1,2.6.4:")
     depends_on("cmake", type="build")
     depends_on("m4", type="build")
+    depends_on("json-c")
+    depends_on("libyaml")
+    depends_on("readline")
 
     # Require scotch with ptscotch - corresponds to standard OpenFOAM setup
     depends_on("scotch~metis+mpi~int64", when="+scotch~int64")


### PR DESCRIPTION
Tested on  `%gcc@13.3.0 arch=linux-ubuntu22.04-x86_64_v4`