### PR TITLE
Solver: Increase ASP setup determinism

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2712,7 +2712,7 @@ class Spec:
                 return name, depflag
 
             def spec_and_dependency_types(
-                s: Union[Spec, Tuple[Spec, str]],
+                s: Union[Spec, Tuple[Spec, str]]
             ) -> Tuple[Spec, dt.DepFlag]:
                 """Given a non-string key in the literal, extracts the spec
                 and its dependency types.
@@ -3798,7 +3798,7 @@ class Spec:
             for dep in sorted(itertools.chain.from_iterable(self._dependencies.values())):
                 yield dep.spec.name
                 yield dep.depflag
-                yield hash(dep.spec)
+                yield dep.spec._cmp_iter
 
         yield deps
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3774,9 +3774,6 @@ class Spec:
     def _cmp_iter(self):
         """Lazily yield components of self for comparison."""
 
-        for item in self._cmp_node():
-            yield item
-
         # If there is ever a breaking change to hash computation, whether accidental or purposeful,
         # two specs can be identical modulo DAG hash, depending on what time they were concretized
         # From the perspective of many operation in Spack (database, build cache, etc) a different
@@ -3794,13 +3791,12 @@ class Spec:
         # TODO: spec hashing.
         yield self.process_hash() if self.concrete else None
 
-        def deps():
-            for dep in sorted(itertools.chain.from_iterable(self._dependencies.values())):
-                yield dep.spec.name
-                yield dep.depflag
-                yield dep.spec._cmp_iter
+        for edge in self.traverse_edges(order="breadth", cover="edges"):
+            def yield_edge():
+                yield edge.spec._cmp_node
+                yield edge.depflag
+            yield yield_edge
 
-        yield deps
 
     @property
     def namespace_if_anonymous(self):


### PR DESCRIPTION
Particular solver setup operations were performed in a manner allowing non determinism in the ordering of ASP rule generation. This PR ensures those operations are performed in an ordered fashion.

Resolving this allows for increased concretization cache hit rates

* Ensures sorting Spec objects is deterministic

Previously `spack.spec.Spec._cmp_iter` compared spec dependencies based on their spec hashes (among other attributes). This was insufficient for cases where abstract specs have dependencies that are conditional based on other dependencies introduced variance in two similar specs being compared, i.e.
in the case where a spec depends on pkg a when pkg b is version x and depends on package c when pkg b is version y.

This PR ensures a proper comparison is affected without unduly impacting spec comparison performance. 


Note: this PR is only part of the effort to enforce more determinism in ASP behavior in Spack, covering only the Spec related facets of that process, full determinism should not be expected until both this and #49471 land.

This PR in concert with #49471 produces the following benchmarks:
### Benchmarks

#### Develop Baseline:

##### `spack spec py-torch` timing from develop binary mirror w/ `--reuse`

```
real	        1m26.394s
user	1m15.934s
sys	        0m2.149s
```

##### Concretization cache hit rate for `py-torch`

0% (0/5)


##### Concretization cache hit rate for `zlib`

20% (1/5) - once 5 runs have been completed, hit rate is 100%

#### After these changes:

##### `spack spec py-torch` timing from develop binary mirror w/ `--reuse`
```
real	        1m22.092s
user	1m8.950s
sys	        0m2.623s
```

##### Concretization Cache hit rate for `py-torch`

100% (5/5)

##### Concretization Cache hit rate for `zlib`

100% (5/5)

Benchmarks performed on:
darwin-sonoma-m1

