### PR TITLE
amr-wind+rocm depends_on rocrand and rocprim

### DIFF
--- a/var/spack/repos/builtin/packages/amr-wind/package.py
+++ b/var/spack/repos/builtin/packages/amr-wind/package.py
@@ -258,6 +258,7 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("fftw", when="@3.3.1: +fft")
 
     depends_on("rocrand", when="+rocm")
+    depends_on("rocprim", when="+rocm")
 
     for arch in CudaPackage.cuda_arch_values:
         depends_on("hypre+cuda cuda_arch=%s" % arch, when="+cuda+hypre cuda_arch=%s" % arch)

--- a/var/spack/repos/builtin/packages/amr-wind/package.py
+++ b/var/spack/repos/builtin/packages/amr-wind/package.py
@@ -257,6 +257,8 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("fftw", when="@2.1: +waves2amr")
     depends_on("fftw", when="@3.3.1: +fft")
 
+    depends_on("rocrand", when="+rocm")
+
     for arch in CudaPackage.cuda_arch_values:
         depends_on("hypre+cuda cuda_arch=%s" % arch, when="+cuda+hypre cuda_arch=%s" % arch)
     for arch in ROCmPackage.amdgpu_targets:


### PR DESCRIPTION
Trying to fix:
* [amr-wind@3.4.0 /myawmghbisztb4h7ripzkmmz7ppjh5zm E4S ](https://gitlab.spack.io/spack/spack/-/jobs/15848229)
```
==> Installing amr-wind-3.4.0-myawmghbisztb4h7ripzkmmz7ppjh5zm [1/1]
==> No patches needed for amr-wind
==> amr-wind: Executing phase: 'cmake'
...
  >> 68    CMake Error at submods/amrex/Tools/CMake/AMReXParallelBackends.cmake
           :295 (find_package):
     69      Could not find a package configuration file provided by "rocrand" 
           with any
     70      of the following names:
     71    
     72        rocrandConfig.cmake
     73        rocrand-config.cmake
     74    
```

... so we can merge:
* https://github.com/spack/spack/pull/43521