### PR TITLE
(NEW) test_test_timeout: test new timeout option in #49839

### DIFF
--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -309,3 +309,26 @@ def test_test_output_multiple_specs(
     # part result summaries, you'll have to look at the "test-out.txt" files
     # for each spec.
     assert "1 failed, 2 passed of 3 specs" in out
+
+
+def test_test_timeout(mock_test_stage, mock_packages, mock_archive, mock_fetch, install_mockery):
+    """Confirm the stand-alone test times out."""
+    install("standalone-timeout", fail_on_error=False)
+
+    # Make sure the timeout value is less than the sleep in the mock package.
+    out = spack_test("run", "--timeout", "10", "standalone-timeout", fail_on_error=False)
+
+    # Make sure the test actually failed.
+    assert "1 failed of 1 spec" in out
+
+    # Grab test stage directory contents.
+    stage_files = os.listdir(mock_test_stage)
+    testdir = os.path.join(mock_test_stage, stage_files[0])
+    testdir_files = os.listdir(testdir)
+    testlogs = [name for name in testdir_files if str(name).endswith("test-out.txt")]
+
+    # Grab the output from the test log of the spec to ensure received the timeout signal.
+    outfile = os.path.join(testdir, testlogs[0])
+    with open(outfile, "r", encoding="utf-8") as f:
+        test_log = f.read()
+    assert "Test failure: The process has stopped unexpectedly (signal 15)" in test_log

--- a/var/spack/repos/builtin.mock/packages/standalone-timeout/package.py
+++ b/var/spack/repos/builtin.mock/packages/standalone-timeout/package.py
@@ -1,0 +1,26 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class StandaloneTimeout(Package):
+    """This package exercises the stand-alone test timeout feature."""
+
+    homepage = "http://www.example.com/simple_timeout"
+    url = "http://www.unit-test-should-replace-this-url/simple_timeout-1.0.tar.gz"
+
+    version("1.0", md5="123456789abcdef0123456789abcdefg")
+    version("0.9", md5="0123456789abcdef0123456789abcdef")
+
+    provides("standalone-ifc")
+
+    def test_timeout(self):
+        """simple timeout test"""
+        import time
+
+        # Make sure the value here exceeds the value in the unit test.
+        time.sleep(20)
+
+        print("Ran test_timeout")

--- a/var/spack/repos/builtin.mock/packages/standalone-timeout/package.py
+++ b/var/spack/repos/builtin.mock/packages/standalone-timeout/package.py
@@ -14,8 +14,6 @@ class StandaloneTimeout(Package):
     version("1.0", md5="123456789abcdef0123456789abcdefg")
     version("0.9", md5="0123456789abcdef0123456789abcdef")
 
-    provides("standalone-ifc")
-
     def test_timeout(self):
         """simple timeout test"""
         import time


### PR DESCRIPTION
Depends on #49839 

Adds a unit test to exercise the stand-alone test timeout option.