### PR TITLE
wrf: Remove fortran variant from hdf5

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -256,8 +256,7 @@ class Wrf(Package):
     depends_on("zlib-api")
     depends_on("perl")
     depends_on("jemalloc", when="%aocc")
-    # not sure if +fortran is required, but seems like a good idea
-    depends_on("hdf5+fortran+hl+mpi")
+    depends_on("hdf5+hl+mpi")
     # build script use csh
     depends_on("tcsh", type=("build"))
     # time is not installed on all systems b/c bash provides it


### PR DESCRIPTION
This merge removes the +fortran variant when building HDF5 for WRF. This seems unnecessary, and prevents building WRF with some versions of Intel MPI, as HDF5 doesn't appear to build with Fortran support and Intel MPI.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
