### PR TITLE
spec_parser.py: concrete variants with `:=`

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1771,7 +1771,7 @@ class SpackSolverSetup:
 
             # make a spec indicating whether the variant has this conditional value
             variant_has_value = spack.spec.Spec()
-            variant_has_value.variants[name] = spack.variant.AbstractVariant(name, value.value)
+            variant_has_value.variants[name] = vt.VariantBase(name, value.value)
 
             if value.when:
                 # the conditional value is always "possible", but it imposes its when condition as

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -638,7 +638,7 @@ class TestSpecSemantics:
         a = Spec("multivalue-variant foo=bar")
         b = Spec("multivalue-variant foo=bar,baz")
         # The specs are abstract and they **could** be constrained
-        assert a.satisfies(b)
+        assert b.satisfies(a) and not a.satisfies(b)
         # An abstract spec can instead be constrained
         assert a.constrain(b)
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -633,6 +633,23 @@ def specfile_for(default_mock_concretization):
             ],
             "zlib %[virtuals=fortran] gcc@14.1 %[virtuals=c,cxx] clang",
         ),
+        # test := and :== syntax for key value pairs
+        (
+            "gcc languages:=c,c++",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "gcc"),
+                Token(SpecTokens.KEY_VALUE_PAIR, "languages:=c,c++"),
+            ],
+            "gcc languages:='c,c++'",
+        ),
+        (
+            "gcc languages:==c,c++",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "gcc"),
+                Token(SpecTokens.PROPAGATED_KEY_VALUE_PAIR, "languages:==c,c++"),
+            ],
+            "gcc languages:=='c,c++'",
+        ),
     ],
 )
 def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_package):


### PR DESCRIPTION
Similar to the range-or-specific-version ambiguity of `@1.2` in the past which was solved with `@1.2` vs `@=1.2` we still have the ambiguity of `name=a,b,c` in multi-valued variants. Do they mean "at least a,b,c" or "exactly a,b,c"?

This issue comes up in for example `gcc languages=c,cxx`; there's no way to exclude `fortran`.

The ambiguity is resolved with syntax `:=` to distinguish concrete from abstract.

The following strings parse as **concrete** variants:

* `name:=a,b,c` => values exactly {a, b, c}
* `name:=a` => values exactly {a}
* `+name` => values exactly {True}
* `~name` => values exactly {False}

The following strings parse as **abstract** variants:

* `name=a,b,c` values at least {a, b, c}
* `name=*` special case for testing existence of a variant; values are at least the empty set {}

As a reminder

* `satisfies(lhs, rhs)` means `concretizations(lhs)` ⊆ `concretizations(rhs)`
* `intersects(lhs, rhs)` means `concretizations(lhs)` ∩ `concretizations(rhs)` ≠ ∅

where `concretizations(...)` is the set of sets of variant values in this case.

The satisfies semantics are:

* rhs abstract: rhs values is a subset of lhs values (whether lhs is abstract or concrete)
* lhs concrete, rhs concrete: set equality
* lhs abstract, rhs concrete: false

and intersects should mean

* lhs and rhs abstract: true (the union is a valid concretization under both)
* lhs or rhs abstract: true iff the abstract variant's values are a subset of the concrete one
* lhs concrete, rhs concrete: set equality

Concrete specs with single-valued variants are printed `+foo`, `~foo` and `foo=bar`; only multi-valued variants are printed with `foo:=bar,baz` to reduce the visual noise.