### PR TITLE
ci: add support for high priority local mirror

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -20,8 +20,9 @@ ci:
         - k=$CI_GPG_KEY_ROOT/intermediate_ci_signing_key.gpg; [[ -r $k ]] && spack gpg trust $k
         - k=$CI_GPG_KEY_ROOT/spack_public_key.gpg; [[ -r $k ]] && spack gpg trust $k
       script::
-      - - spack config blame mirrors
-        - spack --color=always --backtrace ci rebuild -j ${SPACK_BUILD_JOBS} --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+      - - if [ -n "$SPACK_EXTRA_MIRROR" ]; then spack mirror add local "$SPACK_EXTRA_MIRROR"; fi
+        - spack config blame mirrors
+      - - spack --color=always --backtrace ci rebuild -j ${SPACK_BUILD_JOBS} --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
       after_script:
       - - cat /proc/loadavg || true
         - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true


### PR DESCRIPTION
The primary motivation behind this change is to allow us to use a new local binary mirror at the University of Oregon. This should result in faster downloads (speeding up CI) and less data transfer from S3 (reducing our cloud bill).

You can see this feature working as intended here:
https://gitlab.spack.io/spack/spack/-/jobs/15455724/viewer#L88
```
==> Installing gcc-runtime-7.5.0-zabdpeisvgei2rktk5zsr6v7rd6fal67 [2/8]
==> Fetching https://uo-spack-mirror.e4s.io:9000/spack-binaries/develop/build_cache/linux-ubuntu18.04-x86_64_v3-gcc-7.5.0-gcc-runtime-7.5.0-zabdpeisvgei2rktk5zsr6v7rd6fal67.spec.json.sig
```