### PR TITLE
libsm: add v1.2.6

### DIFF
--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -15,6 +15,7 @@ class Libsm(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.2.6", sha256="166b4b50d606cdd83f1ddc61b5b9162600034f848b3e32ccbb0e63536b7d6cdd")
     version("1.2.5", sha256="a11c3d23b60dce0c13256a8ce9478c1ea330719c0747b5adfbce60571198fa57")
     version("1.2.4", sha256="51464ce1abce323d5b6707ceecf8468617106e1a8a98522f8342db06fd024c15")
     version("1.2.3", sha256="1e92408417cb6c6c477a8a6104291001a40b3bb56a4a60608fdd9cd2c5a0f320")


### PR DESCRIPTION
This PR adds `libsm`, v1.2.6, [diff](https://gitlab.freedesktop.org/xorg/lib/libsm/-/compare/libSM-1.2.5...libSM-1.2.6?from_project_id=699). Minor change in how dependency on `xtrans` is defined should not be relevant since we don't provide `uuid` (though it could be found systemwide; but would not lead to failure).