### PR TITLE
pumi: remove redundant compiler deps

### DIFF
--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -67,10 +67,6 @@ class Pumi(CMakePackage):
         "Disable the check for testing new versions.",
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
-
     depends_on("cxx", type="build")
     depends_on("c", type="build")
     depends_on("fortran", type="build", when="+fortran")


### PR DESCRIPTION
This PR removes redundant compiler `depends_on(...)` statements.