### PR TITLE
pmix: un-deprecate pmix@3.2.3 still distributed by rhel9/rocky9

### DIFF
--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -67,11 +67,8 @@ class Pmix(AutotoolsPackage):
         sha256="145f05a6c621bfb3fc434776b615d7e6d53260cc9ba340a01f55b383e07c842e",
         deprecated=True,
     )
-    version(
-        "3.2.3",
-        sha256="9b835f23c2f94a193c14012ee68b3657a61c568598cdd1212a3716b32d41a135",
-        deprecated=True,
-    )
+    # rhel9/rocky9 still distributing pmix@3.2.3
+    version("3.2.3", sha256="9b835f23c2f94a193c14012ee68b3657a61c568598cdd1212a3716b32d41a135")
     version(
         "3.2.2",
         sha256="7e7fafe2b338dab42a94002d99330a5bb0ebbdd06381ec65953a87c94db3dd23",


### PR DESCRIPTION
Would suggest to un-deprecate pmix@3.2.3, which are still being distributed by `rhel9_5` and `rock9_4`.

I believe not only us are still using system pmix, deprecating would lead to external pmix to fail with not quite reasonable error message.

**RHEL 9.5**

```console
$ uname -r
5.14.0-503.34.1.el9_5.x86_64

$ dnf list pmix
Available Packages
pmix.i686                         3.2.3-5.el9                       rhel-9-for-x86_64-appstream-rpms
pmix.x86_64                       3.2.3-5.el9                       rhel-9-for-x86_64-appstream-rpms
```


**Rocky 9.4**

```console
$ uname -r
5.14.0-427.42.1.el9_4.x86_64

$ dnf list pmix
Available Packages
pmix.i686                           3.2.3-5.el9                         appstream 
pmix.x86_64                         3.2.3-5.el9                         appstream 
```