### PR TITLE
Add dbus patch for container builds.

### DIFF
--- a/var/spack/repos/builtin/packages/dbus/meson_post_install.patch
+++ b/var/spack/repos/builtin/packages/dbus/meson_post_install.patch
@@ -1,0 +1,9 @@
+diff --git a/meson_post_install.py b/meson_post_install.py
+index cfc03b22..1d007ad6 100755
+--- a/meson_post_install.py
++++ b/meson_post_install.py
+@@ -103,4 +103,3 @@ def post_install_exe():
+ 
+ if __name__ == "__main__":
+     post_install_relocation()
+-    post_install_exe()

--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -42,6 +42,9 @@ class Dbus(AutotoolsPackage, MesonPackage):
     version("1.8.6", sha256="eded83ca007b719f32761e60fd8b9ffd0f5796a4caf455b01b5a5ef740ebd23f")
     version("1.8.4", sha256="3ef63dc8d0111042071ee7f7bafa0650c6ce2d7be957ef0b7ec269495a651ff8")
     version("1.8.2", sha256="5689f7411165adc953f37974e276a3028db94447c76e8dd92efe910c6d3bae08")
+    # Skip function that tries to do something if you're root that doesn't work in a container.
+    # Only tested on 1.15.10, but probably works for other versions as well.
+    patch('meson_post_install.patch', sha256='d121f842418af606f414ebfc523b51fdd23a2d231e73d66229a4b0ab3486edc4', when='@1.15.10')
 
     variant("xml_docs", default=False, description="Build XML documentation")
     variant("system-socket", default="default", description="Location for the DBus system socket")

--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -44,7 +44,11 @@ class Dbus(AutotoolsPackage, MesonPackage):
     version("1.8.2", sha256="5689f7411165adc953f37974e276a3028db94447c76e8dd92efe910c6d3bae08")
     # Skip function that tries to do something if you're root that doesn't work in a container.
     # Only tested on 1.15.10, but probably works for other versions as well.
-    patch('meson_post_install.patch', sha256='d121f842418af606f414ebfc523b51fdd23a2d231e73d66229a4b0ab3486edc4', when='@1.15.10')
+    patch(
+        "meson_post_install.patch",
+        sha256="d121f842418af606f414ebfc523b51fdd23a2d231e73d66229a4b0ab3486edc4",
+        when="@1.15.10",
+    )
 
     variant("xml_docs", default=False, description="Build XML documentation")
     variant("system-socket", default="default", description="Location for the DBus system socket")


### PR DESCRIPTION
Add a patch to the dbus package to remove a final python script function that doesn't do anything when installing as a regular user and breaks if you are building as root and lack the specific group that it is expecting (which most containers probably will).  Specifically set for only 1.15.10 right now, but only because that's all I've tested.  Likely applies to any versions with that specific file run at the end of the installation.