### PR TITLE
Mfem cmake

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/ams/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ams/package.py
@@ -103,6 +103,7 @@ class Ams(CMakePackage, CudaPackage):
                 depends_on(
                     "umpire +cuda cuda_arch={0}".format(sm_), when="cuda_arch={0}".format(sm_)
                 )
+        conflicts("^mfem build_system=cmake")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ascent/package.py
@@ -286,6 +286,7 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mfem~mpi", when="+mfem~mpi")
     depends_on("mfem+shared", when="+mfem+shared")
     depends_on("mfem~shared", when="+mfem~shared")
+    conflicts("^mfem build_system=cmake")
 
     # occa
     depends_on("occa", when="+occa")

--- a/var/spack/repos/spack_repo/builtin/packages/axom/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/axom/package.py
@@ -199,6 +199,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
         depends_on("mfem+mpi", when="+mpi")
         depends_on("mfem~mpi", when="~mpi")
         depends_on("mfem@4.5.0:", when="@0.7.0:")
+        conflicts("^mfem build_system=cmake")
 
     depends_on("python", when="+python")
 

--- a/var/spack/repos/spack_repo/builtin/packages/cardioid/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cardioid/package.py
@@ -35,6 +35,8 @@ class Cardioid(CMakePackage):
     depends_on("cmake@3.1:", type="build")
     depends_on("perl", type="build")
 
+    conflicts("^mfem build_system=cmake")
+
     def cmake_args(self):
         spec = self.spec
         args = [

--- a/var/spack/repos/spack_repo/builtin/packages/ceed/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ceed/package.py
@@ -283,6 +283,7 @@ class Ceed(BundlePackage, CudaPackage, ROCmPackage):
             when="@4.0.0+mfem+rocm amdgpu_target={0}".format(target),
         )
     depends_on("mfem@4.2.0+occa", when="@4.0.0+mfem+occa")
+    conflicts("^mfem build_system=cmake")
     depends_on("laghos@3.1", when="@4.0.0+mfem")
     depends_on("remhos@1.0", when="@4.0.0+mfem")
     # ceed-3.0

--- a/var/spack/repos/spack_repo/builtin/packages/dray/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dray/package.py
@@ -111,6 +111,7 @@ class Dray(Package, CudaPackage):
     depends_on("mfem+conduit~threadsafe")
     depends_on("mfem+shared", when="+shared")
     depends_on("mfem~shared", when="~shared")
+    conflicts("^mfem build_system=cmake")
     depends_on("gmake", type="build")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:

--- a/var/spack/repos/spack_repo/builtin/packages/glvis/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/glvis/package.py
@@ -113,6 +113,7 @@ class Glvis(MakefilePackage):
     depends_on("mfem@3.3", when="@3.3")
     depends_on("mfem@3.2", when="@3.2")
     depends_on("mfem@3.1", when="@3.1")
+    conflicts("^mfem build_system=cmake")
 
     with when("@:3"):
         depends_on("gl")

--- a/var/spack/repos/spack_repo/builtin/packages/laghos/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/laghos/package.py
@@ -38,6 +38,7 @@ class Laghos(MakefilePackage):
 
     depends_on("mfem+mpi+metis", when="+metis")
     depends_on("mfem+mpi~metis", when="~metis")
+    conflicts("^mfem build_system=cmake")
 
     depends_on("mfem@develop", when="@develop")
     depends_on("mfem@4.2.0:", when="@3.1")

--- a/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
@@ -530,6 +530,74 @@ class Mfem(Package, CMakePackage, CudaPackage, ROCmPackage):
     patch("mfem-4.7.patch", when="@4.7.0")
     patch("mfem-4.7-sundials-7.patch", when="@4.7.0+sundials ^sundials@7:")
 
+    @property
+    def suitesparse_components(self):
+        """Return the SuiteSparse components needed by MFEM."""
+        ss_comps = "umfpack,cholmod,colamd,amd,camd,ccolamd,suitesparseconfig"
+        if self.spec.satisfies("@3.2:"):
+            ss_comps = "klu,btf," + ss_comps
+        return ss_comps
+
+    @property
+    def sundials_components(self):
+        """Return the SUNDIALS components needed by MFEM."""
+        spec = self.spec
+        sun_comps = "arkode,cvodes,nvecserial,kinsol"
+        if "+mpi" in spec:
+            if spec.satisfies("@4.2:"):
+                sun_comps += ",nvecparallel,nvecmpiplusx"
+            else:
+                sun_comps += ",nvecparhyp,nvecparallel"
+        if "+cuda" in spec and "+cuda" in spec["sundials"]:
+            sun_comps += ",nveccuda"
+        if "+rocm" in spec and "+rocm" in spec["sundials"]:
+            sun_comps += ",nvechip"
+        return sun_comps
+
+    @property
+    def headers(self):
+        """Export the main mfem header, mfem.hpp."""
+        hdrs = HeaderList(find(self.prefix.include, "mfem.hpp", recursive=False))
+        return hdrs or None
+
+    @property
+    def libs(self):
+        """Export the mfem library file."""
+        libs = find_libraries(
+            "libmfem", root=self.prefix.lib, shared=("+shared" in self.spec), recursive=False
+        )
+        return libs or None
+
+    @property
+    def config_mk(self):
+        """Export the location of the config.mk file.
+        This property can be accessed using pkg["mfem"].config_mk
+        """
+        dirs = [self.prefix, self.prefix.share.mfem]
+        for d in dirs:
+            f = join_path(d, "config.mk")
+            if os.access(f, os.R_OK):
+                return FileList(f)
+        return FileList(find(self.prefix, "config.mk", recursive=True))
+
+    @property
+    def test_mk(self):
+        """Export the location of the test.mk file.
+        This property can be accessed using pkg["mfem"].test_mk.
+        In version 3.3.2 and newer, the location of test.mk is also defined
+        inside config.mk, variable MFEM_TEST_MK.
+        """
+        dirs = [self.prefix, self.prefix.share.mfem]
+        for d in dirs:
+            f = join_path(d, "test.mk")
+            if os.access(f, os.R_OK):
+                return FileList(f)
+        return FileList(find(self.prefix, "test.mk", recursive=True))
+
+    @property
+    def xlinker(self):
+        return "-Wl," if "~cuda" in self.spec else "-Xlinker="
+
 
 def str_to_timerid(timer_type):
     timer_ids = {"auto": "-1", "std": "0", "posix": "2", "mac": "4", "mpi": "6"}
@@ -1299,70 +1367,6 @@ class GenericBuilder(AnyBuilder, GenericBuilder):
         for f in files_with_bom:
             filter_file(bom, "", f)
 
-    @property
-    def suitesparse_components(self):
-        """Return the SuiteSparse components needed by MFEM."""
-        ss_comps = "umfpack,cholmod,colamd,amd,camd,ccolamd,suitesparseconfig"
-        if self.spec.satisfies("@3.2:"):
-            ss_comps = "klu,btf," + ss_comps
-        return ss_comps
-
-    @property
-    def sundials_components(self):
-        """Return the SUNDIALS components needed by MFEM."""
-        spec = self.spec
-        sun_comps = "arkode,cvodes,nvecserial,kinsol"
-        if "+mpi" in spec:
-            if spec.satisfies("@4.2:"):
-                sun_comps += ",nvecparallel,nvecmpiplusx"
-            else:
-                sun_comps += ",nvecparhyp,nvecparallel"
-        if "+cuda" in spec and "+cuda" in spec["sundials"]:
-            sun_comps += ",nveccuda"
-        if "+rocm" in spec and "+rocm" in spec["sundials"]:
-            sun_comps += ",nvechip"
-        return sun_comps
-
-    @property
-    def headers(self):
-        """Export the main mfem header, mfem.hpp."""
-        hdrs = HeaderList(find(self.prefix.include, "mfem.hpp", recursive=False))
-        return hdrs or None
-
-    @property
-    def libs(self):
-        """Export the mfem library file."""
-        libs = find_libraries(
-            "libmfem", root=self.prefix.lib, shared=("+shared" in self.spec), recursive=False
-        )
-        return libs or None
-
-    @property
-    def config_mk(self):
-        """Export the location of the config.mk file.
-        This property can be accessed using pkg["mfem"].config_mk
-        """
-        dirs = [self.prefix, self.prefix.share.mfem]
-        for d in dirs:
-            f = join_path(d, "config.mk")
-            if os.access(f, os.R_OK):
-                return FileList(f)
-        return FileList(find(self.prefix, "config.mk", recursive=True))
-
-    @property
-    def test_mk(self):
-        """Export the location of the test.mk file.
-        This property can be accessed using pkg["mfem"].test_mk.
-        In version 3.3.2 and newer, the location of test.mk is also defined
-        inside config.mk, variable MFEM_TEST_MK.
-        """
-        dirs = [self.prefix, self.prefix.share.mfem]
-        for d in dirs:
-            f = join_path(d, "test.mk")
-            if os.access(f, os.R_OK):
-                return FileList(f)
-        return FileList(find(self.prefix, "test.mk", recursive=True))
-
     # See also find_system_libraries in lib/spack/llnl/util/filesystem.py
     # where the similar list of paths is used.
     sys_lib_paths = [
@@ -1378,17 +1382,13 @@ class GenericBuilder(AnyBuilder, GenericBuilder):
     def is_sys_lib_path(self, dir):
         return dir in self.sys_lib_paths
 
-    @property
-    def xlinker(self):
-        return "-Wl," if "~cuda" in self.spec else "-Xlinker="
-
     # Similar to spec[pkg].libs.ld_flags but prepends rpath flags too.
     # Also does not add system library paths as defined by 'sys_lib_paths'
     # above -- this is done to avoid issues like this:
     # https://github.com/mfem/mfem/issues/1088.
     def ld_flags_from_library_list(self, libs_list):
         flags = [
-            "%s-rpath,%s" % (self.xlinker, dir)
+            "%s-rpath,%s" % (self.pkg.xlinker, dir)
             for dir in libs_list.directories
             if not self.is_sys_lib_path(dir)
         ]
@@ -1398,7 +1398,7 @@ class GenericBuilder(AnyBuilder, GenericBuilder):
 
     def ld_flags_from_dirs(self, pkg_dirs_list, pkg_libs_list):
         flags = [
-            "%s-rpath,%s" % (self.xlinker, dir)
+            "%s-rpath,%s" % (self.pkg.xlinker, dir)
             for dir in pkg_dirs_list
             if not self.is_sys_lib_path(dir)
         ]

--- a/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
@@ -10,11 +10,12 @@ from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.generic import Package
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 from spack_repo.builtin.build_systems.generic import GenericBuilder
-
+from spack_repo.builtin.build_systems.cmake import CMakeBuilder
+from spack_repo.builtin.build_systems.generic import GenericBuilder
 from spack.package import *
 
 
-class Mfem(Package, CudaPackage, ROCmPackage):
+class Mfem(Package, CMakePackage, CudaPackage, ROCmPackage):
     """Free, lightweight, scalable C++ library for finite element methods."""
 
     tags = ["fem", "finite-elements", "high-order", "amr", "hpc", "radiuss", "e4s"]
@@ -26,7 +27,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
 
     test_requires_compiler = True
 
-    build_system("generic", default="generic")
+    build_system("generic", "cmake", default="generic")
 
     # Recommended mfem builds to test when updating this file: see the shell
     # script 'test_builds.sh' in the same directory as this file.
@@ -200,7 +201,13 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     variant("gslib", default=False, description="Enable functionality based on GSLIB")
     variant("mpfr", default=False, description="Enable precise, 1D quadrature rules")
     variant("lapack", default=False, description="Use external blas/lapack routines")
-    variant("debug", default=False, description="Build debug instead of optimized version")
+    # CMake package has build_type variant instead
+    variant(
+        "debug",
+        default=False,
+        description="Build debug instead of optimized version",
+        when="build_system=generic",
+    )
     variant("netcdf", default=False, description="Enable Cubit/Genesis reader")
     variant("conduit", default=False, description="Enable binary data I/O using Conduit")
     variant("zlib", default=True, description="Support zip'd streams for I/O")
@@ -239,6 +246,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
 
     conflicts("+shared", when="@:3.3.2")
     conflicts("~static~shared")
+    # CMake only handles one build mode at a time
+    conflicts("+shared+static", when="build_system=cmake")
     conflicts("~threadsafe", when="@:3+openmp")
 
     conflicts("+cuda", when="@:3")
@@ -521,6 +530,12 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     patch("mfem-4.7.patch", when="@4.7.0")
     patch("mfem-4.7-sundials-7.patch", when="@4.7.0+sundials ^sundials@7:")
 
+
+def str_to_timerid(timer_type):
+    timer_ids = {"auto": "-1", "std": "0", "posix": "2", "mac": "4", "mpi": "6"}
+    return timer_ids[timer_type]
+
+
 class AnyBuilder(BaseBuilder):
     @run_after("install")
     def cache_test_sources(self):
@@ -531,6 +546,7 @@ class AnyBuilder(BaseBuilder):
         make("examples/clean", parallel=False)
         extra_install_tests = [self.examples_src_dir, self.examples_data_dir]
         cache_extra_test_sources(self.pkg, extra_install_tests)
+
 
 # without splitting the cache_test_sources into AnyBuilder,
 # cache_extra_test_sources was not available in the GenericBuilder
@@ -720,7 +736,7 @@ class GenericBuilder(AnyBuilder, GenericBuilder):
         if "~static" in spec:
             options += ["STATIC=NO"]
         if "+shared" in spec:
-            options += ["SHARED=YES", "PICFLAG=%s" % (xcompiler + pkg.compiler.cxx_pic_flag)]
+            options += ["SHARED=YES", "PICFLAG=%s" % (xcompiler + self.pkg.compiler.cxx_pic_flag)]
 
         if "+mpi" in spec:
             options += ["MPICXX=%s" % spec["mpi"].mpicxx]
@@ -1092,10 +1108,9 @@ class GenericBuilder(AnyBuilder, GenericBuilder):
                 "UMPIRE_LIB=%s" % ld_flags_from_library_list(umpire_libs),
             ]
 
-        timer_ids = {"std": "0", "posix": "2", "mac": "4", "mpi": "6"}
         timer = spec.variants["timer"].value
         if timer != "auto":
-            options += ["MFEM_TIMER_TYPE=%s" % timer_ids[timer]]
+            options += ["MFEM_TIMER_TYPE=%s" % str_to_timerid(timer)]
 
         if "+conduit" in spec:
             conduit = spec["conduit"]
@@ -1390,3 +1405,55 @@ class GenericBuilder(AnyBuilder, GenericBuilder):
         flags += ["-L%s" % dir for dir in pkg_dirs_list if not self.is_sys_lib_path(dir)]
         flags += ["-l%s" % lib for lib in pkg_libs_list]
         return " ".join(flags)
+
+class CMakeBuilder(CMakeBuilder):
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("MFEM_USE_MPI", "mpi"),
+            self.define_from_variant("MFEM_USE_METIS", "metis"),
+            self.define_from_variant("MFEM_USE_OPENMP", "openmp"),
+            self.define_from_variant("MFEM_USE_OCCA", "occa"),
+            self.define_from_variant("MFEM_USE_RAJA", "raja"),
+            self.define_from_variant("MFEM_USE_CEED", "libceed"),
+            self.define_from_variant("MFEM_USE_UMPIRE", "umpire"),
+            self.define_from_variant("MFEM_USE_AMGX", "amgx"),
+            self.define_from_variant("MFEM_THREAD_SAFE", "threadsafe"),
+            self.define_from_variant("MFEM_USE_SUPERLU", "superlu-dist"),
+            self.define_from_variant("MFEM_USE_STRUMPACK", "strumpack"),
+            self.define_from_variant("MFEM_USE_SUITESPARSE", "suite-sparse"),
+            self.define_from_variant("MFEM_USE_PETSC", "petsc"),
+            self.define_from_variant("MFEM_USE_MUMPS", "mumps"),
+            self.define_from_variant("MFEM_USE_SLEPC", "slepc"),
+            self.define_from_variant("MFEM_USE_SUNDIALS", "sundials"),
+            self.define_from_variant("MFEM_USE_PUMI", "pumi"),
+            self.define_from_variant("MFEM_USE_GSLIB", "gslib"),
+            self.define_from_variant("MFEM_USE_MPFR", "mpfr"),
+            self.define_from_variant("MFEM_USE_LAPACK", "lapack"),
+            self.define_from_variant("MFEM_USE_NETCDF", "netcdf"),
+            self.define_from_variant("MFEM_USE_CONDUIT", "conduit"),
+            self.define_from_variant("MFEM_USE_ZLIB", "zlib"),
+            self.define_from_variant("MFEM_USE_GNUTLS", "gnutls"),
+            self.define_from_variant("MFEM_USE_LIBUNWIND", "libunwind"),
+            self.define_from_variant("MFEM_USE_FMS", "fms"),
+            self.define_from_variant("MFEM_USE_GINKGO", "ginkgo"),
+            self.define_from_variant("MFEM_USE_HIOP", "hiop"),
+            self.define_from_variant("MFEM_ENABLE_EXAMPLES", "examples"),
+            self.define_from_variant("MFEM_ENABLE_MINIAPPS", "miniapps"),
+            self.define_from_variant("MFEM_USE_EXCEPTIONS", "exceptions"),
+            self.define_from_variant("MFEM_PRECISION", "precision"),
+            self.define("MFEM_ENABLE_TESTING", True),
+        ]
+        if "+shared" in self.spec:
+            args.append(self.define("BUILD_SHARED_LIBS", True))
+        else:
+            args.append(self.define("BUILD_SHARED_LIBS", False))
+
+        cxxstd = self.spec.variants["cxxstd"].value
+        if cxxstd != "auto":
+            args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
+
+        timer = self.spec.variants["timer"].value
+        if timer != "auto":
+            args.append(self.define("MFEM_TIMER_TYPE", str_to_timerid(timer)))
+
+        return args

--- a/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
@@ -924,14 +924,14 @@ class GenericBuilder(AnyBuilder, GenericBuilder):
             ]
 
         if "+suite-sparse" in spec:
-            ss_spec = "suite-sparse:" + self.suitesparse_components
+            ss_spec = "suite-sparse:" + self.pkg.suitesparse_components
             options += [
                 "SUITESPARSE_OPT=-I%s" % spec[ss_spec].prefix.include,
                 "SUITESPARSE_LIB=%s" % ld_flags_from_library_list(spec[ss_spec].libs),
             ]
 
         if "+sundials" in spec:
-            sun_spec = "sundials:" + self.sundials_components
+            sun_spec = "sundials:" + self.pkg.sundials_components
             options += [
                 "SUNDIALS_OPT=%s" % spec[sun_spec].headers.cpp_flags,
                 "SUNDIALS_LIB=%s" % ld_flags_from_library_list(spec[sun_spec].libs),

--- a/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
@@ -9,6 +9,7 @@ import sys
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.generic import Package
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.build_systems.generic import GenericBuilder
 
 from spack.package import *
 
@@ -24,6 +25,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     maintainers("v-dobrev", "tzanio", "acfisher", "markcmiller86")
 
     test_requires_compiler = True
+
+    build_system("generic", default="generic")
 
     # Recommended mfem builds to test when updating this file: see the shell
     # script 'test_builds.sh' in the same directory as this file.
@@ -518,6 +521,28 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     patch("mfem-4.7.patch", when="@4.7.0")
     patch("mfem-4.7-sundials-7.patch", when="@4.7.0+sundials ^sundials@7:")
 
+class AnyBuilder(BaseBuilder):
+    @run_after("install")
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        # Clean the 'examples' directory -- at least one example is always built
+        # and we do not want to cache executables.
+        make("examples/clean", parallel=False)
+        extra_install_tests = [self.examples_src_dir, self.examples_data_dir]
+        cache_extra_test_sources(self.pkg, extra_install_tests)
+
+# without splitting the cache_test_sources into AnyBuilder,
+# cache_extra_test_sources was not available in the GenericBuilder
+# took the idea from the superlu package
+class GenericBuilder(AnyBuilder, GenericBuilder):
+    #
+    # Note: Although MFEM does support CMake configuration, MFEM
+    # development team indicates that vanilla GNU Make is the
+    # preferred mode of configuration of MFEM and the mode most
+    # likely to be up to date in supporting *all* of MFEM's
+    # configuration options. So, don't use CMake
+    #
     phases = ["configure", "build", "install"]
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
@@ -530,16 +555,9 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             env.set("OMPI_CXX", spack_cxx)
             env.set("MPICXX_CXX", spack_cxx)
 
-    #
-    # Note: Although MFEM does support CMake configuration, MFEM
-    # development team indicates that vanilla GNU Make is the
-    # preferred mode of configuration of MFEM and the mode most
-    # likely to be up to date in supporting *all* of MFEM's
-    # configuration options. So, don't use CMake
-    #
     def get_make_config_options(self, spec, prefix):
         def yes_no(varstr):
-            return "YES" if varstr in self.spec else "NO"
+            return "YES" if varstr in spec else "NO"
 
         xcompiler = "" if "~cuda" in spec else "-Xcompiler="
 
@@ -632,18 +650,18 @@ class Mfem(Package, CudaPackage, ROCmPackage):
 
         # Determine C++ standard to use:
         cxxstd = None
-        if self.spec.satisfies("@4.0.0:"):
+        if spec.satisfies("@4.0.0:"):
             cxxstd = "11"
-        if self.spec.satisfies("^raja@2022.03.0:"):
+        if spec.satisfies("^raja@2022.03.0:"):
             cxxstd = "14"
-        if self.spec.satisfies("^umpire@2022.03.0:"):
+        if spec.satisfies("^umpire@2022.03.0:"):
             cxxstd = "14"
-        if self.spec.satisfies("^sundials@6.4.0:"):
+        if spec.satisfies("^sundials@6.4.0:"):
             cxxstd = "14"
-        if self.spec.satisfies("^ginkgo"):
+        if spec.satisfies("^ginkgo"):
             cxxstd = "14"
         # When rocPRIM is used (e.g. by PETSc + ROCm) we need C++14:
-        if self.spec.satisfies("^rocprim@5.5.0:"):
+        if spec.satisfies("^rocprim@5.5.0:"):
             cxxstd = "14"
         cxxstd_req = spec.variants["cxxstd"].value
         if cxxstd_req != "auto":
@@ -655,7 +673,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             if "+cuda" in spec:
                 cxxstd_flag = "-std=c++" + cxxstd
             else:
-                cxxstd_flag = getattr(self.compiler, "cxx" + cxxstd + "_flag")
+                cxxstd_flag = getattr(self.pkg.compiler, "cxx" + cxxstd + "_flag")
 
         cuda_arch = None if "~cuda" in spec else spec.variants["cuda_arch"].value
 
@@ -663,8 +681,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
 
         if cxxflags:
             # Add opt/debug flags if they are not present in global cxx flags
-            opt_flag_found = any(f in self["cxx"].opt_flags for f in cxxflags)
-            debug_flag_found = any(f in self["cxx"].debug_flags for f in cxxflags)
+            opt_flag_found = any(f in self.pkg.compiler.opt_flags for f in cxxflags)
+            debug_flag_found = any(f in self.pkg.compiler.debug_flags for f in cxxflags)
 
             if "+debug" in spec:
                 if not debug_flag_found:
@@ -702,7 +720,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         if "~static" in spec:
             options += ["STATIC=NO"]
         if "+shared" in spec:
-            options += ["SHARED=YES", "PICFLAG=%s" % (xcompiler + self.compiler.cxx_pic_flag)]
+            options += ["SHARED=YES", "PICFLAG=%s" % (xcompiler + pkg.compiler.cxx_pic_flag)]
 
         if "+mpi" in spec:
             options += ["MPICXX=%s" % spec["mpi"].mpicxx]
@@ -782,8 +800,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                 # The "+openmp" in the spec means strumpack will TRY to find
                 # OpenMP; if not found, we should not add any flags -- how do
                 # we figure out if strumpack found OpenMP?
-                if not self.spec.satisfies("%apple-clang"):
-                    sp_opt += [xcompiler + self.compiler.openmp_flag]
+                if not spec.satisfies("%apple-clang"):
+                    sp_opt += [xcompiler + pkg.compiler.openmp_flag]
             if "^parmetis" in strumpack:
                 parmetis = strumpack["parmetis"]
                 sp_opt += [parmetis.headers.cpp_flags]
@@ -937,7 +955,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             ]
 
         if "+openmp" in spec:
-            options += ["OPENMP_OPT=%s" % (xcompiler + self.compiler.openmp_flag)]
+            options += ["OPENMP_OPT=%s" % (xcompiler + pkg.compiler.openmp_flag)]
 
         if "+cuda" in spec:
             options += [
@@ -1168,7 +1186,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             mumps_opt = ["-I%s" % mumps.prefix.include]
             if "+openmp" in mumps:
                 if not self.spec.satisfies("%apple-clang"):
-                    mumps_opt += [xcompiler + self.compiler.openmp_flag]
+                    mumps_opt += [xcompiler + compiler.openmp_flag]
             options += [
                 "MUMPS_OPT=%s" % " ".join(mumps_opt),
                 "MUMPS_LIB=%s" % ld_flags_from_library_list(mumps.libs),
@@ -1176,19 +1194,19 @@ class Mfem(Package, CudaPackage, ROCmPackage):
 
         return options
 
-    def configure(self, spec, prefix):
+    def configure(self, pkg, spec, prefix):
         options = self.get_make_config_options(spec, prefix)
         make("config", *options, parallel=False)
         make("info", parallel=False)
 
-    def build(self, spec, prefix):
+    def build(self, pkg, spec, prefix):
         make("lib")
 
     @run_after("build")
     def check_or_test(self):
         # Running 'make check' or 'make test' may fail if MFEM_MPIEXEC or
         # MFEM_MPIEXEC_NP are not set appropriately.
-        if not self.run_tests:
+        if not self.pkg.run_tests:
             # check we can build ex1 (~mpi) or ex1p (+mpi).
             make("-C", "examples", "ex1p" if ("+mpi" in self.spec) else "ex1", parallel=False)
             # make('check', parallel=False)
@@ -1196,7 +1214,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             make("all")
             make("test", parallel=False)
 
-    def install(self, spec, prefix):
+    def install(self, pkg, spec, prefix):
         make("install", parallel=False)
 
         # TODO: The way the examples and miniapps are being installed is not
@@ -1232,23 +1250,14 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     examples_src_dir = "examples"
     examples_data_dir = "data"
 
-    @run_after("install")
-    def cache_test_sources(self):
-        """Copy the example source files after the package is installed to an
-        install test subdirectory for use during `spack test run`."""
-        # Clean the 'examples' directory -- at least one example is always built
-        # and we do not want to cache executables.
-        make("examples/clean", parallel=False)
-        cache_extra_test_sources(self, [self.examples_src_dir, self.examples_data_dir])
-
     def test_ex10(self):
         """build and run ex10(p)"""
         # MFEM has many examples to serve as a suitable smoke check. ex10
         # was chosen arbitrarily among the examples that work both with
         # MPI and without it
-        test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
+        test_dir = join_path(self.test_suite.current_test_cache_dir, self.pkg.examples_src_dir)
 
-        mesh = join_path("..", self.examples_data_dir, "beam-quad.mesh")
+        mesh = join_path("..", self.pkg.examples_data_dir, "beam-quad.mesh")
         test_exe = "ex10p" if ("+mpi" in self.spec) else "ex10"
 
         with working_dir(test_dir):

--- a/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
@@ -294,6 +294,8 @@ class Mfem(Package, CMakePackage, CudaPackage, ROCmPackage):
     conflicts("^mpich@4:", when="@:4.3+mpi")
 
     depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
     depends_on("gmake", type="build")
 
     depends_on("mpi", when="+mpi")

--- a/var/spack/repos/spack_repo/builtin/packages/remhos/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/remhos/package.py
@@ -37,6 +37,7 @@ class Remhos(MakefilePackage):
 
     depends_on("mfem@develop", when="@develop")
     depends_on("mfem@4.1.0:", when="@1.0")
+    conflicts("^mfem build_system=cmake")
 
     @property
     def build_targets(self):

--- a/var/spack/repos/spack_repo/builtin/packages/visit/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/visit/package.py
@@ -196,6 +196,7 @@ class Visit(CMakePackage):
     depends_on("mfem@4.4:", when="+mfem")
     depends_on("mfem+shared+exceptions+fms+conduit", when="+mfem")
     depends_on("libfms@0.2:", when="+mfem")
+    conflicts("^mfem build_system=cmake")
 
     with when("+adios2"):
         depends_on("adios2")

--- a/var/spack/repos/spack_repo/builtin/packages/visit_mfem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/visit_mfem/package.py
@@ -46,6 +46,7 @@ class VisitMfem(CMakePackage):
 
     depends_on("cmake", type="build")
     depends_on("mfem")
+    conflicts("^mfem build_system=cmake")
     depends_on("visit")
 
     extends("visit")

--- a/var/spack/repos/spack_repo/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/xsdk/package.py
@@ -140,6 +140,7 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
         cuda_var="cuda",
         rocm_var="rocm",
     )
+    conflicts("^mfem build_system=cmake")
 
     xsdk_depends_on("superlu-dist@9.1.0", when="@1.1.0", cuda_var="cuda", rocm_var="rocm")
     xsdk_depends_on("superlu-dist@8.2.1", when="@1.0.0", cuda_var="cuda", rocm_var="rocm")

--- a/var/spack/repos/spack_repo/builtin/packages/xsdk_examples/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/xsdk_examples/package.py
@@ -49,6 +49,8 @@ class XsdkExamples(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("mfem+strumpack", when="^xsdk+strumpack")
         depends_on("mfem+ginkgo", when="^xsdk+ginkgo")
         depends_on("mfem+hiop", when="^xsdk+hiop")
+        conflicts("^mfem build_system=cmake")
+
         depends_on("sundials+magma", when="+cuda")
 
     depends_on("mpi")


### PR DESCRIPTION
We are developing tools that are built using CMake and link against mfem. We have found it is much more convenient to have a version of mfem that's built with CMake as integration into the downstream project is much more streamlined.

This is an initial implementation of splitting the spack package into the `Package` and `Builder` components to support both build systems. So far, I have not tested all variants. I'm hoping that the mfem team has CI/CD for their spack builds and can add `build_system=cmake` to the mix to validate everything is working as expected.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
