### PR TITLE
gcc: do not pass abs paths to --with-ld and --with-as

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -826,18 +826,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if spec.satisfies("languages=jit"):
             options.append("--enable-host-shared")
 
-        # Binutils
-        if spec.satisfies("+binutils"):
-            binutils = spec["binutils"].prefix.bin
-            options.extend(
-                [
-                    "--with-gnu-ld",
-                    "--with-ld=" + binutils.ld,
-                    "--with-gnu-as",
-                    "--with-as=" + binutils.join("as"),
-                ]
-            )
-
         # enable_bootstrap
         if spec.satisfies("+bootstrap"):
             options.extend(["--enable-bootstrap"])


### PR DESCRIPTION
Looks like you cannot do `-fuse-ld=...` at runtime if you configure GCC with `--with-ld=/abs/path/to/bin/ld`.

During the build `binutils/bin` is in PATH, and at runtime we have a spec file that adds a programs search path `-B binutils/bin`. So there shouldn't be a need to configure `--with-ld`.
