### PR TITLE
libcxi: disable ze, cuda, rocm autodetection

### DIFF
--- a/var/spack/repos/builtin/packages/libcxi/package.py
+++ b/var/spack/repos/builtin/packages/libcxi/package.py
@@ -65,9 +65,15 @@ class Libcxi(AutotoolsPackage):
 
         if self.spec.satisfies("+level_zero"):
             args.append(f"--with-ze={self.spec['oneapi-level-zero'].prefix}")
+        else:
+            args.append("--without-ze")
         if self.spec.satisfies("+cuda"):
             args.append(f"--with-cuda={self.spec['cuda'].prefix}")
+        else:
+            args.append("--without-cuda")
         if self.spec.satisfies("+rocm"):
             args.append(f"--with-rocm={self.spec['hip'].prefix}")
+        else:
+            args.append("--without-rocm")
 
         return args


### PR DESCRIPTION
Only enable `ze`, `cuda` and `rocm` if explicitly requested.