### PR TITLE
acts dependencies: new versions as of 2025/03/31

### DIFF
--- a/var/spack/repos/builtin/packages/acts-algebra-plugins/package.py
+++ b/var/spack/repos/builtin/packages/acts-algebra-plugins/package.py
@@ -16,6 +16,7 @@ class ActsAlgebraPlugins(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.27.0", sha256="c2081b399b7f4e004bebd5bf8250ed9596b113002fe445bca7fdac24d2c5932c")
     version("0.26.2", sha256="0170f22e1a75493b86464f27991117bc2c5a9d52554c75786e321d4c591990e7")
     version("0.26.1", sha256="8eb1e9e28ec2839d149b6a6bddd0f983b0cdf71c286c0aeb67ede31727c5b7d3")
     version("0.26.0", sha256="301702e3d0a3d12e46ae6d949f3027ddebd0b1167cbb3004d9a4a5697d3adc7f")
@@ -40,8 +41,10 @@ class ActsAlgebraPlugins(CMakePackage):
 
     depends_on("cmake@3.14:", type="build")
     depends_on("vecmem@1.5.0:", when="+vecmem")
+    depends_on("vecmem@1.14.0:", when="+vecmem @0.27:")
     depends_on("eigen@3.4.0:", when="+eigen")
     depends_on("vc@1.4.3:", when="+vc")
+    depends_on("vc@1.4.5:", when="+vc @0.27:")
     depends_on("root@6.18.0:", when="+smatrix")
     depends_on("fastor@0.6.4:", when="+fastor")
 

--- a/var/spack/repos/builtin/packages/detray/package.py
+++ b/var/spack/repos/builtin/packages/detray/package.py
@@ -19,6 +19,7 @@ class Detray(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.94.0", sha256="a04e8193757846df50d0fbec858744dd66629a98be8ffc6faa04c2ab51770492")
     version("0.93.0", sha256="7d56771d213649de836905efbb21b5be59cc966b00417b0b1fa85bfe12ac92da")
     version("0.92.0", sha256="512669c1ea51936b0fe871fb5a33450b54161e811e48cc51445dc83fe3338c42")
     version("0.91.0", sha256="6aa822f8bdc7339286d2255079a00ecc3204c0e194c5cf9d0fc5b9262c3cfb39")


### PR DESCRIPTION
This commit adds a new version of ACTS algebra plugins (v0.27.0) as well as detray (v0.94.0).