### PR TITLE
new package: regenie

### DIFF
--- a/var/spack/repos/builtin/packages/bgen/dont-build-with-bundled-deps.patch
+++ b/var/spack/repos/builtin/packages/bgen/dont-build-with-bundled-deps.patch
@@ -1,0 +1,97 @@
+diff --git a/wscript b/wscript
+index a6385d9..1a17fc0 100644
+--- a/wscript
++++ b/wscript
+@@ -24,6 +24,8 @@ def configure( cfg ):
+ 		raise Exception( "Unknown value for --mode, please specify --mode=debug or --mode=release" )
+ 
+ 	cfg.check_cxx( lib='z', uselib_store='zlib', msg = 'zlib' )
++	cfg.check_cxx( lib='zstd', uselib_store='zstd', msg = 'zstd' )
++	cfg.check_cxx( lib='sqlite3', uselib_store='sqlite', msg = 'sqlite' )
+ 	if platform.system() != "Darwin":
+ 		cfg.check_cxx( lib='rt', uselib_store='rt', msg = 'rt' )
+ 		cfg.check_cxx( lib='pthread', uselib_store='pthread', msg = 'pthread' )
+@@ -63,7 +65,7 @@ def build( bld ):
+ 		use = 'zlib zstd sqlite3 db',
+ 		export_includes = 'genfile/include'
+ 	)
+-	bld.recurse( [ '3rd_party', 'appcontext', 'genfile', 'db', 'apps', 'example', 'test', 'R' ] )
++	bld.recurse( [ 'appcontext', 'genfile', 'db', 'apps', 'example', 'test', 'R' ] )
+ 	# Copy files into rbgen package directory
+ 	for source in bgen_sources:
+ 		bld( rule = 'cp ${SRC} ${TGT}', source = source, target = 'R/rbgen/src/bgen/' + os.path.basename( source.abspath() ), always = True )
+@@ -125,66 +127,19 @@ class ReleaseBuilder:
+ 		rbgen_dir = os.path.join( tempdir, release_stub )
+ 		shutil.copytree( 'R/package/', rbgen_dir )
+ 		os.makedirs( os.path.join( rbgen_dir, "src", "include" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "include", "boost" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "include", "zstd-1.1.0" ))
+ 		os.makedirs( os.path.join( rbgen_dir, "src", "db" ))
+ 		os.makedirs( os.path.join( rbgen_dir, "src", "bgen" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "boost" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "sqlite3" ))
+-		os.makedirs( os.path.join( rbgen_dir, "src", "zstd-1.1.0" ))
+ 
+ 		# Copy source files in
+ 		from glob import glob
+ 		for filename in glob( 'src/*.cpp' ):
+ 			shutil.copy( filename, os.path.join( rbgen_dir, "src", "bgen", os.path.basename( filename ) ) )
+ 
+-		for filename in glob( 'db/src/*.cpp' ):
+-			shutil.copy( filename, os.path.join( rbgen_dir, "src", "db", os.path.basename( filename ) ) )
+-
+-		for filename in glob( '3rd_party/sqlite3/sqlite3/sqlite3.c' ):
+-			shutil.copy( filename, os.path.join( rbgen_dir, "src", "sqlite3", os.path.basename( filename ) ) )
+-
+-		for filename in glob( '3rd_party/zstd-1.1.0/lib/common/*.c' ) + glob( '3rd_party/zstd-1.1.0/lib/compress/*.c' ) + glob( '3rd_party/zstd-1.1.0/lib/decompress/*.c' ):
+-			shutil.copy( filename, os.path.join( rbgen_dir, "src", "zstd-1.1.0", os.path.basename( filename ) ) )
+-
+-		boostGlobs = [
+-			'libs/system/src/*.cpp',
+-			'libs/thread/src/*.cpp',
+-			'libs/thread/src/*.inl',
+-			'libs/thread/src/pthread/once_atomic.cpp',
+-			'libs/thread/src/pthread/thread.cpp',
+-			'libs/thread/src/pthread/timeconv.inl',
+-			'libs/filesystem/src/*.cpp',
+-			'libs/date_time/src/posix_time/*.cpp',
+-			'libs/timer/src/*.cpp',
+-			'libs/chrono/src/*.cpp',
+-		]
+-
+-		for pattern in boostGlobs:
+-			for filename in glob( '3rd_party/boost_1_55_0/%s' % pattern ):
+-				shutil.copy( filename, os.path.join( rbgen_dir, "src", "boost", os.path.basename( filename ) ) )
+-
+ 		include_paths = [
+-			"3rd_party/boost_1_55_0/boost/",
+-			"3rd_party/zstd-1.1.0/",
+-			"3rd_party/sqlite3/",
+ 			"genfile/include/genfile",
+ 			"db/include/db"
+ 		]
+ 		
+-		boostHeaderLibs = [
+-			'system',
+-			'thread',
+-			'filesystem',
+-			'date_time',
+-			'timer',
+-			'chrono',
+-			'preprocessor',
+-			'function',
+-			'optional',
+-			'mpl'
+-		]
+-		
+ 		for include_path in include_paths:
+ 			for root, path, filenames in os.walk( include_path ):
+ 				self.makedirs( os.path.join( rbgen_dir, "src", "include", root ))
+@@ -198,7 +153,6 @@ class ReleaseBuilder:
+ 					):
+ 						dest = os.path.join( rbgen_dir, "src", "include", root, name )
+ 						shutil.copy( fullname, os.path.join( rbgen_dir, "src", "include", fullname ))
+-						#print "Copied \"%s\"." % fullname
+ 
+ 		tarball = self.create_tarball( 'rbgen', release_stub, tempdir )
+ 		return os.path.join( tempdir, tarball )

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -44,4 +44,3 @@ class Bgen(WafPackage):
             src_dir = join_path(prefix.src.bgen)
             makedirs(src_dir)
             install_tree(self.stage.source_path, src_dir)
-

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -18,6 +18,7 @@ class Bgen(WafPackage):
     homepage = "https://enkre.net/cgi-bin/code/bgen"
 
     license("BSL-1.0")
+    maintainers("teaguesterling")
 
     version(
         "1.1.7",
@@ -27,3 +28,9 @@ class Bgen(WafPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+
+    def flag_handler(self, name, flags):
+        # Version 1.1.7 not compatible with C++17
+        if name == "cxxflags":
+            flags.append("-std=c++14")
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -26,11 +26,22 @@ class Bgen(WafPackage):
         url="https://enkre.net/cgi-bin/code/bgen/tarball/6ac2d582f9/BGEN-6ac2d582f9.tar.gz",
     )
 
+    variant("source", default=False, description="Install source tree as well")
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("fossil", type="build")
 
     def flag_handler(self, name, flags):
         # Version 1.1.7 not compatible with C++17
         if name == "cxxflags":
-            flags.append("-std=c++14")
+            flags.append("-std=c++11")
         return (flags, None, None)
+
+    def install(self, spec, prefix):
+        super().install(spec, prefix)
+        if spec.satisfies("+source"):
+            src_dir = join_path(prefix.src.bgen)
+            makedirs(src_dir)
+            install_tree(self.stage.source_path, src_dir)
+

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -27,6 +27,7 @@ class Bgen(WafPackage):
     )
 
     variant("headers", default=True, description="Install headers")
+    variant("libs", default=True, description="Install static libraries")
     variant("bundled-deps", default=False, description="Use bundled 3rd party dependencies")
     variant("full-source", default=False, description="Install source tree as well")
 
@@ -99,7 +100,17 @@ class Bgen(WafPackage):
                 if src not in ["genfile"]:
                     install_tree(src_dir, code_dir)
 
+        if spec.satisfies("+libs"):
+            mkdirp(prefix.lib.bgen)
+            build_dir = join_path(self.stage.source_path, "build")
+            install(join_path(build_dir, "libbgen.a"), prefix.lib.bgen)
+            install(join_path(build_dir, "db/libdb.a"), prefix.lib.bgen.db)
+
         if spec.satisfies("+full-source"):
             src_dir = join_path(prefix.opt.src.bgen)
             makedirs(src_dir)
             install_tree(self.stage.source_path, src_dir)
+
+    @property
+    def bgen_static_lib_dir(self):
+        return self.install.lib.bgen

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -101,7 +101,7 @@ class Bgen(WafPackage):
                     install_tree(src_dir, code_dir)
 
         if spec.satisfies("+libs"):
-            mkdirp(prefix.lib.bgen)
+            mkdirp(prefix.lib.bgen.db)
             build_dir = join_path(self.stage.source_path, "build")
             install(join_path(build_dir, "libbgen.a"), prefix.lib.bgen)
             install(join_path(build_dir, "db/libdb.a"), prefix.lib.bgen.db)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -26,21 +26,80 @@ class Bgen(WafPackage):
         url="https://enkre.net/cgi-bin/code/bgen/tarball/6ac2d582f9/BGEN-6ac2d582f9.tar.gz",
     )
 
-    variant("source", default=False, description="Install source tree as well")
+    variant("headers", default=True, description="Install headers")
+    variant("bundled-deps", default=False, description="Use bundled 3rd party dependencies")
+    variant("full-source", default=False, description="Install source tree as well")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fossil", type="build")
+    depends_on("zlib-api")
+
+    with when("~bundled-deps"):
+        # Upper bound of boost not known. Doesn't work with 1.85
+        depends_on(
+            "boost@1.55:+chrono+date_time+exception+filesystem+math+system+thread+timer+shared"
+        )
+        depends_on("sqlite@3")
+        depends_on("zstd libs=shared,static")
+        patch("dont-build-with-bundled-deps.patch")
 
     def flag_handler(self, name, flags):
         # Version 1.1.7 not compatible with C++17
         if name == "cxxflags":
             flags.append("-std=c++11")
+        elif name == "ldflags":
+            deps = ["zlib-api"]
+            if self.spec.satisfies("~bundled-deps"):
+                deps += ["boost", "zstd", "sqlite"]
+            for dep in deps:
+                flags.append(self.spec[dep].libs.ld_flags)
         return (flags, None, None)
+
+    def patch(self):
+        filter_file("-Wno-c++11-long-long", "", "wscript", string=True)  # Creates lots of noise
+
+        if self.spec.satisfies("^boost@1.56:"):
+            filter_file(
+                "(total_count == 0)", 
+                "(*total_count == 0)", 
+                "appcontext/src/CmdLineUIContext.cpp",
+                string=True,
+            )
+
+        # Update build script to remove references to bundled dependencies
+        if self.spec.satisfies("~bundled-deps"):
+            for dep, old_include in [
+                ("boost", '"3rd_party/boost_1_55_0/boost/"'),
+                ("zstd", '"3rd_party/zstd-1.1.0/"'),
+                ("sqlite", '"3rd_party/sqlite3/"'),
+            ]:
+                header_dirs = self.spec[dep].headers.directories
+                new_include = ", ".join(f'"{d}"' for d in header_dirs)
+                filter_file(old_include, new_include, "wscript")
+            filter_file(
+                '"sqlite3/sqlite3.h"',
+                "<sqlite3.h>",
+                "db/include/db/SQLite3Connection.hpp",
+                "db/include/db/SQLite3Statement.hpp",
+                "db/include/db/SQLStatement.hpp",
+                "db/src/SQLite3Statement.cpp",
+                "db/src/SQLStatement.cpp",
+                string=True,
+            )
 
     def install(self, spec, prefix):
         super().install(spec, prefix)
-        if spec.satisfies("+source"):
-            src_dir = join_path(prefix.src.bgen)
+        if spec.satisfies("+headers"):
+            for src in ["appcontext", "db", "genfile"]:
+                include_dir = join_path(self.stage.source_path, src, "include")
+                src_dir = join_path(self.stage.source_path, src, "src")
+                code_dir = join_path(prefix.src.bgen, src)
+                install_tree(include_dir, prefix.include.bgen)
+                if src not in ["genfile"]:
+                    install_tree(src_dir, code_dir)
+
+        if spec.satisfies("+full-source"):
+            src_dir = join_path(prefix.opt.src.bgen)
             makedirs(src_dir)
             install_tree(self.stage.source_path, src_dir)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -18,7 +18,6 @@ class Bgen(WafPackage):
     homepage = "https://enkre.net/cgi-bin/code/bgen"
 
     license("BSL-1.0")
-    maintainers("teaguesterling")
 
     version(
         "1.1.7",
@@ -26,21 +25,5 @@ class Bgen(WafPackage):
         url="https://enkre.net/cgi-bin/code/bgen/tarball/6ac2d582f9/BGEN-6ac2d582f9.tar.gz",
     )
 
-    variant("source", default=False, description="Install source tree as well")
-
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    depends_on("fossil", type="build")
-
-    def flag_handler(self, name, flags):
-        # Version 1.1.7 not compatible with C++17
-        if name == "cxxflags":
-            flags.append("-std=c++11")
-        return (flags, None, None)
-
-    def install(self, spec, prefix):
-        super().install(spec, prefix)
-        if spec.satisfies("+source"):
-            src_dir = join_path(prefix.src.bgen)
-            makedirs(src_dir)
-            install_tree(self.stage.source_path, src_dir)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -18,6 +18,7 @@ class Bgen(WafPackage):
     homepage = "https://enkre.net/cgi-bin/code/bgen"
 
     license("BSL-1.0")
+    maintainers("teaguesterling")
 
     version(
         "1.1.7",
@@ -25,5 +26,21 @@ class Bgen(WafPackage):
         url="https://enkre.net/cgi-bin/code/bgen/tarball/6ac2d582f9/BGEN-6ac2d582f9.tar.gz",
     )
 
+    variant("source", default=False, description="Install source tree as well")
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("fossil", type="build")
+
+    def flag_handler(self, name, flags):
+        # Version 1.1.7 not compatible with C++17
+        if name == "cxxflags":
+            flags.append("-std=c++11")
+        return (flags, None, None)
+
+    def install(self, spec, prefix):
+        super().install(spec, prefix)
+        if spec.satisfies("+source"):
+            src_dir = join_path(prefix.src.bgen)
+            makedirs(src_dir)
+            install_tree(self.stage.source_path, src_dir)

--- a/var/spack/repos/builtin/packages/bgen/package.py
+++ b/var/spack/repos/builtin/packages/bgen/package.py
@@ -62,8 +62,8 @@ class Bgen(WafPackage):
 
         if self.spec.satisfies("^boost@1.56:"):
             filter_file(
-                "(total_count == 0)", 
-                "(*total_count == 0)", 
+                "(total_count == 0)",
+                "(*total_count == 0)",
                 "appcontext/src/CmdLineUIContext.cpp",
                 string=True,
             )

--- a/var/spack/repos/builtin/packages/regenie/fix-cxxopts-with-new-boost.patch
+++ b/var/spack/repos/builtin/packages/regenie/fix-cxxopts-with-new-boost.patch
@@ -1,0 +1,19 @@
+diff --git a/src/Regenie.cpp b/src/Regenie.cpp
+index b501f4f..4a06c21 100755
+--- a/src/Regenie.cpp
++++ b/src/Regenie.cpp
+@@ -1393,11 +1393,11 @@ void read_params_and_check(int& argc, char *argv[], struct param* params, struct
+     check_seed(params->rng_seed, vm.count("seed"));
+     print_args(arguments, valid_args, sout);
+ 
+-  } catch (const cxxopts::OptionException& e) {
++  } catch (const cxxopts::exceptions::exception& msg) {
+     if (sout.coss.is_open())
+       print_header(sout.coss);
+     print_header(cout);
+-    sout << "ERROR: " << e.what() << endl << params->err_help << "\n";
++    sout << "ERROR: " << msg.what() << endl << params->err_help << "\n";
+     exit(EXIT_FAILURE);
+   } catch (const std::string& msg) {// after opening sout
+     sout <<  "ERROR: " <<  msg << "\n" <<  params->err_help << "\n";
+

--- a/var/spack/repos/builtin/packages/regenie/package.py
+++ b/var/spack/repos/builtin/packages/regenie/package.py
@@ -18,47 +18,61 @@ class Regenie(CMakePackage):
 
     version("4.1", sha256="a7d8ad321ca66bd10fa5ed651c63069886f5cb5ef8e900ca9a0c5b7e3dfc7da5")
 
-    variant("boostio", default=True, description="Build with Boost IO support")
+    variant("with-boostio", default=True, description="Build with Boost IO support")
+    variant("with-htslib", default=True, description="Build with HTSLib support")
     variant("static", default=False, description="Build a statically linked version")
     variant("bundled-eigen", default=False, description="Build with vendored eigen library")
     variant("bundled-cxxopts", default=False, description="Build with vendored cxxopts library")
     variant("bundled-lbfgspp", default=False, description="Build with vendored LBFGSpp library")
     variant(
-        "bgen-bundled-deps", default=False, description="Build with sqlite, boost, and zstd from bgen"
+        "bgen-bundled-deps",
+        default=False,
+        description="Build with sqlite, boost, and zstd from bgen",
     )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
+    depends_on("cmake@3.13:", type="build")
     depends_on("zlib-api")
     depends_on("openssl")
     depends_on("bzip2")
     depends_on("lzma")
     depends_on("libdeflate")
+    depends_on("python")
     depends_on("netlib-lapack+lapacke+external-blas")
     depends_on("openblas threads=openmp")
-    depends_on("htslib")
-    depends_on("htslib+pic", when="+static")
-    depends_on("python@3")
     depends_on("bgen+headers+libs", when="~bgen-bundled-deps")
     depends_on("bgen+full-source", when="+bgen-bundled-deps")
-    depends_on("cmake@3.13:")
-    depends_on("boost+iostreams", when="+boostio")
+    depends_on("boost+iostreams", when="+with-boostio")
     depends_on("eigen@3.4:", when="~bundled-eigen")
     depends_on("cxxopts@3", when="~bundled-cxxopts")
     depends_on("cxxopts@3.0", when="~bundled-cxxopts+bgen-bundled-deps")
     depends_on("lbfgspp", when="~bundled-lbfgspp")
 
+    with when("+with-htslib"):
+        depends_on("htslib")
+        depends_on("htslib+pic", when="+static")
+
     with when("~bgen-bundled-deps"):
         depends_on("bgen~bundled-deps")
         depends_on("zstd")
         depends_on("sqlite@3")
-        depends_on("boost@1.55:+chrono+date_time+exception+filesystem+math+system+thread+timer")
+
+        # regenie forces use of C++11 standard, boost::math requires C++14 after v1.82
+        depends_on(
+            "boost@1.55:1.81+chrono+date_time+exception+filesystem+math+system+thread+timer"
+        )
         depends_on("zstd libs=static", when="+static")
         with when("~static"):
             depends_on("zstd libs=shared")
             depends_on("boost+shared")
+
+    # cxxopts changed the name of the base exception class after 3.0
+    # This patch also changed the exception variable from e to msg to avoid any
+    # misleading error messages pointing to "e" from boost::math
+    patch("fix-cxxopts-with-new-boost.patch", when="^cxxopts@3.1:")
 
     def patch(self):
         satisfies = self.spec.satisfies
@@ -91,21 +105,6 @@ class Regenie(CMakePackage):
 
         # Record any libraries that will be statically linked by default
         statics = ["hts"]
-        statics_lib_overrides = {
-            "boost": [
-                "boost_chrono",
-                "boost_exception",
-                "boost_date_time",
-                "boost_filesystem",
-                "boost_math",
-                "boost_system",
-                "boost_thread",
-                "boost_timer",
-            ]
-        }
-
-        if satisfies("+boostio"):
-            statics_lib_overrides["boost"].append("boost_iostreams")
 
         # Avoid using (some) vendored dependencies included with regenie
         for dep, old_path in [
@@ -115,19 +114,15 @@ class Regenie(CMakePackage):
         ]:
             if self.spec.satisfies(f"~bundled-{dep}"):
                 lib = self.spec[dep]
-                filter_file(
-                    old_path, 
-                    dep_dirs(lib.headers), 
-                    "CMakeLists.txt",
-                    string=True,
-                )
+                filter_file(old_path, dep_dirs(lib.headers), "CMakeLists.txt", string=True)
 
         # Avoid using vendored dependencies distribued with bgen
         if satisfies("~bgen-bundled-deps"):
+
+            # zstd and sqlite can be replaced with subsitutions
             for dep, lib_name, old_lib, old_inc in [
                 ("zstd", "zstd", "zstd-1.1.0", "zstd-1.1.0/lib"),
                 ("sqlite", "sqlite3", "sqlite3", "sqlite3"),
-                ("boost", "boost", "boost_1_55_0", "boost_1_55_0/"),
             ]:
                 lib = self.spec[dep]
                 lib_pat = f'"${{BGEN_PATH}}/build/3rd_party/{old_lib}"'
@@ -136,36 +131,65 @@ class Regenie(CMakePackage):
                 filter_file(inc_pat, dep_dirs(lib.headers), "CMakeLists.txt", string=True)
                 statics.append(lib_name)
 
+            # Boost needs more careful handling using find_package since bgen created a single
+            # static archive that doesn't find/replace as easily
+            statics.append("boost")
+            boost = self.spec["boost"]
+            boost_vers = boost.version.up_to(2)
+            boost_comps = [
+                "chrono",
+                "exception",
+                "date_time",
+                "filesystem",
+                "system",
+                "thread",
+                "timer",
+            ]
+            if satisfies("+with-boostio"):
+                boost_comps.append("iostreams")
+            boost_lib = (
+                "find_library(Boost_LIBRARY libboost.a"
+                ' HINTS "${BGEN_PATH}/build/3rd_party/boost_1_55_0" REQUIRED)'
+            )
+            boost_pkg = (
+                f"find_package(Boost {boost_vers}" f" COMPONENTS {' '.join(boost_comps)} REQUIRED)"
+            )
+            for find, replace in [
+                (boost_lib, boost_pkg),
+                ("${Boost_LIBRARY}", "${Boost_LIBRARIES}"),
+                ("${BGEN_PATH}/3rd_party/boost_1_55_0/", "${Boost_INCLUDE_DIR}"),
+            ]:
+                filter_file(find, replace, "CMakeLists.txt", string=True)
+
         # Convert static libraries to shared unless we are actually building static
         if satisfies("~static"):
-            for lib_name in statics:
-                if lib_name in statics_lib_overrides:
-                    lib_override = " ".join(statics_lib_overrides[lib_name])
-                else:
-                    lib_override = lib_name
-                filter_file(f"lib{lib_name}.a", lib_override, "CMakeLists.txt", string=True)
-        elif satisfies("~bgen-bundled-deps"):
-            for lib_name, overrides in statics_lib_overrides.items():
-                override = [f"lib{override}.a" for override in statics_lib_overrides[lib_name]]
-                filter_file(f"lib{lib_name}.a", " ".join(override), "CMakeLists.txt", string=True)
+            for lib in statics:
+                filter_file(f"lib{lib}.a", lib, "CMakeLists.txt", string=True)
 
+        # The bgen package installs libraries and headers in more traditional locations
+        # if we don't use the full source option. Patch the paths for compiling
         bgen = self.spec["bgen"]
         if satisfies("^bgen~full-source"):
             for old_path, new_path in [
                 ("${BGEN_PATH}/build", bgen.prefix.lib.bgen),
-                ("${BGEN_PATH} ${BGEN_PATH}/genfile/include/", f"{bgen.prefix.include} {bgen.prefix.include.genfile}"),
+                (
+                    "${BGEN_PATH} ${BGEN_PATH}/genfile/include/",
+                    f"{bgen.prefix.include} {bgen.prefix.include.bgen}",
+                ),
                 ("${BGEN_PATH}/db/include/", bgen.prefix.include.db),
             ]:
                 filter_file(old_path, new_path, "CMakeLists.txt", string=True)
 
     def setup_build_environment(self, env):
         bgen = self.spec["bgen"]
-        htslib = self.spec["htslib"]
         openblas = self.spec["openblas"]
-        env.set("HTSLIB_PATH", htslib.prefix.lib)
         env.set("OPENBLAS_ROOT", openblas.prefix)
-        env.set("STATIC", "1" if self.spec.satisfies("+static") else "0")
-        env.set("HAS_BOOST_IOSTREAM", "1" if self.spec.satisfies("+boostio") else "0")
+        if self.spec.satisfies("+static"):
+            env.set("STATIC", "1")
+        if self.spec.satisfies("+with-boostio"):
+            env.set("HAS_BOOST_IOSTREAM", "1")
+        if self.spec.satisfies("with-htslib"):
+            env.set("HTSLIB_PATH", self.spec["htslib"].prefix.lib)
         if self.spec.satisfies("^bgen~full-source"):
             env.set("BGEN_PATH", bgen.prefix)
         else:

--- a/var/spack/repos/builtin/packages/regenie/package.py
+++ b/var/spack/repos/builtin/packages/regenie/package.py
@@ -1,0 +1,151 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Regenie(CMakePackage):
+    """regenie is a C++ program for whole genome regression modelling of large genome-wide
+    association studies."""
+
+    homepage = "https://rgcgithub.github.io/regenie/"
+    url = "https://github.com/rgcgithub/regenie/archive/refs/tags/v4.1.tar.gz"
+
+    maintainers("teaguesterling")
+
+    license("MIT", checked_by="teaguesterling")
+
+    version("4.1", sha256="a7d8ad321ca66bd10fa5ed651c63069886f5cb5ef8e900ca9a0c5b7e3dfc7da5")
+
+    variant("boostio", default=True, description="Build with Boost IO support")
+    variant("static", default=False, description="Build a statically linked version")
+    variant("builtin-eigen", default=False, description="Build with vendored eigen library")
+    variant("builtin-cxxopts", default=False, description="Build with vendored cxxopts library")
+    variant("builtin-lbfgspp", default=False, description="Build with vendored LBFGSpp library")
+    variant(
+        "bgen-builtins", default=False, description="Build with sqlite, boost, and zstd from bgen"
+    )
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
+    depends_on("zlib")  # Not zlib-api
+    depends_on("openssl")
+    depends_on("bzip2")
+    depends_on("lzma")
+    depends_on("libdeflate")
+    depends_on("netlib-lapack+lapacke+external-blas")
+    depends_on("openblas threads=openmp")
+    depends_on("htslib")
+    depends_on("htslib+pic", when="+static")
+    depends_on("python@3")
+    depends_on("bgen+source")
+    depends_on("cmake@3.13:")
+    depends_on("boost+iostreams", when="+boostio")
+    depends_on("eigen@3.4:", when="~builtin-eigen")
+    depends_on("cxxopts@3", when="~builtin-cxxopts")
+    depends_on("cxxopts@3.0", when="~builtin-cxxopts+bgen-builtins")
+    depends_on("lbfgspp", when="~builtin-lbfgspp")
+
+    with when("~bgen-builtins"):
+        depends_on("zstd")
+        depends_on("sqlite@3")
+        depends_on("boost@1.55+chrono+date_time+exception+filesystem+math+system+thread+timer")
+        depends_on("zstd libs=static", when="+static")
+        with when("~static"):
+            depends_on("zstd libs=shared")
+            depends_on("boost+shared")
+
+    def patch(self):
+        satisfies = self.spec.satisfies
+
+        def dep_dirs(dep):
+            return " ".join(f'"{d}"' for d in dep.directories)
+
+        # Avoid accidentally linking against system
+        filter_file("-L/usr/lib", "", "Makefile")  # Don't explictly link system
+        filter_file("-Wno-c11-extensions", "", "CMakeLists.txt")  # Flag doesn't exist
+
+        # libcrypt needs to be defined explicitly and libssl needs to be linked
+        # before everything else or symbols will not be found
+        ssl = self.spec["openssl"]
+        filter_file(
+            r"  find_library\(CRYPTO_LIB crypto REQUIRED\)",
+            f"  find_library(CRYPTO_LIB crypto HINTS {dep_dirs(ssl.libs)})\n"
+            f"  find_library(SSL_LIB ssl HINTS {dep_dirs(ssl.libs)})\n"
+            "  target_link_libraries(regenie PUBLIC ${SSL_LIB})",
+            "CMakeLists.txt",
+        )
+        # libblas needs to be defined before lapack
+        filter_file(
+            r"\$\{LAPACK_LIB\} -llapacke \$\{BLAS_LIB\}",
+            "${BLAS_LIB} ${LAPACK_LIB} -llapacke",
+            "CMakeLists.txt",
+        )
+
+        # Record any libraries that will be statically linked by default
+        statics = ["hts"]
+        statics_lib_overrides = {
+            "boost": [
+                "boost_chrono",
+                "boost_exception",
+                "boost_date_time",
+                "boost_filesystem",
+                "boost_math",
+                "boost_system",
+                "boost_thread",
+                "boost_timer",
+            ]
+        }
+
+        if satisfies("+boostio"):
+            statics_lib_overrides["boost"].append("boost_iostreams")
+
+        # Avoid using (some) vendored dependencies included with regenie
+        for dep, old_path in [
+            ("eigen", r"\$\{EXTERN_LIBS_PATH\}/eigen-3.4.0/"),
+            ("cxxopts", r"\$\{EXTERN_LIBS_PATH\}/cxxopts/include/"),
+            ("lbfgspp", r"\$\{EXTERN_LIBS_PATH\}/LBFGSpp/include/"),
+        ]:
+            if self.spec.satisfies(f"~builtin-{dep}"):
+                lib = self.spec[dep]
+                filter_file(old_path, dep_dirs(lib.headers), "CMakeLists.txt")
+
+        # Avoid using vendored dependencies distribued with bgen
+        if satisfies("~bgen-builtins"):
+            for dep, lib_name, old_lib, old_inc in [
+                ("zstd", "zstd", "zstd-1.1.0", "zstd-1.1.0/lib"),
+                ("sqlite", "sqlite3", "sqlite3", "sqlite3"),
+                ("boost", "boost", "boost_1_55_0", "boost_1_55_0/"),
+            ]:
+                lib = self.spec[dep]
+                lib_pat = f'"\\$\\{{BGEN_PATH\\}}/build/3rd_party/{old_lib}"'
+                inc_pat = f"\\$\\{{BGEN_PATH\\}}/3rd_party/{old_inc}"
+                filter_file(lib_pat, dep_dirs(lib.libs), "CMakeLists.txt")
+                filter_file(inc_pat, dep_dirs(lib.headers), "CMakeLists.txt")
+                statics.append(lib_name)
+
+        # Convert static libraries to shared unless we are actually building static
+        if satisfies("~static"):
+            for lib_name in statics:
+                if lib_name in statics_lib_overrides:
+                    lib_override = " ".join(statics_lib_overrides[lib_name])
+                else:
+                    lib_override = lib_name
+                filter_file(f"lib{lib_name}\\.a", lib_override, "CMakeLists.txt")
+        elif satisfies("~bgen-builtins"):
+            for lib_name, overrides in statics_lib_overrides.items():
+                override = [f"lib{override}.a" for override in statics_lib_overrides[lib_name]]
+                filter_file(f"lib{lib_name}\\.a", " ".join(override), "CMakeLists.txt")
+
+    def setup_build_environment(self, env):
+        bgen = self.spec["bgen"]
+        htslib = self.spec["htslib"]
+        openblas = self.spec["openblas"]
+        env.set("BGEN_PATH", bgen.prefix.src.bgen)
+        env.set("HTSLIB_PATH", htslib.prefix.lib)
+        env.set("OPENBLAS_ROOT", openblas.prefix)
+        env.set("STATIC", "1" if self.spec.satisfies("+static") else "0")
+        env.set("HAS_BOOST_IOSTREAM", "1" if self.spec.satisfies("+boostio") else "0")

--- a/var/spack/repos/builtin/packages/regenie/package.py
+++ b/var/spack/repos/builtin/packages/regenie/package.py
@@ -20,18 +20,18 @@ class Regenie(CMakePackage):
 
     variant("boostio", default=True, description="Build with Boost IO support")
     variant("static", default=False, description="Build a statically linked version")
-    variant("builtin-eigen", default=False, description="Build with vendored eigen library")
-    variant("builtin-cxxopts", default=False, description="Build with vendored cxxopts library")
-    variant("builtin-lbfgspp", default=False, description="Build with vendored LBFGSpp library")
+    variant("bundled-eigen", default=False, description="Build with vendored eigen library")
+    variant("bundled-cxxopts", default=False, description="Build with vendored cxxopts library")
+    variant("bundled-lbfgspp", default=False, description="Build with vendored LBFGSpp library")
     variant(
-        "bgen-builtins", default=False, description="Build with sqlite, boost, and zstd from bgen"
+        "bgen-bundled-deps", default=False, description="Build with sqlite, boost, and zstd from bgen"
     )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
-    depends_on("zlib")  # Not zlib-api
+    depends_on("zlib-api")
     depends_on("openssl")
     depends_on("bzip2")
     depends_on("lzma")
@@ -41,18 +41,19 @@ class Regenie(CMakePackage):
     depends_on("htslib")
     depends_on("htslib+pic", when="+static")
     depends_on("python@3")
-    depends_on("bgen+source")
+    depends_on("bgen+headers+libs")
     depends_on("cmake@3.13:")
     depends_on("boost+iostreams", when="+boostio")
-    depends_on("eigen@3.4:", when="~builtin-eigen")
-    depends_on("cxxopts@3", when="~builtin-cxxopts")
-    depends_on("cxxopts@3.0", when="~builtin-cxxopts+bgen-builtins")
-    depends_on("lbfgspp", when="~builtin-lbfgspp")
+    depends_on("eigen@3.4:", when="~bundled-eigen")
+    depends_on("cxxopts@3", when="~bundled-cxxopts")
+    depends_on("cxxopts@3.0", when="~bundled-cxxopts+bgen-bundled-deps")
+    depends_on("lbfgspp", when="~bundled-lbfgspp")
 
-    with when("~bgen-builtins"):
+    with when("~bgen-bundled-deps"):
+        depends_on("bgen~bundled-deps")
         depends_on("zstd")
         depends_on("sqlite@3")
-        depends_on("boost@1.55+chrono+date_time+exception+filesystem+math+system+thread+timer")
+        depends_on("boost@1.55:+chrono+date_time+exception+filesystem+math+system+thread+timer")
         depends_on("zstd libs=static", when="+static")
         with when("~static"):
             depends_on("zstd libs=shared")
@@ -65,24 +66,26 @@ class Regenie(CMakePackage):
             return " ".join(f'"{d}"' for d in dep.directories)
 
         # Avoid accidentally linking against system
-        filter_file("-L/usr/lib", "", "Makefile")  # Don't explictly link system
-        filter_file("-Wno-c11-extensions", "", "CMakeLists.txt")  # Flag doesn't exist
+        filter_file("-L/usr/lib", "", "Makefile", string=True)  # Don't explictly link system
+        filter_file("-Wno-c11-extensions", "", "CMakeLists.txt", string=True)  # Flag doesn't exist
 
         # libcrypt needs to be defined explicitly and libssl needs to be linked
         # before everything else or symbols will not be found
         ssl = self.spec["openssl"]
         filter_file(
-            r"  find_library\(CRYPTO_LIB crypto REQUIRED\)",
+            "  find_library(CRYPTO_LIB crypto REQUIRED)",
             f"  find_library(CRYPTO_LIB crypto HINTS {dep_dirs(ssl.libs)})\n"
             f"  find_library(SSL_LIB ssl HINTS {dep_dirs(ssl.libs)})\n"
             "  target_link_libraries(regenie PUBLIC ${SSL_LIB})",
             "CMakeLists.txt",
+            string=True,
         )
         # libblas needs to be defined before lapack
         filter_file(
-            r"\$\{LAPACK_LIB\} -llapacke \$\{BLAS_LIB\}",
+            "${LAPACK_LIB} -llapacke ${BLAS_LIB}",
             "${BLAS_LIB} ${LAPACK_LIB} -llapacke",
             "CMakeLists.txt",
+            string=True,
         )
 
         # Record any libraries that will be statically linked by default
@@ -105,26 +108,31 @@ class Regenie(CMakePackage):
 
         # Avoid using (some) vendored dependencies included with regenie
         for dep, old_path in [
-            ("eigen", r"\$\{EXTERN_LIBS_PATH\}/eigen-3.4.0/"),
-            ("cxxopts", r"\$\{EXTERN_LIBS_PATH\}/cxxopts/include/"),
-            ("lbfgspp", r"\$\{EXTERN_LIBS_PATH\}/LBFGSpp/include/"),
+            ("eigen", r"${EXTERN_LIBS_PATH}/eigen-3.4.0/"),
+            ("cxxopts", r"${EXTERN_LIBS_PATH}/cxxopts/include/"),
+            ("lbfgspp", r"${EXTERN_LIBS_PATH}/LBFGSpp/include/"),
         ]:
-            if self.spec.satisfies(f"~builtin-{dep}"):
+            if self.spec.satisfies(f"~bundled-{dep}"):
                 lib = self.spec[dep]
-                filter_file(old_path, dep_dirs(lib.headers), "CMakeLists.txt")
+                filter_file(
+                    old_path, 
+                    dep_dirs(lib.headers), 
+                    "CMakeLists.txt",
+                    string=True,
+                )
 
         # Avoid using vendored dependencies distribued with bgen
-        if satisfies("~bgen-builtins"):
+        if satisfies("~bgen-bundled-deps"):
             for dep, lib_name, old_lib, old_inc in [
                 ("zstd", "zstd", "zstd-1.1.0", "zstd-1.1.0/lib"),
                 ("sqlite", "sqlite3", "sqlite3", "sqlite3"),
                 ("boost", "boost", "boost_1_55_0", "boost_1_55_0/"),
             ]:
                 lib = self.spec[dep]
-                lib_pat = f'"\\$\\{{BGEN_PATH\\}}/build/3rd_party/{old_lib}"'
-                inc_pat = f"\\$\\{{BGEN_PATH\\}}/3rd_party/{old_inc}"
-                filter_file(lib_pat, dep_dirs(lib.libs), "CMakeLists.txt")
-                filter_file(inc_pat, dep_dirs(lib.headers), "CMakeLists.txt")
+                lib_pat = f'"${{BGEN_PATH}}/build/3rd_party/{old_lib}"'
+                inc_pat = f"${{BGEN_PATH}}/3rd_party/{old_inc}"
+                filter_file(lib_pat, dep_dirs(lib.libs), "CMakeLists.txt", string=True)
+                filter_file(inc_pat, dep_dirs(lib.headers), "CMakeLists.txt", string=True)
                 statics.append(lib_name)
 
         # Convert static libraries to shared unless we are actually building static
@@ -134,11 +142,11 @@ class Regenie(CMakePackage):
                     lib_override = " ".join(statics_lib_overrides[lib_name])
                 else:
                     lib_override = lib_name
-                filter_file(f"lib{lib_name}\\.a", lib_override, "CMakeLists.txt")
-        elif satisfies("~bgen-builtins"):
+                filter_file(f"lib{lib_name}.a", lib_override, "CMakeLists.txt", string=True)
+        elif satisfies("~bgen-bundled-deps"):
             for lib_name, overrides in statics_lib_overrides.items():
                 override = [f"lib{override}.a" for override in statics_lib_overrides[lib_name]]
-                filter_file(f"lib{lib_name}\\.a", " ".join(override), "CMakeLists.txt")
+                filter_file(f"lib{lib_name}.a", " ".join(override), "CMakeLists.txt")
 
     def setup_build_environment(self, env):
         bgen = self.spec["bgen"]

--- a/var/spack/repos/builtin/packages/regenie/package.py
+++ b/var/spack/repos/builtin/packages/regenie/package.py
@@ -41,7 +41,8 @@ class Regenie(CMakePackage):
     depends_on("htslib")
     depends_on("htslib+pic", when="+static")
     depends_on("python@3")
-    depends_on("bgen+headers+libs")
+    depends_on("bgen+headers+libs", when="~bgen-bundled-deps")
+    depends_on("bgen+full-source", when="+bgen-bundled-deps")
     depends_on("cmake@3.13:")
     depends_on("boost+iostreams", when="+boostio")
     depends_on("eigen@3.4:", when="~bundled-eigen")
@@ -146,14 +147,26 @@ class Regenie(CMakePackage):
         elif satisfies("~bgen-bundled-deps"):
             for lib_name, overrides in statics_lib_overrides.items():
                 override = [f"lib{override}.a" for override in statics_lib_overrides[lib_name]]
-                filter_file(f"lib{lib_name}.a", " ".join(override), "CMakeLists.txt")
+                filter_file(f"lib{lib_name}.a", " ".join(override), "CMakeLists.txt", string=True)
+
+        bgen = self.spec["bgen"]
+        if satisfies("^bgen~full-source"):
+            for old_path, new_path in [
+                ("${BGEN_PATH}/build", bgen.prefix.lib.bgen),
+                ("${BGEN_PATH} ${BGEN_PATH}/genfile/include/", f"{bgen.prefix.include} {bgen.prefix.include.genfile}"),
+                ("${BGEN_PATH}/db/include/", bgen.prefix.include.db),
+            ]:
+                filter_file(old_path, new_path, "CMakeLists.txt", string=True)
 
     def setup_build_environment(self, env):
         bgen = self.spec["bgen"]
         htslib = self.spec["htslib"]
         openblas = self.spec["openblas"]
-        env.set("BGEN_PATH", bgen.prefix.src.bgen)
         env.set("HTSLIB_PATH", htslib.prefix.lib)
         env.set("OPENBLAS_ROOT", openblas.prefix)
         env.set("STATIC", "1" if self.spec.satisfies("+static") else "0")
         env.set("HAS_BOOST_IOSTREAM", "1" if self.spec.satisfies("+boostio") else "0")
+        if self.spec.satisfies("^bgen~full-source"):
+            env.set("BGEN_PATH", bgen.prefix)
+        else:
+            env.set("BGEN_PATH", bgen.prefix.opt.bgen)


### PR DESCRIPTION
Adds the regenie package while also using spack-based dependencies as much as possible instead of vendor dependencies from both regenie and bgen packages. This includes some patches for expanded compatibility with newer versions of the dependencies.

This depends on https://github.com/spack/spack/pull/49357/ to add the requisite features for linking.