### PR TITLE
Re-add MPI to Windows CI

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/windows-vis/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/windows-vis/spack.yaml
@@ -6,7 +6,7 @@
 spack:
   view: false
   specs:
-  - "vtk@9: ~mpi"
+  - "vtk@9:"
 
   cdash:
     build-group: Windows Visualization (Kitware)

--- a/share/spack/gitlab/cloud_pipelines/stacks/windows-vis/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/windows-vis/spack.yaml
@@ -6,7 +6,7 @@
 spack:
   view: false
   specs:
-  - "vtk@9:"
+  - "vtk@9: +mpi"
 
   cdash:
     build-group: Windows Visualization (Kitware)


### PR DESCRIPTION
Vtk's MPI variant was disabled in Windows CI due to flakey concretizer behavior. I believe this has since been resolved, so we should restore building VTK w/ MPI on Windows.

Edit: making this a draft as gitlab is not rebuilding specs

Depends on #50263 