### PR TITLE
hep: enable more acts variants

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -17,7 +17,7 @@ spack:
         tbb: [intel-tbb]
       variants: +mpi
     acts:
-      require: +alignment +analysis +dd4hep +edm4hep +examples +fatras +fatras_geant4 +geant4 +geomodel +hepmc3 +json +odd +onnx +podio +pythia8 +python +svg +tgeo +traccc cxxstd=20
+      require: +alignment +analysis +dd4hep +edm4hep +examples +fatras +fatras_geant4 +geant4 +geomodel +hepmc3 +json +odd +onnx +podio +pythia8 +python +svg +tgeo cxxstd=20
     celeritas:
       require: +geant4 +hepmc3 +root +shared cxxstd=20
     hip:
@@ -109,7 +109,7 @@ spack:
   - yoda +root
 
   # CUDA
-  #- acts +cuda +traccc cuda_arch=80
+  - acts +cuda +traccc cuda_arch=80
   #- celeritas +cuda ~openmp +vecgeom cuda_arch=80
   - root +cuda +cudnn +tmva-gpu
   - vecgeom +cuda cuda_arch=80

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -17,7 +17,7 @@ spack:
         tbb: [intel-tbb]
       variants: +mpi
     acts:
-      require: +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +svg +tgeo cxxstd=20
+      require: +alignment +analysis +dd4hep +edm4hep +examples +fatras +fatras_geant4 +geant4 +geomodel +hepmc3 +json +odd +onnx +podio +pythia8 +python +svg +tgeo +traccc cxxstd=20
     celeritas:
       require: +geant4 +hepmc3 +root +shared cxxstd=20
     hip:


### PR DESCRIPTION
This PR enables more variants of the `acts` package in gitlab CI. In particular, it will enable the following new branches of the package graph:
- `+traccc +cuda` to pull in `detray`
- `+onnx` to pull in `py-onnxruntime`