### PR TITLE
spack style --spec-strings: fix non-str constant issue

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -636,7 +636,7 @@ def _spec_str_ast(path: str, tree: ast.AST, handler: SpecStrHandler) -> None:
     """Walk the AST of a Python file and apply handler to formatted spec strings."""
     has_constant = sys.version_info >= (3, 8)
     for node in ast.walk(tree):
-        if has_constant and isinstance(node, ast.Constant):
+        if has_constant and isinstance(node, ast.Constant) and isinstance(node.value, str):
             current_str = node.value
         elif not has_constant and isinstance(node, ast.Str):
             current_str = node.s

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -415,7 +415,7 @@ def test_spec_strings(tmp_path):
     (tmp_path / "example.py").write_text(
         """\
 def func(x):
-    print("dont fix %s me" % x)
+    print("dont fix %s me" % x, 3)
     return x.satisfies("+foo %gcc +bar") and x.satisfies("%gcc +baz")
 """
     )
@@ -500,7 +500,7 @@ spec:
         (tmp_path / "example.py").read_text()
         == """\
 def func(x):
-    print("dont fix %s me" % x)
+    print("dont fix %s me" % x, 3)
     return x.satisfies("+foo +bar %gcc") and x.satisfies("+baz %gcc")
 """
     )


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
