### PR TITLE
madgraph5_aMC: add variant to install models

### DIFF
--- a/var/spack/repos/builtin/packages/madgraph5amc/package.py
+++ b/var/spack/repos/builtin/packages/madgraph5amc/package.py
@@ -60,6 +60,7 @@ class Madgraph5amc(MakefilePackage):
     variant(
         "models",
         values=(
+            "None",
             "2HDM",
             "4Gen",
             "DY_SM",
@@ -87,7 +88,7 @@ class Madgraph5amc(MakefilePackage):
             "uutt_sch_4fermion",
             "uutt_tch_scalar",
         ),
-        default=None,
+        default="None",
         multi=True,
         description="Models that will be installed by Madgraph. These models can be used"
         "without them being installed first, then madgraph will download them"
@@ -190,7 +191,7 @@ class Madgraph5amc(MakefilePackage):
                 )
             mg5("install-pythia8-interface")
 
-        if spec.variants["models"].value:
+        if spec.variants["models"].value != ["None"]:
             with open("install-models", "w") as f:
                 f.write(
                     "\n".join([f"import model {model}" for model in spec.variants["models"].value])

--- a/var/spack/repos/builtin/packages/madgraph5amc/package.py
+++ b/var/spack/repos/builtin/packages/madgraph5amc/package.py
@@ -57,6 +57,42 @@ class Madgraph5amc(MakefilePackage):
     variant("ninja", default=False, description="Use external installation" + " of Ninja")
     variant("collier", default=False, description="Use external installation" + " of Collier")
     variant("pythia8", default=False, description="Use external installation of Pythia8")
+    variant(
+        "models",
+        values=(
+            "2HDM",
+            "4Gen",
+            "DY_SM",
+            "EWdim6",
+            "IDM_NLO_EW_CM_UFO",
+            "RS",
+            "SMScalars",
+            "TopEffTh",
+            "heft",
+            "heft_v4",
+            "loop_qcd_qed_sm",
+            "loop_qcd_qed_sm_4FS",
+            "loop_qcd_qed_sm_Gmu",
+            "loop_qcd_qed_sm_Gmu_4FS",
+            "loop_qcd_qed_sm_Gmu_4FS_ew",
+            "loop_qcd_qed_sm_a0",
+            "loop_qcd_qed_sm_forSUSY",
+            "mssm_v4",
+            "nmssm",
+            "sextet_diquarks",
+            "sm_v4",
+            "top-philic_NLO_EW_CM_UFO",
+            "triplet_diquarks",
+            "usrmod_v4",
+            "uutt_sch_4fermion",
+            "uutt_tch_scalar",
+        ),
+        default=[],
+        multi=True,
+        description="Models that will be installed by Madgraph. These models can be used"
+        "without them being installed first, then madgraph will download them"
+        "when importing them. These models are taken from http://madgraph.phys.ucl.ac.be/Downloads/models",
+    )
 
     conflicts("%gcc@10:", when="@2.7.3")
 
@@ -143,6 +179,7 @@ class Madgraph5amc(MakefilePackage):
             join_path(prefix, "Template", "LO", "Source", "make_opts"),
         )
 
+        mg5 = Executable(join_path(prefix, "bin", "mg5_aMC"))
         # TODO: Fix for reproducibility, see https://github.com/spack/spack/pull/41128#issuecomment-2305777485
         if "+pythia8" in spec:
             with open("install-pythia8-interface", "w") as f:
@@ -151,8 +188,14 @@ class Madgraph5amc(MakefilePackage):
                         install mg5amc_py8_interface
                 """
                 )
-            mg5 = Executable(join_path(prefix, "bin", "mg5_aMC"))
             mg5("install-pythia8-interface")
+
+        if spec.variants["models"].value:
+            with open("install-models", "w") as f:
+                f.write(
+                    "\n".join([f"import model {model}" for model in spec.variants["models"].value])
+                )
+            mg5("install-models")
 
     def url_for_version(self, version):
         major = str(version).split(".")[0]

--- a/var/spack/repos/builtin/packages/madgraph5amc/package.py
+++ b/var/spack/repos/builtin/packages/madgraph5amc/package.py
@@ -87,7 +87,7 @@ class Madgraph5amc(MakefilePackage):
             "uutt_sch_4fermion",
             "uutt_tch_scalar",
         ),
-        default=[],
+        default=None,
         multi=True,
         description="Models that will be installed by Madgraph. These models can be used"
         "without them being installed first, then madgraph will download them"


### PR DESCRIPTION
The new variant `models` will install the models that are selected. This has the advantages that the models don't have to be downloaded every time (although they are quite small) a new user uses them, and they appear when running `display modellist`. Currently, if the madgraph installation folder is not writable I don't seem to be able to download and install them locally, that is a different problem that would also be solved by making the models available in the installation folder.

I ran this and it seems to work. I get weird ownership of the newly installed model (under `<install>/models) when running as root:

```
drwxr-sr-x. 10 root root  4.0K Mar 18 22:12 .
drwxr-sr-x. 17 root root  4.0K Mar 18 22:11 ..
drwxr-sr-x.  2 root root  4.0K Mar 18 22:11 MSSM_SLHA2
...
drwxr-sr-x.  4  501 games 4.0K Mar 18 22:12 loop_qcd_qed_sm_Gmu
```
But this also happens when running the command to install manually. Perhaps a better approach would be to unpack the models directly from Spack without calling madgraph to install them, but I don't know if madgraph does anything else besides unpacking them.