### PR TITLE
py-zfit: add through v0.25.0

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -97,6 +97,7 @@ spack:
   - py-uhi
   - py-uproot +lz4 +xrootd +zstd
   - py-vector
+  - py-zfit
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet ~root # pythia8 and root circularly depend
   - rivet
   - root ~cuda

--- a/var/spack/repos/builtin/packages/py-zfit/package.py
+++ b/var/spack/repos/builtin/packages/py-zfit/package.py
@@ -54,7 +54,7 @@ class PyZfit(PythonPackage):
     # TODO: remove "build" once fixed in spack that tests need "run", not "build"
     with default_args(type=("build", "run")):
         depends_on("py-tensorflow")
-        depends_on("py-tensorflow-probability +py-tensorflow")
+        depends_on("py-tensorflow-probability")
 
         depends_on("py-tensorflow@2.16.2:2.19", type=("run"), when="@0.25.0:")
         depends_on("py-tensorflow-probability@0.25:0.26", type=("run"), when="@0.25.0:")

--- a/var/spack/repos/builtin/packages/py-zfit/package.py
+++ b/var/spack/repos/builtin/packages/py-zfit/package.py
@@ -19,6 +19,7 @@ class PyZfit(PythonPackage):
 
     tags = ["likelihood", "statistics", "inference", "fitting", "hep"]
 
+	version("0.25.0", sha256="ac5a92bc284094eae55dd9afe1fe2c8f3f67a402dfc7a8ad6087a9ea29ff2b41")
     version("0.24.3", sha256="0efe47a5c597f7c730ac25495625f8bb4460f2fa4a0f4c387f503339ac8e91b5")
     version("0.24.2", sha256="6b83315e16e07d8472d92b142b377d8d7314411d27fe8033168037fd4583f5f6")
     version("0.24.1", sha256="9a0423302ac5647e910feadce634b8b0a1806c1866f4f55795db64918cbdd2d8")

--- a/var/spack/repos/builtin/packages/py-zfit/package.py
+++ b/var/spack/repos/builtin/packages/py-zfit/package.py
@@ -56,6 +56,9 @@ class PyZfit(PythonPackage):
         depends_on("py-tensorflow")
         depends_on("py-tensorflow-probability +py-tensorflow")
 
+        depends_on("py-tensorflow@2.16.2:2.19", type=("run"), when="@0.25.0:")
+        depends_on("py-tensorflow-probability@0.25:0.26", type=("run"), when="@0.25.0:")
+        
         depends_on("py-tensorflow@2.16.2:2.18", type=("run"), when="@0.24.3:")
         depends_on("py-tensorflow@2.18", type=("run"), when="@0.24:0.24.2")
         depends_on("py-tensorflow-probability@0.25", type=("run"), when="@0.24:")

--- a/var/spack/repos/builtin/packages/py-zfit/package.py
+++ b/var/spack/repos/builtin/packages/py-zfit/package.py
@@ -19,7 +19,7 @@ class PyZfit(PythonPackage):
 
     tags = ["likelihood", "statistics", "inference", "fitting", "hep"]
 
-	version("0.25.0", sha256="ac5a92bc284094eae55dd9afe1fe2c8f3f67a402dfc7a8ad6087a9ea29ff2b41")
+    version("0.25.0", sha256="ac5a92bc284094eae55dd9afe1fe2c8f3f67a402dfc7a8ad6087a9ea29ff2b41")
     version("0.24.3", sha256="0efe47a5c597f7c730ac25495625f8bb4460f2fa4a0f4c387f503339ac8e91b5")
     version("0.24.2", sha256="6b83315e16e07d8472d92b142b377d8d7314411d27fe8033168037fd4583f5f6")
     version("0.24.1", sha256="9a0423302ac5647e910feadce634b8b0a1806c1866f4f55795db64918cbdd2d8")

--- a/var/spack/repos/builtin/packages/py-zfit/package.py
+++ b/var/spack/repos/builtin/packages/py-zfit/package.py
@@ -19,6 +19,18 @@ class PyZfit(PythonPackage):
 
     tags = ["likelihood", "statistics", "inference", "fitting", "hep"]
 
+    version("0.24.3", sha256="0efe47a5c597f7c730ac25495625f8bb4460f2fa4a0f4c387f503339ac8e91b5")
+    version("0.24.2", sha256="6b83315e16e07d8472d92b142b377d8d7314411d27fe8033168037fd4583f5f6")
+    version("0.24.1", sha256="9a0423302ac5647e910feadce634b8b0a1806c1866f4f55795db64918cbdd2d8")
+    version("0.24.0", sha256="d2d30886c154a6583c615b68cd43bd156cb7f7576c584c48fb72f5ab89c9d94b")
+    version("0.23.0", sha256="19ec469e1703bd38f8b8957871851ee22fa2e68f0a57b7867cc40ea77df98cc5")
+    version("0.22.0", sha256="b88fe03ab91d1327fd1f23ba27d602fa8a4a82d74bd8ed5d7c08f167a6b223df")
+    version("0.21.1", sha256="7636c42c93d299bcc4346afe46df1ba615acedbc2380711e68a3e47a5445d4fa")
+    version("0.21.0", sha256="9d57f8210c5177df615de7f27d937cf0fc9237fb83360e291e2361604d7fe947")
+    version("0.20.3", sha256="c300ce5d4dd75d351184c4e10c1b1afb7969f99be1f803e8dd50b09ecc951406")
+    version("0.20.2", sha256="f822ff857346fe5b244e0a13f6fa2f2216c60d8c93f512405890289e2fbfac97")
+    version("0.20.1", sha256="c834953548be6e1a69ce48eb561b63a6ca8c6cee3bad2d33b98fa5c16001fc27")
+    version("0.20", sha256="ec39f0118fe8f918a488dacc633279321a06bb88fc0dc09207830516177ca4ff")
     version("0.18.2", sha256="099b111e135937966b4c6342c7738731f112aea33e1b9f4a9785d2eac9e530f1")
     version("0.18.1", sha256="fbc6b3a636d8dc74fb2e69dfec5855f534c4583ec18efac9e9107ad45b18eb43")
     version("0.18.0", sha256="21d9479480f74945c67707b715780693bd4e94062c551bf41fe04a2eddb47fab")
@@ -27,7 +39,10 @@ class PyZfit(PythonPackage):
     version("0.15.5", sha256="00a1138429e8a7f830c9e229b9c0bcd6071b95dadd8c87eb81191079fb679225")
     version("0.14.1", sha256="66d1e349403f1d6c6350138d0f2b422046bcbdfb34fd95453dadae29a8b0c98a")
 
-    depends_on("python@3.9:3.11", type=("build", "run"))
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("python@:3.11", type=("build", "run"), when="@:0.18")
+    depends_on("python@:3.12", type=("build", "run"), when="@0.20:")
+
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-setuptools-scm-git-archive", type="build")
     depends_on("py-setuptools-scm@3.4:+toml", type="build")
@@ -37,6 +52,15 @@ class PyZfit(PythonPackage):
 
     # TODO: remove "build" once fixed in spack that tests need "run", not "build"
     with default_args(type=("build", "run")):
+        depends_on("py-tensorflow")
+        depends_on("py-tensorflow-probability +py-tensorflow")
+
+        depends_on("py-tensorflow@2.16.2:2.18", type=("run"), when="@0.24.3:")
+        depends_on("py-tensorflow@2.18", type=("run"), when="@0.24:0.24.2")
+        depends_on("py-tensorflow-probability@0.25", type=("run"), when="@0.24:")
+
+        depends_on("py-tensorflow@2.16", type=("run"), when="@0.20:")
+        depends_on("py-tensorflow-probability@0.24", type=("run"), when="@0.20:")
 
         depends_on("py-tensorflow@2.15", type=("run"), when="@0.18")
         depends_on("py-tensorflow-probability@0.23", type=("run"), when="@0.18")
@@ -52,10 +76,10 @@ class PyZfit(PythonPackage):
             depends_on("nlopt@2.7.1: +python")
 
         with when("+hs3"):
-            depends_on("py-asdf")
+            depends_on("py-asdf@:3")
 
         depends_on("py-attrs", when="@0.15:")
-        depends_on("py-typing-extensions", when="^python@:3.8")
+        depends_on("py-typing-extensions", when="@:0.17 ^python@:3.8")
         depends_on("py-boost-histogram")
         depends_on("py-colorama")
         depends_on("py-colored")
@@ -71,7 +95,8 @@ class PyZfit(PythonPackage):
         depends_on("py-numpy@1.16:")
         depends_on("py-ordered-set")
         depends_on("py-pandas")
-        depends_on("py-pydantic@:1")
+        depends_on("py-pydantic@:1", when="@:0.21")
+        depends_on("py-pydantic@2:", when="@0.22:")
         depends_on("py-pyyaml")
         depends_on("py-scipy@1.2:")
         depends_on("py-tabulate")

--- a/var/spack/repos/builtin/packages/py-zfit/package.py
+++ b/var/spack/repos/builtin/packages/py-zfit/package.py
@@ -58,7 +58,7 @@ class PyZfit(PythonPackage):
 
         depends_on("py-tensorflow@2.16.2:2.19", type=("run"), when="@0.25.0:")
         depends_on("py-tensorflow-probability@0.25:0.26", type=("run"), when="@0.25.0:")
-        
+
         depends_on("py-tensorflow@2.16.2:2.18", type=("run"), when="@0.24.3:")
         depends_on("py-tensorflow@2.18", type=("run"), when="@0.24:0.24.2")
         depends_on("py-tensorflow-probability@0.25", type=("run"), when="@0.24:")

--- a/var/spack/repos/builtin/packages/py-zfit/package.py
+++ b/var/spack/repos/builtin/packages/py-zfit/package.py
@@ -56,18 +56,18 @@ class PyZfit(PythonPackage):
         depends_on("py-tensorflow")
         depends_on("py-tensorflow-probability")
 
-        depends_on("py-tensorflow@2.16.2:2.19", type=("run"), when="@0.25.0:")
-        depends_on("py-tensorflow-probability@0.25:0.26", type=("run"), when="@0.25.0:")
+        depends_on("py-tensorflow@2.16.2:2.19", when="@0.25.0:")
+        depends_on("py-tensorflow-probability@0.25:0.26", when="@0.25.0:")
 
-        depends_on("py-tensorflow@2.16.2:2.18", type=("run"), when="@0.24.3:")
-        depends_on("py-tensorflow@2.18", type=("run"), when="@0.24:0.24.2")
-        depends_on("py-tensorflow-probability@0.25", type=("run"), when="@0.24:")
+        depends_on("py-tensorflow@2.16.2:2.18", when="@0.24.3:")
+        depends_on("py-tensorflow@2.18", when="@0.24:0.24.2")
+        depends_on("py-tensorflow-probability@0.25", when="@0.24:")
 
-        depends_on("py-tensorflow@2.16", type=("run"), when="@0.20:")
-        depends_on("py-tensorflow-probability@0.24", type=("run"), when="@0.20:")
+        depends_on("py-tensorflow@2.16", when="@0.20:")
+        depends_on("py-tensorflow-probability@0.24", when="@0.20:")
 
-        depends_on("py-tensorflow@2.15", type=("run"), when="@0.18")
-        depends_on("py-tensorflow-probability@0.23", type=("run"), when="@0.18")
+        depends_on("py-tensorflow@2.15", when="@0.18")
+        depends_on("py-tensorflow-probability@0.23", when="@0.18")
 
         depends_on("py-tensorflow@2.13", when="@0.15:0.17")
         depends_on("py-tensorflow-probability@0.21", when="@0.16:0.17")


### PR DESCRIPTION
This PR adds `py-zfit`, through v0.24.3. This adds the relevant python and tensorflow limits. The `tensorflow-probability[tf]` extra requires `py-tensorflow-probability +py-tensorflow` now.

Needs:
- [x] #49347 (for `py-setuptools-scm` upper bound)

Test build:
```
==> Installing py-zfit-0.24.3-3yaf7awqavihux2sxgtlagemre34iih3 [106/106]
==> No binary for py-zfit-0.24.3-3yaf7awqavihux2sxgtlagemre34iih3 found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/z/zfit/zfit-0.24.3.tar.gz
==> No patches needed for py-zfit
==> py-zfit: Executing phase: 'install'
==> py-zfit: Successfully installed py-zfit-0.24.3-3yaf7awqavihux2sxgtlagemre34iih3
  Stage: 0.84s.  Install: 2.55s.  Post-install: 1.64s.  Total: 5.37s
[+] /opt/software/linux-ubuntu25.04-skylake/gcc-14.2.0/py-zfit-0.24.3-3yaf7awqavihux2sxgtlagemre34iih3
```