### PR TITLE
Patch bug in elpa's cpp

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -64,6 +64,12 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         )
 
     patch("fujitsu.patch", when="%fj")
+    # wrong filename handling in elpa's custom preprocessor
+    patch(
+        "https://gitlab.mpcdf.mpg.de/elpa/elpa/-/commit/5a821b79dd2905c691fc0973c9f3044904ac2653.diff",
+        sha256="90f18c84e740a35d726e44078a111fac3b6278a0e750ce1f3ea154ee78e93298",
+        when="@:2025.01.001",
+    )
 
     depends_on("autoconf@2.71:", type="build", when="@master")
     depends_on("automake", type="build", when="@master")


### PR DESCRIPTION
Elpa's custom preprocessor createst temporary files for which it assembles long filenames and then uses the last 250 characters. This results in compilation errors when the first character happens to be a dash.

This PR contains information about elpa versions that will only be available in spack once https://github.com/spack/spack/pull/49335 is merged.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
