### PR TITLE
variant.py: reserved names is a set

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -654,7 +654,7 @@ def variant(
         msg += " @*r{{[{0}, variant '{1}']}}"
         return llnl.util.tty.color.colorize(msg.format(pkg.name, name))
 
-    if name in spack.variant.reserved_names:
+    if name in spack.variant.RESERVED_NAMES:
 
         def _raise_reserved_name(pkg):
             msg = "The name '%s' is reserved by Spack" % name

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1694,7 +1694,7 @@ class Spec:
         Known flags currently include "arch"
         """
 
-        if propagate and name in vt.reserved_names:
+        if propagate and name in vt.RESERVED_NAMES:
             raise UnsupportedPropagationError(
                 f"Propagation with '==' is not supported for '{name}'."
             )
@@ -3007,9 +3007,8 @@ class Spec:
         # but are not necessarily recorded by the package's class
         propagate_variants = [name for name, variant in spec.variants.items() if variant.propagate]
 
-        not_existing = set(spec.variants) - (
-            set(pkg_variants) | set(vt.reserved_names) | set(propagate_variants)
-        )
+        not_existing = set(spec.variants)
+        not_existing.difference_update(pkg_variants, vt.RESERVED_NAMES, propagate_variants)
 
         if not_existing:
             raise vt.UnknownVariantError(
@@ -4652,7 +4651,7 @@ def substitute_abstract_variants(spec: Spec):
         if name == "dev_path":
             spec.variants.substitute(vt.SingleValuedVariant(name, v._original_value))
             continue
-        elif name in vt.reserved_names:
+        elif name in vt.RESERVED_NAMES:
             continue
 
         variant_defs = spack.repo.PATH.get_pkg_class(spec.fullname).variant_definitions(name)

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -21,7 +21,7 @@ import spack.spec
 import spack.spec_parser
 
 #: These are variant names used by Spack internally; packages can't use them
-reserved_names = [
+RESERVED_NAMES = {
     "arch",
     "architecture",
     "dev_path",
@@ -31,7 +31,7 @@ reserved_names = [
     "patches",
     "platform",
     "target",
-]
+}
 
 special_variant_values = [None, "none", "*"]
 
@@ -832,7 +832,7 @@ def prevalidate_variant_value(
         only if the variant is a reserved variant.
     """
     # don't validate wildcards or variants with reserved names
-    if variant.value == ("*",) or variant.name in reserved_names or variant.propagate:
+    if variant.value == ("*",) or variant.name in RESERVED_NAMES or variant.propagate:
         return []
 
     # raise if there is no definition at all


### PR DESCRIPTION
always used for inclusion tests. also reduce unnecessary allocation in one use case with set difference.