### PR TITLE
google-cloud-cli: Install missing "platform" directory

### DIFF
--- a/var/spack/repos/builtin/packages/google-cloud-cli/package.py
+++ b/var/spack/repos/builtin/packages/google-cloud-cli/package.py
@@ -101,3 +101,5 @@ class GoogleCloudCli(Package):
 
         install_tree("bin", prefix.bin)
         install_tree("lib", prefix.lib)
+        ignore_bundledpython = lambda p: p == "bundledpythonunix"
+        install_tree("platform", prefix.platform, ignore=ignore_bundledpython)


### PR DESCRIPTION
Ignore the bundled Python since it's provided by Spack.

This fixes the "gsutil" command.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
