### PR TITLE
Packages: add missing compiler dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/amp/package.py
+++ b/var/spack/repos/builtin/packages/amp/package.py
@@ -31,6 +31,10 @@ class Amp(CMakePackage):
     variant("trilinos", default=True, description="Build with support for Trilinos")
     variant("zlib", default=True, description="Build with support for zlib")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     # Everything should be compiled position independent (-fpic)
     depends_on("blas")
     depends_on("lapack")

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -65,6 +65,7 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
     license_url = "https://www.amd.com/en/developer/aocc/aocc-compiler/eula.html"
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("libxml2")
     depends_on("zlib-api")

--- a/var/spack/repos/builtin/packages/aocl-da/package.py
+++ b/var/spack/repos/builtin/packages/aocl-da/package.py
@@ -52,6 +52,8 @@ class AoclDa(CMakePackage):
         when="@5.0",
     )
 
+    depends_on("c", type="build")
+
     depends_on("cmake@3.22:", type="build")
     for vers in ["5.0"]:
         with when(f"@={vers}"):

--- a/var/spack/repos/builtin/packages/aragorn/package.py
+++ b/var/spack/repos/builtin/packages/aragorn/package.py
@@ -28,6 +28,8 @@ class Aragorn(Package):
         expand=False,
     )
 
+    depends_on("c", type="build")
+
     # fix checksum error
     def url_for_version(self, version):
         return f"http://www.ansikte.se/ARAGORN/Downloads/aragorn{version}.c"

--- a/var/spack/repos/builtin/packages/babelstream/package.py
+++ b/var/spack/repos/builtin/packages/babelstream/package.py
@@ -25,6 +25,8 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage, MakefilePackage):
     version("main", branch="main")
     maintainers("tomdeakin", "kaanolgu", "tom91136")
     # Previous maintainers: "robj0nes"
+
+    depends_on("c", type="build")
     depends_on("cxx", type="build", when="languages=cxx")
     depends_on("fortran", type="build", when="languages=fortran")
     # Languages

--- a/var/spack/repos/builtin/packages/bam-readcount/package.py
+++ b/var/spack/repos/builtin/packages/bam-readcount/package.py
@@ -16,6 +16,7 @@ class BamReadcount(CMakePackage):
     version("1.0.1", sha256="8ebf84d9efee0f2d3b43f0452dbf16b27337c960e25128f6a7173119e62588b8")
     version("0.8.0", sha256="4f4dd558e3c6bfb24d6a57ec441568f7524be6639b24f13ea6f2bb350c7ea65f")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/bioawk/package.py
+++ b/var/spack/repos/builtin/packages/bioawk/package.py
@@ -16,6 +16,8 @@ class Bioawk(MakefilePackage):
 
     version("1.0", sha256="316a6561dda41e8327b85106db3704e94e23d7a89870392d19ef8559f7859e2d")
 
+    depends_on("c", type="build")
+
     depends_on("zlib-api")
     depends_on("bison", type=("build"))
 

--- a/var/spack/repos/builtin/packages/blat/package.py
+++ b/var/spack/repos/builtin/packages/blat/package.py
@@ -16,6 +16,8 @@ class Blat(Package):
     version("37", sha256="88ee2b272d42ab77687c61d200b11f1d58443951069feb7e10226a2509f84cf2")
     version("35", sha256="06d9bcf114ec4a4b21fef0540a0532556b6602322a5a2b33f159dc939ae53620")
 
+    depends_on("c", type="build")
+
     depends_on("libpng")
     depends_on("uuid", when="@37:")
     depends_on("mysql-client", when="@37:")

--- a/var/spack/repos/builtin/packages/bucky/package.py
+++ b/var/spack/repos/builtin/packages/bucky/package.py
@@ -19,6 +19,8 @@ class Bucky(MakefilePackage):
 
     requires("%gcc", msg="bucky can only be compiled with GCC")
 
+    depends_on("cxx", type="build")
+
     build_directory = "src"
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/casper/package.py
+++ b/var/spack/repos/builtin/packages/casper/package.py
@@ -23,6 +23,7 @@ class Casper(MakefilePackage):
     )
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("jellyfish@2.2.3:")
     depends_on("boost+exception")

--- a/var/spack/repos/builtin/packages/connect-proxy/package.py
+++ b/var/spack/repos/builtin/packages/connect-proxy/package.py
@@ -16,6 +16,8 @@ class ConnectProxy(MakefilePackage):
 
     version("1.105", sha256="07366026b1f81044ecd8da9b5b5b51321327ecdf6ba23576271a311bbd69d403")
 
+    depends_on("c", type="build")
+
     def build(self, spec, prefix):
         make("CC={0}".format(spack_cc))
 

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -37,10 +37,6 @@ class CrayMpich(MpichEnvironmentModifications, Package, CudaPackage, ROCmPackage
     version("7.7.14")
     version("7.7.13")
 
-    depends_on("c", type="build")
-    depends_on("cxx", type="build")
-    depends_on("fortran", type="build")
-
     depends_on("cray-pmi")
     depends_on("libfabric")
 

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -37,6 +37,10 @@ class CrayMpich(MpichEnvironmentModifications, Package, CudaPackage, ROCmPackage
     version("7.7.14")
     version("7.7.13")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("cray-pmi")
     depends_on("libfabric")
 

--- a/var/spack/repos/builtin/packages/dataspaces/package.py
+++ b/var/spack/repos/builtin/packages/dataspaces/package.py
@@ -34,6 +34,8 @@ class Dataspaces(AutotoolsPackage):
     variant("ptag", default="250", description="Cray UGNI protection tag", values=is_string)
     variant("mpi", default=True, description="Use MPI for collective communication")
 
+    depends_on("c", type="build")
+
     depends_on("m4", type="build")
     depends_on("automake", type="build")
     depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/dhpmm-f/package.py
+++ b/var/spack/repos/builtin/packages/dhpmm-f/package.py
@@ -15,6 +15,9 @@ class DhpmmF(MakefilePackage):
 
     version("alpha", sha256="35321ecbc749f2682775ffcd27833afc8c8eb4fa7753ce769727c9d1fe097848")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("blas", type="link")
     depends_on("lapack", type="link")
 

--- a/var/spack/repos/builtin/packages/dialign-tx/package.py
+++ b/var/spack/repos/builtin/packages/dialign-tx/package.py
@@ -18,6 +18,8 @@ class DialignTx(MakefilePackage):
 
     build_directory = "source"
 
+    depends_on("c", type="build")
+
     conflicts("%gcc@6:")
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/dicom3tools/package.py
+++ b/var/spack/repos/builtin/packages/dicom3tools/package.py
@@ -26,6 +26,7 @@ class Dicom3tools(MakefilePackage):
         description="default UID Root assignment",
     )
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("bzip2", type="build")

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -125,6 +125,7 @@ class Dihydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
     )
 
     # Dependencies
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("catch2@3.0.1:", type=("build", "test"), when="+developer")

--- a/var/spack/repos/builtin/packages/dire/package.py
+++ b/var/spack/repos/builtin/packages/dire/package.py
@@ -21,6 +21,7 @@ class Dire(Package):
 
     version("2.004", sha256="8cc1213b58fec744fdaa50834560a14b141de99efb2c3e3d3d47f3d6d84b179f")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("zlib-api")

--- a/var/spack/repos/builtin/packages/dray/package.py
+++ b/var/spack/repos/builtin/packages/dray/package.py
@@ -65,6 +65,7 @@ class Dray(Package, CudaPackage):
     # set to false for systems that implicitly link mpi
     variant("blt_find_mpi", default=True, description="Use BLT CMake Find MPI logic")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/eclipse-gcj-parser/package.py
+++ b/var/spack/repos/builtin/packages/eclipse-gcj-parser/package.py
@@ -28,6 +28,8 @@ class EclipseGcjParser(Package):
         expand=False,
     )
 
+    depends_on("c", type="build")
+
     @property
     def gcj(self):
         """Obtain Executable for the gcj included with this GCC,

--- a/var/spack/repos/builtin/packages/examinimd/package.py
+++ b/var/spack/repos/builtin/packages/examinimd/package.py
@@ -33,6 +33,8 @@ class Examinimd(MakefilePackage):
 
     conflicts("+openmp", when="+pthreads")
 
+    depends_on("cxx", type="build")
+
     depends_on("kokkos-legacy")
     depends_on("mpi", when="+mpi")
 

--- a/var/spack/repos/builtin/packages/fasttree/package.py
+++ b/var/spack/repos/builtin/packages/fasttree/package.py
@@ -31,6 +31,8 @@ class Fasttree(Package):
 
     variant("openmp", default=True, description="Add openmp support to Fasttree.")
 
+    depends_on("c", type="build")
+
     def install(self, spec, prefix):
         cc = Executable(spack_cc)
         if self.spec.satisfies("+openmp"):

--- a/var/spack/repos/builtin/packages/ferret/package.py
+++ b/var/spack/repos/builtin/packages/ferret/package.py
@@ -30,6 +30,7 @@ class Ferret(Package):
     variant("datasets", default=False, description="Install Ferret standard datasets")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")
     depends_on("fortran", type="build")  # generated
 
     depends_on("hdf5+hl")

--- a/var/spack/repos/builtin/packages/ffb/package.py
+++ b/var/spack/repos/builtin/packages/ffb/package.py
@@ -22,6 +22,10 @@ class Ffb(MakefilePackage):
     patch("xvx.patch")
     patch("gffv3tr.patch")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("mpi")
     depends_on("blas")
     depends_on("scalapack")

--- a/var/spack/repos/builtin/packages/ffr/package.py
+++ b/var/spack/repos/builtin/packages/ffr/package.py
@@ -32,6 +32,9 @@ class Ffr(MakefilePackage):
     patch("gfortran_format_31.patch", when="@3.1.004 %gcc")
     patch("gfortran_format_30.patch", when="@3.0_000 %gcc")
 
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("mpi")
     depends_on("metis@:4", type="link")
 

--- a/var/spack/repos/builtin/packages/flamemaster/package.py
+++ b/var/spack/repos/builtin/packages/flamemaster/package.py
@@ -127,6 +127,9 @@ class Flamemaster(CMakePackage):
     variant("eglib", default=False, description="Build with EG lib")
     variant("sundials", default=True, description="with sundials")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("blas")
     depends_on("lapack")
     depends_on("cmake@3.12", type="build")

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -23,6 +23,7 @@ class Fontconfig(AutotoolsPackage):
     version("2.11.1", sha256="b6b066c7dce3f436fdc0dfbae9d36122b38094f4f53bd8dffd45e195b0540d8d")
 
     depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")
 
     # freetype2 21.0.15+ provided by freetype 2.8.1+
     depends_on("freetype@2.8.1:", when="@2.13:")

--- a/var/spack/repos/builtin/packages/fplo/package.py
+++ b/var/spack/repos/builtin/packages/fplo/package.py
@@ -44,6 +44,10 @@ class Fplo(MakefilePackage):
     # Sets the correct python module import order.
     patch("fedit_py.patch")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("mkl")
     depends_on("ncurses")
     depends_on("perl", type="run")

--- a/var/spack/repos/builtin/packages/fsl/package.py
+++ b/var/spack/repos/builtin/packages/fsl/package.py
@@ -26,6 +26,9 @@ class Fsl(Package, CudaPackage):
     version("6.0.4", sha256="58b88f38e080b05d70724d57342f58e1baf56e2bd3b98506a72b4446cad5033e")
     version("5.0.10", sha256="ca183e489320de0e502a7ba63230a7f55098917a519e8c738b005d526e700842")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("python", type=("build", "run"))
     depends_on("expat")
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/grib-api/package.py
+++ b/var/spack/repos/builtin/packages/grib-api/package.py
@@ -70,6 +70,8 @@ class GribApi(CMakePackage):
     # tests are enabled but the testing scripts don't use it.
     # depends_on('valgrind', type='test', when='+test')
 
+    depends_on("fortran", type="build", when="+fortran")
+
     depends_on("netcdf-c", when="+netcdf")
     depends_on("openjpeg@1.5.0:1.5", when="jp2k=openjpeg")
     depends_on("jasper", when="jp2k=jasper")
@@ -84,11 +86,6 @@ class GribApi(CMakePackage):
 
     # CMAKE_INSTALL_RPATH must be a semicolon-separated list.
     patch("cmake_install_rpath.patch")
-
-    @run_before("cmake")
-    def check_fortran(self):
-        if "+fortran" in self.spec and self.compiler.fc is None:
-            raise InstallError("Fortran interface requires a Fortran compiler!")
 
     def cmake_args(self):
         var_opt_list = [

--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -67,6 +67,8 @@ class HdfEos2(AutotoolsPackage):
 
     conflicts("~static", when="~shared", msg="At least one of +static or +shared must be set")
 
+    depends_on("c", type="build")
+
     # Build dependencies
     depends_on("hdf")
     # Because hdf always depends on zlib and jpeg in spack, the tests below in configure_args

--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -38,6 +38,8 @@ class Hipsycl(CMakePackage, ROCmPackage):
     variant("cuda", default=False, description="Enable CUDA backend for SYCL kernels")
     variant("rocm", default=False, description="Enable ROCM backend for SYCL kernels")
 
+    depends_on("cxx", type="build")
+
     depends_on("cmake@3.5:", type="build")
     depends_on("boost +filesystem", when="@:0.8")
     depends_on("boost@1.67.0:1.69.0 +filesystem +fiber +context cxxstd=17", when="@0.9.1:")

--- a/var/spack/repos/builtin/packages/improved-rdock/package.py
+++ b/var/spack/repos/builtin/packages/improved-rdock/package.py
@@ -22,6 +22,7 @@ class ImprovedRdock(MakefilePackage):
 
     version("main", branch="main")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("popt")

--- a/var/spack/repos/builtin/packages/itensor/package.py
+++ b/var/spack/repos/builtin/packages/itensor/package.py
@@ -37,6 +37,7 @@ class Itensor(MakefilePackage):
     variant("hdf5", default=False, description="Build rockstar with HDF5 support.")
     variant("shared", default=False, description="Also build dynamic libraries.")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("lapack")

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -117,6 +117,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     conflicts("+gold", when="platform=darwin", msg="gold does not work on Darwin")
     conflicts("+lld", when="platform=darwin", msg="lld does not work on Darwin")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.17.0:", type="build")

--- a/var/spack/repos/builtin/packages/lcals/package.py
+++ b/var/spack/repos/builtin/packages/lcals/package.py
@@ -30,6 +30,8 @@ class Lcals(MakefilePackage):
         values=("sse", "avx", "MIC"),
     )
 
+    depends_on("cxx", type="build")
+
     @property
     def build_targets(self):
         targets = []

--- a/var/spack/repos/builtin/packages/ldak/package.py
+++ b/var/spack/repos/builtin/packages/ldak/package.py
@@ -24,6 +24,8 @@ class Ldak(Package):
 
     variant("glpk", default=False, description="Use glpk instead of vendored qsopt")
 
+    depends_on("c", type="build")
+
     depends_on("zlib-api")
     depends_on("blas")
     depends_on("lapack")

--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -133,6 +133,9 @@ class Libmesh(AutotoolsPackage):
         "variant.",
     )
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("boost", when="+boost")
 
     # TODO: replace this with an explicit list of components of Boost,

--- a/var/spack/repos/builtin/packages/lorene/package.py
+++ b/var/spack/repos/builtin/packages/lorene/package.py
@@ -30,6 +30,9 @@ class Lorene(MakefilePackage):
         description="Build Bin_star solver for binary neutron star systems",
     )
 
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("blas")
     depends_on("fftw @3:", when="+fftw")
     depends_on("gsl")

--- a/var/spack/repos/builtin/packages/mapsplice2/package.py
+++ b/var/spack/repos/builtin/packages/mapsplice2/package.py
@@ -19,6 +19,9 @@ class Mapsplice2(MakefilePackage):
     patch("Makefile.patch")
     patch("mapsplice_ebwt.patch")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("bowtie")
     depends_on("ncurses", type="link")
     depends_on("samtools", type="link")

--- a/var/spack/repos/builtin/packages/mpitrampoline/package.py
+++ b/var/spack/repos/builtin/packages/mpitrampoline/package.py
@@ -59,6 +59,7 @@ class Mpitrampoline(CMakePackage):
     version("1.0.1", sha256="4ce91b99fb6d2dab481b5e477b6b6a0709add48cf0f287afbbb440fdf3232500")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")
     depends_on("fortran", type="build")  # generated
 
     variant("shared", default=True, description="Build a shared version of the library")

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -19,7 +19,9 @@ class Mptensor(CMakePackage):
     variant("mpi", default=False, description="Build with MPI library")
     variant("doc", default=False, description="build documentation with Doxygen")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")
 
     depends_on("cmake@3.6:", type="build")
     depends_on("mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -28,6 +28,8 @@ class Msmpi(Package):
 
     provides("mpi")
 
+    depends_on("c", type="build")
+
     depends_on("win-wdk")
 
     patch("ifort_compat.patch")

--- a/var/spack/repos/builtin/packages/mumax/package.py
+++ b/var/spack/repos/builtin/packages/mumax/package.py
@@ -30,6 +30,8 @@ class Mumax(MakefilePackage, CudaPackage):
     variant("cuda", default=True, description="Use CUDA; must be true")
     variant("gnuplot", default=False, description="Use gnuplot for graphs")
 
+    depends_on("c", type="build")
+
     depends_on("cuda")
     depends_on("go", type="build")
     depends_on("gnuplot", type="run", when="+gnuplot")

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -99,6 +99,9 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
     # Handle change in python-config for python@3.8:
     patch("namd-python38.patch", when="interface=python ^python@3.8:")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("charmpp@7.0.0:", when="@3.0:")
     depends_on("charmpp@6.10.1:6", when="@2.14:2")
     depends_on("charmpp@6.8.2", when="@2.13")

--- a/var/spack/repos/builtin/packages/nn-c/package.py
+++ b/var/spack/repos/builtin/packages/nn-c/package.py
@@ -19,6 +19,8 @@ class NnC(AutotoolsPackage):
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     configure_directory = "nn"
 

--- a/var/spack/repos/builtin/packages/openfdtd/package.py
+++ b/var/spack/repos/builtin/packages/openfdtd/package.py
@@ -23,6 +23,8 @@ class Openfdtd(MakefilePackage):
 
     variant("mpi", default=False, description="Build with MPI Support")
 
+    depends_on("c", type="build")
+
     depends_on("mpi", when="+mpi")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -82,6 +82,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
         variant("dynamic", default=False, description="Link with MSVC's dynamic runtime library")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("zlib-api")
     depends_on("perl@5.14.0:", type=("build", "test"))

--- a/var/spack/repos/builtin/packages/openstf/package.py
+++ b/var/spack/repos/builtin/packages/openstf/package.py
@@ -22,6 +22,8 @@ class Openstf(MakefilePackage):
 
     variant("mpi", default=False, description="Build with MPI Support")
 
+    depends_on("c", type="build")
+
     depends_on("mpi", when="+mpi")
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/orc/package.py
+++ b/var/spack/repos/builtin/packages/orc/package.py
@@ -15,6 +15,7 @@ class Orc(CMakePackage):
 
     version("1.6.5", sha256="df5885db8fa2e4435db8d486c6c7fc4e2c565d6197eee27729cf9cbdf36353c0")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("maven")

--- a/var/spack/repos/builtin/packages/pacparser/package.py
+++ b/var/spack/repos/builtin/packages/pacparser/package.py
@@ -25,6 +25,7 @@ class Pacparser(MakefilePackage):
     )
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("python", when="+python")
     depends_on("py-setuptools", when="+python", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/parquet-cpp/package.py
+++ b/var/spack/repos/builtin/packages/parquet-cpp/package.py
@@ -18,6 +18,7 @@ class ParquetCpp(CMakePackage):
 
     depends_on("arrow")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     # TODO: replace this with an explicit list of components of Boost,

--- a/var/spack/repos/builtin/packages/pdftk/package.py
+++ b/var/spack/repos/builtin/packages/pdftk/package.py
@@ -22,6 +22,8 @@ class Pdftk(MakefilePackage):
 
     version("2.02", sha256="118f6a25fd3acaafb58824dce6f97cdc07e56050e666b90e4c4ef426ea37b8c1")
 
+    depends_on("cxx", type="build")
+
     depends_on("eclipse-gcj-parser", type="build")
 
     # Only takes effect in phases not overridden here

--- a/var/spack/repos/builtin/packages/prank/package.py
+++ b/var/spack/repos/builtin/packages/prank/package.py
@@ -13,6 +13,7 @@ class Prank(Package):
 
     version("170427", sha256="623eb5e9b5cb0be1f49c3bf715e5fabceb1059b21168437264bdcd5c587a8859")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("mafft")

--- a/var/spack/repos/builtin/packages/psi4/package.py
+++ b/var/spack/repos/builtin/packages/psi4/package.py
@@ -26,6 +26,7 @@ class Psi4(CMakePackage):
         values=("Debug", "Release"),
     )
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     # Required dependencies

--- a/var/spack/repos/builtin/packages/regcm/package.py
+++ b/var/spack/repos/builtin/packages/regcm/package.py
@@ -55,6 +55,8 @@ class Regcm(AutotoolsPackage):
         description="Build NetCDF using the high performance parallel " "NetCDF implementation.",
     )
 
+    depends_on("fortran", type="build")
+
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
     depends_on("hdf5")

--- a/var/spack/repos/builtin/packages/revocap-refiner/package.py
+++ b/var/spack/repos/builtin/packages/revocap-refiner/package.py
@@ -19,6 +19,10 @@ class RevocapRefiner(MakefilePackage):
 
     parallel = False
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     # add space between literal and identifier.
     patch("add_space.patch")
     # remove unused function getIndices.

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -69,6 +69,9 @@ class Rose(AutotoolsPackage):
     # --------------------------------------------------------------------------
     # Dependencies
     # --------------------------------------------------------------------------
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("autoconf@2.69:", type="build")
     depends_on("automake@1.14:", type="build")
     depends_on("libtool@2.4:", type="build")

--- a/var/spack/repos/builtin/packages/simmetrix-simmodsuite/package.py
+++ b/var/spack/repos/builtin/packages/simmetrix-simmodsuite/package.py
@@ -540,6 +540,8 @@ class SimmetrixSimmodsuite(Package):
     variant("parallelmesh", default=False, description="enable parallel meshing")
     variant("paralleladapt", default=False, description="enable parallel adaptation")
 
+    depends_on("c", type="build")
+
     depends_on("mpi")
     depends_on("libtirpc", type="link")
     depends_on("gmake", type="build")

--- a/var/spack/repos/builtin/packages/sollve/package.py
+++ b/var/spack/repos/builtin/packages/sollve/package.py
@@ -55,6 +55,9 @@ class Sollve(CMakePackage):
     variant("argobots", default=True, description="Use Argobots in BOLT")
     extends("python", when="+python")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     # Build dependency
     depends_on("cmake@3.4.3:", type="build")
     depends_on("python", type="build")

--- a/var/spack/repos/builtin/packages/sos/package.py
+++ b/var/spack/repos/builtin/packages/sos/package.py
@@ -65,6 +65,10 @@ class Sos(AutotoolsPackage):
     variant("hard-polling", default=False, description="Enable hard polling of wait calls")
     variant("fortran", default=False, description="Enable fortran API")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -22,6 +22,8 @@ class SpectrumMpi(BundlePackage):
 
     requires("platform=linux")
 
+    depends_on("c", type="build")
+
     executables = ["^ompi_info$"]
 
     @classmethod

--- a/var/spack/repos/builtin/packages/srilm/package.py
+++ b/var/spack/repos/builtin/packages/srilm/package.py
@@ -26,6 +26,9 @@ class Srilm(MakefilePackage):
     variant("pic", default=False, description="Build position independent code")
     variant("liblbfgs", default=False, description="Enable libLBFGS")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("iconv")
     depends_on("liblbfgs", when="+liblbfgs")
     depends_on("gawk", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/stripack/package.py
+++ b/var/spack/repos/builtin/packages/stripack/package.py
@@ -29,6 +29,8 @@ class Stripack(MakefilePackage):
         url="https://people.sc.fsu.edu/~jburkardt/f_src/stripack/stripack.f90",
     )
 
+    depends_on("fortran", type="build")
+
     @run_before("build")
     def run_mkmake(self):
         config = [

--- a/var/spack/repos/builtin/packages/sumaclust/package.py
+++ b/var/spack/repos/builtin/packages/sumaclust/package.py
@@ -19,6 +19,8 @@ class Sumaclust(MakefilePackage):
         url="https://git.metabarcoding.org/obitools/sumaclust/uploads/69f757c42f2cd45212c587e87c75a00f/sumaclust_v1.0.20.tar.gz",
     )
 
+    depends_on("c", type="build")
+
     def build(self, spec, prefix):
         make("CC={0}".format(spack_cc))
 

--- a/var/spack/repos/builtin/packages/sw4lite/package.py
+++ b/var/spack/repos/builtin/packages/sw4lite/package.py
@@ -30,6 +30,8 @@ class Sw4lite(MakefilePackage, CudaPackage):
     )
     variant("ckernel", default=False, description="C or Fortran kernel")
 
+    depends_on("cxx", type="build")
+
     depends_on("blas")
     depends_on("lapack")
     depends_on("mpi")

--- a/var/spack/repos/builtin/packages/tmalign/package.py
+++ b/var/spack/repos/builtin/packages/tmalign/package.py
@@ -28,6 +28,8 @@ class Tmalign(Package):
 
     variant("fast-math", default=False, description="Enable fast math", when="@20220412:")
 
+    depends_on("cxx", type="build")
+
     with when("@20220412:"):
         phases = ["build", "install"]
 

--- a/var/spack/repos/builtin/packages/tmscore/package.py
+++ b/var/spack/repos/builtin/packages/tmscore/package.py
@@ -22,6 +22,8 @@ class Tmscore(Package):
 
     variant("fast-math", default=False, description="Enable fast math")
 
+    depends_on("cxx", type="build")
+
     phases = ["build", "install"]
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/unrar/package.py
+++ b/var/spack/repos/builtin/packages/unrar/package.py
@@ -23,7 +23,7 @@ class Unrar(MakefilePackage):
 
     def edit(self, spec, prefix):
         makefile = FileFilter("makefile")
-        makefile.filter("LIBFLAGS=-fPIC", "LIBFLAGS={0}".format(self.compiler.cc_pic_flag))
+        makefile.filter("LIBFLAGS=-fPIC", "LIBFLAGS={0}".format(self.compiler.cxx_pic_flag))
         makefile.filter("DESTDIR=/usr", "DESTDIR={0}".format(self.prefix))
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/usalign/package.py
+++ b/var/spack/repos/builtin/packages/usalign/package.py
@@ -31,6 +31,8 @@ class Usalign(Package):
 
     variant("fast-math", default=False, description="Enable fast math")
 
+    depends_on("cxx", type="build")
+
     phases = ["build", "install"]
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -68,6 +68,10 @@ class Vasp(MakefilePackage, CudaPackage):
     variant("shmem", default=True, description="Enable use_shmem build flag")
     variant("hdf5", default=False, when="@6.2:", description="Enabled HDF5 support")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("rsync", type="build")
     depends_on("blas")
     depends_on("lapack")

--- a/var/spack/repos/builtin/packages/xabclib/package.py
+++ b/var/spack/repos/builtin/packages/xabclib/package.py
@@ -15,6 +15,9 @@ class Xabclib(MakefilePackage):
 
     version("1.03", sha256="9d200f40f1db87abc26cfe75a22db3a6d972988a28fc0ce8421a0c88cc574d1a")
 
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+
     def edit(self, spec, prefix):
         cc = [spack_cc, "-O3", self.compiler.openmp_flag]
         fc = [spack_fc, "-O3", self.compiler.openmp_flag]

--- a/var/spack/repos/builtin/packages/xios/package.py
+++ b/var/spack/repos/builtin/packages/xios/package.py
@@ -57,6 +57,9 @@ class Xios(Package):
 
     patch("earcut_missing_include_2.6.patch", when="@2.6:")
 
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("netcdf-c+mpi")
     depends_on("netcdf-fortran")
     depends_on("hdf5+mpi")

--- a/var/spack/repos/builtin/packages/zpares/package.py
+++ b/var/spack/repos/builtin/packages/zpares/package.py
@@ -19,6 +19,8 @@ class Zpares(MakefilePackage):
     variant("mpi", default=False, description="Activates MPI support")
     variant("mumps", default=False, description="Activates MUMPS support")
 
+    depends_on("fortran", type="build")
+
     depends_on("mumps+mpi", when="+mumps+mpi")
     depends_on("mumps~mpi", when="+mumps~mpi")
     depends_on("lapack")


### PR DESCRIPTION
All of these packages use some form of `spack_cc`, `self.compiler.cc`, or `self.compiler.cc_pic_flag`, but are missing a C dependency. Same for other compilers or flags.

Note that many of these compilers may be erroneous. For example, `unrar` is a pure C++ library, but we were querying `self.compiler.cc_pic_flag`. Maintainers of these recipes are encouraged to double check that my changes are correct. But without something changing, all of these packages are currently broken now that compilers-as-deps has been merged.

Closes #49854