### PR TITLE
embree: add v4.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/embree/package.py
+++ b/var/spack/repos/builtin/packages/embree/package.py
@@ -14,6 +14,7 @@ class Embree(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("4.4.0", sha256="acb517b0ea0f4b442235d5331b69f96192c28da6aca5d5dde0cbe40799638d5c")
     version("4.3.3", sha256="8a3bc3c3e21aa209d9861a28f8ba93b2f82ed0dc93341dddac09f1f03c36ef2d")
     version("4.3.2", sha256="dc7bb6bac095b2e7bc64321435acd07c6137d6d60e4b79ec07bb0b215ddf81cb")
     version("4.3.1", sha256="824edcbb7a8cd393c5bdb7a16738487b21ecc4e1d004ac9f761e934f97bb02a4")


### PR DESCRIPTION
This PR adds `embree`, v4.4.0 ([diff](https://github.com/RenderKit/embree/compare/v4.3.3...v4.4.0)).