### PR TITLE
qt-tools: conflicts +assistant when 6.8.2

### DIFF
--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -36,6 +36,9 @@ class QtTools(QtPackage):
         description="Qt Widgets Designer for designing and building GUIs with Qt Widgets.",
     )
 
+    # use of relative path in https://github.com/qt/qttools/blob/6.8.2/.gitmodules
+    conflicts("+assistant", when="@6.8.2", msg="Incorrect git submodule prevents +assistant")
+
     depends_on("llvm +clang")
 
     depends_on("qt-base +network")


### PR DESCRIPTION
This PR ensures that `qt-tools` cannot use `+assistant` when 6.8.2, due to an incorrect relative submodule path in https://github.com/qt/qttools/blob/6.8.2/.gitmodules that does not work on GitHub.

This path has already been corrected for 6.8.3, so affects only 1 version.