### PR TITLE
KokkosKernels: apply PR 2296 as patch

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -250,6 +250,9 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     variant("shared", default=True, description="Build shared libraries")
 
+    patch("pr_2296_430.patch", when="@4.3.00:4.4.00")
+    patch("pr_2296_400.patch", when="@4.0.00:4.2.01")
+
     # sanity check
     sanity_check_is_file = [join_path("include", "KokkosKernels_config.h")]
     sanity_check_is_dir = ["include"]

--- a/var/spack/repos/builtin/packages/kokkos-kernels/pr_2296_400.patch
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/pr_2296_400.patch
@@ -1,0 +1,16 @@
+diff --git a/sparse/src/KokkosSparse_spadd_handle.hpp b/sparse/src/KokkosSparse_spadd_handle.hpp
+index 6d726e3da..01d96f551 100644
+--- a/sparse/src/KokkosSparse_spadd_handle.hpp
++++ b/sparse/src/KokkosSparse_spadd_handle.hpp
+@@ -76,10 +76,6 @@ class SPADDHandle {
+    */
+   size_type get_c_nnz() { return this->result_nnz_size; }
+ 
+-  void set_sort_option(int option) { this->sort_option = option; }
+-
+-  int get_sort_option() { return this->sort_option; }
+-
+   /**
+    * \brief Default constructor.
+    */
+

--- a/var/spack/repos/builtin/packages/kokkos-kernels/pr_2296_430.patch
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/pr_2296_430.patch
@@ -1,0 +1,16 @@
+diff --git a/sparse/src/KokkosSparse_spadd_handle.hpp b/sparse/src/KokkosSparse_spadd_handle.hpp
+index ea9594ca3..8d2830958 100644
+--- a/sparse/src/KokkosSparse_spadd_handle.hpp
++++ b/sparse/src/KokkosSparse_spadd_handle.hpp
+@@ -102,10 +102,6 @@ class SPADDHandle {
+    */
+   size_type get_c_nnz() { return this->result_nnz_size; }
+ 
+-  void set_sort_option(int option) { this->sort_option = option; }
+-
+-  int get_sort_option() { return this->sort_option; }
+-
+ #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+   SpaddCusparseData cusparseData;
+ #endif
+


### PR DESCRIPTION
@eugeneswalker @lucbv 

KokkosKernels PR being patched in: https://github.com/kokkos/kokkos-kernels/pull/2296
Applies this fix to affected versions (4.0.00:4.4.00).
This fixes issue #49622, which was about oneapi as the compiler but the issue also affects clang 19 and up.

Tested by installing these versions with clang 19:
```
-- linux-rhel9-skylake_avx512 / clang@19.1.0 --------------------
kokkos-kernels@4.0.00  kokkos-kernels@4.1.00  kokkos-kernels@4.2.01  kokkos-kernels@4.3.01  kokkos-kernels@4.4.01
kokkos-kernels@4.0.01  kokkos-kernels@4.2.00  kokkos-kernels@4.3.00  kokkos-kernels@4.4.00
```

(this supersedes https://github.com/spack/spack/pull/49624 which also fixes the issue but this covers more cases and more KokkosKernels versions)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
