### PR TITLE
Revert "Ensure consistent EOL on Windows Ci"

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/win64/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/win64/ci.yaml
@@ -5,7 +5,6 @@ ci:
       - Write-Output "Done"
 
       before_script::
-      - git config core.autocrlf true
       - fsutil 8dot3name set C:\ 0
       - . .\share\spack\setup-env.ps1
       - If (Test-Path -path C:\\key\intermediate_ci_signing_key.gpg) { spack.ps1 gpg trust C:\\key\intermediate_ci_signing_key.gpg }


### PR DESCRIPTION
Reverts spack/spack#49377 as #49377 is improved upon (and therefor superfluous) to https://github.com/spack/spack-infrastructure/pull/1081