### PR TITLE
easi: add c compiler dependence

### DIFF
--- a/var/spack/repos/builtin/packages/easi/package.py
+++ b/var/spack/repos/builtin/packages/easi/package.py
@@ -29,6 +29,7 @@ class Easi(CMakePackage):
     version("1.1.2", tag="v1.1.2", commit="4c87ef3b3dca9415d116ef102cb8de750ef7e1a0")
 
     depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build", when="@1.5.0: jit=lua")
     depends_on("fortran", type="build")  # generated
 
     variant("python", default=True, description="Install python bindings")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Fixes the following issue
https://github.com/SeisSol/easi/issues/75