### PR TITLE
g2: disable one problematic unit test for intel@:2022

### DIFF
--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -98,4 +98,7 @@ class G2(CMakePackage):
 
     def check(self):
         with working_dir(self.build_directory):
-            make("test")
+            if self.spec.satisfies("%intel@:2022"):
+                ctest("--exclude-regex", "test_gribcreate_.")
+            else:
+                ctest()


### PR DESCRIPTION
This PR disables one problematic unit test for g2 when %intel@:2022.