### PR TITLE
Honor `cmake_prefix_paths` (try 2)

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -505,6 +505,30 @@ def match_predicate(*args):
     return match
 
 
+def dedupe_from_end(sequence, key=None):
+    """Creates a stable de-duplicated list of a hashable sequence by key, keeping later entries
+    in the list.  Because later entries are kept, it is not possible to yield the result.
+
+    Args:
+        sequence: hashable sequence to be de-duplicated
+        key: callable applied on values before uniqueness test; identity
+            by default.
+
+    Returns:
+        stable de-duplication of the sequence, keeping later entries in the list
+
+    Examples:
+
+        Dedupe a list of integers:
+
+            [x for x in dedupe_from_end([1, 2, 1, 3, 2])] == [1, 3, 2]
+
+            [x for x in llnl.util.lang.dedupe_from_end([1,-2,1,3,2], key=abs)] == [1, 3, 2]
+    """
+    reversed_result = list(dedupe(reversed(sequence), key))
+    return reversed(reversed_result)
+
+
 def dedupe(sequence, key=None):
     """Yields a stable de-duplication of an hashable sequence by key
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1076,7 +1076,8 @@ class SetupContext:
                 env.prepend_path("PATH", bin_dir)
 
         for cp_dir in spack.build_systems.cmake.get_cmake_prefix_path(dep.package):
-            env.prepend_path("CMAKE_PREFIX_PATH", cp_dir)
+            env.append_path("CMAKE_PREFIX_PATH", cp_dir)
+        env.prune_duplicate_paths("CMAKE_PREFIX_PATH")
 
 
 def load_external_modules(context: SetupContext) -> None:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1080,7 +1080,7 @@ class SetupContext:
         )
         for cp_dir in reversed(prefix_path):
             env.prepend_path("CMAKE_PREFIX_PATH", cp_dir)
-        env.prune_duplicate_paths("CMAKE_PREFIX_PATH")
+        env.prune_duplicate_paths_from_end("CMAKE_PREFIX_PATH")
 
 
 def load_external_modules(context: SetupContext) -> None:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1075,8 +1075,11 @@ class SetupContext:
             if os.path.isdir(bin_dir):
                 env.prepend_path("PATH", bin_dir)
 
-        for cp_dir in spack.build_systems.cmake.get_cmake_prefix_path(dep.package):
-            env.append_path("CMAKE_PREFIX_PATH", cp_dir)
+        prefix_path = spack.build_systems.cmake.get_cmake_prefix_path(
+            dep.package, direct=dt.LINK | dt.RUN
+        )
+        for cp_dir in reversed(prefix_path):
+            env.prepend_path("CMAKE_PREFIX_PATH", cp_dir)
         env.prune_duplicate_paths("CMAKE_PREFIX_PATH")
 
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1075,6 +1075,9 @@ class SetupContext:
             if os.path.isdir(bin_dir):
                 env.prepend_path("PATH", bin_dir)
 
+        for cp_dir in spack.build_systems.cmake.get_cmake_prefix_path(dep.package):
+            env.prepend_path("CMAKE_PREFIX_PATH", cp_dir)
+
 
 def load_external_modules(context: SetupContext) -> None:
     """Traverse a package's spec DAG and load any external modules.

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -164,13 +164,15 @@ def generator(*names: str, default: Optional[str] = None) -> None:
         conflicts(f"generator={x}")
 
 
-def get_cmake_prefix_path(pkg: spack.package_base.PackageBase) -> List[str]:
+def get_cmake_prefix_path(
+    pkg: spack.package_base.PackageBase, direct: dt.DepFlag = dt.BUILD | dt.TEST
+) -> List[str]:
     """Obtain the CMAKE_PREFIX_PATH entries for a package, based on the cmake_prefix_path package
     attribute of direct build/test and transitive link dependencies."""
     edges = traverse.traverse_topo_edges_generator(
         traverse.with_artificial_edges([pkg.spec]),
         visitor=traverse.MixedDepthVisitor(
-            direct=dt.BUILD | dt.TEST, transitive=dt.LINK, key=traverse.by_dag_hash
+            direct=direct, transitive=dt.LINK, key=traverse.by_dag_hash
         ),
         key=traverse.by_dag_hash,
         root=False,

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -52,7 +52,8 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages
         mpileaks_spec = spack.concretize.concretize_one("mpileaks")
 
         # Ensure our reference variable is clean.
-        os.environ["CMAKE_PREFIX_PATH"] = "/hello" + os.pathsep + "/world"
+        hello_world_paths = [os.path.normpath(p) for p in ("/hello", "/world")]
+        os.environ["CMAKE_PREFIX_PATH"] = os.pathsep.join(hello_world_paths)
 
         shell_out = load(shell, "mpileaks")
 
@@ -69,7 +70,7 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages
         paths_shell = extract_value(shell_out, "CMAKE_PREFIX_PATH")
 
         # We should've prepended new paths, and keep old ones.
-        assert paths_shell[-2:] == ["/hello", "/world"]
+        assert paths_shell[-2:] == hello_world_paths
 
         # All but the last two paths are added by spack load; lookup what packages they're from.
         pkgs = [prefix_to_pkg(p) for p in paths_shell[:-2]]

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -17,6 +17,12 @@ install = SpackCommand("install")
 location = SpackCommand("location")
 
 
+def extract_value(output, set_command, variable):
+    match = re.search(set_command % variable, output, flags=re.MULTILINE)
+    value = match.group(1)
+    return value.split(os.pathsep)
+
+
 def test_manpath_trailing_colon(
     install_mockery, mock_fetch, mock_archive, mock_packages, working_env
 ):
@@ -44,6 +50,34 @@ def test_manpath_trailing_colon(
     )
 
 
+def test_load_custom_cmake_prefix_path(
+    install_mockery, mock_fetch, mock_archive, mock_packages, working_env
+):
+    def test_load_shell(shell, set_command):
+        """Test that `spack load` includes custom cmake prefix path"""
+        dependency = "define-cmake-prefix-paths"
+        pkg = f"depends-on-{dependency}"
+        install(pkg)
+        pkg_spec = spack.concretize.concretize_one(pkg)
+
+        shell_out = load(shell, pkg)
+        cmake_prefix_paths = extract_value(shell_out, set_command, "CMAKE_PREFIX_PATH")
+
+        # The custom cmake_prefix_path should be the first in the list
+        assert pkg_spec[dependency].prefix.test == cmake_prefix_paths[0]
+
+    if sys.platform == "win32":
+        shell, set_command = ("--bat", r'set "%s=(.*)"')
+        test_load_shell(shell, set_command)
+    else:
+        params = [("--sh", r"export %s=([^;]*)"), ("--csh", r"setenv %s ([^;]*)")]
+        shell, set_command = params[0]
+        paths_sh = test_load_shell(shell, set_command)
+        shell, set_command = params[1]
+        paths_csh = test_load_shell(shell, set_command)
+        assert paths_sh == paths_csh
+
+
 def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages, working_env):
     def test_load_shell(shell, set_command):
         """Test that `spack load` applies prefix inspections of its required runtime deps in
@@ -57,17 +91,12 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages
 
         shell_out = load(shell, "mpileaks")
 
-        def extract_value(output, variable):
-            match = re.search(set_command % variable, output, flags=re.MULTILINE)
-            value = match.group(1)
-            return value.split(os.pathsep)
-
         # Map a prefix found in CMAKE_PREFIX_PATH back to a package name in mpileaks' DAG.
         prefix_to_pkg = lambda prefix: next(
             s.name for s in mpileaks_spec.traverse() if s.prefix == prefix
         )
 
-        paths_shell = extract_value(shell_out, "CMAKE_PREFIX_PATH")
+        paths_shell = extract_value(shell_out, set_command, "CMAKE_PREFIX_PATH")
 
         # We should've prepended new paths, and keep old ones.
         assert paths_shell[-2:] == hello_world_paths
@@ -88,7 +117,8 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages
 
         # Lastly, do we keep track that mpileaks was loaded?
         assert (
-            extract_value(shell_out, uenv.spack_loaded_hashes_var)[0] == mpileaks_spec.dag_hash()
+            extract_value(shell_out, set_command, uenv.spack_loaded_hashes_var)[0]
+            == mpileaks_spec.dag_hash()
         )
         return paths_shell
 

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -10,7 +10,14 @@ from datetime import datetime, timedelta
 import pytest
 
 import llnl.util.lang
-from llnl.util.lang import dedupe, match_predicate, memoized, pretty_date, stable_args
+from llnl.util.lang import (
+    dedupe,
+    dedupe_from_end,
+    match_predicate,
+    memoized,
+    pretty_date,
+    stable_args,
+)
 
 
 @pytest.fixture()
@@ -275,6 +282,11 @@ def test_memoized_unhashable(args, kwargs):
 def test_dedupe():
     assert [x for x in dedupe([1, 2, 1, 3, 2])] == [1, 2, 3]
     assert [x for x in dedupe([1, -2, 1, 3, 2], key=abs)] == [1, -2, 3]
+
+
+def test_dedupe_from_end():
+    assert [x for x in dedupe_from_end([1, 2, 1, 3, 2])] == [1, 3, 2]
+    assert [x for x in dedupe_from_end([1, -2, 1, 3, 2], key=abs)] == [1, 3, 2]
 
 
 def test_grouped_exception():

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, Iterable, List, MutableMapping, Optional
 
 from llnl.path import path_to_os_path, system_path_filter
 from llnl.util import tty
-from llnl.util.lang import dedupe
+from llnl.util.lang import dedupe, dedupe_from_end
 
 import spack.error
 
@@ -90,6 +90,13 @@ def deprioritize_system_paths(paths: List[Path]) -> List[Path]:
 def prune_duplicate_paths(paths: List[Path]) -> List[Path]:
     """Returns the input list with duplicates removed, otherwise preserving order."""
     return list(dedupe(paths))
+
+
+def prune_duplicate_paths_from_end(paths: List[Path]) -> List[Path]:
+    """Returns the input list with duplicates removed, keeping later entries,
+    otherwise preserving order.
+    """
+    return list(dedupe_from_end(paths))
 
 
 def get_path(name: str) -> List[Path]:
@@ -437,6 +444,17 @@ class PruneDuplicatePaths(NameModifier):
         env[self.name] = self.separator.join(directories)
 
 
+class PruneDuplicatePathsFromEnd(NameModifier):
+    def execute(self, env: MutableMapping[str, str]):
+        tty.debug(f"PruneDuplicatePathsFromEnd: {self.name}", level=3)
+        environment_value = env.get(self.name, "")
+        directories = environment_value.split(self.separator) if environment_value else []
+        directories = prune_duplicate_paths_from_end(
+            [path_to_os_path(os.path.normpath(x)).pop() for x in directories]
+        )
+        env[self.name] = self.separator.join(directories)
+
+
 def _validate_path_value(name: str, value: Any) -> Union[str, pathlib.PurePath]:
     """Ensure the value for an env variable is string or path"""
     types = (str, pathlib.PurePath)
@@ -667,6 +685,17 @@ class EnvironmentModifications:
             separator: separator for the paths (default: os.pathsep)
         """
         item = PruneDuplicatePaths(name, separator=separator, trace=self._trace())
+        self.env_modifications.append(item)
+
+    def prune_duplicate_paths_from_end(self, name: str, separator: str = os.pathsep):
+        """Stores a request to remove duplicates from a path list, starting from the end, otherwise
+        preserving the order.
+
+        Args:
+            name: name of the environment variable
+            separator: separator for the paths (default: os.pathsep)
+        """
+        item = PruneDuplicatePathsFromEnd(name, separator=separator, trace=self._trace())
         self.env_modifications.append(item)
 
     def group_by_name(self) -> Dict[str, ModificationList]:


### PR DESCRIPTION
This PR is a continuation of:

- https://github.com/spack/spack/pull/42569, which was then reverted by...
- https://github.com/spack/spack/pull/49237

The goals for this PR:

- [x] Use "prepending" instead of "appending" of environment variables
- [x] Exclude build-only dependencies from the `CMAKE_PREFIX_PATH`
- [x] Unit test that demonstrates the correct run-time value of `CMAKE_PREFIX_PATH` when loading a package that provides a `cmake_prefix_paths` property

In https://github.com/spack/spack/pull/49237, @haampie mentioned:

> - Putting this in `_make_runnable` while `CMAKE_PREFIX_PATH` is also modified in `_make_buildtime_detectable` is not consistent.
> - `prune_duplicate_paths` shouldn't be called in a loop.

I would appreciate guidance on two items:

- This is deep enough code that I do not understand under what circumstances `_make_buildtime_detectable` should be called.  Is there an obvious tweak I could make that would address your concern about inconsistencies between `_make_buildtime_detectable` and `_make_runnable`?
- Is there a place you recommend calling `prune_duplicate_paths`?  Are you okay with invoking once outside of the `for` loop that [begins here](https://github.com/spack/spack/blob/f96b6eac2b97d683b03f60907c6623d0d73368f3/lib/spack/spack/build_environment.py#L1183)?