### PR TITLE
cppgsl: add v4.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/cppgsl/package.py
+++ b/var/spack/repos/builtin/packages/cppgsl/package.py
@@ -15,6 +15,7 @@ class Cppgsl(CMakePackage):
     license("MIT")
 
     version("main", branch="main")
+    version("4.2.0", sha256="2c717545a073649126cb99ebd493fa2ae23120077968795d2c69cbab821e4ac6")
     version("4.1.0", sha256="0a227fc9c8e0bf25115f401b9a46c2a68cd28f299d24ab195284eb3f1d7794bd")
     version("4.0.0", sha256="f0e32cb10654fea91ad56bde89170d78cfbf4363ee0b01d8f097de2ba49f6ce9")
     version("3.1.0", sha256="d3234d7f94cea4389e3ca70619b82e8fb4c2f33bb3a070799f1e18eef500a083")


### PR DESCRIPTION
This PR adds `cppgsl`, v4.2.0, [diff](https://github.com/microsoft/GSL/compare/v4.1.0...v4.2.0).