### PR TITLE
py-setuptools: deprecate old versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-botorch/package.py
+++ b/var/spack/repos/builtin/packages/py-botorch/package.py
@@ -17,25 +17,37 @@ class PyBotorch(PythonPackage):
 
     version("0.8.4", sha256="e2c17efa8fcda3c9353bbd14ba283ddf237d66151097c0af483bbaaaac61288b")
     version("0.8.3", sha256="e529f7adbb2b54f46125ae904682fc0f0d02ab8bdb9067ede521c379b355bf73")
-    version("0.6.4", sha256="3fd28417f55749501a45378f72cd5ca7614e2e05b7b65c6b4eb9b72378bc665a")
 
-    depends_on("python@3.7:", type=("build", "run"))
-    depends_on("python@3.8:", when="@0.8.3:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@:47", when="@:0.6.4", type="build")
-    depends_on("py-setuptools-scm", type="build")
-    depends_on("py-setuptools-scm+toml", when="@0.8.3:", type="build")
-    depends_on("py-torch@1.12:", when="@0.8.3:", type=("build", "run"))
-    depends_on("py-torch@1.9:", type=("build", "run"))
-    depends_on("py-gpytorch@1.10:", when="@0.8.4:", type=("build", "run"))
-    depends_on("py-gpytorch@1.9.1:", when="@0.8.3:", type=("build", "run"))
-    depends_on("py-gpytorch@1.6:", type=("build", "run"))
-    depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-multipledispatch", type=("build", "run"))
-    depends_on("py-pyro-ppl@1.8.4:", when="@0.8.3:", type=("build", "run"))
-    depends_on("py-pyro-ppl@1.8.0", when="@:0.6.4", type=("build", "run"))
-    depends_on("py-linear-operator@0.4.0:", when="@0.8.4:", type=("build", "run"))
-    depends_on("py-linear-operator@0.3.0:", when="@0.8.3:", type=("build", "run"))
+    with default_args(deprecated=True):
+        version("0.6.4", sha256="3fd28417f55749501a45378f72cd5ca7614e2e05b7b65c6b4eb9b72378bc665a")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools")
+        depends_on("py-setuptools@:47", when="@:0.6.4")
+
+        depends_on("py-setuptools-scm")
+        depends_on("py-setuptools-scm+toml", when="@0.8.3:")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.8:", when="@0.8.3:")
+        depends_on("python@3.7:")
+
+        depends_on("py-torch@1.12:", when="@0.8.3:")
+        depends_on("py-torch@1.9:")
+
+        depends_on("py-gpytorch@1.10:", when="@0.8.4:")
+        depends_on("py-gpytorch@1.9.1:", when="@0.8.3:")
+        depends_on("py-gpytorch@1.6:")
+
+        depends_on("py-scipy")
+
+        depends_on("py-multipledispatch")
+
+        depends_on("py-pyro-ppl@1.8.4:", when="@0.8.3:")
+        depends_on("py-pyro-ppl@1.8.0", when="@:0.6.4")
+
+        depends_on("py-linear-operator@0.4.0:", when="@0.8.4:")
+        depends_on("py-linear-operator@0.3.0:", when="@0.8.3:")
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("@0.8.3:"):

--- a/var/spack/repos/builtin/packages/py-deepsig/package.py
+++ b/var/spack/repos/builtin/packages/py-deepsig/package.py
@@ -12,16 +12,20 @@ class PyDeepsig(PythonPackage):
     homepage = "https://github.com/Kaleidophon/deep-significance"
     pypi = "deepsig/deepsig-1.2.1.tar.gz"
 
-    version("1.2.1", sha256="8543630c00264898116a065f6461c131d026ef75d8703bc631a4fd2bafb31f89")
+    with default_args(deprecated=True):
+        version("1.2.1", sha256="8543630c00264898116a065f6461c131d026ef75d8703bc631a4fd2bafb31f89")
 
-    depends_on("python@3.5.3:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
-    depends_on("py-numpy@1.19.5", type=("build", "run"))
-    depends_on("py-scipy@1.6.0", type=("build", "run"))
-    depends_on("py-tqdm@4.59.0", type=("build", "run"))
-    depends_on("py-joblib@1.0.1", type=("build", "run"))
-    depends_on("py-pandas@1.3.3", type=("build", "run"))
-    depends_on("py-dill@0.3.4", type=("build", "run"))
+    with default_args(type="build"):
+        depends_on("py-setuptools", type="build")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.5.3:")
+        depends_on("py-numpy@1.19.5")
+        depends_on("py-scipy@1.6.0")
+        depends_on("py-tqdm@4.59.0")
+        depends_on("py-joblib@1.0.1")
+        depends_on("py-pandas@1.3.3")
+        depends_on("py-dill@0.3.4")
 
     def patch(self):
         filter_file("README_RAW.md", "README.md", "setup.py", string=True)

--- a/var/spack/repos/builtin/packages/py-openslide-python/package.py
+++ b/var/spack/repos/builtin/packages/py-openslide-python/package.py
@@ -14,7 +14,9 @@ class PyOpenslidePython(PythonPackage):
     license("LGPL-2.1-or-later")
 
     version("1.1.2", sha256="83e064ab4a29658e7ddf86bf1d3e54d2508cc19ece35d55b55519c826e45d83f")
-    version("1.1.1", sha256="33c390fe43e3d7d443fafdd66969392d3e9efd2ecd5d4af73c3dbac374485ed5")
+
+    with default_args(deprecated=True):
+        version("1.1.1", sha256="33c390fe43e3d7d443fafdd66969392d3e9efd2ecd5d4af73c3dbac374485ed5")
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -42,51 +42,20 @@ class PyScipy(PythonPackage):
     version("1.7.2", sha256="fa2dbabaaecdb502641b0b3c00dec05fb475ae48655c66da16c9ed24eda1e711")
     version("1.7.1", sha256="6b47d5fa7ea651054362561a28b1ccc8da9368a39514c1bbf6c0977a1c376764")
     version("1.7.0", sha256="998c5e6ea649489302de2c0bc026ed34284f531df89d2bdc8df3a0d44d165739")
-    version("1.6.3", sha256="a75b014d3294fce26852a9d04ea27b5671d86736beb34acdfc05859246260707")
-    version("1.6.2", sha256="e9da33e21c9bc1b92c20b5328adb13e5f193b924c9b969cd700c8908f315aa59")
-    version("1.6.1", sha256="c4fceb864890b6168e79b0e714c585dbe2fd4222768ee90bc1aa0f8218691b11")
-    version("1.6.0", sha256="cb6dc9f82dfd95f6b9032a8d7ea70efeeb15d5b5fd6ed4e8537bb3c673580566")
-    version("1.5.4", sha256="4a453d5e5689de62e5d38edf40af3f17560bfd63c9c5bd228c18c1f99afa155b")
-    version(
-        "1.5.3",
-        sha256="ddae76784574cc4c172f3d5edd7308be16078dd3b977e8746860c76c195fa707",
-        deprecated=True,
-    )
-    version(
-        "1.5.2",
-        sha256="066c513d90eb3fd7567a9e150828d39111ebd88d3e924cdfc9f8ce19ab6f90c9",
-        deprecated=True,
-    )
-    version(
-        "1.5.1",
-        sha256="039572f0ca9578a466683558c5bf1e65d442860ec6e13307d528749cfe6d07b8",
-        deprecated=True,
-    )
-    version(
-        "1.5.0",
-        sha256="4ff72877d19b295ee7f7727615ea8238f2d59159df0bdd98f91754be4a2767f0",
-        deprecated=True,
-    )
-    version(
-        "1.4.1",
-        sha256="dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59",
-        deprecated=True,
-    )
-    version(
-        "1.4.0",
-        sha256="31f7cfa93b01507c935c12b535e24812594002a02a56803d7cd063e9920d25e8",
-        deprecated=True,
-    )
-    version(
-        "1.3.3",
-        sha256="64bf4e8ae0db2d42b58477817f648d81e77f0b381d0ea4427385bba3f959380a",
-        deprecated=True,
-    )
-    version(
-        "1.3.2",
-        sha256="a03939b431994289f39373c57bbe452974a7da724ae7f9620a1beee575434da4",
-        deprecated=True,
-    )
+    with default_args(deprecated=True):
+        version("1.6.3", sha256="a75b014d3294fce26852a9d04ea27b5671d86736beb34acdfc05859246260707")
+        version("1.6.2", sha256="e9da33e21c9bc1b92c20b5328adb13e5f193b924c9b969cd700c8908f315aa59")
+        version("1.6.1", sha256="c4fceb864890b6168e79b0e714c585dbe2fd4222768ee90bc1aa0f8218691b11")
+        version("1.6.0", sha256="cb6dc9f82dfd95f6b9032a8d7ea70efeeb15d5b5fd6ed4e8537bb3c673580566")
+        version("1.5.4", sha256="4a453d5e5689de62e5d38edf40af3f17560bfd63c9c5bd228c18c1f99afa155b")
+        version("1.5.3", sha256="ddae76784574cc4c172f3d5edd7308be16078dd3b977e8746860c76c195fa707")
+        version("1.5.2", sha256="066c513d90eb3fd7567a9e150828d39111ebd88d3e924cdfc9f8ce19ab6f90c9")
+        version("1.5.1", sha256="039572f0ca9578a466683558c5bf1e65d442860ec6e13307d528749cfe6d07b8")
+        version("1.5.0", sha256="4ff72877d19b295ee7f7727615ea8238f2d59159df0bdd98f91754be4a2767f0")
+        version("1.4.1", sha256="dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59")
+        version("1.4.0", sha256="31f7cfa93b01507c935c12b535e24812594002a02a56803d7cd063e9920d25e8")
+        version("1.3.3", sha256="64bf4e8ae0db2d42b58477817f648d81e77f0b381d0ea4427385bba3f959380a")
+        version("1.3.2", sha256="a03939b431994289f39373c57bbe452974a7da724ae7f9620a1beee575434da4")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -14,6 +14,8 @@ class PySetuptools(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-62.3.2-py3-none-any.whl"
     list_url = "https://pypi.org/simple/setuptools/"
 
+    maintainers("RobertMaaskant")
+
     tags = ["build-tools"]
 
     # Requires railroad
@@ -31,12 +33,14 @@ class PySetuptools(Package, PythonExtension):
     version("75.8.1", sha256="3bc32c0b84c643299ca94e77f834730f126efd621de0cc1de64119e0e17dab1f")
     version("75.8.0", sha256="e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3")
     version("75.3.2", sha256="90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9")
+    # Last version supporting Python 3.8
     version("75.3.1", sha256="ccd77cda9d3bc3d3e99036d221b91d15f86e53195139d643b5b5299d42463cd3")
     version("75.3.0", sha256="f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd")
     version("69.2.0", sha256="c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c")
     version("69.1.1", sha256="02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56")
     version("69.0.3", sha256="385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05")
     version("68.2.2", sha256="b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a")
+    # Last version supporting Python 3.7
     version("68.0.0", sha256="11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f")
     version("67.6.0", sha256="b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2")
     version("65.5.0", sha256="f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356")
@@ -47,21 +51,42 @@ class PySetuptools(Package, PythonExtension):
     version("62.6.0", sha256="c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178")
     version("62.4.0", sha256="5a844ad6e190dccc67d6d7411d119c5152ce01f7c76be4d8a1eaa314501bba77")
     version("62.3.2", sha256="68e45d17c9281ba25dc0104eadd2647172b3472d9e01f911efa57965e8d51a36")
+    # Last version supporting Python 3.6
     version("59.4.0", sha256="feb5ff19b354cde9efd2344ef6d5e79880ce4be643037641b49508bbb850d060")
     version("58.2.0", sha256="2551203ae6955b9876741a26ab3e767bb3242dafe86a32a749ea0d78b6792f11")
     version("57.4.0", sha256="a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6")
-    version("57.1.0", sha256="ddae4c1b9220daf1e32ba9d4e3714df6019c5b583755559be84ff8199f7e1fe3")
-    version("51.0.0", sha256="8c177936215945c9a37ef809ada0fab365191952f7a123618432bbfac353c529")
-    version("50.3.2", sha256="2c242a0856fbad7efbe560df4a7add9324f340cf48df43651e9604924466794a")
-    version("50.1.0", sha256="4537c77e6e7dc170081f8547564551d4ff4e4999717434e1257600bbd3a23296")
-    version("49.6.0", sha256="4dd5bb0a0a0cff77b46ca5dd3a84857ee48c83e8223886b556613c724994073f")
-    version("49.2.0", sha256="272c7f48f5cddc5af5901f4265274c421c7eede5c8bc454ac2903d3f8fc365e9")
-    version("46.1.3", sha256="4fe404eec2738c20ab5841fa2d791902d2a645f32318a7850ef26f8d7215a8ee")
-    version("44.1.1", sha256="27a714c09253134e60a6fa68130f78c7037e5562c4f21f8f318f2ae900d152d5")
-    version("44.1.0", sha256="992728077ca19db6598072414fb83e0a284aca1253aaf2e24bb1e55ee6db1a30")
-    version("43.0.0", sha256="a67faa51519ef28cd8261aff0e221b6e4c370f8fb8bada8aa3e7ad8945199963")
 
     with default_args(deprecated=True):
+        version(
+            "57.1.0", sha256="ddae4c1b9220daf1e32ba9d4e3714df6019c5b583755559be84ff8199f7e1fe3"
+        )
+        version(
+            "51.0.0", sha256="8c177936215945c9a37ef809ada0fab365191952f7a123618432bbfac353c529"
+        )
+        version(
+            "50.3.2", sha256="2c242a0856fbad7efbe560df4a7add9324f340cf48df43651e9604924466794a"
+        )
+        version(
+            "50.1.0", sha256="4537c77e6e7dc170081f8547564551d4ff4e4999717434e1257600bbd3a23296"
+        )
+        version(
+            "49.6.0", sha256="4dd5bb0a0a0cff77b46ca5dd3a84857ee48c83e8223886b556613c724994073f"
+        )
+        version(
+            "49.2.0", sha256="272c7f48f5cddc5af5901f4265274c421c7eede5c8bc454ac2903d3f8fc365e9"
+        )
+        version(
+            "46.1.3", sha256="4fe404eec2738c20ab5841fa2d791902d2a645f32318a7850ef26f8d7215a8ee"
+        )
+        version(
+            "44.1.1", sha256="27a714c09253134e60a6fa68130f78c7037e5562c4f21f8f318f2ae900d152d5"
+        )
+        version(
+            "44.1.0", sha256="992728077ca19db6598072414fb83e0a284aca1253aaf2e24bb1e55ee6db1a30"
+        )
+        version(
+            "43.0.0", sha256="a67faa51519ef28cd8261aff0e221b6e4c370f8fb8bada8aa3e7ad8945199963"
+        )
         version(
             "41.4.0", sha256="8d01f7ee4191d9fdcd9cc5796f75199deccb25b154eba82d44d6a042cf873670"
         )
@@ -106,6 +131,9 @@ class PySetuptools(Package, PythonExtension):
         depends_on("python@3.8:", when="@68.1:")
         depends_on("python@3.7:", when="@59.7:")
         depends_on("python@3.6:", when="@51:")
+        depends_on("python@3.5:", when="@44:")
+        depends_on("python@3.4:", when="@40:")
+        depends_on("python@3.3:", when="@30:")
 
         # Uses HTMLParser.unescape
         depends_on("python@:3.8", when="@:41.0")

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -32,8 +32,8 @@ class PySetuptools(Package, PythonExtension):
     version("75.8.2", sha256="558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f")
     version("75.8.1", sha256="3bc32c0b84c643299ca94e77f834730f126efd621de0cc1de64119e0e17dab1f")
     version("75.8.0", sha256="e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3")
-    version("75.3.2", sha256="90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9")
     # Last version supporting Python 3.8
+    version("75.3.2", sha256="90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9")
     version("75.3.1", sha256="ccd77cda9d3bc3d3e99036d221b91d15f86e53195139d643b5b5299d42463cd3")
     version("75.3.0", sha256="f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd")
     version("69.2.0", sha256="c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c")

--- a/var/spack/repos/builtin/packages/py-zope-interface/package.py
+++ b/var/spack/repos/builtin/packages/py-zope-interface/package.py
@@ -31,13 +31,16 @@ class PyZopeInterface(PythonPackage):
     version("5.5.0", sha256="700ebf9662cf8df70e2f0cb4988e078c53f65ee3eefd5c9d80cf988c4175c8e3")
     version("5.4.0", sha256="5dba5f530fec3f0988d83b78cc591b58c0b6eb8431a85edd1569a0539a8a5a0e")
     version("5.1.0", sha256="40e4c42bd27ed3c11b2c983fecfb03356fae1209de10686d03c02c8696a1d90e")
-    version("4.5.0", sha256="57c38470d9f57e37afb460c399eb254e7193ac7fb8042bd09bdc001981a9c74c")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"), when="@4.5.0")
-    depends_on("python@2.7:2.8,3.5:", type=("build", "run"), when="@5.1.0:")
-    depends_on("python@3.7:", type=("build", "run"), when="@6:")
-    depends_on("python@3.8:", type=("build", "run"), when="@7:")
+    with default_args(deprecated=True):
+        version("4.5.0", sha256="57c38470d9f57e37afb460c399eb254e7193ac7fb8042bd09bdc001981a9c74c")
 
-    depends_on("py-setuptools", type=("build", "run"))
-    depends_on("py-setuptools@:73", type=("build", "run"), when="@7.1:")
-    depends_on("py-setuptools@:45", type=("build", "run"), when="@4.5.0")
+    with default_args(type=("build", "run")):
+        depends_on("python@3.8:", when="@7:")
+        depends_on("python@3.7:", when="@6:")
+        depends_on("python@2.7:2.8,3.5:", when="@5.1.0:")
+        depends_on("python@2.7:2.8,3.4:", when="@4.5.0")
+
+        depends_on("py-setuptools@:73", when="@7.1:")
+        depends_on("py-setuptools@:45", when="@4.5.0")
+        depends_on("py-setuptools")


### PR DESCRIPTION
The older versions for `py-setuptools` are causing a lot of CI failures. This is a start in trying to either deprecate those versions or fix their dependents.

All packages dependent on the old versions have also been deprecated. Rinse repeat for their dependents.

I tried to be thorough in checking these packages can be safely deprecated. Just in case I missed something, I added myself as a maintainer so I can be made aware and fix those unforeseen issues.