### PR TITLE
bgen: fix cxxflags for newer compilers, add dependencies, install libs/headers

### DIFF
--- a/var/spack/repos/builtin/packages/bgen/dont-build-with-bundled-deps.patch
+++ b/var/spack/repos/builtin/packages/bgen/dont-build-with-bundled-deps.patch
@@ -1,0 +1,97 @@
+diff --git a/wscript b/wscript
+index a6385d9..1a17fc0 100644
+--- a/wscript
++++ b/wscript
+@@ -24,6 +24,8 @@ def configure( cfg ):
+ 		raise Exception( "Unknown value for --mode, please specify --mode=debug or --mode=release" )
+ 
+ 	cfg.check_cxx( lib='z', uselib_store='zlib', msg = 'zlib' )
++	cfg.check_cxx( lib='zstd', uselib_store='zstd', msg = 'zstd' )
++	cfg.check_cxx( lib='sqlite3', uselib_store='sqlite', msg = 'sqlite' )
+ 	if platform.system() != "Darwin":
+ 		cfg.check_cxx( lib='rt', uselib_store='rt', msg = 'rt' )
+ 		cfg.check_cxx( lib='pthread', uselib_store='pthread', msg = 'pthread' )
+@@ -63,7 +65,7 @@ def build( bld ):
+ 		use = 'zlib zstd sqlite3 db',
+ 		export_includes = 'genfile/include'
+ 	)
+-	bld.recurse( [ '3rd_party', 'appcontext', 'genfile', 'db', 'apps', 'example', 'test', 'R' ] )
++	bld.recurse( [ 'appcontext', 'genfile', 'db', 'apps', 'example', 'test', 'R' ] )
+ 	# Copy files into rbgen package directory
+ 	for source in bgen_sources:
+ 		bld( rule = 'cp ${SRC} ${TGT}', source = source, target = 'R/rbgen/src/bgen/' + os.path.basename( source.abspath() ), always = True )
+@@ -125,66 +127,19 @@ class ReleaseBuilder:
+ 		rbgen_dir = os.path.join( tempdir, release_stub )
+ 		shutil.copytree( 'R/package/', rbgen_dir )
+ 		os.makedirs( os.path.join( rbgen_dir, "src", "include" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "include", "boost" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "include", "zstd-1.1.0" ))
+ 		os.makedirs( os.path.join( rbgen_dir, "src", "db" ))
+ 		os.makedirs( os.path.join( rbgen_dir, "src", "bgen" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "boost" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "sqlite3" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "zstd-1.1.0" ))
+ 
+ 		# Copy source files in
+ 		from glob import glob
+ 		for filename in glob( 'src/*.cpp' ):
+ 			shutil.copy( filename, os.path.join( rbgen_dir, "src", "bgen", os.path.basename( filename ) ) )
+ 
+-		for filename in glob( 'db/src/*.cpp' ):
+-			shutil.copy( filename, os.path.join( rbgen_dir, "src", "db", os.path.basename( filename ) ) )
+-
+-		for filename in glob( '3rd_party/sqlite3/sqlite3/sqlite3.c' ):
+-			shutil.copy( filename, os.path.join( rbgen_dir, "src", "sqlite3", os.path.basename( filename ) ) )
+-
+-		for filename in glob( '3rd_party/zstd-1.1.0/lib/common/*.c' ) + glob( '3rd_party/zstd-1.1.0/lib/compress/*.c' ) + glob( '3rd_party/zstd-1.1.0/lib/decompress/*.c' ):
+-			shutil.copy( filename, os.path.join( rbgen_dir, "src", "zstd-1.1.0", os.path.basename( filename ) ) )
+-
+-		boostGlobs = [
+-			'libs/system/src/*.cpp',
+-			'libs/thread/src/*.cpp',
+-			'libs/thread/src/*.inl',
+-			'libs/thread/src/pthread/once_atomic.cpp',
+-			'libs/thread/src/pthread/thread.cpp',
+-			'libs/thread/src/pthread/timeconv.inl',
+-			'libs/filesystem/src/*.cpp',
+-			'libs/date_time/src/posix_time/*.cpp',
+-			'libs/timer/src/*.cpp',
+-			'libs/chrono/src/*.cpp',
+-		]
+-
+-		for pattern in boostGlobs:
+-			for filename in glob( '3rd_party/boost_1_55_0/%s' % pattern ):
+-				shutil.copy( filename, os.path.join( rbgen_dir, "src", "boost", os.path.basename( filename ) ) )
+-
+ 		include_paths = [
+-			"3rd_party/boost_1_55_0/boost/",
+-			"3rd_party/zstd-1.1.0/",
+-			"3rd_party/sqlite3/",
+ 			"genfile/include/genfile",
+ 			"db/include/db"
+ 		]
+ 		
+-		boostHeaderLibs = [
+-			'system',
+-			'thread',
+-			'filesystem',
+-			'date_time',
+-			'timer',
+-			'chrono',
+-			'preprocessor',
+-			'function',
+-			'optional',
+-			'mpl'
+-		]
+-		
+ 		for include_path in include_paths:
+ 			for root, path, filenames in os.walk( include_path ):
+ 				self.makedirs( os.path.join( rbgen_dir, "src", "include", root ))
+@@ -198,7 +153,6 @@ class ReleaseBuilder:
+ 					):
+ 						dest = os.path.join( rbgen_dir, "src", "include", root, name )
+ 						shutil.copy( fullname, os.path.join( rbgen_dir, "src", "include", fullname ))
+-						#print "Copied \"%s\"." % fullname
+ 
+ 		tarball = self.create_tarball( 'rbgen', release_stub, tempdir )
+ 		return os.path.join( tempdir, tarball )

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -44,4 +44,3 @@ class Bgen(WafPackage):
             src_dir = join_path(prefix.src.bgen)
             makedirs(src_dir)
             install_tree(self.stage.source_path, src_dir)
-

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -18,6 +18,7 @@ class Bgen(WafPackage):
     homepage = "https://enkre.net/cgi-bin/code/bgen"
 
     license("BSL-1.0")
+    maintainers("teaguesterling")
 
     version(
         "1.1.7",
@@ -27,3 +28,9 @@ class Bgen(WafPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+
+    def flag_handler(self, name, flags):
+        # Version 1.1.7 not compatible with C++17
+        if name == "cxxflags":
+            flags.append("-std=c++14")
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -26,11 +26,22 @@ class Bgen(WafPackage):
         url="https://enkre.net/cgi-bin/code/bgen/tarball/6ac2d582f9/BGEN-6ac2d582f9.tar.gz",
     )
 
+    variant("source", default=False, description="Install source tree as well")
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("fossil", type="build")
 
     def flag_handler(self, name, flags):
         # Version 1.1.7 not compatible with C++17
         if name == "cxxflags":
-            flags.append("-std=c++14")
+            flags.append("-std=c++11")
         return (flags, None, None)
+
+    def install(self, spec, prefix):
+        super().install(spec, prefix)
+        if spec.satisfies("+source"):
+            src_dir = join_path(prefix.src.bgen)
+            makedirs(src_dir)
+            install_tree(self.stage.source_path, src_dir)
+

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -27,6 +27,7 @@ class Bgen(WafPackage):
     )
 
     variant("headers", default=True, description="Install headers")
+    variant("libs", default=True, description="Install static libraries")
     variant("bundled-deps", default=False, description="Use bundled 3rd party dependencies")
     variant("full-source", default=False, description="Install source tree as well")
 
@@ -99,7 +100,17 @@ class Bgen(WafPackage):
                 if src not in ["genfile"]:
                     install_tree(src_dir, code_dir)
 
+        if spec.satisfies("+libs"):
+            mkdirp(prefix.lib.bgen)
+            build_dir = join_path(self.stage.source_path, "build")
+            install(join_path(build_dir, "libbgen.a"), prefix.lib.bgen)
+            install(join_path(build_dir, "db/libdb.a"), prefix.lib.bgen.db)
+
         if spec.satisfies("+full-source"):
             src_dir = join_path(prefix.opt.src.bgen)
             makedirs(src_dir)
             install_tree(self.stage.source_path, src_dir)
+
+    @property
+    def bgen_static_lib_dir(self):
+        return self.install.lib.bgen

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -101,7 +101,7 @@ class Bgen(WafPackage):
                     install_tree(src_dir, code_dir)
 
         if spec.satisfies("+libs"):
-            mkdirp(prefix.lib.bgen)
+            mkdirp(prefix.lib.bgen.db)
             build_dir = join_path(self.stage.source_path, "build")
             install(join_path(build_dir, "libbgen.a"), prefix.lib.bgen)
             install(join_path(build_dir, "db/libdb.a"), prefix.lib.bgen.db)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -26,21 +26,80 @@ class Bgen(WafPackage):
         url="https://enkre.net/cgi-bin/code/bgen/tarball/6ac2d582f9/BGEN-6ac2d582f9.tar.gz",
     )
 
-    variant("source", default=False, description="Install source tree as well")
+    variant("headers", default=True, description="Install headers")
+    variant("bundled-deps", default=False, description="Use bundled 3rd party dependencies")
+    variant("full-source", default=False, description="Install source tree as well")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fossil", type="build")
+    depends_on("zlib-api")
+
+    with when("~bundled-deps"):
+        # Upper bound of boost not known. Doesn't work with 1.85
+        depends_on(
+            "boost@1.55:+chrono+date_time+exception+filesystem+math+system+thread+timer+shared"
+        )
+        depends_on("sqlite@3")
+        depends_on("zstd libs=shared,static")
+        patch("dont-build-with-bundled-deps.patch")
 
     def flag_handler(self, name, flags):
         # Version 1.1.7 not compatible with C++17
         if name == "cxxflags":
             flags.append("-std=c++11")
+        elif name == "ldflags":
+            deps = ["zlib-api"]
+            if self.spec.satisfies("~bundled-deps"):
+                deps += ["boost", "zstd", "sqlite"]
+            for dep in deps:
+                flags.append(self.spec[dep].libs.ld_flags)
         return (flags, None, None)
+
+    def patch(self):
+        filter_file("-Wno-c++11-long-long", "", "wscript", string=True)  # Creates lots of noise
+
+        if self.spec.satisfies("^boost@1.56:"):
+            filter_file(
+                "(total_count == 0)", 
+                "(*total_count == 0)", 
+                "appcontext/src/CmdLineUIContext.cpp",
+                string=True,
+            )
+
+        # Update build script to remove references to bundled dependencies
+        if self.spec.satisfies("~bundled-deps"):
+            for dep, old_include in [
+                ("boost", '"3rd_party/boost_1_55_0/boost/"'),
+                ("zstd", '"3rd_party/zstd-1.1.0/"'),
+                ("sqlite", '"3rd_party/sqlite3/"'),
+            ]:
+                header_dirs = self.spec[dep].headers.directories
+                new_include = ", ".join(f'"{d}"' for d in header_dirs)
+                filter_file(old_include, new_include, "wscript")
+            filter_file(
+                '"sqlite3/sqlite3.h"',
+                "<sqlite3.h>",
+                "db/include/db/SQLite3Connection.hpp",
+                "db/include/db/SQLite3Statement.hpp",
+                "db/include/db/SQLStatement.hpp",
+                "db/src/SQLite3Statement.cpp",
+                "db/src/SQLStatement.cpp",
+                string=True,
+            )
 
     def install(self, spec, prefix):
         super().install(spec, prefix)
-        if spec.satisfies("+source"):
-            src_dir = join_path(prefix.src.bgen)
+        if spec.satisfies("+headers"):
+            for src in ["appcontext", "db", "genfile"]:
+                include_dir = join_path(self.stage.source_path, src, "include")
+                src_dir = join_path(self.stage.source_path, src, "src")
+                code_dir = join_path(prefix.src.bgen, src)
+                install_tree(include_dir, prefix.include.bgen)
+                if src not in ["genfile"]:
+                    install_tree(src_dir, code_dir)
+
+        if spec.satisfies("+full-source"):
+            src_dir = join_path(prefix.opt.src.bgen)
             makedirs(src_dir)
             install_tree(self.stage.source_path, src_dir)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -18,7 +18,6 @@ class Bgen(WafPackage):
     homepage = "https://enkre.net/cgi-bin/code/bgen"
 
     license("BSL-1.0")
-    maintainers("teaguesterling")
 
     version(
         "1.1.7",
@@ -26,21 +25,5 @@ class Bgen(WafPackage):
         url="https://enkre.net/cgi-bin/code/bgen/tarball/6ac2d582f9/BGEN-6ac2d582f9.tar.gz",
     )
 
-    variant("source", default=False, description="Install source tree as well")
-
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    depends_on("fossil", type="build")
-
-    def flag_handler(self, name, flags):
-        # Version 1.1.7 not compatible with C++17
-        if name == "cxxflags":
-            flags.append("-std=c++11")
-        return (flags, None, None)
-
-    def install(self, spec, prefix):
-        super().install(spec, prefix)
-        if spec.satisfies("+source"):
-            src_dir = join_path(prefix.src.bgen)
-            makedirs(src_dir)
-            install_tree(self.stage.source_path, src_dir)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -18,6 +18,7 @@ class Bgen(WafPackage):
     homepage = "https://enkre.net/cgi-bin/code/bgen"
 
     license("BSL-1.0")
+    maintainers("teaguesterling")
 
     version(
         "1.1.7",
@@ -25,5 +26,21 @@ class Bgen(WafPackage):
         url="https://enkre.net/cgi-bin/code/bgen/tarball/6ac2d582f9/BGEN-6ac2d582f9.tar.gz",
     )
 
+    variant("source", default=False, description="Install source tree as well")
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("fossil", type="build")
+
+    def flag_handler(self, name, flags):
+        # Version 1.1.7 not compatible with C++17
+        if name == "cxxflags":
+            flags.append("-std=c++11")
+        return (flags, None, None)
+
+    def install(self, spec, prefix):
+        super().install(spec, prefix)
+        if spec.satisfies("+source"):
+            src_dir = join_path(prefix.src.bgen)
+            makedirs(src_dir)
+            install_tree(self.stage.source_path, src_dir)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -62,8 +62,8 @@ class Bgen(WafPackage):
 
         if self.spec.satisfies("^boost@1.56:"):
             filter_file(
-                "(total_count == 0)", 
-                "(*total_count == 0)", 
+                "(total_count == 0)",
+                "(*total_count == 0)",
                 "appcontext/src/CmdLineUIContext.cpp",
                 string=True,
             )


### PR DESCRIPTION
The bgen package doesn't compile with the C++17 standard. Forcing C++11 allows it to compile with newer versions of GCC.

This also installs headers and libraries into more traditional locations and uses spack-provided dependencies instead of the vendored-in versions of boost, sqlite, and zstd, which removing a lot of custom path logic from the wscript.