### PR TITLE
cmake: set CMAKE_POLICY_VERSION_MINIMUM 

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Bootstrap clingo
         run: |
           source share/spack/setup-env.sh
-          spack bootstrap disable github-actions-v0.6
           spack bootstrap disable github-actions-v0.5
+          spack bootstrap disable github-actions-v0.6
           spack external find --not-buildable cmake bison
           spack -d solve zlib
           tree $HOME/.spack/bootstrap/store/

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Bootstrap clingo
         run: |
           source share/spack/setup-env.sh
-          spack bootstrap disable github-actions-v0.5
           spack bootstrap disable github-actions-v0.6
+          spack bootstrap disable github-actions-v0.5
           spack external find --not-buildable cmake bison
           spack -d solve zlib
           tree $HOME/.spack/bootstrap/store/

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -355,6 +355,15 @@ class Cmake(Package):
                 filter_file("mpc++_r)", "mpc++_r mpiFCC)", f, string=True)
                 filter_file("mpifc)", "mpifc mpifrt)", f, string=True)
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # CMake 4.0.0 breaks compatibility with CMake projects requiring a CMake
+        # < 3.5. However, many projects that specify a minimum requirement for
+        # versions older than 3.5 are actually compatible with newer CMake
+        # and do not use CMake 3.4 or older features. This allows those
+        # projects to use a newer CMake
+        if self.spec.satisfies("@4:"):
+            env.set("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
+
     def setup_dependent_package(self, module, dependent_spec):
         """Called before cmake packages's install() methods."""
 


### PR DESCRIPTION
Extracted from #49731 to fix breakage in https://github.com/spack/spack/actions/runs/14186017586

CMake 4.0.0 breaks compatibility with CMake projects requiring a CMake < 3.5. However, many projects that specify a minimum requirement for versions older than 3.5 are actually compatible with newer CMake and do not use CMake 3.4 or older features. This allows those projects to use a newer CMake.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
