### PR TITLE
QtPackage: modify QT_ADDITIONAL_PACKAGES_PREFIX_PATH handling

### DIFF
--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -80,7 +80,12 @@ class Geomodel(CMakePackage):
     depends_on("pythia8", when="+pythia")
     with when("+visualization"):
         depends_on("hdf5+cxx")
-        depends_on("qt +gui +opengl +sql")
+        depends_on("qmake")
+        with when("^[virtuals=qmake] qt"):
+            depends_on("qt +gui +opengl +sql")
+        with when("^[virtuals=qmake] qt-base"):
+            depends_on("qt-base +gui +opengl +sql +widgets")
+            depends_on("qt-5compat")
         depends_on("coin3d")
         depends_on("soqt")
         depends_on("opengl")
@@ -94,5 +99,8 @@ class Geomodel(CMakePackage):
             self.define_from_variant("GEOMODEL_BUILD_EXAMPLES", "examples"),
             self.define_from_variant("GEOMODEL_BUILD_TOOLS", "tools"),
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+            self.define(
+                "GEOMODEL_USE_QT6", self.spec.satisfies("+visualization ^[virtuals=qmake] qt-base")
+            ),
         ]
         return args

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import re
 import shutil
 import sys
 import tempfile

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -59,17 +59,6 @@ class QtPackage(CMakePackage):
         # Start with upstream cmake_args
         args = super().cmake_args()
 
-        # Qt components typically install cmake config files in a single prefix,
-        # so we have to point them to the cmake config files of dependencies
-        qt_prefix_path = []
-        re_qt = re.compile("qt-.*")
-        for dep in self.spec.dependencies():
-            if re_qt.match(dep.name):
-                qt_prefix_path.append(self.spec[dep.name].prefix)
-
-        # Now append all qt-* dependency prefixes into a prefix path
-        args.append(self.define("QT_ADDITIONAL_PACKAGES_PREFIX_PATH", ":".join(qt_prefix_path)))
-
         # Make our CMAKE_INSTALL_RPATH redundant:
         # for prefix of current package ($ORIGIN/../lib type of rpaths),
         args.append(self.define("QT_DISABLE_RPATH", True))
@@ -129,6 +118,11 @@ class QtPackage(CMakePackage):
             env.prepend_path("QMAKE_MODULE_PATH", self.prefix.mkspecs.modules)
         if os.path.exists(self.prefix.plugins):
             env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # Qt components typically install cmake config files in a single prefix,
+        # so we have to point dependencies to the cmake config files.
+        env.prepend_path("QT_ADDITIONAL_PACKAGES_PREFIX_PATH", self.spec.prefix)
 
 
 class QtBase(QtPackage):


### PR DESCRIPTION
Our Qt6 installation places components into different prefixes instead of a single prefix. This affects how `find_package(Qt6 COMPONENTS Core Core5Compat)` searches in `CMAKE_PREFIX_PATH`, where it finds `Qt6Config.cmake` with the `Core` component but not the `Core5Compat` component. We can and do specify `QT_ADDITIONAL_PACKAGES_PREFIX_PATH` with the prefix path of the components.

For some reason (minimal scope?) I put the composition of `QT_ADDITIONAL_PACKAGES_PREFIX_PATH` into the QtPackage `cmake_args`, by walking through the dependency tree. That works for QtPackages but not others, like `geomodel` and `paraview`.

This PR moves the handling of `QT_ADDITIONAL_PACKAGES_PREFIX_PATH` from the QtPackage's `cmake_args` to the dependency's `setup_dependent_build_environment`.