### PR TITLE
solver: don't use tags to compute injected deps

### DIFF
--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -470,7 +470,7 @@ class MinimalDuplicatesCounter(NoDuplicatesCounter):
             gen.fact(fn.max_dupes(package_name, 1))
         gen.newline()
 
-        gen.h2("Packages with at multiple possible nodes (build-tools)")
+        gen.h2("Packages with multiple possible nodes (build-tools)")
         default = spack.config.CONFIG.get("concretizer:duplicates:max_dupes:default", 2)
         for package_name in sorted(self.possible_dependencies() & build_tools):
             max_dupes = spack.config.CONFIG.get(

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -18,8 +18,6 @@ import spack.spec
 import spack.store
 from spack.error import SpackError
 
-RUNTIME_TAG = "runtime"
-
 
 class PossibleGraph(NamedTuple):
     real_pkgs: Set[str]
@@ -50,7 +48,8 @@ class PossibleDependencyGraph:
     ) -> PossibleGraph:
         """Returns the set of possible dependencies, and the set of possible virtuals.
 
-        Both sets always include runtime packages, which may be injected by compilers.
+        Runtime packages, which may be injected by compilers, needs to be added to specs if
+        the dependency is not explicit in the package.py recipe.
 
         Args:
             transitive: return transitive dependencies if True, only direct dependencies if False
@@ -70,14 +69,9 @@ class NoStaticAnalysis(PossibleDependencyGraph):
     def __init__(self, *, configuration: spack.config.Configuration, repo: spack.repo.RepoPath):
         self.configuration = configuration
         self.repo = repo
-        self.runtime_pkgs = set(self.repo.packages_with_tags(RUNTIME_TAG))
-        self.runtime_virtuals = set()
         self._platform_condition = spack.spec.Spec(
             f"platform={spack.platforms.host()} target={archspec.cpu.host().family}:"
         )
-        for x in self.runtime_pkgs:
-            pkg_class = self.repo.get_pkg_class(x)
-            self.runtime_virtuals.update(pkg_class.provided_virtual_names())
 
         try:
             self.libc_pkgs = [x.name for x in self.providers_for("libc")]
@@ -214,8 +208,6 @@ class NoStaticAnalysis(PossibleDependencyGraph):
             for root, children in edges.items():
                 real_packages.update(x for x in children if self._is_possible(pkg_name=x))
 
-        virtuals.update(self.runtime_virtuals)
-        real_packages = real_packages | self.runtime_pkgs
         return PossibleGraph(real_pkgs=real_packages, virtuals=virtuals, edges=edges)
 
     def _package_list(self, specs: Tuple[Union[spack.spec.Spec, str], ...]) -> List[str]:

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -38,10 +38,9 @@ MPI_DEPS = ["fake"]
         (["--transitive", "--deptype=link", "dtbuild1"], {"dtlink2"}),
     ],
 )
-def test_direct_dependencies(cli_args, expected, mock_runtimes):
+def test_direct_dependencies(cli_args, expected, mock_packages):
     out = dependencies(*cli_args)
     result = set(re.split(r"\s+", out.strip()))
-    expected.update(mock_runtimes)
     assert expected == result
 
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -111,14 +111,13 @@ def mpi_names(mock_inspector):
         ("dtbuild1", {"allowed_deps": dt.LINK}, {"dtbuild1", "dtlink2"}),
     ],
 )
-def test_possible_dependencies(pkg_name, fn_kwargs, expected, mock_runtimes, mock_inspector):
+def test_possible_dependencies(pkg_name, fn_kwargs, expected, mock_inspector):
     """Tests possible nodes of mpileaks, under different scenarios."""
-    expected.update(mock_runtimes)
     result, *_ = mock_inspector.possible_dependencies(pkg_name, **fn_kwargs)
     assert expected == result
 
 
-def test_possible_dependencies_virtual(mock_inspector, mock_packages, mock_runtimes, mpi_names):
+def test_possible_dependencies_virtual(mock_inspector, mock_packages, mpi_names):
     expected = set(mpi_names)
     for name in mpi_names:
         expected.update(
@@ -126,7 +125,6 @@ def test_possible_dependencies_virtual(mock_inspector, mock_packages, mock_runti
             for dep in mock_packages.get_pkg_class(name).dependencies_by_name()
             if not mock_packages.is_virtual(dep)
         )
-    expected.update(mock_runtimes)
     expected.update(s.name for s in mock_packages.providers_for("c"))
 
     real_pkgs, *_ = mock_inspector.possible_dependencies(
@@ -146,7 +144,6 @@ def test_possible_dependencies_with_multiple_classes(
     pkgs = ["dt-diamond", "mpileaks"]
     expected = set(mpileaks_possible_deps)
     expected.update({"dt-diamond", "dt-diamond-left", "dt-diamond-right", "dt-diamond-bottom"})
-    expected.update(mock_packages.packages_with_tags("runtime"))
 
     real_pkgs, *_ = mock_inspector.possible_dependencies(*pkgs, allowed_deps=dt.ALL)
     assert set(expected) == real_pkgs

--- a/var/spack/repos/builtin.mock/packages/corge/package.py
+++ b/var/spack/repos/builtin.mock/packages/corge/package.py
@@ -110,9 +110,9 @@ main(int argc, char* argv[])
             f.write(corge_h)
         with open("%s/corge/corgegator.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
             f.write(corgegator_cc)
-        gpp = which("/usr/bin/g++")
+        gpp = which("g++")
         if sys.platform == "darwin":
-            gpp = which("/usr/bin/clang++")
+            gpp = which("clang++")
         gpp(
             "-Dcorge_EXPORTS",
             "-I%s" % self.stage.source_path,

--- a/var/spack/repos/duplicates.test/packages/compiler-wrapper
+++ b/var/spack/repos/duplicates.test/packages/compiler-wrapper
@@ -1,0 +1,1 @@
+../../builtin.mock/packages/compiler-wrapper

--- a/var/spack/repos/edges.test/packages/compiler-wrapper
+++ b/var/spack/repos/edges.test/packages/compiler-wrapper
@@ -1,0 +1,1 @@
+../../builtin.mock/packages/compiler-wrapper


### PR DESCRIPTION
This commit reorders ASP setup, so that rules from possible compilers are collected first.

This allows us to know the dependencies that may be injected before counting the possible dependencies, so we can account for them too.

Proceeding this way makes it easier to inject complex runtimes, like hip. It also makes possible dependencies counters independent of the "runtime" tag used in packages.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
