### PR TITLE
py-asdf: add v4.1.0 and related

### DIFF
--- a/var/spack/repos/builtin/packages/py-asdf-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf-astropy/package.py
@@ -1,0 +1,30 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAsdfAstropy(PythonPackage):
+    """ASDF serialization support for astropy"""
+
+    homepage = "https://asdf-astropy.readthedocs.io/"
+    pypi = "asdf_astropy/asdf_astropy-0.7.1.tar.gz"
+
+    license("BSD-3-Clause", checked_by="lgarrison")
+
+    version("0.7.1", sha256="5aa5a448ee0945bd834a9ba8fb86cf43b39e85d24260e1339b734173ab6024c7")
+
+    depends_on("python@3.10:", type=("build", "run"))
+
+    depends_on("py-setuptools@60:", type="build")
+    depends_on("py-setuptools-scm@3.4: +toml", type="build")
+
+    depends_on("py-asdf@2.14.4:", type=("build", "run"))
+    depends_on("py-asdf-coordinates-schemas@0.3:", type=("build", "run"))
+    depends_on("py-asdf-transform-schemas@0.5:", type=("build", "run"))
+    depends_on("py-asdf-standard@1.1.0:", type=("build", "run"))
+    # depends_on("py-astropy@5.2.0:", type=("build", "run"))
+    conflicts("py-astropy@:5.1")
+    depends_on("py-numpy@1.24:", type=("build", "run"))
+    depends_on("py-packaging@19:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-asdf-coordinates-schemas/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf-coordinates-schemas/package.py
@@ -1,0 +1,26 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAsdfCoordinatesSchemas(PythonPackage):
+    """ASDF schemas for coordinates"""
+
+    homepage = "https://www.asdf-format.org/projects/asdf-coordinates-schemas/"
+    pypi = "asdf_coordinates_schemas/asdf_coordinates_schemas-0.3.0.tar.gz"
+
+    maintainers("lgarrison")
+
+    license("BSD-3-Clause", checked_by="lgarrison")
+
+    version("0.3.0", sha256="c98b6015dcec87a158fcde7798583f0615d08125fa6e1e9de16c4eb03fcd604e")
+
+    depends_on("python@3.9:", type=("build", "run"))
+
+    depends_on("py-setuptools@60:", type="build")
+    depends_on("py-setuptools-scm@3.4: +toml", type="build")
+
+    depends_on("py-asdf@2.12.1:", type=("build", "run"))
+    depends_on("py-asdf-standard@1.1.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-asdf-transform-schemas/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf-transform-schemas/package.py
@@ -15,12 +15,15 @@ class PyAsdfTransformSchemas(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.5.0", sha256="82cf4c782575734a895327f25ff583ce9499d7e2b836fe8880b2d7961c6b462b")
     version("0.3.0", sha256="0cf2ff7b22ccb408fe58ddd9b2441a59ba73fe323e416d59b9e0a4728a7d2dd6")
 
+    depends_on("python@3.9:", when="@0.5.0:", type=("build", "run"))
     depends_on("python@3.8:", type=("build", "run"))
 
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-setuptools-scm@3.4: +toml", type="build")
 
+    depends_on("py-asdf-standard@1.1.0:", when="@0.5.0:", type=("build", "run"))
     depends_on("py-asdf-standard@1.0.1:", type=("build", "run"))
-    depends_on("py-importlib-resources@3:", type=("build", "run"), when="^python@:3.8")
+    depends_on("py-importlib-resources@3:", type=("build", "run"), when="@:0.3.0 ^python@:3.8")

--- a/var/spack/repos/builtin/packages/py-asdf/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf/package.py
@@ -17,6 +17,7 @@ class PyAsdf(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("4.1.0", sha256="0ff44992c85fd768bd9a9512ab7f012afb52ddcee390e9caf67e30d404122da1")
     version("3.5.0", sha256="047ad7bdd8f40b04b8625abfd119a35d18b344301c60ea9ddf63964e7ce19669")
     version("2.15.0", sha256="686f1c91ebf987d41f915cfb6aa70940d7ad17f87ede0be70463147ad2314587")
     version("2.4.2", sha256="6ff3557190c6a33781dae3fd635a8edf0fa0c24c6aca27d8679af36408ea8ff2")


### PR DESCRIPTION
https://github.com/asdf-format/asdf/releases/tag/4.1.0 (no dependency changes)
https://github.com/asdf-format/asdf-transform-schemas/releases/tag/0.5.0
https://github.com/asdf-format/asdf-coordinates-schemas/releases/tag/0.3.0
https://github.com/astropy/asdf-astropy/releases/tag/0.7.1

asdf-astropy has a circular dependency on astropy. However, it's essentially an astropy add-on, so I think it's safe to invert the dependency into a conflict with the wrong astropy versions.