### PR TITLE
ci: use stack-specific local mirrors

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -20,7 +20,7 @@ ci:
         - k=$CI_GPG_KEY_ROOT/intermediate_ci_signing_key.gpg; [[ -r $k ]] && spack gpg trust $k
         - k=$CI_GPG_KEY_ROOT/spack_public_key.gpg; [[ -r $k ]] && spack gpg trust $k
       script::
-      - - if [ -n "$SPACK_EXTRA_MIRROR" ]; then spack mirror add local "$SPACK_EXTRA_MIRROR"; fi
+      - - if [ -n "$SPACK_EXTRA_MIRROR" ]; then spack mirror add local "${SPACK_EXTRA_MIRROR}/${SPACK_CI_STACK_NAME}"; fi
         - spack config blame mirrors
       - - spack --color=always --backtrace ci rebuild -j ${SPACK_BUILD_JOBS} --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
       after_script:


### PR DESCRIPTION
This should help resolve the "No binary found when cache-only was specified" errors we've recently seen in our GitLab CI pipelines.

example failing job here:
https://gitlab.spack.io/spack/spack/-/jobs/15570931#L370

This error is caused when a generate job finds a spec in the local root binary mirror, and that spec does not yet exist in the stack-specific mirror.

The fix here is to instead locally cache the stack-specific mirrors and only use the root-level mirror for public use.