### PR TITLE
gitignore: remove *_archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,7 +201,6 @@ tramp
 
 # Org-mode
 .org-id-locations
-*_archive
 
 # flymake-mode
 *_flymake.*


### PR DESCRIPTION
This is too generic, there will be `*_archive/package.py` files soon that shouldn't be ignored.