### PR TITLE
py-setuptools-scm-git-archive: add v1.4.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools-scm-git-archive/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm-git-archive/package.py
@@ -16,9 +16,10 @@ class PySetuptoolsScmGitArchive(PythonPackage):
 
     license("MIT")
 
+    version("1.4.1", sha256="c418bc77b3974d3ac65f268f058f23e01dc5f991f2233128b0e16a69de227b09")
     version("1.4", sha256="b048b27b32e1e76ec865b0caa4bb85df6ddbf4697d6909f567ac36709f6ef2f0")
     version("1.1", sha256="6026f61089b73fa1b5ee737e95314f41cb512609b393530385ed281d0b46c062")
     version("1.0", sha256="52425f905518247c685fc64c5fdba6e1e74443c8562e141c8de56059be0e31da")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools-scm", type=("build", "run"))
+    depends_on("py-setuptools-scm@:7", type=("build", "run"))


### PR DESCRIPTION
This PR adds `py-setuptools-scm-git-archive`, v1.4.1, which applies the [upper bound](https://github.com/Changaco/setuptools_scm_git_archive/pull/22) on `py-setuptools-scm` without which the package fails. The upper bound applies for all versions.

Test build:
```
==> Installing py-setuptools-scm-git-archive-1.4.1-4tdpb3s2mxqgclg77c6bgwq4ocfecge4 [44/44]
==> No binary for py-setuptools-scm-git-archive-1.4.1-4tdpb3s2mxqgclg77c6bgwq4ocfecge4 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/c4/c418bc77b3974d3ac65f268f058f23e01dc5f991f2233128b0e16a69de227b09.tar.gz
==> No patches needed for py-setuptools-scm-git-archive
==> py-setuptools-scm-git-archive: Executing phase: 'install'
==> py-setuptools-scm-git-archive: Successfully installed py-setuptools-scm-git-archive-1.4.1-4tdpb3s2mxqgclg77c6bgwq4ocfecge4
  Stage: 0.01s.  Install: 0.88s.  Post-install: 0.33s.  Total: 1.33s
[+] /opt/software/linux-ubuntu25.04-skylake/gcc-14.2.0/py-setuptools-scm-git-archive-1.4.1-4tdpb3s2mxqgclg77c6bgwq4ocfecge4
```