### PR TITLE
Update hip support in radiuss packages leveraging blt@0.7.0

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -279,8 +279,8 @@ class CachedCMakeBuilder(CMakeBuilder):
             entries.append("#------------------{0}\n".format("-" * 30))
 
             if spec.satisfies("^blt@0.7:"):
-                rocm_root = dirname(spec["llvm-amdgpu"].prefix)
-                options.append(cmake_cache_path("ROCM_PATH", rocm_root))
+                rocm_root = os.path.dirname(spec["llvm-amdgpu"].prefix)
+                entries.append(cmake_cache_path("ROCM_PATH", rocm_root))
             else:
                 # Explicitly setting HIP_ROOT_DIR may be a patch that is no longer necessary
                 entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -278,17 +278,22 @@ class CachedCMakeBuilder(CMakeBuilder):
             entries.append("# ROCm")
             entries.append("#------------------{0}\n".format("-" * 30))
 
-            # Explicitly setting HIP_ROOT_DIR may be a patch that is no longer necessary
-            entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
-            llvm_bin = spec["llvm-amdgpu"].prefix.bin
-            llvm_prefix = spec["llvm-amdgpu"].prefix
-            # Some ROCm systems seem to point to /<path>/rocm-<ver>/ and
-            # others point to /<path>/rocm-<ver>/llvm
-            if os.path.basename(os.path.normpath(llvm_prefix)) != "llvm":
-                llvm_bin = os.path.join(llvm_prefix, "llvm/bin/")
-            entries.append(
-                cmake_cache_filepath("CMAKE_HIP_COMPILER", os.path.join(llvm_bin, "amdclang++"))
-            )
+            if spec.satisfies("^blt@0.7:"):
+                rocm_root = dirname(spec["llvm-amdgpu"].prefix)
+                options.append(cmake_cache_path("ROCM_PATH", rocm_root))
+            else:
+                # Explicitly setting HIP_ROOT_DIR may be a patch that is no longer necessary
+                entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
+                llvm_bin = spec["llvm-amdgpu"].prefix.bin
+                llvm_prefix = spec["llvm-amdgpu"].prefix
+                # Some ROCm systems seem to point to /<path>/rocm-<ver>/ and
+                # others point to /<path>/rocm-<ver>/llvm
+                if os.path.basename(os.path.normpath(llvm_prefix)) != "llvm":
+                    llvm_bin = os.path.join(llvm_prefix, "llvm/bin/")
+                entries.append(
+                    cmake_cache_filepath("CMAKE_HIP_COMPILER", os.path.join(llvm_bin, "amdclang++"))
+                )
+
             archs = self.spec.variants["amdgpu_target"].value
             if archs[0] != "none":
                 arch_str = ";".join(archs)

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -287,7 +287,7 @@ class CachedCMakeBuilder(CMakeBuilder):
             if os.path.basename(os.path.normpath(llvm_prefix)) != "llvm":
                 llvm_bin = os.path.join(llvm_prefix, "llvm/bin/")
             entries.append(
-                cmake_cache_filepath("CMAKE_HIP_COMPILER", os.path.join(llvm_bin, "clang++"))
+                cmake_cache_filepath("CMAKE_HIP_COMPILER", os.path.join(llvm_bin, "amdclang++"))
             )
             archs = self.spec.variants["amdgpu_target"].value
             if archs[0] != "none":

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -291,7 +291,9 @@ class CachedCMakeBuilder(CMakeBuilder):
                 if os.path.basename(os.path.normpath(llvm_prefix)) != "llvm":
                     llvm_bin = os.path.join(llvm_prefix, "llvm/bin/")
                 entries.append(
-                    cmake_cache_filepath("CMAKE_HIP_COMPILER", os.path.join(llvm_bin, "amdclang++"))
+                    cmake_cache_filepath(
+                        "CMAKE_HIP_COMPILER", os.path.join(llvm_bin, "amdclang++")
+                    )
                 )
 
             archs = self.spec.variants["amdgpu_target"].value

--- a/var/spack/repos/builtin/packages/blt/package.py
+++ b/var/spack/repos/builtin/packages/blt/package.py
@@ -72,6 +72,7 @@ class Blt(Package):
     #  if you export targets this could cause problems in downstream
     #  projects if not handled properly. More info here:
     #  https://llnl-blt.readthedocs.io/en/develop/tutorial/exporting_targets.html
+    version("0.7.0", sha256="df8720a9cba1199d21f1d32649cebb9dddf95aa61bc3ac23f6c8a3c6b6083528")
     version("0.6.2", sha256="84b663162957c1fe0e896ac8e94cbf2b6def4a152ccfa12a293db14fb25191c8")
     version("0.6.1", sha256="205540b704b8da5a967475be9e8f2d1a5e77009b950e7fbf01c0edabc4315906")
     version("0.6.0", sha256="ede355e85f7b11d7c8442b51e4f7871c152093818606e00b1e1cf30f67ebdb23")

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -186,7 +186,7 @@ class Care(CachedCMakePackage, CudaPackage, ROCmPackage):
         compiler = self.compiler
         entries = super().initconfig_compiler_entries()
 
-        if spec.satisfies("+rocm"):
+        if spec.satisfies("+rocm ^blt@:0.6.99"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         llnl_link_helpers(entries, spec, compiler)

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -186,7 +186,7 @@ class Care(CachedCMakePackage, CudaPackage, ROCmPackage):
         compiler = self.compiler
         entries = super().initconfig_compiler_entries()
 
-        if spec.satisfies("+rocm ^blt@:0.6.99"):
+        if spec.satisfies("+rocm ^blt@:0.6"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         llnl_link_helpers(entries, spec, compiler)

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -221,7 +221,7 @@ class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):
         # Default entries are already defined in CachedCMakePackage, inherit them:
         entries = super().initconfig_compiler_entries()
 
-        if spec.satisfies("+rocm"):
+        if spec.satisfies("+rocm ^blt@:0.6.99"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         llnl_link_helpers(entries, spec, compiler)

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -221,7 +221,7 @@ class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):
         # Default entries are already defined in CachedCMakePackage, inherit them:
         entries = super().initconfig_compiler_entries()
 
-        if spec.satisfies("+rocm ^blt@:0.6.99"):
+        if spec.satisfies("+rocm ^blt@:0.6"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         llnl_link_helpers(entries, spec, compiler)

--- a/var/spack/repos/builtin/packages/raja-perf/package.py
+++ b/var/spack/repos/builtin/packages/raja-perf/package.py
@@ -176,7 +176,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         # Default entries are already defined in CachedCMakePackage, inherit them:
         entries = super().initconfig_compiler_entries()
 
-        if spec.satisfies("+rocm ^blt@:0.6.99"):
+        if spec.satisfies("+rocm ^blt@:0.6"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         # adrienbernede-23-01

--- a/var/spack/repos/builtin/packages/raja-perf/package.py
+++ b/var/spack/repos/builtin/packages/raja-perf/package.py
@@ -176,7 +176,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         # Default entries are already defined in CachedCMakePackage, inherit them:
         entries = super().initconfig_compiler_entries()
 
-        if spec.satisfies("+rocm"):
+        if spec.satisfies("+rocm ^blt@:0.6.99"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         # adrienbernede-23-01

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -295,7 +295,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         # Default entries are already defined in CachedCMakePackage, inherit them:
         entries = super().initconfig_compiler_entries()
 
-        if spec.satisfies("+rocm ^blt@:0.6.99"):
+        if spec.satisfies("+rocm ^blt@:0.6"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         llnl_link_helpers(entries, spec, compiler)

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -295,7 +295,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         # Default entries are already defined in CachedCMakePackage, inherit them:
         entries = super().initconfig_compiler_entries()
 
-        if spec.satisfies("+rocm"):
+        if spec.satisfies("+rocm ^blt@:0.6.99"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         llnl_link_helpers(entries, spec, compiler)

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -324,7 +324,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         # Default entries are already defined in CachedCMakePackage, inherit them:
         entries = super().initconfig_compiler_entries()
 
-        if spec.satisfies("+rocm ^blt@:0.6.99"):
+        if spec.satisfies("+rocm ^blt@:0.6"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         option_prefix = "UMPIRE_" if spec.satisfies("@2022.03.0:") else ""

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -324,7 +324,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         # Default entries are already defined in CachedCMakePackage, inherit them:
         entries = super().initconfig_compiler_entries()
 
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm ^blt@:0.6.99"):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         option_prefix = "UMPIRE_" if spec.satisfies("@2022.03.0:") else ""


### PR DESCRIPTION
This PR aims at completing the update of the hip support in radiuss packages thanks to new hip support in blt@0.7.0.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
