### PR TITLE
pfunit: add mpi_f08 variant

### DIFF
--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -100,8 +100,6 @@ class Pfunit(CMakePackage):
         description="Enable MPI Fortran 2008 bindings",
         when="@4.4.0: +mpi",
     )
-    # You can't have mpi_f08 without mpi
-    conflicts("+mpi_f08", when="~mpi")
 
     # The maximum rank of an array in the Fortran 2008 standard is 15
     max_rank = 15

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -100,6 +100,8 @@ class Pfunit(CMakePackage):
         description="Enable MPI Fortran 2008 bindings",
         when="@4.4.0: +mpi",
     )
+    # You can't have mpi_f08 without mpi
+    conflicts("+mpi_f08", when="~mpi")
 
     # The maximum rank of an array in the Fortran 2008 standard is 15
     max_rank = 15
@@ -215,7 +217,7 @@ class Pfunit(CMakePackage):
             )
 
         if spec.satisfies("@4.4.0: +mpi"):
-            args.extend([self.define_from_variant("ENABLE_MPI_F08", "mpi_f08")])
+            args.append(self.define_from_variant("ENABLE_MPI_F08", "mpi_f08"))
 
         return args
 

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -93,6 +93,14 @@ class Pfunit(CMakePackage):
     variant("esmf", default=False, description="Enable esmf support")
     variant("docs", default=False, description="Build docs")
 
+    # pFUnit brought in mpi_f08 support in 4.4.0
+    variant(
+        "mpi_f08",
+        default=False,
+        description="Enable MPI Fortran 2008 bindings",
+        when="@4.4.0: +mpi",
+    )
+
     # The maximum rank of an array in the Fortran 2008 standard is 15
     max_rank = 15
     allowed_array_ranks = tuple(str(i) for i in range(3, max_rank + 1))
@@ -205,6 +213,9 @@ class Pfunit(CMakePackage):
                     self.define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc),
                 ]
             )
+
+        if spec.satisfies("@4.4.0: +mpi"):
+            args.extend([self.define_from_variant("ENABLE_MPI_F08", "mpi_f08")])
 
         return args
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

A user requested a variant for enabling `mpi_f08` support in pFUnit. From `git blame` this seems to have been added in v4.4.0 so I've tried to make the variant reflect that.

We add it as default `False` as that is how it is in the CMake.