### PR TITLE
Concretization Cache: Refactor + manifest testing

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -89,3 +89,7 @@ concretizer:
   # Static analysis may reduce the concretization time by generating smaller ASP problems, in
   # cases where there are requirements that prevent part of the search space to be explored.
   static_analysis: false
+
+  concretization_cache:
+    enable: true
+    url: $misc_cache/concretization

--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -92,4 +92,4 @@ concretizer:
 
   concretization_cache:
     enable: true
-    url: $misc_cache/concretization
+    url: $user_cache_path/concretization

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -363,7 +363,7 @@ When ``false`` or ommitted, all concretization requests will be performed from s
 Path to the location where Spack will root the concretization cache. Currently this only supports
 paths on the local filesystem.
 
-Default location is under the :ref:`Misc Cache` at: ``$misc_cache/concretization``
+Default location is under the :ref:`Misc Cache` at: ``$user_cache_path/concretization``
 
 ------------------------------------
 ``concretization_cache:entry_limit``

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2892,7 +2892,7 @@ def temporary_file_position(stream):
 
 
 @contextmanager
-def current_file_position(stream: IO[str], loc: int, relative_to=io.SEEK_CUR):
+def current_file_position(stream: IO, loc: int, relative_to=io.SEEK_CUR):
     with temporary_file_position(stream):
         stream.seek(loc, relative_to)
         yield

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -95,6 +95,15 @@ properties: Dict[str, Any] = {
             "timeout": {"type": "integer", "minimum": 0},
             "error_on_timeout": {"type": "boolean"},
             "os_compatible": {"type": "object", "additionalProperties": {"type": "array"}},
+            "concretization_cache": {
+                "type": "object",
+                "properties": {
+                    "enable": {"type": "boolean"},
+                    "url": {"type": "string"},
+                    "entry_limit": {"type": "integer", "minimum": 0},
+                    "size_limit": {"type": "integer", "minimum": 0},
+                },
+            },
         },
     }
 }

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -58,15 +58,6 @@ properties: Dict[str, Any] = {
                     {"type": "string"},  # deprecated
                 ]
             },
-            "concretization_cache": {
-                "type": "object",
-                "properties": {
-                    "enable": {"type": "boolean"},
-                    "url": {"type": "string"},
-                    "entry_limit": {"type": "integer", "minimum": 0},
-                    "size_limit": {"type": "integer", "minimum": 0},
-                },
-            },
             "install_hash_length": {"type": "integer", "minimum": 1},
             "install_path_scheme": {"type": "string"},  # deprecated
             "build_stage": {

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -635,23 +635,6 @@ class ConcretizationCache:
     Serializes solver result objects and statistics to json and stores
     at a given endpoint in a cache associated by the sha256 of the
     asp problem and the involved control files.
-
-
-    Cache layout:
-    ```
-    Cache root       Buckets        Entries
-        |        (entry_hash[:2])  (files named by hash)
-        |
-        |-------| - bucket1
-                |        |------| - entry
-                |               | - entry
-                | - bucket2
-                |        |------| - entry
-                |
-                | - bucket3
-                         |------| - entry
-                                | - entry
-    ```
     """
 
     def __init__(self, root: Union[str, None] = None):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -665,8 +665,8 @@ class ConcretizationCache:
         """Prunes the concretization cache according to configured size and entry
         count limits. Cleanup is done in FIFO ordering."""
         # TODO: determine a better default
-        entry_limit = spack.config.get("config:concretization_cache:entry_limit", 1000)
-        bytes_limit = spack.config.get("config:concretization_cache:size_limit", 3e8)
+        entry_limit = spack.config.get("concretizer:concretization_cache:entry_limit", 1000)
+        bytes_limit = spack.config.get("concretizer:concretization_cache:size_limit", 3e8)
         # lock the entire buildcache as we're removing a lot of data from the
         # manifest and cache itself
         entry_count, bytes_count = 0, 0
@@ -1127,7 +1127,7 @@ class PyclingoDriver:
                 problem_repr += "\n" + f.read()
 
         result = None
-        conc_cache_enabled = spack.config.get("config:concretization_cache:enable", False)
+        conc_cache_enabled = spack.config.get("concretizer:concretization_cache:enable", False)
         if conc_cache_enabled:
             result, concretization_stats = CONC_CACHE.fetch(problem_repr)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -684,9 +684,13 @@ class ConcretizationCache:
             # remove takes a write lock, but there's a race
             # if another process adds something to the bucket
             # between the check for emptiness and the remove
+            removed = False
             with self._fc.write_transaction(cache_bucket) as bucket:
                 if bucket and not any(cache_bucket.iterdir()):
                     self._fc.remove(cache_bucket)
+                    removed = True
+            if removed:
+                self._fc.purge_lock(cache_bucket)
 
     def cache_buckets(self):
         """Generator producing cache buckets"""
@@ -802,6 +806,7 @@ class ConcretizationCache:
         bucket, entry = self._prefix_digest(problem)
         cache_path = self.root / bucket / entry
         result, statistics = None, None
+        self._fc.init_entry(bucket)
         with self._fc.read_transaction(bucket) as exists:
             # if exists is false, then there's no chance of a hit
             # in this bucket, as it does not exist

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -751,11 +751,9 @@ class ConcretizationCache:
             return cache_count, cache_byte_size
         return None, None
 
-    def _write_manifest(self,
-                        old_manifest_file: IO[str],
-                        new_manifest_file: IO[str],
-                        entry_count,
-                        entry_bytes):
+    def _write_manifest(
+        self, old_manifest_file: IO[str], new_manifest_file: IO[str], entry_count, entry_bytes
+    ):
         """Writes new concretization cache manifest file.
 
         Arguments:
@@ -808,7 +806,7 @@ class ConcretizationCache:
         # make sure we're always reading from the beginning of the stream
         # concretization cache manifest data lives at the top of the file
         with current_file_position(cache_stream, 0):
-            count, bytes_count =  self._parse_manifest_entry(cache_stream.readline())
+            count, bytes_count = self._parse_manifest_entry(cache_stream.readline())
             if count and bytes_count:
                 return int(count), int(bytes_count)
             return None, None

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -21,25 +21,12 @@ import types
 import typing
 import warnings
 from contextlib import contextmanager
-from typing import (
-    IO,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Callable, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type, Union
 
 import _vendoring.archspec.cpu
 
 import llnl.util.lang
 import llnl.util.tty as tty
-from llnl.util.filesystem import current_file_position
 from llnl.util.lang import elide_list
 
 import spack
@@ -65,6 +52,7 @@ import spack.util.hash
 import spack.util.libc
 import spack.util.module_cmd as md
 import spack.util.path
+import spack.util.timer
 import spack.variant as vt
 import spack.version as vn
 import spack.version.git_ref_lookup
@@ -680,14 +668,13 @@ class ConcretizationCache:
         bytes_limit = spack.config.get("config:concretization_cache:size_limit", 3e8)
         # lock the entire buildcache as we're removing a lot of data from the
         # manifest and cache itself
-        entry_count, bytes_count = 0,0
+        entry_count, bytes_count = 0, 0
         rm_reg: List[pathlib.Path] = []
         for bucket in self.cache_buckets():
             with self._fc.read_transaction(bucket) as f:
                 if not f:
                     raise RuntimeError(
-                        "Attempting to clean non existent cache bucket"
-                        f" {bucket.name}"
+                        "Attempting to clean non existent cache bucket" f" {bucket.name}"
                     )
                 # advance new beyond metadata entry
                 for entry in self.cache_entries(bucket):
@@ -720,7 +707,7 @@ class ConcretizationCache:
             if bucket.is_dir():
                 yield bucket
 
-    def cache_entries(self, bucket:pathlib.Path):
+    def cache_entries(self, bucket: pathlib.Path):
         """Generator producing cache entries within a bucket"""
         for cache_entry in bucket.iterdir():
             if not cache_entry.is_dir():
@@ -837,7 +824,7 @@ class ConcretizationCache:
             if exists:
                 cache_entry_content = None
                 try:
-                    with gzip.open(cache_path, 'rb') as f:
+                    with gzip.open(cache_path, "rb") as f:
                         f.peek(1)  # Try to read at least one byte
                         f.seek(0)
                         cache_entry_content = f.read().decode("utf-8")

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -28,7 +28,6 @@ from typing import (
     List,
     NamedTuple,
     Optional,
-    Sequence,
     Set,
     Tuple,
     Type,
@@ -740,7 +739,7 @@ class ConcretizationCache:
                             "within the concretization cache."
                         )
 
-    def _parse_manifest_entry(self, line: str) -> Sequence[Union[None, str]]:
+    def _parse_manifest_entry(self, line: str) -> Union[Tuple[None, None], Tuple[int, int]]:
         """Returns parsed manifest entry lines
         with handling for invalid reads."""
         if line:
@@ -749,7 +748,9 @@ class ConcretizationCache:
             if cache_metadata_size != 2:
                 tty.warn(f"Invalid cache entry at {line}")
                 return None, None
-            return cache_values
+            cache_count = int(cache_values[0])
+            cache_byte_size = int(cache_values[1])
+            return cache_count, cache_byte_size
         return None, None
 
     def _write_manifest(self, manifest_file: IO[str], entry_count, entry_bytes):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -928,8 +928,8 @@ class ConcretizationCache:
                 tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
                 return
             cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
-            new_bytes = open(new.name, "wb")
-            bytes_written = new_bytes.write(self._zip_cache_entry(json.dumps(cache_dict)))
+            with open(new.name, "wb") as new_bytes:
+                bytes_written = new_bytes.write(self._zip_cache_entry(json.dumps(cache_dict)))
             self._register_cache_update(cache_path, bytes_written)
 
     def fetch(self, problem: str) -> Union[Tuple[Result, List], Tuple[None, None]]:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -732,24 +732,26 @@ class ConcretizationCache:
                     "within the concretization cache."
                 )
 
-    def _results_from_cache(self, cache_entry_buffer: IO[bytes]) -> Union[Result, None]:
+    def _read_text_cache(self, cache_path: pathlib.Path) -> Optional[str]:
+        """Processes a text encoded cache file and returns contexts if it exists"""
+        try:
+            with open(cache_path, "r") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+
+    def _results_from_cache(self, cache_entry_file: str) -> Union[Result, None]:
         """Returns a Results object from the concretizer cache
 
         Reads the cache hit and uses `Result`'s own deserializer
         to produce a new Result object
         """
 
-        with current_file_position(cache_entry_buffer, 0):
-            cache_str = self._unzip_cache_entry(cache_entry_buffer.read())
-            # TODO: Should this be an error if None?
-            # Same for _stats_from_cache
-            if cache_str:
-                cache_entry = json.loads(cache_str)
-                result_json = cache_entry["results"]
-                return Result.from_dict(result_json)
-        return None
+        cache_entry = json.loads(cache_entry_file)
+        result_json = cache_entry["results"]
+        return Result.from_dict(result_json)
 
-    def _stats_from_cache(self, cache_entry_buffer: IO[bytes]) -> Union[List, None]:
+    def _stats_from_cache(self, cache_entry_file: str) -> Union[List, None]:
         """Returns concretization statistic from the
         concretization associated with the cache.
 
@@ -757,14 +759,11 @@ class ConcretizationCache:
         statistics covering the cached concretization run
         and returns the Python data structures
         """
-        with current_file_position(cache_entry_buffer, 0):
-            cache_str = self._unzip_cache_entry(cache_entry_buffer.read())
-            if cache_str:
-                return json.loads(cache_str)["statistics"]
-        return None
+        return json.loads(cache_entry_file)["statistics"]
 
     def _prefix_digest(self, problem: str) -> Tuple[str, str]:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
+        # compress the problem w/ gzip so we can validate checksum w/o decompressing
         prob_digest = spack.util.hash.b32_hash(problem)
         prefix = prob_digest[:2]
         return prefix, prob_digest
@@ -783,14 +782,6 @@ class ConcretizationCache:
         """Returns a Path object representing the cache entry
         corresponding to the given sha256 hash"""
         return pathlib.Path(hash[:2]) / hash
-
-    def _zip_cache_entry(self, cache_data: str):
-        """Compress cache entries via gzip"""
-        return gzip.compress(cache_data.encode("utf-8"))
-
-    def _unzip_cache_entry(self, cache_data: bytes):
-        """Decompresses cache entries, which are gzipped by default"""
-        return gzip.decompress(cache_data).decode("utf-8")
 
     def _safe_remove(self, cache_dir: pathlib.Path) -> bool:
         """Removes cache entries with handling for the case where the entry has been
@@ -818,17 +809,17 @@ class ConcretizationCache:
         Hash membership is computed based on the sha256 of the provided asp
         problem.
         """
-        bucket, entry = self._prefix_digest(problem)
-        cache_path = self.root / bucket / entry
-        self._fc.init_entry(cache_path)
-        with self._fc.write_transaction(bucket) as (old, new):
-            if old:
+        bucket, digest = self._prefix_digest(problem)
+        cache_path = self.root / bucket / digest
+        self._fc.init_entry(bucket)
+        with self._fc.write_transaction(bucket):
+            try:
+                with gzip.open(cache_path, "xb") as cache_entry:
+                    cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
+                    cache_entry.write(json.dumps(cache_dict).encode())
+            except FileExistsError:
                 # Entry for this conc hash exists already, do not overwrite
                 tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
-                return
-            cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
-            with open(cache_path, "wb") as new_bytes:
-                new_bytes.write(self._zip_cache_entry(json.dumps(cache_dict)))
 
     def fetch(self, problem: str) -> Union[Tuple[Result, List], Tuple[None, None]]:
         """Returns the concretization cache result for a lookup based on the given problem.
@@ -840,11 +831,26 @@ class ConcretizationCache:
         bucket, entry = self._prefix_digest(problem)
         cache_path = self.root / bucket / entry
         result, statistics = None, None
-        with self._fc.read_transaction(bucket) as f:
-            if f:
-                bytes_f = open(cache_path, "rb")
-                result = self._results_from_cache(bytes_f)
-                statistics = self._stats_from_cache(bytes_f)
+        with self._fc.read_transaction(bucket) as exists:
+            # if exists is false, then there's no chance of a hit
+            # in this bucket, as it does not exist
+            if exists:
+                cache_entry_content = None
+                try:
+                    with gzip.open(cache_path, 'rb') as f:
+                        f.peek(1)  # Try to read at least one byte
+                        f.seek(0)
+                        cache_entry_content = f.read().decode("utf-8")
+                except gzip.BadGzipFile:
+                    # Cache entry was created pre-compression
+                    # read from plaintext
+                    cache_entry_content = self._read_text_cache(cache_path)
+                except FileNotFoundError:
+                    # cache miss
+                    pass
+                if cache_entry_content:
+                    result = self._results_from_cache(cache_entry_content)
+                    statistics = self._stats_from_cache(cache_entry_content)
         if result and statistics:
             tty.debug(f"Concretization cache hit at {str(cache_path)}")
             return result, statistics

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -665,59 +665,62 @@ class ConcretizationCache:
         bytes_limit = spack.config.get("config:concretization_cache:size_limit", 3e8)
         # lock the entire buildcache as we're removing a lot of data from the
         # manifest and cache itself
+        entry_count, manifest_bytes = 0,0
+
+        import pdb; pdb.set_trace()
         with self._fc.read_transaction(self._cache_manifest) as f:
             entry_count, manifest_bytes = self._extract_cache_metadata(f)
-            if not entry_count or not manifest_bytes:
-                return
-            if entry_count > entry_limit and entry_limit > 0:
-                with self._fc.write_transaction(self._cache_manifest) as (old, new):
-                    # advance new beyond metadata entry
-                    old.readline()
-                    # prune the oldest 10% or until we have removed 10% of
-                    # total bytes starting from oldest entry
-                    # TODO: make this configurable?
-                    prune_count = entry_limit // 10
-                    lines_to_prune = old.readlines(prune_count)
-                    for i, line in enumerate(lines_to_prune):
-                        sha, cache_entry_bytes = self._parse_manifest_entry(line)
-                        if sha and cache_entry_bytes:
-                            cache_path = self._cache_path_from_hash(sha)
-                            if self._fc.remove(cache_path):
-                                entry_count -= 1
-                                manifest_bytes -= int(cache_entry_bytes)
-                        else:
-                            tty.warn(
-                                f"Invalid concretization cache entry: '{line}' on line: {i+1}"
-                            )
-                    self._write_manifest(old, new, entry_count, manifest_bytes)
+        if not entry_count or not manifest_bytes:
+            return
+        if entry_count > entry_limit and entry_limit > 0:
+            with self._fc.write_transaction(self._cache_manifest) as (old, new):
+                # advance new beyond metadata entry
+                old.readline()
+                # prune the oldest 10% or until we have removed 10% of
+                # total bytes starting from oldest entry
+                # TODO: make this configurable?
+                prune_count = entry_limit // 10
+                lines_to_prune = old.readlines(prune_count)
+                for i, line in enumerate(lines_to_prune):
+                    sha, cache_entry_bytes = self._parse_manifest_entry(line)
+                    if sha and cache_entry_bytes:
+                        cache_path = self._cache_path_from_hash(sha)
+                        if self._fc.remove(cache_path):
+                            entry_count -= 1
+                            manifest_bytes -= int(cache_entry_bytes)
+                    else:
+                        tty.warn(
+                            f"Invalid concretization cache entry: '{line}' on line: {i+1}"
+                        )
+                self._write_manifest(old, new, entry_count, manifest_bytes)
 
-            elif manifest_bytes > bytes_limit and bytes_limit > 0:
-                with self._fc.write_transaction(self._cache_manifest) as (old, new):
-                    # advance new beyond metadata entry
-                    old.readline()
-                    # take 10% of current size off
-                    prune_amount = bytes_limit // 10
-                    total_pruned = 0
-                    i = 0
-                    while total_pruned < prune_amount:
-                        sha, manifest_cache_bytes = self._parse_manifest_entry(old.readline())
-                        if sha and manifest_cache_bytes:
-                            manifest_cache_bytes = int(manifest_cache_bytes)
-                            cache_path = self.root / sha[:2] / sha
-                            if self._safe_remove(cache_path):
-                                entry_count -= 1
-                                manifest_bytes -= manifest_cache_bytes
-                                total_pruned += manifest_cache_bytes
-                        else:
-                            tty.warn(
-                                "Invalid concretization cache entry "
-                                f"'{sha} {manifest_cache_bytes}' on line: {i}"
-                            )
-                        i += 1
-                    self._write_manifest(old, new, entry_count, manifest_bytes)
-            for cache_dir in self.root.iterdir():
-                if cache_dir.is_dir() and not any(cache_dir.iterdir()):
-                    self._safe_remove(cache_dir)
+        elif manifest_bytes > bytes_limit and bytes_limit > 0:
+            with self._fc.write_transaction(self._cache_manifest) as (old, new):
+                # advance new beyond metadata entry
+                old.readline()
+                # take 10% of current size off
+                prune_amount = bytes_limit // 10
+                total_pruned = 0
+                i = 0
+                while total_pruned < prune_amount:
+                    sha, manifest_cache_bytes = self._parse_manifest_entry(old.readline())
+                    if sha and manifest_cache_bytes:
+                        manifest_cache_bytes = int(manifest_cache_bytes)
+                        cache_path = self.root / sha[:2] / sha
+                        if self._safe_remove(cache_path):
+                            entry_count -= 1
+                            manifest_bytes -= manifest_cache_bytes
+                            total_pruned += manifest_cache_bytes
+                    else:
+                        tty.warn(
+                            "Invalid concretization cache entry "
+                            f"'{sha} {manifest_cache_bytes}' on line: {i}"
+                        )
+                    i += 1
+                self._write_manifest(old, new, entry_count, manifest_bytes)
+        for cache_dir in self.root.iterdir():
+            if cache_dir.is_dir() and not any(cache_dir.iterdir()):
+                self._safe_remove(cache_dir)
 
     def cache_entries(self):
         """Generator producing cache entries"""

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -680,9 +680,13 @@ class ConcretizationCache:
                     entry_count -= 1
                     bytes_count -= entry_size
         # remove any buckets with no more cache entries
-        for cache_dir in self.cache_buckets():
-            if not any(cache_dir.iterdir()):
-                self._fc.remove(cache_dir)
+        for cache_bucket in self.cache_buckets():
+            # remove takes a write lock, but there's a race
+            # if another process adds something to the bucket
+            # between the check for emptiness and the remove
+            with self._fc.write_transaction(cache_bucket) as bucket:
+                if bucket and not any(cache_bucket.iterdir()):
+                    self._fc.remove(cache_bucket)
 
     def cache_buckets(self):
         """Generator producing cache buckets"""
@@ -775,7 +779,11 @@ class ConcretizationCache:
         bucket, digest = self._prefix_digest(problem)
         cache_path = self.root / bucket / digest
         self._fc.init_entry(bucket)
-        with self._fc.write_transaction(bucket):
+        with self._fc.write_transaction(bucket) as exists:
+            if not exists:
+                # The directory may have been pruned between init entry and the write
+                # transaction, recreate the directory
+                os.makedirs(bucket)
             try:
                 with gzip.open(cache_path, "xb", compresslevel=6) as cache_entry:
                     cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -58,6 +58,7 @@ import spack.version as vn
 import spack.version.git_ref_lookup
 from spack import traverse
 from spack.compilers.libraries import CompilerPropertyDetector
+from spack.util.compression import GZipFileType
 from spack.util.file_cache import DirectoryFileCache
 
 from .core import (
@@ -719,14 +720,6 @@ class ConcretizationCache:
                     "within the concretization cache."
                 )
 
-    def _read_text_cache(self, cache_path: pathlib.Path) -> Optional[str]:
-        """Processes a text encoded cache file and returns contexts if it exists"""
-        try:
-            with open(cache_path, "r") as f:
-                return f.read()
-        except FileNotFoundError:
-            return None
-
     def _results_from_cache(self, cache_entry_file: str) -> Union[Result, None]:
         """Returns a Results object from the concretizer cache
 
@@ -801,7 +794,7 @@ class ConcretizationCache:
         self._fc.init_entry(bucket)
         with self._fc.write_transaction(bucket):
             try:
-                with gzip.open(cache_path, "xb") as cache_entry:
+                with gzip.open(cache_path, "xb", compresslevel=6) as cache_entry:
                     cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
                     cache_entry.write(json.dumps(cache_dict).encode())
             except FileExistsError:
@@ -824,17 +817,22 @@ class ConcretizationCache:
             if exists:
                 cache_entry_content = None
                 try:
-                    with gzip.open(cache_path, "rb") as f:
+                    with gzip.open(cache_path, "rb", compresslevel=6) as f:
                         f.peek(1)  # Try to read at least one byte
                         f.seek(0)
                         cache_entry_content = f.read().decode("utf-8")
-                except gzip.BadGzipFile:
-                    # Cache entry was created pre-compression
-                    # read from plaintext
-                    cache_entry_content = self._read_text_cache(cache_path)
                 except FileNotFoundError:
                     # cache miss
                     pass
+                except OSError:
+                    # Cache may have been created pre compression
+                    # check if gzip, and if so, read from plaintext
+                    # otherwise re raise
+                    with open(cache_path, "rb") as f:
+                        if GZipFileType().matches_magic(f):
+                            cache_entry_content = f.read().decode()
+                        else:
+                            raise
                 if cache_entry_content:
                     result = self._results_from_cache(cache_entry_content)
                     statistics = self._stats_from_cache(cache_entry_content)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -677,7 +677,7 @@ class ConcretizationCache:
                     # total bytes starting from oldest entry
                     # TODO: make this configurable?
                     prune_count = entry_limit // 10
-                    lines_to_prune = new.readlines(prune_count)
+                    lines_to_prune = old.readlines(prune_count)
                     for i, line in enumerate(lines_to_prune):
                         sha, cache_entry_bytes = self._parse_manifest_entry(line)
                         if sha and cache_entry_bytes:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -666,16 +666,13 @@ class ConcretizationCache:
         # lock the entire buildcache as we're removing a lot of data from the
         # manifest and cache itself
         with self._fc.read_transaction(self._cache_manifest) as f:
-            count, cache_bytes = self._extract_cache_metadata(f)
-            if not count or not cache_bytes:
+            entry_count, manifest_bytes = self._extract_cache_metadata(f)
+            if not entry_count or not manifest_bytes:
                 return
-            entry_count = int(count)
-            manifest_bytes = int(cache_bytes)
             if entry_count > entry_limit and entry_limit > 0:
                 with self._fc.write_transaction(self._cache_manifest) as (old, new):
-                    self._synchronize_manifest(old, new)
                     # advance new beyond metadata entry
-                    new.readline()
+                    old.readline()
                     # prune the oldest 10% or until we have removed 10% of
                     # total bytes starting from oldest entry
                     # TODO: make this configurable?
@@ -692,33 +689,32 @@ class ConcretizationCache:
                             tty.warn(
                                 f"Invalid concretization cache entry: '{line}' on line: {i+1}"
                             )
-                    self._write_manifest(new, entry_count, manifest_bytes)
+                    self._write_manifest(old, new, entry_count, manifest_bytes)
 
             elif manifest_bytes > bytes_limit and bytes_limit > 0:
                 with self._fc.write_transaction(self._cache_manifest) as (old, new):
-                    self._synchronize_manifest(old, new)
                     # advance new beyond metadata entry
-                    new.readline()
+                    old.readline()
                     # take 10% of current size off
                     prune_amount = bytes_limit // 10
                     total_pruned = 0
                     i = 0
                     while total_pruned < prune_amount:
-                        sha, manifest_cache_bytes = self._parse_manifest_entry(new.readline())
+                        sha, manifest_cache_bytes = self._parse_manifest_entry(old.readline())
                         if sha and manifest_cache_bytes:
-                            entry_bytes = int(manifest_cache_bytes)
+                            manifest_cache_bytes = int(manifest_cache_bytes)
                             cache_path = self.root / sha[:2] / sha
                             if self._safe_remove(cache_path):
                                 entry_count -= 1
-                                entry_bytes -= entry_bytes
-                                total_pruned += entry_bytes
+                                manifest_bytes -= manifest_cache_bytes
+                                total_pruned += manifest_cache_bytes
                         else:
                             tty.warn(
                                 "Invalid concretization cache entry "
                                 f"'{sha} {manifest_cache_bytes}' on line: {i}"
                             )
                         i += 1
-                    self._write_manifest(new, entry_count, manifest_bytes)
+                    self._write_manifest(old, new, entry_count, manifest_bytes)
             for cache_dir in self.root.iterdir():
                 if cache_dir.is_dir() and not any(cache_dir.iterdir()):
                     self._safe_remove(cache_dir)
@@ -731,6 +727,8 @@ class ConcretizationCache:
             if cache_dir.is_dir():
                 for cache_entry in cache_dir.iterdir():
                     if not cache_entry.is_dir():
+                        if cache_entry.suffix == ".lock":
+                            continue
                         yield cache_entry
                     else:
                         raise RuntimeError(
@@ -739,7 +737,7 @@ class ConcretizationCache:
                             "within the concretization cache."
                         )
 
-    def _parse_manifest_entry(self, line: str) -> Union[Tuple[None, None], Tuple[int, int]]:
+    def _parse_manifest_entry(self, line: str) -> Union[Tuple[None, None], Tuple[str, str]]:
         """Returns parsed manifest entry lines
         with handling for invalid reads."""
         if line:
@@ -748,12 +746,16 @@ class ConcretizationCache:
             if cache_metadata_size != 2:
                 tty.warn(f"Invalid cache entry at {line}")
                 return None, None
-            cache_count = int(cache_values[0])
-            cache_byte_size = int(cache_values[1])
+            cache_count = cache_values[0]
+            cache_byte_size = cache_values[1]
             return cache_count, cache_byte_size
         return None, None
 
-    def _write_manifest(self, manifest_file: IO[str], entry_count, entry_bytes):
+    def _write_manifest(self,
+                        old_manifest_file: IO[str],
+                        new_manifest_file: IO[str],
+                        entry_count,
+                        entry_bytes):
         """Writes new concretization cache manifest file.
 
         Arguments:
@@ -765,12 +767,11 @@ class ConcretizationCache:
             entry_bytes: new total entry bytes count
 
         """
-        persisted_entries = manifest_file.readlines()
-        manifest_file.truncate(0)
-        manifest_file.write(f"{entry_count} {entry_bytes}\n")
-        manifest_file.writelines(persisted_entries)
+        persisted_entries = old_manifest_file.readlines()
+        new_manifest_file.write(f"{entry_count} {entry_bytes}\n")
+        new_manifest_file.writelines(persisted_entries)
 
-    def _results_from_cache(self, cache_entry_buffer: IO[str]) -> Union[Result, None]:
+    def _results_from_cache(self, cache_entry_buffer: IO[bytes]) -> Union[Result, None]:
         """Returns a Results object from the concretizer cache
 
         Reads the cache hit and uses `Result`'s own deserializer
@@ -787,7 +788,7 @@ class ConcretizationCache:
                 return Result.from_dict(result_json)
         return None
 
-    def _stats_from_cache(self, cache_entry_buffer: IO[str]) -> Union[List, None]:
+    def _stats_from_cache(self, cache_entry_buffer: IO[bytes]) -> Union[List, None]:
         """Returns concretization statistic from the
         concretization associated with the cache.
 
@@ -807,7 +808,10 @@ class ConcretizationCache:
         # make sure we're always reading from the beginning of the stream
         # concretization cache manifest data lives at the top of the file
         with current_file_position(cache_stream, 0):
-            return self._parse_manifest_entry(cache_stream.readline())
+            count, bytes_count =  self._parse_manifest_entry(cache_stream.readline())
+            if count and bytes_count:
+                return int(count), int(bytes_count)
+            return None, None
 
     def _prefix_digest(self, problem: str) -> Tuple[str, str]:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
@@ -833,13 +837,13 @@ class ConcretizationCache:
             spack.util.hash.b32_hash(cache_path), spack.util.crypto.bit_length(sys.maxsize)
         )
 
-    def _zip_cache_entry(self, cache_data):
+    def _zip_cache_entry(self, cache_data: str):
         """Compress cache entries via gzip"""
-        return gzip.compress(cache_data)
+        return gzip.compress(cache_data.encode("utf-8"))
 
-    def _unzip_cache_entry(self, cache_data):
+    def _unzip_cache_entry(self, cache_data: bytes):
         """Decompresses cache entries, which are gzipped by default"""
-        return gzip.decompress(cache_data)
+        return gzip.decompress(cache_data).decode("utf-8")
 
     def _synchronize_manifest(self, old, new):
         """Ensures that cache manifest is synchronized between the original
@@ -864,7 +868,7 @@ class ConcretizationCache:
             self._synchronize_manifest(old, new)
             # check if manifest is empty
             # now all operations can be perofrmed
-            count, cache_bytes = self._extract_cache_metadata(new)
+            count, cache_bytes = self._extract_cache_metadata(old)
             if not count or not cache_bytes:
                 # cache is unintialized
                 count = 0
@@ -874,10 +878,11 @@ class ConcretizationCache:
                 entry_path, entry_bytes = manifest_update
                 count += 1
                 cache_bytes += entry_bytes
-                new.write(f"{entry_path.name} {entry_bytes}")
+                new.write(f"{entry_path.name} {entry_bytes}\n")
             new.seek(0, io.SEEK_SET)
-            new_stats = f"{int(count)+1} {int(cache_bytes)}\n"
+            new_stats = f"{count} {cache_bytes}\n"
             new.write(new_stats)
+            self._manifest_queue.clear()
 
     def _register_cache_update(self, cache_path: pathlib.Path, bytes_written: int):
         """Adds manifest entry to update queue for later updates to the manifest"""
@@ -921,7 +926,8 @@ class ConcretizationCache:
                 tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
                 return
             cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
-            bytes_written = new.write(self._zip_cache_entry(json.dumps(cache_dict)))
+            new_bytes = open(new.name, "wb")
+            bytes_written = new_bytes.write(self._zip_cache_entry(json.dumps(cache_dict)))
             self._register_cache_update(cache_path, bytes_written)
 
     def fetch(self, problem: str) -> Union[Tuple[Result, List], Tuple[None, None]]:
@@ -935,8 +941,9 @@ class ConcretizationCache:
         result, statistics = None, None
         with self._fc.read_transaction(cache_path) as f:
             if f:
-                result = self._results_from_cache(f)
-                statistics = self._stats_from_cache(f)
+                bytes_f = open(f.name, "rb")
+                result = self._results_from_cache(bytes_f)
+                statistics = self._stats_from_cache(bytes_f)
         if result and statistics:
             tty.debug(f"Concretization cache hit at {str(cache_path)}")
             return result, statistics
@@ -4924,11 +4931,12 @@ class Solver:
         setup = SpackSolverSetup(tests=tests)
         output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=setup_only)
 
-        CONC_CACHE.flush_manifest()
-        CONC_CACHE.cleanup()
-        return self.driver.solve(
+        result = self.driver.solve(
             setup, specs, reuse=reusable_specs, output=output, allow_deprecated=allow_deprecated
         )
+        CONC_CACHE.flush_manifest()
+        CONC_CACHE.cleanup()
+        return result
 
     def solve(self, specs, **kwargs):
         """

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -15,6 +15,7 @@ import os
 import pathlib
 import pprint
 import re
+import shutil
 import sys
 import types
 import typing
@@ -64,13 +65,12 @@ import spack.util.hash
 import spack.util.libc
 import spack.util.module_cmd as md
 import spack.util.path
-import spack.util.timer
 import spack.variant as vt
 import spack.version as vn
 import spack.version.git_ref_lookup
 from spack import traverse
 from spack.compilers.libraries import CompilerPropertyDetector
-from spack.util.file_cache import FileCache
+from spack.util.file_cache import DirectoryFileCache
 
 from .core import (
     AspFunction,
@@ -646,16 +646,31 @@ class ConcretizationCache:
     Serializes solver result objects and statistics to json and stores
     at a given endpoint in a cache associated by the sha256 of the
     asp problem and the involved control files.
+
+
+    Cache layout:
+    ```
+    Cache root       Buckets        Entries
+        |        (entry_hash[:2])  (files named by hash)
+        |
+        |-------| - bucket1
+                |        |------| - entry
+                |               | - entry
+                | - bucket2
+                |        |------| - entry
+                |
+                | - bucket3
+                         |------| - entry
+                                | - entry
+    ```
     """
 
     def __init__(self, root: Union[str, None] = None):
         root = root or spack.config.get(
-            "config:concretization_cache:url", spack.paths.default_conc_cache_path
+            "concretizer:concretization_cache:url", spack.paths.default_conc_cache_path
         )
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
-        self._fc = FileCache(self.root)
-        self._cache_manifest = ".cache_manifest"
-        self._manifest_queue: List[Tuple[pathlib.Path, int]] = []
+        self._fc = DirectoryFileCache(self.root)
 
     def cleanup(self):
         """Prunes the concretization cache according to configured size and entry
@@ -665,112 +680,57 @@ class ConcretizationCache:
         bytes_limit = spack.config.get("config:concretization_cache:size_limit", 3e8)
         # lock the entire buildcache as we're removing a lot of data from the
         # manifest and cache itself
-        entry_count, manifest_bytes = 0,0
-
-        import pdb; pdb.set_trace()
-        with self._fc.read_transaction(self._cache_manifest) as f:
-            entry_count, manifest_bytes = self._extract_cache_metadata(f)
-        if not entry_count or not manifest_bytes:
-            return
-        if entry_count > entry_limit and entry_limit > 0:
-            with self._fc.write_transaction(self._cache_manifest) as (old, new):
+        entry_count, bytes_count = 0,0
+        rm_reg: List[pathlib.Path] = []
+        for bucket in self.cache_buckets():
+            with self._fc.read_transaction(bucket) as f:
+                if not f:
+                    raise RuntimeError(
+                        "Attempting to clean non existent cache bucket"
+                        f" {bucket.name}"
+                    )
                 # advance new beyond metadata entry
-                old.readline()
-                # prune the oldest 10% or until we have removed 10% of
-                # total bytes starting from oldest entry
-                # TODO: make this configurable?
-                prune_count = entry_limit // 10
-                lines_to_prune = old.readlines(prune_count)
-                for i, line in enumerate(lines_to_prune):
-                    sha, cache_entry_bytes = self._parse_manifest_entry(line)
-                    if sha and cache_entry_bytes:
-                        cache_path = self._cache_path_from_hash(sha)
-                        if self._fc.remove(cache_path):
-                            entry_count -= 1
-                            manifest_bytes -= int(cache_entry_bytes)
-                    else:
-                        tty.warn(
-                            f"Invalid concretization cache entry: '{line}' on line: {i+1}"
-                        )
-                self._write_manifest(old, new, entry_count, manifest_bytes)
+                for entry in self.cache_entries(bucket):
+                    entry_count += 1
+                    bytes_count += entry.stat().st_size
+                    rm_reg.append(entry)
+        rm_reg.sort(key=lambda x: x.stat().st_mtime, reverse=True)
+        while (entry_count > entry_limit or bytes_count > bytes_limit) and rm_reg:
+            entry_to_rm = rm_reg.pop()
+            entry_bucket = self._cache_bucket_from_path(entry_to_rm)
+            with self._fc.write_transaction(entry_bucket) as valid_bucket:
+                # cache bucket was removed by another process, that's fine
+                # try pruning something else
+                if not valid_bucket:
+                    continue
+                entry_size = entry_to_rm.stat().st_size
+                removed = self._safe_remove(entry_to_rm)
+                if removed:
+                    entry_count -= 1
+                    bytes_count -= entry_size
+        # remove any buckets with no more cache entries
+        for cache_dir in self.cache_buckets():
+            if not any(cache_dir.iterdir()):
+                self._fc.remove(cache_dir)
 
-        elif manifest_bytes > bytes_limit and bytes_limit > 0:
-            with self._fc.write_transaction(self._cache_manifest) as (old, new):
-                # advance new beyond metadata entry
-                old.readline()
-                # take 10% of current size off
-                prune_amount = bytes_limit // 10
-                total_pruned = 0
-                i = 0
-                while total_pruned < prune_amount:
-                    sha, manifest_cache_bytes = self._parse_manifest_entry(old.readline())
-                    if sha and manifest_cache_bytes:
-                        manifest_cache_bytes = int(manifest_cache_bytes)
-                        cache_path = self.root / sha[:2] / sha
-                        if self._safe_remove(cache_path):
-                            entry_count -= 1
-                            manifest_bytes -= manifest_cache_bytes
-                            total_pruned += manifest_cache_bytes
-                    else:
-                        tty.warn(
-                            "Invalid concretization cache entry "
-                            f"'{sha} {manifest_cache_bytes}' on line: {i}"
-                        )
-                    i += 1
-                self._write_manifest(old, new, entry_count, manifest_bytes)
-        for cache_dir in self.root.iterdir():
-            if cache_dir.is_dir() and not any(cache_dir.iterdir()):
-                self._safe_remove(cache_dir)
+    def cache_buckets(self):
+        """Generator producing cache buckets"""
+        for bucket in self.root.iterdir():
+            # skip bucket lockfiles
+            if bucket.is_dir():
+                yield bucket
 
-    def cache_entries(self):
-        """Generator producing cache entries"""
-        for cache_dir in self.root.iterdir():
-            # ensure component is cache entry directory
-            # not metadata file
-            if cache_dir.is_dir():
-                for cache_entry in cache_dir.iterdir():
-                    if not cache_entry.is_dir():
-                        if cache_entry.suffix == ".lock":
-                            continue
-                        yield cache_entry
-                    else:
-                        raise RuntimeError(
-                            "Improperly formed concretization cache. "
-                            f"Directory {cache_entry.name} is improperly located "
-                            "within the concretization cache."
-                        )
-
-    def _parse_manifest_entry(self, line: str) -> Union[Tuple[None, None], Tuple[str, str]]:
-        """Returns parsed manifest entry lines
-        with handling for invalid reads."""
-        if line:
-            cache_values = line.strip("\n").split(" ")
-            cache_metadata_size = len(cache_values)
-            if cache_metadata_size != 2:
-                tty.warn(f"Invalid cache entry at {line}")
-                return None, None
-            cache_count = cache_values[0]
-            cache_byte_size = cache_values[1]
-            return cache_count, cache_byte_size
-        return None, None
-
-    def _write_manifest(
-        self, old_manifest_file: IO[str], new_manifest_file: IO[str], entry_count, entry_bytes
-    ):
-        """Writes new concretization cache manifest file.
-
-        Arguments:
-            manifest_file: IO stream opened for readin
-                            and writing wrapping the manifest file
-                            with cursor at calltime set to location
-                            where manifest should be truncated
-            entry_count: new total entry count
-            entry_bytes: new total entry bytes count
-
-        """
-        persisted_entries = old_manifest_file.readlines()
-        new_manifest_file.write(f"{entry_count} {entry_bytes}\n")
-        new_manifest_file.writelines(persisted_entries)
+    def cache_entries(self, bucket:pathlib.Path):
+        """Generator producing cache entries within a bucket"""
+        for cache_entry in bucket.iterdir():
+            if not cache_entry.is_dir():
+                yield cache_entry
+            else:
+                raise RuntimeError(
+                    "Improperly formed concretization cache. "
+                    f"Directory {cache_entry.name} is improperly located "
+                    "within the concretization cache."
+                )
 
     def _results_from_cache(self, cache_entry_buffer: IO[bytes]) -> Union[Result, None]:
         """Returns a Results object from the concretizer cache
@@ -803,17 +763,6 @@ class ConcretizationCache:
                 return json.loads(cache_str)["statistics"]
         return None
 
-    def _extract_cache_metadata(self, cache_stream: IO[str]):
-        """Extracts and returns cache entry count and bytes count from head of manifest
-        file"""
-        # make sure we're always reading from the beginning of the stream
-        # concretization cache manifest data lives at the top of the file
-        with current_file_position(cache_stream, 0):
-            count, bytes_count = self._parse_manifest_entry(cache_stream.readline())
-            if count and bytes_count:
-                return int(count), int(bytes_count)
-            return None, None
-
     def _prefix_digest(self, problem: str) -> Tuple[str, str]:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
         prob_digest = spack.util.hash.b32_hash(problem)
@@ -826,17 +775,14 @@ class ConcretizationCache:
         prefix, digest = self._prefix_digest(problem)
         return pathlib.Path(prefix) / digest
 
+    def _cache_bucket_from_path(self, cache_entry: pathlib.Path) -> str:
+        """Returns the 2 byte cache entry bucket string from a cache entry"""
+        return cache_entry.parent.name
+
     def _cache_path_from_hash(self, hash: str) -> pathlib.Path:
         """Returns a Path object representing the cache entry
         corresponding to the given sha256 hash"""
         return pathlib.Path(hash[:2]) / hash
-
-    def _lock_prefix_from_cache_path(self, cache_path: str):
-        """Returns the bit location corresponding to a given cache entry path
-        for file locking"""
-        return spack.util.hash.base32_prefix_bits(
-            spack.util.hash.b32_hash(cache_path), spack.util.crypto.bit_length(sys.maxsize)
-        )
 
     def _zip_cache_entry(self, cache_data: str):
         """Compress cache entries via gzip"""
@@ -846,59 +792,12 @@ class ConcretizationCache:
         """Decompresses cache entries, which are gzipped by default"""
         return gzip.decompress(cache_data).decode("utf-8")
 
-    def _synchronize_manifest(self, old, new):
-        """Ensures that cache manifest is synchronized between the original
-        and temporary file created by the file cache write transaction manager
-
-        Returns both stream cursors to beginning of each stream
-        """
-        # synchronize manifests as old will be deleted by
-        # filecache once the context manager exits
-        # skip the manifest header data
-        old.readline()
-        cache_context = old.read()
-        old.seek(0, io.SEEK_SET)
-        # write an empty to line for manifest header
-        new.write("\n")
-        new.write(cache_context)
-        new.seek(0, io.SEEK_SET)
-
-    def flush_manifest(self):
-        """Updates the concretization cache manifest file after a cache write operation
-        Updates the current byte count and entry counts and writes to the head of the
-        manifest file"""
-        manifest_file = self.root / self._cache_manifest
-        manifest_file.touch(exist_ok=True)
-        with self._fc.write_transaction(self._cache_manifest) as (old, new):
-            self._synchronize_manifest(old, new)
-            # check if manifest is empty
-            # now all operations can be perofrmed
-            count, cache_bytes = self._extract_cache_metadata(old)
-            if not count or not cache_bytes:
-                # cache is unintialized
-                count = 0
-                cache_bytes = 0
-            new.seek(0, io.SEEK_END)
-            for manifest_update in self._manifest_queue:
-                entry_path, entry_bytes = manifest_update
-                count += 1
-                cache_bytes += entry_bytes
-                new.write(f"{entry_path.name} {entry_bytes}\n")
-            new.seek(0, io.SEEK_SET)
-            new_stats = f"{count} {cache_bytes}\n"
-            new.write(new_stats)
-            self._manifest_queue.clear()
-
-    def _register_cache_update(self, cache_path: pathlib.Path, bytes_written: int):
-        """Adds manifest entry to update queue for later updates to the manifest"""
-        self._manifest_queue.append((cache_path, bytes_written))
-
-    def _safe_remove(self, cache_dir: pathlib.Path):
+    def _safe_remove(self, cache_dir: pathlib.Path) -> bool:
         """Removes cache entries with handling for the case where the entry has been
         removed already or there are multiple cache entries in a directory"""
         try:
             if cache_dir.is_dir():
-                cache_dir.rmdir()
+                shutil.rmtree(cache_dir)
             else:
                 cache_dir.unlink()
             return True
@@ -919,21 +818,17 @@ class ConcretizationCache:
         Hash membership is computed based on the sha256 of the provided asp
         problem.
         """
-        cache_path = self._cache_path_from_problem(problem)
-        if self._fc.init_entry(cache_path):
-            # if an entry for this conc hash exists already, we're don't want
-            # to overwrite, just exit
-            tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
-            return
-        with self._fc.write_transaction(cache_path) as (old, new):
+        bucket, entry = self._prefix_digest(problem)
+        cache_path = self.root / bucket / entry
+        self._fc.init_entry(cache_path)
+        with self._fc.write_transaction(bucket) as (old, new):
             if old:
                 # Entry for this conc hash exists already, do not overwrite
                 tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
                 return
             cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
-            with open(new.name, "wb") as new_bytes:
-                bytes_written = new_bytes.write(self._zip_cache_entry(json.dumps(cache_dict)))
-            self._register_cache_update(cache_path, bytes_written)
+            with open(cache_path, "wb") as new_bytes:
+                new_bytes.write(self._zip_cache_entry(json.dumps(cache_dict)))
 
     def fetch(self, problem: str) -> Union[Tuple[Result, List], Tuple[None, None]]:
         """Returns the concretization cache result for a lookup based on the given problem.
@@ -942,11 +837,12 @@ class ConcretizationCache:
         Python objects cached on disk representing the concretization results and statistics
         or returns none if no cache entry was found.
         """
-        cache_path = self._cache_path_from_problem(problem)
+        bucket, entry = self._prefix_digest(problem)
+        cache_path = self.root / bucket / entry
         result, statistics = None, None
-        with self._fc.read_transaction(cache_path) as f:
+        with self._fc.read_transaction(bucket) as f:
             if f:
-                bytes_f = open(f.name, "rb")
+                bytes_f = open(cache_path, "rb")
                 result = self._results_from_cache(bytes_f)
                 statistics = self._stats_from_cache(bytes_f)
         if result and statistics:
@@ -4939,7 +4835,6 @@ class Solver:
         result = self.driver.solve(
             setup, specs, reuse=reusable_specs, output=output, allow_deprecated=allow_deprecated
         )
-        CONC_CACHE.flush_manifest()
         CONC_CACHE.cleanup()
         return result
 
@@ -5004,7 +4899,6 @@ class Solver:
             for spec in result.specs:
                 reusable_specs.extend(spec.traverse())
 
-        CONC_CACHE.flush_manifest()
         CONC_CACHE.cleanup()
 
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -822,10 +822,10 @@ class ConcretizationCache:
                     pass
                 except OSError:
                     # Cache may have been created pre compression
-                    # check if gzip, and if so, read from plaintext
+                    # check if gzip, and if not, read from plaintext
                     # otherwise re raise
                     with open(cache_path, "rb") as f:
-                        if GZipFileType().matches_magic(f):
+                        if not GZipFileType().matches_magic(f):
                             cache_entry_content = f.read().decode()
                         else:
                             raise

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -7,7 +7,7 @@ import copy
 import enum
 import errno
 import functools
-import hashlib
+import gzip
 import io
 import itertools
 import json
@@ -28,6 +28,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -671,15 +672,16 @@ class ConcretizationCache:
                 return
             entry_count = int(count)
             manifest_bytes = int(cache_bytes)
-            # move beyond the metadata entry
-            f.readline()
             if entry_count > entry_limit and entry_limit > 0:
                 with self._fc.write_transaction(self._cache_manifest) as (old, new):
+                    self._synchronize_manifest(old, new)
+                    # advance new beyond metadata entry
+                    new.readline()
                     # prune the oldest 10% or until we have removed 10% of
                     # total bytes starting from oldest entry
                     # TODO: make this configurable?
                     prune_count = entry_limit // 10
-                    lines_to_prune = f.readlines(prune_count)
+                    lines_to_prune = new.readlines(prune_count)
                     for i, line in enumerate(lines_to_prune):
                         sha, cache_entry_bytes = self._parse_manifest_entry(line)
                         if sha and cache_entry_bytes:
@@ -691,16 +693,19 @@ class ConcretizationCache:
                             tty.warn(
                                 f"Invalid concretization cache entry: '{line}' on line: {i+1}"
                             )
-                    self._write_manifest(f, entry_count, manifest_bytes)
+                    self._write_manifest(new, entry_count, manifest_bytes)
 
             elif manifest_bytes > bytes_limit and bytes_limit > 0:
                 with self._fc.write_transaction(self._cache_manifest) as (old, new):
+                    self._synchronize_manifest(old, new)
+                    # advance new beyond metadata entry
+                    new.readline()
                     # take 10% of current size off
                     prune_amount = bytes_limit // 10
                     total_pruned = 0
                     i = 0
                     while total_pruned < prune_amount:
-                        sha, manifest_cache_bytes = self._parse_manifest_entry(f.readline())
+                        sha, manifest_cache_bytes = self._parse_manifest_entry(new.readline())
                         if sha and manifest_cache_bytes:
                             entry_bytes = int(manifest_cache_bytes)
                             cache_path = self.root / sha[:2] / sha
@@ -714,7 +719,7 @@ class ConcretizationCache:
                                 f"'{sha} {manifest_cache_bytes}' on line: {i}"
                             )
                         i += 1
-                    self._write_manifest(f, entry_count, manifest_bytes)
+                    self._write_manifest(new, entry_count, manifest_bytes)
             for cache_dir in self.root.iterdir():
                 if cache_dir.is_dir() and not any(cache_dir.iterdir()):
                     self._safe_remove(cache_dir)
@@ -735,17 +740,19 @@ class ConcretizationCache:
                             "within the concretization cache."
                         )
 
-    def _parse_manifest_entry(self, line):
+    def _parse_manifest_entry(self, line: str) -> Sequence[Union[None, str]]:
         """Returns parsed manifest entry lines
         with handling for invalid reads."""
         if line:
             cache_values = line.strip("\n").split(" ")
-            if len(cache_values) < 2:
+            cache_metadata_size = len(cache_values)
+            if cache_metadata_size != 2:
                 tty.warn(f"Invalid cache entry at {line}")
                 return None, None
+            return cache_values
         return None, None
 
-    def _write_manifest(self, manifest_file, entry_count, entry_bytes):
+    def _write_manifest(self, manifest_file: IO[str], entry_count, entry_bytes):
         """Writes new concretization cache manifest file.
 
         Arguments:
@@ -770,7 +777,7 @@ class ConcretizationCache:
         """
 
         with current_file_position(cache_entry_buffer, 0):
-            cache_str = cache_entry_buffer.read()
+            cache_str = self._unzip_cache_entry(cache_entry_buffer.read())
             # TODO: Should this be an error if None?
             # Same for _stats_from_cache
             if cache_str:
@@ -788,7 +795,7 @@ class ConcretizationCache:
         and returns the Python data structures
         """
         with current_file_position(cache_entry_buffer, 0):
-            cache_str = cache_entry_buffer.read()
+            cache_str = self._unzip_cache_entry(cache_entry_buffer.read())
             if cache_str:
                 return json.loads(cache_str)["statistics"]
         return None
@@ -803,7 +810,7 @@ class ConcretizationCache:
 
     def _prefix_digest(self, problem: str) -> Tuple[str, str]:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
-        prob_digest = hashlib.sha256(problem.encode()).hexdigest()
+        prob_digest = spack.util.hash.b32_hash(problem)
         prefix = prob_digest[:2]
         return prefix, prob_digest
 
@@ -825,28 +832,51 @@ class ConcretizationCache:
             spack.util.hash.b32_hash(cache_path), spack.util.crypto.bit_length(sys.maxsize)
         )
 
+    def _zip_cache_entry(self, cache_data):
+        """Compress cache entries via gzip"""
+        return gzip.compress(cache_data)
+
+    def _unzip_cache_entry(self, cache_data):
+        """Decompresses cache entries, which are gzipped by default"""
+        return gzip.decompress(cache_data)
+
+    def _synchronize_manifest(self, old, new):
+        """Ensures that cache manifest is synchronized between the original
+        and temporary file created by the file cache write transaction manager
+
+        Returns both stream cursors to beginning of each stream
+        """
+        # synchronize manifests as old will be deleted by
+        # filecache once the context manager exits
+        cache_context = old.read()
+        old.seek(0, io.SEEK_SET)
+        new.write(cache_context)
+        new.seek(0, io.SEEK_SET)
+
     def flush_manifest(self):
         """Updates the concretization cache manifest file after a cache write operation
         Updates the current byte count and entry counts and writes to the head of the
         manifest file"""
         manifest_file = self.root / self._cache_manifest
         manifest_file.touch(exist_ok=True)
-        with open(manifest_file, "r+", encoding="utf-8") as f:
+        with self._fc.write_transaction(self._cache_manifest) as (old, new):
+            self._synchronize_manifest(old, new)
             # check if manifest is empty
-            count, cache_bytes = self._extract_cache_metadata(f)
+            # now all operations can be perofrmed
+            count, cache_bytes = self._extract_cache_metadata(new)
             if not count or not cache_bytes:
                 # cache is unintialized
                 count = 0
                 cache_bytes = 0
-            f.seek(0, io.SEEK_END)
+            new.seek(0, io.SEEK_END)
             for manifest_update in self._manifest_queue:
                 entry_path, entry_bytes = manifest_update
                 count += 1
                 cache_bytes += entry_bytes
-                f.write(f"{entry_path.name} {entry_bytes}")
-            f.seek(0, io.SEEK_SET)
+                new.write(f"{entry_path.name} {entry_bytes}")
+            new.seek(0, io.SEEK_SET)
             new_stats = f"{int(count)+1} {int(cache_bytes)}\n"
-            f.write(new_stats)
+            new.write(new_stats)
 
     def _register_cache_update(self, cache_path: pathlib.Path, bytes_written: int):
         """Adds manifest entry to update queue for later updates to the manifest"""
@@ -890,7 +920,7 @@ class ConcretizationCache:
                 tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
                 return
             cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
-            bytes_written = new.write(json.dumps(cache_dict))
+            bytes_written = new.write(self._zip_cache_entry(json.dumps(cache_dict)))
             self._register_cache_update(cache_path, bytes_written)
 
     def fetch(self, problem: str) -> Union[Tuple[Result, List], Tuple[None, None]]:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -851,8 +851,12 @@ class ConcretizationCache:
         """
         # synchronize manifests as old will be deleted by
         # filecache once the context manager exits
+        # skip the manifest header data
+        old.readline()
         cache_context = old.read()
         old.seek(0, io.SEEK_SET)
+        # write an empty to line for manifest header
+        new.write("\n")
         new.write(cache_context)
         new.seek(0, io.SEEK_SET)
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3942,7 +3942,7 @@ def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_co
     # 1000 is an absurdly low cache size, all entries should be pruned
     assert real_count == 0, "Concretization cache did not properly prune on byte limit"
 
-
+@pytest.mark.skipif(sys.platform == "win32", reason="No locks on Windows")
 def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we're not leaving dangling lockfiles when we perform cleanup
     operations"""

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3954,6 +3954,7 @@ def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable
     for file in spack.solver.asp.CONC_CACHE.root.iterdir():
         if file.is_file() and file.suffix == ".lock":
             lock_count += 1
-    assert lock_count == 1, f"Unexpected number of lockfiles {lock_count} \
+    assert (
+        lock_count == 1
+    ), f"Unexpected number of lockfiles {lock_count} \
 concretization cache cleanup operation failed."
-

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3938,7 +3938,8 @@ def test_concretization_cache_manifest_metadata_extraction(
         ), f"Invalid cache metadata read, count value was {count}, but parsed {cache_count}"
         assert (
             cache_byte_size == byte_size
-        ), f"Invalid cache metadata read, byte size value was {byte_size}, but parsed {cache_byte_size}"
+        ), f"Invalid cache metadata read,"
+        "byte size value was {byte_size}, but parsed {cache_byte_size}"
 
 
 def test_concretization_cache_manifest_updating(use_concretization_cache, mutable_config):
@@ -3961,10 +3962,12 @@ def test_concretization_cache_manifest_updating(use_concretization_cache, mutabl
         byte_size += entry.stat().st_size
     assert (
         parsed_count == count
-    ), f"Concretization cache manifest entry count incorrect. Expected count {count}, got {parsed_count}"
+    ), f"Concretization cache manifest entry count incorrect. "
+    "Expected count {count}, got {parsed_count}"
     assert (
         parsed_byte_size == byte_size
-    ), f"Concretization cache manifest byte count incorrect. Expected count {byte_size}, got {parsed_byte_size}"
+    ), f"Concretization cache manifest byte count incorrect. "
+    "Expected count {byte_size}, got {parsed_byte_size}"
 
 
 def test_concretization_cache_cleanup_count(use_concretization_cache, mutable_config):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import io
 import os
 import pathlib
 import platform
@@ -3915,3 +3916,36 @@ def test_satisfies_conditional_spec(
     assert abstract_spec.satisfies(conditional_spec) is expected_abstract
     assert concrete_spec.satisfies(conditional_spec) is expected_concrete
     assert concrete_spec.satisfies(abstract_spec)
+def test_concretization_cache_manifest_metadata_extraction(use_concretization_cache, mutable_config, monkeypatch):
+    """Test that the concretization cache is able to correctly extract manifest data"""
+    cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
+    cache = cache_root / ".cache_manifest"
+    with cache.open("r") as f:
+        cache_metadata = f.readline().strip("\n").split(" ")
+        assert len(cache_metadata) == 2, f"Invalid cache metadata structure: {len(cache_metadata)} values detected"
+        f.seek(0, io.SEEK_CUR)
+        cache_count, cache_byte_size = spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
+        count, byte_size = cache_metadata
+        assert cache_count == count, f"Invalid cache metadata read, count value was {count}, but parsed {cache_count}"
+        assert cache_byte_size == byte_size, f"Invalid cache metadata read, byte size value was {byte_size}, but parsed {cache_byte_size}"
+
+
+def test_concretization_cache_manifest_updating(use_concretization_cache, mutable_config, monkeypatch):
+    """Tests that the concretization cache manifest keeps proper track of all manifest entries"""
+    def extract_cache_metadata(cache_root: pathlib.Path):
+        cache = cache_root / ".cache_manifest"
+        with cache.open("r") as f:
+            return spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
+
+    cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
+    spack.concretize.concretize_one("zlib")
+    spack.concretize.concretize_one("hdf5")
+    spack.concretize.concretize_one("py-black")
+    parsed_count, parsed_byte_size = extract_cache_metadata(cache_root)
+    count = 0
+    byte_size = 0
+    for i, entry in enumerate(spack.solver.asp.CONC_CACHE.cache_entries()):
+        count += i
+        byte_size += entry.stat().st_size
+    assert parsed_count == count, f"Concretization cache manifest entry count incorrect. Expected count {count}, got {parsed_count}"
+    assert parsed_byte_size == byte_size, f"Concretization cache manifest byte count incorrect. Expected count {byte_size}, got {parsed_byte_size}"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3932,31 +3932,6 @@ def get_current_cache_data():
     return count, byte_size
 
 
-def test_concretization_cache_manifest_metadata_extraction(
-    use_concretization_cache, mutable_config
-):
-    """Test that the concretization cache is able to correctly extract manifest data"""
-    cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
-    cache = cache_root / ".cache_manifest"
-    with cache.open("r") as f:
-        cache_metadata = f.readline().strip("\n").split(" ")
-        assert (
-            len(cache_metadata) == 2
-        ), f"Invalid cache metadata structure: {len(cache_metadata)} values detected"
-        f.seek(0, io.SEEK_CUR)
-        cache_count, cache_byte_size = spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
-        count, byte_size = cache_metadata
-        count = int(count)
-        byte_size = int(byte_size)
-        assert (
-            cache_count == count
-        ), f"Invalid cache metadata read, count value was {count}, but parsed {cache_count}"
-        assert (
-            cache_byte_size == byte_size
-        ), f"Invalid cache metadata read,"
-        "byte size value was {byte_size}, but parsed {cache_byte_size}"
-
-
 def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we are cleaning the cache when we should be respective to the
     number of entries allowed in the cache"""

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3917,21 +3917,33 @@ def test_satisfies_conditional_spec(
     assert concrete_spec.satisfies(conditional_spec) is expected_concrete
     assert concrete_spec.satisfies(abstract_spec)
 def test_concretization_cache_manifest_metadata_extraction(use_concretization_cache, mutable_config, monkeypatch):
+def test_concretization_cache_manifest_metadata_extraction(
+    use_concretization_cache, mutable_config
+):
     """Test that the concretization cache is able to correctly extract manifest data"""
     cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
     cache = cache_root / ".cache_manifest"
     with cache.open("r") as f:
         cache_metadata = f.readline().strip("\n").split(" ")
-        assert len(cache_metadata) == 2, f"Invalid cache metadata structure: {len(cache_metadata)} values detected"
+        assert (
+            len(cache_metadata) == 2
+        ), f"Invalid cache metadata structure: {len(cache_metadata)} values detected"
         f.seek(0, io.SEEK_CUR)
         cache_count, cache_byte_size = spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
         count, byte_size = cache_metadata
-        assert cache_count == count, f"Invalid cache metadata read, count value was {count}, but parsed {cache_count}"
-        assert cache_byte_size == byte_size, f"Invalid cache metadata read, byte size value was {byte_size}, but parsed {cache_byte_size}"
+        count = int(count)
+        byte_size = int(byte_size)
+        assert (
+            cache_count == count
+        ), f"Invalid cache metadata read, count value was {count}, but parsed {cache_count}"
+        assert (
+            cache_byte_size == byte_size
+        ), f"Invalid cache metadata read, byte size value was {byte_size}, but parsed {cache_byte_size}"
 
 
-def test_concretization_cache_manifest_updating(use_concretization_cache, mutable_config, monkeypatch):
+def test_concretization_cache_manifest_updating(use_concretization_cache, mutable_config):
     """Tests that the concretization cache manifest keeps proper track of all manifest entries"""
+
     def extract_cache_metadata(cache_root: pathlib.Path):
         cache = cache_root / ".cache_manifest"
         with cache.open("r") as f:
@@ -3947,5 +3959,38 @@ def test_concretization_cache_manifest_updating(use_concretization_cache, mutabl
     for i, entry in enumerate(spack.solver.asp.CONC_CACHE.cache_entries()):
         count += i
         byte_size += entry.stat().st_size
-    assert parsed_count == count, f"Concretization cache manifest entry count incorrect. Expected count {count}, got {parsed_count}"
-    assert parsed_byte_size == byte_size, f"Concretization cache manifest byte count incorrect. Expected count {byte_size}, got {parsed_byte_size}"
+    assert (
+        parsed_count == count
+    ), f"Concretization cache manifest entry count incorrect. Expected count {count}, got {parsed_count}"
+    assert (
+        parsed_byte_size == byte_size
+    ), f"Concretization cache manifest byte count incorrect. Expected count {byte_size}, got {parsed_byte_size}"
+
+
+def test_concretization_cache_cleanup_count(use_concretization_cache, mutable_config):
+    """Tests to ensure we are cleaning the cache when we should be and that the manifest is updated
+    correctly and reflects the current state of the cache"""
+
+    def get_current_cache_data():
+        count, byte_size = 0, 0
+        for i, entry in enumerate(spack.solver.asp.CONC_CACHE.cache_entries()):
+            count += i
+            byte_size += entry.stat().st_size
+        return count, byte_size
+
+    def extract_cache_metadata():
+        cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
+        cache = cache_root / ".cache_manifest"
+        with cache.open("r") as f:
+            return spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
+
+    spack.config.set("config:concretization_cache:entry_size", 2)
+    spack.concretize.concretize_one("zlib")
+    spack.concretize.concretize_one("hdf5")
+    # cleanup should be run after the third execution
+    spack.concretize.concretize_one("py-black")
+
+    real_count, real_size = get_current_cache_data()
+    manifest_count, manifest_size = extract_cache_metadata()
+    assert real_count == manifest_count
+    assert real_size == manifest_size

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3212,15 +3212,6 @@ def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusabl
         assert (spec1.dag_hash() == spec2.dag_hash()) == reusable
 
 
-
-def get_current_cache_data():
-    count, byte_size = 0, 0
-    for bucket in spack.solver.asp.CONC_CACHE.cache_buckets():
-        for entry in spack.solver.asp.CONC_CACHE.cache_entries(bucket):
-            count += 1
-            byte_size += entry.stat().st_size
-    return count, byte_size
-
 def extract_cache_metadata():
     cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
     cache = cache_root / ".cache_manifest"
@@ -3881,9 +3872,7 @@ def test_satisfies_conditional_spec(
     assert concrete_spec.satisfies(abstract_spec)
 
 
-def test_concretization_cache_roundtrip(
-    mock_packages, use_concretization_cache, monkeypatch, mutable_config
-):
+def test_concretization_cache_roundtrip(use_concretization_cache, monkeypatch, mutable_config):
     """Tests whether we can write the results of a clingo solve to the cache
     and load the same spec request from the cache to produce identical specs"""
     # Force determinism:
@@ -3934,6 +3923,15 @@ def test_concretization_cache_roundtrip(
         assert h == spack.concretize.concretize_one("hdf5")
 
 
+def get_current_cache_data():
+    count, byte_size = 0, 0
+    for bucket in spack.solver.asp.CONC_CACHE.cache_buckets():
+        for entry in spack.solver.asp.CONC_CACHE.cache_entries(bucket):
+            count += 1
+            byte_size += entry.stat().st_size
+    return count, byte_size
+
+
 def test_concretization_cache_manifest_metadata_extraction(
     use_concretization_cache, mutable_config
 ):
@@ -3957,23 +3955,6 @@ def test_concretization_cache_manifest_metadata_extraction(
             cache_byte_size == byte_size
         ), f"Invalid cache metadata read,"
         "byte size value was {byte_size}, but parsed {cache_byte_size}"
-
-
-def test_concretization_cache_manifest_updating(use_concretization_cache, mutable_config):
-    """Tests that the concretization cache manifest keeps proper track of all manifest entries"""
-    spack.concretize.concretize_one("zlib")
-    spack.concretize.concretize_one("hdf5")
-    spack.concretize.concretize_one("py-black")
-    parsed_count, parsed_byte_size = extract_cache_metadata()
-    count = 0
-    byte_size = 0
-    for entry in spack.solver.asp.CONC_CACHE.cache_entries():
-        count += 1
-        byte_size += entry.stat().st_size
-    assert parsed_count == count, "Concretization cache manifest entry count incorrect. "
-    f"Expected count {count}, got {parsed_count}"
-    assert parsed_byte_size == byte_size, "Concretization cache manifest byte count incorrect. "
-    f"Expected count {byte_size}, got {parsed_byte_size}"
 
 
 def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_config):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3941,3 +3941,19 @@ def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_co
     # ensure there's fewer cache entries
     # 1000 is an absurdly low cache size, all entries should be pruned
     assert real_count == 0, "Concretization cache did not properly prune on byte limit"
+
+
+def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable_config):
+    """Tests to ensure we're not leaving dangling lockfiles when we perform cleanup
+    operations"""
+    spack.config.set("concretizer:concretization_cache:entry_limit", 1)
+    spack.concretize.concretize_one("zlib")
+    spack.concretize.concretize_one("hdf5")
+    # cleanup should have been run and there should be no lockfiles
+    lock_count = 0
+    for file in spack.solver.asp.CONC_CACHE.root.iterdir():
+        if file.is_file() and file.suffix == ".lock":
+            lock_count += 1
+    assert lock_count == 1, f"Unexpected number of lockfiles {lock_count} \
+concretization cache cleanup operation failed."
+

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3874,24 +3874,6 @@ def test_satisfies_conditional_spec(
 def test_concretization_cache_roundtrip(use_concretization_cache, monkeypatch, mutable_config):
     """Tests whether we can write the results of a clingo solve to the cache
     and load the same spec request from the cache to produce identical specs"""
-    # Force determinism:
-    # Solver setup is normally non-deterministic due to non-determinism in
-    # asp solver setup logic generation. The only other inputs to the cache keys are
-    # the .lp files, which are invariant over the course of this test.
-    # This method forces the same setup to be produced for the same specs
-    # which gives us a guarantee of cache hits, as it removes the only
-    # element of non deterministic solver setup for the same spec
-    # Basically just a quick and dirty memoization
-    solver_setup = spack.solver.asp.SpackSolverSetup.setup
-
-    def _setup(self, specs, *, reuse=None, allow_deprecated=False):
-        if not getattr(_setup, "cache_setup", None):
-            cache_setup = solver_setup(self, specs, reuse=reuse, allow_deprecated=allow_deprecated)
-            setattr(_setup, "cache_setup", cache_setup)
-        return getattr(_setup, "cache_setup")
-
-    # monkeypatch our forced determinism setup method into solver setup
-    monkeypatch.setattr(spack.solver.asp.SpackSolverSetup, "setup", _setup)
 
     assert spack.config.get("concretizer:concretization_cache:enable")
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import io
 import os
 import pathlib
 import platform

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1,6 +1,8 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import gzip
+import json
 import os
 import pathlib
 import platform
@@ -3881,8 +3883,9 @@ def test_concretization_cache_roundtrip(use_concretization_cache, monkeypatch, m
     # memoization
     h = spack.concretize.concretize_one("hdf5")
 
-    # due to our forced determinism above, we should not be observing
-    # cache misses, assert that we're not storing any new cache entries
+    # ASP output should be stable, concretizing the same spec
+    # should have the same problem output
+    # assert that we're not storing any new cache entries
     def _ensure_no_store(self, problem: str, result, statistics, test=False):
         # always throw, we never want to reach this code path
         assert False, "Concretization cache hit expected"
@@ -3959,3 +3962,28 @@ def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable
         lock_count == 1
     ), f"Unexpected number of lockfiles {lock_count} \
 concretization cache cleanup operation failed."
+
+
+def test_concretization_cache_uncompressed_entry(use_concretization_cache, monkeypatch):
+    def store(self, problem, result, statistics, test = False):
+        bucket, digest = self._prefix_digest(problem)
+        cache_path = self.root / bucket / digest
+        self._fc.init_entry(bucket)
+        with self._fc.write_transaction(bucket) as exists:
+            if not exists:
+                # The directory may have been pruned between init entry and the write
+                # transaction, recreate the directory
+                os.makedirs(bucket)
+            try:
+                with open(cache_path, "x") as cache_entry:
+                    cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
+                    cache_entry.write(json.dumps(cache_dict))
+            except FileExistsError:
+                # Entry for this conc hash exists already, do not overwrite
+                pass
+
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", store)
+    # Store the results in plaintext
+    spack.concretize.concretize_one("zlib")
+    # Ensure fetch can handle the plaintext cache entry
+    spack.concretize.concretize_one("zlib")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import gzip
 import json
 import os
 import pathlib
@@ -3965,7 +3964,7 @@ concretization cache cleanup operation failed."
 
 
 def test_concretization_cache_uncompressed_entry(use_concretization_cache, monkeypatch):
-    def store(self, problem, result, statistics, test = False):
+    def store(self, problem, result, statistics, test=False):
         bucket, digest = self._prefix_digest(problem)
         cache_path = self.root / bucket / digest
         self._fc.init_entry(bucket)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3893,7 +3893,7 @@ def test_concretization_cache_roundtrip(use_concretization_cache, monkeypatch, m
     # monkeypatch our forced determinism setup method into solver setup
     monkeypatch.setattr(spack.solver.asp.SpackSolverSetup, "setup", _setup)
 
-    assert spack.config.get("config:concretization_cache:enable")
+    assert spack.config.get("concretizer:concretization_cache:enable")
 
     # run one standard concretization to populate the cache and the setup method
     # memoization
@@ -3935,7 +3935,7 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     """Tests to ensure we are cleaning the cache when we should be respective to the
     number of entries allowed in the cache"""
 
-    spack.config.set("config:concretization_cache:entry_limit", 2)
+    spack.config.set("concretizer:concretization_cache:entry_limit", 2)
     spack.concretize.concretize_one("zlib")
     spack.concretize.concretize_one("hdf5")
     # cleanup should be run after the third execution
@@ -3949,13 +3949,13 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
 def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we are cleaning the cache when we should be respective to the
     size of the cache in bytes"""
-    spack.config.set("config:concretization_cache:size_limit", 3000)
+    spack.config.set("concretizer:concretization_cache:size_limit", 18000)
     spack.concretize.concretize_one("zlib")
     # cleanup should be run after hdf5 is concretized
     spack.concretize.concretize_one("hdf5")
 
     real_count, real_size = get_current_cache_data()
     # ensure we have less than our byte size limit
-    assert real_size < 3000, "Concretization cache cleanup did not reduce enough bytes"
+    assert real_size < 18000, "Concretization cache cleanup did not reduce enough bytes"
     # ensure there's only one cache entry
     assert real_count == 1, "Concretization cache did not properly prune on byte limit"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3974,7 +3974,7 @@ def test_concretization_cache_uncompressed_entry(use_concretization_cache, monke
                 # transaction, recreate the directory
                 os.makedirs(bucket)
             try:
-                with open(cache_path, "x") as cache_entry:
+                with open(cache_path, "x", encoding="utf-8") as cache_entry:
                     cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
                     cache_entry.write(json.dumps(cache_dict))
             except FileExistsError:

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3949,13 +3949,13 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
 def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we are cleaning the cache when we should be respective to the
     size of the cache in bytes"""
-    spack.config.set("concretizer:concretization_cache:size_limit", 18000)
+    spack.config.set("concretizer:concretization_cache:size_limit", 1000)
     spack.concretize.concretize_one("zlib")
     # cleanup should be run after hdf5 is concretized
     spack.concretize.concretize_one("hdf5")
-
     real_count, real_size = get_current_cache_data()
     # ensure we have less than our byte size limit
-    assert real_size < 18000, "Concretization cache cleanup did not reduce enough bytes"
-    # ensure there's only one cache entry
-    assert real_count == 1, "Concretization cache did not properly prune on byte limit"
+    assert real_size < 1000, "Concretization cache cleanup did not reduce enough bytes"
+    # ensure there's fewer cache entries
+    # 1000 is an absurdly low cache size, all entries should be pruned
+    assert real_count == 0, "Concretization cache did not properly prune on byte limit"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3942,6 +3942,7 @@ def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_co
     # 1000 is an absurdly low cache size, all entries should be pruned
     assert real_count == 0, "Concretization cache did not properly prune on byte limit"
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="No locks on Windows")
 def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we're not leaving dangling lockfiles when we perform cleanup

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3212,6 +3212,20 @@ def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusabl
         assert (spec1.dag_hash() == spec2.dag_hash()) == reusable
 
 
+def get_current_cache_data():
+    count, byte_size = 0, 0
+    for entry in spack.solver.asp.CONC_CACHE.cache_entries():
+        count += 1
+        byte_size += entry.stat().st_size
+    return count, byte_size
+
+def extract_cache_metadata():
+    cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
+    cache = cache_root / ".cache_manifest"
+    with cache.open("r") as f:
+        return spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
+
+
 @pytest.mark.regression("42679")
 @pytest.mark.parametrize("compiler_str", ["gcc@=9.4.0", "gcc@=9.4.0-foo"])
 def test_selecting_compiler_with_suffix(mutable_config, mock_packages, compiler_str):
@@ -3945,17 +3959,10 @@ def test_concretization_cache_manifest_metadata_extraction(
 
 def test_concretization_cache_manifest_updating(use_concretization_cache, mutable_config):
     """Tests that the concretization cache manifest keeps proper track of all manifest entries"""
-
-    def extract_cache_metadata(cache_root: pathlib.Path):
-        cache = cache_root / ".cache_manifest"
-        with cache.open("r") as f:
-            return spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
-
-    cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
     spack.concretize.concretize_one("zlib")
     spack.concretize.concretize_one("hdf5")
     spack.concretize.concretize_one("py-black")
-    parsed_count, parsed_byte_size = extract_cache_metadata(cache_root)
+    parsed_count, parsed_byte_size = extract_cache_metadata()
     count = 0
     byte_size = 0
     for entry in spack.solver.asp.CONC_CACHE.cache_entries():
@@ -3967,24 +3974,11 @@ def test_concretization_cache_manifest_updating(use_concretization_cache, mutabl
     f"Expected count {byte_size}, got {parsed_byte_size}"
 
 
-def test_concretization_cache_cleanup(use_concretization_cache, mutable_config):
+def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we are cleaning the cache when we should be and that the manifest is updated
     correctly and reflects the current state of the cache"""
 
-    def get_current_cache_data():
-        count, byte_size = 0, 0
-        for entry in spack.solver.asp.CONC_CACHE.cache_entries():
-            count += 1
-            byte_size += entry.stat().st_size
-        return count, byte_size
-
-    def extract_cache_metadata():
-        cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
-        cache = cache_root / ".cache_manifest"
-        with cache.open("r") as f:
-            return spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
-
-    spack.config.set("config:concretization_cache:entry_size", 2)
+    spack.config.set("config:concretization_cache:entry_limit", 2)
     spack.concretize.concretize_one("zlib")
     spack.concretize.concretize_one("hdf5")
     # cleanup should be run after the third execution
@@ -3992,7 +3986,32 @@ def test_concretization_cache_cleanup(use_concretization_cache, mutable_config):
 
     real_count, real_size = get_current_cache_data()
     manifest_count, manifest_size = extract_cache_metadata()
+    # ensure we only have 2 entries
+    assert real_count == 2, "Concretization cache cleanup pruned incorrectly"
+    # ensure the manifest reports that
     assert real_count == manifest_count, "Concretization cache manifest entry count incorrect. "
     f"Expected count {real_count}, got {manifest_count}"
+    # Ensure the bytes count was updated properly
     assert real_size == manifest_size, "Concretization cache manifest byte count incorrect. "
+    f"Expected count {real_size}, got {manifest_size}"
+
+
+def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_config):
+
+    spack.config.set("config:concretization_cache:size_limit", 3000)
+    spack.concretize.concretize_one("zlib")
+    # cleanup should be run after hdf5 is concretized
+    spack.concretize.concretize_one("hdf5")
+
+    real_count, real_size = get_current_cache_data()
+    manifest_count, manifest_size = extract_cache_metadata()
+    # ensure we have less than our byte size limit
+    assert real_size < 3000, "Concretization cache cleanup did not reduce enough bytes"
+    # ensure there's only one cache entry
+    assert real_count == 1, "Concretization cache did not properly prune on byte limit"
+    # ensure the manifest reports that
+    assert real_size == manifest_size, "Concretization cache manifest entry count incorrect. "
+    f"Expected count {real_count}, got {manifest_count}"
+    # Ensure the manifest count entry was updated correctly
+    assert real_count == manifest_count, "Concretization cache manifest byte count incorrect. "
     f"Expected count {real_size}, got {manifest_size}"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3212,11 +3212,13 @@ def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusabl
         assert (spec1.dag_hash() == spec2.dag_hash()) == reusable
 
 
+
 def get_current_cache_data():
     count, byte_size = 0, 0
-    for entry in spack.solver.asp.CONC_CACHE.cache_entries():
-        count += 1
-        byte_size += entry.stat().st_size
+    for bucket in spack.solver.asp.CONC_CACHE.cache_buckets():
+        for entry in spack.solver.asp.CONC_CACHE.cache_entries(bucket):
+            count += 1
+            byte_size += entry.stat().st_size
     return count, byte_size
 
 def extract_cache_metadata():
@@ -3975,8 +3977,8 @@ def test_concretization_cache_manifest_updating(use_concretization_cache, mutabl
 
 
 def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_config):
-    """Tests to ensure we are cleaning the cache when we should be and that the manifest is updated
-    correctly and reflects the current state of the cache"""
+    """Tests to ensure we are cleaning the cache when we should be respective to the
+    number of entries allowed in the cache"""
 
     spack.config.set("config:concretization_cache:entry_limit", 2)
     spack.concretize.concretize_one("zlib")
@@ -3984,34 +3986,21 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     # cleanup should be run after the third execution
     spack.concretize.concretize_one("py-black")
 
-    real_count, real_size = get_current_cache_data()
-    manifest_count, manifest_size = extract_cache_metadata()
+    real_count, _ = get_current_cache_data()
     # ensure we only have 2 entries
     assert real_count == 2, "Concretization cache cleanup pruned incorrectly"
-    # ensure the manifest reports that
-    assert real_count == manifest_count, "Concretization cache manifest entry count incorrect. "
-    f"Expected count {real_count}, got {manifest_count}"
-    # Ensure the bytes count was updated properly
-    assert real_size == manifest_size, "Concretization cache manifest byte count incorrect. "
-    f"Expected count {real_size}, got {manifest_size}"
 
 
 def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_config):
-
+    """Tests to ensure we are cleaning the cache when we should be respective to the
+    size of the cache in bytes"""
     spack.config.set("config:concretization_cache:size_limit", 3000)
     spack.concretize.concretize_one("zlib")
     # cleanup should be run after hdf5 is concretized
     spack.concretize.concretize_one("hdf5")
 
     real_count, real_size = get_current_cache_data()
-    manifest_count, manifest_size = extract_cache_metadata()
     # ensure we have less than our byte size limit
     assert real_size < 3000, "Concretization cache cleanup did not reduce enough bytes"
     # ensure there's only one cache entry
     assert real_count == 1, "Concretization cache did not properly prune on byte limit"
-    # ensure the manifest reports that
-    assert real_size == manifest_size, "Concretization cache manifest entry count incorrect. "
-    f"Expected count {real_count}, got {manifest_count}"
-    # Ensure the manifest count entry was updated correctly
-    assert real_count == manifest_count, "Concretization cache manifest byte count incorrect. "
-    f"Expected count {real_size}, got {manifest_size}"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3953,7 +3953,7 @@ def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable
     spack.config.set("concretizer:concretization_cache:entry_limit", 1)
     spack.concretize.concretize_one("zlib")
     spack.concretize.concretize_one("hdf5")
-    # cleanup should have been run and there should be no lockfiles
+    # cleanup should have been run and there should be one lockfile
     lock_count = 0
     for file in spack.solver.asp.CONC_CACHE.root.iterdir():
         if file.is_file() and file.suffix == ".lock":

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3961,13 +3961,9 @@ def test_concretization_cache_manifest_updating(use_concretization_cache, mutabl
     for entry in spack.solver.asp.CONC_CACHE.cache_entries():
         count += 1
         byte_size += entry.stat().st_size
-    assert (
-        parsed_count == count
-    ), "Concretization cache manifest entry count incorrect. "
+    assert parsed_count == count, "Concretization cache manifest entry count incorrect. "
     f"Expected count {count}, got {parsed_count}"
-    assert (
-        parsed_byte_size == byte_size
-    ), "Concretization cache manifest byte count incorrect. "
+    assert parsed_byte_size == byte_size, "Concretization cache manifest byte count incorrect. "
     f"Expected count {byte_size}, got {parsed_byte_size}"
 
 
@@ -3996,11 +3992,7 @@ def test_concretization_cache_cleanup(use_concretization_cache, mutable_config):
 
     real_count, real_size = get_current_cache_data()
     manifest_count, manifest_size = extract_cache_metadata()
-    assert (
-        real_count == manifest_count
-    ),  "Concretization cache manifest entry count incorrect. "
+    assert real_count == manifest_count, "Concretization cache manifest entry count incorrect. "
     f"Expected count {real_count}, got {manifest_count}"
-    assert (
-        real_size == manifest_size
-    ), "Concretization cache manifest byte count incorrect. "
+    assert real_size == manifest_size, "Concretization cache manifest byte count incorrect. "
     f"Expected count {real_size}, got {manifest_size}"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3212,59 +3212,6 @@ def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusabl
         assert (spec1.dag_hash() == spec2.dag_hash()) == reusable
 
 
-def test_concretization_cache_roundtrip(
-    mock_packages, use_concretization_cache, monkeypatch, mutable_config
-):
-    """Tests whether we can write the results of a clingo solve to the cache
-    and load the same spec request from the cache to produce identical specs"""
-    # Force determinism:
-    # Solver setup is normally non-deterministic due to non-determinism in
-    # asp solver setup logic generation. The only other inputs to the cache keys are
-    # the .lp files, which are invariant over the course of this test.
-    # This method forces the same setup to be produced for the same specs
-    # which gives us a guarantee of cache hits, as it removes the only
-    # element of non deterministic solver setup for the same spec
-    # Basically just a quick and dirty memoization
-    solver_setup = spack.solver.asp.SpackSolverSetup.setup
-
-    def _setup(self, specs, *, reuse=None, allow_deprecated=False):
-        if not getattr(_setup, "cache_setup", None):
-            cache_setup = solver_setup(self, specs, reuse=reuse, allow_deprecated=allow_deprecated)
-            setattr(_setup, "cache_setup", cache_setup)
-        return getattr(_setup, "cache_setup")
-
-    # monkeypatch our forced determinism setup method into solver setup
-    monkeypatch.setattr(spack.solver.asp.SpackSolverSetup, "setup", _setup)
-
-    assert spack.config.get("config:concretization_cache:enable")
-
-    # run one standard concretization to populate the cache and the setup method
-    # memoization
-    h = spack.concretize.concretize_one("hdf5")
-
-    # due to our forced determinism above, we should not be observing
-    # cache misses, assert that we're not storing any new cache entries
-    def _ensure_no_store(self, problem: str, result, statistics, test=False):
-        # always throw, we never want to reach this code path
-        assert False, "Concretization cache hit expected"
-
-    # Assert that we're actually hitting the cache
-    cache_fetch = spack.solver.asp.ConcretizationCache.fetch
-
-    def _ensure_cache_hits(self, problem: str):
-        result, statistics = cache_fetch(self, problem)
-        assert result, "Expected successful concretization cache hit"
-        assert statistics, "Expected statistics to be non null on cache hit"
-        return result, statistics
-
-    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _ensure_no_store)
-    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "fetch", _ensure_cache_hits)
-    # ensure subsequent concretizations of the same spec produce the same spec
-    # object
-    for _ in range(5):
-        assert h == spack.concretize.concretize_one("hdf5")
-
-
 @pytest.mark.regression("42679")
 @pytest.mark.parametrize("compiler_str", ["gcc@=9.4.0", "gcc@=9.4.0-foo"])
 def test_selecting_compiler_with_suffix(mutable_config, mock_packages, compiler_str):
@@ -3916,7 +3863,61 @@ def test_satisfies_conditional_spec(
     assert abstract_spec.satisfies(conditional_spec) is expected_abstract
     assert concrete_spec.satisfies(conditional_spec) is expected_concrete
     assert concrete_spec.satisfies(abstract_spec)
-def test_concretization_cache_manifest_metadata_extraction(use_concretization_cache, mutable_config, monkeypatch):
+
+
+def test_concretization_cache_roundtrip(
+    mock_packages, use_concretization_cache, monkeypatch, mutable_config
+):
+    """Tests whether we can write the results of a clingo solve to the cache
+    and load the same spec request from the cache to produce identical specs"""
+    # Force determinism:
+    # Solver setup is normally non-deterministic due to non-determinism in
+    # asp solver setup logic generation. The only other inputs to the cache keys are
+    # the .lp files, which are invariant over the course of this test.
+    # This method forces the same setup to be produced for the same specs
+    # which gives us a guarantee of cache hits, as it removes the only
+    # element of non deterministic solver setup for the same spec
+    # Basically just a quick and dirty memoization
+    solver_setup = spack.solver.asp.SpackSolverSetup.setup
+
+    def _setup(self, specs, *, reuse=None, allow_deprecated=False):
+        if not getattr(_setup, "cache_setup", None):
+            cache_setup = solver_setup(self, specs, reuse=reuse, allow_deprecated=allow_deprecated)
+            setattr(_setup, "cache_setup", cache_setup)
+        return getattr(_setup, "cache_setup")
+
+    # monkeypatch our forced determinism setup method into solver setup
+    monkeypatch.setattr(spack.solver.asp.SpackSolverSetup, "setup", _setup)
+
+    assert spack.config.get("config:concretization_cache:enable")
+
+    # run one standard concretization to populate the cache and the setup method
+    # memoization
+    h = spack.concretize.concretize_one("hdf5")
+
+    # due to our forced determinism above, we should not be observing
+    # cache misses, assert that we're not storing any new cache entries
+    def _ensure_no_store(self, problem: str, result, statistics, test=False):
+        # always throw, we never want to reach this code path
+        assert False, "Concretization cache hit expected"
+
+    # Assert that we're actually hitting the cache
+    cache_fetch = spack.solver.asp.ConcretizationCache.fetch
+
+    def _ensure_cache_hits(self, problem: str):
+        result, statistics = cache_fetch(self, problem)
+        assert result, "Expected successful concretization cache hit"
+        assert statistics, "Expected statistics to be non null on cache hit"
+        return result, statistics
+
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _ensure_no_store)
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "fetch", _ensure_cache_hits)
+    # ensure subsequent concretizations of the same spec produce the same spec
+    # object
+    for _ in range(5):
+        assert h == spack.concretize.concretize_one("hdf5")
+
+
 def test_concretization_cache_manifest_metadata_extraction(
     use_concretization_cache, mutable_config
 ):
@@ -3957,27 +3958,27 @@ def test_concretization_cache_manifest_updating(use_concretization_cache, mutabl
     parsed_count, parsed_byte_size = extract_cache_metadata(cache_root)
     count = 0
     byte_size = 0
-    for i, entry in enumerate(spack.solver.asp.CONC_CACHE.cache_entries()):
-        count += i
+    for entry in spack.solver.asp.CONC_CACHE.cache_entries():
+        count += 1
         byte_size += entry.stat().st_size
     assert (
         parsed_count == count
-    ), f"Concretization cache manifest entry count incorrect. "
-    "Expected count {count}, got {parsed_count}"
+    ), "Concretization cache manifest entry count incorrect. "
+    f"Expected count {count}, got {parsed_count}"
     assert (
         parsed_byte_size == byte_size
-    ), f"Concretization cache manifest byte count incorrect. "
-    "Expected count {byte_size}, got {parsed_byte_size}"
+    ), "Concretization cache manifest byte count incorrect. "
+    f"Expected count {byte_size}, got {parsed_byte_size}"
 
 
-def test_concretization_cache_cleanup_count(use_concretization_cache, mutable_config):
+def test_concretization_cache_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we are cleaning the cache when we should be and that the manifest is updated
     correctly and reflects the current state of the cache"""
 
     def get_current_cache_data():
         count, byte_size = 0, 0
-        for i, entry in enumerate(spack.solver.asp.CONC_CACHE.cache_entries()):
-            count += i
+        for entry in spack.solver.asp.CONC_CACHE.cache_entries():
+            count += 1
             byte_size += entry.stat().st_size
         return count, byte_size
 
@@ -3995,5 +3996,11 @@ def test_concretization_cache_cleanup_count(use_concretization_cache, mutable_co
 
     real_count, real_size = get_current_cache_data()
     manifest_count, manifest_size = extract_cache_metadata()
-    assert real_count == manifest_count
-    assert real_size == manifest_size
+    assert (
+        real_count == manifest_count
+    ),  "Concretization cache manifest entry count incorrect. "
+    f"Expected count {real_count}, got {manifest_count}"
+    assert (
+        real_size == manifest_size
+    ), "Concretization cache manifest byte count incorrect. "
+    f"Expected count {real_size}, got {manifest_size}"

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -416,8 +416,9 @@ def use_concretization_cache(mutable_config, tmpdir):
     spack.config.set("config:concretization_cache:enable", True)
     # ensure we have an isolated concretization cache
     new_conc_cache_loc = str(tmpdir.mkdir("concretization"))
-    spack.config.set("config:concretization_cache:path", new_conc_cache_loc)
+    spack.config.set("config:concretization_cache:url", new_conc_cache_loc)
     yield
+    shutil.rmtree(tmpdir)
 
 
 #

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -413,10 +413,10 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(scope="function")
 def use_concretization_cache(mutable_config, tmpdir):
     """Enables the use of the concretization cache"""
-    spack.config.set("config:concretization_cache:enable", True)
+    spack.config.set("concretizer:concretization_cache:enable", True)
     # ensure we have an isolated concretization cache
     new_conc_cache_loc = str(tmpdir.mkdir("concretization"))
-    spack.config.set("config:concretization_cache:url", new_conc_cache_loc)
+    spack.config.set("concretizer:concretization_cache:url", new_conc_cache_loc)
     yield
     shutil.rmtree(tmpdir)
 

--- a/lib/spack/spack/test/data/config/concretizer.yaml
+++ b/lib/spack/spack/test/data/config/concretizer.yaml
@@ -5,3 +5,5 @@ concretizer:
     host_compatible: false
   duplicates:
     strategy: minimal
+  concretization_cache:
+    enable: false

--- a/lib/spack/spack/test/data/config/config.yaml
+++ b/lib/spack/spack/test/data/config/config.yaml
@@ -14,5 +14,3 @@ config:
   checksum: true
   dirty: false
   locks: {1}
-  concretization_cache:
-    enable: false

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -163,9 +163,12 @@ def test_purge_directory_cache(directory_cache):
     directory_cache.remove(entry)
     assert not (directory_cache.root / entry).exists(), "Directory cache remove failed, entry remains"
     directory_cache.purge_lock(entry)
-    assert not (directory_cache.root / "." + entry + ".lock").exists(), "Directory Cache lock purge failed, lockfile remains"
+    assert not (directory_cache.root / ("." + entry + ".lock")).exists(), "Directory Cache lock purge failed, lockfile remains"
+
 
 def test_directory_cache_reports_non_existent_entry(directory_cache):
     """Test initializing an entry for a path that doesn't exist"""
     entry = "tmpdir"
-    assert not directory_cache.init_entry(entry), "Directory cache incorrectly validates entries"
+    with directory_cache.write_transaction(entry) as entry_exists:
+        assert not entry_exists, "Directory cache incorrectly validates entries"
+

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -9,13 +9,19 @@ import pytest
 
 import llnl.util.filesystem as fs
 
-from spack.util.file_cache import CacheError, FileCache
+from spack.util.file_cache import CacheError, FileCache, DirectoryFileCache
 
 
 @pytest.fixture()
 def file_cache(tmpdir):
     """Returns a properly initialized FileCache instance"""
     return FileCache(str(tmpdir))
+
+
+@pytest.fixture()
+def directory_cache(tmpdir):
+    """Returns an initialized DirectoryCache instance"""
+    return DirectoryFileCache(str(tmpdir))
 
 
 def test_write_and_read_cache_file(file_cache):
@@ -122,3 +128,44 @@ def test_delete_is_idempotent(file_cache):
     """Deleting a non-existent key should be idempotent, to simplify life when
     running delete with multiple processes"""
     file_cache.remove("test.yaml")
+
+
+def test_destroy_file_cache(file_cache):
+    """Test populating and then destroying a file cache"""
+    with file_cache.write_transaction(os.path.join("tmpdir", "test.yaml")) as (old, new):
+        assert old is None
+        assert new is not None
+        new.write("foobar\n")
+    file_cache.destroy()
+    assert not any(file_cache.root.iterdir()), "File Cache destroy unsucessful, files remain"
+
+
+def test_destroy_directory_cache(directory_cache):
+    """Test populating and then destroying a directory cache"""
+    entry = os.path.join("tmpdir", "subdir")
+    with directory_cache.write_transaction(entry) as entry_exists:
+        if not entry_exists:
+            os.makedirs(os.path.join(directory_cache.root, entry))
+        with open(directory_cache.root / entry / "test.yml", "w", encoding="utf-8") as f:
+            f.write("test")
+    directory_cache.destroy()
+    assert not any(directory_cache.root.iterdir()), "Directory Cache destroy unsucessful, files remain"
+
+
+def test_purge_directory_cache(directory_cache):
+    """Test removing a cache entry and purging the associated lockfile"""
+    entry = "tmpdir"
+    with directory_cache.write_transaction(entry) as entry_exists:
+        if not entry_exists:
+            os.makedirs(directory_cache.root / entry)
+        with open(directory_cache.root / entry / "test.yml", "w", encoding="utf-8") as f:
+            f.write("test")
+    directory_cache.remove(entry)
+    assert not (directory_cache.root / entry).exists(), "Directory cache remove failed, entry remains"
+    directory_cache.purge_lock(entry)
+    assert not (directory_cache.root / "." + entry + ".lock").exists(), "Directory Cache lock purge failed, lockfile remains"
+
+def test_directory_cache_reports_non_existent_entry(directory_cache):
+    """Test initializing an entry for a path that doesn't exist"""
+    entry = "tmpdir"
+    assert not directory_cache.init_entry(entry), "Directory cache incorrectly validates entries"

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -9,7 +9,7 @@ import pytest
 
 import llnl.util.filesystem as fs
 
-from spack.util.file_cache import CacheError, FileCache, DirectoryFileCache
+from spack.util.file_cache import CacheError, DirectoryFileCache, FileCache
 
 
 @pytest.fixture()
@@ -149,7 +149,9 @@ def test_destroy_directory_cache(directory_cache):
         with open(directory_cache.root / entry / "test.yml", "w", encoding="utf-8") as f:
             f.write("test")
     directory_cache.destroy()
-    assert not any(directory_cache.root.iterdir()), "Directory Cache destroy unsucessful, files remain"
+    assert not any(
+        directory_cache.root.iterdir()
+    ), "Directory Cache destroy unsucessful, files remain"
 
 
 def test_purge_directory_cache(directory_cache):
@@ -161,9 +163,13 @@ def test_purge_directory_cache(directory_cache):
         with open(directory_cache.root / entry / "test.yml", "w", encoding="utf-8") as f:
             f.write("test")
     directory_cache.remove(entry)
-    assert not (directory_cache.root / entry).exists(), "Directory cache remove failed, entry remains"
+    assert not (
+        directory_cache.root / entry
+    ).exists(), "Directory cache remove failed, entry remains"
     directory_cache.purge_lock(entry)
-    assert not (directory_cache.root / ("." + entry + ".lock")).exists(), "Directory Cache lock purge failed, lockfile remains"
+    assert not (
+        directory_cache.root / ("." + entry + ".lock")
+    ).exists(), "Directory Cache lock purge failed, lockfile remains"
 
 
 def test_directory_cache_reports_non_existent_entry(directory_cache):
@@ -171,4 +177,3 @@ def test_directory_cache_reports_non_existent_entry(directory_cache):
     entry = "tmpdir"
     with directory_cache.write_transaction(entry) as entry_exists:
         assert not entry_exists, "Directory cache incorrectly validates entries"
-

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -132,7 +132,7 @@ def test_delete_is_idempotent(file_cache):
 
 def test_destroy_file_cache(file_cache):
     """Test populating and then destroying a file cache"""
-    with file_cache.write_transaction(os.path.join("tmpdir", "test.yaml")) as (old, new):
+    with file_cache.write_transaction("test.yaml") as (old, new):
         assert old is None
         assert new is not None
         new.write("foobar\n")

--- a/lib/spack/spack/util/cache.py
+++ b/lib/spack/spack/util/cache.py
@@ -1,0 +1,157 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import errno
+import math
+import os
+import pathlib
+import shutil
+from typing import Dict, Union
+
+from llnl.util.filesystem import rename
+
+from spack.error import SpackError
+from spack.util.lock import Lock, ReadTransaction, WriteTransaction
+
+
+class Cache:
+    """This class manages cached data in the filesystem.
+
+    - Cache files are fetched and stored by unique keys.  Keys can be relative
+      paths, so that there can be some hierarchy in the cache.
+
+    """
+    def __init__(self, root: Union[str, pathlib.Path], timeout=120):
+        """Create a cache object.
+
+        This will create the cache directory if it does not exist yet.
+
+        Args:
+            root: specifies the root directory where the cache stores files
+
+            timeout: when there is contention among multiple Spack processes
+                for cache files, this specifies how long Spack should wait
+                before assuming that there is a deadlock.
+        """
+        if isinstance(root, str):
+            root = pathlib.Path(root)
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+
+        self._locks: Dict[Union[pathlib.Path, str], Lock] = {}
+        self.lock_timeout = timeout
+
+    def destroy(self):
+        """Remove all files under the cache root."""
+        for f in self.root.iterdir():
+            if f.is_dir():
+                shutil.rmtree(f, True)
+            else:
+                f.unlink()
+
+    def cache_path(self, key: Union[str, pathlib.Path]):
+        """Path to the file in the cache for a particular key."""
+        return self.root / key
+
+    def _lock_path(self, key: Union[str, pathlib.Path]):
+        """Path to the file in the cache for a particular key."""
+        keyfile = os.path.basename(key)
+        keydir = os.path.dirname(key)
+
+        return self.root / keydir / ("." + keyfile + ".lock")
+
+    def _get_lock(self, key: Union[str, pathlib.Path]):
+        """Create a lock for a key, if necessary, and return a lock object."""
+        if key not in self._locks:
+            self._locks[key] = Lock(str(self._lock_path(key)), default_timeout=self.lock_timeout)
+        return self._locks[key]
+
+    def _entry_validation(self, cache_path: pathlib.Path) -> bool:
+        """Validates a given potential cache key"""
+        raise NotImplementedError("Must be implemented by subclass")
+
+    def _rm_cache_entry(self, cache_path:pathlib.Path):
+        """Removes a cache entry"""
+        raise NotImplementedError("Must be implemented by subclass")
+
+    def _acquire_read_fn(self, path: pathlib.Path):
+        """Returns a function pointer to be used as a callback when acquiring
+         a read lock during a read transaction """
+        raise NotImplementedError("Must be implemented by subclass")
+
+    def _acquire_write_fn(self, path: pathlib.Path):
+        """Returns a functin pointer to be used as a callback when acquring a read lock
+        during a write transaction"""
+        raise NotImplementedError("Must be implemented by subclass")
+
+    def init_entry(self, key: Union[str, pathlib.Path]):
+        """Ensure we can access a cache file. Create a lock for it if needed.
+
+        Return whether the cache file exists yet or not.
+        """
+        cache_path = self.cache_path(key)
+        valid = self._entry_validation(cache_path)
+        # ensure lock is created for this key
+        self._get_lock(key)
+        return valid
+
+    def read_transaction(self, key: Union[str, pathlib.Path]):
+        """Get a read transaction on a file cache item.
+
+        Returns a ReadTransaction context manager and opens the cache file for
+        reading.  You can use it like this:
+
+           with file_cache_object.read_transaction(key) as cache_file:
+               cache_file.read()
+
+        """
+        path = self.cache_path(key)
+        return ReadTransaction(
+            self._get_lock(key), acquire=self._acquire_read_fn(path)  # type: ignore
+        )
+
+    def write_transaction(self, key: Union[str, pathlib.Path]):
+        """Get a write transaction on a file cache item.
+
+        Returns a WriteTransaction context manager that opens a temporary file
+        for writing.  Once the context manager finishes, if nothing went wrong,
+        moves the file into place on top of the old file atomically.
+
+        """
+        path = self.cache_path(key)
+        if os.path.exists(path) and not os.access(path, os.W_OK):
+            raise CacheError(f"Insufficient permissions to write to file cache at {path}")
+
+        return WriteTransaction(
+            self._get_lock(key), acquire=lambda: self._acquire_write_fn(path)  # type: ignore
+        )
+
+    def mtime(self, key: Union[str, pathlib.Path]) -> float:
+        """Return modification time of cache key, or -inf if it does not exist.
+
+        Time is in units returned by os.stat in the mtime field, which is
+        platform-dependent.
+
+        """
+        if not self.init_entry(key):
+            return -math.inf
+        else:
+            return self.cache_path(key).stat().st_mtime
+
+    def remove(self, key: Union[str, pathlib.Path]):
+        entry = self.cache_path(key)
+        lock = self._get_lock(key)
+        try:
+            lock.acquire_write()
+            self._rm_cache_entry(entry)
+        except OSError as e:
+            # File not found is OK, so remove is idempotent.
+            if e.errno != errno.ENOENT:
+                raise
+        finally:
+            lock.release_write()
+
+
+class CacheError(SpackError):
+    pass

--- a/lib/spack/spack/util/cache.py
+++ b/lib/spack/spack/util/cache.py
@@ -122,7 +122,7 @@ class Cache:
             raise CacheError(f"Insufficient permissions to write to file cache at {path}")
 
         return WriteTransaction(
-            self._get_lock(key), acquire=lambda: self._acquire_write_fn(path)  # type: ignore
+            self._get_lock(key), acquire=self._acquire_write_fn(path)  # type: ignore
         )
 
     def mtime(self, key: Union[str, pathlib.Path]) -> float:

--- a/lib/spack/spack/util/cache.py
+++ b/lib/spack/spack/util/cache.py
@@ -20,6 +20,7 @@ class Cache:
       paths, so that there can be some hierarchy in the cache.
 
     """
+
     def __init__(self, root: Union[str, pathlib.Path], timeout=120):
         """Create a cache object.
 
@@ -69,13 +70,13 @@ class Cache:
         """Validates a given potential cache key"""
         raise NotImplementedError("Must be implemented by subclass")
 
-    def _rm_cache_entry(self, cache_path:pathlib.Path):
+    def _rm_cache_entry(self, cache_path: pathlib.Path):
         """Removes a cache entry"""
         raise NotImplementedError("Must be implemented by subclass")
 
     def _acquire_read_fn(self, path: pathlib.Path):
         """Returns a function pointer to be used as a callback when acquiring
-         a read lock during a read transaction """
+        a read lock during a read transaction"""
         raise NotImplementedError("Must be implemented by subclass")
 
     def _acquire_write_fn(self, path: pathlib.Path):

--- a/lib/spack/spack/util/cache.py
+++ b/lib/spack/spack/util/cache.py
@@ -9,8 +9,6 @@ import pathlib
 import shutil
 from typing import Dict, Union
 
-from llnl.util.filesystem import rename
-
 from spack.error import SpackError
 from spack.util.lock import Lock, ReadTransaction, WriteTransaction
 
@@ -91,10 +89,10 @@ class Cache:
         Return whether the cache file exists yet or not.
         """
         cache_path = self.cache_path(key)
-        valid = self._entry_validation(cache_path)
+        validation_result = self._entry_validation(cache_path)
         # ensure lock is created for this key
         self._get_lock(key)
-        return valid
+        return validation_result
 
     def read_transaction(self, key: Union[str, pathlib.Path]):
         """Get a read transaction on a file cache item.

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -3,16 +3,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import errno
-import math
 import os
 import pathlib
 import shutil
-from typing import IO, Dict, Optional, Tuple, Union
+from typing import IO, Optional, Tuple, Union
 
 from llnl.util.filesystem import rename
 
-from spack.error import SpackError
-from spack.util.lock import Lock, ReadTransaction, WriteTransaction
+from spack.util.cache import Cache, CacheError
 
 
 def _maybe_open(path: Union[str, pathlib.Path]) -> Optional[IO[str]]:
@@ -39,7 +37,7 @@ class ReadContextManager:
 
 
 class WriteContextManager:
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: Union[str, pathlib.Path]) -> None:
         self.path = path
         self.tmp_path = f"{self.path}.tmp"
 
@@ -60,78 +58,29 @@ class WriteContextManager:
             rename(self.tmp_path, self.path)
 
 
-class FileCache:
-    """This class manages cached data in the filesystem.
-
-    - Cache files are fetched and stored by unique keys.  Keys can be relative
-      paths, so that there can be some hierarchy in the cache.
+class FileCache(Cache):
+    """This class manages cached data per file
 
     - The FileCache handles locking cache files for reading and writing, so
       client code need not manage locks for cache entries.
-
     """
+    def _acquire_read_fn(self, path):
+        return lambda: ReadContextManager(path)
 
-    def __init__(self, root: Union[str, pathlib.Path], timeout=120):
-        """Create a file cache object.
+    def _acquire_write_fn(self, path):
+        return lambda: WriteContextManager(path)
 
-        This will create the cache directory if it does not exist yet.
-
-        Args:
-            root: specifies the root directory where the cache stores files
-
-            timeout: when there is contention among multiple Spack processes
-                for cache files, this specifies how long Spack should wait
-                before assuming that there is a deadlock.
-        """
-        if isinstance(root, str):
-            root = pathlib.Path(root)
-        self.root = root
-        self.root.mkdir(parents=True, exist_ok=True)
-
-        self._locks: Dict[Union[pathlib.Path, str], Lock] = {}
-        self.lock_timeout = timeout
-
-    def destroy(self):
-        """Remove all files under the cache root."""
-        for f in self.root.iterdir():
-            if f.is_dir():
-                shutil.rmtree(f, True)
-            else:
-                f.unlink()
-
-    def cache_path(self, key: Union[str, pathlib.Path]):
-        """Path to the file in the cache for a particular key."""
-        return self.root / key
-
-    def _lock_path(self, key: Union[str, pathlib.Path]):
-        """Path to the file in the cache for a particular key."""
-        keyfile = os.path.basename(key)
-        keydir = os.path.dirname(key)
-
-        return self.root / keydir / ("." + keyfile + ".lock")
-
-    def _get_lock(self, key: Union[str, pathlib.Path]):
-        """Create a lock for a key, if necessary, and return a lock object."""
-        if key not in self._locks:
-            self._locks[key] = Lock(str(self._lock_path(key)), default_timeout=self.lock_timeout)
-        return self._locks[key]
-
-    def init_entry(self, key: Union[str, pathlib.Path]):
-        """Ensure we can access a cache file. Create a lock for it if needed.
-
-        Return whether the cache file exists yet or not.
-        """
-        cache_path = self.cache_path(key)
+    def _entry_validation(self, cache_path):
         # Avoid using pathlib here to allow the logic below to
         # function as is
         # TODO: Maybe refactor the following logic for pathlib
         exists = os.path.exists(cache_path)
         if exists:
             if not cache_path.is_file():
-                raise CacheError("Cache file is not a file: %s" % cache_path)
+                raise CacheError(f"Cache file is not a file: {cache_path}")
 
             if not os.access(cache_path, os.R_OK):
-                raise CacheError("Cannot access cache file: %s" % cache_path)
+                raise CacheError(f"Cannot access cache file: {cache_path}")
         else:
             # if the file is hierarchical, make parent directories
             parent = cache_path.parent
@@ -140,67 +89,25 @@ class FileCache:
 
             if not os.access(parent, os.R_OK | os.W_OK):
                 raise CacheError("Cannot access cache directory: %s" % parent)
-
-            # ensure lock is created for this key
-            self._get_lock(key)
         return exists
 
-    def read_transaction(self, key: Union[str, pathlib.Path]):
-        """Get a read transaction on a file cache item.
-
-        Returns a ReadTransaction context manager and opens the cache file for
-        reading.  You can use it like this:
-
-           with file_cache_object.read_transaction(key) as cache_file:
-               cache_file.read()
-
-        """
-        path = self.cache_path(key)
-        return ReadTransaction(
-            self._get_lock(key), acquire=lambda: ReadContextManager(path)  # type: ignore
-        )
-
-    def write_transaction(self, key: Union[str, pathlib.Path]):
-        """Get a write transaction on a file cache item.
-
-        Returns a WriteTransaction context manager that opens a temporary file
-        for writing.  Once the context manager finishes, if nothing went wrong,
-        moves the file into place on top of the old file atomically.
-
-        """
-        path = self.cache_path(key)
-        if os.path.exists(path) and not os.access(path, os.W_OK):
-            raise CacheError(f"Insufficient permissions to write to file cache at {path}")
-
-        return WriteTransaction(
-            self._get_lock(key), acquire=lambda: WriteContextManager(path)  # type: ignore
-        )
-
-    def mtime(self, key: Union[str, pathlib.Path]) -> float:
-        """Return modification time of cache file, or -inf if it does not exist.
-
-        Time is in units returned by os.stat in the mtime field, which is
-        platform-dependent.
-
-        """
-        if not self.init_entry(key):
-            return -math.inf
-        else:
-            return self.cache_path(key).stat().st_mtime
-
-    def remove(self, key: Union[str, pathlib.Path]):
-        file = self.cache_path(key)
-        lock = self._get_lock(key)
-        try:
-            lock.acquire_write()
-            file.unlink()
-        except OSError as e:
-            # File not found is OK, so remove is idempotent.
-            if e.errno != errno.ENOENT:
-                raise
-        finally:
-            lock.release_write()
+    def _rm_cache_entry(self, cache_path):
+        cache_path.unlink()
 
 
-class CacheError(SpackError):
-    pass
+class DirectoryFileCache(Cache):
+    """This class manages cached data on a per directory level"""
+    def _acquire_read_fn(self, path):
+        pass
+
+    def _acquire_write_fn(self, path):
+        pass
+
+    def _entry_validation(self, cache_path):
+        cache_path.mkdir(parents=True, exist_ok=True)
+        return True
+
+    def _rm_cache_entry(self, cache_path):
+        shutil.rmtree(cache_path)
+
+

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -106,7 +106,7 @@ class DirectoryFileCache(Cache):
         return lambda: path.exists()
 
     def _entry_validation(self, cache_path):
-        if not cache_path.is_dir():
+        if cache_path.exists() and not cache_path.is_dir():
             raise CacheError(
                 "Entry must refer to directory (bucket) not a file. "
                 "If a File level cache is required, use FileCache"

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -119,9 +119,8 @@ class DirectoryFileCache(Cache):
     def _rm_cache_entry(self, cache_path):
         shutil.rmtree(cache_path)
 
-    def remove(self, key: Union[str, pathlib.Path]):
-        super(DirectoryFileCache, self).remove(key)
-        # cleanup lockfile itself as well
+    def purge_lock(self, key):
+        # cleanup lockfile itself
         lock = self._get_lock(key)
         lock.cleanup()
         # remove from lock dict

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -64,6 +64,7 @@ class FileCache(Cache):
     - The FileCache handles locking cache files for reading and writing, so
       client code need not manage locks for cache entries.
     """
+
     def _acquire_read_fn(self, path):
         return lambda: ReadContextManager(path)
 
@@ -97,6 +98,7 @@ class FileCache(Cache):
 
 class DirectoryFileCache(Cache):
     """This class manages cached data on a per directory level"""
+
     def _acquire_read_fn(self, path):
         return lambda: path.exists()
 
@@ -105,7 +107,10 @@ class DirectoryFileCache(Cache):
 
     def _entry_validation(self, cache_path):
         if not cache_path.is_dir():
-            raise CacheError("Entry must refer to directory (bucket) not a file. If a File level cache is required, use FileCache")
+            raise CacheError(
+                "Entry must refer to directory (bucket) not a file. "
+                "If a File level cache is required, use FileCache"
+            )
         cache_path.mkdir(parents=True, exist_ok=True)
         if not os.access(cache_path, os.R_OK | os.W_OK):
             raise CacheError(f"Cannot read/write from cache bucket {cache_path}")
@@ -113,5 +118,3 @@ class DirectoryFileCache(Cache):
 
     def _rm_cache_entry(self, cache_path):
         shutil.rmtree(cache_path)
-
-

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -118,3 +118,11 @@ class DirectoryFileCache(Cache):
 
     def _rm_cache_entry(self, cache_path):
         shutil.rmtree(cache_path)
+
+    def remove(self, key: Union[str, pathlib.Path]):
+        super(DirectoryFileCache, self).remove(key)
+        # cleanup lockfile itself as well
+        lock = self._get_lock(key)
+        lock.cleanup()
+        # remove from lock dict
+        self._locks.pop(key)

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -98,13 +98,17 @@ class FileCache(Cache):
 class DirectoryFileCache(Cache):
     """This class manages cached data on a per directory level"""
     def _acquire_read_fn(self, path):
-        pass
+        return lambda: path.exists()
 
     def _acquire_write_fn(self, path):
-        pass
+        return lambda: path.exists()
 
     def _entry_validation(self, cache_path):
+        if not cache_path.is_dir():
+            raise CacheError("Entry must refer to directory (bucket) not a file. If a File level cache is required, use FileCache")
         cache_path.mkdir(parents=True, exist_ok=True)
+        if not os.access(cache_path, os.R_OK | os.W_OK):
+            raise CacheError(f"Cannot read/write from cache bucket {cache_path}")
         return True
 
     def _rm_cache_entry(self, cache_path):


### PR DESCRIPTION
#48198 Introduces the concretization cache, and associated manifest. However it only added testing for the cache itself, not the manifest or cleanup procedures.

This PR:

- [x] Adds tests for the manifest and cleanup
- [x] Refactors the manifest to update correctly
- [x] Refactors the cache to store base32 hashes like the rest of Spack's hashes
- [x] gzips the cache entries for a smaller memory footprint

`FileCache` class was refactored into an abstract base `Cache` class which provides the general cache read/write transaction interface, and a `FileCache` and `DirectoryCache` child classes, `FileCache` which should be functionally identical to the `FileCache` class pre refactor, deals with caches at the individual file level, and `DirectoryCache`, which is mean to provide a directory level or "bucket" caching level. 
