### PR TITLE
fastjet: add an optimization and warning flag when building

### DIFF
--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -141,5 +141,5 @@ class Fastjet(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":
-            flags.append(f"-std=c++{self.spec.variants['cxxstd'].value}")
+            flags.append(f"-O2 -Wall -std=c++{self.spec.variants['cxxstd'].value}")
         return (None, flags, None)


### PR DESCRIPTION
Currently fastjet is being compiled without optimizations, and it has been reported that it is much slower than in other places where it is compiled with optimizations.
fastjet compiled with spack (or run `source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh` if access to CVMFS is available):
```
$ fastjet-config --config
This is FastJet version 3.4.2

Configuration invocation was

  /tmp/root/spack-stage/spack-stage-fastjet-3.4.2-4a6xxffub6i7ksfjjcdd36yvozwaszim/spack-src/configure  '--prefix=/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-01-21/x86_64-almalinux9-gcc14.2.0-opt/fastjet/3.4.2-4a6xxf' '--enable-allcxxplugins' '--enable-shared' '--disable-auto-ptr' '--enable-limited-thread-safety' 'CC=/cvmfs/2025-01-19-scratch/spack/lib/spack/env/gcc/gcc' 'CXX=/cvmfs/2025-01-19-scratch/spack/lib/spack/env/gcc/g++' 'CXXFLAGS=-std=c++20' 'FC=/cvmfs/2025-01-19-scratch/spack/lib/spack/env/gcc/gfortran'
...
```
on the LCG stacks (used to compare for speed, run `source /cvmfs/sft.cern.ch/lcg/views/devkey/latest/x86_64-el9-gcc14-opt/setup.sh` on an Alma9 machine with CVMFS):
```
$ fastjet-config --config
This is FastJet version 3.4.3

Configuration invocation was

  /build/jenkins/workspace/lcg_nightly_pipeline/build/externals/fastjet-3.4.3/src/fastjet/3.4.3/configure  '--prefix=/cvmfs/sft-nightlies.cern.ch/lcg/latest/fastjet/3.4.3-7b8bd/x86_64-el9-gcc14-opt' '--enable-shared' '--enable-allplugins' '--disable-auto-ptr' '--enable-limited-thread-safety' '--enable-thread-safety' 'CC=/cvmfs/sft.cern.ch/lcg/releases/gcc/14.2.0-2f0a0/x86_64-el9/bin/gcc' 'CXX=/cvmfs/sft.cern.ch/lcg/releases/gcc/14.2.0-2f0a0/x86_64-el9/bin/g++' 'CXXFLAGS=-O2 -Wall -std=c++20' 'FC=/cvmfs/sft.cern.ch/lcg/releases/gcc/14.2.0-2f0a0/x86_64-el9/bin/gfortran'
```

Note the difference is the -O2 flag and the -Wall (that I've also added) in CXXFLAGS. When checking the commands that were used for building there isn't any `-ON`, and I think the default is always without optimizations.

Tagging @m-fila and @andresailer.