### PR TITLE
Simplify specifying virtuals on edges

### DIFF
--- a/PACKAGE_API.md
+++ b/PACKAGE_API.md
@@ -1,0 +1,16 @@
+# Package API v1.1
+
+**Simplified form for virtuals on edges**
+
+Virtuals on edges can now be written omitting the `virtuals=` preamble
+within `[]` brackets. This makes the following specs:
+```
+hdf5 ^[virtuals=mpi] mpich
+hdf5 ^[virtuals=lapack,blas] openblas 
+```
+equivalent to the shorter form:
+```
+hdf5 ^[mpi] mpich
+hdf5 ^[lapack,blas] openblas 
+```
+

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -18,7 +18,7 @@ spack_version = __version__
 #: version is incremented when the package API is extended in a backwards-compatible way. The major
 #: version is incremented upon breaking changes. This version is changed independently from the
 #: Spack version.
-package_api_version = (1, 0)
+package_api_version = (1, 1)
 
 #: The minimum Package API version that this version of Spack is compatible with. This should
 #: always be a tuple of the form ``(major, 0)``, since compatibility with vX.Y implies

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -135,6 +135,7 @@ class SpecTokens(TokenBase):
     # FILENAME
     FILENAME = rf"(?:{FILENAME})"
     # Package name
+    UNQUALIFIED_PACKAGE_LIST = rf"(?:{IDENTIFIER},{VALUE})"
     FULLY_QUALIFIED_PACKAGE_NAME = rf"(?:{DOTTED_IDENTIFIER})"
     UNQUALIFIED_PACKAGE_NAME = rf"(?:{IDENTIFIER})"
     # DAG hash
@@ -438,18 +439,35 @@ class EdgeAttributeParser:
 
     def parse(self):
         attributes = {}
+
+        def _add_edge_attribute(*, key: str, value: str):
+            key = key.strip("'\" ")
+            if key not in ("deptypes", "virtuals"):
+                raise SpecParsingError(
+                    "the only accepted edge attributes are 'deptypes' and 'virtuals'",
+                    self.ctx.current_token,
+                    self.literal_str,
+                )
+
+            if key in attributes:
+                raise SpecParsingError(
+                    f"'{key}' is specified multiple times on the edge",
+                    self.ctx.current_token,
+                    self.literal_str,
+                )
+
+            value = value.strip("'\" ").split(",")
+            attributes[key] = value
+
         while True:
             if self.ctx.accept(SpecTokens.KEY_VALUE_PAIR):
                 name, value = self.ctx.current_token.value.split("=", maxsplit=1)
-                name = name.strip("'\" ")
-                value = value.strip("'\" ").split(",")
-                attributes[name] = value
-                if name not in ("deptypes", "virtuals"):
-                    msg = (
-                        "the only edge attributes that are currently accepted "
-                        'are "deptypes" and "virtuals"'
-                    )
-                    raise SpecParsingError(msg, self.ctx.current_token, self.literal_str)
+                _add_edge_attribute(key=name, value=value)
+            elif self.ctx.accept(SpecTokens.UNQUALIFIED_PACKAGE_LIST) or self.ctx.accept(
+                SpecTokens.UNQUALIFIED_PACKAGE_NAME
+            ):
+                value = self.ctx.current_token.value
+                _add_edge_attribute(key="virtuals", value=value)
             # TODO: Add code to accept bool variants here as soon as use variants are implemented
             elif self.ctx.accept(SpecTokens.END_EDGE_PROPERTIES):
                 break

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -601,6 +601,41 @@ def specfile_for(default_mock_concretization):
             ],
             "zlib foo==bar",
         ),
+        # Alias for [<virtuals>] on edges are normalized when round tripping
+        (
+            "trilinos ^[mpi] mpich",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "trilinos"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="mpi"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="mpich"),
+            ],
+            "trilinos ^[virtuals=mpi] mpich",
+        ),
+        (
+            "trilinos ^[mpi,lapack] mpich",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "trilinos"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_LIST, value="mpi,lapack"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="mpich"),
+            ],
+            "trilinos ^[virtuals=lapack,mpi] mpich",
+        ),
+        (
+            "trilinos ^[mpi,lapack deptypes=link,run] mpich",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "trilinos"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_LIST, value="mpi,lapack"),
+                Token(SpecTokens.KEY_VALUE_PAIR, "deptypes=link,run"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="mpich"),
+            ],
+            "trilinos ^[deptypes=link,run virtuals=lapack,mpi] mpich",
+        ),
     ],
 )
 def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_package):
@@ -735,7 +770,7 @@ def test_cli_spec_roundtrip(args, expected):
         ("y ^x@@1.2", r"y ^x@@1.2\n    ^"),
         ("x@1.2::", r"x@1.2::\n      ^"),
         ("x::", r"x::\n ^^"),
-        ("cflags=''-Wl,a,b,c''", r"cflags=''-Wl,a,b,c''\n            ^ ^ ^ ^^"),
+        ("cflags=''-Wl,a,b,c''", r"cflags=''-Wl,a,b,c''\n            ^     ^^"),
         ("@1.2:   develop   = foo", r"@1.2:   develop   = foo\n                  ^^"),
         ("@1.2:develop   = foo", r"@1.2:develop   = foo\n               ^^"),
     ],
@@ -1011,6 +1046,8 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         ("^[@foo] zlib", "edge attributes"),
         ("x ^[deptypes=link]foo ^[deptypes=run]foo", "conflicting dependency types"),
         ("x ^[deptypes=build,link]foo ^[deptypes=link]foo", "conflicting dependency types"),
+        ("foo ^[mpi lapack]", "'virtuals' is specified multiple times"),
+        ("foo ^[virtuals=mpi lapack]", "'virtuals' is specified multiple times"),
         # TODO: Remove this as soon as use variants are added and we can parse custom attributes
         ("^[foo=bar] zlib", "edge attributes"),
         # Propagating reserved names generates a parse error


### PR DESCRIPTION
This commit adds syntactic sugar for specs specifying virtuals like:
```
hdf5 ^[virtuals=mpi] mpich
```
Since within the `[]` brackets we only allow variants, we can assume that a value, or value list, that appear without a corresponding key is associated with the `virtuals` key. In this way the spec above is equivalent to:
```
hdf5 ^[mpi] mpich
```

This will be particularly useful when compiler are deps, as it will allow users to write:
```
trilinos %[fortran] gcc %[c,cxx] apple-clang
```
instead of the more cumbersome:
```
trilinos %[virtuals=fortran] gcc %[virtuals=c,cxx] apple-clang
```


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
