### PR TITLE
Windows: MSVC provide fortran

### DIFF
--- a/etc/spack/defaults/windows/packages.yaml
+++ b/etc/spack/defaults/windows/packages.yaml
@@ -20,3 +20,6 @@ packages:
       cxx: [msvc]
       mpi: [msmpi]
       gl: [wgl]
+  mpi:
+    require:
+    - one_of: [msmpi]

--- a/var/spack/repos/builtin/packages/compiler-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/compiler-wrapper/package.py
@@ -228,41 +228,6 @@ class CompilerWrapper(Package):
             env.prepend_path("SPACK_COMPILER_WRAPPER_PATH", item)
 
     def setup_dependent_package(self, module, dependent_spec):
-        if sys.platform != "win32":
-            bin_dir = self.bin_dir()
-
-            if dependent_spec.has_virtual_dependency("c"):
-                compiler_pkg = dependent_spec["c"].package
-                setattr(
-                    module,
-                    "spack_cc",
-                    str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["c"]),
-                )
-
-            if dependent_spec.has_virtual_dependency("cxx"):
-                compiler_pkg = dependent_spec["cxx"].package
-                setattr(
-                    module,
-                    "spack_cxx",
-                    str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["cxx"]),
-                )
-
-            if dependent_spec.has_virtual_dependency("fortran"):
-                compiler_pkg = dependent_spec["fortran"].package
-                setattr(
-                    module,
-                    "spack_fc",
-                    str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["fortran"]),
-                )
-                setattr(
-                    module,
-                    "spack_f77",
-                    str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["fortran"]),
-                )
-        else:
-            self._setup_win_dependent_package(module, dependent_spec)
-
-    def _setup_win_dependent_package(self, module, dependent_spec):
         def _spack_compiler_attribute(*, language: str) -> str:
             compiler_pkg = dependent_spec[language].package
             if sys.platform != "win32":

--- a/var/spack/repos/builtin/packages/compiler-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/compiler-wrapper/package.py
@@ -263,18 +263,29 @@ class CompilerWrapper(Package):
             self._setup_win_dependent_package(module, dependent_spec)
 
     def _setup_win_dependent_package(self, module, dependent_spec):
+        def _spack_compiler_attribute(*, language: str) -> str:
+            compiler_pkg = dependent_spec[language].package
+            if sys.platform != "win32":
+                # On non-Windows we return the appropriate path to the compiler wrapper
+                return str(self.bin_dir() / compiler_pkg.compiler_wrapper_link_paths[language])
+
+            # On Windows we return the real compiler
+            if language == "c":
+                return compiler_pkg.cc
+            elif language == "cxx":
+                return compiler_pkg.cxx
+            elif language == "fortran":
+                return compiler_pkg.fortran
+        
         if dependent_spec.has_virtual_dependency("c"):
-            compiler_pkg = dependent_spec["c"].package
-            setattr(module, "spack_cc", compiler_pkg.cc)
+            setattr(module, "spack_cc", _spack_compiler_attribute(language="c"))
 
         if dependent_spec.has_virtual_dependency("cxx"):
-            compiler_pkg = dependent_spec["cxx"].package
-            setattr(module, "spack_cxx", compiler_pkg.cxx)
+            setattr(module, "spack_cxx", _spack_compiler_attribute(language="cxx"))
 
         if dependent_spec.has_virtual_dependency("fortran"):
-            compiler_pkg = dependent_spec["fortran"].package
-            setattr(module, "spack_fc", compiler_pkg.fortran)
-            setattr(module, "spack_f77", compiler_pkg.fortran)
+            setattr(module, "spack_fc", _spack_compiler_attribute(language="fortran"))
+            setattr(module, "spack_f77", _spack_compiler_attribute(language="fortran"))
 
     @property
     def disable_new_dtags(self) -> str:

--- a/var/spack/repos/builtin/packages/compiler-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/compiler-wrapper/package.py
@@ -228,32 +228,53 @@ class CompilerWrapper(Package):
             env.prepend_path("SPACK_COMPILER_WRAPPER_PATH", item)
 
     def setup_dependent_package(self, module, dependent_spec):
-        bin_dir = self.bin_dir()
+        if sys.platform != "win32":
+            bin_dir = self.bin_dir()
 
+            if dependent_spec.has_virtual_dependency("c"):
+                compiler_pkg = dependent_spec["c"].package
+                setattr(
+                    module,
+                    "spack_cc",
+                    str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["c"]),
+                )
+
+            if dependent_spec.has_virtual_dependency("cxx"):
+                compiler_pkg = dependent_spec["cxx"].package
+                setattr(
+                    module,
+                    "spack_cxx",
+                    str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["cxx"]),
+                )
+
+            if dependent_spec.has_virtual_dependency("fortran"):
+                compiler_pkg = dependent_spec["fortran"].package
+                setattr(
+                    module,
+                    "spack_fc",
+                    str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["fortran"]),
+                )
+                setattr(
+                    module,
+                    "spack_f77",
+                    str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["fortran"]),
+                )
+        else:
+            self._setup_win_dependent_package(module, dependent_spec)
+
+    def _setup_win_dependent_package(self, module, dependent_spec):
         if dependent_spec.has_virtual_dependency("c"):
             compiler_pkg = dependent_spec["c"].package
-            setattr(
-                module, "spack_cc", str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["c"])
-            )
+            setattr(module, "spack_cc", compiler_pkg.cc)
 
         if dependent_spec.has_virtual_dependency("cxx"):
             compiler_pkg = dependent_spec["cxx"].package
-            setattr(
-                module, "spack_cxx", str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["cxx"])
-            )
+            setattr(module, "spack_cxx", compiler_pkg.cxx)
 
         if dependent_spec.has_virtual_dependency("fortran"):
             compiler_pkg = dependent_spec["fortran"].package
-            setattr(
-                module,
-                "spack_fc",
-                str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["fortran"]),
-            )
-            setattr(
-                module,
-                "spack_f77",
-                str(bin_dir / compiler_pkg.compiler_wrapper_link_paths["fortran"]),
-            )
+            setattr(module, "spack_fc", compiler_pkg.fortran)
+            setattr(module, "spack_f77", compiler_pkg.fortran)
 
     @property
     def disable_new_dtags(self) -> str:

--- a/var/spack/repos/builtin/packages/compiler-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/compiler-wrapper/package.py
@@ -276,7 +276,7 @@ class CompilerWrapper(Package):
                 return compiler_pkg.cxx
             elif language == "fortran":
                 return compiler_pkg.fortran
-        
+
         if dependent_spec.has_virtual_dependency("c"):
             setattr(module, "spack_cc", _spack_compiler_attribute(language="c"))
 

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -33,6 +33,7 @@ class Msmpi(Package):
     patch("ifort_compat.patch")
 
     requires("platform=windows")
+    requires("%msvc")
 
     @classmethod
     def determine_version(cls, exe):
@@ -48,11 +49,10 @@ class Msmpi(Package):
         # MSMPI does not vendor compiler wrappers, instead arguments should
         # be manually supplied to compiler by consuming package
         # Note: This is not typical of MPI installations
-        dependent_module = dependent_spec.package.module
-        self.spec.mpicc = dependent_module.spack_cc
-        self.spec.mpicxx = dependent_module.spack_cxx
-        self.spec.mpifc = dependent_module.spack_fc
-        self.spec.mpif77 = dependent_module.spack_f77
+        self.spec.mpicc = dependent_spec["c"].package.cc
+        self.spec.mpicxx = dependent_spec["cxx"].package.cxx
+        self.spec.mpifc = dependent_spec["fortran"].package.fortran
+        self.spec.mpif77 = dependent_spec["fortran"].package.fortran
 
 
 class GenericBuilder(GenericBuilder):

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -23,8 +23,8 @@ class Msmpi(Package):
     version("10.1.1", sha256="63c7da941fc4ffb05a0f97bd54a67968c71f63389a0d162d3182eabba1beab3d")
     version("10.0.0", sha256="cfb53cf53c3cf0d4935ab58be13f013a0f7ccb1189109a5b8eea0fcfdcaef8c1")
 
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     provides("mpi")
 

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -52,7 +52,7 @@ class Msvc(Package, CompilerPackage):
     # compiler wrappers
     compiler_wrapper_link_paths = {"c": "", "cxx": "", "fortran": ""}
 
-    provides("c", "cxx")
+    provides("c", "cxx", "fortran")
     requires("platform=windows", msg="MSVC is only supported on Windows")
 
     @classmethod

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -119,6 +119,9 @@ class Msvc(Package, CompilerPackage):
 
         env.set("CC", self.cc)
         env.set("CXX", self.cxx)
+        if self.fortran:
+            env.set("FC", self.fortran)
+            env.set("F77", self.fortran)
 
     def init_msvc(self):
         # To use the MSVC compilers, VCVARS must be invoked

--- a/var/spack/repos/builtin/packages/win-wdk/package.py
+++ b/var/spack/repos/builtin/packages/win-wdk/package.py
@@ -116,7 +116,7 @@ class WinWdk(Package):
         This name is not properly formated so that Windows understands it as an executable
         We rename so as to allow Windows to run the WGL installer"""
         installer = glob.glob(os.path.join(self.stage.source_path, "linkid=**"))
-        if len(installer) > 1:
+        if len(installer)!= 1:
             raise RuntimeError(
                 "Fetch has failed, unable to determine installer path from:\n%s"
                 % "\n".join(installer)

--- a/var/spack/repos/builtin/packages/win-wdk/package.py
+++ b/var/spack/repos/builtin/packages/win-wdk/package.py
@@ -116,10 +116,15 @@ class WinWdk(Package):
         This name is not properly formated so that Windows understands it as an executable
         We rename so as to allow Windows to run the WGL installer"""
         installer = glob.glob(os.path.join(self.stage.source_path, "linkid=**"))
-        if len(installer)!= 1:
+        fetch_size = len(installer)
+        if fetch_size > 1:
             raise RuntimeError(
-                "Fetch has failed, unable to determine installer path from:\n%s"
-                % "\n".join(installer)
+                "Fetch has failed, ambiguous behavior, fetch has pulled too much. "
+                "Unable to determine installer path from:\n%s" % "\n".join(installer)
+            )
+        elif fetch_size < 1:
+            raise RuntimeError(
+                "Fetch has failed, nothing was fetched from:\n%s" % "\n".join(installer)
             )
         installer = installer[0]
         os.rename(installer, os.path.join(self.stage.source_path, "wdksetup.exe"))


### PR DESCRIPTION
Sets `msvc` as providing fortran as it does and a few other smaller fixes