### PR TITLE
Fix ci failures in mock packages due to changed license

### DIFF
--- a/var/spack/repos/builtin.mock/packages/conditionally-extends-direct-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditionally-extends-direct-dep/package.py
@@ -1,5 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 

--- a/var/spack/repos/builtin.mock/packages/conditionally-extends-transitive-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditionally-extends-transitive-dep/package.py
@@ -1,5 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 


### PR DESCRIPTION
Follow up to https://github.com/spack/spack/pull/48025 which merged in a set test packages that had the old license header.