### PR TITLE
style.py: add `spack style --spec-strings` for compat with v1.0

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -617,6 +617,19 @@ def _spec_str_default_handler(path: str, line: int, col: int, old: str, new: str
     print(f"{path}:{line}:{col}: `{old}` -> `{new}`")
 
 
+def _rewrite_spec_strings(path: str, line: int, col: int, old: str, new: str):
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    new_line = lines[line - 1].replace(old, new)
+    if new_line == lines[line - 1]:
+        tty.warn(f"{path}:{line}:{col}: could not apply fix: `{old}` -> `{new}`")
+        return
+    lines[line - 1] = new_line
+    print(f"{path}:{line}:{col}: fixed `{old}` -> `{new}`")
+    with open(path, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+
 SpecStrHandler = Callable[[str, int, int, str, str], None]
 
 
@@ -638,9 +651,13 @@ def _spec_str_ast(path: str, node: ast.AST, handler: SpecStrHandler) -> None:
 def _spec_str_json_and_yaml(path: str, data: dict, handler: SpecStrHandler) -> None:
     """Walk a YAML or JSON data structure and print reformatted spec strings."""
     queue = [data]
+    seen = set()
 
     while queue:
         current = queue.pop(0)
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
         if isinstance(current, dict):
             queue.extend(current.values())
             queue.extend(current.keys())
@@ -668,6 +685,10 @@ def _check_spec_strings(
 
         try:
             with open(path, "r", encoding="utf-8") as f:
+                # skip files that are likely too large to be user code or config
+                if os.fstat(f.fileno()).st_size > 1024 * 1024:
+                    warnings.warn(f"skipping {path}: too large.")
+                    continue
                 if is_json_or_yaml:
                     _spec_str_json_and_yaml(path, spack.util.spack_yaml.load_config(f), handler)
                 elif is_python:
@@ -681,9 +702,8 @@ def style(parser, args):
     if args.spec_strings:
         if not args.files:
             tty.die("No files provided to check spec strings.")
-        if args.fix:
-            tty.die("spack style --fix not yet implemented for --spec-strings.")
-        return _check_spec_strings(args.files)
+        handler = _rewrite_spec_strings if args.fix else _spec_str_default_handler
+        return _check_spec_strings(args.files, handler)
 
     # save initial working directory for relativizing paths later
     args.initial_working_dir = os.getcwd()

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -6,8 +6,9 @@ import ast
 import os
 import re
 import sys
+import warnings
 from itertools import islice, zip_longest
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
@@ -16,6 +17,9 @@ from llnl.util.filesystem import working_dir
 import spack.paths
 import spack.repo
 import spack.util.git
+import spack.util.spack_yaml
+from spack.spec_parser import SPEC_TOKENIZER, SpecTokens
+from spack.tokenize import Token
 from spack.util.executable import Executable, which
 
 description = "runs source code style checks on spack"
@@ -197,6 +201,13 @@ def setup_parser(subparser):
         metavar="TOOL",
         action="append",
         help="specify tools to skip (choose from %s)" % ", ".join(tool_names),
+    )
+    subparser.add_argument(
+        "--spec-strings",
+        action="store_true",
+        help="upgrade spec strings in Python, JSON and YAML files for compatibility with Spack "
+        "v1.0 and v0.x. Example: spack style --spec-strings $(git ls-files). Note: this flag "
+        "will be removed in Spack v1.0.",
     )
 
     subparser.add_argument("files", nargs=argparse.REMAINDER, help="specific files to check")
@@ -507,7 +518,173 @@ def _bootstrap_dev_dependencies():
         spack.bootstrap.ensure_environment_dependencies()
 
 
+IS_PROBABLY_COMPILER = re.compile(r"%[a-zA-Z_][a-zA-Z0-9\-]")
+
+
+def _spec_str_reorder_compiler(idx: int, blocks: List[List[Token]]) -> None:
+    # only move the compiler to the back if it exists and is not already at the end
+    if not 0 <= idx < len(blocks) - 1:
+        return
+    # ensure there is at least one non-WS token after the compiler token
+    for block in blocks[idx + 1 :]:
+        if any(token.kind != SpecTokens.WS for token in block):
+            break
+    else:
+        return
+    # rotate left and always add at least one WS token between compiler and previous token
+    compiler_block = blocks.pop(idx)
+    if compiler_block[0].kind != SpecTokens.WS:
+        compiler_block.insert(0, Token(SpecTokens.WS, " "))
+    # delete the WS tokens from the new first block if it was at the very start, to prevent leading
+    # WS tokens.
+    while idx == 0 and blocks[0][0].kind == SpecTokens.WS:
+        blocks[0].pop(0)
+    blocks.append(compiler_block)
+
+
+def _spec_str_reformat(spec_str: str):
+    """Given any string, try to parse as spec string, and rotate the compiler token to the end
+    of each spec instance."""
+    # We parse blocks of tokens that include leading whitespace, and move the compiler block to
+    # the end when we hit a dependency ^... or the end of a string.
+    # [@3.1][ +foo][ +bar][ %gcc@3.1][ +baz]
+    # [@3.1][ +foo][ +bar][ +baz][ %gcc@3.1]
+
+    current_block: List[Token] = []
+    blocks: List[List[Token]] = []
+    compiler_block_idx = -1
+    in_edge_attr = False
+
+    for token in SPEC_TOKENIZER.tokenize(spec_str):
+        if token.kind == SpecTokens.UNEXPECTED:
+            # parsing error, we cannot fix this string.
+            return None
+        elif token.kind in (SpecTokens.COMPILER, SpecTokens.COMPILER_AND_VERSION):
+            # multiple compilers are not supported in Spack v0.x, so early return
+            if compiler_block_idx != -1:
+                return None
+            current_block.append(token)
+            blocks.append(current_block)
+            current_block = []
+            compiler_block_idx = len(blocks) - 1
+        elif token.kind in (
+            SpecTokens.START_EDGE_PROPERTIES,
+            SpecTokens.DEPENDENCY,
+            SpecTokens.UNQUALIFIED_PACKAGE_NAME,
+            SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME,
+        ):
+            _spec_str_reorder_compiler(compiler_block_idx, blocks)
+            compiler_block_idx = -1
+            if token.kind == SpecTokens.START_EDGE_PROPERTIES:
+                in_edge_attr = True
+            current_block.append(token)
+            blocks.append(current_block)
+            current_block = []
+        elif token.kind == SpecTokens.END_EDGE_PROPERTIES:
+            in_edge_attr = False
+            current_block.append(token)
+            blocks.append(current_block)
+            current_block = []
+        elif in_edge_attr:
+            current_block.append(token)
+        elif token.kind in (
+            SpecTokens.VERSION_HASH_PAIR,
+            SpecTokens.GIT_VERSION,
+            SpecTokens.VERSION,
+            SpecTokens.PROPAGATED_BOOL_VARIANT,
+            SpecTokens.BOOL_VARIANT,
+            SpecTokens.PROPAGATED_KEY_VALUE_PAIR,
+            SpecTokens.KEY_VALUE_PAIR,
+            SpecTokens.DAG_HASH,
+        ):
+            current_block.append(token)
+            blocks.append(current_block)
+            current_block = []
+        elif token.kind == SpecTokens.WS:
+            current_block.append(token)
+        else:
+            raise ValueError(f"unexpected token {token}")
+
+    if current_block:
+        blocks.append(current_block)
+    _spec_str_reorder_compiler(compiler_block_idx, blocks)
+
+    new_spec_str = "".join(token.value for block in blocks for token in block)
+    return new_spec_str if spec_str != new_spec_str else None
+
+
+def _spec_str_default_handler(path: str, line: int, col: int, old: str, new: str):
+    print(f"{path}:{line}:{col}: `{old}` -> `{new}`")
+
+
+SpecStrHandler = Callable[[str, int, int, str, str], None]
+
+
+def _spec_str_ast(path: str, node: ast.AST, handler: SpecStrHandler) -> None:
+    """Walk the AST of a Python file and print reformatted spec strings."""
+    for node in ast.walk(node):
+        if (
+            not isinstance(node, ast.Constant)
+            or not isinstance(node.value, str)
+            or not IS_PROBABLY_COMPILER.search(node.value)
+        ):
+            continue
+        current = node.value
+        new = _spec_str_reformat(current)
+        if new is not None:
+            handler(path, node.lineno, node.col_offset, current, new)
+
+
+def _spec_str_json_and_yaml(path: str, data: dict, handler: SpecStrHandler) -> None:
+    """Walk a YAML or JSON data structure and print reformatted spec strings."""
+    queue = [data]
+
+    while queue:
+        current = queue.pop(0)
+        if isinstance(current, dict):
+            queue.extend(current.values())
+            queue.extend(current.keys())
+        elif isinstance(current, list):
+            queue.extend(current)
+        elif isinstance(current, str) and IS_PROBABLY_COMPILER.search(current):
+            new = _spec_str_reformat(current)
+            if new is not None:
+                mark = getattr(current, "_start_mark", None)
+                if mark:
+                    line, col = mark.line + 1, mark.column + 1
+                else:
+                    line, col = 0, 0
+                handler(path, line, col, current, new)
+
+
+def _check_spec_strings(
+    paths: List[str], handler: SpecStrHandler = _spec_str_default_handler
+) -> None:
+    for path in paths:
+        is_json_or_yaml = path.endswith(".json") or path.endswith(".yaml") or path.endswith(".yml")
+        is_python = path.endswith(".py")
+        if not is_json_or_yaml and not is_python:
+            continue
+
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                if is_json_or_yaml:
+                    _spec_str_json_and_yaml(path, spack.util.spack_yaml.load_config(f), handler)
+                elif is_python:
+                    _spec_str_ast(path, ast.parse(f.read()), handler)
+        except (OSError, spack.util.spack_yaml.SpackYAMLError, SyntaxError, ValueError):
+            warnings.warn(f"skipping {path}")
+            continue
+
+
 def style(parser, args):
+    if args.spec_strings:
+        if not args.files:
+            tty.die("No files provided to check spec strings.")
+        if args.fix:
+            tty.die("spack style --fix not yet implemented for --spec-strings.")
+        return _check_spec_strings(args.files)
+
     # save initial working directory for relativizing paths later
     args.initial_working_dir = os.getcwd()
 

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -525,11 +525,8 @@ def _spec_str_reorder_compiler(idx: int, blocks: List[List[Token]]) -> None:
     # only move the compiler to the back if it exists and is not already at the end
     if not 0 <= idx < len(blocks) - 1:
         return
-    # ensure there is at least one non-WS token after the compiler token
-    for block in blocks[idx + 1 :]:
-        if any(token.kind != SpecTokens.WS for token in block):
-            break
-    else:
+    # if there's only whitespace after the compiler, don't move it
+    if all(token.kind == SpecTokens.WS for block in blocks[idx + 1 :] for token in block):
         return
     # rotate left and always add at least one WS token between compiler and previous token
     compiler_block = blocks.pop(idx)
@@ -634,7 +631,7 @@ SpecStrHandler = Callable[[str, int, int, str, str], None]
 
 
 def _spec_str_ast(path: str, tree: ast.AST, handler: SpecStrHandler) -> None:
-    """Walk the AST of a Python file and print reformatted spec strings."""
+    """Walk the AST of a Python file and apply handler to reformatted spec strings."""
     has_constant = sys.version_info >= (3, 8)
     for node in ast.walk(tree):
         if has_constant and isinstance(node, ast.Constant):
@@ -651,7 +648,7 @@ def _spec_str_ast(path: str, tree: ast.AST, handler: SpecStrHandler) -> None:
 
 
 def _spec_str_json_and_yaml(path: str, data: dict, handler: SpecStrHandler) -> None:
-    """Walk a YAML or JSON data structure and print reformatted spec strings."""
+    """Walk a YAML or JSON data structure and apply handler to reformatted spec strings."""
     queue = [data]
     seen = set()
 

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -539,9 +539,9 @@ def _spec_str_reorder_compiler(idx: int, blocks: List[List[Token]]) -> None:
     blocks.append(compiler_block)
 
 
-def _spec_str_reformat(spec_str: str):
+def _spec_str_format(spec_str: str) -> Optional[str]:
     """Given any string, try to parse as spec string, and rotate the compiler token to the end
-    of each spec instance."""
+    of each spec instance. Returns the formatted string if it was changed, otherwise None."""
     # We parse blocks of tokens that include leading whitespace, and move the compiler block to
     # the end when we hit a dependency ^... or the end of a string.
     # [@3.1][ +foo][ +bar][ %gcc@3.1][ +baz]
@@ -610,11 +610,16 @@ def _spec_str_reformat(spec_str: str):
     return new_spec_str if spec_str != new_spec_str else None
 
 
+SpecStrHandler = Callable[[str, int, int, str, str], None]
+
+
 def _spec_str_default_handler(path: str, line: int, col: int, old: str, new: str):
+    """A SpecStrHandler that prints formatted spec strings and their locations."""
     print(f"{path}:{line}:{col}: `{old}` -> `{new}`")
 
 
-def _rewrite_spec_strings(path: str, line: int, col: int, old: str, new: str):
+def _spec_str_fix_handler(path: str, line: int, col: int, old: str, new: str):
+    """A SpecStrHandler that updates formatted spec strings in files."""
     with open(path, "r", encoding="utf-8") as f:
         lines = f.readlines()
     new_line = lines[line - 1].replace(old, new)
@@ -627,11 +632,8 @@ def _rewrite_spec_strings(path: str, line: int, col: int, old: str, new: str):
         f.writelines(lines)
 
 
-SpecStrHandler = Callable[[str, int, int, str, str], None]
-
-
 def _spec_str_ast(path: str, tree: ast.AST, handler: SpecStrHandler) -> None:
-    """Walk the AST of a Python file and apply handler to reformatted spec strings."""
+    """Walk the AST of a Python file and apply handler to formatted spec strings."""
     has_constant = sys.version_info >= (3, 8)
     for node in ast.walk(tree):
         if has_constant and isinstance(node, ast.Constant):
@@ -642,13 +644,13 @@ def _spec_str_ast(path: str, tree: ast.AST, handler: SpecStrHandler) -> None:
             continue
         if not IS_PROBABLY_COMPILER.search(current_str):
             continue
-        new = _spec_str_reformat(current_str)
+        new = _spec_str_format(current_str)
         if new is not None:
             handler(path, node.lineno, node.col_offset, current_str, new)
 
 
 def _spec_str_json_and_yaml(path: str, data: dict, handler: SpecStrHandler) -> None:
-    """Walk a YAML or JSON data structure and apply handler to reformatted spec strings."""
+    """Walk a YAML or JSON data structure and apply handler to formatted spec strings."""
     queue = [data]
     seen = set()
 
@@ -663,7 +665,7 @@ def _spec_str_json_and_yaml(path: str, data: dict, handler: SpecStrHandler) -> N
         elif isinstance(current, list):
             queue.extend(current)
         elif isinstance(current, str) and IS_PROBABLY_COMPILER.search(current):
-            new = _spec_str_reformat(current)
+            new = _spec_str_format(current)
             if new is not None:
                 mark = getattr(current, "_start_mark", None)
                 if mark:
@@ -676,9 +678,8 @@ def _spec_str_json_and_yaml(path: str, data: dict, handler: SpecStrHandler) -> N
 def _check_spec_strings(
     paths: List[str], handler: SpecStrHandler = _spec_str_default_handler
 ) -> None:
-    """Open Python, JSON and YAML files, and reformat their string literals that look like spec
-    strings. A handler is called for each reformatting, which can be used to print or apply
-    fixes."""
+    """Open Python, JSON and YAML files, and format their string literals that look like spec
+    strings. A handler is called for each formatting, which can be used to print or apply fixes."""
     for path in paths:
         is_json_or_yaml = path.endswith(".json") or path.endswith(".yaml") or path.endswith(".yml")
         is_python = path.endswith(".py")
@@ -704,7 +705,7 @@ def style(parser, args):
     if args.spec_strings:
         if not args.files:
             tty.die("No files provided to check spec strings.")
-        handler = _rewrite_spec_strings if args.fix else _spec_str_default_handler
+        handler = _spec_str_fix_handler if args.fix else _spec_str_default_handler
         return _check_spec_strings(args.files, handler)
 
     # save initial working directory for relativizing paths later

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -633,19 +633,21 @@ def _rewrite_spec_strings(path: str, line: int, col: int, old: str, new: str):
 SpecStrHandler = Callable[[str, int, int, str, str], None]
 
 
-def _spec_str_ast(path: str, node: ast.AST, handler: SpecStrHandler) -> None:
+def _spec_str_ast(path: str, tree: ast.AST, handler: SpecStrHandler) -> None:
     """Walk the AST of a Python file and print reformatted spec strings."""
-    for node in ast.walk(node):
-        if (
-            not isinstance(node, ast.Constant)
-            or not isinstance(node.value, str)
-            or not IS_PROBABLY_COMPILER.search(node.value)
-        ):
+    has_constant = sys.version_info >= (3, 8)
+    for node in ast.walk(tree):
+        if has_constant and isinstance(node, ast.Constant):
+            current_str = node.value
+        elif not has_constant and isinstance(node, ast.Str):
+            current_str = node.s
+        else:
             continue
-        current = node.value
-        new = _spec_str_reformat(current)
+        if not IS_PROBABLY_COMPILER.search(current_str):
+            continue
+        new = _spec_str_reformat(current_str)
         if new is not None:
-            handler(path, node.lineno, node.col_offset, current, new)
+            handler(path, node.lineno, node.col_offset, current_str, new)
 
 
 def _spec_str_json_and_yaml(path: str, data: dict, handler: SpecStrHandler) -> None:

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -676,6 +676,9 @@ def _spec_str_json_and_yaml(path: str, data: dict, handler: SpecStrHandler) -> N
 def _check_spec_strings(
     paths: List[str], handler: SpecStrHandler = _spec_str_default_handler
 ) -> None:
+    """Open Python, JSON and YAML files, and reformat their string literals that look like spec
+    strings. A handler is called for each reformatting, which can be used to print or apply
+    fixes."""
     for path in paths:
         is_json_or_yaml = path.endswith(".json") or path.endswith(".yaml") or path.endswith(".yml")
         is_python = path.endswith(".py")

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -409,3 +409,65 @@ def test_case_sensitive_imports(tmp_path: pathlib.Path):
 def test_pkg_imports():
     assert spack.cmd.style._module_part(spack.paths.prefix, "spack.pkg.builtin.boost") is None
     assert spack.cmd.style._module_part(spack.paths.prefix, "spack.pkg") is None
+
+
+def test_spec_strings(tmp_path):
+    (tmp_path / "example.py").write_text(
+        """\
+def func(x):
+    print("dont fix %s me" % x)
+    return x.satisfies("+foo %gcc +bar") and x.satisfies("%gcc +baz")
+"""
+    )
+    (tmp_path / "example.json").write_text(
+        """\
+{
+    "spec": [
+        "+foo %gcc +bar~nope   ^dep %clang +yup @3.2 target=x86_64 /abcdef ^another   %gcc   ",
+        "%gcc +baz"
+    ],
+    "%gcc x=y": 2
+}
+"""
+    )
+    (tmp_path / "example.yaml").write_text(
+        """\
+spec:
+  - "+foo   %gcc +bar"
+  - "%gcc +baz"
+  - "this is fine %clang"
+"%gcc x=y": 2
+"""
+    )
+
+    issues = set()
+
+    def collect_issues(path: str, line: int, col: int, old: str, new: str):
+        issues.add((path, line, col, old, new))
+
+    spack.cmd.style._check_spec_strings(
+        [
+            str(tmp_path / "nonexistent.py"),
+            str(tmp_path / "example.py"),
+            str(tmp_path / "example.json"),
+            str(tmp_path / "example.yaml"),
+        ],
+        handler=collect_issues,
+    )
+
+    assert issues == {
+        (
+            str(tmp_path / "example.json"),
+            3,
+            9,
+            "+foo %gcc +bar~nope   ^dep %clang +yup @3.2 target=x86_64 /abcdef ^another   %gcc   ",
+            "+foo +bar~nope %gcc   ^dep +yup @3.2 target=x86_64 /abcdef %clang ^another   %gcc   ",
+        ),
+        (str(tmp_path / "example.json"), 4, 9, "%gcc +baz", "+baz %gcc"),
+        (str(tmp_path / "example.json"), 6, 5, "%gcc x=y", "x=y %gcc"),
+        (str(tmp_path / "example.py"), 3, 23, "+foo %gcc +bar", "+foo +bar %gcc"),
+        (str(tmp_path / "example.py"), 3, 57, "%gcc +baz", "+baz %gcc"),
+        (str(tmp_path / "example.yaml"), 2, 5, "+foo   %gcc +bar", "+foo +bar   %gcc"),
+        (str(tmp_path / "example.yaml"), 3, 5, "%gcc +baz", "+baz %gcc"),
+        (str(tmp_path / "example.yaml"), 5, 1, "%gcc x=y", "x=y %gcc"),
+    }

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -481,7 +481,7 @@ spec:
             str(tmp_path / "example.json"),
             str(tmp_path / "example.yaml"),
         ],
-        handler=spack.cmd.style._rewrite_spec_strings,
+        handler=spack.cmd.style._spec_str_fix_handler,
     )
 
     assert (

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -445,6 +445,7 @@ spec:
     def collect_issues(path: str, line: int, col: int, old: str, new: str):
         issues.add((path, line, col, old, new))
 
+    # check for issues with custom handler
     spack.cmd.style._check_spec_strings(
         [
             str(tmp_path / "nonexistent.py"),
@@ -471,3 +472,36 @@ spec:
         (str(tmp_path / "example.yaml"), 3, 5, "%gcc +baz", "+baz %gcc"),
         (str(tmp_path / "example.yaml"), 5, 1, "%gcc x=y", "x=y %gcc"),
     }
+
+    # fix the issues in the files
+    spack.cmd.style._check_spec_strings(
+        [
+            str(tmp_path / "nonexistent.py"),
+            str(tmp_path / "example.py"),
+            str(tmp_path / "example.json"),
+            str(tmp_path / "example.yaml"),
+        ],
+        handler=spack.cmd.style._rewrite_spec_strings,
+    )
+
+    assert (tmp_path / "example.json").read_text() == """\
+{
+    "spec": [
+        "+foo +bar~nope %gcc   ^dep +yup @3.2 target=x86_64 /abcdef %clang ^another   %gcc   ",
+        "+baz %gcc"
+    ],
+    "x=y %gcc": 2
+}
+"""
+    assert (tmp_path / "example.py").read_text() == """\
+def func(x):
+    print("dont fix %s me" % x)
+    return x.satisfies("+foo +bar %gcc") and x.satisfies("+baz %gcc")
+"""
+    assert (tmp_path / "example.yaml").read_text() == """\
+spec:
+  - "+foo +bar   %gcc"
+  - "+baz %gcc"
+  - "this is fine %clang"
+"x=y %gcc": 2
+"""

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -484,7 +484,9 @@ spec:
         handler=spack.cmd.style._rewrite_spec_strings,
     )
 
-    assert (tmp_path / "example.json").read_text() == """\
+    assert (
+        (tmp_path / "example.json").read_text()
+        == """\
 {
     "spec": [
         "+foo +bar~nope %gcc   ^dep +yup @3.2 target=x86_64 /abcdef %clang ^another   %gcc   ",
@@ -493,15 +495,22 @@ spec:
     "x=y %gcc": 2
 }
 """
-    assert (tmp_path / "example.py").read_text() == """\
+    )
+    assert (
+        (tmp_path / "example.py").read_text()
+        == """\
 def func(x):
     print("dont fix %s me" % x)
     return x.satisfies("+foo +bar %gcc") and x.satisfies("+baz %gcc")
 """
-    assert (tmp_path / "example.yaml").read_text() == """\
+    )
+    assert (
+        (tmp_path / "example.yaml").read_text()
+        == """\
 spec:
   - "+foo +bar   %gcc"
   - "+baz %gcc"
   - "this is fine %clang"
 "x=y %gcc": 2
 """
+    )

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1867,7 +1867,7 @@ _spack_stage() {
 _spack_style() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -b --base -a --all -r --root-relative -U --no-untracked -f --fix --root -t --tool -s --skip"
+        SPACK_COMPREPLY="-h --help -b --base -a --all -r --root-relative -U --no-untracked -f --fix --root -t --tool -s --skip --spec-strings"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2896,7 +2896,7 @@ complete -c spack -n '__fish_spack_using_command stage' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command stage' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack style
-set -g __fish_spack_optspecs_spack_style h/help b/base= a/all r/root-relative U/no-untracked f/fix root= t/tool= s/skip=
+set -g __fish_spack_optspecs_spack_style h/help b/base= a/all r/root-relative U/no-untracked f/fix root= t/tool= s/skip= spec-strings
 
 complete -c spack -n '__fish_spack_using_command style' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command style' -s h -l help -d 'show this help message and exit'
@@ -2916,6 +2916,8 @@ complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -f -a to
 complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -d 'specify which tools to run (default: import, isort, black, flake8, mypy)'
 complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -f -a skip
 complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -d 'specify tools to skip (choose from import, isort, black, flake8, mypy)'
+complete -c spack -n '__fish_spack_using_command style' -l spec-strings -f -a spec_strings
+complete -c spack -n '__fish_spack_using_command style' -l spec-strings -d 'upgrade spec strings in Python, JSON and YAML files for compatibility with Spack v1.0 and v0.x. Example: spack style --spec-strings $(git ls-files). Note: this flag will be removed in Spack v1.0.'
 
 # spack tags
 set -g __fish_spack_optspecs_spack_tags h/help i/installed a/all


### PR DESCRIPTION
Adds `spack style --spec-strings` which detects spec strings in Python, JSON and YAML files and formats the `%compiler` bit so that they are compatible with both Spack v0.x and v1.0:

```
before: `+foo %gcc +bar`
 after: `+foo +bar %gcc`

before: `%gcc x=y`
 after: `x=y %gcc`
```

It preserves original white space as much as possible. It can be used as follows:

```
spack style --spec-strings $(git ls-files)
spack style --spec-strings $(find . -name '*.yaml')
```

There is no recursion of directories.

I added `--fix`, but that should be used with caution because of false positives. Not every string can be fixed thanks to multiline python / yaml strings.

Funnily enough if you run this on Spack itself it finds its own tests cases:

```
$ spack style --spec-strings $(git ls-files)
lib/spack/spack/test/cmd/style.py:463:12: `+foo %gcc +bar~nope   ^dep %clang +yup @3.2 target=x86_64 /abcdef ^another   %gcc   ` -> `+foo +bar~nope %gcc   ^dep +yup @3.2 target=x86_64 /abcdef %clang ^another   %gcc   `
lib/spack/spack/test/cmd/style.py:466:47: `%gcc +baz` -> `+baz %gcc`
lib/spack/spack/test/cmd/style.py:467:47: `%gcc x=y` -> `x=y %gcc`
lib/spack/spack/test/cmd/style.py:468:46: `+foo %gcc +bar` -> `+foo +bar %gcc`
lib/spack/spack/test/cmd/style.py:469:46: `%gcc +baz` -> `+baz %gcc`
lib/spack/spack/test/cmd/style.py:470:47: `+foo   %gcc +bar` -> `+foo +bar   %gcc`
lib/spack/spack/test/cmd/style.py:471:47: `%gcc +baz` -> `+baz %gcc`
lib/spack/spack/test/cmd/style.py:472:47: `%gcc x=y` -> `x=y %gcc`
```