### PR TITLE
Build environment: add external pkgconfig dirs even when they are system paths

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1216,14 +1216,21 @@ class SetupContext:
         return env
 
     def _make_buildtime_detectable(self, dep: spack.spec.Spec, env: EnvironmentModifications):
-        if is_system_path(dep.prefix):
-            return
-
-        env.prepend_path("CMAKE_PREFIX_PATH", dep.prefix)
-        for d in ("lib", "lib64", "share"):
-            pcdir = os.path.join(dep.prefix, d, "pkgconfig")
-            if os.path.isdir(pcdir):
-                env.prepend_path("PKG_CONFIG_PATH", pcdir)
+        if not is_system_path(dep.prefix):
+            env.prepend_path("CMAKE_PREFIX_PATH", dep.prefix)
+            for d in ("lib", "lib64", "share"):
+                pcdir = os.path.join(dep.prefix, d, "pkgconfig")
+                if os.path.isdir(pcdir):
+                    env.prepend_path("PKG_CONFIG_PATH", pcdir)
+        else:
+            # If the build is using externals in system paths, we add them to
+            # PKG_CONFIG_PATH so that Spack-built pkgconfig can find them
+            for d in ("lib", "lib64", "share"):
+                pcfile = os.path.join(
+                    dep.prefix, d, "pkgconfig", f"{dep.package.pkg_config_name}.pc"
+                )
+                if os.path.exists(pcfile):
+                    env.append_path("PKG_CONFIG_PATH", os.path.dirname(pcfile))
 
     def _make_runnable(self, dep: spack.spec.Spec, env: EnvironmentModifications):
         if is_system_path(dep.prefix):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -823,6 +823,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         return importlib.import_module(cls.__module__)
 
     @classproperty
+    def pkg_config_name(cls):
+        return f"{cls.__name__.lower()}"
+
+    @classproperty
     def namespace(cls):
         """Spack namespace for the package, which identifies its repo."""
         return spack.repo.namespace_from_fullname(cls.__module__)

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+import pathlib
 import platform
 import posixpath
 import sys
@@ -10,6 +11,7 @@ import pytest
 
 import archspec.cpu
 
+import llnl.util.filesystem as fs
 from llnl.path import Path, convert_to_platform_path
 from llnl.util.filesystem import HeaderList, LibraryList
 
@@ -22,6 +24,7 @@ import spack.deptypes as dt
 import spack.package_base
 import spack.paths
 import spack.spec
+import spack.util.environment
 import spack.util.spack_yaml as syaml
 from spack.build_environment import UseMode, _static_to_shared_library, dso_suffix
 from spack.context import Context
@@ -326,6 +329,42 @@ def test_external_config_env(mock_packages, mutable_config, working_env):
     spack.build_environment.setup_package(cmake_client.package, False)
 
     assert os.environ["TEST_ENV_VAR_SET"] == "yes it's set"
+
+
+def test_external_pkgconfig(mock_packages, mutable_config, working_env, monkeypatch, tmpdir):
+    fake_cmake_prefix = pathlib.Path(tmpdir)
+    cmake_config = {"externals": [{"spec": "cmake@1.0", "prefix": f"{fake_cmake_prefix}"}]}
+    spack.config.set("packages:cmake", cmake_config)
+    cmake_pcdir = fake_cmake_prefix / "lib64" / "pkgconfig"
+    fs.mkdirp(str(cmake_pcdir))
+
+    cmake_client = spack.concretize.concretize_one("cmake-client")
+
+    spack.build_environment.setup_package(cmake_client.package, False)
+    assert f"{cmake_pcdir}" in os.environ["PKG_CONFIG_PATH"]
+    os.environ.clear()
+
+    _old_is_system_path = spack.util.environment.is_system_path
+
+    def _is_system_path(x):
+        if pathlib.Path(x).resolve() == fake_cmake_prefix.resolve():
+            return True
+        else:
+            return _old_is_system_path(x)
+
+    # Note: this is setting build_environment's import of is_system_path,
+    # because it is doing a "from ... import ..."
+    monkeypatch.setattr(spack.build_environment, "is_system_path", _is_system_path)
+    spack.build_environment.setup_package(cmake_client.package, False)
+    assert (
+        "PKG_CONFIG_PATH" not in os.environ
+        or f"{cmake_pcdir}" not in os.environ["PKG_CONFIG_PATH"]
+    )
+    os.environ.clear()
+
+    fs.touch(cmake_pcdir / "cmake.pc")
+    spack.build_environment.setup_package(cmake_client.package, False)
+    assert f"{cmake_pcdir}" in os.environ["PKG_CONFIG_PATH"]
 
 
 @pytest.mark.regression("9107")


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/48293

Spack-built pkgconfig won't search system paths for `.pc` files, so if there is an external in a system path, spack wasn't adding its associated `pkgconfig` dir to PKG_CONFIG_PATH.

When an external is a system path, this PR makes it so that spack will add its associated `pkgconfig` dir if the associated `.pc` file is found there. If there are no externals in system paths then Spack will not add them to PKG_CONFIG_PATH; even if there are externals in system paths, if their associated .pc files are not found, then Spack will not add those system paths to PKG_CONFIG_PATH.

Packages can define `pkg_config_name` to help spack find the right .pc file. It defaults to the (lower-cased) name of the package, e.g. `zlib.pc` for the `zlib` package.
