### PR TITLE
concretizer: Ignore provider weights for runtimes

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1682,10 +1682,11 @@ opt_criterion(45, "preferred providers (non-roots)").
 #minimize{ 0@245: #true }.
 #minimize{ 0@45: #true }.
 #minimize{
-    Weight@45+Priority,ProviderNode,Virtual
-    : provider_weight(ProviderNode, Virtual, Weight),
-      not attr("root", ProviderNode),
-      build_priority(ProviderNode, Priority)
+    Weight@45+Priority,X,Provider,Virtual
+    : provider_weight(node(X, Provider), Virtual, Weight),
+      not attr("root", node(X, Provider)),
+      build_priority(node(X, Provider), Priority),
+      not runtime(Provider)
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.


### PR DESCRIPTION
Runtimes are inherently tied to the associated compilers, and choices among runtimes should be delegated to the compiler prioritization criteria not the provider weights. 

This fixes a bug causing concretization to mix compilers more than necessary to avoid using the runtime associated with the compiler specified for the root. 

E.g. `foo%oneapi` building dependencies with `%gcc` to minimize edges on which `intel-oneapi-runtime` provides `fortran-rt`.

TODO:
- [ ] Distinguish between runtimes inextricably linked with a compiler (e.g. `gcc-runtime`, `intel-oneapi-runtime`) and those that are not (e.g. `glibc`, `musl`).
