### PR TITLE
cppzmq: depends on c

### DIFF
--- a/var/spack/repos/builtin/packages/cppzmq/package.py
+++ b/var/spack/repos/builtin/packages/cppzmq/package.py
@@ -29,7 +29,8 @@ class Cppzmq(CMakePackage):
     version("4.2.3", sha256="3e6b57bf49115f4ae893b1ff7848ead7267013087dc7be1ab27636a97144d373")
     version("4.2.2", sha256="3ef50070ac5877c06c6bb25091028465020e181bbfd08f110294ed6bc419737d")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("drafts", default=False, description="Build and install draft classes and methods")
 


### PR DESCRIPTION
This PR ensures that `cppzmq` gets a C compiler.