### PR TITLE
g4tendl: avoid closing bracket that breaks lmod

### DIFF
--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class G4tendl(Package):
-    """Geant4 data for incident particles [optional]"""
+    """Optional Geant4 data for incident particles."""
 
     homepage = "https://geant4.web.cern.ch"
     url = "https://geant4-data.web.cern.ch/geant4-data/datasets/G4TENDL.1.3.tar.gz"


### PR DESCRIPTION
The closing bracket in the tendl description causes lmod to die because the closing quote `]])` turns into the apparently unparseable `]]])`.

This should probably be a warning/error in the more general case, but I'm not sure how to do that with the module generator...

```
Lmod has detected the following error:  Unable to load module because of error when
evaluating modulefile:
     /lustre/orion/world-shared/hep143/share/lmod/linux-sles15-x86_64/Core/g4tendl/1.4.lua: [string
"-- -*- lua -*-..."]:10: ')' expected near ']'
     Please check the modulefile and especially if there is a line number specified in the above
message
While processing the following module(s):
    Module fullname     Module Filename
    ---------------     ---------------
    g4tendl/1.4         /lustre/orion/world-shared/hep143/share/lmod/linux-sles15-x86_64/Core/g4tendl/1.4.lua
    geant4-data/11.3.0  /lustre/orion/world-shared/hep143/share/lmod/linux-sles15-x86_64/Core/geant4-data/11.3.0.lua
```