### PR TITLE
Documentation: remote URL inclusion updates

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -710,14 +710,6 @@ Only the ``file``, ``ftp``, ``http`` and ``https`` protocols (or schemes) are
 supported. Spack-specific, environment and user path variables can be used.
 (See :ref:`config-file-variables` for more information.)
 
-.. note::
-
-   Recursive includes are not currently processed in a breadth-first manner
-   so the value of a configuration option that is altered by multiple included
-   files may not be what you expect. This will be addressed in a future
-   update.
-
-
 .. warning::
 
    Recursive includes are not currently processed in a breadth-first manner

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -686,7 +686,8 @@ the environment.
    spack:
      include:
      - environment/relative/path/to/config.yaml
-     - https://github.com/path/to/raw/config/packages.yaml
+     - path: https://github.com/path/to/raw/config/compilers.yaml
+       sha256: 26e871804a92cd07bb3d611b31b4156ae93d35b6a6d6e0ef3a67871fcb1d258b
      - /absolute/path/to/packages.yaml
      - path: /path/to/$os/$target/environment
        optional: true
@@ -700,14 +701,22 @@ with the ``optional`` clause and conditional with the ``when`` clause. (See
 
 Files are listed using paths to individual files or directories containing them.
 Path entries may be absolute or relative to the environment or specified as 
-URLs. URLs to individual files need link to the **raw** form of the file's 
+URLs. URLs to individual files must link to the **raw** form of the file's 
 contents (e.g., `GitHub
 <https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#viewing-or-copying-the-raw-file-content>`_ 
 or `GitLab
-<https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository>`_).
+<https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository>`_) **and** include a valid sha256 for the file.
 Only the ``file``, ``ftp``, ``http`` and ``https`` protocols (or schemes) are
 supported. Spack-specific, environment and user path variables can be used.
 (See :ref:`config-file-variables` for more information.)
+
+.. note::
+
+   Recursive includes are not currently processed in a breadth-first manner
+   so the value of a configuration option that is altered by multiple included
+   files may not be what you expect. This will be addressed in a future
+   update.
+
 
 .. warning::
 

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -40,8 +40,22 @@ can be used for conditional activation in the ``when`` clauses.
 Included files can be specified by path or by their parent directory.
 Paths may be absolute, relative (to the configuration file including the path), 
 or specified as URLs. Only the ``file``, ``ftp``, ``http`` and ``https`` protocols (or
-schemes) are supported. Spack-specific, environment and user path variables
+schemes) are supported.  Spack-specific, environment and user path variables
 can be used. (See :ref:`config-file-variables` for more information.)
+
+A ``sha256`` is required for remote file URLs and must be specified as follows:
+
+.. code-block:: yaml
+
+   include:
+   - path: https://github.com/path/to/raw/config/compilers.yaml
+     sha256: 26e871804a92cd07bb3d611b31b4156ae93d35b6a6d6e0ef3a67871fcb1d258b
+
+Additionally, remote file URLs must link to the **raw** form of the file's
+contents (e.g., `GitHub
+<https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#viewing-or-copying-the-raw-file-content>`_
+or `GitLab
+<https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository>`_).
 
 .. warning::
 

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -40,7 +40,7 @@ can be used for conditional activation in the ``when`` clauses.
 Included files can be specified by path or by their parent directory.
 Paths may be absolute, relative (to the configuration file including the path), 
 or specified as URLs. Only the ``file``, ``ftp``, ``http`` and ``https`` protocols (or
-schemes) are supported.  Spack-specific, environment and user path variables
+schemes) are supported. Spack-specific, environment and user path variables
 can be used. (See :ref:`config-file-variables` for more information.)
 
 A ``sha256`` is required for remote file URLs and must be specified as follows:


### PR DESCRIPTION
Seems the documentation from #48784 was not complete w.r.t URL examples or details (e.g., lacked a reference to the `sha256` requirement).
