### PR TITLE
Build Env: Load external modules based on dep type

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -881,17 +881,17 @@ def get_rpath_deps(pkg: spack.package_base.PackageBase) -> List[spack.spec.Spec]
     return _get_rpath_deps_from_spec(pkg.spec, pkg.transitive_rpaths)
 
 
-def load_external_modules(pkg):
+def load_external_modules(external_specs):
     """Traverse a package's spec DAG and load any external modules.
 
     Traverse a package's dependencies and load any external modules
     associated with them.
 
     Args:
-        pkg (spack.package_base.PackageBase): package to load deps for
+        external_specs: an iterable set of external specs (should be ordered based on traversal)
     """
-    for dep in list(pkg.spec.traverse()):
-        external_modules = dep.external_modules or []
+    for spec, _ in external_specs:
+        external_modules = spec.external_modules or []
         for external_module in external_modules:
             load_module(external_module)
 
@@ -946,7 +946,7 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
         for mod in pkg.compiler.modules:
             load_module(mod)
 
-    load_external_modules(pkg)
+    load_external_modules(setup_context.external)
 
     # Make sure nothing's strange about the Spack environment.
     validate(env_mods, tty.warn)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -881,21 +881,6 @@ def get_rpath_deps(pkg: spack.package_base.PackageBase) -> List[spack.spec.Spec]
     return _get_rpath_deps_from_spec(pkg.spec, pkg.transitive_rpaths)
 
 
-def load_external_modules(context: SetupContext) -> None:
-    """Traverse a package's spec DAG and load any external modules.
-
-    Traverse a package's dependencies and load any external modules
-    associated with them.
-
-    Args:
-        context: A populated SetupContext object
-    """
-    for spec, _ in context.external:
-        external_modules = spec.external_modules or []
-        for external_module in external_modules:
-            load_module(external_module)
-
-
 def setup_package(pkg, dirty, context: Context = Context.BUILD):
     """Execute all environment setup routines."""
     if context not in (Context.BUILD, Context.TEST):
@@ -1233,6 +1218,21 @@ class SetupContext:
             bin_dir = os.path.join(dep.prefix, d)
             if os.path.isdir(bin_dir):
                 env.prepend_path("PATH", bin_dir)
+
+
+def load_external_modules(context: SetupContext) -> None:
+    """Traverse a package's spec DAG and load any external modules.
+
+    Traverse a package's dependencies and load any external modules
+    associated with them.
+
+    Args:
+        context: A populated SetupContext object
+    """
+    for spec, _ in context.external:
+        external_modules = spec.external_modules or []
+        for external_module in external_modules:
+            load_module(external_module)
 
 
 def _setup_pkg_and_run(

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -881,16 +881,16 @@ def get_rpath_deps(pkg: spack.package_base.PackageBase) -> List[spack.spec.Spec]
     return _get_rpath_deps_from_spec(pkg.spec, pkg.transitive_rpaths)
 
 
-def load_external_modules(external_specs):
+def load_external_modules(context: SetupContext) -> None:
     """Traverse a package's spec DAG and load any external modules.
 
     Traverse a package's dependencies and load any external modules
     associated with them.
 
     Args:
-        external_specs: an iterable set of external specs (should be ordered based on traversal)
+        context: A populated SetupContext object
     """
-    for spec, _ in external_specs:
+    for spec, _ in context.external:
         external_modules = spec.external_modules or []
         for external_module in external_modules:
             load_module(external_module)
@@ -946,7 +946,7 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
         for mod in pkg.compiler.modules:
             load_module(mod)
 
-    load_external_modules(setup_context.external)
+    load_external_modules(setup_context)
 
     # Make sure nothing's strange about the Spack environment.
     validate(env_mods, tty.warn)


### PR DESCRIPTION
Only load modules based on the build/link dependency types for a given package's build environment construction.
Re-use the `SetupContext` object for traversal of externals.

This fixes a bug which I confirmed with my builds. Before anything in the DAG with an external module was getting loaded. However, the environment modifications are tied to the context manager. So for something using a module + environment modifications the specs that don't actually depend on the package with the module were getting it loaded AND not getting environment modifications. Double jeopardy. 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
