### PR TITLE
openmpi: fix `+internal-libevent` variant

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1084,9 +1084,15 @@ with '-Wl,-commons,use_dylibs' and without
             config_args.extend(["--enable-debug"])
 
         # Package dependencies
-        for dep in ["libevent", "lustre", "singularity", "valgrind"]:
+        for dep in ["lustre", "singularity", "valgrind"]:
             if "^" + dep in spec:
                 config_args.append("--with-{0}={1}".format(dep, spec[dep].prefix))
+
+        # libevent support
+        if spec.satisfies("+internal-libevent"):
+            config_args.append("--with-libevent=internal")
+        elif "^libevent" in spec:
+            config_args.append("--with-libevent={0}".format(spec["libevent"].prefix))
 
         # PMIx support
         if spec.satisfies("+internal-pmix"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

The `+internal-libevent` variant in the `openmpi` package seems to be broken. The logic is:

```python
    variant("internal-libevent", default=False, description="Use internal libevent")
...
    # Libevent is required when *vendored* PMIx is used
    depends_on("libevent@2:", when="~internal-libevent")
...
        # Package dependencies
        for dep in ["libevent", "lustre", "singularity", "valgrind"]:
            if "^" + dep in spec:
                config_args.append("--with-{0}={1}".format(dep, spec[dep].prefix))
```

Compare this to, say, another `+internal-` variant like `pmix`:
```python
    variant("internal-pmix", default=False, description="Use internal pmix")
...
    # PMIx is unavailable for @1, and required for @2:
    # OpenMPI @2: includes a vendored version:
    with when("~internal-pmix"):
        depends_on("pmix@1", when="@2")
        depends_on("pmix@3.2:", when="@4:")
        depends_on("pmix@4.2.4:", when="@5:")

        # pmix@4.2.3 contains a breaking change, compat fixed in openmpi@4.1.6
        # See https://www.mail-archive.com/announce@lists.open-mpi.org//msg00158.html
        depends_on("pmix@:4.2.2", when="@:4.1.5")
...
        # PMIx support
        if spec.satisfies("+internal-pmix"):
            config_args.append("--with-pmix=internal")
        elif "^pmix" in spec:
            config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
```

Notice that there is no logic for `if spec.satisfies("+internal-hwloc"):` so it can never be configured. When I try and build:

```
2 errors found in build log:
     1690    checking for libev static libs... -lev
     1691    checking for event.h... (cached) no
     1692    checking will libev support be built... no
     1693    configure: WARNING: Either libevent or libev support is required, but neither
     1694    configure: WARNING: was found. Please use the configure options to point us
     1695    configure: WARNING: to where we can find one or the other library
  >> 1696    configure: error: Cannot continue
     1697    configure: ===== done with 3rd-party/openpmix configure =====
  >> 1698    configure: error: Could not find viable pmix build.
```
And I think this is failing because I might have `libevent` from Brew and the build is going nuts? I'm not sure, but I noticed that `--with-libevent=internal` was never passed to the configure string before this fix:
```
    '/var/folders/31/16x8_l1s72s2kw0w7byr03qm0000gp/T/mathomp4/spack-stage/spack-stage-openmpi-5.0.6-7pdpqdvqpoasxpjtqfxieoayiq2iecnu/spack-src/configure' '--prefix=/Users/mathomp4/spack-mathomp4/opt/spack/darwin-sequoia-m1/apple-clang-16.0.0/openmpi-5.0.6-7pdpqdvqpoasxpjtqfxieoayiq2iecnu' '--enable-shared' '--disable-silent-rules' '--disable-sphinx' '--enable-builtin-atomics' '--disable-static' '--enable-mpi1-compatibility' '--without-xpmem' '--without-ofi' '--without-psm2' '--without-fca' '--without-mxm' '--without-ucc' '--without-knem' '--without-ucx' '--without-hcoll' '--without-psm' '--without-verbs' '--without-cma' '--without-cray-xpmem' '--without-slurm' '--without-tm' '--without-alps' '--without-lsf' '--without-sge' '--without-loadleveler' '--disable-memchecker' '--with-pmix=internal' '--with-zlib=/Users/mathomp4/spack-mathomp4/opt/spack/darwin-sequoia-m1/apple-clang-16.0.0/zlib-ng-2.2.3-pxnn7td6kxhodjhl3c5f772qblzp4iui' '--with-hwloc=internal' '--disable-java' '--disable-mpi-java' '--disable-io-romio' '--with-gpfs=no' '--without-cuda' '--enable-wrapper-rpath' '--disable-wrapper-runpath' 'CFLAGS=-DYY_BUF_SIZE=1048576' '--disable-debug'
```

So in this PR, I copy what is used by `pmix` and this successfully allows openmpi to build with `+internal-openmpi` from what I see. Though I of course defer to @hppritcha and  @naughtont3 if I might be misreading things.