### PR TITLE
ci: replace 'graviton3' with 'neoverse_v1'

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -188,7 +188,7 @@ default:
 
 .generate-neoverse_v1:
   extends: [ ".generate-base" ]
-  tags: ["spack", "public", "medium", "aarch64", "graviton3"]
+  tags: ["spack", "public", "medium", "aarch64", "neoverse_v1"]
 
 .generate-neoverse-v2:
   extends: [ ".generate-base" ]

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/neoverse_v1/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/neoverse_v1/ci.yaml
@@ -1,4 +1,4 @@
 ci:
   pipeline-gen:
   - build-job:
-      tags: ["aarch64", "graviton3"]
+      tags: ["aarch64", "neoverse_v1"]


### PR DESCRIPTION
neoverse_v1 matches the name of the stack and more accurately captures the requirement for these jobs. The relevant runners in GitLab already bear both tags, so this shouldn't affect how jobs get assigned to runners.