### PR TITLE
chapel: remove requirements on compilers

### DIFF
--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -567,26 +567,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("cmake@3.16:")
     depends_on("cmake@3.20:", when="llvm=bundled")
 
-    # ensure we can map the spack compiler name to one of the ones we recognize
-    requires(
-        "%aocc",
-        "%apple-clang",
-        "%arm",
-        "%clang",
-        "%cce",
-        "%cray-prgenv-cray",
-        "%cray-prgenv-gnu",
-        "%cray-prgenv-intel",
-        "%cray-prgenv-pgi",
-        "%dpcpp",
-        "%gcc",
-        "%intel",
-        "%llvm",
-        "%oneapi",
-        "%rocmcc",
-        policy="one_of",
-    )
-
     def unset_chpl_env_vars(self, env):
         # Clean the environment from any pre-set CHPL_ variables that affect the build
         for var in self.chpl_env_vars:


### PR DESCRIPTION
The requirements were redundant before ("require any of the compiler that Spack supports"), and even outdated (`%cray-prgenv-*` is not a compiler in v0.23).

When compilers turned into nodes, these constraints, with the "one_of" policy, started being unsat under certain conditions e.g. we can't compile anymore with GCC and depend on LLVM as a library.

Remove the requirements to make the recipe solvable again.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
