### PR TITLE
Duplicate libblas_patch --> liblapack_path in Coinhsl package

### DIFF
--- a/var/spack/repos/builtin/packages/coinhsl/package.py
+++ b/var/spack/repos/builtin/packages/coinhsl/package.py
@@ -62,7 +62,7 @@ class Coinhsl(MesonPackage, AutotoolsPackage):
         args.append(f"-Dlibblas={blas}")
         args.extend([f"-Dlibblas_path={p}" for p in blas_paths])
         args.append(f"-Dliblapack={lapack}")
-        args.extend([f"-Dlibblas_path={p}" for p in lapack_paths])
+        args.extend([f"-Dliblapack_path={p}" for p in lapack_paths])
         if spec.satisfies("+metis"):
             metis = spec["metis"]
             if metis.satisfies("@5"):


### PR DESCRIPTION
This fixes what is clearly a typo in the coinhsl package. `libblas_path` was set twice, while `liblapack_path` was not set.