### PR TITLE
msvc: do not detect unless ends with .exe

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
@@ -59,7 +59,7 @@ class Msvc(Package, CompilerPackage):
 
     @classmethod
     def determine_version(cls, exe):
-        if not exe.name.endswith(".exe"):
+        if not exe.name.endswith(".exe") and not exe.name.endswith(".bat"):
             # Not on windows, can't possibly be msvc
             return
 

--- a/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
@@ -59,7 +59,7 @@ class Msvc(Package, CompilerPackage):
 
     @classmethod
     def determine_version(cls, exe):
-        if not exe.name.endswith(".exe") and not exe.name.endswith(".bat"):
+        if not exe.endswith(".exe") and not exe.endswith(".bat"):
             # Not on windows, can't possibly be msvc
             return
 

--- a/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
@@ -59,6 +59,10 @@ class Msvc(Package, CompilerPackage):
 
     @classmethod
     def determine_version(cls, exe):
+        if not exe.name.endswith(".exe"):
+            # Not on windows, can't possibly be msvc
+            return
+
         # MSVC compiler does not have a proper version argument
         # Errors out and prints version info with no args
         is_ifx = "ifx.exe" in str(exe)


### PR DESCRIPTION
Eliminates warnings on linux systems for `ifx` and `ifort` failing to detect as fortran compilers for msvc.
