### PR TITLE
Add a custom CI file to trigger radiuss-spack-configs CI on LC

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/gitlab-ci.yml
@@ -1,0 +1,16 @@
+
+# On snapshot releases, trigger radiuss-spack-configs CI for compatibility check
+trigger-radiuss-spack-configs:
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^develop-/
+      when: on_success
+    - when: never
+  variables:
+    MY_SPACK_REPO: ${CI_PROJECT_URL}
+    MY_SPACK_COMMIT: ""
+    MY_SPACK_BRANCH: ${CI_COMMIT_BRANCH}
+  trigger:
+    project: radiuss/radiuss-spack-configs
+    branch: ${TRIGGER_PROJECT_BRANCH}
+
+


### PR DESCRIPTION
This PR is a proposal to add a gitlab-ci.yml file in the RADIUSS CI configuration directory that will allow us to configure our [Spack mirror on LC](https://lc.llnl.gov/gitlab/radiuss/spack-mirror) to trigger the [radiuss-spack-configs CI](https://github.com/LLNL/radiuss-spack-configs/pull/122) and test that our packages keep building on LC systems with the latest snapshot releases automatically.

Pro:
- This is what I think is the easiest way to trigger our CI. Otherwise I would have to implement something to track the creation of a "develop-XXXX-XX-XX" tag in Spack and trigger our CI through API, which is cumbersome.

Cons:
- This adds a file to Spack that is not used by Spack itself...

TODO:
- [ ] Need to make sure this works on pipelines triggered by new tags.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
