### PR TITLE
voms: add v2.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/voms/package.py
+++ b/var/spack/repos/builtin/packages/voms/package.py
@@ -15,6 +15,7 @@ class Voms(AutotoolsPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("2.1.2", sha256="171cfa66b000422761b2a534a84ad88b646c675ff7910409b08b900775dbf035")
     version("2.1.0", sha256="2fd2468620af531c02e9ac495aaaf2a8d5b8cfbe24d4904f2e8fa7f64cdeeeec")
 
     depends_on("c", type="build")

--- a/var/spack/repos/builtin/packages/voms/package.py
+++ b/var/spack/repos/builtin/packages/voms/package.py
@@ -34,6 +34,7 @@ class Voms(AutotoolsPackage):
 
     force_autoreconf = True
 
+    @when("@:2.1.0")
     def patch(self):
         filter_file(
             r"/usr/bin/soapcpp2", f"{self.spec['gsoap'].prefix.bin.soapcpp2}", "m4/wsdl2h.m4"


### PR DESCRIPTION
This PR adds `voms`, v2.1.2, [diff](https://github.com/italiangrid/voms/compare/v2.1.0...v2.1.2). Patch addressed upstream.