### PR TITLE
trilinos: work around stk floating point exception handling on macos

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -973,6 +973,12 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             # the MacOSX{nn.n}.sdk since that breaks at every xcode update
             options.append(define_tpl_enable("DLlib", False))
 
+            # math_errhandling is an 'extern int' and not a constexpr in MacOS
+            # headers and this is not accounted for directly in the STK code
+            if spec.satisfies("+stk"):
+                options.append(define("STK_HAVE_FP_EXCEPT", False))
+                options.append(define("STK_HAVE_FP_ERRNO", False))
+
         # ################# Explicit template instantiation #################
 
         complex_s = spec.variants["complex"].value

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -975,7 +975,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
             # math_errhandling is an 'extern int' and not a constexpr in MacOS
             # headers and this is not accounted for directly in the STK code
-            if spec.satisfies("+stk"):
+            # so we must disable floating point exception handling in that case
+            if spec.satisfies("@16: +stk"):
                 options.append(define("STK_HAVE_FP_EXCEPT", False))
                 options.append(define("STK_HAVE_FP_ERRNO", False))
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
