### PR TITLE
SST: update package maintainers

### DIFF
--- a/var/spack/repos/builtin/packages/sst-core/package.py
+++ b/var/spack/repos/builtin/packages/sst-core/package.py
@@ -15,7 +15,7 @@ class SstCore(AutotoolsPackage):
     git = "https://github.com/sstsimulator/sst-core.git"
     url = "https://github.com/sstsimulator/sst-core/releases/download/v14.1.0_Final/sstcore-14.1.0.tar.gz"
 
-    maintainers("berquist", "naromero77")
+    maintainers("berquist", "jmlapre", "naromero77")
 
     license("BSD-3-Clause")
 

--- a/var/spack/repos/builtin/packages/sst-dumpi/package.py
+++ b/var/spack/repos/builtin/packages/sst-dumpi/package.py
@@ -17,7 +17,7 @@ class SstDumpi(AutotoolsPackage):
     url = "https://github.com/sstsimulator/sst-dumpi/archive/refs/tags/v13.0.0_Final.tar.gz"
     git = "https://github.com/sstsimulator/sst-dumpi.git"
 
-    maintainers("berquist", "jpkenny", "calewis")
+    maintainers("berquist", "jmlapre")
 
     license("BSD-3-Clause")
 

--- a/var/spack/repos/builtin/packages/sst-elements/package.py
+++ b/var/spack/repos/builtin/packages/sst-elements/package.py
@@ -15,7 +15,7 @@ class SstElements(AutotoolsPackage):
     git = "https://github.com/sstsimulator/sst-elements.git"
     url = "https://github.com/sstsimulator/sst-elements/releases/download/v14.1.0_Final/sstelements-14.1.0.tar.gz"
 
-    maintainers("berquist", "naromero77")
+    maintainers("berquist", "jmlapre", "naromero77")
 
     license("BSD-3-Clause")
 

--- a/var/spack/repos/builtin/packages/sst-macro/package.py
+++ b/var/spack/repos/builtin/packages/sst-macro/package.py
@@ -18,7 +18,7 @@ class SstMacro(AutotoolsPackage):
     git = "https://github.com/sstsimulator/sst-macro.git"
     url = "https://github.com/sstsimulator/sst-macro/releases/download/v14.1.0_Final/sstmacro-14.1.0.tar.gz"
 
-    maintainers("berquist")
+    maintainers("berquist", "jmlapre")
 
     version("14.1.0", sha256="241f42f5c460b0e7462592a7f412bda9c9de19ad7a4b62c22f35be4093b57014")
     version("14.0.0", sha256="3962942268dd9fe6ebd4462e2d6d305ab757f3f510487e84687146a8d461be13")

--- a/var/spack/repos/builtin/packages/sst-transports/package.py
+++ b/var/spack/repos/builtin/packages/sst-transports/package.py
@@ -12,7 +12,7 @@ class SstTransports(CMakePackage):
     homepage = "https://github.com/sstsimulator"
     git = "https://github.com/jjwilke/sst-transports.git"
 
-    maintainers("jjwilke")
+    maintainers("berquist", "jmlapre")
 
     license("BSD-3-Clause")
 


### PR DESCRIPTION
Adds @jmlapre as a maintainer to all `sst-*` packages and removes others who have either left the project or are not involved with Spack.
