### PR TITLE
spec.to_dict: round trip whether deps are direct

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -766,7 +766,7 @@ class Database:
             spec_node_dict = spec_node_dict[spec.name]
         if "dependencies" in spec_node_dict:
             yaml_deps = spec_node_dict["dependencies"]
-            for dname, dhash, dtypes, _, virtuals in spec_reader.read_specfile_dep_specs(
+            for dname, dhash, dtypes, _, virtuals, direct in spec_reader.read_specfile_dep_specs(
                 yaml_deps
             ):
                 # It is important that we always check upstream installations in the same order,
@@ -785,7 +785,9 @@ class Database:
                     )
                     continue
 
-                spec._add_dependency(child, depflag=dt.canonicalize(dtypes), virtuals=virtuals)
+                spec._add_dependency(
+                    child, depflag=dt.canonicalize(dtypes), virtuals=virtuals, direct=direct
+                )
 
     def _read_from_file(self, filename: pathlib.Path, *, reindex: bool = False) -> None:
         """Fill database from file, do not maintain old data.

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -543,14 +543,6 @@ compiled. The compiler-wrapper is explicitly represented as a node in the DAG, a
         },
       }
     }
-
-Version 7
----------
-
-Version 7 does not change the lockfile format itself, but reflects
-a change in the specfile format. This adds the ``direct`` key for
-direct dependency edges. These are not relevant for environment
-behavior and merely require a change of specfile reader.
 """
 
 from .environment import (

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -544,6 +544,13 @@ compiled. The compiler-wrapper is explicitly represented as a node in the DAG, a
       }
     }
 
+Version 7
+---------
+
+Version 7 does not change the lockfile format itself, but reflects
+a change in the specfile format. This adds the ``direct`` key for
+direct dependency edges. These are not relevant for environment
+behavior and merely require a change of specfile reader.
 """
 
 from .environment import (

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -129,7 +129,7 @@ spack:
 valid_environment_name_re = r"^\w[\w-]*$"
 
 #: version of the lockfile format. Must increase monotonically.
-lockfile_format_version = 7
+lockfile_format_version = 6
 
 
 READER_CLS = {
@@ -139,7 +139,6 @@ READER_CLS = {
     4: spack.spec.SpecfileV3,
     5: spack.spec.SpecfileV4,
     6: spack.spec.SpecfileV5,
-    7: spack.spec.SpecfileV6,
 }
 
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -129,7 +129,7 @@ spack:
 valid_environment_name_re = r"^\w[\w-]*$"
 
 #: version of the lockfile format. Must increase monotonically.
-lockfile_format_version = 6
+lockfile_format_version = 7
 
 
 READER_CLS = {
@@ -139,6 +139,7 @@ READER_CLS = {
     4: spack.spec.SpecfileV3,
     5: spack.spec.SpecfileV4,
     6: spack.spec.SpecfileV5,
+    7: spack.spec.SpecfileV6,
 }
 
 
@@ -2261,9 +2262,14 @@ class Environment:
         # and add them to the spec, including build specs
         for lockfile_key, node_dict in json_specs_by_hash.items():
             name, data = reader.name_and_data(node_dict)
-            for _, dep_hash, deptypes, _, virtuals in reader.dependencies_from_node_dict(data):
+            for _, dep_hash, deptypes, _, virtuals, direct in reader.dependencies_from_node_dict(
+                data
+            ):
                 specs_by_hash[lockfile_key]._add_dependency(
-                    specs_by_hash[dep_hash], depflag=dt.canonicalize(deptypes), virtuals=virtuals
+                    specs_by_hash[dep_hash],
+                    depflag=dt.canonicalize(deptypes),
+                    virtuals=virtuals,
+                    direct=direct,
                 )
 
             if "build_spec" in node_dict:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -186,7 +186,7 @@ CLEARSIGN_FILE_REGEX = re.compile(
 )
 
 #: specfile format version. Must increase monotonically
-SPECFILE_FORMAT_VERSION = 6
+SPECFILE_FORMAT_VERSION = 5
 
 
 class InstallStatus(enum.Enum):
@@ -2779,10 +2779,8 @@ class Spec:
             spec = SpecfileV3.load(data)
         elif int(data["spec"]["_meta"]["version"]) == 4:
             spec = SpecfileV4.load(data)
-        elif int(data["spec"]["_meta"]["version"]) == 5:
-            spec = SpecfileV5.load(data)
         else:
-            spec = SpecfileV6.load(data)
+            spec = SpecfileV5.load(data)
 
         # Any git version should
         for s in spec.traverse():
@@ -5292,22 +5290,18 @@ class SpecfileV5(SpecfileV4):
     def legacy_compiler(cls, node):
         raise RuntimeError("The 'compiler' option is unexpected in specfiles at v5 or greater")
 
-
-class SpecfileV6(SpecfileV5):
-    SPEC_VERSION = 6
-
     @classmethod
     def extract_info_from_dep(cls, elt, hash):
         dep_hash = elt[hash.name]
         deptypes = elt["parameters"]["deptypes"]
         hash_type = hash.name
         virtuals = elt["parameters"]["virtuals"]
-        direct = elt["parameters"]["direct"]
+        direct = elt["parameters"].get("direct", True)
         return dep_hash, deptypes, hash_type, virtuals, direct
 
 
 #: Alias to the latest version of specfiles
-SpecfileLatest = SpecfileV6
+SpecfileLatest = SpecfileV5
 
 
 class LazySpecCache(collections.defaultdict):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2427,19 +2427,22 @@ class Spec:
         # Note: Relies on sorting dict by keys later in algorithm.
         deps = self._dependencies_dict(depflag=hash.depflag)
         if deps:
-            d["dependencies"] = [
-                {
-                    "name": name,
-                    hash.name: dspec.spec._cached_hash(hash),
-                    "parameters": {
-                        "deptypes": dt.flag_to_tuple(dspec.depflag),
-                        "virtuals": dspec.virtuals,
-                        "direct": dspec.direct,
-                    },
-                }
-                for name, edges_for_name in sorted(deps.items())
-                for dspec in edges_for_name
-            ]
+            dependencies = []
+            for name, edges_for_name in sorted(deps.items()):
+                for dspec in edges_for_name:
+                    dep_attrs = {
+                        "name": name,
+                        hash.name: dspec.spec._cached_hash(hash),
+                        "parameters": {
+                            "deptypes": dt.flag_to_tuple(dspec.depflag),
+                            "virtuals": dspec.virtuals,
+                        },
+                    }
+                    if dspec.direct:
+                        dep_attrs["parameters"]["direct"] = True
+                    dependencies.append(dep_attrs)
+
+            d["dependencies"] = dependencies
 
         # Name is included in case this is replacing a virtual.
         if self._build_spec:
@@ -5296,7 +5299,7 @@ class SpecfileV5(SpecfileV4):
         deptypes = elt["parameters"]["deptypes"]
         hash_type = hash.name
         virtuals = elt["parameters"]["virtuals"]
-        direct = elt["parameters"].get("direct", True)
+        direct = elt["parameters"].get("direct", False)
         return dep_hash, deptypes, hash_type, virtuals, direct
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2735,7 +2735,7 @@ class Spec:
                 return name, depflag
 
             def spec_and_dependency_types(
-                s: Union[Spec, Tuple[Spec, str]]
+                s: Union[Spec, Tuple[Spec, str]],
             ) -> Tuple[Spec, dt.DepFlag]:
                 """Given a non-string key in the literal, extracts the spec
                 and its dependency types.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -186,7 +186,7 @@ CLEARSIGN_FILE_REGEX = re.compile(
 )
 
 #: specfile format version. Must increase monotonically
-SPECFILE_FORMAT_VERSION = 5
+SPECFILE_FORMAT_VERSION = 6
 
 
 class InstallStatus(enum.Enum):
@@ -2434,6 +2434,7 @@ class Spec:
                     "parameters": {
                         "deptypes": dt.flag_to_tuple(dspec.depflag),
                         "virtuals": dspec.virtuals,
+                        "direct": dspec.direct,
                     },
                 }
                 for name, edges_for_name in sorted(deps.items())
@@ -2734,7 +2735,7 @@ class Spec:
                 return name, depflag
 
             def spec_and_dependency_types(
-                s: Union[Spec, Tuple[Spec, str]],
+                s: Union[Spec, Tuple[Spec, str]]
             ) -> Tuple[Spec, dt.DepFlag]:
                 """Given a non-string key in the literal, extracts the spec
                 and its dependency types.
@@ -2778,8 +2779,10 @@ class Spec:
             spec = SpecfileV3.load(data)
         elif int(data["spec"]["_meta"]["version"]) == 4:
             spec = SpecfileV4.load(data)
-        else:
+        elif int(data["spec"]["_meta"]["version"]) == 5:
             spec = SpecfileV5.load(data)
+        else:
+            spec = SpecfileV6.load(data)
 
         # Any git version should
         for s in spec.traverse():
@@ -5082,7 +5085,7 @@ class SpecfileReaderBase:
 
         # Pass 0: Determine hash type
         for node in nodes:
-            for _, _, _, dhash_type, _ in cls.dependencies_from_node_dict(node):
+            for _, _, _, dhash_type, _, _ in cls.dependencies_from_node_dict(node):
                 any_deps = True
                 if dhash_type:
                     hash_type = dhash_type
@@ -5113,11 +5116,12 @@ class SpecfileReaderBase:
         # Pass 2: Finish construction of all DAG edges (including build specs)
         for node_hash, node in hash_dict.items():
             node_spec = node["node_spec"]
-            for _, dhash, dtype, _, virtuals in cls.dependencies_from_node_dict(node):
+            for _, dhash, dtype, _, virtuals, direct in cls.dependencies_from_node_dict(node):
                 node_spec._add_dependency(
                     hash_dict[dhash]["node_spec"],
                     depflag=dt.canonicalize(dtype),
                     virtuals=virtuals,
+                    direct=direct,
                 )
             if "build_spec" in node.keys():
                 _, bhash, _ = cls.extract_build_spec_info_from_node_dict(node, hash_type=hash_type)
@@ -5158,9 +5162,9 @@ class SpecfileV1(SpecfileReaderBase):
         for node in nodes:
             # get dependency dict from the node.
             name, data = cls.name_and_data(node)
-            for dname, _, dtypes, _, virtuals in cls.dependencies_from_node_dict(data):
+            for dname, _, dtypes, _, virtuals, direct in cls.dependencies_from_node_dict(data):
                 deps[name]._add_dependency(
-                    deps[dname], depflag=dt.canonicalize(dtypes), virtuals=virtuals
+                    deps[dname], depflag=dt.canonicalize(dtypes), virtuals=virtuals, direct=direct
                 )
 
         reconstruct_virtuals_on_edges(result)
@@ -5198,7 +5202,7 @@ class SpecfileV1(SpecfileReaderBase):
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
             else:
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
-            yield dep_name, dep_hash, list(deptypes), hash_type, list(virtuals)
+            yield dep_name, dep_hash, list(deptypes), hash_type, list(virtuals), True
 
 
 class SpecfileV2(SpecfileReaderBase):
@@ -5235,13 +5239,15 @@ class SpecfileV2(SpecfileReaderBase):
                 # new format: elements of dependency spec are keyed.
                 for h in ht.HASHES:
                     if h.name in elt:
-                        dep_hash, deptypes, hash_type, virtuals = cls.extract_info_from_dep(elt, h)
+                        dep_hash, deptypes, hash_type, virtuals, direct = (
+                            cls.extract_info_from_dep(elt, h)
+                        )
                         break
                 else:  # We never determined a hash type...
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
             else:
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
-            result.append((dep_name, dep_hash, list(deptypes), hash_type, list(virtuals)))
+            result.append((dep_name, dep_hash, list(deptypes), hash_type, list(virtuals), direct))
         return result
 
     @classmethod
@@ -5249,7 +5255,8 @@ class SpecfileV2(SpecfileReaderBase):
         dep_hash, deptypes = elt[hash.name], elt["type"]
         hash_type = hash.name
         virtuals = []
-        return dep_hash, deptypes, hash_type, virtuals
+        direct = True
+        return dep_hash, deptypes, hash_type, virtuals, direct
 
     @classmethod
     def extract_build_spec_info_from_node_dict(cls, node, hash_type=ht.dag_hash.name):
@@ -5270,7 +5277,8 @@ class SpecfileV4(SpecfileV2):
         deptypes = elt["parameters"]["deptypes"]
         hash_type = hash.name
         virtuals = elt["parameters"]["virtuals"]
-        return dep_hash, deptypes, hash_type, virtuals
+        direct = True
+        return dep_hash, deptypes, hash_type, virtuals, direct
 
     @classmethod
     def load(cls, data):
@@ -5285,8 +5293,21 @@ class SpecfileV5(SpecfileV4):
         raise RuntimeError("The 'compiler' option is unexpected in specfiles at v5 or greater")
 
 
+class SpecfileV6(SpecfileV5):
+    SPEC_VERSION = 6
+
+    @classmethod
+    def extract_info_from_dep(cls, elt, hash):
+        dep_hash = elt[hash.name]
+        deptypes = elt["parameters"]["deptypes"]
+        hash_type = hash.name
+        virtuals = elt["parameters"]["virtuals"]
+        direct = elt["parameters"]["direct"]
+        return dep_hash, deptypes, hash_type, virtuals, direct
+
+
 #: Alias to the latest version of specfiles
-SpecfileLatest = SpecfileV5
+SpecfileLatest = SpecfileV6
 
 
 class LazySpecCache(collections.defaultdict):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -496,6 +496,10 @@ e: *id002
         "hdf5~~mpi++shared",
         "hdf5 cflags==-g foo==bar cxxflags==-O3",
         "hdf5 cflags=-g foo==bar cxxflags==-O3",
+        "hdf5%gcc",
+        "hdf5%cmake",
+        "hdf5^gcc",
+        "hdf5^cmake",
     ],
 )
 def test_pickle_roundtrip_for_abstract_specs(spec_str):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -519,3 +519,25 @@ def test_specfile_alias_is_updated():
     specfile_class_name = f"SpecfileV{spack.spec.SPECFILE_FORMAT_VERSION}"
     specfile_cls = getattr(spack.spec, specfile_class_name)
     assert specfile_cls is spack.spec.SpecfileLatest
+
+
+@pytest.mark.parametrize("spec_str", ["mpileaks %gcc", "mpileaks ^zmpi ^callpath%gcc"])
+def test_direct_edges_and_round_tripping_to_dict(spec_str, default_mock_concretization):
+    """Tests that we preserve edge information when round-tripping to dict"""
+    original = Spec(spec_str)
+    reconstructed = Spec.from_dict(original.to_dict())
+    assert original == reconstructed
+    assert original.to_dict() == reconstructed.to_dict()
+
+    concrete = default_mock_concretization(spec_str)
+    concrete_reconstructed = Spec.from_dict(concrete.to_dict())
+    assert concrete == concrete_reconstructed
+    assert concrete.to_dict() == concrete_reconstructed.to_dict()
+
+    # Ensure we don't get 'direct' in concrete JSON specs, for the time being
+    d = concrete.to_dict()
+    for node in d["spec"]["nodes"]:
+        if "dependencies" not in node:
+            continue
+        for dependency_data in node["dependencies"]:
+            assert "direct" not in dependency_data["parameters"]


### PR DESCRIPTION
Fixes #49799

Modify the specfile format to include information about which dependencies are direct. This only affects abstract specs, as all dependencies on concrete specs are direct.

Older formats are used only for concrete specs, so all edges are read as direct.
