### PR TITLE
postgresql: add missing perl build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -75,8 +75,9 @@ class Postgresql(AutotoolsPackage):
     depends_on("perl+opcode", when="+perl")
     depends_on("python", when="+python")
     depends_on("libxml2", when="+xml")
-    depends_on("flex", when="@17:")
-    depends_on("bison", when="@17:")
+    depends_on("perl", when="@17:", type="build")
+    depends_on("flex", when="@17:", type="build")
+    depends_on("bison", when="@17:", type="build")
     depends_on("pkgconfig", when="+xml", type="build")
 
     @property


### PR DESCRIPTION
Without it, the build fails with errors like this:
```
Can't locate File/Compare.pm in @INC (you may need to install the File::Compare module) (@INC contains: ...) at ../../../src/backend/catalog/Catalog.pm line 19.
```