### PR TITLE
hip: add missing HIPCC_LINK_FLAGS_APPEND

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -503,6 +503,11 @@ class Hip(CMakePackage):
                 "--rocm-path={0}".format(paths["rocm-path"]),
                 separator=" ",
             )
+            env.append_path(
+                "HIPCC_LINK_FLAGS_APPEND",
+                "--rocm-path={0}".format(paths["rocm-path"]),
+                separator=" ",
+            )
         elif self.spec.satisfies("+cuda"):
             env.set("CUDA_PATH", self.spec["cuda"].prefix)
             env.set("HIP_PATH", self.spec.prefix)
@@ -515,6 +520,11 @@ class Hip(CMakePackage):
             # This is picked up by hipcc.
             env.append_path(
                 "HIPCC_COMPILE_FLAGS_APPEND",
+                f"--gcc-toolchain={self.compiler.prefix}",
+                separator=" ",
+            )
+            env.append_path(
+                "HIPCC_LINK_FLAGS_APPEND",
                 f"--gcc-toolchain={self.compiler.prefix}",
                 separator=" ",
             )

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -524,9 +524,7 @@ class Hip(CMakePackage):
                 separator=" ",
             )
             env.append_path(
-                "HIPCC_LINK_FLAGS_APPEND",
-                f"--gcc-toolchain={self.compiler.prefix}",
-                separator=" ",
+                "HIPCC_LINK_FLAGS_APPEND", f"--gcc-toolchain={self.compiler.prefix}", separator=" "
             )
             # This is picked up by CMake when using HIP as a CMake language.
             env.append_path("HIPFLAGS", f"--gcc-toolchain={self.compiler.prefix}", separator=" ")

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -499,14 +499,10 @@ class Hip(CMakePackage):
             # bin/.hipVersion file can still be parsed.
             # See also https://github.com/ROCm/HIP/issues/2223
             env.append_path(
-                "HIPCC_COMPILE_FLAGS_APPEND",
-                "--rocm-path={0}".format(paths["rocm-path"]),
-                separator=" ",
+                "HIPCC_COMPILE_FLAGS_APPEND", f"--rocm-path={paths['rocm-path']}", separator=" "
             )
             env.append_path(
-                "HIPCC_LINK_FLAGS_APPEND",
-                "--rocm-path={0}".format(paths["rocm-path"]),
-                separator=" ",
+                "HIPCC_LINK_FLAGS_APPEND", f"--rocm-path={paths['rocm-path']}", separator=" "
             )
         elif self.spec.satisfies("+cuda"):
             env.set("CUDA_PATH", self.spec["cuda"].prefix)


### PR DESCRIPTION
Linking with `hipcc` will still fail if wrong GCC is selected. Mirror `HIPCC_LINK_FLAGS_APPEND` to match `HIPCC_COMPILE_FLAGS_APPEND`