### PR TITLE
py-loky: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-loky/package.py
+++ b/var/spack/repos/builtin/packages/py-loky/package.py
@@ -1,0 +1,20 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyLoky(PythonPackage):
+    """Reusable Process Pool Executor"""
+
+    homepage = "https://loky.readthedocs.io"
+    pypi = "loky/loky-3.5.1.tar.gz"
+
+    license("BSD-3-Clause", checked_by="RobertMaaskant")
+
+    version("3.5.1", sha256="bcd1d718f005d06b099da856305cb337be36f552d49794f0b86df628a885eefe")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-cloudpickle", type=("build", "run"))


### PR DESCRIPTION
Tested using https://github.com/joblib/loky/tree/3.5.1?tab=readme-ov-file#usage

Added because it is a dependency of `py-deephyper@0.9.3`.