### PR TITLE
py-kiwisolver: add v1.4.6, v1.4.7, v1.4.8

### DIFF
--- a/var/spack/repos/builtin/packages/py-cppy/package.py
+++ b/var/spack/repos/builtin/packages/py-cppy/package.py
@@ -13,6 +13,8 @@ class PyCppy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.3.1", sha256="55b5307c11874f242ea135396f398cb67a5bbde4fab3e3c3294ea5fce43a6d68")
+    version("1.3.0", sha256="da7413a286d5d31626ba35ed2c70ddfb033520cc81310088ba5a57d34039f604")
     version("1.2.1", sha256="83b43bf17b1085ac15c5debdb42154f138b928234b21447358981f69d0d6fe1b")
     version("1.1.0", sha256="4eda6f1952054a270f32dc11df7c5e24b259a09fddf7bfaa5f33df9fb4a29642")
 

--- a/var/spack/repos/builtin/packages/py-kiwisolver/package.py
+++ b/var/spack/repos/builtin/packages/py-kiwisolver/package.py
@@ -11,6 +11,9 @@ class PyKiwisolver(PythonPackage):
     homepage = "https://github.com/nucleic/kiwi"
     pypi = "kiwisolver/kiwisolver-1.1.0.tar.gz"
 
+    version("1.4.8", sha256="23d5f023bdc8c7e54eb65f03ca5d5bb25b601eac4d7f1a042888a1f45237987e")
+    version("1.4.7", sha256="9893ff81bd7107f7b685d3017cc6583daadb4fc26e4a888350df530e41980a60")
+    version("1.4.6", sha256="3cda29d601445e6aa11f80d90a9b8c2ae501650c55d7ad29829bd44499c9e7e0")
     version("1.4.5", sha256="e57e563a57fb22a142da34f38acc2fc1a5c864bc29ca1517a88abc963e60d6ec")
     version("1.4.4", sha256="d41997519fcba4a1e46eb4a2fe31bc12f0ff957b2b81bac28db24744f333e955")
     version("1.3.2", sha256="fc4453705b81d03568d5b808ad8f09c77c47534f6ac2e72e733f9ca4714aa75c")
@@ -25,10 +28,13 @@ class PyKiwisolver(PythonPackage):
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"), when="@1.2.0:")
     depends_on("python@3.7:", type=("build", "run"), when="@1.3.2:")
+    depends_on("python@3.8:", type=("build", "run"), when="@1.4.6:")
+    depends_on("python@3.10:", type=("build", "run"), when="@1.4.8:")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@61.2:", when="@1.4.4:", type="build")
     depends_on("py-setuptools-scm@3.4.3:+toml", when="@1.4.4:", type="build")
     depends_on("py-cppy@1.1.0:", type="build", when="@1.2.0:")
     depends_on("py-cppy@1.2.0:", type="build", when="@1.4.4:")
+    depends_on("py-cppy@1.3.0:", type="build", when="@1.4.8:")
     depends_on("py-typing-extensions", when="@1.4.4: ^python@:3.7", type=("build", "run"))


### PR DESCRIPTION
This PR adds `py-kiwisolver`, thru v1.4.8, [minor dependency changes](https://github.com/nucleic/kiwi/compare/1.4.5...1.4.8).

This PR adds `py-cppy`, v1.3.0 and v1.3.1, [minimal changes](https://github.com/nucleic/cppy/compare/1.2.1...1.3.1).