### PR TITLE
geant4: add v11.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -21,6 +21,7 @@ class Geant4(CMakePackage):
 
     maintainers("drbenmorgan", "sethrj")
 
+    version("11.3.1", sha256="9059da076928f25cab1ff1f35e0f611a4d7fe005e374e9b8d7f3ff2434b7af54")
     version("11.3.0", sha256="d9d71daff8890a7b5e0e33ea9a65fe6308ad6713000b43ba6705af77078e7ead")
     version("11.2.2", sha256="3a8d98c63fc52578f6ebf166d7dffaec36256a186d57f2520c39790367700c8d")
     version("11.2.1", sha256="76c9093b01128ee2b45a6f4020a1bcb64d2a8141386dea4674b5ae28bcd23293")


### PR DESCRIPTION
This PR adds `geant4`, 11.3.1 ([patch release notes](https://geant4.web.cern.ch/download/release-notes/notes-v11.3.1.txt)). No changes to data file requirements. No changes to CMakeLists (outside of removal of WITH_GEANT4_UIVIS from examples).