### PR TITLE
Add rocm 6.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/amdsmi/package.py
+++ b/var/spack/repos/builtin/packages/amdsmi/package.py
@@ -19,6 +19,7 @@ class Amdsmi(CMakePackage):
     libraries = ["libamd_smi"]
 
     license("MIT")
+    version("6.3.3", sha256="e23abc65a1cd75764d7da049b91cce2a095b287279efcd4f90b4b9b63b974dd5")
     version("6.3.2", sha256="1ed452eedfe51ac6e615d7bfe0bd7a0614f21113874ae3cbea7df72343cc2d13")
     version("6.3.1", sha256="a3a5a711052e813b9be9304d5e818351d3797f668ec2a455e61253a73429c355")
     version("6.3.0", sha256="7234c46648938239385cd5db57516ed53985b8c09d2f0828ae8f446386d8bd1e")

--- a/var/spack/repos/builtin/packages/aqlprofile/package.py
+++ b/var/spack/repos/builtin/packages/aqlprofile/package.py
@@ -8,6 +8,20 @@ import spack.platforms
 from spack.package import *
 
 _versions = {
+    "6.3.3": {
+        "apt": (
+            "5fe2b18e75e8c0a66069af8446399796818f7340a9ef5f2b52adaa79ee8e2a37",
+            "https://repo.radeon.com/rocm/apt/6.3.3/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.60303-74~20.04_amd64.deb",
+        ),
+        "yum": (
+            "bc501f9f4ec27a2fa402f4ad057f15ccb5a79bd25f44baa44f19e0427fb46a79",
+            "https://repo.radeon.com/rocm/rhel8/6.3.3/main/hsa-amd-aqlprofile-1.0.0.60303-74.el8.x86_64.rpm",
+        ),
+        "zyp": (
+            "81e5e9c2b373973c675962eefb60311394b35f54e00872de6a646f180c32805f",
+            "https://repo.radeon.com/rocm/zyp/6.3.3/main/hsa-amd-aqlprofile-1.0.0.60303-sles155.74.x86_64.rpm",
+        ),
+    },
     "6.3.2": {
         "apt": (
             "bef302bf344c9297f9fb64a4a93f360721a467185bc4fefbeecb307dd956c504",
@@ -290,6 +304,7 @@ class Aqlprofile(Package):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -29,6 +29,7 @@ class Comgr(CMakePackage):
     license("NCSA")
 
     version("master", branch="amd-stg-open")
+    version("6.3.3", sha256="4df9aba24e574edf23844c0d2d9dda112811db5c2b08c9428604a21b819eb23d")
     version("6.3.2", sha256="1f52e45660ea508d3fe717a9903fe27020cee96de95a3541434838e0193a4827")
     version("6.3.1", sha256="e9c2481cccacdea72c1f8d3970956c447cec47e18dfb9712cbbba76a2820552c")
     version("6.3.0", sha256="79580508b039ca6c50dfdfd7c4f6fbcf489fe1931037ca51324818851eea0c1c")
@@ -90,6 +91,7 @@ class Comgr(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         # llvm libs are linked statically, so this *could* be a build dep
@@ -118,6 +120,7 @@ class Comgr(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/composable-kernel/package.py
+++ b/var/spack/repos/builtin/packages/composable-kernel/package.py
@@ -18,6 +18,7 @@ class ComposableKernel(CMakePackage):
     license("MIT")
 
     version("master", branch="develop")
+    version("6.3.3", sha256="b7102efba044455416a6127af1951019fe8365a653ea7eb0b1d83bb4542c9309")
     version("6.3.2", sha256="875237fe493ff040f8f63b827cddf2ff30a8d3aa18864f87d0e35323c7d62a2d")
     version("6.3.1", sha256="3e8c8c832ca3f9ceb99ab90f654b93b7db876f08d90eda87a70bc629c854052a")
     version("6.3.0", sha256="274f87fc27ec2584c76b5bc7ebdbe172923166b6b93e66a24f98475b44be272d")
@@ -61,6 +62,7 @@ class ComposableKernel(CMakePackage):
 
     for ver in [
         "master",
+        "6.3.3",
         "6.3.2",
         "6.3.1",
         "6.3.0",

--- a/var/spack/repos/builtin/packages/hip-tensor/package.py
+++ b/var/spack/repos/builtin/packages/hip-tensor/package.py
@@ -16,6 +16,7 @@ class HipTensor(CMakePackage, ROCmPackage):
     maintainers("srekolam", "afzpatel")
 
     version("master", branch="master")
+    version("6.3.3", sha256="2f4e34c5a96004e24fcdf70f9157f1079ab177a78f6dbf96ea8290f668257c23")
     version("6.3.2", sha256="094db6d759eb32e9d15c36fce7f5b5d46ba81416953a8d9435b2fb9c161d8c83")
     version("6.3.1", sha256="142401331526e6da3fa172cce283f1c053056cb59cf431264443da76cee2f168")
     version("6.3.0", sha256="9a4acef722e838ec702c6b111ebc1fff9d5686ae5c79a9f5a82e5fac2a5e406a")
@@ -47,12 +48,24 @@ class HipTensor(CMakePackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"composable-kernel@{ver}", when=f"@{ver}")
         depends_on(f"rocm-cmake@{ver}", when=f"@{ver}")
 
-    for ver in ["6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in [
+        "6.1.0",
+        "6.1.1",
+        "6.1.2",
+        "6.2.0",
+        "6.2.1",
+        "6.2.4",
+        "6.3.0",
+        "6.3.1",
+        "6.3.2",
+        "6.3.3",
+    ]:
         depends_on(f"hipcc@{ver}", when=f"@{ver}")
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -25,6 +25,7 @@ class Hip(CMakePackage):
     license("MIT")
 
     version("master", branch="master")
+    version("6.3.3", sha256="aa3a5466304d1dbee0d976b50fccb710dd12e2e1d5534793396447c0ff845e2c")
     version("6.3.2", sha256="66a4eba98bd74fc7126ce7cb4d59653b22075fe95a70412fe283dc806ae366e0")
     version("6.3.1", sha256="76f862493c4912a06e0e0b8da3917c2ba7481f1e05f2c23ffd5e05f8c44e3037")
     version("6.3.0", sha256="950bfaf108a0af44eb169646f81f564f75f49e974acd06139b77245cfd327267")
@@ -119,6 +120,7 @@ class Hip(CMakePackage):
             "6.3.0",
             "6.3.1",
             "6.3.2",
+            "6.3.3",
         ]:
             depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
             depends_on(f"comgr@{ver}", when=f"@{ver}")
@@ -146,6 +148,7 @@ class Hip(CMakePackage):
             "6.3.0",
             "6.3.1",
             "6.3.2",
+            "6.3.3",
         ]:
             depends_on(f"hipify-clang@{ver}", when=f"@{ver}")
 
@@ -167,6 +170,7 @@ class Hip(CMakePackage):
             "6.3.0",
             "6.3.1",
             "6.3.2",
+            "6.3.3",
         ]:
             depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 
@@ -185,10 +189,11 @@ class Hip(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hipcc@{ver}", when=f"@{ver}")
 
-    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"rocprofiler-register@{ver}", when=f"@{ver}")
 
     # roc-obj-ls requirements
@@ -250,6 +255,7 @@ class Hip(CMakePackage):
         )
     # Add hip-clr sources thru the below
     for d_version, d_shasum in [
+        ("6.3.3", "8e5adca8f8c2d99d4a4e49605dd6b56b7881b762ee8ce15b4a7000e3cd982fec"),
         ("6.3.2", "ec13dc4ffe212beee22171cb2825d2b16cdce103c835adddb482b9238cf4f050"),
         ("6.3.1", "bfb8a4a59e7bd958e2cd4bf6f14c6cdea601d9827ebf6dc7af053a90e963770f"),
         ("6.3.0", "829e61a5c54d0c8325d02b0191c0c8254b5740e63b8bfdb05eec9e03d48f7d2c"),
@@ -309,6 +315,7 @@ class Hip(CMakePackage):
         )
     # Add hipother sources thru the below
     for d_version, d_shasum in [
+        ("6.3.3", "95cb2aab4bd996f0bd5f38427412cd768692a11fad70b97d20e402f32b1ef03e"),
         ("6.3.2", "1623d823de49471aae3ecb1fad0e9cdddf9301a4089f1fd44f78ac2ff0c20fb2"),
         ("6.3.1", "caa69147227bf72fa7b076867f84579456ef55af63efec29914265a80602df42"),
         ("6.3.0", "a28eb1e8fe239b41e744584d45d676925ca210968ecb21bfa60678cf8e86eeb7"),

--- a/var/spack/repos/builtin/packages/hipblas-common/package.py
+++ b/var/spack/repos/builtin/packages/hipblas-common/package.py
@@ -15,6 +15,7 @@ class HipblasCommon(CMakePackage):
 
     license("MIT")
 
+    version("6.3.3", sha256="b2b77abb5c851674839b583dc313684b5f6aa676e8186ff0a5696b6962c2b4da")
     version("6.3.2", sha256="29aa1ac1a0f684a09fe2ea8a34ae8af3622c27708c7df403a7481e75174e1984")
     version("6.3.1", sha256="512e652483b5580713eca14db3fa633d0441cd7c02cdb0d26e631ea605b9231b")
     version("6.3.0", sha256="240bb1b0f2e6632447e34deae967df259af1eec085470e58a6d0aa040c8530b0")

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -24,6 +24,7 @@ class Hipblas(CMakePackage, CudaPackage, ROCmPackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("6.3.3", sha256="8f645a5c9298170e71354437188eeca8272ff2b98077e9f34d1ca0fd7f27b7f8")
     version("6.3.2", sha256="6e86d4f8657e13665e37fdf3174c3a30f4c7dff2c4e2431d1be110cd7d463971")
     version("6.3.1", sha256="77a1845254d738c43a48bc52fa3e94499ed83535b5771408ff476122bc4b7b7c")
     version("6.3.0", sha256="72604c1896e42e65ea2b3e905159af6ec5eede6a353678009c47d0a24f462c92")
@@ -94,6 +95,7 @@ class Hipblas(CMakePackage, CudaPackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-cmake@{ver}", when=f"+rocm @{ver}")
         depends_on(f"rocm-openmp-extras@{ver}", type="test", when=f"+rocm @{ver}")
@@ -122,6 +124,7 @@ class Hipblas(CMakePackage, CudaPackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
         "develop",
     ]:
@@ -130,7 +133,7 @@ class Hipblas(CMakePackage, CudaPackage, ROCmPackage):
     for tgt in ROCmPackage.amdgpu_targets:
         depends_on(f"rocblas amdgpu_target={tgt}", when=f"+rocm amdgpu_target={tgt}")
         depends_on(f"rocsolver amdgpu_target={tgt}", when=f"+rocm amdgpu_target={tgt}")
-    for ver in ["6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"hipblas-common@{ver}", when=f"@{ver}")
 
     @classmethod

--- a/var/spack/repos/builtin/packages/hipblaslt/package.py
+++ b/var/spack/repos/builtin/packages/hipblaslt/package.py
@@ -16,6 +16,7 @@ class Hipblaslt(CMakePackage):
     maintainers("srekolam", "afzpatel", "renjithravindrankannath")
 
     license("MIT")
+    version("6.3.3", sha256="f32d666b37bdbecbf924cc98653fa3d30a0de629039d4dad44d35a2082e39e5a")
     version("6.3.2", sha256="cc4875b1a5cf1708a7576c42aff6b4cb790cb7337f5dc2df33119a4aadcef027")
     version("6.3.1", sha256="9a18a2e44264a21cfe58ed102fd3e34b336f23d6c191ca2da726e8e0883ed663")
     version("6.3.0", sha256="e570996037ea42eeca4c9b8b0b77a202d40be1a16068a6245595c551d80bdcad")
@@ -53,6 +54,7 @@ class Hipblaslt(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
@@ -61,7 +63,7 @@ class Hipblaslt(CMakePackage):
     for ver in ["6.0.0", "6.0.2", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.4"]:
         depends_on(f"hipblas@{ver}", when=f"@{ver}")
 
-    for ver in ["6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"hipblas-common@{ver}", when=f"@{ver}")
         depends_on(f"rocm-smi-lib@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/hipcc/package.py
+++ b/var/spack/repos/builtin/packages/hipcc/package.py
@@ -23,6 +23,7 @@ class Hipcc(CMakePackage):
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
 
     license("MIT")
+    version("6.3.3", sha256="4df9aba24e574edf23844c0d2d9dda112811db5c2b08c9428604a21b819eb23d")
     version("6.3.2", sha256="1f52e45660ea508d3fe717a9903fe27020cee96de95a3541434838e0193a4827")
     version("6.3.1", sha256="e9c2481cccacdea72c1f8d3970956c447cec47e18dfb9712cbbba76a2820552c")
     version("6.3.0", sha256="79580508b039ca6c50dfdfd7c4f6fbcf489fe1931037ca51324818851eea0c1c")

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -17,6 +17,7 @@ class Hipcub(CMakePackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause")
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
+    version("6.3.3", sha256="4ce22aba007c6c8a8b2231adefa7785b1869e5fdd4af29b0371a499a523c2dc6")
     version("6.3.2", sha256="4a1443c2ea12c3aa05fb65703eb309ccf8b893f9e6cbebec4ccf5502ba54b940")
     version("6.3.1", sha256="e5d100c7b8f95fe6243ad9f22170c136aa34db4e588136bec54ede7cb2e7f12f")
     version("6.3.0", sha256="a609cde18cefa90a1970049cc5630f2ec263f12961aa85993897580da2ca0456")
@@ -86,6 +87,7 @@ class Hipcub(CMakePackage, CudaPackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocprim@{ver}", when=f"+rocm @{ver}")
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -24,6 +24,7 @@ class Hipfft(CMakePackage, CudaPackage, ROCmPackage):
     license("MIT")
 
     version("master", branch="master")
+    version("6.3.3", sha256="c032d59a45b0eb4441539498bd4c22d8442fbc554cb08d6cb452a1d27be6c57c")
     version("6.3.2", sha256="5d9e662c7d67f4c814cad70476b57651df5ae6b65f371ca6dbb5aa51d9eeb6f5")
     version("6.3.1", sha256="b709df2d0115748ed004d0cddce829cb0f9ec3761eb855e61f0097cab04e4806")
     version("6.3.0", sha256="08a0c800f531247281b4dbe8de9567a6fde4f432829a451a720d0b0a3c711059")
@@ -93,6 +94,7 @@ class Hipfft(CMakePackage, CudaPackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/hipfort/package.py
+++ b/var/spack/repos/builtin/packages/hipfort/package.py
@@ -16,6 +16,7 @@ class Hipfort(CMakePackage):
     license("MIT")
 
     maintainers("cgmb", "srekolam", "renjithravindrankannath", "afzpatel")
+    version("6.3.3", sha256="dacb7d5a30689e6a8f81ec251daaa4a74b40f1d28145953c7d42ccd29cecee7c")
     version("6.3.2", sha256="d2438971199637eb2e09519c1f2300cdd7a84b4d948034a7cd1ce3e441faf5de")
     version("6.3.1", sha256="8141bf3d05ab4f91c561815134707123e3d06486bf775224b9a3a4cc8ee8f56f")
     version("6.3.0", sha256="9e7f4420c75430cdb9046c0c4dbe656f22128b0672b2e261d50a6e92e47cc6d3")
@@ -70,6 +71,7 @@ class Hipfort(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", type="build", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/hipify-clang/package.py
+++ b/var/spack/repos/builtin/packages/hipify-clang/package.py
@@ -19,6 +19,7 @@ class HipifyClang(CMakePackage):
     license("MIT")
 
     version("master", branch="master")
+    version("6.3.3", sha256="94d32b0e02c0c34debb9a8034cb5fcd6c2ee35b67350c64690034cf94cd38ddd")
     version("6.3.2", sha256="c0da5118be8207fab6d19803417c0b8d2db5bc766279038527cbd6fa92b25c67")
     version("6.3.1", sha256="5f9d9a65545f97b18c6a0d4394dca1bcdee10737a5635b79378ea505081f9315")
     version("6.3.0", sha256="9fced04f9e36350bdbabd730c446b55a898e2f4ba82078855bcf5dea3b5e8dc8")
@@ -78,6 +79,7 @@ class HipifyClang(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
@@ -100,6 +102,7 @@ class HipifyClang(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/hiprand/package.py
+++ b/var/spack/repos/builtin/packages/hiprand/package.py
@@ -24,6 +24,7 @@ class Hiprand(CMakePackage, CudaPackage, ROCmPackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("6.3.3", sha256="ea0d7638a463c06d30692205f8c591d3fe025b58a772226ca1c972e723118a2f")
     version("6.3.2", sha256="0a08ed7554c161b095c866cd5e6f0d63cdf063e5b3c1183afa6ac18bad94a575")
     version("6.3.1", sha256="ec43bf64eda348cf53c2767e553fd9561540dc50ae3ce95ca916404aa9a3eafb")
     version("6.3.0", sha256="7464c1e48f4e1a97a5e5978146641971d068886038810876b60acb5dfb6c4d39")
@@ -105,6 +106,7 @@ class Hiprand(CMakePackage, CudaPackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
         "develop",
     ]:

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -29,6 +29,7 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("6.3.3", sha256="529263f9abe5b7485bbabedc3993630abaa0d5fd547c4add0993d1cb0d71e226")
     version("6.3.2", sha256="885c999da8e4aa0b4cb9584bc0fc0d6a8c8d56f5e7ee6d211c608003eff22aa7")
     version("6.3.1", sha256="793074ebaa4a3b16dc6e4d2a54ecbb259f1e0ec7fdcd7f885da622a1d1478b76")
     version("6.3.0", sha256="a0443f0b894cedd5af59af4fadcb3c38daa728ca32c13b9741fb19e2d828a089")
@@ -111,6 +112,7 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
         "develop",
     ]:

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -21,6 +21,7 @@ class Hipsparse(CMakePackage, CudaPackage, ROCmPackage):
     libraries = ["libhipsparse"]
 
     license("MIT")
+    version("6.3.3", sha256="61c26eb93e857c942a03ea4350a403e20191be465041e542ad7da00058e89ead")
     version("6.3.2", sha256="9fbc3468632fdc828d7bae386c2737eb371d78811f53da7348b417fb00d62808")
     version("6.3.1", sha256="d64bc48e0aa5ec2f48853272a9c554b37ec98cb0724135e45f21b1340df7bccb")
     version("6.3.0", sha256="550fd5a480490e631507e8c34b2b0cf9cbc2ad2a5bf84e8ea0a8fad96eecb25a")
@@ -93,6 +94,7 @@ class Hipsparse(CMakePackage, CudaPackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
         depends_on(f"rocsparse@{ver}", when=f"+rocm @{ver}")

--- a/var/spack/repos/builtin/packages/hipsparselt/package.py
+++ b/var/spack/repos/builtin/packages/hipsparselt/package.py
@@ -21,6 +21,7 @@ class Hipsparselt(CMakePackage, ROCmPackage):
     maintainers("srekolam", "afzpatel", "renjithravindrankannath")
 
     license("MIT")
+    version("6.3.3", sha256="6b756e20fddb37b8c1237ef8e124452c9bdd46acad8a40699d10b609d0d2ebfc")
     version("6.3.2", sha256="a0b30b478eff822dd7fa1c116ad99dcdf14ece1c33aae04ac71b594efd4d9866")
     version("6.3.1", sha256="403d4c0ef47f89510452a20be6cce72962f21761081fc19a7e0e27e7f0c4ccfd")
     version("6.3.0", sha256="f67ed4900101686596add37824d0628f1e71cf6a30d827a0519b3c3657f63ac3")
@@ -60,13 +61,14 @@ class Hipsparselt(CMakePackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"hipsparse@{ver}", when=f"@{ver}")
         depends_on(f"rocm-openmp-extras@{ver}", when=f"@{ver}", type="test")
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
 
-    for ver in ["6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"rocm-smi-lib@{ver}", when=f"@{ver}")
 
     depends_on("cmake@3.5:", type="build")

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -23,6 +23,7 @@ class HsaRocrDev(CMakePackage):
     libraries = ["libhsa-runtime64"]
 
     version("master", branch="master")
+    version("6.3.3", sha256="aa2e30d3d68707d6df4840e954bb08cc13cd312cec1a98a64d97adbe07262f50")
     version("6.3.2", sha256="aaecaa7206b6fa1d5d7b8f7c1f7c5057a944327ba4779448980d7e7c7122b074")
     version("6.3.1", sha256="547ceeeda9a41cdffa21e57809dc5834f94938a0a2809c283aebcbcf01901df0")
     version("6.3.0", sha256="8fd6bcd6a5afd0ae5a59e33b786a525f575183d38c34049c2dab6b9270a1ca3b")
@@ -108,6 +109,7 @@ class HsaRocrDev(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
@@ -132,6 +134,7 @@ class HsaRocrDev(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -34,6 +34,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     license("Apache-2.0")
 
     version("master", branch="amd-stg-open")
+    version("6.3.3", sha256="4df9aba24e574edf23844c0d2d9dda112811db5c2b08c9428604a21b819eb23d")
     version("6.3.2", sha256="1f52e45660ea508d3fe717a9903fe27020cee96de95a3541434838e0193a4827")
     version("6.3.1", sha256="e9c2481cccacdea72c1f8d3970956c447cec47e18dfb9712cbbba76a2820552c")
     version("6.3.0", sha256="79580508b039ca6c50dfdfd7c4f6fbcf489fe1931037ca51324818851eea0c1c")
@@ -174,6 +175,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
         when="@master +rocm-device-libs",
     )
     for d_version, d_shasum in [
+        ("6.3.3", "aa2e30d3d68707d6df4840e954bb08cc13cd312cec1a98a64d97adbe07262f50"),
         ("6.3.2", "aaecaa7206b6fa1d5d7b8f7c1f7c5057a944327ba4779448980d7e7c7122b074"),
         ("6.3.1", "547ceeeda9a41cdffa21e57809dc5834f94938a0a2809c283aebcbcf01901df0"),
         ("6.3.0", "8fd6bcd6a5afd0ae5a59e33b786a525f575183d38c34049c2dab6b9270a1ca3b"),

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -19,6 +19,7 @@ class Migraphx(CMakePackage):
     libraries = ["libmigraphx"]
 
     license("MIT")
+    version("6.3.3", sha256="a268baa99b145a32fe282e407cf923b1c1022f2ddab36d7178537b860fdfcf8d")
     version("6.3.2", sha256="4e6b9800919e99070c0289616657592c23ff66a55230409f38e5c7e099c0d89b")
     version("6.3.1", sha256="c60df20b3c890c469265ae6f273fb5d43cc13c8c514f76dd7b4d195d9e44ba85")
     version("6.3.0", sha256="21550e5cecf1b26c02e1c4633c7c4c6eb5e37be8758d7a2641f10cfdf4203636")
@@ -107,6 +108,7 @@ class Migraphx(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
         depends_on(f"hip@{ver}", when=f"@{ver}")
@@ -125,6 +127,7 @@ class Migraphx(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocmlir@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -20,6 +20,7 @@ class MiopenHip(CMakePackage):
     libraries = ["libMIOpen"]
 
     license("MIT")
+    version("6.3.3", sha256="755beaec2e97aa4fafcdb07e4becbcddcb0c3cef6af256a04716d46e90c2f520")
     version("6.3.2", sha256="7abda3b437e396a1611a6f63e73ab1656d45d5405194504136c0ccbb75b81fea")
     version("6.3.1", sha256="edb82a74086fb96f8d7ee9e50a180302f716332cd0dff96bf7244bdc6fab5895")
     version("6.3.0", sha256="171834978d6316a5ec7607d4b10c7c69e5bfe9064edae8bdb9b207e578b41c1d")
@@ -103,6 +104,7 @@ class MiopenHip(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
         depends_on(f"hip@{ver}", when=f"@{ver}")
@@ -147,6 +149,7 @@ class MiopenHip(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"composable-kernel@{ver}", when=f"@{ver} +ck")
     for ver in ["5.4.0", "5.4.3", "5.5.0"]:
@@ -163,11 +166,12 @@ class MiopenHip(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"roctracer-dev@{ver}", when=f"@{ver}")
-    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"rocrand@{ver}", when=f"@{ver}")
-    for ver in ["6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"hipblas@{ver}", when=f"@{ver}")
         depends_on(f"hipblaslt@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/mivisionx/package.py
+++ b/var/spack/repos/builtin/packages/mivisionx/package.py
@@ -25,6 +25,7 @@ class Mivisionx(CMakePackage):
         return url.format(version)
 
     license("MIT")
+    version("6.3.3", sha256="6ab255305b786c6152ffe12211f329d2bc56823bb2192a945b9aa5efe6731b82")
     version("6.3.2", sha256="2e7984e4ef2e6195aa9afa11030b8418aee885bec9befa220b9b53b5229b7fae")
     version("6.3.1", sha256="1f7bd1f6b61401bc642b50e96411344b092b09189534c5d6ba2f4c661d1af0ce")
     version("6.3.0", sha256="bc16881eae11140025b8fbd00bc741763548d41345dbe954c8d8659f4dccfe9e")
@@ -240,6 +241,7 @@ class Mivisionx(CMakePackage):
             "6.3.0",
             "6.3.1",
             "6.3.2",
+            "6.3.3",
         ]:
             depends_on(f"miopen-hip@{ver}", when=f"@{ver}")
         for ver in [
@@ -263,6 +265,7 @@ class Mivisionx(CMakePackage):
             "6.3.0",
             "6.3.1",
             "6.3.2",
+            "6.3.3",
         ]:
             depends_on(f"migraphx@{ver}", when=f"@{ver}")
             depends_on(f"hip@{ver}", when=f"@{ver}")
@@ -285,6 +288,7 @@ class Mivisionx(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
         depends_on("python@3.5:", type="build")
@@ -303,6 +307,7 @@ class Mivisionx(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rpp@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -21,6 +21,12 @@ class Rccl(CMakePackage):
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
     libraries = ["librccl"]
     version(
+        "6.3.3",
+        tag="rocm-6.3.3",
+        commit="9a0e6a114c8f7371fa3050b413a350d6945fb7db",
+        submodules=True,
+    )
+    version(
         "6.3.2",
         tag="rocm-6.3.2",
         commit="9a0e6a114c8f7371fa3050b413a350d6945fb7db",
@@ -101,6 +107,7 @@ class Rccl(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
         depends_on(f"hip@{ver}", when=f"@{ver}")
@@ -125,6 +132,7 @@ class Rccl(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rdc/package.py
+++ b/var/spack/repos/builtin/packages/rdc/package.py
@@ -26,6 +26,7 @@ class Rdc(CMakePackage):
         return url.format(version)
 
     license("MIT")
+    version("6.3.3", sha256="9be314ea8d7e7af58ac4a24f5720f54d51ba553d3e1751bc9cfc4bff98494fab")
     version("6.3.2", sha256="e0780b8ef46d7b9885eb06a0b9eb56924fdf090ade71a66360a0bee1d9d7295d")
     version("6.3.1", sha256="88a96f13c0010a7f9e63f7a5a5531ae1d57ef1a722bac232c8544cde6245e120")
     version("6.3.0", sha256="419afd9c8e50a872fb0a922e29c8578664ed88e0b79bf558db0a1e864aa8fecf")
@@ -82,6 +83,7 @@ class Rdc(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-smi-lib@{ver}", type=("build", "link"), when=f"@{ver}")
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
@@ -104,9 +106,10 @@ class Rdc(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
-    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"amdsmi@{ver}", when=f"@{ver}")
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/rocal/package.py
+++ b/var/spack/repos/builtin/packages/rocal/package.py
@@ -15,6 +15,7 @@ class Rocal(CMakePackage):
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
 
     license("MIT")
+    version("6.3.3", sha256="aaccd951f176356561d8ab8210696d80a94553fd48ace72993a7cfac4b98d6cf")
     version("6.3.2", sha256="ceae8a86770c1f5d8cb56f4c38d6b354e16bda6b877cf93417d6a3e4e33354c6")
     version("6.3.1", sha256="e332c9c2b2eb4081d7dd8a66a141f95fe8c7fccbbfdd0fea7572a62a28a62bbb")
     version("6.3.0", sha256="162a0c15e6e7e09c0e13a9d01a493ba3199b77919addf396cd5d273ebf44d759")
@@ -28,7 +29,7 @@ class Rocal(CMakePackage):
     depends_on("ffmpeg@4.4:")
     depends_on("abseil-cpp", when="@6.3:")
 
-    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"mivisionx@{ver}", when=f"@{ver}")
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
         depends_on(f"rpp@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -25,6 +25,7 @@ class Rocalution(CMakePackage):
     libraries = ["librocalution_hip"]
 
     license("MIT")
+    version("6.3.3", sha256="bec6388e74b74922c2dc3af0d73ff0e4cafdabad9e8473181079df09de81c11a")
     version("6.3.2", sha256="b13118a5c0af08a666d80af78d52bdfba12ed134f6745ab36d8de75ed3bc7584")
     version("6.3.1", sha256="94b78b34ac750c09831aa70a3d7f8cd220c540a75e4f91c391ba435de420c536")
     version("6.3.0", sha256="a7476e1ce79915cb8e01917de372ae6b15d7e51b1a25e15cde346dadf2391068")
@@ -88,6 +89,7 @@ class Rocalution(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocprim@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -22,6 +22,7 @@ class Rocblas(CMakePackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("6.3.3", sha256="73e91bd50c920b818742fa5bf9990c0676be5bfbafe321d5781607dc2ce27060")
     version("6.3.2", sha256="455cad760d926c21101594197c4456f617e5873a8f17bb3e14bd762018545a9e")
     version("6.3.1", sha256="88d2de6ce6b23a157eea8be63408350848935e4dfc3e27e5f2add78834c6d6ba")
     version("6.3.0", sha256="051f53bb69a9aba55a0c66c32688bf6af80e29e4a6b56b380b3c427e7a6aff9d")
@@ -90,10 +91,11 @@ class Rocblas(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-openmp-extras@{ver}", type="test", when=f"@{ver}")
 
-    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"rocm-smi-lib@{ver}", type="test", when=f"@{ver}")
 
     depends_on("rocm-cmake@master", type="build", when="@master:")
@@ -120,13 +122,14 @@ class Rocblas(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"llvm-amdgpu@{ver}", type="build", when=f"@{ver}")
         depends_on(f"rocminfo@{ver}", type="build", when=f"@{ver}")
         depends_on(f"rocm-cmake@{ver}", type="build", when=f"@{ver}")
 
-    for ver in ["6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"hipblaslt@{ver}", when=f"@{ver}")
     depends_on("python@3.6:", type="build")
 
@@ -164,6 +167,7 @@ class Rocblas(CMakePackage):
         ("@6.3.0", "aca95d1743c243dd0dd0c8b924608bc915ce1ae7"),
         ("@6.3.1", "aca95d1743c243dd0dd0c8b924608bc915ce1ae7"),
         ("@6.3.2", "aca95d1743c243dd0dd0c8b924608bc915ce1ae7"),
+        ("@6.3.3", "aca95d1743c243dd0dd0c8b924608bc915ce1ae7"),
     ]:
         resource(
             name="Tensile",

--- a/var/spack/repos/builtin/packages/rocdecode/package.py
+++ b/var/spack/repos/builtin/packages/rocdecode/package.py
@@ -17,6 +17,7 @@ class Rocdecode(CMakePackage):
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
 
     license("MIT")
+    version("6.3.3", sha256="e72f53674527b7a6c3cba3b7555fee32117f0875107fd9e632a2ec1d5ce03489")
     version("6.3.2", sha256="39ff3c21c81a73910dcfe6a147edaddecc21575a3077f0f99971c8d2f6d0e7d5")
     version("6.3.1", sha256="94da1a61167abaf3f983ae5d62bffb22bb8ba3eb1c9d9fc7c68ed9a066aa4e52")
     version("6.3.0", sha256="931f49ff86fa34929b03cec8e7becde78d0c49c1c3a23a13203fecd2b392b242")
@@ -38,7 +39,18 @@ class Rocdecode(CMakePackage):
 
     depends_on("libva", type="build", when="@6.2:")
 
-    for ver in ["6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in [
+        "6.1.0",
+        "6.1.1",
+        "6.1.2",
+        "6.2.0",
+        "6.2.1",
+        "6.2.4",
+        "6.3.0",
+        "6.3.1",
+        "6.3.2",
+        "6.3.3",
+    ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -20,6 +20,7 @@ class Rocfft(CMakePackage):
 
     license("MIT")
     version("master", branch="master")
+    version("6.3.3", sha256="b2edb5c39215b98e0abc485d2b277a0b8c6f87f06e9b0770a60f5568ef52e62e")
     version("6.3.2", sha256="0511d04d2367dcac6b35bc6b449337ba37bb623b8382fb11178fc608b5435437")
     version("6.3.1", sha256="f8aa0e68d8e303725d0be8ae1d7c0113b6ca019a3b9f08572abf8a02db690662")
     version("6.3.0", sha256="afc716c95d1c80097f7a965e0c3cf1fe246c9fdf10a8fd9a303202156bd3811d")
@@ -99,6 +100,7 @@ class Rocfft(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocjpeg/package.py
+++ b/var/spack/repos/builtin/packages/rocjpeg/package.py
@@ -18,13 +18,14 @@ class Rocjpeg(CMakePackage):
 
     license("MIT")
 
+    version("6.3.3", sha256="65081b20ab3df82337fdcaf3d4e614c75f946656a4ea7bc00ac0d1bbd81e3e83")
     version("6.3.2", sha256="4e1ec9604152e818afa85360f1e0ef9e98bfb8a97ca0989980063e2ece015c16")
     version("6.3.1", sha256="f4913cbc63e11b9b418d33b0f9ba0fec0aa00b23285090acfd435e1ba1c21e42")
     version("6.3.0", sha256="2623b8f8bb61cb418d00c695e8ff0bc5979e1bb2d61d6c327a27d676c89e89cb")
 
     depends_on("cxx", type="build")
 
-    for ver in ["6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
         depends_on(f"hip@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocm-bandwidth-test/package.py
+++ b/var/spack/repos/builtin/packages/rocm-bandwidth-test/package.py
@@ -17,6 +17,7 @@ class RocmBandwidthTest(CMakePackage):
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
 
     version("master", branch="master")
+    version("6.3.3", sha256="d33f656eb6ba7db78b41c4bcf6d830b511dc97c6d645760e6d05edd07fcaefba")
     version("6.3.2", sha256="3754831244d7c4f6314fc25b3e929adf9abe44c9cb60621dd8ae5d1aa930ae55")
     version("6.3.1", sha256="98002e4104929a62a308114ed82fba530880359a17f90ebd62a2ca49c2baac78")
     version("6.3.0", sha256="6d1e444b962e7a40fb9f20c87631865d3e04e8c9027fd21b439bee9b62d0070c")
@@ -88,6 +89,7 @@ class RocmBandwidthTest(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
@@ -110,6 +112,7 @@ class RocmBandwidthTest(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -20,6 +20,7 @@ class RocmCmake(CMakePackage):
     license("MIT")
 
     version("master", branch="master")
+    version("6.3.3", sha256="4238cccc22226ba9487185fc2faa66b11c0cb8e7982240332e1b919cec8d909e")
     version("6.3.2", sha256="f5104c2289da99a70d8c4c1befbca4f8efa7c89711eaac7b6b63592cd4bd99a8")
     version("6.3.1", sha256="6994a5bdeea55cd41ec01ab4142785ea02bbdcb83e70f6911095c7cea766ebe8")
     version("6.3.0", sha256="45a1b96f85ae28a7f62895ddc4d6648500b883af250f52f6417bafb31b3cc75d")
@@ -65,6 +66,7 @@ class RocmCmake(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocm-core/package.py
+++ b/var/spack/repos/builtin/packages/rocm-core/package.py
@@ -19,6 +19,7 @@ class RocmCore(CMakePackage):
     libraries = ["librocm-core"]
 
     license("MIT")
+    version("6.3.3", sha256="d2a3900424dea1dcc0e303c288d2c07e1345c2d5348398449998e8007fe7fd44")
     version("6.3.2", sha256="3243f661e5e995341e81127a6096ac80169b8481826ebadc02e24020f1ff985d")
     version("6.3.1", sha256="f8196f3aafe03bd93ae2947162f34098fd08ddbad4eb3deaf92acd434b480304")
     version("6.3.0", sha256="4fa981335426195028dd6b3a05228a2ebe8e601023a1e99130bba1b14bf60178")
@@ -45,7 +46,18 @@ class RocmCore(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    for ver in ["6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in [
+        "6.1.0",
+        "6.1.1",
+        "6.1.2",
+        "6.2.0",
+        "6.2.1",
+        "6.2.4",
+        "6.3.0",
+        "6.3.1",
+        "6.3.2",
+        "6.3.3",
+    ]:
         depends_on("llvm-amdgpu", when=f"@{ver}+asan")
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
+++ b/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
@@ -24,6 +24,7 @@ class RocmDbgapi(CMakePackage):
     license("MIT")
 
     version("master", branch="amd-master")
+    version("6.3.3", sha256="25c8e9f4a22f23004f2fc1998c284095b193591eb6143b47380455754948ab98")
     version("6.3.2", sha256="0e7cea6ae2eb737ad378787d2ef5f6cbaf9dfb483bb5e61e716601a145677adf")
     version("6.3.1", sha256="1843423c91a22cf83bef5f14cb50f55ba333047e03e75296b9f9522facde5822")
     version("6.3.0", sha256="c46ca562fbbac8673c22ee5c92d62ddf6c7dfd7faceeb66d3876cde6beda8872")
@@ -80,6 +81,7 @@ class RocmDbgapi(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"hsa-rocr-dev@{ver}", type="build", when=f"@{ver}")
@@ -103,6 +105,7 @@ class RocmDbgapi(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocm-debug-agent/package.py
+++ b/var/spack/repos/builtin/packages/rocm-debug-agent/package.py
@@ -17,6 +17,7 @@ class RocmDebugAgent(CMakePackage):
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
     libraries = ["librocm-debug-agent"]
+    version("6.3.3", sha256="27407c5cabec3d9757ffe5eb729639ccb3ad3b086f57f101854b73479a6f0f51")
     version("6.3.2", sha256="578aa08b10a456eebd2b548afd86339bd5a5df807611ffd20cc3006eaae74836")
     version("6.3.1", sha256="0e28a9febf3b95cc6bbf8eae91091bf22a8f49fe9558171251f8f9afe666f9d7")
     version("6.3.0", sha256="c8c3461395b2fc1e136d61eb5a36ba9f3f751eb00cb9d830f498de2e5d4299d5")
@@ -95,6 +96,7 @@ class RocmDebugAgent(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
         depends_on(f"rocm-dbgapi@{ver}", when=f"@{ver}")
@@ -117,6 +119,7 @@ class RocmDebugAgent(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocm-device-libs/package.py
+++ b/var/spack/repos/builtin/packages/rocm-device-libs/package.py
@@ -24,6 +24,7 @@ class RocmDeviceLibs(CMakePackage):
     maintainers("srekolam", "renjithravindrankannath", "haampie", "afzpatel")
 
     version("master", branch="amd-stg-open")
+    version("6.3.3", sha256="4df9aba24e574edf23844c0d2d9dda112811db5c2b08c9428604a21b819eb23d")
     version("6.3.2", sha256="1f52e45660ea508d3fe717a9903fe27020cee96de95a3541434838e0193a4827")
     version("6.3.1", sha256="e9c2481cccacdea72c1f8d3970956c447cec47e18dfb9712cbbba76a2820552c")
     version("6.3.0", sha256="79580508b039ca6c50dfdfd7c4f6fbcf489fe1931037ca51324818851eea0c1c")
@@ -84,6 +85,7 @@ class RocmDeviceLibs(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
@@ -106,6 +108,7 @@ class RocmDeviceLibs(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocm-examples/package.py
+++ b/var/spack/repos/builtin/packages/rocm-examples/package.py
@@ -18,6 +18,7 @@ class RocmExamples(CMakePackage):
 
     license("MIT")
 
+    version("6.3.3", sha256="5e5bdffb4bf56d30c5f8dd8fda95d162362d17e446396e6b6a3afe8d293039f3")
     version("6.3.2", sha256="7a71dcfec782338af1d838f86b692974368e362de8ad85d5ec26c23b0afbab9e")
     version("6.3.1", sha256="c5093cd6641de478b940d2e36d6723f7ef1ccad3f4f96caf0394def2e6c7e325")
     version("6.3.0", sha256="809b5212d86d182586d676752b192967aee3bde6df8bbbe67558b221d63f5c7c")
@@ -29,7 +30,7 @@ class RocmExamples(CMakePackage):
 
     depends_on("glfw", type="build")
 
-    for ver in ["6.3.2", "6.3.1", "6.3.0", "6.2.4", "6.2.1", "6.2.0"]:
+    for ver in ["6.3.3", "6.3.2", "6.3.1", "6.3.0", "6.2.4", "6.2.1", "6.2.0"]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"hipify-clang@{ver}", when=f"@{ver}")
         depends_on(f"hipcub@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocm-gdb/package.py
+++ b/var/spack/repos/builtin/packages/rocm-gdb/package.py
@@ -17,6 +17,7 @@ class RocmGdb(AutotoolsPackage):
     license("LGPL-2.0-or-later")
 
     maintainers("srekolam", "renjithravindrankannath")
+    version("6.3.3", sha256="51678b588f65f92f50c2336707322cf4973fa96d03e268ec5956ac1a9f2ebaa3")
     version("6.3.2", sha256="85b03c1fb99f55272f4732dff58e8ba0a1add454a79d2b9d471df200366d0c7e")
     version("6.3.1", sha256="954236518491ba547f849be7c86e71ff95ef24535f66acabfd45040e11c25d7b")
     version("6.3.0", sha256="4a41ffbc4f7a5970181ee0aae07f0ea4cda278870cd60a562b25001f1365e29f")
@@ -79,6 +80,7 @@ class RocmGdb(AutotoolsPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-dbgapi@{ver}", type="link", when=f"@{ver}")
         depends_on(f"comgr@{ver}", type="link", when=f"@{ver}")
@@ -101,6 +103,7 @@ class RocmGdb(AutotoolsPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocm-opencl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl/package.py
@@ -35,6 +35,7 @@ class RocmOpencl(CMakePackage):
     license("MIT")
 
     version("master", branch="main")
+    version("6.3.3", sha256="8e5adca8f8c2d99d4a4e49605dd6b56b7881b762ee8ce15b4a7000e3cd982fec"),
     version("6.3.2", sha256="ec13dc4ffe212beee22171cb2825d2b16cdce103c835adddb482b9238cf4f050"),
     version("6.3.1", sha256="bfb8a4a59e7bd958e2cd4bf6f14c6cdea601d9827ebf6dc7af053a90e963770f")
     version("6.3.0", sha256="829e61a5c54d0c8325d02b0191c0c8254b5740e63b8bfdb05eec9e03d48f7d2c")
@@ -131,6 +132,7 @@ class RocmOpencl(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"comgr@{ver}", type="build", when=f"@{ver}")
@@ -148,6 +150,7 @@ class RocmOpencl(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"aqlprofile@{ver}", type="link", when=f"@{ver}")
 
@@ -169,6 +172,7 @@ class RocmOpencl(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -36,6 +36,7 @@ aomp = [
     "8c8240d948817ab1874eff0406d6053ee0518902427e0236e6b4d2cee84ff882",
     "8fefdd0d9eecd11866ddecbe039347560469eb69d974934005d480eac4432b81",
     "eeda81dafd17df7e1d2b9dbf91a23924c6dd8de29f0792725fc25a6cd1d9c5fa",
+    "b43b889b5778572d6d348c6a6614dc02258212004d1f1f64f0cdc74dc3249e86",
 ]
 
 devlib = [
@@ -60,6 +61,7 @@ devlib = [
     "79580508b039ca6c50dfdfd7c4f6fbcf489fe1931037ca51324818851eea0c1c",
     "e9c2481cccacdea72c1f8d3970956c447cec47e18dfb9712cbbba76a2820552c",
     "1f52e45660ea508d3fe717a9903fe27020cee96de95a3541434838e0193a4827",
+    "4df9aba24e574edf23844c0d2d9dda112811db5c2b08c9428604a21b819eb23d",
 ]
 
 llvm = [
@@ -84,6 +86,7 @@ llvm = [
     "79580508b039ca6c50dfdfd7c4f6fbcf489fe1931037ca51324818851eea0c1c",
     "e9c2481cccacdea72c1f8d3970956c447cec47e18dfb9712cbbba76a2820552c",
     "1f52e45660ea508d3fe717a9903fe27020cee96de95a3541434838e0193a4827",
+    "4df9aba24e574edf23844c0d2d9dda112811db5c2b08c9428604a21b819eb23d",
 ]
 
 flang = [
@@ -108,6 +111,7 @@ flang = [
     "43f10662706dbf22b0090839fd590d9fc633e7339b19aaee7578322ea6809275",
     "2e38ba138312d18b2677347839a960802bb04090bb92b5e6a15ac06ed789dbc0",
     "4b4d8025a215c52e62dd6317cafce224d95f91040e90942c9a93ade568a8dd48",
+    "e0f650fc633ab4a8eab30b0c1ba0efb46ec596b540c3a4c13ca24d92c512d255",
 ]
 
 extras = [
@@ -132,6 +136,7 @@ extras = [
     "22cdd87b1d66e7e7f9e30fd9031fcbf01ce0b631551959144bb42e7f1dba28cb",
     "4050c60cbbf582122cc0a30b4a99200341c426f2fa3d81ac8dc61f5a0890ed15",
     "70b49c1198bf176498ec4a94584b8ed8a07f623ebfa567e4fcf1a6545b635185",
+    "9615235b4d5ae78e43ca4854f316b83e75f7d9ed3fc187ed1869b7d8d7e26341",
 ]
 
 versions = [
@@ -156,6 +161,7 @@ versions = [
     "6.3.0",
     "6.3.1",
     "6.3.2",
+    "6.3.3",
 ]
 versions_dict = dict()  # type: Dict[str,Dict[str,str]]
 components = ["aomp", "devlib", "llvm", "flang", "extras"]
@@ -179,6 +185,7 @@ class RocmOpenmpExtras(Package):
     license("Apache-2.0")
 
     maintainers("srekolam", "renjithravindrankannath", "estewart08", "afzpatel")
+    version("6.3.3", sha256=versions_dict["6.3.3"]["aomp"])
     version("6.3.2", sha256=versions_dict["6.3.2"]["aomp"])
     version("6.3.1", sha256=versions_dict["6.3.1"]["aomp"])
     version("6.3.0", sha256=versions_dict["6.3.0"]["aomp"])
@@ -237,6 +244,7 @@ class RocmOpenmpExtras(Package):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 
@@ -300,7 +308,18 @@ class RocmOpenmpExtras(Package):
     for ver in ["6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.4"]:
         depends_on(f"hsakmt-roct@{ver}", when=f"@{ver}")
 
-    for ver in ["6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in [
+        "6.1.0",
+        "6.1.1",
+        "6.1.2",
+        "6.2.0",
+        "6.2.1",
+        "6.2.4",
+        "6.3.0",
+        "6.3.1",
+        "6.3.2",
+        "6.3.3",
+    ]:
         depends_on(f"comgr@{ver}", when=f"@{ver}")
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
+++ b/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
@@ -23,6 +23,7 @@ class RocmSmiLib(CMakePackage):
     libraries = ["librocm_smi64"]
 
     version("master", branch="master")
+    version("6.3.3", sha256="679dfd0cbd213d27660e546584ab013afea286eff95928d748d168503305c9c4")
     version("6.3.2", sha256="29a9190143dfcbafeac93d8064b00c9320dbca57a3344adb009ec17d9b09d036")
     version("6.3.1", sha256="0f45e4823e361a1c6ac560eabf6000c3b59e08bcd96e87150149149e861c6a63")
     version("6.3.0", sha256="573cfb759f8c7700fdcb0c28d045aed0f2d950692bb66a10bd589b89b8f48d0f")
@@ -73,10 +74,22 @@ class RocmSmiLib(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 
-    for ver in ["6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in [
+        "6.1.0",
+        "6.1.1",
+        "6.1.2",
+        "6.2.0",
+        "6.2.1",
+        "6.2.4",
+        "6.3.0",
+        "6.3.1",
+        "6.3.2",
+        "6.3.3",
+    ]:
         depends_on("llvm-amdgpu", when=f"@{ver}+asan")
 
     patch(

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -18,6 +18,7 @@ class RocmTensile(CMakePackage):
     license("MIT")
 
     maintainers("srekolam", "renjithravindrankannath", "haampie", "afzpatel")
+    version("6.3.3", sha256="5849fc3898e9cea05569c0ee102c13043c4df67079119572687bc42f274ae496")
     version("6.3.2", sha256="700e43a22d7e6309bf74624b18a42bb0132ef35716fccec897d3045a97759e6a")
     version("6.3.1", sha256="9882e8f949e1eb1d4b7dbd215370ecce643852dd2ce6e021d59cd49d32ba9dea")
     version("6.3.0", sha256="7ae90d1a513dc6f000a45f644b360305ef212ab3dff7b0217b6addabebf932e1")
@@ -89,6 +90,7 @@ class RocmTensile(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-cmake@{ver}", type="build", when=f"@{ver}")
         depends_on(f"hip@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -21,6 +21,7 @@ class RocmValidationSuite(CMakePackage):
     license("MIT")
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
+    version("6.3.3", sha256="3d1afc47f6bd491991f6deb80f84d00041497e7fd564fd0129622263b5b87cc1")
     version("6.3.2", sha256="c13d1efc21358901074f73c48f9cc8531cd5c6d28b7702d022f3efbbaf4b4286")
     version("6.3.1", sha256="5a5ec682729292d57838191e217a3475d662c5c25a7bd79c4996fdf4b5e36a5a")
     version("6.3.0", sha256="1e2b7eee002dd922625bcf792104e265cc5a57bec21f13d79d68036aa84b422f")
@@ -122,17 +123,18 @@ class RocmValidationSuite(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocminfo@{ver}", when=f"@{ver}")
         depends_on(f"rocblas@{ver}", when=f"@{ver}")
         depends_on(f"rocm-smi-lib@{ver}", when=f"@{ver}")
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
-    for ver in ["6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"hiprand@{ver}", when=f"@{ver}")
         depends_on(f"rocrand@{ver}", when=f"@{ver}")
 
-    for ver in ["6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"hipblaslt@{ver}", when=f"@{ver}")
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/rocminfo/package.py
+++ b/var/spack/repos/builtin/packages/rocminfo/package.py
@@ -17,6 +17,7 @@ class Rocminfo(CMakePackage):
     maintainers("srekolam", "renjithravindrankannath", "haampie")
 
     version("master", branch="master")
+    version("6.3.3", sha256="08390b2babe6dc832887098c5d3a5253d655430a18751f3446a56c7422b26dd2")
     version("6.3.2", sha256="a98a32bae0e118397b5559b4a584c9363191bb2d1f45fe13b09f502016745e8f")
     version("6.3.1", sha256="30cf7ed537c066e325a8731d0fbe62be2f0f66c8700a06f334e787e9f0f87437")
     version("6.3.0", sha256="40e2ef89e135770196022761cb929af93c80c41869082b3ef80e42b7772267d0")
@@ -90,6 +91,7 @@ class Rocminfo(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
         "master",
     ]:
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
@@ -112,6 +114,7 @@ class Rocminfo(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocmlir/package.py
+++ b/var/spack/repos/builtin/packages/rocmlir/package.py
@@ -17,6 +17,7 @@ class Rocmlir(CMakePackage):
 
     maintainers("srekolam", "afzpatel", "renjithravindrankannath")
 
+    version("6.3.3", sha256="87242b811536132a02ce79fe430c70485f9b1477de22d8376e7e923a9c9ad98b")
     version("6.3.2", sha256="5911e880a66faecb08d242efa3e5eb6f8ce32cb21ea09dec36f4aef111c395fb")
     version("6.3.1", sha256="b9e0ea8cfb83c20553b1ec1556752958afaa421a8d7326b1da748395ba7b75ac")
     version("6.3.0", sha256="8dd167250e138fac0609f4ed06fc6a4dca5edad346166a291f20b4dad99bbd0b")
@@ -80,6 +81,7 @@ class Rocmlir(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -16,6 +16,7 @@ class Rocprim(CMakePackage):
     license("MIT")
 
     maintainers("cgmb", "srekolam", "renjithravindrankannath", "afzpatel")
+    version("6.3.3", sha256="15e4f8dfc71175c568f8afa87e3e0e3c7ad0680c8bca0d9db3a39936ec185813")
     version("6.3.2", sha256="fbb4839992eaba838f798408636da30f0d61b669513dae185ab790c5fa5595c4")
     version("6.3.1", sha256="37690d9f326d68379d52a21fe9184061d38b15263a566f1f182d539e4b3277d5")
     version("6.3.0", sha256="d97c6edcf1f636721f8c023b54f3fad968b48b0709a95ecd640ec0ab1057069e")
@@ -81,6 +82,7 @@ class Rocprim(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"comgr@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocprofiler-compute/package.py
+++ b/var/spack/repos/builtin/packages/rocprofiler-compute/package.py
@@ -17,6 +17,7 @@ class RocprofilerCompute(CMakePackage):
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
 
     license("MIT")
+    version("6.3.3", sha256="0f563874f71b593cbdcdf0eea58b08c7437f1abf807f0886a3a30afa9e7f4953")
     version("6.3.2", sha256="317f19acfa6e6780923e6c8144c3c223b523c382588df528b6df001fae38d13d")
 
     depends_on("python@3.8:")

--- a/var/spack/repos/builtin/packages/rocprofiler-dev/package.py
+++ b/var/spack/repos/builtin/packages/rocprofiler-dev/package.py
@@ -18,6 +18,7 @@ class RocprofilerDev(CMakePackage):
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
     libraries = ["librocprofiler64"]
     license("MIT")
+    version("6.3.3", sha256="7ca6900b4a81f9dc0d7cdfe3be39372b3bf25f3c8304256705003294772890bd")
     version("6.3.2", sha256="c440ac79fa9f3e8c1decbfd83557d5cbbc4bb720927880b33dc36e682f37ec26")
     version("6.3.1", sha256="c4666c1167e551cfafc343b092506834477556ba6f7b0739552d660fd69c30fb")
     version("6.3.0", sha256="45ddc1d87a33bb27e9445e642a3495fef21cec1e545793b2ca5f551743961b1f")
@@ -90,6 +91,7 @@ class RocprofilerDev(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
         depends_on(f"rocminfo@{ver}", when=f"@{ver}")
@@ -109,6 +111,7 @@ class RocprofilerDev(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocm-smi-lib@{ver}", when=f"@{ver}")
@@ -131,6 +134,7 @@ class RocprofilerDev(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"aqlprofile@{ver}", when=f"@{ver}")
         depends_on(f"comgr@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocprofiler-register/package.py
+++ b/var/spack/repos/builtin/packages/rocprofiler-register/package.py
@@ -19,6 +19,7 @@ class RocprofilerRegister(CMakePackage):
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
 
     license("MIT")
+    version("6.3.3", sha256="afe4b1017ca604259de8cf7d06f98680bae63180214b914fcd7bd5da116b58c3")
     version("6.3.2", sha256="2e973dd10af220cd37838c13f3c7d52671f5cf846a3f06311b138770b62f51f4")
     version("6.3.1", sha256="82e2fbd2da058503398848c3e662f518e99f9bccb7b98880aa321c1f6511fca9")
     version("6.3.0", sha256="51aae00e7a8bb44a369de9626fca360c80879034ab43092eb6e4ccfa1b51ca47")

--- a/var/spack/repos/builtin/packages/rocprofiler-sdk/package.py
+++ b/var/spack/repos/builtin/packages/rocprofiler-sdk/package.py
@@ -22,6 +22,12 @@ class RocprofilerSdk(CMakePackage):
     license("MIT")
 
     version(
+        "6.3.3",
+        tag="rocm-6.3.3",
+        commit="95a3964ee26ac45618517f24669858bdb39ea7d2",
+        submodules=True,
+    )
+    version(
         "6.3.2",
         tag="rocm-6.3.2",
         commit="f5d3fd3d3460c74cb8935f0021e31f0bff5cb305",
@@ -48,7 +54,7 @@ class RocprofilerSdk(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    for ver in ["6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.2.4", "6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocm-cmake@{ver}", when=f"@{ver}")
         depends_on(f"aqlprofile@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocprofiler-systems/package.py
+++ b/var/spack/repos/builtin/packages/rocprofiler-systems/package.py
@@ -19,6 +19,13 @@ class RocprofilerSystems(CMakePackage):
     version("amd-mainline", branch="amd-mainline", submodules=True)
     version("amd-staging", branch="amd-staging", submodules=True)
     version(
+        "6.3.3",
+        git="https://github.com/ROCm/rocprofiler-systems",
+        tag="rocm-6.3.3",
+        commit="f03ef1dd9a4e984e3e72056352532e6149e742fc",
+        submodules=True,
+    )
+    version(
         "6.3.2",
         git="https://github.com/ROCm/rocprofiler-systems",
         tag="rocm-6.3.2",
@@ -107,7 +114,7 @@ class RocprofilerSystems(CMakePackage):
     depends_on("automake", when="+rocm")
     depends_on("libtool", when="+rocm")
     with when("+rocm"):
-        for ver in ["6.3.0", "6.3.1", "6.3.2"]:
+        for ver in ["6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
             depends_on(f"rocm-smi-lib@{ver}", when=f"@{ver}")
             depends_on(f"hip@{ver}", when=f"@{ver}")
             depends_on(f"roctracer-dev@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocpydecode/package.py
+++ b/var/spack/repos/builtin/packages/rocpydecode/package.py
@@ -13,6 +13,7 @@ class Rocpydecode(CMakePackage):
     url = "https://github.com/ROCm/rocPyDecode/archive/refs/tags/rocm-6.2.0.tar.gz"
 
     maintainers("afzpatel", "srekolam", "renjithravindrankannath")
+    version("6.3.3", sha256="df45b4a64ed3e550229fd91bcf7896d1a8fe377dd1ff88d2e6a71897b981180d")
     version("6.3.2", sha256="c1b4dba9f8a28299279ad4e4aeb0c857c3a9772d016fcc0f164940f22faa6dee")
     version("6.3.1", sha256="77ed22ee23409b004676fb1a11b963324b878e786dae0a56fdef58375716c9eb")
     version("6.3.0", sha256="4d0d969fb32328d8277b5cc451ee875428f58c12c1d4b3ff33247774ecc6caf8")
@@ -24,7 +25,7 @@ class Rocpydecode(CMakePackage):
     depends_on("ffmpeg@4.4:6")
     depends_on("dlpack")
 
-    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2"]:
+    for ver in ["6.2.0", "6.2.1", "6.2.4", "6.3.0", "6.3.1", "6.3.2", "6.3.3"]:
         depends_on(f"rocdecode@{ver}", when=f"@{ver}")
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -24,6 +24,7 @@ class Rocrand(CMakePackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("6.3.3", sha256="d55be9d367af28d87d983d649329b7ef04641e74d39064b98aeee4b9980af4eb")
     version("6.3.2", sha256="57f364806369ddb80761ce44187920075cf446de527dd1fbc6adbb4b4b3e9bb8")
     version("6.3.1", sha256="80d86c31ec9cb40f5c5532281b42cf99fbc8a81e3ffd3bc8b3bbe4a7e509bf5f")
     version("6.3.0", sha256="396d2dc842c64d29f577365c348fbccd6260a11431eec61f233fdb0f38b7625d")
@@ -131,6 +132,7 @@ class Rocrand(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -45,6 +45,7 @@ class Rocsolver(CMakePackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("6.3.3", sha256="0e8bb906513555d349b6a20cb17976402f5ea6702668efcdda595a2e2d516b46")
     version("6.3.2", sha256="834f532c54bdf0e4900e73ffb0544068071976175559c8bf3c50d7a3b7230a3a")
     version("6.3.1", sha256="ffa70c4dedeb20a33cf79d4ae3e95ade2ae5202f819459b19a0ebf62c380bba0")
     version("6.3.0", sha256="48861f7b86379f2b825c0496d1d9318c6e29426d083b361c10f685b0ddd66274")
@@ -113,6 +114,7 @@ class Rocsolver(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocblas@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -38,6 +38,7 @@ class Rocsparse(CMakePackage):
     conflicts("+asan", when="os=centos8")
 
     license("MIT")
+    version("6.3.3", sha256="e316d46b40e99976f4acaa097d6ebf5c2caf1ff2bd3c5b1de04c93c1dac90516")
     version("6.3.2", sha256="665a85517d50e5ef37b1f953ccb17108d6a5cb30db21c5364bd50a41d44c61f2")
     version("6.3.1", sha256="95c9dcc8421711f2f203a34c2830c5ac504e127922e0a83dbc68bccd5509c72f")
     version("6.3.0", sha256="38aaf1cc55f57566a3056a970f73f40a9a4930583d6e57fc9c7745a127029227")
@@ -89,6 +90,7 @@ class Rocsparse(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocprim@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -17,6 +17,7 @@ class Rocthrust(CMakePackage):
     tags = ["rocm"]
 
     maintainers("cgmb", "srekolam", "renjithravindrankannath", "afzpatel")
+    version("6.3.3", sha256="564f5b2621bc707c0dda0d09702642876fc4d1b8cd9a83d1324539b768653e8b")
     version("6.3.2", sha256="c3991bbd9f8b0e3ecbc18a7d014446608bfe2a3660a8d9e3dcc136d784883935")
     version("6.3.1", sha256="a63dd161f4b30be7fcc4ad4184b948646233d59b5ca13c239f723ab59c607a1a")
     version("6.3.0", sha256="553e67bc0a7fb2d129b15fd4b8889f9ee56ebd29bc885a1fb32918dfcfa3b955")
@@ -79,6 +80,7 @@ class Rocthrust(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocprim@{ver}", when=f"@{ver}")

--- a/var/spack/repos/builtin/packages/roctracer-dev-api/package.py
+++ b/var/spack/repos/builtin/packages/roctracer-dev-api/package.py
@@ -18,6 +18,7 @@ class RoctracerDevApi(Package):
     license("MIT")
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
+    version("6.3.3", sha256="0d03ebd058291d584be6bf8b114292c666a799b0fd23c697e1c6cb2b6d43f990")
     version("6.3.2", sha256="ca8e93fc37f4671db28df5cb7a24b48f3d4879a188e4780e45961bba3725bb8a")
     version("6.3.1", sha256="89e4ab249f527131f684714c9135c69eaad1a63b7e74bae718b1617543b94426")
     version("6.3.0", sha256="6eb09e3b3b45ed68b2ac7ed6848521e645569bcd4a1f3a336cf2473a801308a2")

--- a/var/spack/repos/builtin/packages/roctracer-dev/package.py
+++ b/var/spack/repos/builtin/packages/roctracer-dev/package.py
@@ -21,6 +21,7 @@ class RoctracerDev(CMakePackage, ROCmPackage):
     libraries = ["libroctracer64"]
 
     license("MIT")
+    version("6.3.3", sha256="0d03ebd058291d584be6bf8b114292c666a799b0fd23c697e1c6cb2b6d43f990")
     version("6.3.2", sha256="ca8e93fc37f4671db28df5cb7a24b48f3d4879a188e4780e45961bba3725bb8a")
     version("6.3.1", sha256="89e4ab249f527131f684714c9135c69eaad1a63b7e74bae718b1617543b94426")
     version("6.3.0", sha256="6eb09e3b3b45ed68b2ac7ed6848521e645569bcd4a1f3a336cf2473a801308a2")
@@ -97,6 +98,7 @@ class RoctracerDev(CMakePackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
         depends_on(f"rocminfo@{ver}", when=f"@{ver}")
@@ -123,6 +125,7 @@ class RoctracerDev(CMakePackage, ROCmPackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/rocwmma/package.py
+++ b/var/spack/repos/builtin/packages/rocwmma/package.py
@@ -26,6 +26,7 @@ class Rocwmma(CMakePackage):
     license("MIT")
 
     maintainers("srekolam", "renjithravindrankannath", "afzpatel")
+    version("6.3.3", sha256="5bfd2909cc9b4601bb83ddd79da6cfa4075afa6d6e9396d9bbe1df844163fbd2")
     version("6.3.2", sha256="f9dc5e837ac30efe4600775fb309e46ed8ef112a673435663d2ef7fdf28f8f12")
     version("6.3.1", sha256="9afd06c58b405dd86535ea1ca479fd6f9d717fa8665710bb64fc8027a26e6ac7")
     version("6.3.0", sha256="8dcd06599083dc3a67958a1b6f7c29c1880758eb6ff579143e0fb162985b0612")
@@ -96,6 +97,7 @@ class Rocwmma(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on("rocm-cmake@%s:" % ver, type="build", when="@" + ver)
         depends_on("llvm-amdgpu@" + ver, type="build", when="@" + ver)
@@ -119,6 +121,7 @@ class Rocwmma(CMakePackage):
         "6.3.0",
         "6.3.1",
         "6.3.2",
+        "6.3.3",
     ]:
         depends_on("rocm-smi-lib@" + ver, when="@" + ver)
 

--- a/var/spack/repos/builtin/packages/rpp/package.py
+++ b/var/spack/repos/builtin/packages/rpp/package.py
@@ -27,6 +27,7 @@ class Rpp(CMakePackage):
 
     maintainers("srekolam", "afzpatel")
     license("MIT")
+    version("6.3.3", sha256="e6b586679a3705bf6b7bb3c5852541d329bd967e110999ac59dc052b49a92cbc")
     version("6.3.2", sha256="05f0e063c61f5039661a4d5a80113ebb7b9782d0958c29375a8e1e2e759b88bc")
     version("6.3.1", sha256="6e7da82bf7b6d642d605370329e4e719af10bb5c6af30079b5d0b60cdcb91a48")
     version("6.3.0", sha256="130a6bd2fc4278956c6450a3c49243651576b1031e6a485aa62453b9dc3b4d51")
@@ -172,6 +173,7 @@ class Rpp(CMakePackage):
                 "6.3.0",
                 "6.3.1",
                 "6.3.2",
+                "6.3.3",
             ]:
                 depends_on("hip@" + ver, when="@" + ver)
         with when("@:1.2"):


### PR DESCRIPTION
Adding ROCm 6.3.3

I wasn't sure what devlib hash to use for `rocm-openmp-extras`. Need to complete `rocm-openmp-extras` update before merging. How do we get the hash for device libs for 6.3.3?
* https://github.com/spack/spack/pull/48787/files#diff-2960acc5816e55462af7bc56ff505f99fda815109ced930e1a4ca269455772b5R62

@renjithravindrankannath @srekolam @afzpatel 
