### PR TITLE
NVHPC compiers use GNU standard libraries, hence depend on compatible…

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/nvhpc/package.py
@@ -459,7 +459,7 @@ class Nvhpc(Package, CompilerPackage):
 
     # The NVHPC compilers use GNU headers and libraries, which also means they
     # need a compatible linker.
-    depends_on("binutils +ld", type="build, run")
+    depends_on("binutils +ld", type=("build", "run"))
     depends_on("gcc languages=c,c++,fortran", type="run")
 
     variant("blas", default=True, description="Enable BLAS")

--- a/var/spack/repos/spack_repo/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/nvhpc/package.py
@@ -457,7 +457,7 @@ class Nvhpc(Package, CompilerPackage):
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
 
-    The NVHPC compilers use GNU headers and libraries, which also means they
+    # The NVHPC compilers use GNU headers and libraries, which also means they
     # need a compatible linker.
     depends_on("binutils +ld", type="build, run")
     depends_on("gcc languages=c,c++,fortran", type="run")

--- a/var/spack/repos/spack_repo/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/nvhpc/package.py
@@ -457,6 +457,9 @@ class Nvhpc(Package, CompilerPackage):
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
 
+    The NVHPC compilers use GNU headers and libraries, which also means they
+    # need a compatible linker.
+    depends_on("binutils +ld", type="build, run")
     depends_on("gcc languages=c,c++,fortran", type="run")
 
     variant("blas", default=True, description="Enable BLAS")


### PR DESCRIPTION
… GNU linker.

The compiler toolchain is selected already using makelocalrc included in nvhpc, but this does not set the ld to be used. It seems like ld is fixed at the "build" stage, but to enhance robustness we also load binutils at "run" stage in case someone is compiling with nvc++ but linking with the ld command.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
