### PR TITLE
rocminfo: extends python

### DIFF
--- a/var/spack/repos/builtin/packages/rocminfo/package.py
+++ b/var/spack/repos/builtin/packages/rocminfo/package.py
@@ -44,6 +44,7 @@ class Rocminfo(CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("cmake@3:", type="build")
+    extends("python@3:")
 
     for ver in [
         "5.3.0",


### PR DESCRIPTION
`rocm_agent_enumerator` is a python script