### PR TITLE
Sundials: expand patch `when` rule

### DIFF
--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -288,7 +288,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     # ==========================================================================
     # https://github.com/LLNL/sundials/pull/434
     # https://github.com/LLNL/sundials/pull/437
-    patch("sundials-hip-platform.patch", when="@7.0.0 +rocm")
+    patch("sundials-hip-platform.patch", when="@6.7.0:7.0.0 +rocm")
 
     # https://github.com/spack/spack/issues/29526
     patch("nvector-pic.patch", when="@6.1.0:6.2.0 +rocm")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Error previous to expanding the patch to version 6.7.0:
```
spack-stage-sundials-6.7.0-i66xsgr63pg66vmrd6a2ts73oyghvog4/spack-src/include/sundials/sundials_hip_policies.hpp:39:59: error: use of undeclared identifier 'WARP_SIZE'
   39 | constexpr const sunindextype MAX_WARPS = MAX_BLOCK_SIZE / WARP_SIZE;
      |                                                           ^
```