### PR TITLE
binder: add C dependency

### DIFF
--- a/var/spack/repos/builtin/packages/binder/package.py
+++ b/var/spack/repos/builtin/packages/binder/package.py
@@ -29,6 +29,7 @@ class Binder(CMakePackage):
     version("1.1.0", tag="v1.0.0", commit="3de7949343197295250f988716d511a264b21324")
     version("1.0.0", tag="v1.0.0", commit="3de7949343197295250f988716d511a264b21324")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     # Add dependencies


### PR DESCRIPTION
binder depends on C, as seen in its root-level CMakeLists.txt file.
