### PR TITLE
util-linux-uuid: add v2.41

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -17,6 +17,7 @@ class UtilLinuxUuid(AutotoolsPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("2.41", sha256="c014b5861695b603d0be2ad1e6f10d5838b9d7859e1dd72d01504556817d8a87")
     version("2.40.4", sha256="5b3b1435c02ba201ebaa5066bb391965a614b61721155dfb7f7b6569e95b0627")
     version("2.40.3", sha256="6d72589a24b7feccdf8db20336bb984f64c7cfc2ceb044ef01cac5dce480284e")
     version("2.40.2", sha256="7bec316b713a14c6be1a5721aa0e56a3b6170277329e6e1f1a56013cc91eece0")


### PR DESCRIPTION
https://www.kernel.org/pub/linux/utils/util-linux/v2.41/v2.41-ReleaseNotes:

> util-linux 2.41 Release Notes
> =============================
>  
> Release highlights
> ------------------
> 
> libuuid:
>   - Now supports RFC9562 UUIDs.
> 
> 
> Changes between v2.40 and v2.41
> -------------------------------
> 
> libuuid:
>     - support non-cached scenarios (when -lpthread is unavailable) (by Karel Zak)
>     - fix gcc15 warnings (by Cristian Rodríguez)
>     - set variant in the corrrect byte __uuid_set_variant_and_version (by oittaa)
>     - link test_uuid_time with pthread (by Thomas Weißschuh)
>     - construct UUIDv7 without "struct uuid" (by Thomas Weißschuh)
>     - construct UUIDv6 without "struct uuid" (by Thomas Weißschuh)
>     - add helper to set version and variant in uuid_t (by Thomas Weißschuh)
>     - test time-based UUID generation (by Thomas Weißschuh)
>     - drop duplicate assignment liuuid_la_LDFLAGS (by Karel Zak)
>     - fix v6 generation (by Thomas Weißschuh)
>     - clear uuidd cache on fork() (by Thomas Weißschuh)
>     - split uuidd cache into dedicated struct (by Thomas Weißschuh)
>     - drop check for HAVE_TLS (by Thomas Weißschuh)
>     - add support for RFC9562 UUIDs (by Thomas Weißschuh)
>     - (man) fix function declarations (by CismonX)

Diff: https://github.com/util-linux/util-linux/compare/v2.40.4...v2.41