### PR TITLE
py-black: add v24.4.0 -> 25.1.0

### DIFF
--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -133,7 +133,7 @@ def mypy_root_spec() -> str:
 
 def black_root_spec() -> str:
     """Return the root spec used to bootstrap black"""
-    return _root_spec("py-black@:24.1.0")
+    return _root_spec("py-black@25.1.0")
 
 
 def flake8_root_spec() -> str:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -133,7 +133,7 @@ def mypy_root_spec() -> str:
 
 def black_root_spec() -> str:
     """Return the root spec used to bootstrap black"""
-    return _root_spec("py-black@25.1.0")
+    return _root_spec("py-black@:25.1.0")
 
 
 def flake8_root_spec() -> str:

--- a/var/spack/repos/builtin/packages/py-aiohappyeyeballs/package.py
+++ b/var/spack/repos/builtin/packages/py-aiohappyeyeballs/package.py
@@ -1,0 +1,19 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAiohappyeyeballs(PythonPackage):
+    """This library exists to allow connecting with Happy Eyeballs (RFC 8305)
+    when you already have a list of addrinfo and not a DNS name."""
+
+    homepage = "https://github.com/aio-libs/aiohappyeyeballs"
+    pypi = "aiohappyeyeballs/aiohappyeyeballs-2.6.1.tar.gz"
+
+    version("2.6.1", sha256="c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558")
+
+    depends_on("py-poetry-core@1:", type="build")
+    depends_on("py-poetry-core@2:", type="build", when="@2.4.5:")
+    depends_on("python@3.9:", when="@2.4.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-aiohttp/package.py
+++ b/var/spack/repos/builtin/packages/py-aiohttp/package.py
@@ -34,7 +34,7 @@ class PyAiohttp(PythonPackage):
     depends_on("py-setuptools@46.4:", type="build")
 
     with default_args(type=("build", "run")):
-        depends_on("py-aiohappyeyeballs@2.5.0:", when="@3.11:")
+        depends_on("py-aiohappyeyeballs@2.3:", when="@3.10:")
         depends_on("py-propcache@0.2.0:", when="@3.11:")
         depends_on("py-attrs@17.3.0:")
         depends_on("py-charset-normalizer@2:3", when="@3.8.4:")

--- a/var/spack/repos/builtin/packages/py-aiohttp/package.py
+++ b/var/spack/repos/builtin/packages/py-aiohttp/package.py
@@ -17,6 +17,7 @@ class PyAiohttp(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.11.16", sha256="16f8a2c9538c14a557b4d309ed4d0a7c60f0253e8ed7b6c9a2859a7582f8b1b8")
     version("3.9.5", sha256="edea7d15772ceeb29db4aff55e482d4bcfb6ae160ce144f2682de02f6d693551")
     version("3.9.4", sha256="6ff71ede6d9a5a58cfb7b6fffc83ab5d4a63138276c771ac91ceaaddf5459644")
     version("3.9.0", sha256="09f23292d29135025e19e8ff4f0a68df078fe4ee013bca0105b2e803989de92d")
@@ -28,23 +29,28 @@ class PyAiohttp(PythonPackage):
 
     depends_on("c", type="build")  # generated
 
+    depends_on("python@3.9:", when="@3.11:")
     depends_on("python@3.8:", when="@3.9:")
     depends_on("py-setuptools@46.4:", type="build")
 
-    depends_on("py-attrs@17.3.0:", type=("build", "run"))
-    depends_on("py-charset-normalizer@2:3", when="@3.8.4:", type=("build", "run"))
-    depends_on("py-charset-normalizer@2", when="@3.8.0:3.8.3", type=("build", "run"))
-    depends_on("py-multidict@4.5:6", when="@3.6.3:", type=("build", "run"))
-    depends_on("py-multidict@4.5:4", when="@:3.6.2", type=("build", "run"))
-    depends_on("py-async-timeout@4", when="@3.8.0 ^python@:3.10", type=("build", "run"))
-    depends_on("py-async-timeout@3", when="@:3.7.4 ^python@:3.10", type=("build", "run"))
-    depends_on("py-asynctest@0.13.0", when="@3.8.0: ^python@:3.7", type=("build", "run"))
-    depends_on("py-yarl@1", type=("build", "run"))
-    depends_on("py-typing-extensions@3.7.4:", when="@3.8: ^python@:3.7", type=("build", "run"))
-    depends_on("py-typing-extensions@3.6.5:", when="@3.7", type=("build", "run"))
-    depends_on("py-typing-extensions@3.6.5:", when="@:3.6 ^python@:3.7", type=("build", "run"))
-    depends_on("py-frozenlist@1.1.1:", when="@3.8.1:", type=("build", "run"))
-    depends_on("py-aiosignal@1.1.2:", when="@3.8.1:", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("py-aiohappyeyeballs@2.5.0:", when="@3.11:")
+        depends_on("py-propcache@0.2.0:", when="@3.11:")
+        depends_on("py-attrs@17.3.0:")
+        depends_on("py-charset-normalizer@2:3", when="@3.8.4:")
+        depends_on("py-charset-normalizer@2", when="@3.8.0:3.8.3")
+        depends_on("py-multidict@4.5:6", when="@3.6.3:")
+        depends_on("py-multidict@4.5:4", when="@:3.6.2")
+        depends_on("py-async-timeout@4:", when="@3.8.0 ^python@:3.10")
+        depends_on("py-async-timeout@3", when="@:3.7.4 ^python@:3.10")
+        depends_on("py-asynctest@0.13.0", when="@3.8.0: ^python@:3.7")
+        depends_on("py-yarl@1.17:", when="@3.11:")
+        depends_on("py-yarl@1")
+        depends_on("py-typing-extensions@3.7.4:", when="@3.8: ^python@:3.7")
+        depends_on("py-typing-extensions@3.6.5:", when="@3.7")
+        depends_on("py-typing-extensions@3.6.5:", when="@:3.6 ^python@:3.7")
+        depends_on("py-frozenlist@1.1.1:", when="@3.8.1:")
+        depends_on("py-aiosignal@1.1.2:", when="@3.8.1:")
 
     # Historical dependencies
     depends_on("py-chardet@2.0:3", when="@:3.7", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-async-timeout/package.py
+++ b/var/spack/repos/builtin/packages/py-async-timeout/package.py
@@ -14,6 +14,7 @@ class PyAsyncTimeout(PythonPackage):
 
     license("Apache-2.0")
 
+    version("4.0.3", sha256="4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f")
     version("4.0.2", sha256="2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15")
     version("4.0.1", sha256="b930cb161a39042f9222f6efb7301399c87eeab394727ec5437924a36d6eef51")
     version("4.0.0", sha256="7d87a4e8adba8ededb52e579ce6bc8276985888913620c935094c2276fd83382")

--- a/var/spack/repos/builtin/packages/py-black/package.py
+++ b/var/spack/repos/builtin/packages/py-black/package.py
@@ -17,6 +17,12 @@ class PyBlack(PythonPackage):
     license("MIT", checked_by="tgamblin")
     maintainers("spack/spack-releasers")
 
+    version("25.1.0", sha256="33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666")
+    version("24.10.0", sha256="846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875")
+    version("24.8.0", sha256="2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f")
+    version("24.4.2", sha256="c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d")
+    version("24.4.1", sha256="5241612dc8cad5b6fd47432b8bd04db80e07cfbc53bb69e9ae18985063bcb8dd")
+    version("24.4.0", sha256="f07b69fda20578367eaebbd670ff8fc653ab181e1ff95d84497f9fa20e7d0641")
     version("24.3.0", sha256="a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f")
     version("24.2.0", sha256="bce4f25c27c3435e4dace4815bcb2008b87e167e3bf4ee47ccdc5ce906eb4894")
     version("24.1.1", sha256="48b5760dcbfe5cf97fd4fba23946681f3a81514c6ab8a45b50da67ac8fbc6c7b")

--- a/var/spack/repos/builtin/packages/py-black/package.py
+++ b/var/spack/repos/builtin/packages/py-black/package.py
@@ -69,7 +69,9 @@ class PyBlack(PythonPackage):
 
         depends_on("py-colorama@0.4.3:", when="+colorama")
         depends_on("py-uvloop@0.15.2:", when="+uvloop")
-        depends_on("py-aiohttp@3.7.4:", when="+d")
+        with when("+d"):
+            depends_on("py-aiohttp@3.10:", when="@24.10")
+            depends_on("py-aiohttp@3.7.4:")
         depends_on("py-ipython@7.8:", when="+jupyter")
         depends_on("py-tokenize-rt@3.2:", when="+jupyter")
 

--- a/var/spack/repos/builtin/packages/py-black/package.py
+++ b/var/spack/repos/builtin/packages/py-black/package.py
@@ -70,7 +70,7 @@ class PyBlack(PythonPackage):
         depends_on("py-colorama@0.4.3:", when="+colorama")
         depends_on("py-uvloop@0.15.2:", when="+uvloop")
         with when("+d"):
-            depends_on("py-aiohttp@3.10:", when="@24.10")
+            depends_on("py-aiohttp@3.10:", when="@24.10:")
             depends_on("py-aiohttp@3.7.4:")
         depends_on("py-ipython@7.8:", when="+jupyter")
         depends_on("py-tokenize-rt@3.2:", when="+jupyter")

--- a/var/spack/repos/builtin/packages/py-poetry-core/package.py
+++ b/var/spack/repos/builtin/packages/py-poetry-core/package.py
@@ -13,6 +13,7 @@ class PyPoetryCore(PythonPackage):
 
     license("MIT")
 
+    version("2.1.2", sha256="f9dbbbd0ebf9755476a1d57f04b30e9aecf71ca9dc2fcd4b17aba92c0002aa04")
     version("1.8.1", sha256="67a76c671da2a70e55047cddda83566035b701f7e463b32a2abfeac6e2a16376")
     version("1.7.0", sha256="8f679b83bd9c820082637beca1204124d5d2a786e4818da47ec8acefd0353b74")
     version("1.6.1", sha256="0f9b0de39665f36d6594657e7d57b6f463cc10f30c28e6d1c3b9ff54c26c9ac3")
@@ -23,11 +24,12 @@ class PyPoetryCore(PythonPackage):
 
     depends_on("c", type="build")  # generated
 
-    depends_on("python@3.8:3", when="@1.7.0:", type=("build", "run"))
-    depends_on("python@3.7:3", when="@1.1.0:", type=("build", "run"))
-    depends_on("python@:3", type=("build", "run"))
-    depends_on("py-importlib-metadata@1.7:", when="@1.1:1.6 ^python@:3.7", type=("build", "run"))
-    depends_on("py-importlib-metadata@1.7:1", when="@:1.0 ^python@:3.7", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:3", when="@2:")
+        depends_on("python@3.8:3", when="@1.7:")
+        depends_on("python@3.7:3", when="@1.1:")
+        depends_on("py-importlib-metadata@1.7:", when="@1.1:1.6 ^python@:3.7")
+        depends_on("py-importlib-metadata@1.7:1", when="@:1.0 ^python@:3.7")
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/source/p/poetry-core/{0}-{1}.tar.gz"

--- a/var/spack/repos/builtin/packages/py-propcache/package.py
+++ b/var/spack/repos/builtin/packages/py-propcache/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPropcache(PythonPackage):
+    """Fast property caching"""
+
+    homepage = "https://github.com/aio-libs/propcache"
+    pypi = "propcache/propcache-0.3.1.tar.gz"
+
+    license("Apache-2.0")
+
+    version("0.3.1", sha256="40d980c33765359098837527e18eddefc9a24cea5b45e078a7f3bb5b032c6ecf")
+
+    depends_on("py-setuptools@47:", type="build")
+    depends_on("py-expandvars", type="build")
+    depends_on("py-tomli", when="^python@:3.10", type="build")
+    depends_on("py-cython", type="build")
+
+    depends_on("python@3.9:", when="@0.2.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-yarl/package.py
+++ b/var/spack/repos/builtin/packages/py-yarl/package.py
@@ -29,6 +29,8 @@ class PyYarl(PythonPackage):
     depends_on("py-cython", type="build")
 
     with default_args(type=("build", "run")):
+        depends_on("python@3.9:", when="@1.15.3:")
+        depends_on("python@3.7:", when="@1.8:")
         depends_on("py-multidict@4.0:")
         depends_on("py-propcache@0.2:", when="@1.14:")
         depends_on("py-idna@2.0:")

--- a/var/spack/repos/builtin/packages/py-yarl/package.py
+++ b/var/spack/repos/builtin/packages/py-yarl/package.py
@@ -21,12 +21,14 @@ class PyYarl(PythonPackage):
     version("1.4.2", sha256="58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b")
     version("1.3.0", sha256="024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9")
 
-    depends_on("c", type="build")  # generated
-
-    depends_on("py-expandvars", type="build", when="@1.18:")
-    depends_on("py-setuptools@40:", type="build", when="@1.7.2:")
-    depends_on("py-setuptools", type="build")
-    depends_on("py-cython", type="build")
+    with default_args(type="build"):
+        depends_on("c")
+        depends_on("py-expandvars", when="@1.18:")
+        depends_on("py-setuptools@40:", when="@1.7.2:")
+        depends_on("py-setuptools")
+        # requires https://github.com/cython/cython/commit/ea38521bf59edef9e6d22cbabf44229848091a76
+        depends_on("py-cython@3:", when="@1.15.4:")
+        depends_on("py-cython")
 
     with default_args(type=("build", "run")):
         depends_on("python@3.9:", when="@1.15.3:")
@@ -36,7 +38,7 @@ class PyYarl(PythonPackage):
         depends_on("py-idna@2.0:")
         depends_on("py-typing-extensions@3.7.4:", when="@1.7.2: ^python@:3.7")
 
-    @run_before("install")
+    @run_before("install", when="@:1.9")
     def fix_cython(self):
         if self.spec.satisfies("@1.7.2:"):
             pyxfile = "yarl/_quoting_c"

--- a/var/spack/repos/builtin/packages/py-yarl/package.py
+++ b/var/spack/repos/builtin/packages/py-yarl/package.py
@@ -30,7 +30,7 @@ class PyYarl(PythonPackage):
 
     with default_args(type=("build", "run")):
         depends_on("py-multidict@4.0:")
-        depends_on("py-propcache@0.2.1:", when="@1.18:")
+        depends_on("py-propcache@0.2:", when="@1.14:")
         depends_on("py-idna@2.0:")
         depends_on("py-typing-extensions@3.7.4:", when="@1.7.2: ^python@:3.7")
 

--- a/var/spack/repos/builtin/packages/py-yarl/package.py
+++ b/var/spack/repos/builtin/packages/py-yarl/package.py
@@ -14,6 +14,7 @@ class PyYarl(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.18.3", sha256="ac1801c45cbf77b6c99242eeff4fffb5e4e73a800b5c4ad4fc0be5def634d2e1")
     version("1.9.2", sha256="04ab9d4b9f587c06d801c2abfe9317b77cdf996c65a90d5e84ecc45010823571")
     version("1.8.1", sha256="af887845b8c2e060eb5605ff72b6f2dd2aab7a761379373fd89d314f4752abbf")
     version("1.7.2", sha256="45399b46d60c253327a460e99856752009fcee5f5d3c80b2f7c0cae1c38d56dd")
@@ -22,13 +23,16 @@ class PyYarl(PythonPackage):
 
     depends_on("c", type="build")  # generated
 
+    depends_on("py-expandvars", type="build", when="@1.18:")
     depends_on("py-setuptools@40:", type="build", when="@1.7.2:")
     depends_on("py-setuptools", type="build")
     depends_on("py-cython", type="build")
 
-    depends_on("py-multidict@4.0:", type=("build", "run"))
-    depends_on("py-idna@2.0:", type=("build", "run"))
-    depends_on("py-typing-extensions@3.7.4:", when="@1.7.2: ^python@:3.7", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("py-multidict@4.0:")
+        depends_on("py-propcache@0.2.1:", when="@1.18:")
+        depends_on("py-idna@2.0:")
+        depends_on("py-typing-extensions@3.7.4:", when="@1.7.2: ^python@:3.7")
 
     @run_before("install")
     def fix_cython(self):


### PR DESCRIPTION
New versions of py-black necessary to build the version of py-black used in the CI style check.

Also update bootstrap environment to match the version used in CI.
