### PR TITLE
Revert "TCL: Ensure system tcl doesn't impact build"

### DIFF
--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -182,12 +182,6 @@ class AnyBuilder(BaseBuilder):
 class AutotoolsBuilder(AnyBuilder, spack.build_systems.autotools.AutotoolsBuilder):
     configure_directory = "unix"
 
-    # if TCL is present on the system this may be set to the system's
-    # existing TCL so ensure it is unset
-    # https://wiki.tcl-lang.org/page/TCL%5FLIBRARY
-    def setup_build_environment(self, env):
-        env.set("TCL_LIBRARY", "")
-
     def install(self, pkg, spec, prefix):
         with working_dir(self.build_directory):
             make("install")


### PR DESCRIPTION
NOTE: The reverted PR is probably not the cause of the build failure.

Reverts spack/spack#49325.

This reverts a PR that appears to break `tcl` builds in CI, e.g. https://gitlab.spack.io/spack/spack/-/pipelines/1004592, https://gitlab.spack.io/spack/spack/-/jobs/15490191.