### PR TITLE
geomodel: depend on c

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -71,7 +71,7 @@ spack:
   - geant4 ~vtk ^[virtuals=qmake] qt
   - geant4 ~vtk ^[virtuals=qmake] qt-base
   #- genie +atmo
-  - geomodel +examples +fsl +geomodelg4 +hepmc3 +pythia +tools +visualization
+  - geomodel +examples +fullsimlight +geomodelg4 +hepmc3 +pythia +tools +visualization
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
   #- herwig3 +njet +vbfnlo  # Note: herwig3 fails to find evtgen

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -71,6 +71,7 @@ spack:
   - geant4 ~vtk ^[virtuals=qmake] qt
   - geant4 ~vtk ^[virtuals=qmake] qt-base
   #- genie +atmo
+  - geomodel +examples +fsl +geomodelg4 +hepmc3 +pythia +tools +visualization
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
   #- herwig3 +njet +vbfnlo  # Note: herwig3 fails to find evtgen

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -65,8 +65,8 @@ class Geomodel(CMakePackage):
 
     conflicts("+fullsimlight", when="+fsl", msg="FSL triggers the build of the FullSimLight")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.16:", type="build")
 

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -65,6 +65,7 @@ class Geomodel(CMakePackage):
 
     conflicts("+fullsimlight", when="+fsl", msg="FSL triggers the build of the FullSimLight")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.16:", type="build")

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -90,7 +90,7 @@ class Geomodel(CMakePackage):
             depends_on("qt-5compat")
         depends_on("coin3d")
         depends_on("soqt")
-        depends_on("opengl")
+        depends_on("gl")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/soqt/package.py
+++ b/var/spack/repos/builtin/packages/soqt/package.py
@@ -23,7 +23,8 @@ class Soqt(CMakePackage):
     depends_on("cmake@3:", type="build")
 
     depends_on("coin3d")
-    depends_on("opengl")
+    depends_on("gl")
+    depends_on("glu")
 
     variant(
         "static_defaults",


### PR DESCRIPTION
This PR ensures that `geomodel` gets a C compiler. 

Due to e.g. https://gitlab.cern.ch/GeoModelDev/GeoModel/-/blob/main/GeoModelVisualization/CMakeLists.txt?ref_type=heads#L7. @stephenmsachs I can't file upstream PRs but this is an avoidable dependency. There are also other occurrences in the FSL plugins and examples. I'm going to require a C compiler for all cases rather than figuring out which combination exactly requires it.