### PR TITLE
py-uv: add v0.6.8

### DIFF
--- a/var/spack/repos/builtin/packages/py-uv/package.py
+++ b/var/spack/repos/builtin/packages/py-uv/package.py
@@ -13,6 +13,7 @@ class PyUv(PythonPackage):
 
     license("APACHE 2.0 or MIT")
 
+    version("0.6.8", sha256="45ecd70cfe42132ff84083ecb37fe7a8d2feac3eacd7a5872e7a002fb260940f")
     version("0.4.27", sha256="c13eea45257362ecfa2a2b31de9b62fbd0542e211a573562d98ab7c8fc50d8fc")
     version("0.4.17", sha256="01564bd760eff885ad61f44173647a569732934d1a4a558839c8088fbf75e53f")
     version("0.4.16", sha256="2144995a87b161d063bd4ef8294b1e948677bd90d01f8394d0e3fca037bb847f")
@@ -21,8 +22,9 @@ class PyUv(PythonPackage):
     depends_on("rust", type=("build", "run"))
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-maturin@1:1", type="build")
-    depends_on("cmake", type="build")
+    depends_on("cmake", type="build", when="@:0.6.3")
 
+    @when("@:0.6.3")
     def setup_build_environment(self, env):
         env.set("CMAKE", self.spec["cmake"].prefix.bin.cmake)
 


### PR DESCRIPTION
https://github.com/astral-sh/uv/releases/tag/0.6.8

The cmake dependency was lifted in 0.6.4: https://github.com/astral-sh/uv/commit/c3d809d276dc0e0c0ce0dae2abd50be72ab11f8a