### PR TITLE
yoda: add v2.1.0; rivet: add v4.1.0

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -106,7 +106,7 @@ spack:
   - vecgeom ~cuda
   - whizard +fastjet +gosam hepmc=3 +lcio +lhapdf +openloops +openmp +pythia8
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp
-  - yoda +root
+  - yoda +hdf5 +highfive
 
   # CUDA
   #- acts +cuda +traccc cuda_arch=80

--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -92,6 +92,7 @@ class Rivet(AutotoolsPackage):
     depends_on("fastjet@3.4.0:", when="@3.1.7:")
     depends_on("fjcontrib")
     depends_on("highfive", when="@4:")
+    depends_on("yaml-cpp", when="@4.1:")
     depends_on("python", type=("build", "run"))
     depends_on("py-cython@0.24.0:", type="build")
     depends_on("swig", type="build")
@@ -158,6 +159,9 @@ class Rivet(AutotoolsPackage):
 
         if self.spec.satisfies("^highfive"):
             args += ["--with-highfive=" + self.spec["highfive"].prefix]
+
+        if self.spec.satisfies("^yaml-cpp"):
+            args += ["--with-yaml-cpp=" + self.spec["yaml-cpp"].prefix]
 
         args += ["--disable-pdfmanual"]
 

--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -70,6 +70,7 @@ class Rivet(AutotoolsPackage):
     depends_on("yoda@1.9.11:", when="@3.1.11:")
     depends_on("yoda@:1", when="@:3")
     depends_on("yoda@2.0.1:", when="@4.0.0:")
+    depends_on("yoda@2.1.0:", when="@4.1.0:")
 
     # The following versions were not a part of LCG stack
     # and thus the exact version of YODA is unknown

--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -18,6 +18,8 @@ class Rivet(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("4.1.0", sha256="6548a351a44e5a4303fb2277e7521690a9d84195df96d92c707b816f3b40c843")
+    version("4.0.3", sha256="dbb97b769d1877f34c3c50190127bfda7847bcec79ba1de59561fdf43cdd4869")
     version("4.0.2", sha256="65a3b36f42bff782ed2767930e669e09b140899605d7972fc8f77785b4a882c0")
     version("4.0.1", sha256="4e8692d6e8a53961c77983eb6ba4893c3765cf23f705789e4d865be4892eff79")
     version("4.0.0", sha256="d3c42d9b83ede3e7f4b534535345c2e06e6dafb851454c2b0a5d2331ab0f04d0")

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -17,6 +17,7 @@ class Yoda(AutotoolsPackage):
     license("GPL-3.0-or-later")
 
     version("2.1.0", sha256="eba2efa58d407e5ca60205593339cdab12b7659255020358454b0f6502d115c2")
+    version("2.0.3", sha256="c066b1ae723e7cc76011e134fe9d69b378670ae03aae8a2781b0606692440143")
     version("2.0.2", sha256="31a41413641189814ff3c6bbb96ac5d17d2b68734fe327d06794cdbd3a540399")
     version("2.0.1", sha256="ae5a78eaae5574a5159d4058839d0983c9923558bfc88fbce21d251fd925d260")
     version("2.0.0", sha256="680f43dabebb3167ce1c5dee72d1c2c285c3190751245aa51e3260a005a99575")

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Yoda(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -73,25 +73,25 @@ class Yoda(AutotoolsPackage):
     version("1.0.4", sha256="697fe397c69689feecb2a731e19b2ff85e19343b8198c4f18a7064c4f7123950")
     version("1.0.3", sha256="6a1d1d75d9d74da457726ea9463c1b0b6ba38d4b43ef54e1c33f885e70fdae4b")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
-    variant("root", default=False, description="Enable ROOT interface")
+    variant("hdf5", default=False, description="Enable HDF5 compatibility", when="@2.1:")
+    variant("highfive", default=False, description="Enable HighFive compatibility", when="@2.1:")
+    variant("root", default=False, description="Enable ROOT interface", when="@:2.0")
 
     depends_on("python", type=("build", "link", "run"))
     depends_on("py-future", type=("build", "run"))
     depends_on("zlib-api")
-    depends_on("boost", when="@:1.6.0", type=("build", "run"))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when="@:1.6.0", type=("build", "run"))
+    depends_on("boost@1.48: ", when="@:1.5", type=("build", "run"))
+    depends_on("yaml-cpp", type=("build", "link", "run"), when="@2.1:")
     depends_on("py-cython@0.18:", type="build", when="@:1.4.0")
     depends_on("py-cython@0.20:", type="build", when="@1.4.0:1.6.5")
     depends_on("py-cython@0.23.5:", type="build", when="@1.6.5:1.8.0")
     depends_on("py-cython@0.24:", type="build", when="@1.8.0:")
     depends_on("py-matplotlib", when="@1.3.0:", type=("build", "run"))
+
+    depends_on("hdf5", type=("build", "link", "run"), when="+hdf5")
+    depends_on("highfive", type=("build", "link", "run"), when="+highfive")
     depends_on("root", type=("build", "link", "run"), when="+root")
 
     extends("python")
@@ -116,8 +116,12 @@ class Yoda(AutotoolsPackage):
     def configure_args(self):
         args = []
         if self.spec.satisfies("@:1.6.0"):
-            args.append("--with-boost=" + self.spec["boost"].prefix)
+            args.append(f"--with-boost={self.spec['boost'].prefix}")
+        if self.spec.satisfies("@2.1:"):
+            args.append(f"--with-yaml-cpp={self.spec['yaml-cpp'].prefix}")
 
+        args.extend(self.with_or_without("h5", variant="hdf5"))
+        args.extend(self.with_or_without("highfive", variant="highfive", activation_value="prefix"))
         args.extend(self.enable_or_disable("root"))
 
         return args

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -92,6 +92,8 @@ class Yoda(AutotoolsPackage):
 
     depends_on("hdf5", type=("build", "link", "run"), when="+hdf5")
     depends_on("highfive", type=("build", "link", "run"), when="+highfive")
+
+    depends_on("root", type=("build", "link", "run"), when="@2.1:")
     depends_on("root", type=("build", "link", "run"), when="+root")
 
     extends("python")

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -16,6 +16,7 @@ class Yoda(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("2.1.0", sha256="eba2efa58d407e5ca60205593339cdab12b7659255020358454b0f6502d115c2")
     version("2.0.2", sha256="31a41413641189814ff3c6bbb96ac5d17d2b68734fe327d06794cdbd3a540399")
     version("2.0.1", sha256="ae5a78eaae5574a5159d4058839d0983c9923558bfc88fbce21d251fd925d260")
     version("2.0.0", sha256="680f43dabebb3167ce1c5dee72d1c2c285c3190751245aa51e3260a005a99575")

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -123,7 +123,9 @@ class Yoda(AutotoolsPackage):
             args.append(f"--with-yaml-cpp={self.spec['yaml-cpp'].prefix}")
 
         args.extend(self.with_or_without("h5", variant="hdf5"))
-        args.extend(self.with_or_without("highfive", variant="highfive", activation_value="prefix"))
+        args.extend(
+            self.with_or_without("highfive", variant="highfive", activation_value="prefix")
+        )
         args.extend(self.enable_or_disable("root"))
 
         return args


### PR DESCRIPTION
This PR adds `rivet` v4.1.0 ([diff](https://gitlab.com/hepcedar/rivet/-/compare/rivet-4.0.3...rivet-4.1.0)), and `yoda` v2.1.0 ([diff](https://gitlab.com/hepcedar/yoda/-/compare/yoda-2.0.3...yoda-2.1.0)). This package is built in gitlab CI.
