### PR TITLE
Fix: tensorflow empty config vars

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/allow-empty-config-environment-variables.patch
+++ b/var/spack/repos/builtin/packages/py-tensorflow/allow-empty-config-environment-variables.patch
@@ -1,0 +1,26 @@
+From ac0fca8559c2384240a00599a46816bbb5afb93f Mon Sep 17 00:00:00 2001
+From: Thomas Dickerson <elfprince13@gmail.com>
+Date: Tue, 11 Mar 2025 14:07:34 -0400
+Subject: [PATCH] Allow empty configuration values to be supplied from
+ environment
+
+For example it may be desirable for `CC_OPT_FLAGS` to be empty.
+---
+ configure.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/configure.py b/configure.py
+index ec04fcfdd0cc67..ac19b856d7c914 100644
+--- a/configure.py
++++ b/configure.py
+@@ -529,7 +529,9 @@ def get_from_env_or_user_or_default(environ_cp, var_name, ask_for_var,
+     string value for var_name
+   """
+   var = environ_cp.get(var_name)
+-  if not var:
++  # an intentionally empty value in the
++  # environment is not the same as no value
++  if var is None:
+     var = get_input(ask_for_var)
+     print('\n')
+   if not var:

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -487,6 +487,14 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         when="@2.9:2.10.0",
     )
 
+    # can set an upper bound if/when
+    # https://github.com/tensorflow/tensorflow/pull/89032 is merged
+    patch(
+        "allow-empty-config-environment-variables.patch",
+        sha256="e061875c2ca9c157a7837d02afdd25205817def3460745523d5089bbeaa77d29",
+        when="@1.4.0:"
+    )
+
     # Version 2.10 produces an error related to cuBLAS:
     # E tensorflow/stream_executor/cuda/cuda_blas.cc:2981] Unable to register
     # cuBLAS factory: Attempting to register factory for plugin cuBLAS when one

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -492,7 +492,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     patch(
         "allow-empty-config-environment-variables.patch",
         sha256="e061875c2ca9c157a7837d02afdd25205817def3460745523d5089bbeaa77d29",
-        when="@1.4.0:"
+        when="@1.4.0:",
     )
 
     # Version 2.10 produces an error related to cuBLAS:


### PR DESCRIPTION
Currently if Spack decides CC_OPT_FLAGS should be empty, this incorrectly drops Tensorflow's `./configure.py` into interactive mode. Fix allows Tensorflow to distinguish between empty and not set.

Incidentally this patch is also pending at tensorflow/tensorflow#89032 so we can set an upper bound in package.py if that ever makes it into a release.