### PR TITLE
seacas: add 2025-03-13 (bug fix, new functionality, portability)

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -35,7 +35,7 @@ class Seacas(CMakePackage):
     # ###################### Versions ##########################
     version("master", branch="master")
     version(
-        "2025-03-13", sha256="d4c5062307959050edcc4529e1b86f0e305dca8fb50826c8d1e4c20d390ee73f"
+        "2025-03-13", sha256="406aff5b8908d6a3bf6687d825905990101caa9cf8c1213a508938eed2134d6d"
     )
     version(
         "2025-02-27", sha256="224468d6215b4f4b15511ee7a29f755cdd9e7be18c08dfece9d9991e68185cfc"

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -35,6 +35,9 @@ class Seacas(CMakePackage):
     # ###################### Versions ##########################
     version("master", branch="master")
     version(
+        "2025-03-13", sha256="d4c5062307959050edcc4529e1b86f0e305dca8fb50826c8d1e4c20d390ee73f"
+    )
+    version(
         "2025-02-27", sha256="224468d6215b4f4b15511ee7a29f755cdd9e7be18c08dfece9d9991e68185cfc"
     )
     version(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Some bug fixes and new functionality:

* Fix problem with file-per-rank input assigning incorrect node ownership
* Change aprepro default output format to full precision
  * Added legacy_output_format() function and --legacy_output_format command line format to use legacy format instead.
  * Cleaned up aprepro help/usage output
* Various analyzer recommended changes
* Windows portability fixes.