### PR TITLE
libsmeagol: add dependency fortran for build

### DIFF
--- a/var/spack/repos/builtin/packages/libsmeagol/package.py
+++ b/var/spack/repos/builtin/packages/libsmeagol/package.py
@@ -18,6 +18,7 @@ class Libsmeagol(MakefilePackage):
     version("main", branch="main")
     version("1.2", commit="fefed1bb4fceca584c3014debb169e8ed4ce1289")
 
+    depends_on("fortran", type="build")
     depends_on("mpi")
     depends_on("blas")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add dependency `fortran` due to PR #45189