### PR TITLE
concretizer: add family option to "target:granularity" for Spack environments.

### DIFF
--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -6,6 +6,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/concretizer.py
    :lines: 12-
 """
+
 from typing import Any, Dict
 
 LIST_OF_SPECS = {"type": "array", "items": {"type": "string"}}
@@ -54,7 +55,10 @@ properties: Dict[str, Any] = {
                 "type": "object",
                 "properties": {
                     "host_compatible": {"type": "boolean"},
-                    "granularity": {"type": "string", "enum": ["generic", "microarchitectures"]},
+                    "granularity": {
+                        "type": "string",
+                        "enum": ["generic", "microarchitectures", "family"],
+                    },
                 },
             },
             "unify": {

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Classes to analyze the input of a solve, and provide information to set up the ASP problem"""
+
 import collections
 from typing import Dict, List, NamedTuple, Set, Tuple, Union
 
@@ -123,6 +124,9 @@ class NoStaticAnalysis(PossibleDependencyGraph):
         candidate_targets = [default_target] + default_target.ancestors
         granularity = self.configuration.get("concretizer:targets:granularity")
         host_compatible = self.configuration.get("concretizer:targets:host_compatible")
+
+        if granularity == "family":
+            return [default_target.family]
 
         # Add targets which are not compatible with the current host
         if not host_compatible:

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1729,7 +1729,15 @@ class TestConcretize:
         s = spack.concretize.concretize_one("conditional-values-in-variant@1.60.0")
         assert "cxxstd" in s.variants
 
-    def test_target_granularity(self):
+    def test_target_granularity_family(self):
+        default_target = spack.platforms.test.Test.default
+        family_target = archspec.cpu.TARGETS[default_target].family.name
+        s = Spec("python")
+        assert spack.concretize.concretize_one(s).satisfies("target=%s" % default_target)
+        with spack.config.override("concretizer:targets", {"granularity": "family"}):
+            assert spack.concretize.concretize_one(s).satisfies("target=%s" % family_target)
+
+    def test_target_granularity_generic(self):
         # The test architecture uses core2 as the default target. Check that when
         # we configure Spack for "generic" granularity we concretize for x86_64
         default_target = spack.platforms.test.Test.default


### PR DESCRIPTION
This should hopefully remove `spack.yaml` files where only the target architecture is the different.