### PR TITLE
compilers: add `.stdcxx_libs` to the compiler adaptor

### DIFF
--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -190,6 +190,10 @@ class CompilerAdaptor:
         self._lang_exists_or_raise("f77", lang=Languages.FORTRAN)
         return self.compilers[Languages.FORTRAN].package.fortran
 
+    @property
+    def stdcxx_libs(self):
+        return self._maybe_return_attribute("stdcxx_libs", lang=Languages.CXX)
+
 
 class DeprecatedCompiler(lang.DeprecatedProperty):
     def __init__(self) -> None:

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -138,6 +138,7 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
     }
 
     implicit_rpath_libs = ["libclang"]
+    stdcxx_libs = ("-lstdc++",)
 
     def _standard_flag(self, *, language: str, standard: str) -> str:
         flags = {

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -618,7 +618,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-Os", "-Ofast", "-Og"]
 
     implicit_rpath_libs = ["libgcc", "libgfortran"]
-    stdcxx_libs = "-lstdc++"
+    stdcxx_libs = ("-lstdc++",)
 
     def _standard_flag(self, *, language, standard):
         flags = {

--- a/var/spack/repos/builtin/packages/grackle/package.py
+++ b/var/spack/repos/builtin/packages/grackle/package.py
@@ -28,6 +28,8 @@ class Grackle(Package):
     depends_on("libtool", when="@2.2:")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("fortran", type="build")
     depends_on("tcsh", type="build")
     depends_on("mpi")


### PR DESCRIPTION
This property is used by a few recipes, including `cp2k` under certain configurations

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
