### PR TITLE
simsipm: add version 2.1.0 and a variant for setting the C++ standard

### DIFF
--- a/var/spack/repos/builtin/packages/simsipm/package.py
+++ b/var/spack/repos/builtin/packages/simsipm/package.py
@@ -20,6 +20,7 @@ class Simsipm(CMakePackage):
 
     license("MIT")
 
+    version("2.1.0", sha256="e99fcf81f88419c7d7ee6aecec0bbc7a0abc85c5430a4f910a8962d6f5c54e02")
     version("2.0.2", sha256="ba60ed88b54b1b29d089f583dbce93b3272b0b13d47772941339f1503ee3fa48")
     version("1.2.4", sha256="1c633bebb19c490b5e6dfa5ada4a6bc7ec36348237c2626d57843a25af923211")
 
@@ -28,12 +29,21 @@ class Simsipm(CMakePackage):
     variant("python", default=False, description="Build pybind11-based python bindings")
     variant("openmp", default=False, description="Use OpenMP", when="@:1")
 
+    variant(
+        "cxxstd",
+        default="17",
+        values=("11", "14", "17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building.",
+    )
+
     extends("python", when="+python")
     depends_on("python@3.6:", when="+python", type=("build", "run"))
     depends_on("py-pybind11", when="+python", type=("build", "link"))
 
     def cmake_args(self):
         args = [
+            self.define("CMAKE_CXX_STANDARD", self.spec.variants["cxxstd"].value),
             self.define_from_variant("SIPM_BUILD_PYTHON", "python"),
             self.define_from_variant("SIPM_ENABLE_OPENMP", "openmp"),
             self.define("SIPM_ENABLE_TEST", self.run_tests),


### PR DESCRIPTION
From the release notes in https://github.com/EdoPro98/SimSiPM/releases/tag/v2.1.0 nothing seems to have changed with respect to dependencies. Bulit successfully with GCC 14 on Alma 9, and GCC 11 and 13 in Ubuntu 22 and 24 respectively.