### PR TITLE
Ensure multiline YAML strings are formatted using the "|" style

### DIFF
--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -313,6 +313,34 @@ def test_config_add_override_from_file(mutable_empty_config, tmpdir):
     )
 
 
+def test_config_add_preserve_multiline_string(mutable_empty_config, tmpdir):
+    config("--scope", "site", "add", "config:test1:foo")
+    contents = """spack:
+  config::
+    multi_line_test: |-
+      testing a multi
+      line string
+"""
+
+    file = str(tmpdir.join("spack.yaml"))
+    with open(file, "w", encoding="utf-8") as f:
+        f.write(contents)
+    config("add", "-f", file)
+    config("add", "config:test2:bar")
+    output = config("get", "config")
+
+    assert (
+        output
+        == """config:
+  multi_line_test: |-
+    testing a multi
+    line string
+  test2: bar
+  test1: foo
+"""
+    )
+
+
 def test_config_add_override_leaf_from_file(mutable_empty_config, tmpdir):
     config("--scope", "site", "add", "config:template_dirs:test1")
     contents = """spack:

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -182,6 +182,8 @@ class OrderedLineRepresenter(representer.RoundTripRepresenter):
     def represent_str(self, data):
         if hasattr(data, "override") and data.override:
             data = data + ":"
+        if len(data.splitlines()) > 1:
+            return super().represent_scalar('tag:yaml.org,2002:str', data, style="|")
         return super().represent_str(data)
 
 

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -183,7 +183,7 @@ class OrderedLineRepresenter(representer.RoundTripRepresenter):
         if hasattr(data, "override") and data.override:
             data = data + ":"
         if len(data.splitlines()) > 1:
-            return super().represent_scalar('tag:yaml.org,2002:str', data, style="|")
+            return super().represent_scalar("tag:yaml.org,2002:str", data, style="|")
         return super().represent_str(data)
 
 


### PR DESCRIPTION
This merge updates the formatting of multiline YAML strings to use the "|" style instead of forcing them to be formatted with newline characters.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
