### PR TITLE
libunwind: variant component value setjump -> setjmp

### DIFF
--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -50,7 +50,7 @@ class Libunwind(AutotoolsPackage):
 
     variant(
         "components",
-        values=any_combination_of("coredump", "ptrace", "setjump"),
+        values=any_combination_of("coredump", "ptrace", "setjmp"),
         description="Build specified libunwind libraries",
     )
 


### PR DESCRIPTION
This PR fixes a typo in the `libunwind` variant `components` where the correct value is `setjmp`, not `setjump`.

With `setjump`, the configure flags `--enable-setjump` and `--disable-setjump` result in
```
configure: WARNING: unrecognized options: --disable-setjump
```
Indeed, the correct flag is `setjmp` without `u`, per https://github.com/libunwind/libunwind/blob/v1.8.1/configure.ac#L196 (and as far back as the oldest version, https://github.com/libunwind/libunwind/blob/v1.2.1/configure.ac#L124).

There are no explicit users of this flag in the builtin repository.