### PR TITLE
actsvg: add v0.4.51

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -17,7 +17,7 @@ spack:
         tbb: [intel-tbb]
       variants: +mpi
     acts:
-      require: +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python ~svg +tgeo cxxstd=20
+      require: +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +svg +tgeo cxxstd=20
     celeritas:
       require: +geant4 +hepmc3 +root +shared cxxstd=20
     hip:

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -360,7 +360,9 @@ class Acts(CMakePackage, CudaPackage):
         depends_on("actsvg@0.4.35:", when="@28:")
         depends_on("actsvg@0.4.39:", when="@32:")
         depends_on("actsvg@0.4.40:", when="@32.1:")
-        depends_on("actsvg@0.4.51:", when="@37:")  # https://github.com/acts-project/actsvg/issues/94
+        depends_on(
+            "actsvg@0.4.51:", when="@37:"
+        )  # https://github.com/acts-project/actsvg/issues/94
     depends_on("acts-algebra-plugins @0.24:", when="+traccc")
     depends_on("autodiff @0.6:", when="@17: +autodiff")
     depends_on("autodiff @0.5.11:0.5.99", when="@1.2:16 +autodiff")

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -360,7 +360,7 @@ class Acts(CMakePackage, CudaPackage):
         depends_on("actsvg@0.4.35:", when="@28:")
         depends_on("actsvg@0.4.39:", when="@32:")
         depends_on("actsvg@0.4.40:", when="@32.1:")
-        depends_on("actsvg@0.4.50:", when="@37:")
+        depends_on("actsvg@0.4.51:", when="@37:")  # https://github.com/acts-project/actsvg/issues/94
     depends_on("acts-algebra-plugins @0.24:", when="+traccc")
     depends_on("autodiff @0.6:", when="@17: +autodiff")
     depends_on("autodiff @0.5.11:0.5.99", when="@1.2:16 +autodiff")

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -19,6 +19,7 @@ class Actsvg(CMakePackage):
 
     license("MPL-2.0")
 
+    version("0.4.51", sha256="937385f7703c0d2d9c0af03bd5083d3f1fdac17ff573476a5fc5b1f8e3cd98b7")
     version("0.4.50", sha256="c97fb1cc75cbf23caebd3c6fb8716354bdbd0a77ad39dc43dae963692f3256e1")
     version("0.4.48", sha256="0f230c31c64b939e4d311afd997dbaa87a375454cf1595661a449b97943412c9")
     version("0.4.47", sha256="11924fddbdd01f6337875797dc3a97b62be565688e678485e992bcfc9bfb142f")


### PR DESCRIPTION
This PR adds `actsvg`, v0.4.51 ([diff](https://github.com/acts-project/actsvg/compare/v0.4.50...v0.4.51)). Main change is to correctly propagate the version number to the installation, which allows `acts` to correctly assess compatibility in CMake `find_package`, hence the update there. And this in turn allows `acts +svg` to work in CI.