### PR TITLE
openfoam: Fix flags for latest Arm compiler versions

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/openfoam_arm.patch
+++ b/var/spack/repos/builtin/packages/openfoam/openfoam_arm.patch
@@ -1,0 +1,44 @@
+diff --git a/wmake/rules/linuxARM64Arm/c b/wmake/rules/linuxARM64Arm/c
+index 8850f93416..3d02366d2d 100644
+--- a/wmake/rules/linuxARM64Arm/c
++++ b/wmake/rules/linuxARM64Arm/c
+@@ -18,7 +18,7 @@ ctoo        = $(WM_SCHEDULER) $(cc) $(cFLAGS) -c $< -o $@
+ 
+ include $(GENERAL_RULES)/Clang/link-c
+ 
+-LINKLIBSO  += -armpl
+-LINKEXE    += -armpl
++LINKLIBSO  += -L$(ARMPL_LIBRARIES) -Wl,-rpath $(ARMPL_LIBRARIES) -larmpl -fveclib=ArmPL
++LINKEXE    += -L$(ARMPL_LIBRARIES) -Wl,-rpath=$(ARMPL_LIBRARIES) -larmpl -fveclib=ArmPL
+ 
+ #------------------------------------------------------------------------------
+diff --git a/wmake/rules/linuxARM64Arm/c++ b/wmake/rules/linuxARM64Arm/c++
+index 430762435b..d1ab9ea923 100644
+--- a/wmake/rules/linuxARM64Arm/c++
++++ b/wmake/rules/linuxARM64Arm/c++
+@@ -21,7 +21,7 @@ cxxtoo      = $(Ctoo)
+ 
+ include $(GENERAL_RULES)/Clang/link-c++
+ 
+-LINKLIBSO  += -armpl
+-LINKEXE    += -armpl
++LINKLIBSO  += -L$(ARMPL_LIBRARIES) -Wl,-rpath=$(ARMPL_LIBRARIES) -larmpl -fveclib=ArmPL
++LINKEXE    += -L$(ARMPL_LIBRARIES) -Wl,-rpath=$(ARMPL_LIBRARIES) -larmpl -fveclib=ArmPL
+ 
+ #------------------------------------------------------------------------------
+diff --git a/wmake/rules/linuxARM64Arm/c++Opt b/wmake/rules/linuxARM64Arm/c++Opt
+index 7a4e09d9f4..da3e03d6fb 100644
+--- a/wmake/rules/linuxARM64Arm/c++Opt
++++ b/wmake/rules/linuxARM64Arm/c++Opt
+@@ -1,2 +1,2 @@
+ c++DBUG     =
+-c++OPT      = -ffp-contract=fast -ffast-math -O3 -funsafe-math-optimizations -fsimdmath -armpl
++c++OPT      = -ffp-contract=fast -ffast-math -O3 -funsafe-math-optimizations -I$(ARMPL_INCLUDES) -fveclib=ArmPL
+diff --git a/wmake/rules/linuxARM64Arm/cOpt b/wmake/rules/linuxARM64Arm/cOpt
+index 10aa6fc610..1fe2d80eaf 100644
+--- a/wmake/rules/linuxARM64Arm/cOpt
++++ b/wmake/rules/linuxARM64Arm/cOpt
+@@ -1,2 +1,2 @@
+ cDBUG       =
+-cOPT        = -ffp-contract=fast -ffast-math -O3 -armpl
++cOPT        = -ffp-contract=fast -ffast-math -O3 -I$(ARMPL_INCLUDES) -fveclib=ArmPL

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -429,6 +429,9 @@ class Openfoam(Package):
         sha256="bad4b0e80fd26ea702bce9ccfb925edbbaa3308f70392fe6da2c7671b1d39bea",
     )
 
+    # Fix: compile flags for Arm Compiler for Linux 24.10 and Arm Toolchain for Linux
+    patch("openfoam_arm.patch")
+
     # Some user config settings
     # default: 'compile-option': '-spack',
     # default: 'mplib': 'USERMPI',  # User-defined mpi for spack


### PR DESCRIPTION
OpenFOAM currently uses deprecated flags for the Arm compiler, this patch fixes the flags to work for both Arm Compiler for Linux 24.10 and the upcoming Arm Toolchain for Linux.