### PR TITLE
py-confluent-kafka: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-confluent-kafka/package.py
+++ b/var/spack/repos/builtin/packages/py-confluent-kafka/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyConfluentKafka(PythonPackage):
+    """Confluent's Kafka Python Client."""
+
+    homepage = "https://docs.confluent.io/kafka-clients/python"
+    pypi = "confluent-kafka/confluent-kafka-2.6.0.tar.gz"
+
+    license("Apache-2.0", checked_by="github_user1")
+
+    version("2.6.0", sha256="f7afe69639bd2ab15404dd46a76e06213342a23cb5642d873342847cb2198c87")
+
+    depends_on("c", type="build")
+    depends_on("py-setuptools", type="build")
+    depends_on("librdkafka@2.6.0:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Adds the py-confluent-kafka package. Note that there are more recent releases, but 2.6.0 is the one I've tested and the one that I need for https://github.com/spack/spack/pull/49590, so I won't add newer ones until they are needed.