### PR TITLE
enfore std11 for diffutils and libind2

### DIFF
--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -50,3 +50,8 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
         output = Executable(exe)("--version", output=str, error=str)
         match = re.search(r"diff \(GNU diffutils\) (\S+)", output)
         return match.group(1) if match else None
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            flags.append("-std=c11")
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/libidn2/package.py
+++ b/var/spack/repos/builtin/packages/libidn2/package.py
@@ -33,3 +33,8 @@ class Libidn2(AutotoolsPackage, GNUMirrorPackage):
 
     # in-source build fails
     build_directory = "spack-build"
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            flags.append("-std=c11")
+        return (flags, None, None)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
fixes #49306 and #49307

(alternatively, maybe my compiler is not well configured, and I should define flags in `~/.spack/linux/compilers.yaml`?

```
compilers:
- compiler:
    spec: intel@=2021.9.0
    paths:
      cc: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/icc
      cxx: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/icpc
      f77: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/ifort
      fc: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/ifort
    flags:
      cflags: "-std=c11"
      cxxflags: "-std=c++17"
    operating_system: centos7
    target: x86_64
    modules: [intel/23.1.0]
    environment: {}
    extra_rpaths: []
```