### PR TITLE
py-rpy2: add missing libiconv

### DIFF
--- a/var/spack/repos/builtin/packages/py-rpy2/package.py
+++ b/var/spack/repos/builtin/packages/py-rpy2/package.py
@@ -61,7 +61,7 @@ class PyRpy2(PythonPackage):
 
     depends_on("py-backports-zoneinfo", type=("build", "run"), when="@3.5.17: ^python@:3.8")
 
-    depends_on("libiconv", type=("link"))
+    depends_on("iconv", type=("link"))
 
     # These are from 2019 and predate the pyproject.toml config that currently exists
     with when("@3.0.0:3.0.4"):

--- a/var/spack/repos/builtin/packages/py-rpy2/package.py
+++ b/var/spack/repos/builtin/packages/py-rpy2/package.py
@@ -61,6 +61,8 @@ class PyRpy2(PythonPackage):
 
     depends_on("py-backports-zoneinfo", type=("build", "run"), when="@3.5.17: ^python@:3.8")
 
+    depends_on("libiconv", type=("link"))
+
     # These are from 2019 and predate the pyproject.toml config that currently exists
     with when("@3.0.0:3.0.4"):
         # Doesn't support post-distutil removal until 3.5.13


### PR DESCRIPTION
Add a missing depends on iconv that is needed for the wheel to build