### PR TITLE
cryptopp: depends on cxx

### DIFF
--- a/var/spack/repos/builtin/packages/cryptopp/package.py
+++ b/var/spack/repos/builtin/packages/cryptopp/package.py
@@ -33,6 +33,7 @@ class Cryptopp(MakefilePackage):
 
     variant("shared", default=True, description="Build shared object versions of libraries.")
 
+    depends_on("cxx", type="build")
     depends_on("gmake", type="build")
 
     def url_for_version(self, version):


### PR DESCRIPTION
This PR ensures that `cryptopp` gets a C++ compiler.