### PR TITLE
ci: decrease style checks setup time

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -25,14 +25,16 @@ jobs:
       with:
         python-version: '3.13'
         cache: 'pip'
+        cache-dependency-path: '.github/workflows/requirements/style/requirements.txt'
     - name: Install Python Packages
       run: |
-        pip install --upgrade pip setuptools
         pip install -r .github/workflows/requirements/style/requirements.txt
     - name: vermin (Spack's Core)
-      run: vermin --backport importlib --backport argparse --violations --backport typing -t=3.6- -vvv lib/spack/spack/ lib/spack/llnl/ bin/
+      run: |
+        vermin --backport importlib --backport argparse --violations --backport typing -t=3.6- -vvv lib/spack/spack/ lib/spack/llnl/ bin/
     - name: vermin (Repositories)
-      run: vermin --backport importlib --backport argparse --violations --backport typing -t=3.6- -vvv var/spack/repos
+      run: |
+        vermin --backport importlib --backport argparse --violations --backport typing -t=3.6- -vvv var/spack/repos
 
   # Run style checks on the files that have been changed
   style:
@@ -49,14 +51,11 @@ jobs:
     - name: Install Python packages
       run: |
         pip install -r .github/workflows/requirements/style/requirements.txt
-    - name: Setup git configuration
-      run: |
-        git config --global user.email "spack@example.com"
-        git config --global user.name "Test User"
     - name: Run style tests
       run: |
-          bin/spack style --base HEAD^1
-          bin/spack license verify
+        bin/spack style --base HEAD^1
+        bin/spack license verify
+        pylint -j $(nproc) --disable=all --enable=unspecified-encoding --ignore-paths=lib/spack/external lib
 
   audit:
     uses: ./.github/workflows/audit.yaml
@@ -103,21 +102,3 @@ jobs:
           spack -d bootstrap now --dev
           spack -d style -t black
           spack unit-test -V
-
-  # Further style checks from pylint
-  pylint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
-        with:
-          python-version: '3.13'
-          cache: 'pip'
-      - name: Install Python packages
-        run: |
-          pip install --upgrade pip setuptools pylint
-      - name: Pylint (Spack Core)
-        run: |
-          pylint -j 4 --disable=all --enable=unspecified-encoding --ignore-paths=lib/spack/external lib

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -40,23 +40,23 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
-        fetch-depth: 0
+        fetch-depth: 2
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
       with:
         python-version: '3.13'
         cache: 'pip'
+        cache-dependency-path: '.github/workflows/requirements/style/requirements.txt'
     - name: Install Python packages
       run: |
-        pip install --upgrade pip setuptools
         pip install -r .github/workflows/requirements/style/requirements.txt
     - name: Setup git configuration
       run: |
-        # Need this for the git tests to succeed.
-        git --version
-        . .github/workflows/bin/setup_git.sh
+        git config --global user.email "spack@example.com"
+        git config --global user.name "Test User"
     - name: Run style tests
       run: |
-          share/spack/qa/run-style-tests
+          bin/spack style --base HEAD^1
+          bin/spack license verify
 
   audit:
     uses: ./.github/workflows/audit.yaml

--- a/.github/workflows/requirements/style/requirements.txt
+++ b/.github/workflows/requirements/style/requirements.txt
@@ -5,3 +5,4 @@ isort==6.0.1
 mypy==1.15.0
 types-six==1.17.0.20250304
 vermin==1.6.0
+pylint==3.3.6


### PR DESCRIPTION
Using `depth: 2` instead of pulling the entire repository allows us to still check the full history of a pull request due to GitHub Actions magic merge commit. See https://stackoverflow.com/a/74268200 for additional info.

Decreases execution time of style checks from 2m (pylint and style combined) to ~30-45s.