### PR TITLE
BlisBase: Setting appropriate CPU configuration for build of blis packages

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/blis/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/blis/package.py
@@ -82,7 +82,7 @@ class BlisBase(MakefilePackage):
 
     def edit(self, spec, prefix):
         # To ensure auto should always be the last argument for base and derived class
-        config_args = self.configure_args() + ["auto"]
+        config_args = self.configure_args() + ["generic"]
         configure("--prefix={0}".format(prefix), *config_args)
 
     @run_after("install")

--- a/var/spack/repos/spack_repo/builtin/packages/blis/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/blis/package.py
@@ -37,6 +37,7 @@ class BlisBase(MakefilePackage):
         multi=True,
         description="Build shared libs, static libs or both",
     )
+    variant("config", default="auto", description="CPU architecture configuration")
 
     # TODO: add cpu variants. Currently using auto.
     # If one knl, should the default be memkind ?
@@ -82,7 +83,8 @@ class BlisBase(MakefilePackage):
 
     def edit(self, spec, prefix):
         # To ensure auto should always be the last argument for base and derived class
-        config_args = self.configure_args() + ["generic"]
+        mconfig = self.spec.variants["config"].value
+        config_args = self.configure_args() + [mconfig]
         configure("--prefix={0}".format(prefix), *config_args)
 
     @run_after("install")


### PR DESCRIPTION
As detailed in https://github.com/spack/spack/issues/49376 the default configuration "auto" of BlisBase causes the build of blis packages to ignore the spack compiler march and pick the arch of the local machine.  In the spirit of spack, I think it would be more appropriate to use the "generic" config, which does not set `-march` and other cpu-specific optimizations.  This config only (potentially) sets `-O0 -O2 -g -funsafe-math-optimizations -ffp-contract=fast`.