### PR TITLE
libxcrypt: add v4.4.36, v4.4.38

### DIFF
--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -22,6 +22,8 @@ class Libxcrypt(AutotoolsPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("4.4.38", sha256="80304b9c306ea799327f01d9a7549bdb28317789182631f1b54f4511b4206dd6")
+    version("4.4.36", sha256="e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943")
     version("4.4.35", sha256="a8c935505b55f1df0d17f8bfd59468c7c6709a1d31831b0f8e3e045ab8fd455d")
     version("4.4.34", sha256="bb3f467af21c48046ce662186eb2ddf078ca775c441fdf1c3628448a3833a230")
     version("4.4.33", sha256="e87acf9c652c573a4713d5582159f98f305d56ed5f754ce64f57d4194d6b3a6f")

--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -23,6 +23,7 @@ class Libxcrypt(AutotoolsPackage):
     license("LGPL-2.1-or-later")
 
     version("4.4.38", sha256="80304b9c306ea799327f01d9a7549bdb28317789182631f1b54f4511b4206dd6")
+    # 4.4.37 requires pkg-config and is not included here
     version("4.4.36", sha256="e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943")
     version("4.4.35", sha256="a8c935505b55f1df0d17f8bfd59468c7c6709a1d31831b0f8e3e045ab8fd455d")
     version("4.4.34", sha256="bb3f467af21c48046ce662186eb2ddf078ca775c441fdf1c3628448a3833a230")


### PR DESCRIPTION
Release notes:
- https://github.com/besser82/libxcrypt/releases/tag/v4.4.36
- https://github.com/besser82/libxcrypt/releases/tag/v4.4.38

No significant build changes as far as I can tell: https://github.com/besser82/libxcrypt/compare/v4.4.35...v4.4.38

Both added versions compile and tests pass (`spack install --verbose --test=root libxcrypt@4.4.36`).

Skipped adding v4.4.37 due to a hard requirement on pkg-config. See https://github.com/besser82/libxcrypt/issues/198 for details.