### PR TITLE
ginkgo: fix ginkgo amd arch not used

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -219,6 +219,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
             if archs != "none":
                 arch_str = ";".join(archs)
                 args.append("-DGINKGO_HIP_AMDGPU={0}".format(arch_str))
+                args.append("-DCMAKE_HIP_ARCHITECTURES={0}".format(arch_str))
             if spec.satisfies("^hip@5.2.0:"):
                 args.append(
                     self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip)


### PR DESCRIPTION
When I install ginkgo using rocmcc 6.1.2 via this spec:
```
ginkgo@1.9.0~cuda~develtools~full_optimizations+half_precision~hwloc~ipo~mpi+openmp+rocm~sde+shared~sycl amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-rhel8-zen3
```
The amdgpu_target is not correctly forwarded to CMake, and it ends up compiling for a default architecture, which is gfx906. 
At runtime, this leads to repeatable issue such as the solvers not converging. (IMO ginkgo should check for error to know if a kernel failed to be launched... but it does not seem to be doing so properly).

Anyway, at least for ginkgo 1.8.0 and 1.9.0, this cmake flags is needed for cmake to use the correct amdclang (rocmcc flag).

I didn't add guards for version such as "1.8:" because it will not hurt to have it for earlier ginkgo version (I'll simply be unused) and could also fix older releases..

```
CMAKE_HIP_ARCHITECTURES="arch0[,arch1]*"
```

@MarcelKoch, @hartwiganzt 

@spackbot fix style