### PR TITLE
Fix: WarpX Build Phases (Python)

### DIFF
--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -326,11 +326,11 @@ class Warpx(CMakePackage, PythonExtension):
 
         return args
 
-    phases = ("cmake", "build", "install", "pip_install_nodeps")
-    build_targets = ["all"]
-    with when("+python"):
-        build_targets += ["pip_wheel"]
+    phases = ["cmake", "build", "install"]
+    #with when("+python"):
+    #    phases += ["pip_install_nodeps"]
 
+    @run_after("install", when="+python")
     def pip_install_nodeps(self, spec, prefix):
         """Install everything from build directory."""
         pip = spec["python"].command


### PR DESCRIPTION
Fix #49546 builds without Python in WarpX.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
