### PR TITLE
raja: Apply workarounds for oneAPI compiler for problem with build

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -175,6 +175,13 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         when="^hip@6.0",
     )
 
+    # Fix compilation issue reported by Intel from their new compiler version
+    patch(
+        "https://github.com/LLNL/RAJA/pull/1668.patch?full_index=1",
+        sha256="c0548fc5220f24082fb2592d5b4e8b7c8c783b87906d5f0950d53953d25161f6",
+        when="@2024.02.1:2024.02.99 %oneapi@2025:",
+    )
+
     variant("openmp", default=False, description="Build OpenMP backend")
     variant("shared", default=False, description="Build shared libs")
     variant("desul", default=False, description="Build desul atomics backend")


### PR DESCRIPTION
[raja@2024.02.1 /jf3faqwgrinvkn4hssfaaufu3wi7c3au E4S OneAPI](https://gitlab.spack.io/spack/spack/-/jobs/15439140)

```
 >> 147    /tmp/root/spack-stage/spack-stage-raja-2024.02.1-jf3faqwgrinvkn4hss
            faaufu3wi7c3au/spack-src/include/RAJA/pattern/kernel/Tile.hpp:174:3
            0: error: no member named 'block_id' in 'IterableTiler<Iterable>'
     148      174 |       return block_id != rhs.block_id;
     149          |                          ~~~ ^
  >> 150    /tmp/root/spack-stage/spack-stage-raja-2024.02.1-jf3faqwgrinvkn4hss
            faaufu3wi7c3au/spack-src/include/RAJA/pattern/kernel/Tile.hpp:180:2
            9: error: no member named 'block_id' in 'IterableTiler<Iterable>'
     151      180 |       return block_id < rhs.block_id;
     152          |                         ~~~ ^
```

FYI: @eugeneswalker, @rscohn2 