### PR TITLE
Fix Bazel 6:8 on modern toolchains

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/no_werror.patch
+++ b/var/spack/repos/builtin/packages/bazel/no_werror.patch
@@ -1,0 +1,56 @@
+diff --git a/distdir_deps.bzl b/distdir_deps.bzl
+index fabaf84a31..14cef576d7 100644
+--- a/distdir_deps.bzl
++++ b/distdir_deps.bzl
+@@ -242,6 +242,10 @@ DIST_DEPS = {
+             "https://mirror.bazel.build/github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz",
+             "https://github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz",
+         ],
++        "patch_args": ["-p1"],
++        "patches": [
++            "//third_party:upb/no_werror.patch",
++        ],
+         "used_in": [
+             "additional_distfiles",
+         ],
+diff --git a/third_party/upb/no_werror.patch b/third_party/upb/no_werror.patch
+new file mode 100644
+index 0000000000..d2b0154739
+--- /dev/null
++++ b/third_party/upb/no_werror.patch
+@@ -0,0 +1,21 @@
++diff --git a/bazel/build_defs.bzl b/bazel/build_defs.bzl
++index b5bc64f0..376f1436 100644
++--- a/bazel/build_defs.bzl
+++++ b/bazel/build_defs.bzl
++@@ -34,13 +34,13 @@ _DEFAULT_COPTS = []
++ _DEFAULT_CPPOPTS.extend([
++     "-Wextra",
++     # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
++-    "-Werror",
+++    # "-Werror",
++     "-Wno-long-long",
++ ])
++ _DEFAULT_COPTS.extend([
++     "-std=c99",
++-    "-pedantic",
++-    "-Werror=pedantic",
+++    # "-pedantic",
+++    # "-Werror=pedantic",
++     "-Wall",
++     "-Wstrict-prototypes",
++     # GCC (at least) emits spurious warnings for this that cannot be fixed
+diff --git a/tools/cpp/unix_cc_toolchain_config.bzl b/tools/cpp/unix_cc_toolchain_config.bzl
+index 1dd0e7a6e7..4b401ac4f4 100644
+--- a/tools/cpp/unix_cc_toolchain_config.bzl
++++ b/tools/cpp/unix_cc_toolchain_config.bzl
+@@ -1357,3 +1357,3 @@ # Linux artifact name patterns are the default.
+             unfiltered_compile_flags_feature,
+-            treat_warnings_as_errors_feature,
++            # treat_warnings_as_errors_feature,
+             archive_param_file_feature,
+@@ -1394,3 +1394,3 @@ # macOS artifact name patterns differ from the defaults only for dynamic
+             unfiltered_compile_flags_feature,
+-            treat_warnings_as_errors_feature,
++            # treat_warnings_as_errors_feature,
+             archive_param_file_feature,

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -210,8 +210,12 @@ class Bazel(Package):
     # https://github.com/bazelbuild/bazel/pull/23667 doesn't cleanly apply on older versions...
     # however... it is commonly accepted the -Werror should only be used for project developers
     # and not for building releases for end users so just nuke it from orbit when we find it.
-    patch("no_werror.patch", when="@6:8", sha256="4f4ad047701f7c5f10840ce4f065d352d50429bf09d44bb4c814fbe14c1d2c2f")
-    
+    patch(
+        "no_werror.patch",
+        when="@6:8",
+        sha256="4f4ad047701f7c5f10840ce4f065d352d50429bf09d44bb4c814fbe14c1d2c2f",
+    )
+
     executables = ["^bazel$"]
 
     # Download resources to perform offline build with bazel.

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -207,9 +207,11 @@ class Bazel(Package):
     # Newer versions of grpc and abseil dependencies are needed but are not in bazel-4.0.0
     conflicts("@4.0.0", when="%gcc@11:")
 
-    # https://github.com/bazelbuild/bazel/pull/23667
-    conflicts("%apple-clang@16:", when="@:7.3")
-
+    # https://github.com/bazelbuild/bazel/pull/23667 doesn't cleanly apply on older versions...
+    # however... it is commonly accepted the -Werror should only be used for project developers
+    # and not for building releases for end users so just nuke it from orbit when we find it.
+    patch("no_werror.patch", when="@6:8", sha256="4f4ad047701f7c5f10840ce4f065d352d50429bf09d44bb4c814fbe14c1d2c2f")
+    
     executables = ["^bazel$"]
 
     # Download resources to perform offline build with bazel.


### PR DESCRIPTION
This should fix bazels between 6.0 (inclusive) and 8.0 (exclusive) on modern toolchains including apple-clang and others which issue warnings the bazel devs did not anticipate. This removes the conflict introduced in spack/spack#47228.