### PR TITLE
Copy logs failed job

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -764,7 +764,7 @@ def copy_tree(
 
     files = glob.glob(src)
     if not files:
-        raise OSError("No such file or directory: '{0}'".format(src))
+        raise OSError("No such file or directory: '{0}'".format(src), errno.ENOENT)
 
     # For Windows hard-links and junctions, the source path must exist to make a symlink. Add
     # all symlinks to this list while traversing the tree, then when finished, make all

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -640,7 +640,7 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
             archive_files = [str(f) for f in archive_root.rglob("*") if os.path.isfile(f)]
         else:
             msg = f"No archived files detected at {archive_root}"
-            tty.warn(msg)
+            tty.debug(msg)
 
     # Try zipped and unzipped versions of the build log
     build_log_zipped = package_metadata_root / "spack-build-out.txt.gz"

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -24,6 +24,7 @@ from llnl.util.tty.color import cescape, colorize
 
 import spack
 import spack.binary_distribution as bindist
+import spack.builder
 import spack.config as cfg
 import spack.environment as ev
 import spack.error
@@ -634,7 +635,7 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
             archive_files = []
             archive_root = package_metadata_root / "archived-files"
             if archive_root.is_dir():
-                archive_files = [f for f in archive_root.rglob("*") if f.is_file()]
+                archive_files = [str(f) for f in archive_root.rglob("*") if f.is_file()]
             else:
                 msg = "Cannot copy package archived files: archived-files must be a directory"
                 tty.warn(msg)

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -639,8 +639,7 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
         if os.path.isdir(archive_root):
             archive_files = [str(f) for f in archive_root.rglob("*") if os.path.isfile(f)]
         else:
-            msg = f"No archived files detected at {archive_root}"
-            tty.debug(msg)
+            tty.debug(f"No archived files detected at {archive_root}")
 
     # Try zipped and unzipped versions of the build log
     build_log_zipped = package_metadata_root / "spack-build-out.txt.gz"
@@ -661,8 +660,7 @@ def copy_test_logs_to_artifacts(test_stage, job_test_dir):
     """
     tty.debug(f"test stage: {test_stage}")
     if not os.path.exists(test_stage):
-        msg = f"Cannot copy test logs: job test stage ({test_stage}) does not exist"
-        tty.error(msg)
+        tty.error(f"Cannot copy test logs: job test stage ({test_stage}) does not exist")
         return
 
     copy_files_to_artifacts(

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -623,10 +623,9 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
     try:
         package_metadata_root = pathlib.Path(spack.store.STORE.layout.metadata_path(job_spec))
         if not package_metadata_root.is_dir():
-            pkg_cls = spack.repo.PATH.get_pkg_class(job_spec.name)
-            job_pkg = pkg_cls(job_spec)
+            job_pkg = job_spec.package
 
-            package_metadata_root = job_pkg.stage.path
+            package_metadata_root = pathlib.Path(job_pkg.stage.path)
             archive_files = spack.builder.create(job_pkg).archive_files
             tty.warn("Package not installed, falling back to use stage dir")
             tty.debug(f"stage dir: {package_metadata_root}")
@@ -635,7 +634,7 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
             archive_files = []
             archive_root = package_metadata_root / "archived-files"
             if archive_root.is_dir():
-                archive_files = [str(f) for f in archive_root.rglob("*") if f.is_file()]
+                archive_files = [str(f) for f in archive_root.rglob("*") if os.path.isfile(f)]
             else:
                 msg = "Cannot copy package archived files: archived-files must be a directory"
                 tty.warn(msg)

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -653,7 +653,7 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
     build_env_mods = package_metadata_root / "spack-build-env.txt"
 
     for f in [build_log_zipped, build_log, build_env_mods, *archive_files]:
-        copy_files_to_artifacts(str(f), job_log_dir)
+        copy_files_to_artifacts(str(f), job_log_dir, compress_artifacts=True)
 
 
 def copy_test_logs_to_artifacts(test_stage, job_test_dir):
@@ -670,7 +670,9 @@ def copy_test_logs_to_artifacts(test_stage, job_test_dir):
         tty.error(msg)
         return
 
-    copy_files_to_artifacts(os.path.join(test_stage, "*", "*.txt"), job_test_dir)
+    copy_files_to_artifacts(
+        os.path.join(test_stage, "*", "*.txt"), job_test_dir, compress_artifacts=True
+    )
 
 
 def download_and_extract_artifacts(url, work_dir) -> str:

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -623,28 +623,24 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
         tty.warn("Cannot copy artifacts for non-concrete specs")
         return
 
-    try:
-        package_metadata_root = pathlib.Path(spack.store.STORE.layout.metadata_path(job_spec))
-        if not package_metadata_root.is_dir():
-            job_pkg = job_spec.package
+    package_metadata_root = pathlib.Path(spack.store.STORE.layout.metadata_path(job_spec))
+    if not os.path.isdir(package_metadata_root):
+        # Fallback to using the stage directory
+        job_pkg = job_spec.package
 
-            package_metadata_root = pathlib.Path(job_pkg.stage.path)
-            archive_files = spack.builder.create(job_pkg).archive_files
-            tty.warn("Package not installed, falling back to use stage dir")
-            tty.debug(f"stage dir: {package_metadata_root}")
+        package_metadata_root = pathlib.Path(job_pkg.stage.path)
+        archive_files = spack.builder.create(job_pkg).archive_files
+        tty.warn("Package not installed, falling back to use stage dir")
+        tty.debug(f"stage dir: {package_metadata_root}")
+    else:
+        # Get the package's archived files
+        archive_files = []
+        archive_root = package_metadata_root / "archived-files"
+        if os.path.isdir(archive_root):
+            archive_files = [str(f) for f in archive_root.rglob("*") if os.path.isfile(f)]
         else:
-            # Get the package's archived files
-            archive_files = []
-            archive_root = package_metadata_root / "archived-files"
-            if archive_root.is_dir():
-                archive_files = [str(f) for f in archive_root.rglob("*") if os.path.isfile(f)]
-            else:
-                msg = "Cannot copy package archived files: archived-files must be a directory"
-                tty.warn(msg)
-
-    except spack.error.SpackError as e:
-        tty.error(f"Cannot copy logs: {str(e)}")
-        return
+            msg = f"No archived files detected at {archive_root}"
+            tty.warn(msg)
 
     # Try zipped and unzipped versions of the build log
     build_log_zipped = package_metadata_root / "spack-build-out.txt.gz"

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -619,6 +619,9 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
         job_log_dir: path into which build log should be copied
     """
     tty.debug(f"job spec: {job_spec}")
+    if not job_spec.concrete:
+        tty.warn("Cannot copy artifacts for non-concrete specs")
+        return
 
     try:
         package_metadata_root = pathlib.Path(spack.store.STORE.layout.metadata_path(job_spec))
@@ -641,10 +644,6 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
 
     except spack.error.SpackError as e:
         tty.error(f"Cannot copy logs: {str(e)}")
-        return
-    except AssertionError:
-        msg = f"Cannot copy stage logs: job spec ({job_spec}) must be concrete"
-        tty.error(msg)
         return
 
     # Try zipped and unzipped versions of the build log

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -613,7 +613,7 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
     job_spec, and attempts to copy the files into the directory given
     by job_log_dir.
 
-    Args:
+    Parameters:
         job_spec: spec associated with spack install log
         job_log_dir: path into which build log should be copied
     """
@@ -621,23 +621,38 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
 
     try:
         package_metadata_root = pathlib.Path(spack.store.STORE.layout.metadata_path(job_spec))
+        if not package_metadata_root.is_dir():
+            pkg_cls = spack.repo.PATH.get_pkg_class(job_spec.name)
+            job_pkg = pkg_cls(job_spec)
+
+            package_metadata_root = job_pkg.stage.path
+            archive_files = spack.builder.create(job_pkg).archive_files
+            tty.warn("Package not installed, falling back to use stage dir")
+            tty.debug(f"stage dir: {package_metadata_root}")
+        else:
+            # Get the package's archived files
+            archive_files = []
+            archive_root = package_metadata_root / "archived-files"
+            if archive_root.is_dir():
+                archive_files = [f for f in archive_root.rglob("*") if f.is_file()]
+            else:
+                msg = "Cannot copy package archived files: archived-files must be a directory"
+                tty.warn(msg)
+
     except spack.error.SpackError as e:
         tty.error(f"Cannot copy logs: {str(e)}")
         return
+    except AssertionError:
+        msg = f"Cannot copy stage logs: job spec ({job_spec}) must be concrete"
+        tty.error(msg)
+        return
 
-    # Get the package's archived files
-    archive_files = []
-    archive_root = package_metadata_root / "archived-files"
-    if archive_root.is_dir():
-        archive_files = [f for f in archive_root.rglob("*") if f.is_file()]
-    else:
-        msg = "Cannot copy package archived files: archived-files must be a directory"
-        tty.warn(msg)
-
+    # Try zipped and unzipped versions of the build log
     build_log_zipped = package_metadata_root / "spack-build-out.txt.gz"
+    build_log = package_metadata_root / "spack-build-out.txt"
     build_env_mods = package_metadata_root / "spack-build-env.txt"
 
-    for f in [build_log_zipped, build_env_mods, *archive_files]:
+    for f in [build_log_zipped, build_log, build_env_mods, *archive_files]:
         copy_files_to_artifacts(str(f), job_log_dir)
 
 

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import copy
+import glob
 import gzip
 import json
 import os
@@ -66,14 +67,15 @@ def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):
         compress_artifacts (bool): option to compress copied artifacts using Gzip
     """
     try:
-        if compress_artifacts and not is_gzipped(src):
-            # Compress and copy in one step
-            src_name = os.path.basename(src)
-            zipped = os.path.join(artifacts_dir, f"{src_name}.gz")
-            with open(src, "rb") as fin, gzip.open(zipped, "wb") as fout:
-                shutil.copyfileobj(fin, fout)
-        else:
-            fs.copy(src, artifacts_dir)
+        for s in glob.glob(src):
+            if compress_artifacts and not is_gzipped(s):
+                # Compress and copy in one step
+                src_name = os.path.basename(s)
+                zipped = os.path.join(artifacts_dir, f"{src_name}.gz")
+                with open(s, "rb") as fin, gzip.open(zipped, "wb") as fout:
+                    shutil.copyfileobj(fin, fout)
+            else:
+                fs.copy(s, artifacts_dir)
     except Exception as err:
         msg = (
             f"Unable to copy files ({src}) to artifacts {artifacts_dir} due to "

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -36,7 +36,6 @@ from spack.reporters import CDash, CDashConfiguration
 from spack.reporters.cdash import SPACK_CDASH_TIMEOUT
 from spack.reporters.cdash import build_stamp as cdash_build_stamp
 
-
 IS_WINDOWS = sys.platform == "win32"
 SPACK_RESERVED_TAGS = ["public", "protected", "notary"]
 

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import copy
+import gzip
 import json
 import os
 import re
+import shutil
 import sys
 import time
 from collections import deque
@@ -34,12 +36,6 @@ from spack.reporters import CDash, CDashConfiguration
 from spack.reporters.cdash import SPACK_CDASH_TIMEOUT
 from spack.reporters.cdash import build_stamp as cdash_build_stamp
 
-try:
-    import gzip  # noqa
-
-    GZIP_SUPPORTED = True
-except ImportError:
-    GZIP_SUPPORTED = False
 
 IS_WINDOWS = sys.platform == "win32"
 SPACK_RESERVED_TAGS = ["public", "protected", "notary"]
@@ -70,12 +66,12 @@ def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):
         artifacts_dir (str): the destination directory
     """
     try:
-        if GZIP_SUPPORTED and compress_artifacts and not is_gzipped(src):
+        if compress_artifacts and not is_gzipped(src):
             # Compress and copy in one step
             src_name = os.path.basename(src)
             zipped = os.path.join(artifacts_dir, f"{src_name}.gz")
             with open(src, "rb") as fin, gzip.open(zipped, "wb") as fout:
-                fout.writelines(fin)
+                shutil.copyfileobj(fin, fout)
         else:
             fs.copy(src, artifacts_dir)
     except Exception as err:

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import copy
-import gzip
 import json
 import os
 import re
@@ -35,6 +34,13 @@ from spack.reporters import CDash, CDashConfiguration
 from spack.reporters.cdash import SPACK_CDASH_TIMEOUT
 from spack.reporters.cdash import build_stamp as cdash_build_stamp
 
+try:
+    import gzip  # noqa
+
+    GZIP_SUPPORTED = True
+except ImportError:
+    GZIP_SUPPORTED = False
+
 IS_WINDOWS = sys.platform == "win32"
 SPACK_RESERVED_TAGS = ["public", "protected", "notary"]
 
@@ -64,7 +70,7 @@ def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):
         artifacts_dir (str): the destination directory
     """
     try:
-        if compress_artifacts and not is_gzipped(src):
+        if GZIP_SUPPORTED and compress_artifacts and not is_gzipped(src):
             # Compress and copy in one step
             src_name = os.path.basename(src)
             zipped = os.path.join(artifacts_dir, f"{src_name}.gz")

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -100,11 +100,12 @@ def copy_files_to_artifacts(
         else:
             fs.copy(src, artifacts_dir)
     except Exception as err:
-        msg = (
-            f"Unable to copy files ({src}) to artifacts {artifacts_dir} due to "
-            f"exception: {str(err)}"
+        tty.warn(
+            (
+                f"Unable to copy files ({src}) to artifacts {artifacts_dir} due to "
+                f"exception: {str(err)}"
+            )
         )
-        tty.warn(msg)
 
 
 def win_quote(quote_str: str) -> str:

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -45,10 +45,10 @@ SPACK_RESERVED_TAGS = ["public", "protected", "notary"]
 _urlopen = web_util.urlopen
 
 
-def copy_gzipped(glob_or_path, dest):
+def copy_gzipped(glob_or_path: str, dest: str) -> None:
     """Copy all of the files in the source glob/path to the destination.
 
-    Parameters:
+    Args:
         glob_or_path: path to file to test
         dest: destination path to copy to
     """
@@ -82,11 +82,13 @@ def copy_gzipped(glob_or_path, dest):
                 shutil.copyfileobj(fin, fout)
 
 
-def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):
+def copy_files_to_artifacts(
+    src: str, artifacts_dir: str, *, compress_artifacts: bool = False
+) -> None:
     """
     Copy file(s) to the given artifacts directory
 
-    Parameters:
+    Args:
         src (str): the glob-friendly path expression for the file(s) to copy
         artifacts_dir (str): the destination directory
         compress_artifacts (bool): option to compress copied artifacts using Gzip

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -63,6 +63,7 @@ def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):
     Parameters:
         src (str): the glob-friendly path expression for the file(s) to copy
         artifacts_dir (str): the destination directory
+        compress_artifacts (bool): option to compress copied artifacts using Gzip
     """
     try:
         if compress_artifacts and not is_gzipped(src):

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import copy
+import gzip
 import json
 import os
 import re
@@ -40,7 +41,26 @@ SPACK_RESERVED_TAGS = ["public", "protected", "notary"]
 _urlopen = web_util.urlopen
 
 
-def copy_files_to_artifacts(src, artifacts_dir):
+def is_gzipped(path):
+    """Check if the path is a gzipped file
+
+    Parameters:
+        path: path to file to test
+
+    Returns:
+        Trye if file is gzipped, otherwise False
+    """
+    try:
+        with gzip.open(path, "r") as f:
+            f.read(1)
+        return True
+    except gzip.BadGzipFile:
+        return False
+    except FileNotFoundError:
+        return False
+
+
+def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):
     """
     Copy file(s) to the given artifacts directory
 
@@ -49,7 +69,14 @@ def copy_files_to_artifacts(src, artifacts_dir):
         artifacts_dir (str): the destination directory
     """
     try:
-        fs.copy(src, artifacts_dir)
+        if compress_artifacts and not is_gzipped(src):
+            # Compress and copy in one step
+            src_name = os.path.dirname(src)
+            zipped = os.path.join(artifacts_dir, f"{src_name}.gz")
+            with open(src, "rb") as fin, gzip.open(zipped, "wb") as fout:
+                fout.writelines(fin)
+        else:
+            fs.copy(src, artifacts_dir)
     except Exception as err:
         msg = (
             f"Unable to copy files ({src}) to artifacts {artifacts_dir} due to "

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -71,7 +71,13 @@ def copy_gzipped(glob_or_path, dest):
         else:
             # Compress and copy in one step
             src_name = os.path.basename(src)
-            zipped = os.path.join(dest, f"{src_name}.gz")
+            if os.path.isdir(dest):
+                zipped = os.path.join(dest, f"{src_name}.gz")
+            elif not dest.endswith(".gz"):
+                zipped = f"{dest}.gz"
+            else:
+                zipped = dest
+
             with open(src, "rb") as fin, gzip.open(zipped, "wb") as fout:
                 shutil.copyfileobj(fin, fout)
 

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -49,7 +49,7 @@ def is_gzipped(path):
         path: path to file to test
 
     Returns:
-        Trye if file is gzipped, otherwise False
+        True if file is gzipped, otherwise False
     """
     with open(path, "rb") as fd:
         return compression.GZipFileType.matches_magic(fd)
@@ -66,7 +66,7 @@ def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):
     try:
         if compress_artifacts and not is_gzipped(src):
             # Compress and copy in one step
-            src_name = os.path.dirname(src)
+            src_name = os.path.basename(src)
             zipped = os.path.join(artifacts_dir, f"{src_name}.gz")
             with open(src, "rb") as fin, gzip.open(zipped, "wb") as fout:
                 fout.writelines(fin)

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import copy
+import errno
 import glob
 import gzip
 import json
@@ -54,7 +55,7 @@ def copy_gzipped(glob_or_path, dest):
 
     files = glob.glob(glob_or_path)
     if not files:
-        raise OSError("No such file or directory: '{0}'".format(glob_or_path))
+        raise OSError("No such file or directory: '{0}'".format(glob_or_path), errno.ENOENT)
     if len(files) > 1 and not os.path.isdir(dest):
         raise ValueError(
             "'{0}' matches multiple files but '{1}' is not a directory".format(glob_or_path, dest)

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -52,7 +52,7 @@ def is_gzipped(path):
         True if file is gzipped, otherwise False
     """
     with open(path, "rb") as fd:
-        return compression.GZipFileType.matches_magic(fd)
+        return compression.GZipFileType().matches_magic(fd)
 
 
 def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -26,6 +26,7 @@ import spack.error
 import spack.mirrors.mirror
 import spack.schema
 import spack.spec
+import spack.util.compression as compression
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
@@ -50,14 +51,8 @@ def is_gzipped(path):
     Returns:
         Trye if file is gzipped, otherwise False
     """
-    try:
-        with gzip.open(path, "r") as f:
-            f.read(1)
-        return True
-    except gzip.BadGzipFile:
-        return False
-    except FileNotFoundError:
-        return False
+    with open(path, "rb") as fd:
+        return compression.GZipFileType.matches_magic(fd)
 
 
 def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -44,17 +44,35 @@ SPACK_RESERVED_TAGS = ["public", "protected", "notary"]
 _urlopen = web_util.urlopen
 
 
-def is_gzipped(path):
-    """Check if the path is a gzipped file
+def copy_gzipped(glob_or_path, dest):
+    """Copy all of the files in the source glob/path to the destination.
 
     Parameters:
-        path: path to file to test
-
-    Returns:
-        True if file is gzipped, otherwise False
+        glob_or_path: path to file to test
+        dest: destination path to copy to
     """
-    with open(path, "rb") as fd:
-        return compression.GZipFileType().matches_magic(fd)
+
+    files = glob.glob(glob_or_path)
+    if not files:
+        raise OSError("No such file or directory: '{0}'".format(glob_or_path))
+    if len(files) > 1 and not os.path.isdir(dest):
+        raise ValueError(
+            "'{0}' matches multiple files but '{1}' is not a directory".format(glob_or_path, dest)
+        )
+
+    def is_gzipped(path):
+        with open(path, "rb") as fd:
+            return compression.GZipFileType().matches_magic(fd)
+
+    for src in files:
+        if is_gzipped(src):
+            fs.copy(src, dest)
+        else:
+            # Compress and copy in one step
+            src_name = os.path.basename(src)
+            zipped = os.path.join(dest, f"{src_name}.gz")
+            with open(src, "rb") as fin, gzip.open(zipped, "wb") as fout:
+                shutil.copyfileobj(fin, fout)
 
 
 def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):
@@ -67,15 +85,11 @@ def copy_files_to_artifacts(src, artifacts_dir, *, compress_artifacts=False):
         compress_artifacts (bool): option to compress copied artifacts using Gzip
     """
     try:
-        for s in glob.glob(src):
-            if compress_artifacts and not is_gzipped(s):
-                # Compress and copy in one step
-                src_name = os.path.basename(s)
-                zipped = os.path.join(artifacts_dir, f"{src_name}.gz")
-                with open(s, "rb") as fin, gzip.open(zipped, "wb") as fout:
-                    shutil.copyfileobj(fin, fout)
-            else:
-                fs.copy(s, artifacts_dir)
+
+        if compress_artifacts:
+            copy_gzipped(src, artifacts_dir)
+        else:
+            fs.copy(src, artifacts_dir)
     except Exception as err:
         msg = (
             f"Unable to copy files ({src}) to artifacts {artifacts_dir} due to "

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -453,7 +453,7 @@ def ci_rebuild(args):
 
     # Arguments when installing the root from sources
     deps_install_args = install_args + ["--only=dependencies"]
-    root_install_args = install_args + ["--only=package"]
+    root_install_args = install_args + ["--keep-stage", "--only=package"]
 
     if cdash_handler:
         # Add additional arguments to `spack install` for CDash reporting.
@@ -492,6 +492,9 @@ def ci_rebuild(args):
 
     # Copy logs and archived files from the install metadata (.spack) directory to artifacts now
     spack_ci.copy_stage_logs_to_artifacts(job_spec, job_log_dir)
+
+    # Clear the stage directory
+    spack.stage.purge()
 
     # If the installation succeeded and we're running stand-alone tests for
     # the package, run them and copy the output. Failures of any kind should

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -245,7 +245,6 @@ def test_ci_copy_stage_logs_to_artifacts_fail(tmpdir, default_mock_concretizatio
     ci.copy_stage_logs_to_artifacts(concrete_spec, log_dir)
     _, err = capfd.readouterr()
     assert "Unable to copy files" in err
-    assert "No such file or directory" in err
 
 
 def test_ci_copy_test_logs_to_artifacts_fail(tmpdir, capfd):

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -245,6 +245,7 @@ def test_ci_copy_stage_logs_to_artifacts_fail(tmpdir, default_mock_concretizatio
     ci.copy_stage_logs_to_artifacts(concrete_spec, log_dir)
     _, err = capfd.readouterr()
     assert "Unable to copy files" in err
+    assert "No such file or directory" in err
 
 
 def test_ci_copy_test_logs_to_artifacts_fail(tmpdir, capfd):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Fallback to copying logs from the stage dir and add a `spack.stage.purge` to the `spack ci rebuild` command.

Added compression to build and test artifacts, inspired by the fact the the install tree compresses the build log.