### PR TITLE
compiler-wrapper: respect -x and --language

### DIFF
--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -754,7 +754,7 @@ def test_system_path_cleanup(wrapper_environment, wrapper_dir):
 
 
 def test_language_from_flags(wrapper_environment, wrapper_dir):
-    """Tes that the compiler language mode is determined by -x/--language flags if present"""
+    """Test that the compiler language mode is determined by -x/--language flags if present"""
     cc = wrapper_dir / "cc"
 
     for flag_value, lang in [("c", "CC"), ("c++", "CXX"), ("f77", "F77"), ("f95", "FC")]:

--- a/var/spack/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -43,7 +43,7 @@ class CompilerWrapper(Package):
     if sys.platform != "win32":
         version(
             "1.0",
-            sha256="c65a9d2b2d4eef67ab5cb0684d706bb9f005bb2be94f53d82683d7055bdb837c",
+            sha256="db44e5898aa9b8605e3cfe53a51649b4df504066f0f13562432f584fc88a5038",
             expand=False,
         )
     else:


### PR DESCRIPTION
To compile hip code, the clang++ is invoked with -x hip, so we should
derive the language from the -x flag.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
