### PR TITLE
qt-*: add v6.8.2

### DIFF
--- a/var/spack/repos/builtin/packages/qt-5compat/package.py
+++ b/var/spack/repos/builtin/packages/qt-5compat/package.py
@@ -17,6 +17,7 @@ class Qt5compat(QtPackage):
 
     license("LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only")
 
+    version("6.8.2", sha256="9b78a025f17d65eb826ee153f167546e6c12790235d75b7f4fcd03c166d9c689")
     version("6.8.1", sha256="5e51feb8d9362d860017ae72f63daa5caeddf3ec3396e73a4b27c672536fd774")
     version("6.8.0", sha256="0ea312a2d7e7033857712273e5ea42e61d1f485d23420307f7bbf0b8ca701453")
     version("6.7.3", sha256="959634d1a6a53f9a483882e81da87ec182ff44d7747a0cc771c786b0f2cf52e0")

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -134,6 +134,7 @@ class QtBase(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.2", sha256="9dddbb2ea3c107e20a99b816c1c6ba1483915325918936dda2c762bd73836ad9")
     version("6.8.1", sha256="9b81b83e4079d2f79ae057902973fc0ebb10d566ec022f483e7c0f2294acb19c")
     version("6.8.0", sha256="3e526ceaaf615005bc89a98ee8a52b87db6fefe7155595bf75c40fd82cd1a7ce")
     version("6.7.3", sha256="65771d1618cab08ec5e9bbfdc265b5d2ce2ccf0373143d7d9d139647a7196aec")

--- a/var/spack/repos/builtin/packages/qt-declarative/package.py
+++ b/var/spack/repos/builtin/packages/qt-declarative/package.py
@@ -15,6 +15,7 @@ class QtDeclarative(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.2", sha256="1c29e98fac88f6d3b8a790248f4e6ad80439fe6e791116339d080e064ad8ae91")
     version("6.8.1", sha256="c3f41f5de5b2f02aa31bc5668f617f65d9adb3fb1939679b2a57a73a98c36ed6")
     version("6.8.0", sha256="d28e15cec7754ee16588deace17ee83d75e2613f4751a79dd60c277721f7480f")
     version("6.7.3", sha256="f39fa4e7e3b4011e52fc55fbde5f41e61815bffea432869abc9b90aa4de07613")

--- a/var/spack/repos/builtin/packages/qt-quick3d/package.py
+++ b/var/spack/repos/builtin/packages/qt-quick3d/package.py
@@ -15,6 +15,7 @@ class QtQuick3d(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.2", sha256="2901927d84fa3e55cd598575fa8a47dd97c770ed3c1893af9c9ee2aa167b7433")
     version("6.8.1", sha256="67878e0ecb9e8b760567364afd3c1b90d8c65087d8f676e9df51cad95df1bf21")
     version("6.8.0", sha256="3fc965c7c867e21d894e5394ec1c3f7626ecb895e335115661133ac499a14408")
     version("6.7.3", sha256="3e68f3a9a330e7b9a92ddf5b8d7a0874a107ea77636c788f598de65e327eb4a0")

--- a/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
+++ b/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
@@ -15,6 +15,7 @@ class QtQuicktimeline(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.2", sha256="74050e1b87495a500b66d114ba2311e9d2feb5bdadb46979b6986aedf93cd97e")
     version("6.8.1", sha256="29d79b17c0de962ce5dc9f2984eb89b701946522537cf5c90ca803c75148de19")
     version("6.8.0", sha256="3128c0f1a9e944c52ac8d080ecab7e7ed2a37e67cd06ab573dc178b3f8832fb4")
     version("6.7.3", sha256="81ce374a22bf00d53d0a9d5293d6495a224137e9427e4d4913d87f2f0adc5a58")

--- a/var/spack/repos/builtin/packages/qt-shadertools/package.py
+++ b/var/spack/repos/builtin/packages/qt-shadertools/package.py
@@ -17,6 +17,7 @@ class QtShadertools(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.2", sha256="13d62df354ca2ca034d8a28263ee67104a6d94f5671417152556eb5eb3d64839")
     version("6.8.1", sha256="b780ae2746d98fa3fc896c8ea8cd5c17ea360bedb33948e7343946bd9b115c24")
     version("6.8.0", sha256="19a6fce3e958d8e8d6cb2c13501a4a8fa61ad9e5bc0cd0496901b34012f2362e")
     version("6.7.3", sha256="8ec6a48c41d49b6f9595659169b2c69aecd46e96a88131f19f6a4cda394fa3f4")

--- a/var/spack/repos/builtin/packages/qt-svg/package.py
+++ b/var/spack/repos/builtin/packages/qt-svg/package.py
@@ -17,6 +17,7 @@ class QtSvg(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.2", sha256="b2d1f8acc7471658c963cacf8dc99912fd20e7072b3bdf7a53ccf99ba41788e8")
     version("6.8.1", sha256="288f233991686bc411a11cc331fb1be5f12ed43be03e29639158e545685ce7c9")
     version("6.8.0", sha256="ec3112668b7b8cfd1790bf4f936268dd6d32251ea81bb20d3aa4c4bac2031866")
     version("6.7.3", sha256="2852d8f1f52b60f0624ca5edf479125e4b32d579b1177d8b76d8e28fac98a701")

--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -19,6 +19,7 @@ class QtTools(QtPackage):
     license("BSD-3-Clause")
 
     # src/assistant/qlitehtml is a submodule that is not in the git archive
+    version("6.8.2", commit="8aa2456d4461516f54c98916fcd699557afb41ad", submodules=True)
     version("6.8.1", commit="b0d66c51cbda17b213bed73d379f0900c77f457c", submodules=True)
     version("6.8.0", commit="3dd2b6ad0dd1a0480628b4cc74cb7b89a89e4a61", submodules=True)
     version("6.7.3", commit="ec4747e62a837a0262212a5f4fb03734660c7360", submodules=True)


### PR DESCRIPTION
This PR adds `qt-*`, v6.8.2, which is a bugfix release. This package is tested in gitlab CI.