### PR TITLE
bugfix: concretization shouldn't require concrete packages to be known

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3005,6 +3005,10 @@ class SpackSolverSetup:
 
         # Fail if we already know an unreachable node is requested
         for spec in specs:
+            # concrete roots don't need their dependencies verified
+            if spec.concrete:
+                continue
+
             missing_deps = [
                 str(d)
                 for d in spec.traverse()


### PR DESCRIPTION
Concretization setup was checking whether any input spec has a dependency that's *not* in the set of possible dependencies for all roots in the solve. There are two reasons to check this:

1. The user could be asking for a dependency that none of the roots has, or
2. The user could be asking for a dependency that doesn't exist.

For abstract roots, (2) implies (1), and the check makes sense.  For concrete roots, we don't care, because the spec has already been built. If a `package.py` no longer depends on something it did before, it doesn't matter -- it's already built. If the dependency no longer exists, we also do not care -- we already built it and there's an installation for it somewhere. 

When you concretize an environment with a lockfile, *many* of the input specs are concrete, and we don't need to build them. If a package changes its dependencies, or if a `package.py` is removed for a concrete input spec, that shouldn't cause an already-built environment to fail concretization.

A user reported that this was happening with an error like:

```console
spack concretize
==> Error: Package chapel does not depend on py-protobuf@5.28.2/a4rf4glr2tntfwsz6myzwmlk5iu25t74
```

Or, with traceback:
```console
  File "/apps/other/spack-devel/lib/spack/spack/solver/asp.py", line 3014, in setup
    raise spack.spec.InvalidDependencyError(spec.name, missing_deps)
spack.spec.InvalidDependencyError: Package chapel does not depend on py-protobuf@5.28.2/a4rf4glr2tntfwsz6myzwmlk5iu25t74
```

Fix this by skipping the check for concrete input specs. We already ignore conflicts, etc. for concrete/external specs, and we do not need metadata in the solve for concrete dependencies b/c they're imposed by hash constraints.

- [x] Ignore the package existence check for concrete input specs.
