### PR TITLE
py-pyarrow: add depends_on c

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -37,6 +37,7 @@ class PyPyarrow(PythonPackage):
     version("0.11.0", sha256="07a6fd71c5d7440f2c42383dd2c5daa12d7f0a012f1e88288ed08a247032aead")
     version("0.9.0", sha256="7db8ce2f0eff5a00d6da918ce9f9cfec265e13f8a119b4adb1595e5b19fd6242")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     with default_args(type="build"):


### PR DESCRIPTION
Add dependency on c compiler when building `py-pyarrow`.

Needed because the package was failing to build with the error:
`eval: SPACK_CC_LINKER_ARG: ERROR: LINKER ARG WAS NOT SET, MAYBE THE PACKAGE DOES NOT DEPEND ON CC?`
