### PR TITLE
dyninst: %gcc only required for versions <13

### DIFF
--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -81,7 +81,7 @@ class Dyninst(CMakePackage):
         sha256="0064d8d51bd01bd0035e1ebc49276f627ce6366d4524c92cf47d3c09b0031f96",
     )
 
-    requires("%gcc", when="@:13.0.0", msg="dyninst builds only with GCC")
+    requires("%gcc", when="@:12", msg="dyninst builds only with GCC")
 
     # No Mac support (including apple-clang)
     conflicts("platform=darwin", msg="macOS is not supported")


### PR DESCRIPTION
Version ranges are inclusive so I think we need this update to properly allow `dyninst@13 %oneapi`, for example.

Without this PR, I observe the following:
```
$> spack spec -I hpctoolkit ^dyninst@13 %oneapi
==> Error: failed to concretize `hpctoolkit ^dyninst@13` for the following reasons:
     1. dyninst: dyninst builds only with GCC
```

Fixes:
* https://github.com/spack/spack/pull/44033