### PR TITLE
kokkos-kernels@4.3.01 %oneapi: spadd handle: delete sort_option getter/sette…

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -160,6 +160,8 @@ class KokkosKernels(CMakePackage, CudaPackage):
     depends_on("kokkos@3.0.00", when="@3.0.00")
     depends_on("cmake@3.16:", type="build")
 
+    patch("pr2296-spadd-handle-delete-sort-option.patch", when="@4.3.01 %oneapi@2025")
+
     backends = {
         "serial": (False, "enable Serial backend (default)"),
         "cuda": (False, "enable Cuda backend"),

--- a/var/spack/repos/builtin/packages/kokkos-kernels/pr2296-spadd-handle-delete-sort-option.patch
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/pr2296-spadd-handle-delete-sort-option.patch
@@ -1,0 +1,14 @@
+diff -ruN spack-src/sparse/src/KokkosSparse_spadd_handle.hpp spack-src-patched/sparse/src/KokkosSparse_spadd_handle.hpp
+--- spack-src/sparse/src/KokkosSparse_spadd_handle.hpp	2024-05-08 22:01:11.000000000 +0000
++++ spack-src-patched/sparse/src/KokkosSparse_spadd_handle.hpp	2025-03-20 20:42:27.708953166 +0000
+@@ -110,10 +110,6 @@
+    */
+   size_type get_c_nnz() { return this->result_nnz_size; }
+ 
+-  void set_sort_option(int option) { this->sort_option = option; }
+-
+-  int get_sort_option() { return this->sort_option; }
+-
+ #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+   SpaddCusparseData cusparseData;
+ #endif


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/49622

Patch in content of upstream PR to fix `%oneapi@2025` build:
* https://github.com/kokkos/kokkos-kernels/pull/2296

```
==> Installing kokkos-kernels-4.3.01-ianrq7nhfxdt7gegu7qefvn52245w57a [12/12]
==> No binary for kokkos-kernels-4.3.01-ianrq7nhfxdt7gegu7qefvn52245w57a found: installing from source
==> Using cached archive: /spack/var/spack/cache/_source-cache/archive/74/749553a6ea715ba1e56fa0b13b42866bb9880dba7a94e343eadf40d08c68fab8.tar.gz
==> Applied patch /spack/var/spack/repos/builtin/packages/kokkos-kernels/pr2296-spadd-handle-delete-sort-option.patch
==> kokkos-kernels: Executing phase: 'cmake'
==> kokkos-kernels: Executing phase: 'build'
==> kokkos-kernels: Executing phase: 'install'
==> kokkos-kernels: Successfully installed kokkos-kernels-4.3.01-ianrq7nhfxdt7gegu7qefvn52245w57a
  Stage: 0.13s.  Cmake: 0.74s.  Build: 1m 18.86s.  Install: 0.58s.  Post-install: 0.29s.  Total: 1m 20.68s
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/oneapi-2025.0.4/kokkos-kernels-4.3.01-ianrq7nhfxdt7gegu7qefvn52245w57a
```

@lucbv 