### PR TITLE
openmpi: fix v4 +openshmem %oneapi@2023:2025 type cast

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -1267,6 +1267,15 @@ with '-Wl,-commons,use_dylibs' and without
                 else:
                     copy(script_stub, exe)
 
+    @run_before("configure", when="@4:4")
+    def patch_oshmem_implicit_cast(self):
+        filter_file(
+            "void *mca_sshmem_base_start_address = UINTPTR_MAX;",
+            "void *mca_sshmem_base_start_address = (void *) UINTPTR_MAX;",
+            "oshmem/mca/sshmem/base/sshmem_base_open.c",
+            string=True,
+        )
+
     @run_after("install")
     def setup_install_tests(self):
         """


### PR DESCRIPTION
Fix build error for variant `openmpi@4 +openshmem %oneapi@2023:2025 `
- require explicit cast to `(void*)`

Build error:
```
base/sshmem_base_open.c:34:39: error: initialization of 'void *' from 'long unsigned int' makes pointer from integer without a cast [-Wint-conversion]


   34 | void *mca_sshmem_base_start_address = UINTPTR_MAX;
      |                                       ^~~~~~~~~~~
 ```