### PR TITLE
solver: improve error message when single-valued variant cannot be satisfied

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -953,12 +953,14 @@ error(100, "Cannot set variant '{0}' for package '{1}' because the variant condi
      build(node(ID, Package)).
 
 % at most one variant value for single-valued variants.
-error(100, "'{0}' required multiple values for single-valued variant '{1}'", Package, Variant)
+error(100, "'{0}' requires conflicting variant values 'Spec({1}={2})' and 'Spec({1}={3})'", Package, Variant, Value1, Value2)
   :- attr("node", node(ID, Package)),
      node_has_variant(node(ID, Package), Variant, _),
      variant_single_value(node(ID, Package), Variant),
-     build(node(ID, Package)),
-     2 { attr("variant_value", node(ID, Package), Variant, Value) }.
+     attr("variant_value", node(ID, Package), Variant, Value1),
+     attr("variant_value", node(ID, Package), Variant, Value2),
+     Value1 < Value2,
+     build(node(ID, Package)).
 
 error(100, "No valid value for variant '{1}' of package '{0}'", Package, Variant)
   :- attr("node", node(ID, Package)),

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -117,7 +117,7 @@ error(0, "Cannot find a valid provider for virtual {0}", Virtual, startcauses, C
      condition_holds(Cause, node(CID, TriggerPkg)).
 
 % At most one variant value for single-valued variants
-error(0, "'{0}' required multiple values for single-valued variant '{1}'\n    Requested 'Spec({1}={2})' and 'Spec({1}={3})'", Package, Variant, Value1, Value2, startcauses, Cause1, X, Cause2, X)
+error(0, "'{0}' requires conflicting variant values 'Spec({1}={2})' and 'Spec({1}={3})'", Package, Variant, Value1, Value2, startcauses, Cause1, X, Cause2, X)
   :- attr("node", node(X, Package)),
      node_has_variant(node(X, Package), Variant, VariantID),
      variant_single_value(node(X, Package), Variant),

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -29,8 +29,7 @@ external_error_messages = [
 ]
 
 variant_error_messages = [
-    "'fftw' required multiple values for single-valued variant 'mpi'",
-    "    Requested '~mpi' and '+mpi'",
+    "'fftw' requires conflicting variant values '~mpi' and '+mpi'",
     "        required because quantum-espresso depends on fftw+mpi when +invino",
     "          required because quantum-espresso+invino ^fftw~mpi requested explicitly",
     "        required because quantum-espresso+invino ^fftw~mpi requested explicitly",


### PR DESCRIPTION
Closes #49559.

Previously:

```
'pfunit' required multiple values for single-valued variant 'mpi'
```

With this PR:

```
'pfunit' requires conflicting variant values '~mpi' and '+mpi'
```

note that this does not fix the error chain which normally explains why `+mpi` was required.