### PR TITLE
MFEM: Fix missing hipBlas symbol

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -282,6 +282,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
 
     depends_on("mpi", when="+mpi")
     depends_on("hipsparse", when="@4.4.0:+rocm")
+    depends_on("hipblas", when="@4.4.0:+rocm")
 
     with when("+mpi"):
         depends_on("hypre")
@@ -986,9 +987,10 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             if "^rocprim" in spec and not spec["hip"].external:
                 # rocthrust [via petsc+rocm] has a dependency on rocprim
                 hip_headers += spec["rocprim"].headers
-            if "^hipblas" in spec and not spec["hip"].external:
-                # superlu-dist+rocm needs the hipblas header path
-                hip_headers += spec["hipblas"].headers
+            if "^hipblas" in spec:
+                hipblas = spec["hipblas"]
+                hip_headers += hipblas.headers
+                hip_libs += hipblas.libs
             if "%cce" in spec:
                 # We assume the proper Cray CCE module (cce) is loaded:
                 proc = str(spec.target.family)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Error previous to fix:

```
ld.lld: error: undefined symbol: hipblasCreate
>>> referenced by gpu_blas.cpp
>>>               gpu_blas.o:(mfem::GPUBlas::GPUBlas()) in archive ../libmfem.a
```

Thanks for @ebchin and @becker33 for the combined efforts.