### PR TITLE
node-js: run tests with target test-only

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -246,7 +246,8 @@ class NodeJs(Package):
     @run_after("build")
     @on_package_attributes(run_tests=True)
     def build_test(self):
-        make("test")
+        # Note: target "test" requires a full git checkout with linters
+        make("test-only")
         make("test-addons")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
This PR modifies which `node-js` target is used for testing. Since the tar archive [does not include](https://github.com/nodejs/node/blob/ab9660b55aaf78f4b296cf0d613706938a6dca08/Makefile#L1234) some directories (e.g. `tools/eslint`), the regular tests with `make test` fail. The target [`test-only`](https://github.com/nodejs/node/blob/ab9660b55aaf78f4b296cf0d613706938a6dca08/Makefile#L345) exists to avoid running the linter checks. This `test-only` target has [existed](https://github.com/nodejs/node/commit/57bd27eda8ae0f540c14c8480128bca42b387314) since v10.

Note: this still doesn't allow `node-js` to pass all tests (4 test failures), but at least it fixes an early error that prevents it from trying.