### PR TITLE
py-pymoo: add v0.6.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-pymoo/package.py
+++ b/var/spack/repos/builtin/packages/py-pymoo/package.py
@@ -24,6 +24,10 @@ class PyPymoo(PythonPackage):
 
     depends_on("cxx", type="build")  # generated
 
+    with default_args(type="build"):
+        depends_on("py-setuptools")
+        depends_on("py-cython@0.29:", when="@0.6.1.3:")
+
     with default_args(type=("build", "run")):
         depends_on("python@3.4:")
         depends_on("py-autograd")
@@ -38,7 +42,3 @@ class PyPymoo(PythonPackage):
             depends_on("py-alive-progress")
             depends_on("py-dill")
             depends_on("py-deprecated")
-
-    with default_args(type="build"):
-        depends_on("py-setuptools")
-        depends_on("py-cython@0.29:", when="@0.6.1.3:")

--- a/var/spack/repos/builtin/packages/py-pymoo/package.py
+++ b/var/spack/repos/builtin/packages/py-pymoo/package.py
@@ -25,25 +25,19 @@ class PyPymoo(PythonPackage):
     depends_on("cxx", type="build")  # generated
 
     with default_args(type=("build", "run")):
-        depends_on("python@3.9:", when="@0.6.1.3:")
         depends_on("python@3.4:")
-
-        depends_on("py-numpy@1.15:", when="@0.6.1.3:")
-
-        depends_on("py-scipy@1.1:", when="@0.6.1.3:")
-
-        depends_on("py-matplotlib@3:", when="@0.6.1.3:")
-
-        depends_on("py-autograd@1.4:", when="@0.6.1.3:")
         depends_on("py-autograd")
 
-        depends_on("py-cma@3.2.2:", when="@0.6.1.3:")
-
-        depends_on("py-alive-progress", when="@0.6.1.3:")
-
-        depends_on("py-dill", when="@0.6.1.3:")
-
-        depends_on("py-deprecated", when="@0.6.1.3:")
+        with when("@0.6.1.3:"):
+            depends_on("python@3.9:")
+            depends_on("py-numpy@1.15:")
+            depends_on("py-scipy@1.1:")
+            depends_on("py-matplotlib@3:")
+            depends_on("py-autograd@1.4:")
+            depends_on("py-cma@3.2.2:")
+            depends_on("py-alive-progress")
+            depends_on("py-dill")
+            depends_on("py-deprecated")
 
     with default_args(type="build"):
         depends_on("py-setuptools")

--- a/var/spack/repos/builtin/packages/py-pymoo/package.py
+++ b/var/spack/repos/builtin/packages/py-pymoo/package.py
@@ -18,11 +18,33 @@ class PyPymoo(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.6.1.3", sha256="ab440986cbaede547125ca9d1545781fdee94b719488de44119a86b8e9af526e")
     version("0.5.0", sha256="2fbca1716f6b45e430197ce4ce2210070fd3b6b9ec6b17bb25d98486115272c2")
     version("0.4.2", sha256="6ec382a7d29c8775088eec7f245a30fd384b42c40f230018dea0e3bcd9aabdf1")
 
     depends_on("cxx", type="build")  # generated
 
-    depends_on("python@3.4:", type=("build", "run"))
-    depends_on("py-autograd", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:", when="@0.6.1.3:")
+        depends_on("python@3.4:")
+
+        depends_on("py-numpy@1.15:", when="@0.6.1.3:")
+
+        depends_on("py-scipy@1.1:", when="@0.6.1.3:")
+
+        depends_on("py-matplotlib@3:", when="@0.6.1.3:")
+
+        depends_on("py-autograd@1.4:", when="@0.6.1.3:")
+        depends_on("py-autograd")
+
+        depends_on("py-cma@3.2.2:", when="@0.6.1.3:")
+
+        depends_on("py-alive-progress", when="@0.6.1.3:")
+
+        depends_on("py-dill", when="@0.6.1.3:")
+
+        depends_on("py-deprecated", when="@0.6.1.3:")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools")
+        depends_on("py-cython@0.29:", when="@0.6.1.3:")


### PR DESCRIPTION
Release notes:
- https://github.com/anyoptimization/pymoo/releases/tag/0.6.0
- https://github.com/anyoptimization/pymoo/releases/tag/0.6.0.1
- https://github.com/anyoptimization/pymoo/releases/tag/0.6.1.3

Tested by installing and running the example from https://github.com/anyoptimization/pymoo?tab=readme-ov-file#usage.

Added this version because it is a dependency of `py-deephyper@0.9.3`.