### PR TITLE
flux-sched: Apply workarounds for oneAPI compiler for problem with build

### DIFF
--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -111,6 +111,12 @@ class FluxSched(CMakePackage, AutotoolsPackage):
     patch("no-valgrind.patch", when="@:0.20.0")
     patch("jobid-sign-compare-fix.patch", when="@:0.22.0")
 
+    patch(
+        "https://github.com/flux-framework/flux-sched/pull/1338.patch?full_index=1",
+        when="@0.42.2 %oneapi@2025:",
+        sha256="b46579efa70176055f88493caa3fefbfea5a5663a33d9c561b71e83046f763c5",
+    )
+
     def url_for_version(self, version):
         """
         Flux uses a fork of ZeroMQ's Collective Code Construction Contract


### PR DESCRIPTION
[flux-sched@0.42.2 /ajubapcd3yvdpbltaacrunx4xjypg7my E4S OneAPI](https://gitlab.spack.io/spack/spack/-/jobs/15440718)
```
  >> 89    /tmp/root/spack-stage/spack-stage-flux-sched-0.42.2-ajubapcd3yvdpblt
           aacrunx4xjypg7my/spack-src/./src/common/yggdrasil/rbtree.cpp:516:10:
            error: reference to non-static member function must be called
     90      516 |                         this->insert_leaf_base<false>(node, 
           parent);
     91          |                         ~~~~~~^~~~~~~~~~~~~~~~
  >> 92    /tmp/root/spack-stage/spack-stage-flux-sched-0.42.2-ajubapcd3yvdpblt
           aacrunx4xjypg7my/spack-src/./src/common/yggdrasil/rbtree.cpp:521:10:
            error: reference to non-static member function must be called
     93      521 |                         this->insert_leaf_base<false>(node, 
           parent);
     94          |                         ~~~~~~^~~~~~~~~~~~~~~~
     95    2 errors generated..
```
from https://github.com/spack/spack/pull/47317

FYI
@eugeneswalker 
@rscohn2 