### PR TITLE
perl-xml-parser: new expat lib in ${prefix}/lib64

### DIFF
--- a/var/spack/repos/builtin/packages/perl-xml-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-parser/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os.path as osp
+
 from spack.package import *
 
 
@@ -22,8 +24,10 @@ class PerlXmlParser(PerlPackage):
 
     def configure_args(self):
         args = []
-
-        p = self.spec["expat"].prefix.lib
+        if osp.isdir(self.spec["expat"].prefix.lib64):
+            p = self.spec["expat"].prefix.lib64
+        else:
+            p = self.spec["expat"].prefix.lib
         args.append(f"EXPATLIBPATH={p}")
         p = self.spec["expat"].prefix.include
         args.append(f"EXPATINCPATH={p}")


### PR DESCRIPTION
This patch
- detect existence of `${prefix}/lib64` for expat, and
- use `${prefix}/lib64` instead of `${prefix}/lib` if found.