### PR TITLE
Refining sorting of packages

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -36,6 +36,8 @@ from typing import (
 
 import archspec.cpu
 
+from operator import itemgetter, attrgetter
+
 import llnl.util.lang
 import llnl.util.tty as tty
 from llnl.util.filesystem import current_file_position
@@ -2916,7 +2918,7 @@ class SpackSolverSetup:
         """
         # Tell the concretizer about possible values from specs seen in spec_clauses().
         # We might want to order these facts by pkg and name if we are debugging.
-        for pkg_name, variant_def_id, value in sorted(self.variant_values_from_specs):
+        for pkg_name, variant_def_id, value in sorted(self.variant_values_from_specs, key = itemgetter(0,1)):
             try:
                 vid = self.variant_ids_by_def_id[variant_def_id]
             except KeyError:


### PR DESCRIPTION
Occasionally I come across errors when trying to concretize that are to do with trying to compare (using <) a number and a  Bool or a Str and a Bool, i.e.:

`TypeError: '<' not supported between instances of 'str' and 'bool'`

These seem to be because the default approach some parts of the code is to try and sort environment packages or similar, and the sorting code wants to sort across all elements in a list of tuples. However, the last element (element 2) is not comparable, so it complains with the error above. There is a fix that restricts sorting only to the first two elements, and it then fixes the error.

