### PR TITLE
cuda@12.8 requires glibc@2.27

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -690,6 +690,9 @@ class Cuda(Package):
     # Mojave support -- only macOS High Sierra 10.13 is supported.
     conflicts("arch=darwin-mojave-x86_64")
 
+    # cuda-12.8 libcusolver.so requires log2f@GLIBC_2.27
+    conflicts("glibc@:2.26", when="@12.8:")
+
     variant(
         "dev", default=False, description="Enable development dependencies, i.e to use cuda-gdb"
     )


### PR DESCRIPTION
Ref: https://github.com/spack/spack/pull/49217

```
balay@p1 /software/spack-25-02-cuda/opt/spack/linux-fedora41-skylake/gcc-14.2.1/cuda-12.8.0-ojyqsnbmwwipdzgf34wcqjx25zukt263/targets/x86_64-linux/lib (develop =)
$ nm -AoD *.so* |grep log2f@
libcublasLt.so:                 U log2f@GLIBC_2.27
libcublasLt.so.12:                 U log2f@GLIBC_2.27
libcublasLt.so.12.8.3.14:                 U log2f@GLIBC_2.27
libcufile.so:                 U log2f@GLIBC_2.2.5
libcufile.so.0:                 U log2f@GLIBC_2.2.5
libcufile.so.1.13.0:                 U log2f@GLIBC_2.2.5
libcusolver.so:                 U log2f@GLIBC_2.27
libcusolver.so.11:                 U log2f@GLIBC_2.27
libcusolver.so.11.7.2.55:                 U log2f@GLIBC_2.27
libnvJitLink.so:                 U log2f@GLIBC_2.2.5
libnvJitLink.so.12:                 U log2f@GLIBC_2.2.5
libnvJitLink.so.12.8.61:                 U log2f@GLIBC_2.2.5
libnvrtc.alt.so:                 U log2f@GLIBC_2.2.5
libnvrtc.alt.so.12:                 U log2f@GLIBC_2.2.5
libnvrtc.alt.so.12.8.61:                 U log2f@GLIBC_2.2.5
libnvrtc.so:                 U log2f@GLIBC_2.2.5
libnvrtc.so.12:                 U log2f@GLIBC_2.2.5
libnvrtc.so.12.8.61:                 U log2f@GLIBC_2.2.5
```
Essentially cuda-12.8 doesn't work with [default glibc (2.26)] on RHEL7, so add in a conflict so that cuda@12.6 gets used on it. 