### PR TITLE
e4s cray rhel ci: petsc: require +batch

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
@@ -72,6 +72,9 @@ spack:
       require:
       - "~qt ^[virtuals=gl] osmesa"
       - target=x86_64_v3
+    petsc:
+      require:
+      - "+batch"
     trilinos:
       require:
       - one_of: [+amesos +amesos2 +anasazi +aztec +boost +epetra +epetraext +ifpack


### PR DESCRIPTION
Trying to avoid hitting issue with `srun` on cray rhel runners during petsc config:
* [petsc@3.22.4 /mkwptke3c3et27rd3zvqt4io7zb62gdh E4S Cray ](https://gitlab.spack.io/spack/spack/-/jobs/15577225)

@balay @haampie 