### PR TITLE
nvhpc: setup MPI compiler wrappers for spack

### DIFF
--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -576,6 +576,11 @@ class Nvhpc(Package, CompilerPackage):
 
             env.prepend_path("LD_LIBRARY_PATH", mpi_prefix.lib)
 
+            env.set("OMPI_CC", spack_cc)
+            env.set("OMPI_CXX", spack_cxx)
+            env.set("OMPI_FC", spack_fc)
+            env.set("OMPI_F77", spack_f77)
+
     def setup_dependent_package(self, module, dependent_spec):
         if "+mpi" in self.spec or self.provides("mpi"):
             mpi_prefix = Prefix(


### PR DESCRIPTION
Sets OpenMPI environment variables for the bundled mpi included in `nvhpc +mpi`.

Fixes #43445.