### PR TITLE
Parse `%` as `^` in specs 

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2556,7 +2556,7 @@ class SpackSolverSetup:
 
         edges = spec.edges_from_dependents()
         virtuals = [x for x in itertools.chain.from_iterable([edge.virtuals for edge in edges])]
-        if not body:
+        if not body and not spec.concrete:
             for virtual in virtuals:
                 clauses.append(fn.attr("provider_set", spec.name, virtual))
                 clauses.append(fn.attr("virtual_node", virtual))

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -550,6 +550,12 @@ error(100, "Cannot satisfy the request on {0} to have the platform set to {1}", 
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not hash_attr(BuildDependencyHash, "node_platform", BuildDependency, Platform).
 
+error(100, "Cannot satisfy the request on {0} to have the following hash {1}", BuildDependency, BuildHash)
+:- attr("build_requirement", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
+   attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
+   attr("build_requirement", ParentNode, build_requirement("hash", BuildDependency, BuildHash)),
+   BuildHash != BuildDependencyHash.
+
 % External nodes
 :- attr("build_requirement", ParentNode, build_requirement("node", BuildDependency)),
    external(ParentNode),
@@ -616,6 +622,10 @@ attr("node_os_set", node(X, BuildDependency), NodeOS) :-
 
 attr("node_platform_set", node(X, BuildDependency), NodePlatform) :-
   attr("build_requirement", ParentNode, build_requirement("node_platform_set", BuildDependency, NodePlatform)),
+  build_requirement(ParentNode, node(X, BuildDependency)).
+
+attr("hash", node(X, BuildDependency), BuildHash) :-
+  attr("build_requirement", ParentNode, build_requirement("hash", BuildDependency, BuildHash)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -576,6 +576,11 @@ attr("node_version_satisfies", node(X, BuildDependency), Constraint) :-
   attr("build_requirement", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
+attr("variant_set", node(X, BuildDependency), Variant, Value) :-
+  attr("build_requirement", ParentNode, build_requirement("variant_set", BuildDependency, Variant, Value)),
+  build_requirement(ParentNode, node(X, BuildDependency)).
+
+attr("depends_on",  node(X, Parent), node(Y, BuildDependency), "build") :- build_requirement(node(X, Parent), node(Y, BuildDependency)).
 
 1 { attr("provider_set", node(X, BuildDependency), node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1 :-
   attr("build_requirement", ParentNode, build_requirement("provider_set", BuildDependency, Virtual)),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -530,6 +530,26 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
    attr("virtual_on_build_edge", ParentNode, BuildDependency, Virtual),
    not 1 { pkg_fact(BuildDependency, version_satisfies(Constraint, Version)) : hash_attr(BuildDependencyHash, "version", BuildDependency, Version) } 1.
 
+error(100, "Cannot satisfy the request on {0} to have {1}={2}", BuildDependency, Variant, Value)
+:- attr("build_requirement", ParentNode, build_requirement("variant_set", BuildDependency, Variant, Value)),
+   attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
+   not hash_attr(BuildDependencyHash, "variant_value", BuildDependency, Variant, Value).
+
+error(100, "Cannot satisfy the request on {0} to have the target set to {1}", BuildDependency, Target)
+:- attr("build_requirement", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
+   attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
+   not hash_attr(BuildDependencyHash, "node_target", BuildDependency, Target).
+
+error(100, "Cannot satisfy the request on {0} to have the os set to {1}", BuildDependency, NodeOS)
+:- attr("build_requirement", ParentNode, build_requirement("node_os_set", BuildDependency, NodeOS)),
+   attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
+   not hash_attr(BuildDependencyHash, "node_os", BuildDependency, NodeOS).
+
+error(100, "Cannot satisfy the request on {0} to have the platform set to {1}", BuildDependency, Platform)
+:- attr("build_requirement", ParentNode, build_requirement("node_platform_set", BuildDependency, Platform)),
+   attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
+   not hash_attr(BuildDependencyHash, "node_platform", BuildDependency, Platform).
+
 % External nodes
 :- attr("build_requirement", ParentNode, build_requirement("node", BuildDependency)),
    external(ParentNode),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -576,11 +576,28 @@ attr("node_version_satisfies", node(X, BuildDependency), Constraint) :-
   attr("build_requirement", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
+% Account for properties on the build requirements
+%
+% root %gcc@12.0 <properties for gcc> ^dep
+%
 attr("variant_set", node(X, BuildDependency), Variant, Value) :-
   attr("build_requirement", ParentNode, build_requirement("variant_set", BuildDependency, Variant, Value)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 attr("depends_on",  node(X, Parent), node(Y, BuildDependency), "build") :- build_requirement(node(X, Parent), node(Y, BuildDependency)).
+
+attr("node_target_set", node(X, BuildDependency), Target) :-
+  attr("build_requirement", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
+  build_requirement(ParentNode, node(X, BuildDependency)).
+
+attr("node_os_set", node(X, BuildDependency), NodeOS) :-
+  attr("build_requirement", ParentNode, build_requirement("node_os_set", BuildDependency, NodeOS)),
+  build_requirement(ParentNode, node(X, BuildDependency)).
+
+attr("node_platform_set", node(X, BuildDependency), NodePlatform) :-
+  attr("build_requirement", ParentNode, build_requirement("node_platform_set", BuildDependency, NodePlatform)),
+  build_requirement(ParentNode, node(X, BuildDependency)).
+
 
 1 { attr("provider_set", node(X, BuildDependency), node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1 :-
   attr("build_requirement", ParentNode, build_requirement("provider_set", BuildDependency, Virtual)),

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+import platform
 import sys
 
 import jinja2
@@ -3568,9 +3569,39 @@ def test_concrete_multi_valued_variants_when_args(default_mock_concretization):
         assert not s.satisfies("^pkg-b")
 
 
-def test_variants_are_associated_with_compilers(mock_packages, mutable_config, tmp_path):
-    """Tests that % behaves as ^ for variants, i.e. that variants after %<package> are
-    associated with <package>
+@pytest.mark.usefixtures("mock_packages")
+@pytest.mark.parametrize(
+    "constraint_in_yaml,unsat_request,sat_request",
+    [
+        # Arch parts
+        pytest.param(
+            "target=x86_64",
+            "target=core2",
+            "target=x86_64",
+            marks=pytest.mark.skipif(
+                platform.machine() != "x86_64", reason="only valid for x86_64"
+            ),
+        ),
+        pytest.param(
+            "target=core2",
+            "target=x86_64",
+            "target=core2",
+            marks=pytest.mark.skipif(
+                platform.machine() != "x86_64", reason="only valid for x86_64"
+            ),
+        ),
+        ("os=debian6", "os=redhat6", "os=debian6"),
+        ("platform=test", "platform=linux", "platform=test"),
+        # Variants
+        ("~lld", "+lld", "~lld"),
+        ("+lld", "~lld", "+lld"),
+    ],
+)
+def test_spec_parts_on_compilers(
+    constraint_in_yaml, unsat_request, sat_request, mutable_config, tmp_path
+):
+    """Tests that % behaves as ^ for spec parts, i.e. that %<package> target=<target> <variants>
+    etc. is associated with <package>
     """
     packages_yaml = syaml.load_config(
         f"""
@@ -3578,20 +3609,20 @@ def test_variants_are_associated_with_compilers(mock_packages, mutable_config, t
       llvm::
         buildable: false
         externals:
-        - spec: "llvm+clang~lld@20"
+        - spec: "llvm+clang@20 {constraint_in_yaml}"
           prefix: {tmp_path / 'llvm-20'}
     """
     )
     mutable_config.set("packages", packages_yaml["packages"])
 
     # Check the abstract spec is formed correctly
-    abstract_spec = Spec("pkg-a %llvm@20 +clang +lld")
-    assert abstract_spec["llvm"].satisfies("@20 +clang +lld")
+    abstract_spec = Spec(f"pkg-a %llvm@20 +clang {unsat_request}")
+    assert abstract_spec["llvm"].satisfies(f"@20 +clang {unsat_request}")
 
     # Check that we can't concretize the spec, since llvm is not buildable
-    with pytest.raises(spack.error.SpackError):
+    with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
         spack.concretize.concretize_one(abstract_spec)
 
-    # Check we can instead concretize if we use ~lld
-    s = spack.concretize.concretize_one("pkg-a %llvm@20 +clang ~lld")
-    assert s["c"].external and s["c"].satisfies("@20 +clang ~lld")
+    # Check we can instead concretize if we use the correct constraint
+    s = spack.concretize.concretize_one(f"pkg-a %llvm@20 +clang {sat_request}")
+    assert s["c"].external and s["c"].satisfies(f"@20 +clang {sat_request}")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3600,8 +3600,9 @@ def test_concrete_multi_valued_variants_when_args(default_mock_concretization):
 def test_spec_parts_on_fresh_compilers(
     constraint_in_yaml, unsat_request, sat_request, mutable_config, tmp_path
 ):
-    """Tests that % behaves as ^ for spec parts, i.e. that %<package> target=<target> <variants>
-    etc. is associated with <package>, when we concretize without reusing.
+    """Tests that spec parts like targets and variants in `%<package> target=<target> <variants>`
+    are associated with `package` for `%` just as they would be for `^`, when we concretize
+    without reusing.
     """
     packages_yaml = syaml.load_config(
         f"""

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3566,3 +3566,32 @@ def test_concrete_multi_valued_variants_when_args(default_mock_concretization):
     for c in ("foo:=a", "foo:=a,b,c", "foo:=a,b", "foo:=a,c"):
         s = default_mock_concretization(f"mvdefaults {c}")
         assert not s.satisfies("^pkg-b")
+
+
+def test_variants_are_associated_with_compilers(mock_packages, mutable_config, tmp_path):
+    """Tests that % behaves as ^ for variants, i.e. that variants after %<package> are
+    associated with <package>
+    """
+    packages_yaml = syaml.load_config(
+        f"""
+    packages:
+      llvm::
+        buildable: false
+        externals:
+        - spec: "llvm+clang~lld@20"
+          prefix: {tmp_path / 'llvm-20'}
+    """
+    )
+    mutable_config.set("packages", packages_yaml["packages"])
+
+    # Check the abstract spec is formed correctly
+    abstract_spec = Spec("pkg-a %llvm@20 +clang +lld")
+    assert abstract_spec["llvm"].satisfies("@20 +clang +lld")
+
+    # Check that we can't concretize the spec, since llvm is not buildable
+    with pytest.raises(spack.error.SpackError):
+        spack.concretize.concretize_one(abstract_spec)
+
+    # Check we can instead concretize if we use ~lld
+    s = spack.concretize.concretize_one("pkg-a %llvm@20 +clang ~lld")
+    assert s["c"].external and s["c"].satisfies("@20 +clang ~lld")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3597,11 +3597,11 @@ def test_concrete_multi_valued_variants_when_args(default_mock_concretization):
         ("+lld", "~lld", "+lld"),
     ],
 )
-def test_spec_parts_on_compilers(
+def test_spec_parts_on_fresh_compilers(
     constraint_in_yaml, unsat_request, sat_request, mutable_config, tmp_path
 ):
     """Tests that % behaves as ^ for spec parts, i.e. that %<package> target=<target> <variants>
-    etc. is associated with <package>
+    etc. is associated with <package>, when we concretize without reusing.
     """
     packages_yaml = syaml.load_config(
         f"""
@@ -3626,3 +3626,73 @@ def test_spec_parts_on_compilers(
     # Check we can instead concretize if we use the correct constraint
     s = spack.concretize.concretize_one(f"pkg-a %llvm@20 +clang {sat_request}")
     assert s["c"].external and s["c"].satisfies(f"@20 +clang {sat_request}")
+
+
+@pytest.mark.usefixtures("mock_packages", "mutable_database")
+@pytest.mark.parametrize(
+    "constraint_in_yaml,unsat_request,sat_request",
+    [
+        # Arch parts
+        pytest.param(
+            "target=x86_64",
+            "target=core2",
+            "target=x86_64",
+            marks=pytest.mark.skipif(
+                platform.machine() != "x86_64", reason="only valid for x86_64"
+            ),
+        ),
+        pytest.param(
+            "target=core2",
+            "target=x86_64",
+            "target=core2",
+            marks=pytest.mark.skipif(
+                platform.machine() != "x86_64", reason="only valid for x86_64"
+            ),
+        ),
+        ("os=debian6", "os=redhat6", "os=debian6"),
+        ("platform=test", "platform=linux", "platform=test"),
+        # Variants
+        ("~lld", "+lld", "~lld"),
+        ("+lld", "~lld", "+lld"),
+    ],
+)
+def test_spec_parts_on_reused_compilers(
+    constraint_in_yaml, unsat_request, sat_request, mutable_config, tmp_path
+):
+    """Tests that requests of the form <package>%<compiler> <requests> are considered for reused
+    specs, even though build dependency are not part of the ASP problem.
+    """
+    packages_yaml = syaml.load_config(
+        f"""
+    packages:
+      c:
+        require: llvm
+      cxx:
+        require: llvm
+      llvm::
+        buildable: false
+        externals:
+        - spec: "llvm+clang@20 {constraint_in_yaml}"
+          prefix: {tmp_path / 'llvm-20'}
+      mpileaks:
+        buildable: true
+    """
+    )
+    mutable_config.set("packages", packages_yaml["packages"])
+
+    # Install the spec
+    installed_spec = spack.concretize.concretize_one(f"mpileaks %llvm@20 {sat_request}")
+    PackageInstaller([installed_spec.package], fake=True, explicit=True).install()
+
+    # Make mpileaks not buildable
+    mutable_config.set("packages:mpileaks:buildable", False)
+
+    # Check we can't concretize with the unsat request...
+    with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
+        spack.concretize.concretize_one(f"mpileaks %llvm@20 {unsat_request}")
+
+    # ...but we can with the original constraint
+    with spack.config.override("concretizer:reuse", True):
+        s = spack.concretize.concretize_one(f"mpileaks %llvm@20 {sat_request}")
+
+    assert s.dag_hash() == installed_spec.dag_hash()

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3696,3 +3696,14 @@ def test_spec_parts_on_reused_compilers(
         s = spack.concretize.concretize_one(f"mpileaks %llvm@20 {sat_request}")
 
     assert s.dag_hash() == installed_spec.dag_hash()
+
+
+def test_use_compiler_by_hash(mock_packages, mutable_database, mutable_config):
+    """Tests that we can reuse an installed compiler specifying its hash"""
+    installed_spec = spack.concretize.concretize_one("gcc@14.0")
+    PackageInstaller([installed_spec.package], fake=True, explicit=True).install()
+
+    with spack.config.override("concretizer:reuse", True):
+        s = spack.concretize.concretize_one(f"mpileaks %gcc/{installed_spec.dag_hash()}")
+
+    assert s["c"].dag_hash() == installed_spec.dag_hash()

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -163,15 +163,14 @@ packages:
     if cmp_flags:
         compiler_spec = "%gcc@12.100.100"
 
+    cmd_flags_str = f'cflags="{cmd_flags}"' if cmd_flags else ""
+
     if dflags:
-        spec_str = f"x+activatemultiflag {compiler_spec} ^y"
+        spec_str = f"x+activatemultiflag {compiler_spec} ^y {cmd_flags_str}"
         expected_dflags = "-d1 -d2"
     else:
-        spec_str = f"y {compiler_spec}"
+        spec_str = f"y {cmd_flags_str} {compiler_spec}"
         expected_dflags = None
-
-    if cmd_flags:
-        spec_str += f' cflags="{cmd_flags}"'
 
     root_spec = spack.concretize.concretize_one(spec_str)
     spec = root_spec["y"]
@@ -277,6 +276,6 @@ def test_flag_injection_different_compilers(mock_packages, mutable_config):
     """Tests that flag propagation is not activated on nodes with a compiler that is different
     from the propagation source.
     """
-    s = spack.concretize.concretize_one('mpileaks %gcc cflags=="-O2" ^callpath %llvm')
+    s = spack.concretize.concretize_one('mpileaks cflags=="-O2" %gcc ^callpath %llvm')
     assert s.satisfies('cflags="-O2"') and s["c"].name == "gcc"
     assert not s["callpath"].satisfies('cflags="-O2"') and s["callpath"]["c"].name == "llvm"

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -137,7 +137,14 @@ class TestSpecList:
         expected_components = itertools.product(
             ["zlib", "libelf"], ["%gcc", "%intel"], ["+shared", "~shared"]
         )
-        expected = [Spec(" ".join(combo)) for combo in expected_components]
+
+        def _reduce(*, combo):
+            root = Spec(combo[0])
+            for x in combo[1:]:
+                root.constrain(x)
+            return root
+
+        expected = [_reduce(combo=combo) for combo in expected_components]
         assert set(result.specs) == set(expected)
 
     @pytest.mark.regression("16897")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -725,6 +725,18 @@ def specfile_for(default_mock_concretization):
             ],
             "gcc languages:=='c,c++'",
         ),
+        # test <variants> etc. after %
+        (
+            "mvapich %gcc languages:=c,c++ target=x86_64",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "mvapich"),
+                Token(SpecTokens.DEPENDENCY, "%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "gcc"),
+                Token(SpecTokens.KEY_VALUE_PAIR, "languages:=c,c++"),
+                Token(SpecTokens.KEY_VALUE_PAIR, "target=x86_64"),
+            ],
+            "mvapich %gcc languages:='c,c++' arch=None-None-x86_64",
+        ),
     ],
 )
 def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_package):
@@ -786,6 +798,22 @@ def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_p
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="intel"),
             ],
             ['mvapich cflags="-O3 -fPIC"', "emacs ^ncurses%intel"],
+        ),
+        (
+            "mvapich %gcc languages=c,c++ emacs ^ncurses%gcc languages:=c",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="mvapich"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="languages=c,c++"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="emacs"),
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="ncurses"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="languages:=c"),
+            ],
+            ["mvapich %gcc languages=c,c++", "emacs ^ncurses%gcc languages:=c"],
         ),
     ],
 )

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -51,10 +51,6 @@ def dependency_with_version(text):
     )
 
 
-def compiler_with_version_range(text):
-    return text, [Token(SpecTokens.COMPILER_AND_VERSION, value=text)], text
-
-
 @pytest.fixture()
 def specfile_for(default_mock_concretization):
     def _specfile_for(spec_str, filename):
@@ -84,7 +80,6 @@ def specfile_for(default_mock_concretization):
         simple_package_name("3dtk"),
         simple_package_name("ns-3-dev"),
         # Single token anonymous specs
-        ("%intel", [Token(SpecTokens.COMPILER, value="%intel")], "%intel"),
         ("@2.7", [Token(SpecTokens.VERSION, value="@2.7")], "@2.7"),
         ("@2.7:", [Token(SpecTokens.VERSION, value="@2.7:")], "@2.7:"),
         ("@:2.7", [Token(SpecTokens.VERSION, value="@:2.7")], "@:2.7"),
@@ -97,6 +92,14 @@ def specfile_for(default_mock_concretization):
             "arch=test-None-None",
         ),
         # Multiple tokens anonymous specs
+        (
+            "%intel",
+            [
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "intel"),
+            ],
+            "%intel",
+        ),
         (
             "languages=go @4.2:",
             [
@@ -159,7 +162,9 @@ def specfile_for(default_mock_concretization):
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="foo"),
                 Token(SpecTokens.VERSION, value="@2.0"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%bar@1.0"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="bar"),
+                Token(SpecTokens.VERSION, value="@1.0"),
             ],
             "foo@2.0 %bar@1.0",
         ),
@@ -178,7 +183,9 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.VERSION, value="@1.2:1.4,1.6"),
                 Token(SpecTokens.BOOL_VARIANT, value="+debug"),
                 Token(SpecTokens.BOOL_VARIANT, value="~qt_4"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="intel"),
+                Token(SpecTokens.VERSION, value="@12.1"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="stackwalker"),
                 Token(SpecTokens.VERSION, value="@8.1_1e"),
@@ -194,7 +201,9 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.VERSION, value="@1.2:1.4,1.6"),
                 Token(SpecTokens.BOOL_VARIANT, value="~qt_4"),
                 Token(SpecTokens.KEY_VALUE_PAIR, value="debug=2"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="intel"),
+                Token(SpecTokens.VERSION, value="@12.1"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="stackwalker"),
                 Token(SpecTokens.VERSION, value="@8.1_1e"),
@@ -212,7 +221,9 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.KEY_VALUE_PAIR, value="cppflags=-O3"),
                 Token(SpecTokens.BOOL_VARIANT, value="+debug"),
                 Token(SpecTokens.BOOL_VARIANT, value="~qt_4"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="intel"),
+                Token(SpecTokens.VERSION, value="@12.1"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="stackwalker"),
                 Token(SpecTokens.VERSION, value="@8.1_1e"),
@@ -226,7 +237,9 @@ def specfile_for(default_mock_concretization):
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="yaml-cpp"),
                 Token(SpecTokens.VERSION, value="@0.1.8"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%intel@12.1"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="intel"),
+                Token(SpecTokens.VERSION, value="@12.1"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="boost"),
                 Token(SpecTokens.VERSION, value="@3.1.4"),
@@ -237,7 +250,8 @@ def specfile_for(default_mock_concretization):
             r"builtin.yaml-cpp%gcc",
             [
                 Token(SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME, value="builtin.yaml-cpp"),
-                Token(SpecTokens.COMPILER, value="%gcc"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
             ],
             "yaml-cpp %gcc",
         ),
@@ -245,7 +259,8 @@ def specfile_for(default_mock_concretization):
             r"testrepo.yaml-cpp%gcc",
             [
                 Token(SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME, value="testrepo.yaml-cpp"),
-                Token(SpecTokens.COMPILER, value="%gcc"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
             ],
             "yaml-cpp %gcc",
         ),
@@ -254,7 +269,9 @@ def specfile_for(default_mock_concretization):
             [
                 Token(SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME, value="builtin.yaml-cpp"),
                 Token(SpecTokens.VERSION, value="@0.1.8"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="%gcc@7.2.0"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.VERSION, value="@7.2.0"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="boost"),
                 Token(SpecTokens.VERSION, value="@3.1.4"),
@@ -419,11 +436,51 @@ def specfile_for(default_mock_concretization):
             f"develop-branch-version@git.{'a' * 40}=develop+var1+var2",
         ),
         # Compiler with version ranges
-        compiler_with_version_range("%gcc@10.2.1:"),
-        compiler_with_version_range("%gcc@:10.2.1"),
-        compiler_with_version_range("%gcc@10.2.1:12.1.0"),
-        compiler_with_version_range("%gcc@10.1.0,12.2.1:"),
-        compiler_with_version_range("%gcc@:8.4.3,10.2.1:12.1.0"),
+        (
+            "%gcc@10.2.1:",
+            [
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.VERSION, value="@10.2.1:"),
+            ],
+            "%gcc@10.2.1:",
+        ),
+        (
+            "%gcc@:10.2.1",
+            [
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.VERSION, value="@:10.2.1"),
+            ],
+            "%gcc@:10.2.1",
+        ),
+        (
+            "%gcc@10.2.1:12.1.0",
+            [
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.VERSION, value="@10.2.1:12.1.0"),
+            ],
+            "%gcc@10.2.1:12.1.0",
+        ),
+        (
+            "%gcc@10.1.0,12.2.1:",
+            [
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.VERSION, value="@10.1.0,12.2.1:"),
+            ],
+            "%gcc@10.1.0,12.2.1:",
+        ),
+        (
+            "%gcc@:8.4.3,10.2.1:12.1.0",
+            [
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.VERSION, value="@:8.4.3,10.2.1:12.1.0"),
+            ],
+            "%gcc@:8.4.3,10.2.1:12.1.0",
+        ),
         # Special key value arguments
         ("dev_path=*", [Token(SpecTokens.KEY_VALUE_PAIR, value="dev_path=*")], "dev_path='*'"),
         (
@@ -484,7 +541,9 @@ def specfile_for(default_mock_concretization):
             "+ debug % intel @ 12.1:12.6",
             [
                 Token(SpecTokens.BOOL_VARIANT, value="+ debug"),
-                Token(SpecTokens.COMPILER_AND_VERSION, value="% intel @ 12.1:12.6"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="intel"),
+                Token(SpecTokens.VERSION, value="@ 12.1:12.6"),
             ],
             "+debug %intel@12.1:12.6",
         ),
@@ -509,7 +568,8 @@ def specfile_for(default_mock_concretization):
             "@:0.4 % nvhpc",
             [
                 Token(SpecTokens.VERSION, value="@:0.4"),
-                Token(SpecTokens.COMPILER, value="% nvhpc"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="nvhpc"),
             ],
             "@:0.4 %nvhpc",
         ),
@@ -602,7 +662,10 @@ def specfile_for(default_mock_concretization):
             "zlib %[virtuals=c] gcc",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib"),
-                Token(SpecTokens.COMPILER_WITH_VIRTUALS, "%[virtuals=c] gcc"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="virtuals=c"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
             ],
             "zlib %[virtuals=c] gcc",
         ),
@@ -610,7 +673,10 @@ def specfile_for(default_mock_concretization):
             "zlib %[virtuals=c,cxx] gcc",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib"),
-                Token(SpecTokens.COMPILER_WITH_VIRTUALS, "%[virtuals=c,cxx] gcc"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="virtuals=c,cxx"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
             ],
             "zlib %[virtuals=c,cxx] gcc",
         ),
@@ -618,7 +684,11 @@ def specfile_for(default_mock_concretization):
             "zlib %[virtuals=c,cxx] gcc@14.1",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib"),
-                Token(SpecTokens.COMPILER_AND_VERSION_WITH_VIRTUALS, "%[virtuals=c,cxx] gcc@14.1"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="virtuals=c,cxx"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.VERSION, value="@14.1"),
             ],
             "zlib %[virtuals=c,cxx] gcc@14.1",
         ),
@@ -626,10 +696,15 @@ def specfile_for(default_mock_concretization):
             "zlib %[virtuals=fortran] gcc@14.1 %[virtuals=c,cxx] clang",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib"),
-                Token(
-                    SpecTokens.COMPILER_AND_VERSION_WITH_VIRTUALS, "%[virtuals=fortran] gcc@14.1"
-                ),
-                Token(SpecTokens.COMPILER_WITH_VIRTUALS, "%[virtuals=c,cxx] clang"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="virtuals=fortran"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.VERSION, value="@14.1"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="virtuals=c,cxx"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="clang"),
             ],
             "zlib %[virtuals=fortran] gcc@14.1 %[virtuals=c,cxx] clang",
         ),
@@ -694,7 +769,8 @@ def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_p
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="emacs"),
                 Token(SpecTokens.VERSION, value="@1.1.1"),
                 Token(SpecTokens.KEY_VALUE_PAIR, value="cflags=-O3"),
-                Token(SpecTokens.COMPILER, value="%intel"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="intel"),
             ],
             ["mvapich", "emacs @1.1.1 cflags=-O3 %intel"],
         ),
@@ -706,7 +782,8 @@ def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_p
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="emacs"),
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="ncurses"),
-                Token(SpecTokens.COMPILER, value="%intel"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="intel"),
             ],
             ['mvapich cflags="-O3 -fPIC"', "emacs ^ncurses%intel"],
         ),

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2935,7 +2935,7 @@ complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -d 'spec
 complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -f -a skip
 complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -d 'specify tools to skip (choose from import, isort, black, flake8, mypy)'
 complete -c spack -n '__fish_spack_using_command style' -l spec-strings -f -a spec_strings
-complete -c spack -n '__fish_spack_using_command style' -l spec-strings -d 'upgrade spec strings in Python, JSON and YAML files for compatibility with Spack v1.0 and v0.x. Example: spack style --spec-strings $(git ls-files). Note: this flag will be removed in Spack v1.0.'
+complete -c spack -n '__fish_spack_using_command style' -l spec-strings -d 'upgrade spec strings in Python, JSON and YAML files for compatibility with Spack v1.0 and v0.x. Example: spack style --spec-strings $(git ls-files). Note: must be used only on specs from spack v0.X.'
 
 # spack tags
 set -g __fish_spack_optspecs_spack_tags h/help i/installed a/all

--- a/var/spack/test_repos/builtin.mock/packages/llvm/package.py
+++ b/var/spack/test_repos/builtin.mock/packages/llvm/package.py
@@ -17,6 +17,7 @@ class Llvm(Package, CompilerPackage):
     variant(
         "clang", default=True, description="Build the LLVM C/C++/Objective-C compiler frontend"
     )
+    variant("lld", default=True, description="Build the LLVM linker")
 
     provides("c", "cxx", when="+clang")
 


### PR DESCRIPTION
This PR modifies the parser, so that `%` is parsed as a `DEPENDENCY`, and all node properties that follow are associated to the name after the `%`. e.g., in `foo %gcc +binutils` the `+binutils` refers to `gcc` and not to `foo`.

`%` is still parsed as a build-type dependency, at the moment.

Environments, config files and `package.py` files from before Spack v1.0 may have spec strings with package variants, targets, etc. *after* a build dependency, and these will need to be updated. You can use the `spack style --spec-strings` command to do this.

To see what strings will be parsed differently under Spack v1.0, run:

```
spack style --spec-strings FILES
```

where `FILES` is a list of filenames that may contain old specs. To update these spec strings so that they parse correctly under both Spack 1.0 and Spack 0.x, you can run:

```
spack style --fix --spec-strings FILES
```

In the example above, `foo %gcc +binutils` would be rewritten as `foo +binutils %gcc`,
which parses the same in any Spack version.

In addition, this PR fixes several issues with `%` dependencies:

- [x] Ensure we can still constrain compilers on reuse
- [x] Ensure we can reuse a compiler by hash
- [x] Add tests