### PR TITLE
Move %compiler last in static spec strings

### DIFF
--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -129,7 +129,7 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
 )
 def test_concretize_target_ranges(root_target_range, dep_target_range, result, monkeypatch):
     spec = Spec(
-        f"pkg-a %gcc@10 foobar=bar target={root_target_range} ^pkg-b target={dep_target_range}"
+        f"pkg-a foobar=bar target={root_target_range} %gcc@10 ^pkg-b target={dep_target_range}"
     )
     with spack.concretize.disable_compiler_existence_check():
         spec = spack.concretize.concretize_one(spec)

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -1140,7 +1140,7 @@ def test_get_valid_spec_file_no_json(tmp_path, filename):
 
 def test_download_tarball_with_unsupported_layout_fails(tmp_path, mutable_config, capsys):
     layout_version = bindist.CURRENT_BUILD_CACHE_LAYOUT_VERSION + 1
-    spec = Spec("gmake@4.4.1%gcc@13.1.0 arch=linux-ubuntu23.04-zen2")
+    spec = Spec("gmake@4.4.1 arch=linux-ubuntu23.04-zen2 %gcc@13.1.0")
     spec._mark_concrete()
     spec_dict = spec.to_dict()
     spec_dict["buildcache_layout_version"] = layout_version

--- a/lib/spack/spack/test/concretization/compiler_runtimes.py
+++ b/lib/spack/spack/test/concretization/compiler_runtimes.py
@@ -92,7 +92,7 @@ def test_external_nodes_do_not_have_runtimes(runtime_repo, mutable_config, tmp_p
         # Same as before, but tests that we can reuse from a more generic target
         pytest.param(
             "pkg-a%gcc@9.4.0",
-            "pkg-b%gcc@10.2.1 target=x86_64",
+            "pkg-b target=x86_64 %gcc@10.2.1",
             {"pkg-a": "gcc-runtime@9.4.0", "pkg-b": "gcc-runtime@9.4.0"},
             1,
             marks=pytest.mark.skipif(
@@ -101,7 +101,7 @@ def test_external_nodes_do_not_have_runtimes(runtime_repo, mutable_config, tmp_p
         ),
         pytest.param(
             "pkg-a%gcc@10.2.1",
-            "pkg-b%gcc@9.4.0 target=x86_64",
+            "pkg-b target=x86_64 %gcc@9.4.0",
             {
                 "pkg-a": "gcc-runtime@10.2.1 target=x86_64",
                 "pkg-b": "gcc-runtime@9.4.0 target=x86_64",

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -94,7 +94,7 @@ def test_mix_spec_and_compiler_cfg(concretize_scope, test_repo):
     conf_str = _compiler_cfg_one_entry_with_cflags("-Wall")
     update_concretize_scope(conf_str, "compilers")
 
-    s1 = spack.concretize.concretize_one('y %gcc@12.100.100 cflags="-O2"')
+    s1 = spack.concretize.concretize_one('y cflags="-O2" %gcc@12.100.100')
     assert s1.satisfies('cflags="-Wall -O2"')
 
 
@@ -182,7 +182,7 @@ def test_propagate_and_compiler_cfg(concretize_scope, test_repo):
     conf_str = _compiler_cfg_one_entry_with_cflags("-f2")
     update_concretize_scope(conf_str, "compilers")
 
-    root_spec = spack.concretize.concretize_one("v %gcc@12.100.100 cflags=='-f1'")
+    root_spec = spack.concretize.concretize_one("v cflags=='-f1' %gcc@12.100.100")
     assert root_spec["y"].satisfies("cflags='-f1 -f2'")
 
 
@@ -229,7 +229,7 @@ def test_dev_mix_flags(tmp_path, concretize_scope, mutable_mock_env_path, test_r
     env_content = f"""\
 spack:
   specs:
-  - y %gcc@12.100.100 cflags=='-fsanitize=address'
+  - y cflags=='-fsanitize=address' %gcc@12.100.100
   develop:
     y:
       spec: y cflags=='-fsanitize=address'

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -359,10 +359,10 @@ packages:
     update_packages_config(conf_str)
 
     s1 = spack.concretize.concretize_one("y@2.5")
-    assert s1.satisfies("%clang~shared")
+    assert s1.satisfies("~shared%clang")
 
     s2 = spack.concretize.concretize_one("y@2.4")
-    assert s2.satisfies("%gcc+shared")
+    assert s2.satisfies("+shared%gcc")
 
 
 @pytest.mark.regression("34241")
@@ -499,7 +499,7 @@ packages:
     "requirements,expectations",
     [
         (("%gcc", "%clang"), ("%gcc", "%clang")),
-        (("%gcc~shared", "@1.0"), ("%gcc~shared", "@1.0+shared")),
+        (("~shared%gcc", "@1.0"), ("~shared%gcc", "@1.0+shared")),
     ],
 )
 def test_default_and_package_specific_requirements(
@@ -754,7 +754,7 @@ def test_skip_requirement_when_default_requirement_condition_cannot_be_met(
     update_packages_config(packages_yaml)
     s = spack.concretize.concretize_one("mpileaks")
 
-    assert s.satisfies("%clang+shared")
+    assert s.satisfies("+shared %clang")
     # Sanity checks that 'callpath' doesn't have the shared variant, but that didn't
     # cause failures during concretization.
     assert "shared" not in s["callpath"].variants

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1221,7 +1221,7 @@ def test_user_config_path_is_default_when_env_var_is_empty(working_env):
 
 
 def test_default_install_tree(monkeypatch, default_config):
-    s = spack.spec.Spec("nonexistent@x.y.z %none@a.b.c arch=foo-bar-baz")
+    s = spack.spec.Spec("nonexistent@x.y.z arch=foo-bar-baz %none@a.b.c")
     monkeypatch.setattr(s, "dag_hash", lambda length: "abc123")
     _, _, projections = spack.store.parse_install_tree(spack.config.get("config"))
     assert s.format(projections["all"]) == "foo-bar-baz/none-a.b.c/nonexistent-x.y.z-abc123"

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1700,7 +1700,7 @@ def installation_dir_with_headers(tmpdir_factory):
 ##########
 
 
-@pytest.fixture(params=["conflict%clang+foo", "conflict-parent@0.9^conflict~foo"])
+@pytest.fixture(params=["conflict+foo%clang", "conflict-parent@0.9^conflict~foo"])
 def conflict_spec(request):
     """Specs which violate constraints specified with the "conflicts"
     directive in the "conflict" package.

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -53,7 +53,7 @@ def test_no_version_match(pkg_name):
         # Constraints on compilers with a default
         ("%gcc", "has_a_default", "gcc"),
         ("%clang", "has_a_default", "clang"),
-        ("%apple-clang os=elcapitan", "has_a_default", "default"),
+        ("os=elcapitan %apple-clang", "has_a_default", "default"),
         # Constraints on dependencies
         ("^zmpi", "different_by_dep", "zmpi"),
         ("^mpich", "different_by_dep", "mpich"),
@@ -74,7 +74,7 @@ def test_multimethod_calls(
     with spack.config.override(
         "compilers", [compiler_factory(spec="apple-clang@9.1.0", operating_system="elcapitan")]
     ):
-        s = spack.concretize.concretize_one(pkg_name + constraint_str)
+        s = spack.concretize.concretize_one(f"{pkg_name} {constraint_str}")
     msg = f"Method {method_name} from {s} is giving a wrong result"
     assert getattr(s.package, method_name)() == expected_result, msg
 

--- a/lib/spack/spack/test/optional_deps.py
+++ b/lib/spack/spack/test/optional_deps.py
@@ -38,9 +38,9 @@ from spack.spec import Spec
             {"optional-dep-test@1.1%intel": {"pkg-b": None, "pkg-c": None}},
         ),
         (
-            "optional-dep-test@1.1%intel@64.1.2+a",
+            "optional-dep-test@1.1+a%intel@64.1.2",
             {
-                "optional-dep-test@1.1%intel@64.1.2+a": {
+                "optional-dep-test@1.1+a%intel@64.1.2": {
                     "pkg-a": None,
                     "pkg-b": None,
                     "pkg-c": None,
@@ -49,8 +49,8 @@ from spack.spec import Spec
             },
         ),
         (
-            "optional-dep-test@1.1%clang@36.5+a",
-            {"optional-dep-test@1.1%clang@36.5+a": {"pkg-b": None, "pkg-a": None, "pkg-e": None}},
+            "optional-dep-test@1.1+a%clang@36.5",
+            {"optional-dep-test@1.1+a%clang@36.5": {"pkg-b": None, "pkg-a": None, "pkg-e": None}},
         ),
         # Chained MPI
         (

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -159,11 +159,11 @@ def specfile_for(default_mock_concretization):
         ),
         # Version after compiler
         (
-            "foo %bar@1.0 @2.0",
+            "foo @2.0 %bar@1.0",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="foo"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%bar@1.0"),
                 Token(SpecTokens.VERSION, value="@2.0"),
+                Token(SpecTokens.COMPILER_AND_VERSION, value="%bar@1.0"),
             ],
             "foo@2.0%bar@1.0",
         ),
@@ -174,15 +174,15 @@ def specfile_for(default_mock_concretization):
         dependency_with_version("openmpi ^hwloc@1.2e6:1.4b7-rc3"),
         # Complex specs with multiple constraints
         (
-            "mvapich_foo ^_openmpi@1.2:1.4,1.6%intel@12.1+debug~qt_4 ^stackwalker@8.1_1e",
+            "mvapich_foo ^_openmpi@1.2:1.4,1.6+debug~qt_4 %intel@12.1 ^stackwalker@8.1_1e",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="mvapich_foo"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="_openmpi"),
                 Token(SpecTokens.VERSION, value="@1.2:1.4,1.6"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
                 Token(SpecTokens.BOOL_VARIANT, value="+debug"),
                 Token(SpecTokens.BOOL_VARIANT, value="~qt_4"),
+                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="stackwalker"),
                 Token(SpecTokens.VERSION, value="@8.1_1e"),
@@ -190,15 +190,15 @@ def specfile_for(default_mock_concretization):
             "mvapich_foo ^_openmpi@1.2:1.4,1.6%intel@12.1+debug~qt_4 ^stackwalker@8.1_1e",
         ),
         (
-            "mvapich_foo ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug=2 ^stackwalker@8.1_1e",
+            "mvapich_foo ^_openmpi@1.2:1.4,1.6~qt_4 debug=2 %intel@12.1 ^stackwalker@8.1_1e",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="mvapich_foo"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="_openmpi"),
                 Token(SpecTokens.VERSION, value="@1.2:1.4,1.6"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
                 Token(SpecTokens.BOOL_VARIANT, value="~qt_4"),
                 Token(SpecTokens.KEY_VALUE_PAIR, value="debug=2"),
+                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="stackwalker"),
                 Token(SpecTokens.VERSION, value="@8.1_1e"),
@@ -206,17 +206,17 @@ def specfile_for(default_mock_concretization):
             "mvapich_foo ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug=2 ^stackwalker@8.1_1e",
         ),
         (
-            "mvapich_foo ^_openmpi@1.2:1.4,1.6%intel@12.1 cppflags=-O3 +debug~qt_4 "
+            "mvapich_foo ^_openmpi@1.2:1.4,1.6 cppflags=-O3 +debug~qt_4 %intel@12.1 "
             "^stackwalker@8.1_1e",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="mvapich_foo"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="_openmpi"),
                 Token(SpecTokens.VERSION, value="@1.2:1.4,1.6"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
                 Token(SpecTokens.KEY_VALUE_PAIR, value="cppflags=-O3"),
                 Token(SpecTokens.BOOL_VARIANT, value="+debug"),
                 Token(SpecTokens.BOOL_VARIANT, value="~qt_4"),
+                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="stackwalker"),
                 Token(SpecTokens.VERSION, value="@8.1_1e"),
@@ -485,10 +485,10 @@ def specfile_for(default_mock_concretization):
             "a@1:",
         ),
         (
-            "% intel @ 12.1:12.6 + debug",
+            "+ debug % intel @ 12.1:12.6",
             [
-                Token(SpecTokens.COMPILER_AND_VERSION, value="% intel @ 12.1:12.6"),
                 Token(SpecTokens.BOOL_VARIANT, value="+ debug"),
+                Token(SpecTokens.COMPILER_AND_VERSION, value="% intel @ 12.1:12.6"),
             ],
             "%intel@12.1:12.6+debug",
         ),
@@ -639,15 +639,15 @@ def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_p
             ["mvapich cppflags=-O3", "emacs"],
         ),
         (
-            "mvapich emacs @1.1.1 %intel cflags=-O3",
+            "mvapich emacs @1.1.1 cflags=-O3 %intel",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="mvapich"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="emacs"),
                 Token(SpecTokens.VERSION, value="@1.1.1"),
-                Token(SpecTokens.COMPILER, value="%intel"),
                 Token(SpecTokens.KEY_VALUE_PAIR, value="cflags=-O3"),
+                Token(SpecTokens.COMPILER, value="%intel"),
             ],
-            ["mvapich", "emacs @1.1.1 %intel cflags=-O3"],
+            ["mvapich", "emacs @1.1.1 cflags=-O3 %intel"],
         ),
         (
             'mvapich cflags="-O3 -fPIC" emacs^ncurses%intel',
@@ -1231,7 +1231,7 @@ def test_compare_abstract_specs():
         "foo.foo@foo+foo",
         "foo.foo@foo+foo arch=foo-foo-foo",
         "foo.foo@foo+foo arch=foo-foo-foo %foo",
-        "foo.foo@foo+foo arch=foo-foo-foo %foo cflags=foo",
+        "foo.foo@foo+foo arch=foo-foo-foo cflags=foo %foo",
     ]
     specs = [SpecParser(s).next_spec() for s in constraints]
 

--- a/share/spack/bootstrap/github-actions-v0.5/clingo.json
+++ b/share/spack/bootstrap/github-actions-v0.5/clingo.json
@@ -9,7 +9,7 @@
         ]
       ],
       "python": "python@3.10.13",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=aarch64"
+      "spec": "clingo-bootstrap platform=darwin target=aarch64 %apple-clang"
     },
     {
       "binaries": [
@@ -20,7 +20,7 @@
         ]
       ],
       "python": "python@3.11.5",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=aarch64"
+      "spec": "clingo-bootstrap platform=darwin target=aarch64 %apple-clang"
     },
     {
       "binaries": [
@@ -31,7 +31,7 @@
         ]
       ],
       "python": "python@3.12.0",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=aarch64"
+      "spec": "clingo-bootstrap platform=darwin target=aarch64 %apple-clang"
     },
     {
       "binaries": [
@@ -42,7 +42,7 @@
         ]
       ],
       "python": "python@3.6",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=aarch64"
+      "spec": "clingo-bootstrap platform=darwin target=aarch64 %apple-clang"
     },
     {
       "binaries": [
@@ -53,7 +53,7 @@
         ]
       ],
       "python": "python@3.7.17",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=aarch64"
+      "spec": "clingo-bootstrap platform=darwin target=aarch64 %apple-clang"
     },
     {
       "binaries": [
@@ -64,7 +64,7 @@
         ]
       ],
       "python": "python@3.8.18",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=aarch64"
+      "spec": "clingo-bootstrap platform=darwin target=aarch64 %apple-clang"
     },
     {
       "binaries": [
@@ -75,7 +75,7 @@
         ]
       ],
       "python": "python@3.9.18",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=aarch64"
+      "spec": "clingo-bootstrap platform=darwin target=aarch64 %apple-clang"
     },
     {
       "binaries": [
@@ -86,7 +86,7 @@
         ]
       ],
       "python": "python@3.10",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=x86_64"
+      "spec": "clingo-bootstrap platform=darwin target=x86_64 %apple-clang"
     },
     {
       "binaries": [
@@ -97,7 +97,7 @@
         ]
       ],
       "python": "python@3.11",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=x86_64"
+      "spec": "clingo-bootstrap platform=darwin target=x86_64 %apple-clang"
     },
     {
       "binaries": [
@@ -108,7 +108,7 @@
         ]
       ],
       "python": "python@3.12",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=x86_64"
+      "spec": "clingo-bootstrap platform=darwin target=x86_64 %apple-clang"
     },
     {
       "binaries": [
@@ -119,7 +119,7 @@
         ]
       ],
       "python": "python@3.6",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=x86_64"
+      "spec": "clingo-bootstrap platform=darwin target=x86_64 %apple-clang"
     },
     {
       "binaries": [
@@ -130,7 +130,7 @@
         ]
       ],
       "python": "python@3.7",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=x86_64"
+      "spec": "clingo-bootstrap platform=darwin target=x86_64 %apple-clang"
     },
     {
       "binaries": [
@@ -141,7 +141,7 @@
         ]
       ],
       "python": "python@3.8",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=x86_64"
+      "spec": "clingo-bootstrap platform=darwin target=x86_64 %apple-clang"
     },
     {
       "binaries": [
@@ -152,7 +152,7 @@
         ]
       ],
       "python": "python@3.9",
-      "spec": "clingo-bootstrap%apple-clang platform=darwin target=x86_64"
+      "spec": "clingo-bootstrap platform=darwin target=x86_64 %apple-clang"
     },
     {
       "binaries": [
@@ -163,7 +163,7 @@
         ]
       ],
       "python": "python@3.10.13",
-      "spec": "clingo-bootstrap%gcc platform=linux target=aarch64"
+      "spec": "clingo-bootstrap platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -174,7 +174,7 @@
         ]
       ],
       "python": "python@3.11.5",
-      "spec": "clingo-bootstrap%gcc platform=linux target=aarch64"
+      "spec": "clingo-bootstrap platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -185,7 +185,7 @@
         ]
       ],
       "python": "python@3.12.0",
-      "spec": "clingo-bootstrap%gcc platform=linux target=aarch64"
+      "spec": "clingo-bootstrap platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -196,7 +196,7 @@
         ]
       ],
       "python": "python@3.6",
-      "spec": "clingo-bootstrap%gcc platform=linux target=aarch64"
+      "spec": "clingo-bootstrap platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -207,7 +207,7 @@
         ]
       ],
       "python": "python@3.7.17",
-      "spec": "clingo-bootstrap%gcc platform=linux target=aarch64"
+      "spec": "clingo-bootstrap platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -218,7 +218,7 @@
         ]
       ],
       "python": "python@3.8.18",
-      "spec": "clingo-bootstrap%gcc platform=linux target=aarch64"
+      "spec": "clingo-bootstrap platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -229,7 +229,7 @@
         ]
       ],
       "python": "python@3.9.18",
-      "spec": "clingo-bootstrap%gcc platform=linux target=aarch64"
+      "spec": "clingo-bootstrap platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -240,7 +240,7 @@
         ]
       ],
       "python": "python@3.10.13",
-      "spec": "clingo-bootstrap%gcc platform=linux target=ppc64le"
+      "spec": "clingo-bootstrap platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -251,7 +251,7 @@
         ]
       ],
       "python": "python@3.11.5",
-      "spec": "clingo-bootstrap%gcc platform=linux target=ppc64le"
+      "spec": "clingo-bootstrap platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -262,7 +262,7 @@
         ]
       ],
       "python": "python@3.12.0",
-      "spec": "clingo-bootstrap%gcc platform=linux target=ppc64le"
+      "spec": "clingo-bootstrap platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -273,7 +273,7 @@
         ]
       ],
       "python": "python@3.6",
-      "spec": "clingo-bootstrap%gcc platform=linux target=ppc64le"
+      "spec": "clingo-bootstrap platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -284,7 +284,7 @@
         ]
       ],
       "python": "python@3.7.17",
-      "spec": "clingo-bootstrap%gcc platform=linux target=ppc64le"
+      "spec": "clingo-bootstrap platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -295,7 +295,7 @@
         ]
       ],
       "python": "python@3.8.18",
-      "spec": "clingo-bootstrap%gcc platform=linux target=ppc64le"
+      "spec": "clingo-bootstrap platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -306,7 +306,7 @@
         ]
       ],
       "python": "python@3.9.18",
-      "spec": "clingo-bootstrap%gcc platform=linux target=ppc64le"
+      "spec": "clingo-bootstrap platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -317,7 +317,7 @@
         ]
       ],
       "python": "python@3.10.13",
-      "spec": "clingo-bootstrap%gcc platform=linux target=x86_64"
+      "spec": "clingo-bootstrap platform=linux target=x86_64 %gcc"
     },
     {
       "binaries": [
@@ -328,7 +328,7 @@
         ]
       ],
       "python": "python@3.11.5",
-      "spec": "clingo-bootstrap%gcc platform=linux target=x86_64"
+      "spec": "clingo-bootstrap platform=linux target=x86_64 %gcc"
     },
     {
       "binaries": [
@@ -339,7 +339,7 @@
         ]
       ],
       "python": "python@3.12.0",
-      "spec": "clingo-bootstrap%gcc platform=linux target=x86_64"
+      "spec": "clingo-bootstrap platform=linux target=x86_64 %gcc"
     },
     {
       "binaries": [
@@ -350,7 +350,7 @@
         ]
       ],
       "python": "python@3.6",
-      "spec": "clingo-bootstrap%gcc platform=linux target=x86_64"
+      "spec": "clingo-bootstrap platform=linux target=x86_64 %gcc"
     },
     {
       "binaries": [
@@ -361,7 +361,7 @@
         ]
       ],
       "python": "python@3.7.17",
-      "spec": "clingo-bootstrap%gcc platform=linux target=x86_64"
+      "spec": "clingo-bootstrap platform=linux target=x86_64 %gcc"
     },
     {
       "binaries": [
@@ -372,7 +372,7 @@
         ]
       ],
       "python": "python@3.8.18",
-      "spec": "clingo-bootstrap%gcc platform=linux target=x86_64"
+      "spec": "clingo-bootstrap platform=linux target=x86_64 %gcc"
     },
     {
       "binaries": [
@@ -383,7 +383,7 @@
         ]
       ],
       "python": "python@3.9.18",
-      "spec": "clingo-bootstrap%gcc platform=linux target=x86_64"
+      "spec": "clingo-bootstrap platform=linux target=x86_64 %gcc"
     }
   ]
 }

--- a/share/spack/bootstrap/github-actions-v0.5/gnupg.json
+++ b/share/spack/bootstrap/github-actions-v0.5/gnupg.json
@@ -48,7 +48,7 @@
           "23fdd223493f441fa2e5f82d7e02837ecfad831fbfa4c27c175b3e294ed977d1"
         ]
       ],
-      "spec": "gnupg@2.3: %apple-clang platform=darwin target=aarch64"
+      "spec": "gnupg@2.3: platform=darwin target=aarch64 %apple-clang"
     },
     {
       "binaries": [
@@ -98,7 +98,7 @@
           "b9481e122e2cb26f69b70505830d0fcc0d200aadbb6c6572339825f17ad1e52d"
         ]
       ],
-      "spec": "gnupg@2.3: %apple-clang platform=darwin target=x86_64"
+      "spec": "gnupg@2.3: platform=darwin target=x86_64 %apple-clang"
     },
     {
       "binaries": [
@@ -148,7 +148,7 @@
           "228ccb475932f7f40a64e9d87dec045931cc57f71b1dfd4b4c3926107222d96c"
         ]
       ],
-      "spec": "gnupg@2.3: %gcc platform=linux target=aarch64"
+      "spec": "gnupg@2.3: platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -198,7 +198,7 @@
           "98e2bcb4064ec0830d896938bc1fe5264dac611da71ea546b9ca03349b752041"
         ]
       ],
-      "spec": "gnupg@2.3: %gcc platform=linux target=ppc64le"
+      "spec": "gnupg@2.3: platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -248,7 +248,7 @@
           "054fac6eaad7c862ea4661461d847fb069876eb114209416b015748266f7d166"
         ]
       ],
-      "spec": "gnupg@2.3: %gcc platform=linux target=x86_64"
+      "spec": "gnupg@2.3: platform=linux target=x86_64 %gcc"
     }
   ]
 }

--- a/share/spack/bootstrap/github-actions-v0.5/patchelf.json
+++ b/share/spack/bootstrap/github-actions-v0.5/patchelf.json
@@ -8,7 +8,7 @@
           "102800775f789cc293e244899f39a22f0b7a19373305ef0497ca3189223123f3"
         ]
       ],
-      "spec": "patchelf@0.13: %gcc platform=linux target=aarch64"
+      "spec": "patchelf@0.13: platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -18,7 +18,7 @@
           "91cf0a9d4750c04575c5ed3bcdefc4754e1cf9d1cd1bf197eb1fe20ccaa869f1"
         ]
       ],
-      "spec": "patchelf@0.13: %gcc platform=linux target=ppc64le"
+      "spec": "patchelf@0.13: platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -28,7 +28,7 @@
           "73f4bde46b843c96521e3f5c31ab94756491404c1ad6429c9f61dbafbbfa6470"
         ]
       ],
-      "spec": "patchelf@0.13: %gcc platform=linux target=x86_64"
+      "spec": "patchelf@0.13: platform=linux target=x86_64 %gcc"
     }
   ]
 }

--- a/share/spack/bootstrap/github-actions-v0.6/clingo.json
+++ b/share/spack/bootstrap/github-actions-v0.6/clingo.json
@@ -8,7 +8,7 @@
           "ff7f45db1645d1d857a315bf8d63c31447330552528bdf1fccdcf50735e62166"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=aarch64 ^python@3.10"
+      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.10"
     },
     {
       "binaries": [
@@ -18,7 +18,7 @@
           "e7491ac297cbb3f45c80aaf4ca5102e2b655b731e7b6ce7682807d302cb61f1c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=aarch64 ^python@3.11"
+      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.11"
     },
     {
       "binaries": [
@@ -28,7 +28,7 @@
           "91214626a86c21fc0d76918884ec819050d4d52b4f78df7cc9769a83fbee2f71"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=aarch64 ^python@3.12"
+      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.12"
     },
     {
       "binaries": [
@@ -38,7 +38,7 @@
           "db596d9e6d8970d659f4be4cb510f9ba5dc2ec4ea42ecf2aed1325ec5ad72b45"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=aarch64 ^python@3.13"
+      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.13"
     },
     {
       "binaries": [
@@ -48,7 +48,7 @@
           "a7ed91aee1f8d5cfe2ca5ef2e3e74215953ffd2d8b5c722a670f2c303610e90c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=aarch64 ^python@3.8"
+      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.8"
     },
     {
       "binaries": [
@@ -58,7 +58,7 @@
           "c856a98f92b9fa218377cea9272dffa736e93251d987b6386e6abf40058333dc"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=aarch64 ^python@3.9"
+      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.9"
     },
     {
       "binaries": [
@@ -68,7 +68,7 @@
           "d74cc0b44faa69473816dca16a3806123790e6eb9a59f611b1d80da7843f474a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=x86_64 ^python@3.10"
+      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.10"
     },
     {
       "binaries": [
@@ -78,7 +78,7 @@
           "2cb12477504ca8e112522b6d56325ce32024c9466de5b8427fd70a1a81b15020"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=x86_64 ^python@3.11"
+      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.11"
     },
     {
       "binaries": [
@@ -88,7 +88,7 @@
           "4e73426599fa61df1a4faceafa38ade170a3dec45b6d8f333e6c2b6bfe697724"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=x86_64 ^python@3.12"
+      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.12"
     },
     {
       "binaries": [
@@ -98,7 +98,7 @@
           "4309b42e5642bc5c83ede90759b1a0b5d66fffa8991b6213208577626b588cde"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=x86_64 ^python@3.13"
+      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.13"
     },
     {
       "binaries": [
@@ -108,7 +108,7 @@
           "1feeab9e1a81ca56de838ccc234d60957e9ab14da038e38b6687732b7bae1ff6"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=x86_64 ^python@3.6"
+      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.6"
     },
     {
       "binaries": [
@@ -118,7 +118,7 @@
           "1149ab7d5f1c82d8de53f048af8aa5c5dbf0d21da4e4780c06e54b8ee902085b"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=x86_64 ^python@3.7"
+      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.7"
     },
     {
       "binaries": [
@@ -128,7 +128,7 @@
           "d6aeae2dbd7fa3c1d1c62f840a5c01f8e71b64afe2bdc9c90d4087694f7d3443"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=x86_64 ^python@3.8"
+      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.8"
     },
     {
       "binaries": [
@@ -138,7 +138,7 @@
           "81ef2beef78f46979965e5e69cd92b68ff4d2a59dbae1331c648d18b6ded1444"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%apple-clang platform=darwin target=x86_64 ^python@3.9"
+      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.9"
     },
     {
       "binaries": [
@@ -148,7 +148,7 @@
           "3d0830654f9e327fd7ec6dab214050295dbf0832f493937c0c133e516dd2a95a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=aarch64 ^python@3.10"
+      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.10"
     },
     {
       "binaries": [
@@ -158,7 +158,7 @@
           "941b93cd89d5271c740d1b1c870e85f32e5970f9f7b842ad99870399215a93db"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=aarch64 ^python@3.11"
+      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.11"
     },
     {
       "binaries": [
@@ -168,7 +168,7 @@
           "8ca78e345da732643e3d1b077d8156ce89863c25095e4958d4ac6d1a458ae74b"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=aarch64 ^python@3.12"
+      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.12"
     },
     {
       "binaries": [
@@ -178,7 +178,7 @@
           "f6ced988b515494d86a1069f13ae9030caeb40fe951c2460f532123c80399154"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=aarch64 ^python@3.13"
+      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.13"
     },
     {
       "binaries": [
@@ -188,7 +188,7 @@
           "c00855b5cda99639b87c3912ee9c734c0b609dfe7d2c47ea947738c32bab6f03"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=aarch64 ^python@3.6"
+      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.6"
     },
     {
       "binaries": [
@@ -198,7 +198,7 @@
           "aa861cfdf6001fc2da6e83eecc9ad35df424d86d71f6d73e480818942405ce4e"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=aarch64 ^python@3.7"
+      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.7"
     },
     {
       "binaries": [
@@ -208,7 +208,7 @@
           "cb7807cd31fc5e0efe2acc1de1f74c7cef962bcadfc656b09ff853bc33c11bd0"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=aarch64 ^python@3.8"
+      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.8"
     },
     {
       "binaries": [
@@ -218,7 +218,7 @@
           "36e5efb6b15b431b661e9e272904ab3c29ae7b87bf6250c158d545ccefc2f424"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=aarch64 ^python@3.9"
+      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.9"
     },
     {
       "binaries": [
@@ -228,7 +228,7 @@
           "bd492c078b2cdaf327148eee5b0abd5b068dbb3ffa5dae0ec5d53257f471f7f7"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=ppc64le ^python@3.10"
+      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.10"
     },
     {
       "binaries": [
@@ -238,7 +238,7 @@
           "0ebe5e05246c33fc8529e90e21529b29742b5dd6756dbc07534577a90394c0e6"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=ppc64le ^python@3.11"
+      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.11"
     },
     {
       "binaries": [
@@ -248,7 +248,7 @@
           "9f97d3bf78b7642a775f12feb43781d46110793f58a7e69b0b68ac4fff47655c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=ppc64le ^python@3.12"
+      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.12"
     },
     {
       "binaries": [
@@ -258,7 +258,7 @@
           "e7295bb4bcb11a936f39665632ce68c751c9f6cddc44904392a1b33a5290bbbe"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=ppc64le ^python@3.13"
+      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.13"
     },
     {
       "binaries": [
@@ -268,7 +268,7 @@
           "c44e7fbf721383aa8ee57d2305f41377e64a42ab8e02a9d3d6fc792d9b29ad08"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=ppc64le ^python@3.6"
+      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.6"
     },
     {
       "binaries": [
@@ -278,7 +278,7 @@
           "965ba5c1a42f436001162a3f3a0d1715424f2ec8f65c42d6b66efcd4f4566b77"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=ppc64le ^python@3.7"
+      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.7"
     },
     {
       "binaries": [
@@ -288,7 +288,7 @@
           "c8d31089d8f91718a5bde9c6b28cc67bdbadab401c8fdd07b296d588ece4ddfe"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=ppc64le ^python@3.8"
+      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.8"
     },
     {
       "binaries": [
@@ -298,7 +298,7 @@
           "ef3f05d30333a39fd18714b87ee22605679f52fda97f5e592764d1591527bbf3"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=ppc64le ^python@3.9"
+      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.9"
     },
     {
       "binaries": [
@@ -308,7 +308,7 @@
           "a4abec667660307ad5cff0a616d6651e187cc7b1386fd8cd4b6b288a01614076"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=x86_64 ^python@3.10"
+      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.10"
     },
     {
       "binaries": [
@@ -318,7 +318,7 @@
           "a572ab6db954f4a850d1292bb1ef6d6055916784a894d149d657996fa98d0367"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=x86_64 ^python@3.11"
+      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.11"
     },
     {
       "binaries": [
@@ -328,7 +328,7 @@
           "97f8ea17f3df3fb38904450114cbef9b4b0ea9c94da9de7a49b70b707012277a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=x86_64 ^python@3.12"
+      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.12"
     },
     {
       "binaries": [
@@ -338,7 +338,7 @@
           "6599ac06ade0cb3e80695f36492ea94a306f8bde0537482521510076c5981aa0"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=x86_64 ^python@3.13"
+      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.13"
     },
     {
       "binaries": [
@@ -348,7 +348,7 @@
           "90b7cf4dd98e26c58578ad8604738cc32dfbb228cfb981bdfe103c99d0e7b5dd"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=x86_64 ^python@3.6"
+      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.6"
     },
     {
       "binaries": [
@@ -358,7 +358,7 @@
           "dc5dbfd9c05b43c4992bf6666638ae96cee5548921e94eb793ba85727b25ec59"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=x86_64 ^python@3.7"
+      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.7"
     },
     {
       "binaries": [
@@ -368,7 +368,7 @@
           "e8518de25baff7a74bdb42193e6e4b0496e7d0688434c42ce4bdc92fe4293a09"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=x86_64 ^python@3.8"
+      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.8"
     },
     {
       "binaries": [
@@ -378,7 +378,7 @@
           "0c5831932608e7b4084fc6ce60e2b67b77dab76e5515303a049d4d30cd772321"
         ]
       ],
-      "spec": "clingo-bootstrap@spack%gcc platform=linux target=x86_64 ^python@3.9"
+      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.9"
     }
   ]
 }

--- a/share/spack/bootstrap/github-actions-v0.6/gnupg.json
+++ b/share/spack/bootstrap/github-actions-v0.6/gnupg.json
@@ -48,7 +48,7 @@
           "61bcb83dc3fc2ae06fde30b9f79c2596bd0457cf56b4d339c8c562a38ca1c31f"
         ]
       ],
-      "spec": "gnupg@2.4.5%apple-clang platform=darwin target=aarch64"
+      "spec": "gnupg@2.4.5 platform=darwin target=aarch64 %apple-clang"
     },
     {
       "binaries": [
@@ -98,7 +98,7 @@
           "3d36bce8bbd06134445aa3cefa00a80068317b6d082d2b43bb1e3be81ede5849"
         ]
       ],
-      "spec": "gnupg@2.4.5%apple-clang platform=darwin target=x86_64"
+      "spec": "gnupg@2.4.5 platform=darwin target=x86_64 %apple-clang"
     },
     {
       "binaries": [
@@ -153,7 +153,7 @@
           "8398592ab0812d8c76a21deca06da4277d05f4db784e129ead7535bb8988faa2"
         ]
       ],
-      "spec": "gnupg@2.4.5%gcc platform=linux target=aarch64"
+      "spec": "gnupg@2.4.5 platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -208,7 +208,7 @@
           "cc7e4833af58913fa4ab2b7ce3fdb86d214594d54327c7e4eb4ca3f0784c046f"
         ]
       ],
-      "spec": "gnupg@2.4.5%gcc platform=linux target=ppc64le"
+      "spec": "gnupg@2.4.5 platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -263,7 +263,7 @@
           "418b582f84547504b6464913fba5ba196482e86258081bdeb21af519fe8a2933"
         ]
       ],
-      "spec": "gnupg@2.4.5%gcc platform=linux target=x86_64"
+      "spec": "gnupg@2.4.5 platform=linux target=x86_64 %gcc"
     }
   ]
 }

--- a/share/spack/bootstrap/github-actions-v0.6/patchelf.json
+++ b/share/spack/bootstrap/github-actions-v0.6/patchelf.json
@@ -13,7 +13,7 @@
           "820b8013b0b918ad85caa953740497e6c31c09d812bd34d087fc57128bfbdacb"
         ]
       ],
-      "spec": "patchelf@0.17.2%gcc platform=linux target=aarch64"
+      "spec": "patchelf@0.17.2 platform=linux target=aarch64 %gcc"
     },
     {
       "binaries": [
@@ -28,7 +28,7 @@
           "1569df037ea1ea316a50e89f5a0cafa0ce8e20629bbd07fcc3846d9fecd2451c"
         ]
       ],
-      "spec": "patchelf@0.17.2%gcc platform=linux target=ppc64le"
+      "spec": "patchelf@0.17.2 platform=linux target=ppc64le %gcc"
     },
     {
       "binaries": [
@@ -43,7 +43,7 @@
           "79dfb7064e7993a97474c5f6b7560254fe19465a6c4cfc44569852e5a6ab542b"
         ]
       ],
-      "spec": "patchelf@0.17.2%gcc platform=linux target=x86_64"
+      "spec": "patchelf@0.17.2 platform=linux target=x86_64 %gcc"
     }
   ]
 }

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
@@ -30,13 +30,13 @@ spack:
     mpi:
       require: mpich
     mpich:
-      require: '~wrapperrpath ~hwloc %gcc target=neoverse_v2'
+      require: '~wrapperrpath ~hwloc target=neoverse_v2 %gcc'
     tbb:
       require: intel-tbb
     vtk-m:
-      require: "+examples %gcc target=neoverse_v2"
+      require: "+examples target=neoverse_v2 %gcc"
     paraview:
-      require: "+examples %gcc target=neoverse_v2"
+      require: "+examples target=neoverse_v2 %gcc"
 
   specs:
   # CPU

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -20,7 +20,7 @@ spack:
     elfutils:
       variants: ~nls
     gcc-runtime:
-      require: "%gcc target=x86_64_v3"
+      require: "target=x86_64_v3 %gcc"
     hdf5:
       variants: +fortran +hl +shared
     libfabric:
@@ -47,32 +47,32 @@ spack:
         prefix: /opt/intel/oneapi
     unzip:
       require:
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     binutils:
       require:
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
       variants: +ld +gold +headers +libiberty ~nls
     llvm:
       require:
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     ruby:
       require:
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     rust:
       require:
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     krb5:
       require:
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     openssh:
       require:
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     dyninst:
       require:
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     bison:
       require:
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     paraview:
       require:
       - +examples target=x86_64_v3

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -17,7 +17,7 @@ spack:
     mpi:
       require: mpich
     mpich:
-      require: '~wrapperrpath ~hwloc %gcc target=x86_64_v3'
+      require: '~wrapperrpath ~hwloc target=x86_64_v3 %gcc'
     openblas:
       variants: threads=openmp
     paraview:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -26,11 +26,11 @@ spack:
     cmake:
       require:
       - "~qtgui"
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     gmake:
       require:
       - "~guile"
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     hdf5:
       variants: +fortran +hl +shared
     libfabric:
@@ -47,14 +47,14 @@ spack:
     mpich:
       require:
       - '~wrapperrpath ~hwloc'
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     tbb:
       require:
       - intel-tbb
     vtk-m:
       require:
       - "+examples"
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
     visit:
       require:
       - "~gui target=x86_64_v3"
@@ -62,7 +62,7 @@ spack:
       # Don't build GUI support or GLX rendering for HPC/container deployments
       require:
       - "+examples ~qt ^[virtuals=gl] osmesa target=x86_64_v3"
-      - '%gcc target=x86_64_v3'
+      - 'target=x86_64_v3 %gcc'
 
   specs:
   # CPU

--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -128,7 +128,7 @@ class Adios(AutotoolsPackage):
 
     def setup_build_environment(self, env):
         # https://github.com/ornladios/ADIOS/issues/206
-        if self.spec.satisfies("%gcc@10: +fortran"):
+        if self.spec.satisfies("+fortran %gcc@10:"):
             env.set("FCFLAGS", "-fallow-argument-mismatch")
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -257,9 +257,9 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
 
     def setup_build_environment(self, env):
         # https://github.com/ornladios/ADIOS2/issues/2228
-        if self.spec.satisfies("%gcc@10: +fortran"):
+        if self.spec.satisfies("+fortran %gcc@10:"):
             env.set("FFLAGS", "-fallow-argument-mismatch")
-        elif self.spec.satisfies("%fj +fortran"):
+        elif self.spec.satisfies("+fortran %fj"):
             env.set("FFLAGS", "-Ccpp")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/apple-gl/package.py
+++ b/var/spack/repos/builtin/packages/apple-gl/package.py
@@ -39,6 +39,6 @@ class AppleGl(AppleGlBase):
     provides("gl@4.1")
 
     requires(
-        "%apple-clang platform=darwin",
+        "platform=darwin %apple-clang",
         msg="Apple-GL is only available on Darwin, when using Apple Clang",
     )

--- a/var/spack/repos/builtin/packages/apple-glu/package.py
+++ b/var/spack/repos/builtin/packages/apple-glu/package.py
@@ -13,6 +13,6 @@ class AppleGlu(AppleGlBase):
     provides("glu@1.3")
 
     requires(
-        "%apple-clang platform=darwin",
+        "platform=darwin %apple-clang",
         msg="Apple-GLU is only available on Darwin, when using Apple Clang",
     )

--- a/var/spack/repos/builtin/packages/beatnik/package.py
+++ b/var/spack/repos/builtin/packages/beatnik/package.py
@@ -44,7 +44,7 @@ class Beatnik(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos @4:")
     depends_on("kokkos +cuda +cuda_lambda +cuda_constexpr", when="+cuda")
     depends_on("kokkos +rocm", when="+rocm")
-    depends_on("kokkos +wrapper", when="%gcc+cuda")
+    depends_on("kokkos +wrapper", when="+cuda%gcc")
 
     # Cabana dependencies
     depends_on("cabana @0.7.0 +grid +heffte +silo +hdf5 +mpi +arborx", when="@1.1")

--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -62,7 +62,7 @@ class Blaspp(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("cmake@3.15.0:", type="build")
     depends_on("blas")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
     depends_on("rocblas", when="+rocm")
     depends_on("intel-oneapi-mkl", when="+sycl")
     depends_on("intel-oneapi-mkl threads=openmp", when="+sycl")

--- a/var/spack/repos/builtin/packages/ceed/package.py
+++ b/var/spack/repos/builtin/packages/ceed/package.py
@@ -293,7 +293,7 @@ class Ceed(BundlePackage, CudaPackage, ROCmPackage):
     depends_on("remhos@1.0", when="@3.0.0+mfem")
 
     # If using gcc version <= 4.8 build suite-sparse version <= 5.1.0
-    depends_on("suite-sparse@:5.1.0", when="@3.0.0%gcc@:4.8+mfem+petsc")
+    depends_on("suite-sparse@:5.1.0", when="@3.0.0+mfem+petsc%gcc@:4.8")
 
     # ceed-2.0
     depends_on("mfem@3.4.0+mpi+examples+miniapps", when="@2.0.0+mfem~petsc")
@@ -305,7 +305,7 @@ class Ceed(BundlePackage, CudaPackage, ROCmPackage):
     depends_on("hypre~internal-superlu~superlu-dist", when="@2.0.0+mfem+quickbuild")
 
     # If using gcc version <= 4.8 build suite-sparse version <= 5.1.0
-    depends_on("suite-sparse@:5.1.0", when="@2.0.0%gcc@:4.8+mfem+petsc")
+    depends_on("suite-sparse@:5.1.0", when="@2.0.0+mfem+petsc%gcc@:4.8")
 
     # ceed-1.0
     depends_on("mfem@3.3.2+mpi+examples+miniapps", when="@1.0.0+mfem")
@@ -319,4 +319,4 @@ class Ceed(BundlePackage, CudaPackage, ROCmPackage):
     depends_on("hypre~internal-superlu", when="@1.0.0+mfem")
 
     # If using gcc version <= 4.8 build suite-sparse version <= 5.1.0
-    depends_on("suite-sparse@:5.1.0", when="@1.0.0%gcc@:4.8+mfem")
+    depends_on("suite-sparse@:5.1.0", when="@1.0.0+mfem%gcc@:4.8")

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -139,7 +139,7 @@ class Cmake(Package):
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(
-        "%gcc platform=darwin",
+        "platform=darwin %gcc",
         when="@:3.17",
         msg="CMake <3.18 does not compile with GCC on macOS, "
         "please use %apple-clang or a newer CMake release. "

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -527,7 +527,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
             fcflags += ["-qpreprocess", "-qstrict", "-q64"]
             ldflags += ["-Wl,--allow-multiple-definition"]
 
-        if "%gcc@10: +mpi" in spec and spec["mpi"].name in ["mpich", "cray-mpich"]:
+        if "+mpi %gcc@10:" in spec and spec["mpi"].name in ["mpich", "cray-mpich"]:
             fcflags += [
                 "-fallow-argument-mismatch"
             ]  # https://github.com/pmodels/mpich/issues/4300

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -258,7 +258,7 @@ class Dihydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_option("CMAKE_EXPORT_COMPILE_COMMANDS", True))
         entries.append(cmake_cache_option("MPI_ASSUME_NO_BUILTIN_MPI", True))
 
-        if spec.satisfies("%clang +distconv platform=darwin"):
+        if spec.satisfies("+distconv platform=darwin %clang"):
             clang = self.compiler.cc
             clang_bin = os.path.dirname(clang)
             clang_root = os.path.dirname(clang_bin)
@@ -349,7 +349,7 @@ class Dihydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
         return entries
 
     def setup_build_environment(self, env):
-        if self.spec.satisfies("%apple-clang +openmp"):
+        if self.spec.satisfies("+openmp %apple-clang"):
             env.append_flags("CPPFLAGS", self.compiler.openmp_flag)
             env.append_flags("CFLAGS", self.spec["llvm-openmp"].headers.include_flags)
             env.append_flags("CXXFLAGS", self.spec["llvm-openmp"].headers.include_flags)

--- a/var/spack/repos/builtin/packages/dla-future/package.py
+++ b/var/spack/repos/builtin/packages/dla-future/package.py
@@ -135,7 +135,7 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     # Compilation problem triggered by the bundled fmt in Umpire together with
     # fmt 10, which only happens with GCC 9 and nvcc 11.2 and older:
     # https://github.com/eth-cscs/DLA-Future/issues/1044
-    conflicts("^fmt@10:", when="@:0.3.0 %gcc@9 +cuda ^cuda@:11.2 ^umpire@2022.10:")
+    conflicts("^fmt@10:", when="@:0.3.0 +cuda %gcc@9 ^cuda@:11.2 ^umpire@2022.10:")
 
     # Pedantic warnings, triggered by GCC 9 and 10, are always errors until 0.3.1:
     # https://github.com/eth-cscs/DLA-Future/pull/1043

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -158,7 +158,7 @@ class Eccodes(CMakePackage):
         when="@:2.4.0+netcdf",
     )
 
-    @when("%nag+fortran")
+    @when("+fortran%nag")
     def patch(self):
         # A number of Fortran source files assume that the kinds of integer and
         # real variables are specified in bytes. However, the NAG compiler

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -79,7 +79,7 @@ class Evtgen(CMakePackage):
         # the `-undefined dynamic_lookup` flag enables weak linking on Mac
         # Patch taken from CMS recipe:
         # https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_12_1_X/master/evtgen.spec#L48
-        if not self.spec.satisfies("%gcc platform=darwin"):
+        if not self.spec.satisfies("platform=darwin %gcc"):
             return
 
         filter_file("-shared", "-dynamiclib -undefined dynamic_lookup", "make.inc")

--- a/var/spack/repos/builtin/packages/fds/package.py
+++ b/var/spack/repos/builtin/packages/fds/package.py
@@ -52,19 +52,19 @@ class Fds(MakefilePackage):
 
     requires(
         "^openmpi",
-        when="%gcc platform=linux",
+        when="platform=linux %gcc",
         msg="OpenMPI can only be used with GNU Fortran on Linux platform",
     )
 
     requires(
         "^intel-mpi^intel-mkl",
-        when="%intel platform=linux",
+        when="platform=linux %intel",
         msg="Intel MPI and Intel MKL can only be used with Intel Fortran on Linux platform",
     )
 
     requires(
         "^intel-oneapi-mpi^intel-oneapi-mkl",
-        when="%oneapi platform=linux",
+        when="platform=linux %oneapi",
         msg="Intel oneAPI MPI and MKL can only be used with oneAPI Fortran on Linux platform",
     )
 

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -26,7 +26,7 @@ class FftwBase(AutotoolsPackage):
     variant("shared", default=True, description="Build shared libraries")
 
     depends_on("mpi", when="+mpi")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     # https://github.com/FFTW/fftw3/commit/902d0982522cdf6f0acd60f01f59203824e8e6f3
     conflicts("%gcc@8.0:8", when="@3.3.7")
@@ -87,7 +87,7 @@ class FftwBase(AutotoolsPackage):
         return self.spec.variants["precision"].value
 
     def setup_build_environment(self, env):
-        if self.spec.satisfies("%apple-clang +openmp"):
+        if self.spec.satisfies("+openmp %apple-clang"):
             env.append_flags("CPPFLAGS", self.compiler.openmp_flag)
             env.append_flags("CFLAGS", self.spec["llvm-openmp"].headers.include_flags)
             env.append_flags("CXXFLAGS", self.spec["llvm-openmp"].headers.include_flags)

--- a/var/spack/repos/builtin/packages/func/package.py
+++ b/var/spack/repos/builtin/packages/func/package.py
@@ -34,7 +34,7 @@ class Func(CMakePackage):
 
     depends_on("boost")
     depends_on("armadillo", when="+armadillo")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/gccxml/package.py
+++ b/var/spack/repos/builtin/packages/gccxml/package.py
@@ -18,6 +18,6 @@ class Gccxml(CMakePackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    patch("darwin-gcc.patch", when="%gcc platform=darwin")
+    patch("darwin-gcc.patch", when="platform=darwin %gcc")
     # taken from https://github.com/gccxml/gccxml/issues/11#issuecomment-140334118
     patch("gcc-5.patch", when="%gcc@5:")

--- a/var/spack/repos/builtin/packages/gitconddb/package.py
+++ b/var/spack/repos/builtin/packages/gitconddb/package.py
@@ -50,5 +50,5 @@ class Gitconddb(CMakePackage):
     conflicts("%gcc@:7.9", msg="GitCondDB requires GCC 8 or newer for C++17 support")
     conflicts("%apple-clang", when="@:0.1", msg="No Darwin support for clang in older versions")
     conflicts(
-        "%clang platform=darwin", when="@:0.1", msg="No Darwin support for clang in older versions"
+        "platform=darwin %clang", when="@:0.1", msg="No Darwin support for clang in older versions"
     )

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -166,7 +166,7 @@ class Graphviz(AutotoolsPackage):
         if self.spec.satisfies("+quartz"):
             env.set("OBJC", self.compiler.cc)
 
-    @when("%clang platform=darwin")
+    @when("platform=darwin %clang")
     def patch(self):
         # When using Clang, replace GCC's libstdc++ with LLVM's libc++
         mkdirs = ["cmd/dot", "cmd/edgepaint", "cmd/mingle", "plugin/gdiplus"]

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -502,10 +502,10 @@ class Gromacs(CMakePackage, CudaPackage):
     depends_on("sycl", when="+sycl")
     depends_on("lapack")
     depends_on("blas")
-    depends_on("gcc", when="%intel ~intel_provided_gcc")
+    depends_on("gcc", when="~intel_provided_gcc %intel")
     # TODO this can be expanded to all clang-based compilers once
     # the principle is demonstrated to work
-    with when("%oneapi ~intel_provided_gcc"):
+    with when("~intel_provided_gcc %oneapi"):
         depends_on("gcc-runtime@5:", when="@2020")
         depends_on("gcc-runtime@7:", when="@2021:2022")
         depends_on("gcc-runtime@9:", when="@2023:2024")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -345,7 +345,7 @@ class Hdf5(CMakePackage):
             if spec.satisfies("@:1.8.12+cxx~shared"):
                 cmake_flags.append(self.compiler.cxx_pic_flag)
         elif name == "fflags":
-            if spec.satisfies("%cce+fortran"):
+            if spec.satisfies("+fortran%cce"):
                 # Cray compiler generates module files with uppercase names by
                 # default, which is not handled by the CMake scripts. The
                 # following flag forces the compiler to produce module files

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -127,7 +127,7 @@ class Hydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("hipcub +rocm", when="+rocm +cub")
     depends_on("half", when="+half")
 
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     # Fixes https://github.com/spack/spack/issues/42286
     # https://github.com/LLNL/Elemental/pull/177
@@ -175,8 +175,8 @@ class Hydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
 
         entries.append(cmake_cache_option("MPI_ASSUME_NO_BUILTIN_MPI", True))
 
-        if spec.satisfies("%clang +openmp platform=darwin") or spec.satisfies(
-            "%clang +omp_taskloops platform=darwin"
+        if spec.satisfies("+openmp platform=darwin %clang") or spec.satisfies(
+            "+omp_taskloops platform=darwin %clang"
         ):
             clang = self.compiler.cc
             clang_bin = os.path.dirname(clang)
@@ -280,7 +280,7 @@ class Hydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
         return entries
 
     def setup_build_environment(self, env):
-        if self.spec.satisfies("%apple-clang +openmp"):
+        if self.spec.satisfies("+openmp %apple-clang"):
             env.append_flags("CPPFLAGS", self.compiler.openmp_flag)
             env.append_flags("CFLAGS", self.spec["llvm-openmp"].headers.include_flags)
             env.append_flags("CXXFLAGS", self.spec["llvm-openmp"].headers.include_flags)

--- a/var/spack/repos/builtin/packages/icon/package.py
+++ b/var/spack/repos/builtin/packages/icon/package.py
@@ -241,7 +241,7 @@ class Icon(AutotoolsPackage):
                 ]
             )
 
-            if self.spec.satisfies("%oneapi+coupling"):
+            if self.spec.satisfies("+coupling%oneapi"):
                 flags["ICON_YAC_CFLAGS"].extend(["-O2", "-fp-model precise"])
 
             if self.spec.satisfies("+ocean"):
@@ -269,7 +269,7 @@ class Icon(AutotoolsPackage):
                     ["-acc=gpu", "-gpu=cc{0}".format(self.nvidia_targets[gpu])]
                 )
 
-            if self.spec.satisfies("%nvhpc@:23.9+coupling"):
+            if self.spec.satisfies("+coupling%nvhpc@:23.9"):
                 args.append("yac_cv_fc_is_contiguous_works=yes")
 
         else:

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -255,9 +255,9 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder, SetupEnviron
         # Deactivate use of RTM with GCC when on an OS with a very old
         # assembler.
         if (
-            spec.satisfies("%gcc@4.8.0: os=rhel6")
-            or spec.satisfies("%gcc@4.8.0: os=centos6")
-            or spec.satisfies("%gcc@4.8.0: os=scientific6")
+            spec.satisfies("os=rhel6 %gcc@4.8.0:")
+            or spec.satisfies("os=centos6 %gcc@4.8.0:")
+            or spec.satisfies("os=scientific6 %gcc@4.8.0:")
         ):
             filter_file(r"RTM_KEY.*=.*rtm.*", "RTM_KEY =", join_path("build", "linux.gcc.inc"))
 

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -204,7 +204,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     # Note that for Power systems we want the environment to add +powerpc
     # When using a GCC compiler
-    depends_on("opencv@4.1.0: +powerpc", when="+vision %gcc arch=ppc64le:")
+    depends_on("opencv@4.1.0: +powerpc", when="+vision arch=ppc64le: %gcc")
 
     depends_on("cnpy", when="+numpy")
     depends_on("nccl", when="@0.94:0.98.2 +cuda")
@@ -410,7 +410,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             # a shell, which expects :
 
         # Add support for OpenMP with external (Brew) clang
-        if spec.satisfies("%clang platform=darwin"):
+        if spec.satisfies("platform=darwin %clang"):
             clang = self.compiler.cc
             clang_bin = os.path.dirname(clang)
             clang_root = os.path.dirname(clang_bin)

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -79,11 +79,11 @@ class Legion(CMakePackage, ROCmPackage):
     for nvarch in cuda_arch_list:
         depends_on(
             f"kokkos@3.3.01:+cuda+cuda_lambda+wrapper cuda_arch={nvarch}",
-            when=f"%gcc+kokkos+cuda cuda_arch={nvarch}",
+            when=f"+kokkos+cuda cuda_arch={nvarch} %gcc",
         )
         depends_on(
             f"kokkos@3.3.01:+cuda+cuda_lambda~wrapper cuda_arch={nvarch}",
-            when=f"%clang+kokkos+cuda cuda_arch={nvarch}",
+            when=f"+kokkos+cuda cuda_arch={nvarch} %clang",
         )
 
     depends_on("kokkos@3.3.01:~cuda", when="+kokkos~cuda")
@@ -407,7 +407,7 @@ class Legion(CMakePackage, ROCmPackage):
             # default is off.
             options.append("-DLegion_USE_Kokkos=ON")
             os.environ["KOKKOS_CXX_COMPILER"] = self["kokkos"].kokkos_cxx
-            if spec.satisfies("+cuda+cuda_unsupported_compiler ^kokkos%clang +cuda"):
+            if spec.satisfies("+cuda+cuda_unsupported_compiler ^kokkos+cuda %clang"):
                 # Keep CMake CUDA compiler detection happy
                 options.append(
                     self.define("CMAKE_CUDA_FLAGS", "--allow-unsupported-compiler -std=c++17")

--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -35,7 +35,7 @@ class Libffi(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    patch("clang-powerpc-3.2.1.patch", when="@3.2.1%clang platform=linux")
+    patch("clang-powerpc-3.2.1.patch", when="@3.2.1 platform=linux %clang")
     # ref.: https://github.com/libffi/libffi/pull/561
     patch("powerpc-3.3.patch", when="@3.3")
     patch(

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -112,7 +112,7 @@ class Libuv(CMakePackage, AutotoolsPackage):
     # Tries to build an Objective-C file with GCC's C frontend
     # https://github.com/libuv/libuv/issues/2805
     conflicts(
-        "%gcc platform=darwin",
+        "platform=darwin %gcc",
         when="@:1.37.9",
         msg="libuv does not compile with GCC on macOS yet, use clang. "
         "See: https://github.com/libuv/libuv/issues/2805",

--- a/var/spack/repos/builtin/packages/lvarray/package.py
+++ b/var/spack/repos/builtin/packages/lvarray/package.py
@@ -215,7 +215,7 @@ class Lvarray(CMakePackage, CudaPackage):
             debug_flags = "-O0 -g"
             cfg.write(cmake_cache_string("CMAKE_CXX_FLAGS_DEBUG", debug_flags))
 
-            if spec.satisfies("%clang arch=linux-rhel7-ppc64le"):
+            if spec.satisfies("arch=linux-rhel7-ppc64le%clang"):
                 cfg.write(cmake_cache_entry("CMAKE_EXE_LINKER_FLAGS", "-Wl,--no-toc-optimize"))
 
             if spec.satisfies("+cuda"):

--- a/var/spack/repos/builtin/packages/mimalloc/package.py
+++ b/var/spack/repos/builtin/packages/mimalloc/package.py
@@ -107,7 +107,7 @@ class Mimalloc(CMakePackage):
         "debug_ubsan": (
             False,
             "Build with undefined-behavior sanitizer (needs clang++)",
-            "%clang build_type=Debug +use_cxx",
+            "build_type=Debug +use_cxx %clang ",
         ),
         "skip_collect_on_exit": (False, "Skip collecting memory on program exit", None),
     }

--- a/var/spack/repos/builtin/packages/onednn/package.py
+++ b/var/spack/repos/builtin/packages/onednn/package.py
@@ -106,7 +106,7 @@ class Onednn(CMakePackage):
     depends_on("cmake@2.8.12:", when="@2.3:", type="build")
     depends_on("cmake@2.8.11:", type="build")
     depends_on("tbb@2017:", when="cpu_runtime=tbb")
-    depends_on("llvm-openmp", when="%apple-clang cpu_runtime=omp")
+    depends_on("llvm-openmp", when="cpu_runtime=omp %apple-clang")
     depends_on("opencl@1.2:", when="gpu_runtime=ocl")
     depends_on("armcomputelibrary", when="+acl")
     depends_on("tbb", when="cpu_runtime=sycl")
@@ -125,7 +125,7 @@ class Onednn(CMakePackage):
             args.append("-DDNNL_BUILD_TESTS=OFF")
 
         # https://github.com/oneapi-src/oneDNN/issues/591
-        if self.spec.satisfies("%apple-clang cpu_runtime=omp"):
+        if self.spec.satisfies("cpu_runtime=omp %apple-clang"):
             args.extend(
                 [
                     "-DOpenMP_CXX_FLAGS={0}".format(self.compiler.openmp_flag),

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -141,7 +141,7 @@ class Openblas(CMakePackage, MakefilePackage):
 
     # Fixes compilation error on POWER8 with GCC 7
     # https://github.com/OpenMathLib/OpenBLAS/pull/1098
-    patch("power8.patch", when="@0.2.18:0.2.19 %gcc@7.1.0: target=power8")
+    patch("power8.patch", when="@0.2.18:0.2.19 target=power8 %gcc@7.1.0:")
 
     # Change file comments to work around clang 3.9 assembler bug
     # https://github.com/OpenMathLib/OpenBLAS/pull/982

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -168,7 +168,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
 
         # The default glibc provided by CentOS 7 does not provide proper
         # atomic support when using the NVIDIA compilers
-        if self.spec.satisfies("%nvhpc os=centos7"):
+        if self.spec.satisfies("os=centos7 %nvhpc"):
             options.append("-D__STDC_NO_ATOMICS__")
 
         # Make a flag for shared library builds

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -84,7 +84,7 @@ class ParallelNetcdf(AutotoolsPackage):
     # detected using macro AC_FC_LIBRARY_LDFLAGS, which means that we can
     # override the verbose output flag for Fortran compiler on the command line
     # (see below).
-    conflicts("+shared", when="@:1.9%nag+fortran")
+    conflicts("+shared", when="@:1.9+fortran%nag")
 
     @property
     def libs(self):
@@ -145,7 +145,7 @@ class ParallelNetcdf(AutotoolsPackage):
             args += self.enable_or_disable("shared")
             args.extend(["--enable-static", "--disable-silent-rules"])
 
-        if self.spec.satisfies("%nag+fortran+shared"):
+        if self.spec.satisfies("+fortran+shared%nag"):
             args.extend(["ac_cv_prog_fc_v=-Wl,-v", "ac_cv_prog_f77_v=-Wl,-v"])
 
         if self.spec.satisfies("+burstbuffer"):

--- a/var/spack/repos/builtin/packages/py-dask-ml/package.py
+++ b/var/spack/repos/builtin/packages/py-dask-ml/package.py
@@ -57,7 +57,7 @@ class PyDaskMl(PythonPackage):
 
     patch("xgboost_dependency.patch")
 
-    conflicts("+docs", when="%gcc target=aarch64:")
+    conflicts("+docs", when="target=aarch64: %gcc")
 
     @run_after("install")
     def install_docs(self):

--- a/var/spack/repos/builtin/packages/py-dgl/package.py
+++ b/var/spack/repos/builtin/packages/py-dgl/package.py
@@ -49,7 +49,7 @@ class PyDgl(CMakePackage, PythonExtension, CudaPackage):
     )
 
     depends_on("cmake@3.5:", type="build")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     # Python dependencies
     # See python/setup.py

--- a/var/spack/repos/builtin/packages/py-numcodecs/package.py
+++ b/var/spack/repos/builtin/packages/py-numcodecs/package.py
@@ -54,7 +54,7 @@ class PyNumcodecs(PythonPackage):
     depends_on("py-entrypoints", when="@0.10.1:0.11", type=("build", "run"))
     depends_on("py-msgpack", type=("build", "run"), when="+msgpack")
 
-    patch("apple-clang-12.patch", when="%apple-clang@12: @:0.13")
+    patch("apple-clang-12.patch", when="@:0.13 %apple-clang@12:")
 
     # TODO: this package should really depend on blosc, zstd, lz4, zlib, but right now it vendors
     # those libraries without any way to use the system versions.

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -57,7 +57,7 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     for val in CudaPackage.cuda_arch_values:
         depends_on("kokkos cuda_arch={0}".format(val), when="cuda_arch={0}".format(val))
     # Use +wrapper when not %clang %cce
-    depends_on("kokkos+wrapper", when="%gcc+cuda")
+    depends_on("kokkos+wrapper", when="+cuda %gcc")
 
     # ROCm
     for val in ROCmPackage.amdgpu_targets:

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -286,7 +286,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("magma+cuda", when="+magma+cuda")
     depends_on("magma+rocm", when="+magma+rocm")
     depends_on("numactl", when="+numa")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
     depends_on("valgrind", when="+valgrind")
     with when("+rocm"):
         depends_on("hsa-rocr-dev")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -379,7 +379,7 @@ class Python(Package):
     # https://github.com/spack/spack/pull/16222
     # https://github.com/python/cpython/pull/13306
     conflicts(
-        "%gcc platform=darwin",
+        "platform=darwin %gcc",
         msg="CPython does not compile with GCC on macOS yet, use clang. "
         "See: https://github.com/python/cpython/pull/13306",
     )

--- a/var/spack/repos/builtin/packages/qemu/package.py
+++ b/var/spack/repos/builtin/packages/qemu/package.py
@@ -155,7 +155,7 @@ class Qemu(AutotoolsPackage):
             "--disable-docs",
         ]
         extra_cflags = "-Wno-unknown-warning-option"
-        if self.spec.satisfies("%apple-clang platform=darwin"):
+        if self.spec.satisfies("platform=darwin %apple-clang"):
             # qemu 9: uses pthread_jit_write_protect_np which requires OSX 11.0 or newer
             extra_cflags += " -mmacosx-version-min=11.0"
         args.append(f"--extra-cflags={extra_cflags}")

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -125,7 +125,7 @@ class QuantumEspresso(CMakePackage, Package):
     with when("+mpi"):
         depends_on("mpi")
         variant("scalapack", default=True, description="Enables scalapack support")
-        with when("%nvhpc+cuda"):
+        with when("+cuda%nvhpc"):
             # add mpi_gpu_aware variant, False by default
             variant("mpigpu", default=False, description="Enables GPU-aware MPI operations")
 
@@ -292,7 +292,7 @@ class QuantumEspresso(CMakePackage, Package):
 
     # Internal compiler error gcc8 and a64fx, I check only 6.5 and 6.6
     conflicts(
-        "@5.3:", when="%gcc@8 target=a64fx", msg="Internal compiler error with gcc8 and a64fx"
+        "@5.3:", when="target=a64fx %gcc@8", msg="Internal compiler error with gcc8 and a64fx"
     )
 
     conflicts("@6.5:", when="+environ", msg="6.4.x is the latest QE series supported by Environ")

--- a/var/spack/repos/builtin/packages/serialbox/package.py
+++ b/var/spack/repos/builtin/packages/serialbox/package.py
@@ -62,10 +62,10 @@ class Serialbox(CMakePackage):
     patch("ppser_py3.patch", when="@2.2.0:")
 
     # NAG patches:
-    patch("nag/interface.patch", when="@2.0.1:%nag+fortran")
-    patch("nag/examples.patch", when="@2.3.1:%nag+fortran+examples")
-    patch("nag/ftg.patch", when="@2.3.1:%nag+ftg")
-    patch("nag/bool_getters.patch", when="@2.3.1:%nag@7.1:+fortran")
+    patch("nag/interface.patch", when="@2.0.1:+fortran%nag")
+    patch("nag/examples.patch", when="@2.3.1:+fortran+examples%nag")
+    patch("nag/ftg.patch", when="@2.3.1:+ftg%nag")
+    patch("nag/bool_getters.patch", when="@2.3.1:+fortran%nag@7.1:")
 
     # Add missing include directives
     # (part of https://github.com/GridTools/serialbox/pull/259):
@@ -144,7 +144,7 @@ class Serialbox(CMakePackage):
             # undefined reference to
             #     `std::experimental::filesystem::v1::__cxx11::path::
             #         _M_find_extension[abi:cxx11]() const'
-            if self.spec.satisfies("%intel@:19.0.1+std-filesystem"):
+            if self.spec.satisfies("+std-filesystem%intel@:19.0.1"):
                 cmake_flags.append("-D_GLIBCXX_USE_CXX11_ABI=0")
 
         return flags, None, (cmake_flags or None)

--- a/var/spack/repos/builtin/packages/singularity-eos/package.py
+++ b/var/spack/repos/builtin/packages/singularity-eos/package.py
@@ -142,7 +142,7 @@ class SingularityEos(CMakePackage, CudaPackage):
     # can be removed once <1.8.0 versions have been removed
     def flag_handler(self, name, flags):
         if name == "fflags":
-            if self.spec.satisfies("%cce+fortran"):
+            if self.spec.satisfies("+fortran%cce"):
                 # The Cray fortran compiler generates module files with
                 # uppercase names by default, which is not handled by the
                 # CMake scripts. The following flag forces the compiler to

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -156,7 +156,7 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
             args.extend([self.define_from_variant("STRUMPACK_C_INTERFACE", "c_interface")])
 
         # Workaround for linking issue on Mac:
-        if spec.satisfies("%apple-clang +mpi"):
+        if spec.satisfies("+mpi %apple-clang"):
             args.append("-DCMAKE_Fortran_COMPILER=%s" % spec["mpi"].mpifc)
 
         if "+cuda" in spec:

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -270,7 +270,7 @@ class SuiteSparse(Package):
                 ]
             make_args += [f"CMAKE_OPTIONS={' '.join(cmake_args)}"]
 
-        if spec.satisfies("%gcc platform=darwin"):
+        if spec.satisfies("platform=darwin %gcc"):
             make_args += ["LDLIBS=-lm"]
 
         if "%cce" in spec:

--- a/var/spack/repos/builtin/packages/sw4/package.py
+++ b/var/spack/repos/builtin/packages/sw4/package.py
@@ -40,7 +40,7 @@ class Sw4(MakefilePackage):
     depends_on("zfp", when="+zfp")
     depends_on("h5z-zfp@develop", when="+zfp")
     depends_on("fftw@3: +mpi", when="+fftw")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     def setup_build_environment(self, env):
         env.set("CXX", self.spec["mpi"].mpicxx)
@@ -66,7 +66,7 @@ class Sw4(MakefilePackage):
         env.set("EXTRA_LINK_FLAGS", "-lstdc++ -lm -ldl")
         env.append_flags("EXTRA_LINK_FLAGS", self.spec["blas"].libs.ld_flags)
         env.append_flags("EXTRA_LINK_FLAGS", self.spec["lapack"].libs.ld_flags)
-        if self.spec.satisfies("%apple-clang +openmp"):
+        if self.spec.satisfies("+openmp %apple-clang"):
             env.append_flags("EXTRA_LINK_FLAGS", self.spec["llvm-openmp"].libs.ld_flags)
         # From spack/trilinos
         if (

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -205,7 +205,7 @@ class Vasp(MakefilePackage, CudaPackage):
                     "-fallow-argument-mismatch", " -fno-fortran-main", make_include, string=True
                 )
         # fj
-        elif spec.satisfies("@6.4.3: %fj target=a64fx"):
+        elif spec.satisfies("@6.4.3: target=a64fx %fj"):
             include_string += "fujitsu_a64fx"
             omp_flag = "-Kopenmp"
             fc.extend(["simd_nouse_multiple_structures", "-X03"])
@@ -323,7 +323,7 @@ class Vasp(MakefilePackage, CudaPackage):
         os.rename(make_include, "makefile.include")
 
     def setup_build_environment(self, spack_env):
-        if self.spec.satisfies("%nvhpc +cuda"):
+        if self.spec.satisfies("+cuda %nvhpc"):
             spack_env.set("NVHPC_CUDA_HOME", self.spec["cuda"].prefix)
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -184,19 +184,19 @@ class Wrf(Package):
     patch("patches/4.2/var.gen_be.Makefile.patch", when="@4.2:")
     patch("patches/4.2/Makefile.patch", when="@4.2")
     patch("patches/4.2/tirpc_detect.patch", when="@4.2")
-    patch("patches/4.2/add_aarch64.patch", when="@4.2:4.3.1 %gcc target=aarch64:")
-    patch("patches/4.2/add_aarch64_acfl.patch", when="@4.2:4.3.1 %arm target=aarch64:")
+    patch("patches/4.2/add_aarch64.patch", when="@4.2:4.3.1 target=aarch64: %gcc")
+    patch("patches/4.2/add_aarch64_acfl.patch", when="@4.2:4.3.1 target=aarch64: %arm")
     patch("patches/4.2/configure_aocc_2.3.patch", when="@4.2 %aocc@:2.4.0")
     patch("patches/4.2/configure_aocc_3.0.patch", when="@4.2 %aocc@3.0.0:3.2.0")
     patch("patches/4.2/hdf5_fix.patch", when="@4.2:4.5.1 %aocc")
     patch("patches/4.2/derf_fix.patch", when="@=4.2 %aocc")
     patch(
         "patches/4.2/add_tools_flags_acfl2304.patch",
-        when="@4.2:4.4.2 %arm@23.04.1: target=aarch64:",
+        when="@4.2:4.4.2 target=aarch64: %arm@23.04.1:",
     )
 
-    patch("patches/4.3/add_aarch64.patch", when="@4.3.2:4.4.2 %gcc target=aarch64:")
-    patch("patches/4.3/add_aarch64_acfl.patch", when="@4.3.2:4.4.2 %arm target=aarch64:")
+    patch("patches/4.3/add_aarch64.patch", when="@4.3.2:4.4.2 target=aarch64: %gcc")
+    patch("patches/4.3/add_aarch64_acfl.patch", when="@4.3.2:4.4.2 target=aarch64: %arm")
 
     patch("patches/4.4/arch.postamble.patch", when="@4.4:4.5.1")
     patch("patches/4.4/configure.patch", when="@4.4:4.4.2")

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -55,7 +55,7 @@ class Xgboost(CMakePackage, CudaPackage):
         depends_on("cuda@:12.4", when="@:2.1")
 
     depends_on("nccl", when="+nccl")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
     depends_on("hwloc", when="%clang")
 
     # https://github.com/dmlc/xgboost/issues/6972

--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -48,7 +48,7 @@ class YamlCpp(CMakePackage):
     conflicts("%xl@:13.1", when="@0.6.0:", msg="versions 0.6.0: require c++11 support")
     conflicts("%xl_r@:13.1", when="@0.6.0:", msg="versions 0.6.0: require c++11 support")
     conflicts(
-        '%clang cxxflags="-stdlib=libc++"', when="+tests", msg=yaml_cpp_tests_libcxx_error_msg
+        'cxxflags="-stdlib=libc++" %clang', when="+tests", msg=yaml_cpp_tests_libcxx_error_msg
     )
 
     def flag_handler(self, name, flags):

--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -48,7 +48,7 @@ class ZlibNg(AutotoolsPackage, CMakePackage):
     build_system("autotools", "cmake", default="autotools")
 
     # fix building with NVHPC, see https://github.com/zlib-ng/zlib-ng/pull/1698
-    patch("pr-1698.patch", when="@2.1.4:2.1.6%nvhpc+opt")
+    patch("pr-1698.patch", when="@2.1.4:2.1.6+opt%nvhpc")
 
     with when("build_system=cmake"):
         depends_on("cmake@3.5.1:", type="build")

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -165,7 +165,7 @@ class Zoltan(AutotoolsPackage):
         config_fcflags = config_cflags[:]
         config_cxxflags = config_cflags[:]
 
-        if spec.satisfies("%gcc@10:+fortran"):
+        if spec.satisfies("+fortran%gcc@10:"):
             config_fcflags.append("-fallow-argument-mismatch")
 
         # NOTE: Early versions of Zoltan come packaged with a few embedded


### PR DESCRIPTION
Context: #44379

This moves `%compiler` and `%compiler@...` after variants, arch, versions in all static spec strings in the Spack codebase.

The reason for this is that `%` will change meaning in Spack v1.0 from "compiler attribute" to "direct dependency". Currently in a spec string `pkg %gcc +feature`  the `+feature` variant refers to `pkg`, in the future it will refer to `gcc`. It mirrors what we're used to from `pkg ^dep +feature`.

This PR was generated by parsing all string constants as specs from
1. the abstract syntax tree of all `*.py` files
2. the json and yaml trees of all `*.yml`, `*.yaml`, `*.json` files

Dynamically created spec strings are not caught.