### PR TITLE
py-questionary: add 2.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-questionary/package.py
+++ b/var/spack/repos/builtin/packages/py-questionary/package.py
@@ -18,8 +18,8 @@ class PyQuestionary(PythonPackage):
     version("2.1.0", sha256="6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587")
     version("1.9.0", sha256="a050fdbb81406cddca679a6f492c6272da90cb09988963817828f697cf091c55")
 
-    depends_on("python@3.6:3.9", type=("build", "run"), when="@1.9.0")
     depends_on("python@3.8:", type=("build", "run"), when="@2.1.0")
+    depends_on("python@3.6:3.9", type=("build", "run"), when="@1.9.0")
 
     depends_on("py-poetry@1.0.5:", type="build")
     depends_on("py-prompt-toolkit@2.0:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-questionary/package.py
+++ b/var/spack/repos/builtin/packages/py-questionary/package.py
@@ -15,8 +15,11 @@ class PyQuestionary(PythonPackage):
 
     license("MIT")
 
+    version("2.1.0", sha256="6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587")
     version("1.9.0", sha256="a050fdbb81406cddca679a6f492c6272da90cb09988963817828f697cf091c55")
 
-    depends_on("python@3.6:3.9", type=("build", "run"))
+    depends_on("python@3.6:3.9", type=("build", "run"), when="@1.9.0")
+    depends_on("python@3.8:", type=("build", "run"), when="@2.1.0")
+
     depends_on("py-poetry@1.0.5:", type="build")
     depends_on("py-prompt-toolkit@2.0:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-questionary/package.py
+++ b/var/spack/repos/builtin/packages/py-questionary/package.py
@@ -13,6 +13,8 @@ class PyQuestionary(PythonPackage):
     homepage = "https://github.com/tmbo/questionary"
     pypi = "questionary/questionary-1.9.0.tar.gz"
 
+    maintainers("mathomp4")
+
     license("MIT")
 
     version("2.1.0", sha256="6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds py-questionary 2.1.0.

From my reading of the [`pyproject.toml` in 2.1.0](https://github.com/tmbo/questionary/blob/9fbbfa4fd01cebfd7001e1d10ab4102305ecbec4/pyproject.toml#L41-L43), I believe support is now Python 3.8+ (and with https://github.com/tmbo/questionary/pull/420 will soon be Python 3.9+). But I'm going to mention @tmbo here to see if they agree this is the only change needed here for 2.1.0 