### PR TITLE
qt-base: pass SBOM PATH from cmake_args

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -64,6 +64,12 @@ class QtPackage(CMakePackage):
         # for prefixes of dependencies
         args.append(self.define("QT_NO_DISABLE_CMAKE_INSTALL_RPATH_USE_LINK_PATH", True))
 
+        # Pass path variables as cmake arguments since some
+        # are not read from the environment
+        for v in ["QT_ADDITIONAL_PACKAGES_PREFIX_PATH", "QT_ADDITIONAL_SBOM_DOCUMENT_PATHS"]:
+            if v in os.environ:
+                args.append(self.define(v, ";".join(os.environ[v].split(":"))))
+
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -68,7 +68,7 @@ class QtPackage(CMakePackage):
         # are not read from the environment
         for v in ["QT_ADDITIONAL_PACKAGES_PREFIX_PATH", "QT_ADDITIONAL_SBOM_DOCUMENT_PATHS"]:
             if v in os.environ:
-                args.append(self.define(v, ";".join(os.environ[v].split(":"))))
+                args.append(self.define(v, os.environ[v].split(":")))
 
         return args
 


### PR DESCRIPTION
It turns out that #49319 wasn't quite sufficient since that variable is not read from the environment (in contrast to #49297). So, in this PR we get the PATH from the environment and pass it as a CMake argument. Now the SBOMs in Qt 6.9.0-rc1 are built correctly.