### PR TITLE
Improve error message when running parallel test without xdist

### DIFF
--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -17,6 +17,7 @@ except ImportError:
     pytest = None  # type: ignore
 
 import llnl.util.filesystem
+import llnl.util.tty as tty
 import llnl.util.tty.color as color
 from llnl.util.tty.colify import colify
 
@@ -236,6 +237,12 @@ def unit_test(parser, args, unknown_args):
         pytest_root = spack.extensions.load_extension(args.extension)
 
     if args.numprocesses is not None and args.numprocesses > 1:
+        try:
+            import xdist  # noqa: F401
+        except ImportError:
+            tty.error("parallel unit-test requires pytest-xdist module")
+            return 1
+
         pytest_args.extend(
             [
                 "--dist",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

I ran into the very opaque (to me) error when running parallel test. Added better message if missing the required dependencies to run parallel tests.

Old:
```
ERROR: usage: spack [options] [file_or_dir] [file_or_dir] [...]
spack: error: unrecognized arguments: --dist --tx 16*popen//python=spack-tmpconfig spack python
...
```

New:
```
==> Error: parallel unit-test requires pytest-xdist module
```