### PR TITLE
py-python-dateutil: add v2.9.0.post0

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-python-dateutil/package.py
@@ -29,8 +29,12 @@ class PyPythonDateutil(PythonPackage):
         version("1.5", sha256="6f197348b46fb8cdf9f3fcfc2a7d5a97da95db3e2e8667cf657216274fe1b009")
 
     with default_args(type="build"):
-        depends_on("py-setuptools@24.3:")
         depends_on("py-setuptools@:39", when="@2.8.0: ^python@3.3")
+        depends_on("py-setuptools@24.3:")
+
+        # 2.7.1 introduces pyproject.toml which requires toml parsing
+        # libtoml was added in python 3.11, earlier versions require py-tomli
+        depends_on("py-tomli@1:", when="@2.7.1: ^python@:3.10")
 
         depends_on("py-setuptools-scm@:7", when="@2.7.0:")
 

--- a/var/spack/repos/builtin/packages/py-python-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-python-dateutil/package.py
@@ -24,7 +24,9 @@ class PyPythonDateutil(PythonPackage):
     version("2.4.2", sha256="3e95445c1db500a344079a47b171c45ef18f57d188dffdb0e4165c71bea8eb3d")
     version("2.4.0", sha256="439df33ce47ef1478a4f4765f3390eab0ed3ec4ae10be32f2930000c8d19f417")
     version("2.2", sha256="eec865307ebe7f329a6a9945c15453265a449cdaaf3710340828a1934d53e468")
-    version("1.5", sha256="6f197348b46fb8cdf9f3fcfc2a7d5a97da95db3e2e8667cf657216274fe1b009")
+
+    with default_args(deprecated=True):
+        version("1.5", sha256="6f197348b46fb8cdf9f3fcfc2a7d5a97da95db3e2e8667cf657216274fe1b009")
 
     with default_args(type="build"):
         depends_on("py-setuptools@24.3:")
@@ -38,6 +40,6 @@ class PyPythonDateutil(PythonPackage):
         depends_on("python@2.7:2,3.3:", when="@2.7.0:")
         depends_on("python@2.6:2,3.2:", when="@2.1:")
         depends_on("python@3:", when="@2.0")
-        depends_on("python@:2", when="@:1")
+        depends_on("python", when="@:1")
 
         depends_on("py-six@1.5:", when="@2:")

--- a/var/spack/repos/builtin/packages/py-python-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-python-dateutil/package.py
@@ -32,10 +32,6 @@ class PyPythonDateutil(PythonPackage):
         depends_on("py-setuptools@:39", when="@2.8.0: ^python@3.3")
         depends_on("py-setuptools@24.3:")
 
-        # 2.7.1 introduces pyproject.toml which requires toml parsing
-        # libtoml was added in python 3.11, earlier versions require py-tomli
-        depends_on("py-tomli@1:", when="@2.7.1: ^python@:3.10")
-
         depends_on("py-setuptools-scm@:7", when="@2.7.0:")
 
         depends_on("py-wheel", when="@2.8.0:")

--- a/var/spack/repos/builtin/packages/py-python-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-python-dateutil/package.py
@@ -32,7 +32,7 @@ class PyPythonDateutil(PythonPackage):
         depends_on("py-setuptools@:39", when="@2.8.0: ^python@3.3")
         depends_on("py-setuptools@24.3:")
 
-        depends_on("py-setuptools-scm@:7", when="@2.7.0:")
+        depends_on("py-setuptools-scm@:7", when="@2.9.0.post0:")
 
         depends_on("py-wheel", when="@2.8.0:")
 

--- a/var/spack/repos/builtin/packages/py-python-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-python-dateutil/package.py
@@ -13,6 +13,9 @@ class PyPythonDateutil(PythonPackage):
 
     license("Apache-2.0")
 
+    version(
+        "2.9.0.post0", sha256="37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
+    )
     version("2.8.2", sha256="0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86")
     version("2.8.1", sha256="73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c")
     version("2.8.0", sha256="c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e")
@@ -23,7 +26,18 @@ class PyPythonDateutil(PythonPackage):
     version("2.2", sha256="eec865307ebe7f329a6a9945c15453265a449cdaaf3710340828a1934d53e468")
     version("1.5", sha256="6f197348b46fb8cdf9f3fcfc2a7d5a97da95db3e2e8667cf657216274fe1b009")
 
-    depends_on("python@2.7:2.8,3.3:", when="@2.7.5:", type=("build", "run"))
-    depends_on("py-setuptools@24.3:", type="build")
-    depends_on("py-setuptools-scm", type="build", when="@2.7.0:")
-    depends_on("py-six@1.5:", when="@2:", type=("build", "run"))
+    with default_args(type="build"):
+        depends_on("py-setuptools@24.3:")
+        depends_on("py-setuptools@:39", when="@2.8.0: ^python@3.3")
+
+        depends_on("py-setuptools-scm@:7", when="@2.7.0:")
+
+        depends_on("py-wheel", when="@2.8.0:")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@2.7:2,3.3:", when="@2.7.0:")
+        depends_on("python@2.6:2,3.2:", when="@2.1:")
+        depends_on("python@3:", when="@2.0")
+        depends_on("python@:2", when="@:1")
+
+        depends_on("py-six@1.5:", when="@2:")


### PR DESCRIPTION
Release notes:
- https://github.com/dateutil/dateutil/releases/tag/2.9.0
- https://github.com/dateutil/dateutil/releases/tag/2.9.0.post0

Tested by building and running the example in the README on my laptop.

Dependency updates based on setup.py, etc.