### PR TITLE
Bug fix in package crtmv3: link *cmake config files to usable path

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
+import os
+
 from spack.package import *
 
 
@@ -99,3 +102,10 @@ class Crtm(CMakePackage):
             filter_file(
                 "-fbacktrace", "-fbacktrace -ffree-line-length-none", "libsrc/CMakeLists.txt"
             )
+
+    @run_after("install")
+    @when("@3.1.1-build1")
+    def cmake_config_softlinks(self):
+        cmake_config_files = glob.glob(join_path(self.prefix, "cmake/crtm/*"))
+        for srcpath in cmake_config_files:
+            os.symlink(srcpath, join_path(self.prefix, "cmake", os.path.basename(srcpath)))

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -103,8 +103,8 @@ class Crtm(CMakePackage):
                 "-fbacktrace", "-fbacktrace -ffree-line-length-none", "libsrc/CMakeLists.txt"
             )
 
-    @run_after("install")
     @when("@3.1.1-build1")
+    @run_after("install")
     def cmake_config_softlinks(self):
         cmake_config_files = glob.glob(join_path(self.prefix, "cmake/crtm/*"))
         for srcpath in cmake_config_files:


### PR DESCRIPTION
This PR adds a post-install patching function to the crtm recipe to soft link <crtm root>/cmake/crtm/*cmake to <crtm root>/cmake/..

See https://github.com/spack/spack/issues/49322 for more information