### PR TITLE
fix: intel compiler alias typo

### DIFF
--- a/lib/spack/spack/aliases.py
+++ b/lib/spack/spack/aliases.py
@@ -7,7 +7,7 @@ BUILTIN_TO_LEGACY_COMPILER = {
     "llvm": "clang",
     "intel-oneapi-compilers": "oneapi",
     "llvm-amdgpu": "rocmcc",
-    "intel-oneapi-compiler-classic": "intel",
+    "intel-oneapi-compilers-classic": "intel",
     "acfl": "arm",
 }
 
@@ -15,6 +15,6 @@ LEGACY_COMPILER_TO_BUILTIN = {
     "clang": "llvm",
     "oneapi": "intel-oneapi-compilers",
     "rocmcc": "llvm-amdgpu",
-    "intel": "intel-oneapi-compiler-classic",
+    "intel": "intel-oneapi-compilers-classic",
     "arm": "acfl",
 }


### PR DESCRIPTION
This typo was causing issues when concretizing specs with `%intel`

@becker33 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
