### PR TITLE
cmark: add v0.31.1

### DIFF
--- a/var/spack/repos/builtin/packages/cmark/package.py
+++ b/var/spack/repos/builtin/packages/cmark/package.py
@@ -14,6 +14,7 @@ class Cmark(CMakePackage):
 
     license("BSD-2-Clause")
 
+    version("0.31.1", sha256="3da93db5469c30588cfeb283d9d62edfc6ded9eb0edc10a4f5bbfb7d722ea802")
     version("0.31.0", sha256="bbcb8f8c03b5af33fcfcf11a74e9499f20a9043200b8552f78a6e8ba76e04d11")
     version("0.29.0", sha256="2558ace3cbeff85610de3bda32858f722b359acdadf0c4691851865bb84924a6")
     version("0.28.3", sha256="acc98685d3c1b515ff787ac7c994188dadaf28a2d700c10c1221da4199bae1fc")


### PR DESCRIPTION
This PR adds `cmark`, v0.31.1, [bugfix release](https://github.com/commonmark/cmark/releases/tag/0.31.1).