### PR TITLE
gitlab: do not retry legitimate build failures

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -158,10 +158,27 @@ default:
     SPACK_BACKTRACE: 1
   interruptible: true
   timeout: 60 minutes
+  # Retry for everything but "legitimate build failures" (script_failure)
   retry:
     max: 2
     when:
-      - always
+      - unknown_failure
+      - api_failure
+      - stuck_or_timeout_failure
+      - runner_system_failure
+      - runner_unsupported
+      - stale_schedule
+      - job_execution_timeout
+      - archived_failure
+      - unmet_prerequisites
+      - scheduler_failure
+      - data_integrity_failure
+    exit_codes: 42
+  # GitLab will also throw script_failure when it fails to clone the repository.
+  # Retry in that case as well by exiting with a special code (42).
+  hooks:
+    pre_get_sources_script:
+      - GIT_TERMINAL_PROMPT=0 git ls-remote --quiet "$CI_REPOSITORY_URL" FAKE_REF || $(exit 42)
 
 # Generate without tags for cases using external runners
 .generate-base:


### PR DESCRIPTION
Reconfigure our GitLab CI pipelines to avoid retrying jobs that failed deterministically for legitimate reasons.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
