### PR TITLE
wrf-io: add make test

### DIFF
--- a/var/spack/repos/builtin/packages/wrf-io/package.py
+++ b/var/spack/repos/builtin/packages/wrf-io/package.py
@@ -32,3 +32,6 @@ class WrfIo(CMakePackage):
     def cmake_args(self):
         args = [self.define_from_variant("OPENMP", "openmp")]
         return args
+
+    def check(self):
+        make("test")


### PR DESCRIPTION
This PR specifies build-time testing for wrf-io (`def check(self): make("test")`).