### PR TITLE
Do not error when trying to convert corrupted compiler entries

### DIFF
--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -7,6 +7,7 @@ and configuring Spack to use multiple compilers.
 import os
 import re
 import sys
+import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
 import archspec.cpu
@@ -337,7 +338,15 @@ class CompilerFactory:
             pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
             pattern = re.compile(r"|".join(finder.search_patterns(pkg=pkg_cls)))
             filtered_paths = [x for x in candidate_paths if pattern.search(os.path.basename(x))]
-            detected = finder.detect_specs(pkg=pkg_cls, paths=filtered_paths)
+            try:
+                detected = finder.detect_specs(pkg=pkg_cls, paths=filtered_paths)
+            except Exception:
+                warnings.warn(
+                    f"[{__name__}] cannot detect {pkg_name} from the "
+                    f"following paths: {', '.join(filtered_paths)}"
+                )
+                continue
+
             for s in detected:
                 for key in ("flags", "environment", "extra_rpaths"):
                     if key in compiler_dict:

--- a/lib/spack/spack/test/compilers/conversion.py
+++ b/lib/spack/spack/test/compilers/conversion.py
@@ -83,3 +83,12 @@ def tests_compiler_conversion_modules(mock_compiler):
     compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
     assert compiler_spec.external
     assert compiler_spec.external_modules == modules
+
+
+@pytest.mark.regression("49717")
+def tests_compiler_conversion_corrupted_paths(mock_compiler):
+    """Tests that compiler entries with corrupted path do not raise"""
+    mock_compiler["paths"] = {"cc": "gcc", "cxx": "g++", "fc": "gfortran", "f77": "gfortran"}
+    # Test this call doesn't raise
+    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)
+    assert compiler_spec == []


### PR DESCRIPTION
fixes #49717

If no compiler is listed in the 'packages' section of the configuration, Spack will currently try to:
1. Look for a legacy compilers.yaml to convert
2. Look for compilers in PATH

in that order. If an entry in compilers.yaml is corrupted, that should not result in an obscure error. Instead, it should just be skipped.

**Before**
![Screenshot from 2025-03-28 13-33-58](https://github.com/user-attachments/assets/0f76a12a-2acc-4182-9a73-666310486fbf)

**After**
![Screenshot from 2025-03-28 13-33-19](https://github.com/user-attachments/assets/c2714176-64ec-41a3-8256-351e51925678)


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
