### PR TITLE
Conduit: Remove rpath from static link

### DIFF
--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -424,8 +424,6 @@ class Conduit(CMakePackage):
         cfg.write(cmake_cache_entry("CMAKE_EXE_LINKER_FLAGS", linkerflags))
         if spec.satisfies("+shared"):
             cfg.write(cmake_cache_entry("CMAKE_SHARED_LINKER_FLAGS", linkerflags))
-        else:
-            cfg.write(cmake_cache_entry("CMAKE_STATIC_LINKER_FLAGS", linkerflags))
 
         #######################
         # BLT


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
I apparently broke this a while back so I am removing it. I added rpath flags to too many places.

Error from `conduit%clang~shared`:

```
  >> 313    /usr/tce/packages/clang/clang-14.0.6/bin/llvm-ar: error: unknown op
            tion W
     314    OVERVIEW: LLVM Archiver
     315    
     316    USAGE: llvm-ar [options] [-]<operation>[modifiers] [relpos] [count]
             <archive> [files]
     317           llvm-ar -M [<mri-script]
     318    
     319    OPTIONS:
```