### PR TITLE
darwin-aarch64: build outside of spack root dir again

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/darwin/aarch64/config.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/darwin/aarch64/config.yaml
@@ -1,5 +1,3 @@
 config:
-  build_stage:
-  - $spack/tmp/stage
   install_tree:
     root: $spack/opt/spack


### PR DESCRIPTION
Revert "CI: Move the build stage to the project root instead of tmp" #48397 a second time.

For the reason see the first time I reverted it: https://github.com/spack/spack/pull/48397

This time it results in build failure of LLVM 20 #49456 