### PR TITLE
hwdata: add v0.392 and update configure args to fix data path

### DIFF
--- a/var/spack/repos/builtin/packages/hwdata/package.py
+++ b/var/spack/repos/builtin/packages/hwdata/package.py
@@ -18,6 +18,4 @@ class Hwdata(AutotoolsPackage):
     version("0.340", sha256="e3a0ef18af6795a362345a2c2c7177be351cb27b4cc0ed9278b7409759258802")
 
     def configure_args(self):
-        return [
-            f"--datarootdir={self.prefix.share}",   # Will default to /usr/share if not set
-        ]
+        return [f"--datarootdir={self.prefix.share}"]  # Will default to /usr/share if not set

--- a/var/spack/repos/builtin/packages/hwdata/package.py
+++ b/var/spack/repos/builtin/packages/hwdata/package.py
@@ -13,5 +13,11 @@ class Hwdata(AutotoolsPackage):
 
     license("GPL-2.0-or-later OR XFree86-1.1")
 
+    version("0.392", sha256="1f472d8f2ec824d4efe6a75480767c4ce240fa5d91b6428d9f8775035da3ba1f")
     version("0.345", sha256="fafcc97421ba766e08a2714ccc3eebb0daabc99e67d53c2d682721dd01ccf7a7")
     version("0.340", sha256="e3a0ef18af6795a362345a2c2c7177be351cb27b4cc0ed9278b7409759258802")
+
+    def configure_args(self):
+        return [
+            f"--datarootdir={self.prefix.share}",   # Will default to /usr/share if not set
+        ]


### PR DESCRIPTION
This adds a more recent version of hwdata and fixes an issue with the build system attempting to install data in `/usr/share` even when prefix is set properly.
