### PR TITLE
UI: Color external packages differently from installed packages

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -206,7 +206,7 @@ class InstallStatus(enum.Enum):
 
     installed = "@g{[+]}  "
     upstream = "@g{[^]}  "
-    external = "@g{[e]}  "
+    external = "@M{[e]}  "
     absent = "@K{ - }  "
     missing = "@r{[-]}  "
 


### PR DESCRIPTION
Currently, externals show up in `spack find` and `spack spec` install status as a green `[e]`, which is hard to distinguish from the green [+] used for installed packages.

- [x] Make externals magenta instead, so they stand out.

Before:
<img width="338" alt="Screenshot 2025-03-27 at 11 09 00 PM" src="https://github.com/user-attachments/assets/cc7b3939-86e0-4da0-8247-31b4f93831c4" />

After:
<img width="310" alt="Screenshot 2025-03-27 at 11 07 38 PM" src="https://github.com/user-attachments/assets/6a28d0e4-9271-48d1-a271-af99e61aabc8" />

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
