### PR TITLE
gdbm: add v1.25

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -16,6 +16,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    version("1.25", sha256="d02db3c5926ed877f8817b81cd1f92f53ef74ca8c6db543fbba0271b34f393ec")
     version("1.24", sha256="695e9827fdf763513f133910bc7e6cfdb9187943a4fec943e57449723d2b8dbf")
     version("1.23", sha256="74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd")
     version("1.22", sha256="f366c823a6724af313b6bbe975b2809f9a157e5f6a43612a72949138d161d762")


### PR DESCRIPTION
This PR adds `gdbm`, v1.25, [changelog](https://git.savannah.gnu.org/cgit/gdbm.git/log/?h=v1.25).