### PR TITLE
bufr: add v12.2.0 plus several updates

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -22,7 +22,7 @@ class Bufr(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA", "jbathegit")
 
     version("develop", branch="develop")
-    version("12.2.0", sha256="a0dad13b905f3e0311e2b50df47418660b47442dfc3843232712044b47f26a71") # FIXME
+    version("12.2.0", sha256="a0dad13b905f3e0311e2b50df47418660b47442dfc3843232712044b47f26a71")
     version("12.1.0", sha256="b5eae61b50d4132b2933b6e6dfc607e5392727cdc4f46ec7a94a19109d91dcf3")
     version("12.0.1", sha256="525f26238dba6511a453fc71cecc05f59e4800a603de2abbbbfb8cbb5adf5708")
     version("12.0.0", sha256="d01c02ea8e100e51fd150ff1c4a1192ca54538474acb1b7f7a36e8aeab76ee75")

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -22,6 +22,7 @@ class Bufr(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA", "jbathegit")
 
     version("develop", branch="develop")
+    version("12.2.0", sha256="a0dad13b905f3e0311e2b50df47418660b47442dfc3843232712044b47f26a71") # FIXME
     version("12.1.0", sha256="b5eae61b50d4132b2933b6e6dfc607e5392727cdc4f46ec7a94a19109d91dcf3")
     version("12.0.1", sha256="525f26238dba6511a453fc71cecc05f59e4800a603de2abbbbfb8cbb5adf5708")
     version("12.0.0", sha256="d01c02ea8e100e51fd150ff1c4a1192ca54538474acb1b7f7a36e8aeab76ee75")
@@ -56,6 +57,24 @@ class Bufr(CMakePackage):
 
     conflicts("%oneapi@:2024.1", msg="Requires oneapi 2024.2 or later")
 
+    resource(
+        name="testfiles",
+        url="https://ftp.emc.ncep.noaa.gov/static_files/public/bufr-12.2.0.tgz",
+        sha256="0ebc27f6260dc964d38c3966fb583e3ef68279a9879fc28cd4d923e2fc2ea42c",
+        when="@12.2:",
+        expand=False,
+        placement="testfiles",
+    )
+
+    resource(
+        name="testfiles",
+        url="https://ftp.emc.ncep.noaa.gov/static_files/public/bufr-12.1.0.tgz",
+        sha256="28024963cc855b85303def23f2c2c423d21545322c1eff54416229062fed013a",
+        when="@12.1",
+        expand=False,
+        placement="testfiles",
+    )
+
     def url_for_version(self, version):
         pre = "bufr_" if version < Version("12.0.1") else ""
         return (
@@ -74,10 +93,8 @@ class Bufr(CMakePackage):
             self.define("BUILD_TESTS", self.run_tests),
             self.define("BUILD_TESTING", self.run_tests),
             self.define_from_variant("BUILD_UTILS", "utils"),
+            self.define("TEST_FILE_DIR", join_path(self.stage.source_path, "testfiles")),
         ]
-
-        if not self.spec.satisfies("test_files=none"):
-            args.append(self.define_from_variant("TEST_FILE_DIR", "test_files"))
 
         return args
 
@@ -126,6 +143,10 @@ class Bufr(CMakePackage):
             suffixes += ["8", "d"]
         for suffix in suffixes:
             self._setup_bufr_environment(env, suffix)
+
+    @on_package_attributes(run_tests=True)
+    def setup_build_environment(self, env):
+        env.append_path("LD_LIBRARY_PATH", join_path(self.build_directory, "src"))
 
     def check(self):
         with working_dir(self.build_directory):


### PR DESCRIPTION
This PR updates the bufr package:
 - adds @12.2.0
 - adds test files as a Spack resource so they can be prefetched (currently they are downloaded at build time)
 - set LD_LIBRARY_PATH to allow the python tests to run when building +shared