### PR TITLE
dcap: add test dependency on cunit

### DIFF
--- a/var/spack/repos/builtin/packages/dcap/package.py
+++ b/var/spack/repos/builtin/packages/dcap/package.py
@@ -28,6 +28,8 @@ class Dcap(AutotoolsPackage):
     depends_on("libxcrypt")
     depends_on("zlib-api")
 
+    depends_on("cunit", type="test")
+
     variant("plugins", default=True, description="Build plugins")
 
     def patch(self):


### PR DESCRIPTION
This PR adds to `dcap` the test dependency on `cunit`, as used in https://github.com/dCache/dcap/blob/master/tests/test_url.c#L3 (for all versions in spack).
