### PR TITLE
eigen: build test executables when self.run_tests

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -84,7 +84,11 @@ class Eigen(CMakePackage, ROCmPackage):
         env.prepend_path("CPATH", self.prefix.include.eigen3)
 
     def cmake_args(self):
-        args = []
+        args = [
+            self.define("EIGEN_BUILD_TESTING", self.run_tests),
+            self.define("EIGEN_LEAVE_TEST_IN_ALL_TARGET", self.run_tests),
+        ]
+
         if self.spec.satisfies("@:3.4"):
             # CMake fails without this flag
             # https://gitlab.com/libeigen/eigen/-/issues/1656


### PR DESCRIPTION
This PR ensures that the `eigen` test executables are built before running ctest. This also resolves the side-effect of not finding the `resize` test executable and instead picking the `/usr/bin/resize` executable from xterm, which locks up the terminal.

The `EIGEN_BUILD_TESTING` flag is the replacement for `BUILD_TESTING` for the current git main branch and for future releases, so it also added here.