### PR TITLE
path and remote_file_cache: support windows paths

### DIFF
--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -136,30 +136,16 @@ def test_path_debug_padded_filter(debug, monkeypatch):
         assert expected == sup.debug_padded_filter(string)
 
 
-spack_root = os.environ["SPACK_ROOT"]
-
-
 @pytest.mark.parametrize(
     "path,expected",
     [
         ("/home/spack/path/to/file.txt", "/home/spack/path/to/file.txt"),
         ("file:///home/another/config.yaml", "/home/another/config.yaml"),
-        ("path/to.txt", f"{os.sep.join([spack_root, 'path', 'to.txt'])}"),
-    ],
-)
-def test_canonicalize_linux_file(path, expected):
-    """Confirm canonicalize path handles local files and file URLs."""
-    assert sup.canonicalize_path(path) == os.path.normpath(expected)
-
-
-@pytest.mark.parametrize(
-    "path,expected",
-    [
+        ("path/to.txt", os.path.join(os.environ["SPACK_ROOT"], "path", "to.txt")),
         (r"C:\Files (x86)\Windows\10", r"C:\Files (x86)\Windows\10"),
-        (r"C:builds\spack", "C:" + os.path.join(spack_root, "builds", "spack")),
         (r"E:/spack stage", "E:\\spack stage"),
     ],
 )
-def test_canonicalize_windows_file(path, expected):
-    """Confirm canonicalize path handles windows files."""
+def test_canonicalize_file(path, expected):
+    """Confirm canonicalize path handles local files and file URLs."""
     assert sup.canonicalize_path(path) == os.path.normpath(expected)

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -134,3 +134,32 @@ def test_path_debug_padded_filter(debug, monkeypatch):
     monkeypatch.setattr(tty, "_debug", debug)
     with spack.config.override("config:install_tree", {"padded_length": 128}):
         assert expected == sup.debug_padded_filter(string)
+
+
+spack_root = os.environ["SPACK_ROOT"]
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/home/spack/path/to/file.txt", "/home/spack/path/to/file.txt"),
+        ("file:///home/another/config.yaml", "/home/another/config.yaml"),
+        ("path/to.txt", f"{os.sep.join([spack_root, 'path', 'to.txt'])}"),
+    ],
+)
+def test_canonicalize_linux_file(path, expected):
+    """Confirm canonicalize path handles local files and file URLs."""
+    assert sup.canonicalize_path(path) == os.path.normpath(expected)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        (r"C:\Files (x86)\Windows\10", r"C:\Files (x86)\Windows\10"),
+        (r"C:builds\spack", "C:" + os.path.join(spack_root, "builds", "spack")),
+        (r"E:/spack stage", "E:\\spack stage"),
+    ],
+)
+def test_canonicalize_windows_file(path, expected):
+    """Confirm canonicalize path handles windows files."""
+    assert sup.canonicalize_path(path) == os.path.normpath(expected)

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -28,30 +28,20 @@ def test_rfc_local_path_bad_scheme(path, err):
         _ = rfc_util.local_path(path, "")
 
 
-spack_root = os.environ["SPACK_ROOT"]
-
-
 @pytest.mark.parametrize(
     "path,expected",
     [
         ("/a/b/c/d/e/config.py", "/a/b/c/d/e/config.py"),
         ("file:///this/is/a/file/url/include.yaml", "/this/is/a/file/url/include.yaml"),
-        ("relative/packages.txt", os.path.join(spack_root, "relative", "packages.txt")),
-    ],
-)
-def test_rfc_local_linux_file(path, expected):
-    assert rfc_util.local_path(path, "") == os.path.normpath(expected)
-
-
-@pytest.mark.parametrize(
-    "path,expected",
-    [
+        (
+            "relative/packages.txt",
+            os.path.join(os.environ["SPACK_ROOT"], "relative", "packages.txt"),
+        ),
         (r"C:\Files (x86)\Windows\10", r"C:\Files (x86)\Windows\10"),
-        (r"C:builds\spack", "C:" + os.path.join(spack_root, "builds", "spack")),
         (r"D:/spack stage", "D:\\spack stage"),
     ],
 )
-def test_rfc_local_windows_file(path, expected):
+def test_rfc_local_file(path, expected):
     assert rfc_util.local_path(path, "") == os.path.normpath(expected)
 
 

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -28,12 +28,31 @@ def test_rfc_local_path_bad_scheme(path, err):
         _ = rfc_util.local_path(path, "")
 
 
+spack_root = os.environ["SPACK_ROOT"]
+
+
 @pytest.mark.parametrize(
-    "path", ["/a/b/c/d/e/config.py", "file:///this/is/a/file/url/include.yaml"]
+    "path,expected",
+    [
+        ("/a/b/c/d/e/config.py", "/a/b/c/d/e/config.py"),
+        ("file:///this/is/a/file/url/include.yaml", "/this/is/a/file/url/include.yaml"),
+        ("relative/packages.txt", os.path.join(spack_root, "relative", "packages.txt")),
+    ],
 )
-def test_rfc_local_path_file(path):
-    actual = path.split("://")[1] if ":" in path else path
-    assert rfc_util.local_path(path, "") == os.path.normpath(actual)
+def test_rfc_local_linux_file(path, expected):
+    assert rfc_util.local_path(path, "") == os.path.normpath(expected)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        (r"C:\Files (x86)\Windows\10", r"C:\Files (x86)\Windows\10"),
+        (r"C:builds\spack", "C:" + os.path.join(spack_root, "builds", "spack")),
+        (r"D:/spack stage", "D:\\spack stage"),
+    ],
+)
+def test_rfc_local_windows_file(path, expected):
+    assert rfc_util.local_path(path, "") == os.path.normpath(expected)
 
 
 def test_rfc_remote_local_path_no_dest():

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -9,6 +9,7 @@ TODO: this is really part of spack.config. Consolidate it.
 import contextlib
 import getpass
 import os
+import pathlib
 import re
 import subprocess
 import sys
@@ -251,6 +252,16 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
     import urllib.parse
     import urllib.request
 
+    def joined_path(drive, filename, path):
+        if filename:
+            path = drive.upper() + os.path.join(filename, path)
+            return path
+
+        base = default_wd or os.getcwd()
+        tty.debug(f"Using working directory {base} as base for abspath")
+        path = drive.upper() + os.path.join(base, path)
+        return path
+
     # Get file in which path was written in case we need to make it absolute
     # relative to that path.
     filename = None
@@ -260,6 +271,16 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
 
     path = substitute_path_variables(path)
 
+    # Ensure properly process a Windows path
+    win_path = pathlib.PureWindowsPath(path)
+    if win_path.drive:
+        if win_path.is_absolute():
+            return os.path.normpath(str(win_path))
+
+        path = os.sep.join(win_path.parts[1:])
+        return os.path.normpath(joined_path(win_path.drive, filename, path))
+
+    # Now process linux paths and remote URLs
     url = urllib.parse.urlparse(path)
     url_path = urllib.request.url2pathname(url.path)
     if url.scheme:
@@ -270,15 +291,10 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
         # Drop the URL scheme from the local path
         path = url_path
 
-    if not os.path.isabs(path):
-        if filename:
-            path = os.path.join(filename, path)
-        else:
-            base = default_wd or os.getcwd()
-            path = os.path.join(base, path)
-            tty.debug(f"Using working directory {base} as base for abspath")
+    if os.path.isabs(path):
+        return os.path.normpath(path)
 
-    return os.path.normpath(path)
+    return os.path.normpath(joined_path("", filename, path))
 
 
 def longest_prefix_re(string, capture=True):

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -246,21 +246,12 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
 
     Arguments:
         path: path being converted as needed
+        default_wd: optional working directory/root for non-yaml string paths
 
     Returns: An absolute path or non-file URL with path variable substitution
     """
     import urllib.parse
     import urllib.request
-
-    def joined_path(drive, filename, path):
-        if filename:
-            path = drive.upper() + os.path.join(filename, path)
-            return path
-
-        base = default_wd or os.getcwd()
-        tty.debug(f"Using working directory {base} as base for abspath")
-        path = drive.upper() + os.path.join(base, path)
-        return path
 
     # Get file in which path was written in case we need to make it absolute
     # relative to that path.
@@ -274,13 +265,11 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
     # Ensure properly process a Windows path
     win_path = pathlib.PureWindowsPath(path)
     if win_path.drive:
-        if win_path.is_absolute():
-            return os.path.normpath(str(win_path))
+        # Assume only absolute paths are supported with a Windows drive
+        # (though DOS does allow drive-relative paths).
+        return os.path.normpath(str(win_path))
 
-        path = os.sep.join(win_path.parts[1:])
-        return os.path.normpath(joined_path(win_path.drive, filename, path))
-
-    # Now process linux paths and remote URLs
+    # Now process linux-like paths and remote URLs
     url = urllib.parse.urlparse(path)
     url_path = urllib.request.url2pathname(url.path)
     if url.scheme:
@@ -294,7 +283,15 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
     if os.path.isabs(path):
         return os.path.normpath(path)
 
-    return os.path.normpath(joined_path("", filename, path))
+    # Have a relative path so prepend the appropriate dir to make it absolute
+    if filename:
+        # Prepend the directory of the syaml path
+        return os.path.normpath(os.path.join(filename, path))
+
+    # Prepend the default, if provided, or current working directory.
+    base = default_wd or os.getcwd()
+    tty.debug(f"Using working directory {base} as base for abspath")
+    return os.path.normpath(os.path.join(base, path))
 
 
 def longest_prefix_re(string, capture=True):

--- a/lib/spack/spack/util/remote_file_cache.py
+++ b/lib/spack/spack/util/remote_file_cache.py
@@ -4,6 +4,7 @@
 
 import hashlib
 import os.path
+import pathlib
 import shutil
 import tempfile
 import urllib.parse
@@ -76,17 +77,23 @@ def local_path(raw_path: str, sha256: str, make_dest: Optional[Callable[[], str]
     if not raw_path:
         raise ValueError("path argument is required to cache remote files")
 
+    file_schemes = ["", "file"]
+
     # Allow paths (and URLs) to contain spack config/environment variables,
     # etc.
+    win_path = pathlib.PureWindowsPath(raw_path)
+    if win_path.drive:
+        file_schemes.append(win_path.drive.lower().strip(":"))
+
     path = canonicalize_path(raw_path)
+
     url = urllib.parse.urlparse(path)
 
     # Path isn't remote so return absolute, normalized path with substitutions.
-    if url.scheme in ["", "file"]:
-        return path
+    if url.scheme in file_schemes:
+        return os.path.normpath(path)
 
-    # If scheme is not valid, path is not a url
-    # of a type Spack is generally aware
+    # If scheme is not valid, path is not a supported url.
     if validate_scheme(url.scheme):
         # Fetch files from supported URL schemes.
         if url.scheme in ("http", "https", "ftp"):

--- a/lib/spack/spack/util/remote_file_cache.py
+++ b/lib/spack/spack/util/remote_file_cache.py
@@ -69,7 +69,7 @@ def local_path(raw_path: str, sha256: str, make_dest: Optional[Callable[[], str]
         sha256: the expected sha256 for the file
         make_dest: function to create a stage for remote files, if needed (e.g., `mkdtemp`)
 
-    Returns: resolved, normalized local path or None
+    Returns: resolved, normalized local path
 
     Raises:
         ValueError: missing or mismatched arguments, unsupported URL scheme
@@ -81,15 +81,17 @@ def local_path(raw_path: str, sha256: str, make_dest: Optional[Callable[[], str]
 
     # Allow paths (and URLs) to contain spack config/environment variables,
     # etc.
-    win_path = pathlib.PureWindowsPath(raw_path)
+    path = canonicalize_path(raw_path)
+
+    # Save off the Windows drive of the canonicalized path (since now absolute)
+    # to ensure recognized by URL parsing as a valid file "scheme".
+    win_path = pathlib.PureWindowsPath(path)
     if win_path.drive:
         file_schemes.append(win_path.drive.lower().strip(":"))
 
-    path = canonicalize_path(raw_path)
-
     url = urllib.parse.urlparse(path)
 
-    # Path isn't remote so return absolute, normalized path with substitutions.
+    # Path isn't remote so return normalized, absolute path with substitutions.
     if url.scheme in file_schemes:
         return os.path.normpath(path)
 


### PR DESCRIPTION
This PR restores/adds support for Windows paths (with drives _except_ drive-relative) (post-#48784) to `spack.util.path.canonicalize_path()` and `spack.util.remote_file_cache.local_path()`. It also adds unit tests for both methods.