### PR TITLE
py-setuptools-scm: add v8.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -16,6 +16,7 @@ class PySetuptoolsScm(PythonPackage):
 
     license("MIT")
 
+    version("8.2.1", sha256="51cfdd1deefc9b8c08d1a61e940a59c4dec39eb6c285d33fa2f1b4be26c7874d")
     version("8.2.0", sha256="a18396a1bc0219c974d1a74612b11f9dce0d5bd8b1dc55c65f6ac7fd609e8c28")
     version("8.1.0", sha256="42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7")
     version("8.0.4", sha256="b5f43ff6800669595193fd09891564ee9d1d7dcb196cab4b2506d53a2e1c95c7")


### PR DESCRIPTION
https://github.com/pypa/setuptools-scm/blob/v8.2.1/CHANGELOG.md:

> ## v8.2.1
> 
> ### Fixed
> 
> - fix https://github.com/pypa/setuptools-scm/issues/1119: also include pre/post release details in version_tuple
> - fix https://github.com/pypa/setuptools-scm/issues/1112: unpin setuptools for own dependencies due to ubuntu lts bugs
> - add python 3.13 to the support matrix

Diff: https://github.com/pypa/setuptools-scm/compare/v8.2.0...v8.2.1