### PR TITLE
Audit: remove sh invocation on Windows

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -59,7 +59,6 @@ jobs:
     - name: Package audits (without coverage)
       if: ${{ runner.os == 'Windows' }}
       run: |
-          . share/spack/setup-env.sh
           spack -d audit packages
           ./share/spack/qa/validate_last_exit.ps1
           spack -d audit configs


### PR DESCRIPTION
This was passing because powershell only understands failure when commandlets error, but it should have been throwing tons of errors and was not, so that's confusing. Either way, it's not compatible with Windows, and is redundant and Windows shells are inherently setup to run spack thanks to `share/spack/qa/windows_test_setup.ps1`.