### PR TITLE
flux-core: cffi needing for linking

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -93,7 +93,7 @@ class FluxCore(AutotoolsPackage):
     # Use of distutils in configure script dropped in v0.55
     # Detection of cffi version fixed in v0.68
     depends_on("python@:3.11", when="@:0.67", type=("build", "link", "run"))
-    depends_on("py-cffi@1.1:")
+    depends_on("py-cffi@1.1:", type=("build", "link", "run"))
     depends_on("py-pyyaml@3.10:", type=("build", "run"))
     depends_on("py-jsonschema@2.3:", type=("build", "run"), when="@:0.58.0")
     depends_on("py-ply", type=("build", "run"), when="@0.46.1:")

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -93,7 +93,7 @@ class FluxCore(AutotoolsPackage):
     # Use of distutils in configure script dropped in v0.55
     # Detection of cffi version fixed in v0.68
     depends_on("python@:3.11", when="@:0.67", type=("build", "link", "run"))
-    depends_on("py-cffi@1.1:", type=("build", "run"))
+    depends_on("py-cffi@1.1:")
     depends_on("py-pyyaml@3.10:", type=("build", "run"))
     depends_on("py-jsonschema@2.3:", type=("build", "run"), when="@:0.58.0")
     depends_on("py-ply", type=("build", "run"), when="@0.46.1:")


### PR DESCRIPTION
@grondo the build was failing because of [this issue](https://github.com/flux-framework/spack/pull/308) - and the fix (for a successful build) turned out to be adding cffi to be build, runtime, and link (I think the default if you don't specify anything for the type arg).

Note that this is a different issue than the one that it was disabled for last year - that was a missing of py-setuptools.