### PR TITLE
Solver: Increase ASP setup determinism

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1367,14 +1367,16 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         return [
             vspec
             for when_spec, provided in self.provided.items()
-            for vspec in provided
+            for vspec in sorted(provided)
             if self.spec.satisfies(when_spec)
         ]
 
     @classmethod
     def provided_virtual_names(cls):
         """Return sorted list of names of virtuals that can be provided by this package."""
-        return sorted(set(vpkg.name for virtuals in cls.provided.values() for vpkg in virtuals))
+        return sorted(
+            set(vpkg.name for virtuals in cls.provided.values() for vpkg in sorted(virtuals))
+        )
 
     @property
     def prefix(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2006,7 +2006,9 @@ class SpackSolverSetup:
 
     def package_dependencies_rules(self, pkg):
         """Translate 'depends_on' directives into ASP logic."""
-        for cond, deps_by_name in sorted(pkg.dependencies.items()):
+        for cond, deps_by_name in sorted(
+            pkg.dependencies.items()
+        ):  # this is the source of a good deal of non determinism
             for _, dep in sorted(deps_by_name.items()):
                 depflag = dep.depflag
                 # Skip test dependencies if they're not requested

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2006,9 +2006,7 @@ class SpackSolverSetup:
 
     def package_dependencies_rules(self, pkg):
         """Translate 'depends_on' directives into ASP logic."""
-        for cond, deps_by_name in sorted(
-            pkg.dependencies.items()
-        ):  # this is the source of a good deal of non determinism
+        for cond, deps_by_name in sorted(pkg.dependencies.items()):
             for _, dep in sorted(deps_by_name.items()):
                 depflag = dep.depflag
                 # Skip test dependencies if they're not requested


### PR DESCRIPTION
Particular solver setup operations were performed in a manner allowing non determinism in the ordering of ASP rule generation.

Resolving this allows for increased concretization cache hit rates

* Ensures sets are sorted before iteration

Note: this PR does not fully remove ASP setup non determinism, it's just an incremental improvement, #49391 is the final piece to ensure complete consistency in the ASP setup output.

Other note: These changes were originally pulled from #49391