### PR TITLE
unqlite: fix dependency on C++

### DIFF
--- a/var/spack/repos/builtin/packages/unqlite/package.py
+++ b/var/spack/repos/builtin/packages/unqlite/package.py
@@ -18,6 +18,7 @@ class Unqlite(CMakePackage):
     version("master", branch="master")
     version("1.1.9", sha256="33d5b5e7b2ca223942e77d31112d2e20512bc507808414451c8a98a7be5e15c0")
 
+    depends_on("cxx", type="build")  # generated
     depends_on("c", type="build")  # generated
 
     # This patch corresponds to https://github.com/symisc/unqlite/pull/99


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
The package fails to build without `depends_on("c++")` because cmake looks for a C++ compiler.