### PR TITLE
Concretizer cache: disable by default

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1190,7 +1190,7 @@ class PyclingoDriver:
                 problem_repr += "\n" + f.read()
 
         result = None
-        conc_cache_enabled = spack.config.get("config:concretization_cache:enable", True)
+        conc_cache_enabled = spack.config.get("config:concretization_cache:enable", False)
         if conc_cache_enabled:
             result, concretization_stats = CONC_CACHE.fetch(problem_repr)
 


### PR DESCRIPTION
Disables the concretizer cache by default.
In its current state the cache has a low hit rate due to significant non determinism in the ASP setup ordering. For more context w.r.t. non determinism see #49471 and #49391.

We've had a complaint about the cache consuming space while not providing much benefit, so disabling it for the time being.