### PR TITLE
QtPackage: set QT_ADDITIONAL_SBOM_DOCUMENT_PATHS

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -125,7 +125,8 @@ class QtPackage(CMakePackage):
 
         # Qt creates SBOM files based on the used SBOM files in the prefix, and
         # in additional paths for other components.
-        env.prepend_path("QT_ADDITIONAL_SBOM_DOCUMENT_PATHS", self.spec.prefix)
+        self.spec.satisfies("@6.9:"):
+            env.prepend_path("QT_ADDITIONAL_SBOM_DOCUMENT_PATHS", self.spec.prefix)
 
 
 class QtBase(QtPackage):

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -123,6 +123,10 @@ class QtPackage(CMakePackage):
         # so we have to point dependencies to the cmake config files.
         env.prepend_path("QT_ADDITIONAL_PACKAGES_PREFIX_PATH", self.spec.prefix)
 
+        # Qt creates SBOM files based on the used SBOM files in the prefix, and
+        # in additional paths for other components.
+        env.prepend_path("QT_ADDITIONAL_SBOM_DOCUMENT_PATHS", self.spec.prefix)
+
 
 class QtBase(QtPackage):
     """Qt Base (Core, Gui, Widgets, Network, ...)"""

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -125,7 +125,7 @@ class QtPackage(CMakePackage):
 
         # Qt creates SBOM files based on the used SBOM files in the prefix, and
         # in additional paths for other components.
-        self.spec.satisfies("@6.9:"):
+        if self.spec.satisfies("@6.9:"):
             env.prepend_path("QT_ADDITIONAL_SBOM_DOCUMENT_PATHS", self.spec.prefix)
 
 


### PR DESCRIPTION
Qt 6.9.0 (to be released) creates SBOM files for its dependencies. With our installation of components in their own prefixes, we need to pass these prefixes to the search path for the component SBOM files. This PR adds all QtPackage prefixes to `QT_ADDITIONAL_SBOM_DOCUMENT_PATHS` for use in downstream builds. Fixes `qt-quicktimeline@6.9.0-beta3` and `qt-quick3d@6.9.0-beta3` builds which previously could not find the `qt-declarative` SBOM files.