### PR TITLE
nghttp2: add v1.65.0

### DIFF
--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -14,6 +14,7 @@ class Nghttp2(AutotoolsPackage):
 
     license("MIT")
 
+    version("1.65.0", sha256="8ca4f2a77ba7aac20aca3e3517a2c96cfcf7c6b064ab7d4a0809e7e4e9eb9914")
     version("1.64.0", sha256="20e73f3cf9db3f05988996ac8b3a99ed529f4565ca91a49eb0550498e10621e8")
     version("1.63.0", sha256="9318a2cc00238f5dd6546212109fb833f977661321a2087f03034e25444d3dbb")
     version("1.62.1", sha256="d0b0b9d00500ee4aa3bfcac00145d3b1ef372fd301c35bff96cf019c739db1b4")


### PR DESCRIPTION
Release notes: https://github.com/nghttp2/nghttp2/releases/tag/v1.65.0