### PR TITLE
serf: depends on expat

### DIFF
--- a/var/spack/repos/builtin/packages/serf/package.py
+++ b/var/spack/repos/builtin/packages/serf/package.py
@@ -28,6 +28,7 @@ class Serf(SConsPackage):
 
     depends_on("apr")
     depends_on("apr-util")
+    depends_on("expat")
     depends_on("openssl")
     depends_on("python+pythoncmd", type="build")
     depends_on("scons@2.3.0:", type="build")


### PR DESCRIPTION
Tried build svn on very minimal RHEL9, hit `ld: -lexpat not found` error.
This fixes it.

It seem to be available on RHEL9 baseos with GUI installed but for very minimal, it might not.