### PR TITLE
readthedocs: use `uv` to build instead of `pip`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+environment:
+  DOCS_DIR: lib/spack/docs
+
 build:
   os: "ubuntu-22.04"
   apt_packages:
@@ -13,7 +16,7 @@ build:
       - asdf global uv latest
       - uv venv
     install:
-      - uv pip install -r requirements.txt
+      - uv pip install -r $DOCS_DIR/requirements.txt
     build:
       html:
         - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
@@ -24,7 +27,7 @@ sphinx:
 
 python:
   install:
-    - requirements: lib/spack/docs/requirements.txt
+    - requirements: $DOCS_DIR/requirements.txt
 
 search:
   ranking:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,17 @@ build:
     - graphviz
   tools:
     python: "3.11"
+  jobs:
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+      - uv venv
+    install:
+      - uv pip install -r requirements.txt
+    build:
+      html:
+        - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
 
 sphinx:
   configuration: lib/spack/docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,5 @@
 version: 2
 
-environment:
-  DOCS_DIR: lib/spack/docs
-
 build:
   os: "ubuntu-22.04"
   apt_packages:
@@ -16,7 +13,7 @@ build:
       - asdf global uv latest
       - uv venv
     install:
-      - uv pip install -r $DOCS_DIR/requirements.txt
+      - uv pip install -r lib/spack/docs/requirements.txt
     build:
       html:
         - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
@@ -27,7 +24,7 @@ sphinx:
 
 python:
   install:
-    - requirements: $DOCS_DIR/requirements.txt
+    - requirements: lib/spack/docs/requirements.txt
 
 search:
   ranking:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [project]
-name = "spack"
-description = "The spack package manager"
-requires-python = ">=3.6"
-dependencies = ["clingo", "setuptools"]
+name="spack"
+description="The spack package manager"
+requires-python=">=3.6.2"
+dependencies=[
+  "clingo",
+  "setuptools",
+]
 dynamic = ["version"]
 
 [project.scripts]


### PR DESCRIPTION
`uv` is faster than `pip`, and `pip install` can take a while in our readthedocs builds in CI. Try using `uv` instead.

See [readthedocs's docs](https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-uv) for details.
