### PR TITLE
TCL: Ensure system tcl doesn't impact build

### DIFF
--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -182,6 +182,12 @@ class AnyBuilder(BaseBuilder):
 class AutotoolsBuilder(AnyBuilder, spack.build_systems.autotools.AutotoolsBuilder):
     configure_directory = "unix"
 
+    # if TCL is present on the system this may be set to the system's
+    # existing TCL so ensure it is unset
+    # https://wiki.tcl-lang.org/page/TCL%5FLIBRARY
+    def setup_build_environment(self, env):
+        env.set("TCL_LIBRARY", "")
+
     def install(self, pkg, spec, prefix):
         with working_dir(self.build_directory):
             make("install")


### PR DESCRIPTION
If TCL is sourced on a system TCL is being built, the envar `TCL_LIBRARY` may be set with system paths. These paths end up in the configure, and then makefile as paths to install into. This fix ensures that this envar is cleared before building TCL