### PR TITLE
FIX: asp.py abs_control_files shouldn't ask for write rights

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1209,7 +1209,7 @@ class PyclingoDriver:
         full_path = lambda x: os.path.join(parent_dir, x)
         abs_control_files = [full_path(x) for x in control_files]
         for ctrl_file in abs_control_files:
-            with open(ctrl_file, "r+", encoding="utf-8") as f:
+            with open(ctrl_file, "r", encoding="utf-8") as f:
                 problem_repr += "\n" + f.read()
 
         result = None


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This make read-only shared instances otherwise fail if used by multiple users. For example:

(unstable) germann_e@login001:~ $ spack concretize
==> Starting concretization
==> Error: [Errno 13] Permission denied: '/afs/psi.ch/sys/spack/develop/lib/spack/spack/solver/concretize.lp'