### PR TITLE
oneapi-compilers: allow detection of executables symlinked to prefix.bin

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/detection_test.yaml
@@ -21,3 +21,25 @@ paths:
         c: ".*/compiler/2021.2.0/linux/bin/icx"
         cxx: ".*/compiler/2021.2.0/linux/bin/icpx"
         fortran: ".*/compiler/2021.2.0/linux/bin/ifx"
+- layout:
+  - executables:
+    - "bin/icx"
+    - "bin/icpx"
+    script: |
+      echo "Intel(R) oneAPI DPC++ Compiler 2021.2.0 (2021.2.0.20210317)"
+      echo "Target: x86_64-unknown-linux-gnu"
+      echo "Thread model: posix"
+      echo "InstalledDir: /made/up/path",
+  - executables:
+    - "bin/ifx"
+    script: |
+      echo "ifx (IFORT) 2021.2.0 Beta 20201214"
+      echo "Copyright (C) 1985-2020 Intel Corporation.  All rights reserved."
+  platforms: [linux]
+  results:
+  - spec: intel-oneapi-compilers@2021.2.0
+    extra_attributes:
+      compilers:
+        c: ".*/bin/icx"
+        cxx: ".*/bin/icpx"
+        fortran: ".*/bin/ifx"

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -639,7 +639,15 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
             dirs = ", ".join([str(x) for x in sorted(bin_dirs)])
             raise RuntimeError(f"executables found in multiple dirs: {dirs}")
         bin_dir = bin_dirs.pop()
-        prefix_parts = bin_dir.parts[: bin_dir.parts.index("compiler")]
+
+        # Some sites symlink the bindir to the top level of the prefix
+        if "compiler" in bin_dir.parts:
+            # Normal installation
+            prefix_parts = bin_dir.parts[: bin_dir.parts.index("compiler")]
+        else:
+            # Executables from top level bin dir as symlinks
+            prefix_parts = bin_dir.parts[:-1]
+
         computed_prefix = pathlib.Path(*prefix_parts)
         extra_attributes["prefix"] = str(computed_prefix)
 


### PR DESCRIPTION
Some sites symlink `prefix/compilers/latest/linux/bin` to `prefix/bin` to provide a nicer filesystem layout to users. This currently breaks compiler detection.

This PR fixes compiler detection for that case.
