### PR TITLE
libxrender: add v0.9.12

### DIFF
--- a/var/spack/repos/builtin/packages/libxrender/package.py
+++ b/var/spack/repos/builtin/packages/libxrender/package.py
@@ -15,6 +15,7 @@ class Libxrender(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("0.9.12", sha256="0fff64125819c02d1102b6236f3d7d861a07b5216d8eea336c3811d31494ecf7")
     version("0.9.11", sha256="6aec3ca02e4273a8cbabf811ff22106f641438eb194a12c0ae93c7e08474b667")
     version("0.9.10", sha256="770527cce42500790433df84ec3521e8bf095dfe5079454a92236494ab296adf")
     version("0.9.9", sha256="beeac64ff8d225f775019eb7c688782dee9f4cc7b412a65538f8dde7be4e90fe")


### PR DESCRIPTION
Release notes: https://lists.x.org/archives/xorg-announce/2024-December/003567.html

No significant build changes as far as I can tell: https://gitlab.freedesktop.org/xorg/lib/libxrender/-/compare/libXrender-0.9.11...libXrender-0.9.12?from_project_id=730.

`libxrender@0.9.12` fixes a bug when building against `libx11@1.8.11`:

https://lists.x.org/archives/xorg-announce/2025-February/003582.html
> Note that a bug in libXrender versions prior to December's 0.9.12 release
> will cause them to fail to build with the XlibInt.h header from this release,
> so packagers should be sure to update to libXrender 0.9.12 as well.