### PR TITLE
gsoap: depends on c, cxx

### DIFF
--- a/var/spack/repos/builtin/packages/gsoap/package.py
+++ b/var/spack/repos/builtin/packages/gsoap/package.py
@@ -42,6 +42,8 @@ class Gsoap(AutotoolsPackage, SourceforgePackage):
         )
 
     depends_on("openssl")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("bison", type="build")
     depends_on("flex", type="build")


### PR DESCRIPTION
This PR ensures that `gsoap` gets a C and C++ compiler.