### PR TITLE
slepc, py-slepc4py, petsc, py-petsc4py  add v3.23.0

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -20,6 +20,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("main", branch="main")
+    version("3.23.0", sha256="aeebd7094f4d583fd04700e73779caa7d9a3d54742e95eff2c3dd87768a79063")
+    version("3.22.5", sha256="984dba48bd26e7b17d42c078fc4f74d59e9cbc437ee25a8635865eeca9f5dd28")
     version("3.22.4", sha256="c32e9c606b858ff587949ddc5f28da8934b00c41ab1f6d9be5001a705bef62ee")
     version("3.22.3", sha256="88c0d465a3bd688cb17ebf06a17c06d6e9cc457fa6b9643d217389424e6bd795")
     version("3.22.2", sha256="83624de0178b42d37ca1f7f905e1093556c6919fe5accd3e9f11d00a66e11256")

--- a/var/spack/repos/builtin/packages/py-petsc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-petsc4py/package.py
@@ -19,6 +19,8 @@ class PyPetsc4py(PythonPackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
+    version("3.23.0", sha256="3be542580763419750cdc67dc6515bae338320dbb53403f0af7ab5c8a948bf4e")
+    version("3.22.5", sha256="058478cdba163e162d17ad14a8f71d519049a7c84807cd33a14c7f852988ec2e")
     version("3.22.4", sha256="c7bd4dee211bc651217ae2732c56afacd8ac349320049cdfaa2131d7621e6d09")
     version("3.22.3", sha256="7ed43cd027f82033e70f53c99fb530713dab743869d0c0827d22bbd5fb651c43")
     version("3.22.2", sha256="6c56f62ae8819069062436d362a2cc7e44f700026eed72a903c3803afbe59fc3")
@@ -111,6 +113,7 @@ class PyPetsc4py(PythonPackage):
     depends_on("petsc~mpi", when="~mpi")
     depends_on("petsc@main", when="@main")
     for ver in [
+        "3.23",
         "3.22",
         "3.21",
         "3.20",

--- a/var/spack/repos/builtin/packages/py-slepc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-slepc4py/package.py
@@ -17,6 +17,7 @@ class PySlepc4py(PythonPackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
+    version("3.23.0", sha256="cc00cfd02bf302363adf03404bdcf6d8d4f1b9448cb28d4305eef3e88ddd9059")
     version("3.22.2", sha256="bd34d5560a36bafd81a0f071aca03a9fac140c6167b1b8a2f2e580b69a2a3255")
     version("3.22.1", sha256="056d98bf09f5202d25842d5a4a4f553445103e1e26155da52f007c508f3140f8")
     version("3.22.0", sha256="53db52a72e126787768732790ca73dbc6ff6e49d4d1152e9c3641ba71b97738e")
@@ -70,6 +71,7 @@ class PySlepc4py(PythonPackage):
     depends_on("py-petsc4py@main", when="@main", type=("build", "run"))
     depends_on("slepc@main", when="@main")
     for ver in [
+        "3.23",
         "3.22",
         "3.21",
         "3.20",

--- a/var/spack/repos/builtin/packages/slepc/package.py
+++ b/var/spack/repos/builtin/packages/slepc/package.py
@@ -21,6 +21,7 @@ class Slepc(Package, CudaPackage, ROCmPackage):
     test_requires_compiler = True
 
     version("main", branch="main")
+    version("3.23.0", sha256="78252f7b2f540c5fdadadee0fd21f3e6eff810f82cb45482f327b524c8db63d0")
     version("3.22.2", sha256="b60e58b2fa5eb7db05ce5e3a585811b43b1cc7cf89c32266e37b05f0cefd8899")
     version("3.22.1", sha256="badb5cb038d09dbf1cc8f34d194673ab011c69cc46888101955c786d21c8d8c9")
     version("3.22.0", sha256="45eb4d085875b50108c91fd9168ed17bc9158cc3b1e530ac843b26d9981c3db0")
@@ -121,6 +122,7 @@ class Slepc(Package, CudaPackage, ROCmPackage):
     # Cannot mix release and development versions of SLEPc and PETSc:
     depends_on("petsc@main", when="@main")
     for ver in [
+        "3.23",
         "3.22",
         "3.21",
         "3.20",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
