### PR TITLE
xz: add v5.4.7, v5.6.2, v5.6.3 (... it's been a year now since the meltdown)

### DIFF
--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -62,6 +62,7 @@ class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
     conflicts("platform=windows", when="+pic")  # no pic on Windows
     # prior to 5.2.3, build system is for MinGW only, not currently supported by Spack
     conflicts("platform=windows", when="@:5.2.3")
+    conflicts("platform=windows", when="@5.6:")  # CMake is required
 
     patch(
         "nvhpc.patch",

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -27,8 +27,10 @@ class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
 
     license("GPL-2.0-or-later AND Public-Domain AND LGPL-2.1-or-later", checked_by="tgamblin")
 
-    # NOTE: don't add XZ 5.6 until this compromise is resolved:
-    # https://www.openwall.com/lists/oss-security/2024/03/29/4
+    version("5.6.3", sha256="a95a49147b2dbb5487517acc0adcd77f9c2032cf00664eeae352405357d14a6c")
+    version("5.6.2", sha256="e12aa03cbd200597bd4ce11d97be2d09a6e6d39a9311ce72c91ac7deacde3171")
+    # ALERT: don't add XZ 5.6.0 or 5.6.1, https://nvd.nist.gov/vuln/detail/CVE-2024-3094
+    version("5.4.7", sha256="9976ed9cd0764e962d852d7d519ee1c3a7f87aca3b86e5d021a45650ba3ecb41")
     version("5.4.6", sha256="913851b274e8e1d31781ec949f1c23e8dbcf0ecf6e73a2436dc21769dd3e6f49")
     version("5.4.5", sha256="8ccf5fff868c006f29522e386fb4c6a1b66463fbca65a4cfc3c4bd596e895e79")
     version("5.4.1", sha256="dd172acb53867a68012f94c17389401b2f274a1aa5ae8f84cbfb8b7e383ea8d3")


### PR DESCRIPTION
This PR adds `xz`, v5.4.7, v5.6.2, v5.6.3 ([diff](https://github.com/tukaani-project/xz/compare/v5.4.7...v5.6.4)). Test build:
```
[+] /opt/software/linux-ubuntu25.04-skylake/gcc-14.2.0/xz-5.6.3-b5mpylroh4elqndav4yaiezrdh5oamjn
```