### PR TITLE
dd4hep: add a docs variant to build documentation

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -56,7 +56,7 @@ spack:
   - cepgen
   - cernlib +shared
   - collier
-  - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
+  - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 ~docs +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
   - delphes +pythia8
   - dpmjet
   - edm4hep

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -93,6 +93,8 @@ class Dd4hep(CMakePackage):
         " some places in addtion to the debug build type",
     )
 
+    variant("docs", default=False, description="Bulid documentation")
+
     depends_on("cmake @3.12:", type="build")
     depends_on("cmake @3.14:", type="build", when="@1.26:")
     depends_on("boost @1.49:")
@@ -130,6 +132,7 @@ class Dd4hep(CMakePackage):
         depends_on("podio@0.16:", when="@1.24:")
         depends_on("podio@0.16.3:", when="@1.26:")
         depends_on("podio@0.16.7:", when="@1.31:")
+    depends_on("doxygen", type="build", when="+docs")
 
     # See https://github.com/AIDASoft/DD4hep/pull/771 and https://github.com/AIDASoft/DD4hep/pull/876
     conflicts(
@@ -170,6 +173,7 @@ class Dd4hep(CMakePackage):
             self.define_from_variant("DD4HEP_USE_HEPMC3", "hepmc3"),
             self.define_from_variant("DD4HEP_USE_GEANT4_UNITS", "geant4units"),
             self.define_from_variant("DD4HEP_BUILD_DEBUG", "debug"),
+            self.define_from_variant("BUILD_DOCS", "docs"),
             # DD4hep@1.26: with hepmc3@3.2.6: allows compressed hepmc3 files
             self.define(
                 "DD4HEP_HEPMC3_COMPRESSION_SUPPORT", self.spec.satisfies("@1.26: ^hepmc3@3.2.6:")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -93,7 +93,7 @@ class Dd4hep(CMakePackage):
         " some places in addtion to the debug build type",
     )
 
-    variant("docs", default=False, description="Bulid documentation")
+    variant("docs", default=False, description="Build documentation")
 
     depends_on("cmake @3.12:", type="build")
     depends_on("cmake @3.14:", type="build", when="@1.26:")


### PR DESCRIPTION
I'm only adding the dependency on Doxygen and not on LaTeX since it's a huge one. Since the doxygen and the user manuals are available on the web I think the default should be not to build it.