### PR TITLE
py-setuptools: add v76.1.0 -> v78.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-flatbuffers/package.py
+++ b/var/spack/repos/builtin/packages/py-flatbuffers/package.py
@@ -25,4 +25,6 @@ class PyFlatbuffers(PythonPackage):
     version("2.0", sha256="12158ab0272375eab8db2d663ae97370c33f152b27801fa6024e1d6105fd4dd2")
     version("1.12", sha256="63bb9a722d5e373701913e226135b28a6f6ac200d5cc7b4d919fa38d73b44610")
 
+    # https://setuptools.pypa.io/en/latest/history.html#v77-0-0
+    depends_on("py-setuptools@:76", type="build", when="@:24.3.25")
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -19,8 +19,9 @@ class PySetuptools(Package, PythonExtension):
     # Requires railroad
     skip_modules = ["setuptools._vendor", "pkg_resources._vendor"]
 
-    # version("78.0.2", sha256="4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d")
-    # version("78.0.1", sha256="1cc9b32ee94f93224d6c80193cbb768004667aa2f2732a473d6949b0236c1d4e")
+    version("78.1.0", sha256="3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8")
+    version("78.0.2", sha256="4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d")
+    version("78.0.1", sha256="1cc9b32ee94f93224d6c80193cbb768004667aa2f2732a473d6949b0236c1d4e")
     version("77.0.3", sha256="67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c")
     version("77.0.1", sha256="81a234dff81a82bb52e522c8aef145d0dd4de1fd6de4d3b196d0f77dc2fded26")
     version("76.1.0", sha256="34750dcb17d046929f545dec9b8349fe42bf4ba13ddffee78428aec422dbfb73")

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -20,9 +20,18 @@ class PySetuptools(Package, PythonExtension):
     skip_modules = ["setuptools._vendor", "pkg_resources._vendor"]
 
     # version("78.0.2", sha256="4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d")
+    # version("78.0.1", sha256="1cc9b32ee94f93224d6c80193cbb768004667aa2f2732a473d6949b0236c1d4e")
     # version("77.0.3", sha256="67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c")
+    # version("77.0.1", sha256="81a234dff81a82bb52e522c8aef145d0dd4de1fd6de4d3b196d0f77dc2fded26")
     version("76.1.0", sha256="34750dcb17d046929f545dec9b8349fe42bf4ba13ddffee78428aec422dbfb73")
+    version("76.0.0", sha256="199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6")
     version("75.9.1", sha256="0a6f876d62f4d978ca1a11ab4daf728d1357731f978543ff18ecdbf9fd071f73")
+    version("75.8.2", sha256="558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f")
+    version("75.8.1", sha256="3bc32c0b84c643299ca94e77f834730f126efd621de0cc1de64119e0e17dab1f")
+    version("75.8.0", sha256="e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3")
+    version("75.3.2", sha256="90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9")
+    version("75.3.1", sha256="ccd77cda9d3bc3d3e99036d221b91d15f86e53195139d643b5b5299d42463cd3")
+    version("75.3.0", sha256="f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd")
     version("69.2.0", sha256="c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c")
     version("69.1.1", sha256="02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56")
     version("69.0.3", sha256="385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05")
@@ -52,33 +61,6 @@ class PySetuptools(Package, PythonExtension):
     version("43.0.0", sha256="a67faa51519ef28cd8261aff0e221b6e4c370f8fb8bada8aa3e7ad8945199963")
 
     with default_args(deprecated=True):
-        version(
-            "77.0.1", sha256="81a234dff81a82bb52e522c8aef145d0dd4de1fd6de4d3b196d0f77dc2fded26"
-        )
-        version(
-            "78.0.1", sha256="1cc9b32ee94f93224d6c80193cbb768004667aa2f2732a473d6949b0236c1d4e"
-        )
-        version(
-            "76.0.0", sha256="199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6"
-        )
-        version(
-            "75.8.2", sha256="558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
-        )
-        version(
-            "75.8.1", sha256="3bc32c0b84c643299ca94e77f834730f126efd621de0cc1de64119e0e17dab1f"
-        )
-        version(
-            "75.8.0", sha256="e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3"
-        )
-        version(
-            "75.3.2", sha256="90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9"
-        )
-        version(
-            "75.3.1", sha256="ccd77cda9d3bc3d3e99036d221b91d15f86e53195139d643b5b5299d42463cd3"
-        )
-        version(
-            "75.3.0", sha256="f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd"
-        )
         version(
             "41.4.0", sha256="8d01f7ee4191d9fdcd9cc5796f75199deccb25b154eba82d44d6a042cf873670"
         )

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -21,8 +21,8 @@ class PySetuptools(Package, PythonExtension):
 
     # version("78.0.2", sha256="4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d")
     # version("78.0.1", sha256="1cc9b32ee94f93224d6c80193cbb768004667aa2f2732a473d6949b0236c1d4e")
-    # version("77.0.3", sha256="67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c")
-    # version("77.0.1", sha256="81a234dff81a82bb52e522c8aef145d0dd4de1fd6de4d3b196d0f77dc2fded26")
+    version("77.0.3", sha256="67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c")
+    version("77.0.1", sha256="81a234dff81a82bb52e522c8aef145d0dd4de1fd6de4d3b196d0f77dc2fded26")
     version("76.1.0", sha256="34750dcb17d046929f545dec9b8349fe42bf4ba13ddffee78428aec422dbfb73")
     version("76.0.0", sha256="199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6")
     version("75.9.1", sha256="0a6f876d62f4d978ca1a11ab4daf728d1357731f978543ff18ecdbf9fd071f73")

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -19,12 +19,10 @@ class PySetuptools(Package, PythonExtension):
     # Requires railroad
     skip_modules = ["setuptools._vendor", "pkg_resources._vendor"]
 
-    version("76.0.0", sha256="199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6")
+    # version("78.0.2", sha256="4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d")
+    # version("77.0.3", sha256="67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c")
+    version("76.1.0", sha256="34750dcb17d046929f545dec9b8349fe42bf4ba13ddffee78428aec422dbfb73")
     version("75.9.1", sha256="0a6f876d62f4d978ca1a11ab4daf728d1357731f978543ff18ecdbf9fd071f73")
-    version("75.8.2", sha256="558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f")
-    version("75.8.1", sha256="3bc32c0b84c643299ca94e77f834730f126efd621de0cc1de64119e0e17dab1f")
-    version("75.8.0", sha256="e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3")
-    version("75.3.0", sha256="f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd")
     version("69.2.0", sha256="c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c")
     version("69.1.1", sha256="02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56")
     version("69.0.3", sha256="385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05")
@@ -54,6 +52,33 @@ class PySetuptools(Package, PythonExtension):
     version("43.0.0", sha256="a67faa51519ef28cd8261aff0e221b6e4c370f8fb8bada8aa3e7ad8945199963")
 
     with default_args(deprecated=True):
+        version(
+            "77.0.1", sha256="81a234dff81a82bb52e522c8aef145d0dd4de1fd6de4d3b196d0f77dc2fded26"
+        )
+        version(
+            "78.0.1", sha256="1cc9b32ee94f93224d6c80193cbb768004667aa2f2732a473d6949b0236c1d4e"
+        )
+        version(
+            "76.0.0", sha256="199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6"
+        )
+        version(
+            "75.8.2", sha256="558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
+        )
+        version(
+            "75.8.1", sha256="3bc32c0b84c643299ca94e77f834730f126efd621de0cc1de64119e0e17dab1f"
+        )
+        version(
+            "75.8.0", sha256="e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3"
+        )
+        version(
+            "75.3.2", sha256="90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9"
+        )
+        version(
+            "75.3.1", sha256="ccd77cda9d3bc3d3e99036d221b91d15f86e53195139d643b5b5299d42463cd3"
+        )
+        version(
+            "75.3.0", sha256="f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd"
+        )
         version(
             "41.4.0", sha256="8d01f7ee4191d9fdcd9cc5796f75199deccb25b154eba82d44d6a042cf873670"
         )

--- a/var/spack/repos/builtin/packages/py-torch-cluster/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-cluster/package.py
@@ -21,6 +21,8 @@ class PyTorchCluster(PythonPackage):
     depends_on("cxx", type="build")
 
     depends_on("python", type=("build", "link", "run"))
+    # https://setuptools.pypa.io/en/latest/history.html#v77-0-0
+    depends_on("py-setuptools@:76", type="build", when="@:1.6.3")
     depends_on("py-setuptools", type="build")
     depends_on("py-scipy", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-torch-scatter/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-scatter/package.py
@@ -21,6 +21,8 @@ class PyTorchScatter(PythonPackage):
     depends_on("cxx", type="build")
 
     depends_on("python", type=("build", "link", "run"))
+    # https://setuptools.pypa.io/en/latest/history.html#v77-0-0
+    depends_on("py-setuptools@:76", type="build", when="@:2.1.2")
     depends_on("py-setuptools", type="build")
 
     # Undocumented dependencies

--- a/var/spack/repos/builtin/packages/py-torch-spline-conv/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-spline-conv/package.py
@@ -21,6 +21,8 @@ class PyTorchSplineConv(PythonPackage):
     depends_on("cxx", type="build")
 
     depends_on("python", type=("build", "link", "run"))
+    # https://setuptools.pypa.io/en/latest/history.html#v77-0-0
+    depends_on("py-setuptools@:76", type="build", when="@:1.2.2")
     depends_on("py-setuptools", type="build")
 
     # Undocumented dependencies

--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -48,36 +48,13 @@ class PyTorchvision(PythonPackage):
     version("0.9.1", sha256="79964773729880e0eee0e6af13f336041121d4cc8491a3e2c0e5f184cac8a718")
     version("0.9.0", sha256="9351ed92aded632f8c7f59dfadac13c191a834babe682f5785ea47e6fcf6b472")
     version("0.8.2", sha256="9a866c3c8feb23b3221ce261e6153fc65a98ce9ceaa71ccad017016945c178bf")
-    version(
-        "0.8.1",
-        sha256="c46734c679c99f93e5c06654f4295a05a6afe6c00a35ebd26a2cce507ae1ccbd",
-        deprecated=True,
-    )
-    version(
-        "0.8.0",
-        sha256="b5f040faffbfc7bac8d4687d8665bd1196937334589b3fb5fcf15bb69ca25391",
-        deprecated=True,
-    )
-    version(
-        "0.7.0",
-        sha256="fa0a6f44a50451115d1499b3f2aa597e0092a07afce1068750260fa7dd2c85cb",
-        deprecated=True,
-    )
-    version(
-        "0.6.1",
-        sha256="8173680a976c833640ecbd0d7e6f0a11047bf8833433e2147180efc905e48656",
-        deprecated=True,
-    )
-    version(
-        "0.6.0",
-        sha256="02de11b3abe6882de4032ce86dab9c7794cbc84369b44d04e667486580f0f1f7",
-        deprecated=True,
-    )
-    version(
-        "0.5.0",
-        sha256="eb9afc93df3d174d975ee0914057a9522f5272310b4d56c150b955c287a4d74d",
-        deprecated=True,
-    )
+    with default_args(deprecated=True):
+        version("0.8.1", sha256="c46734c679c99f93e5c06654f4295a05a6afe6c00a35ebd26a2cce507ae1ccbd")
+        version("0.8.0", sha256="b5f040faffbfc7bac8d4687d8665bd1196937334589b3fb5fcf15bb69ca25391")
+        version("0.7.0", sha256="fa0a6f44a50451115d1499b3f2aa597e0092a07afce1068750260fa7dd2c85cb")
+        version("0.6.1", sha256="8173680a976c833640ecbd0d7e6f0a11047bf8833433e2147180efc905e48656")
+        version("0.6.0", sha256="02de11b3abe6882de4032ce86dab9c7794cbc84369b44d04e667486580f0f1f7")
+        version("0.5.0", sha256="eb9afc93df3d174d975ee0914057a9522f5272310b4d56c150b955c287a4d74d")
 
     desc = "Enable support for native encoding/decoding of {} formats in torchvision.io"
     variant("png", default=True, description=desc.format("PNG"))
@@ -145,6 +122,8 @@ class PyTorchvision(PythonPackage):
     depends_on("ninja", type="build")
 
     # setup.py
+    # https://setuptools.pypa.io/en/latest/history.html#v77-0-0
+    depends_on("py-setuptools@:76", type="build", when="@:0.21.0")
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
     # https://github.com/pytorch/vision/issues/8460


### PR DESCRIPTION
Add versions:
- 78.0.2
- 78.0.1
- 77.0.3
- 77.0.1
- 76.1.0
- 75.3.2
- 75.3.1

Changelog: https://setuptools.pypa.io/en/latest/history.html

Tested deprecating versions are not breaking dependents by commenting them out (fake delete) and running `spack audit packages`.

Testing new versions don't break dependents using CI runs by adding them one by one and fixing found issues. This is a WIP.