### PR TITLE
WarpX: GitHub Org Moved

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -18,7 +18,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
 
     test_requires_compiler = True
 
-    tags = ["ecp", "e4s"]
+    tags = ["ecp", "e4s", "hpsf"]
 
     maintainers("WeiqunZhang", "asalmgren", "atmyers")
 

--- a/var/spack/repos/builtin/packages/py-amrex/package.py
+++ b/var/spack/repos/builtin/packages/py-amrex/package.py
@@ -15,6 +15,8 @@ class PyAmrex(CMakePackage, PythonExtension, CudaPackage, ROCmPackage):
 
     maintainers("ax3l", "EZoni", "RTSandberg", "sayerhs", "WeiqunZhang")
 
+    tags = ["e4s", "hpsf"]
+
     license("BSD-3-Clause-LBNL")
 
     version("develop", branch="development")

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -15,11 +15,11 @@ class Warpx(CMakePackage, PythonExtension):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/25.03.tar.gz"
-    git = "https://github.com/ECP-WarpX/WarpX.git"
+    url = "https://github.com/BLAST-WarpX/warpx/archive/refs/tags/25.03.tar.gz"
+    git = "https://github.com/BLAST-WarpX/warpx.git"
 
     maintainers("ax3l", "dpgrote", "EZoni", "RemiLehe")
-    tags = ["e4s", "ecp"]
+    tags = ["e4s", "ecp", "hpsf"]
 
     license("BSD-3-Clause-LBNL")
 
@@ -239,34 +239,34 @@ class Warpx(CMakePackage, PythonExtension):
 
     # The symbolic aliases for our +lib target were missing in the install
     # location
-    # https://github.com/ECP-WarpX/WarpX/pull/2626
+    # https://github.com/BLAST-WarpX/warpx/pull/2626
     patch(
-        "https://github.com/ECP-WarpX/WarpX/pull/2626.patch?full_index=1",
+        "https://github.com/BLAST-WarpX/warpx/pull/2626.patch?full_index=1",
         sha256="a431d4664049d6dcb6454166d6a948d8069322a111816ca5ce01553800607544",
         when="@21.12",
     )
 
     # Workaround for AMReX<=22.06 no-MPI Gather
-    # https://github.com/ECP-WarpX/WarpX/pull/3134
+    # https://github.com/BLAST-WarpX/warpx/pull/3134
     # https://github.com/AMReX-Codes/amrex/pull/2793
     patch(
-        "https://github.com/ECP-WarpX/WarpX/pull/3134.patch?full_index=1",
+        "https://github.com/BLAST-WarpX/warpx/pull/3134.patch?full_index=1",
         sha256="b786ce64a3c2c2b96ff2e635f0ee48532e4ae7ad9637dbf03f11c0768c290690",
         when="@22.02:22.05",
     )
 
     # Forgot to install ABLASTR library
-    # https://github.com/ECP-WarpX/WarpX/pull/3141
+    # https://github.com/BLAST-WarpX/warpx/pull/3141
     patch(
-        "https://github.com/ECP-WarpX/WarpX/pull/3141.patch?full_index=1",
+        "https://github.com/BLAST-WarpX/warpx/pull/3141.patch?full_index=1",
         sha256="dab6fb44556ee1fd466a4cb0e20f89bde1ce445c9a51a2c0f59d1740863b5e7d",
         when="@22.04,22.05",
     )
 
     # Fix failing 1D CUDA build
-    # https://github.com/ECP-WarpX/WarpX/pull/3162
+    # https://github.com/BLAST-WarpX/warpx/pull/3162
     patch(
-        "https://github.com/ECP-WarpX/WarpX/pull/3162.patch?full_index=1",
+        "https://github.com/BLAST-WarpX/warpx/pull/3162.patch?full_index=1",
         sha256="0ae573d1390ed8063f84e3402d30d34e522e65dc5dfeea3d07e165127ab373e9",
         when="@22.06",
     )


### PR DESCRIPTION
The WarpX repo moved. ECP succeeded. Long live ECP.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
