### PR TITLE
sherpa: add variant internal_pdfs to avoid fortran

### DIFF
--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -55,6 +55,7 @@ class Sherpa(CMakePackage, AutotoolsPackage):
         description="Enable HepMC (version 3.1+) ROOT support",
         when="+root",
     )
+    variant("internal_pdfs", default=True, description="Enables internal PDFs", when="@3:")
     variant("rivet", default=False, description="Enable Rivet support")
     variant("fastjet", default=True, when="@:2", description="Enable FASTJET")
     variant("openloops", default=False, description="Enable OpenLoops")
@@ -81,9 +82,10 @@ class Sherpa(CMakePackage, AutotoolsPackage):
 
     # Note that the delphes integration seems utterly broken: https://sherpa.hepforge.org/trac/ticket/305
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="@:2")
+    depends_on("fortran", type="build", when="@3: +internal_pdfs")
 
     # autotools dependencies are needed at runtime to compile processes
     depends_on("autoconf", when="@:2")
@@ -158,6 +160,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define_from_variant("SHERPA_ENABLE_GZIP", "gzip"),
             self.define_from_variant("SHERPA_ENABLE_HEPMC3", "hepmc3"),
             self.define_from_variant("SHERPA_ENABLE_HEPMC3_ROOT", "hepmc3root"),
+            self.define_from_variant("SHERPA_ENABLE_INTERNAL_PDFS", "internal_pdfs"),
             self.define_from_variant("SHERPA_ENABLE_LHAPDF", "lhapdf"),
             self.define_from_variant("SHERPA_ENABLE_LHOLE", "lhole"),
             self.define_from_variant("SHERPA_ENABLE_MPI", "mpi"),


### PR DESCRIPTION
This PR adds to `sherpa` a new variant `internal_pdfs` that allows to disable the need for a fortran compiler to compile CT14 and CJK PDF grids. Another PDF provider has to be provided (e.g. `+lhapdf`) but this is not imposed in the package since it's not imposed upstream.