### PR TITLE
apptainer: add v1.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -54,7 +54,7 @@ class Apptainer(SingularityBase):
     version("1.1.3", sha256="c7bf7f4d5955e1868739627928238d02f94ca9fd0caf110b0243d65548427899")
     version("1.0.2", sha256="2d7a9d0a76d5574459d249c3415e21423980d9154ce85e8c34b0600782a7dfd3")
 
-    variant("libsubid", default=True, when="@1.4:")
+    variant("libsubid", default=True, when="@1.4:", description="Enable libsubid support")
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -37,6 +37,7 @@ class Apptainer(SingularityBase):
     )
 
     version("main", branch="main", get_full_repo=True)  # apptainer version uses git describe
+    version("1.4.0", sha256="204cded54046547cb3eb4c7874bdf45892fedc58b0d104195c59d2972cba51d3")
     version("1.3.6", sha256="b5343369e7fdf67572f887d81f8d2b938f099fb39c876d96430d747935960d51")
     version("1.3.5", sha256="fe1c977da952edf1056915b2df67ae2203ef06065d4e4901a237c902329306b2")
     version("1.3.4", sha256="c6ccfdd7c967e5c36dde8711f369c4ac669a16632b79fa0dcaf7e772b7a47397")
@@ -53,17 +54,23 @@ class Apptainer(SingularityBase):
     version("1.1.3", sha256="c7bf7f4d5955e1868739627928238d02f94ca9fd0caf110b0243d65548427899")
     version("1.0.2", sha256="2d7a9d0a76d5574459d249c3415e21423980d9154ce85e8c34b0600782a7dfd3")
 
+    variant("libsubid", default=True, when="@1.4:")
+
     depends_on("c", type="build")  # generated
 
     depends_on("e2fsprogs@1.47:+fuse2fs", type="run")
     depends_on("go@1.17.5:", when="@1.1.0:")
     depends_on("go@1.19:", when="@1.2:")
     depends_on("go@1.20:", when="@1.3:")
+    depends_on("go@1.21:", when="@1.3:")
+    depends_on("go@1.22.7:", when="@1.4:")
     depends_on("gocryptfs@2.4:", type="run", when="@1.3:")
     depends_on("squashfuse", type="run")
     depends_on("squashfuse@0.5.1:", type="run", when="@1.3:")
     depends_on("fuse-overlayfs", type="run")
     depends_on("fuse-overlayfs@1.13:", type="run", when="@1.3:")
+
+    depends_on("shadow", when="+libsubid")
 
     singularity_org = "apptainer"
     singularity_name = "apptainer"
@@ -79,6 +86,10 @@ class Apptainer(SingularityBase):
         options = []
         if spec.satisfies("@1.1.0: +suid"):
             options.append("--with-suid")
+        if spec.satisfies("+libsubid"):
+            options.append("--with-libsubid")
+        else:
+            options.append("--without-libsubid")
         return options
 
     def flag_handler(self, name, flags):

--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -62,7 +62,6 @@ class Apptainer(SingularityBase):
     depends_on("go@1.17.5:", when="@1.1.0:")
     depends_on("go@1.19:", when="@1.2:")
     depends_on("go@1.20:", when="@1.3:")
-    depends_on("go@1.21:", when="@1.3:")
     depends_on("go@1.22.7:", when="@1.4:")
     depends_on("gocryptfs@2.4:", type="run", when="@1.3:")
     depends_on("squashfuse", type="run")


### PR DESCRIPTION
This PR adds `apptainer`, v1.4.0 ([diff](https://github.com/apptainer/apptainer/compare/v1.3.6...v1.4.0)), which upgrades the go dependency and adds optional libsubid support.