### PR TITLE
apple-gl: Update compiler requirement after switch to nodes

### DIFF
--- a/var/spack/repos/builtin/packages/apple-gl/package.py
+++ b/var/spack/repos/builtin/packages/apple-gl/package.py
@@ -38,7 +38,5 @@ class AppleGl(AppleGlBase):
 
     provides("gl@4.1")
 
-    requires(
-        "platform=darwin %apple-clang",
-        msg="Apple-GL is only available on Darwin, when using Apple Clang",
-    )
+    depends_on("apple-clang", type="build")
+    requires("platform=darwin", msg="Apple-GL is only available on Darwin, when using Apple Clang")

--- a/var/spack/repos/builtin/packages/apple-gl/package.py
+++ b/var/spack/repos/builtin/packages/apple-gl/package.py
@@ -38,4 +38,4 @@ class AppleGl(AppleGlBase):
 
     provides("gl@4.1")
 
-    requires("platform=darwin", msg="Apple-GL is only available on Darwin, when using Apple Clang")
+    requires("platform=darwin", msg="Apple-GL is only available on Darwin")

--- a/var/spack/repos/builtin/packages/apple-gl/package.py
+++ b/var/spack/repos/builtin/packages/apple-gl/package.py
@@ -38,5 +38,4 @@ class AppleGl(AppleGlBase):
 
     provides("gl@4.1")
 
-    depends_on("apple-clang", type="build")
     requires("platform=darwin", msg="Apple-GL is only available on Darwin, when using Apple Clang")

--- a/var/spack/repos/builtin/packages/apple-glu/package.py
+++ b/var/spack/repos/builtin/packages/apple-glu/package.py
@@ -12,7 +12,5 @@ class AppleGlu(AppleGlBase):
 
     provides("glu@1.3")
 
-    requires(
-        "platform=darwin %apple-clang",
-        msg="Apple-GLU is only available on Darwin, when using Apple Clang",
-    )
+    depends_on("apple-clang", type="build")
+    requires("platform=darwin", msg="Apple-GL is only available on Darwin, when using Apple Clang")

--- a/var/spack/repos/builtin/packages/apple-glu/package.py
+++ b/var/spack/repos/builtin/packages/apple-glu/package.py
@@ -12,5 +12,4 @@ class AppleGlu(AppleGlBase):
 
     provides("glu@1.3")
 
-    depends_on("apple-clang", type="build")
     requires("platform=darwin", msg="Apple-GL is only available on Darwin, when using Apple Clang")

--- a/var/spack/repos/builtin/packages/apple-glu/package.py
+++ b/var/spack/repos/builtin/packages/apple-glu/package.py
@@ -12,4 +12,4 @@ class AppleGlu(AppleGlBase):
 
     provides("glu@1.3")
 
-    requires("platform=darwin", msg="Apple-GL is only available on Darwin, when using Apple Clang")
+    requires("platform=darwin", msg="Apple-GL is only available on Darwin")


### PR DESCRIPTION
The `apple-gl` package requires `%apple-clang`. After https://github.com/spack/spack/pull/45189, the package (as far as I understand it) can no longer satisfy

```python
requires("%apple-clang")
```

because this property is not accessible to the package anymore, now that compilers are nodes. This leads to the package never being selected.

This PR makes `apple-gl` depend on `apple-clang` instead.