### PR TITLE
Fix concretizer cache config schema and disable

### DIFF
--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -95,6 +95,15 @@ properties: Dict[str, Any] = {
             "timeout": {"type": "integer", "minimum": 0},
             "error_on_timeout": {"type": "boolean"},
             "os_compatible": {"type": "object", "additionalProperties": {"type": "array"}},
+            "cache": {
+                "type": "object",
+                "properties": {
+                    "enable": {"type": "boolean"},
+                    "path": {"type": "string"},
+                    "entry_limit": {"type": "integer", "minimum": 0},
+                    "size_limit": {"type": "integer", "minimum": 0},
+                },
+            },
         },
     }
 }

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -58,15 +58,6 @@ properties: Dict[str, Any] = {
                     {"type": "string"},  # deprecated
                 ]
             },
-            "concretization_cache": {
-                "type": "object",
-                "properties": {
-                    "enable": {"type": "boolean"},
-                    "url": {"type": "string"},
-                    "entry_limit": {"type": "integer", "minimum": 0},
-                    "size_limit": {"type": "integer", "minimum": 0},
-                },
-            },
             "install_hash_length": {"type": "integer", "minimum": 1},
             "install_path_scheme": {"type": "string"},  # deprecated
             "build_stage": {

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -649,7 +649,7 @@ class ConcretizationCache:
 
     def __init__(self, root: Union[str, None] = None):
         root = root or spack.config.get(
-            "config:concretization_cache:url", spack.paths.default_conc_cache_path
+            "concretizer:cache:path", spack.paths.default_conc_cache_path
         )
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
         self._fc = FileCache(self.root)
@@ -660,8 +660,8 @@ class ConcretizationCache:
         """Prunes the concretization cache according to configured size and entry
         count limits. Cleanup is done in FIFO ordering."""
         # TODO: determine a better default
-        entry_limit = spack.config.get("config:concretization_cache:entry_limit", 1000)
-        bytes_limit = spack.config.get("config:concretization_cache:size_limit", 3e8)
+        entry_limit = spack.config.get("concretizer:cache:entry_limit", 1000)
+        bytes_limit = spack.config.get("concretizer:cache:size_limit", 3e8)
         # lock the entire buildcache as we're removing a lot of data from the
         # manifest and cache itself
         with self._fc.read_transaction(self._cache_manifest) as f:
@@ -1215,7 +1215,7 @@ class PyclingoDriver:
                 problem_repr += "\n" + f.read()
 
         result = None
-        conc_cache_enabled = spack.config.get("config:concretization_cache:enable", True)
+        conc_cache_enabled = spack.config.get("concretizer:cache:enable", True)
         if conc_cache_enabled:
             result, concretization_stats = CONC_CACHE.fetch(problem_repr)
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3278,7 +3278,7 @@ def test_concretization_cache_roundtrip(use_concretization_cache, monkeypatch, m
     # monkeypatch our forced determinism setup method into solver setup
     monkeypatch.setattr(spack.solver.asp.SpackSolverSetup, "setup", _setup)
 
-    assert spack.config.get("config:concretization_cache:enable")
+    assert spack.config.get("concretizer:cache:enable")
 
     # run one standard concretization to populate the cache and the setup method
     # memoization

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -353,10 +353,10 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(scope="function")
 def use_concretization_cache(mutable_config, tmpdir):
     """Enables the use of the concretization cache"""
-    spack.config.set("config:concretization_cache:enable", True)
+    spack.config.set("concretizer:cache:enable", True)
     # ensure we have an isolated concretization cache
     new_conc_cache_loc = str(tmpdir.mkdir("concretization"))
-    spack.config.set("config:concretization_cache:path", new_conc_cache_loc)
+    spack.config.set("concretizer:cache:path", new_conc_cache_loc)
     yield
 
 

--- a/lib/spack/spack/test/data/config/concretizer.yaml
+++ b/lib/spack/spack/test/data/config/concretizer.yaml
@@ -5,3 +5,5 @@ concretizer:
     host_compatible: false
   duplicates:
     strategy: minimal
+  cache:
+    enable: false

--- a/lib/spack/spack/test/data/config/config.yaml
+++ b/lib/spack/spack/test/data/config/config.yaml
@@ -14,5 +14,3 @@ config:
   checksum: true
   dirty: false
   locks: {1}
-  concretization_cache:
-    enable: false


### PR DESCRIPTION
This feature is not useful enough to be enabled by default. For a simple
`spack spec zlib` I'm seeing 2 of 7 hits instead of 7 of 7.

Also move config from `config:concretization_cache` to
`concretizer:cache` and rename `url` to `path` since no url can be
provided. This shouldn't be a breaking change given the feature
is not yet part of any release branch.