### PR TITLE
lbzip2: change URL and deprecate

### DIFF
--- a/var/spack/repos/builtin/packages/lbzip2/package.py
+++ b/var/spack/repos/builtin/packages/lbzip2/package.py
@@ -12,6 +12,12 @@ class Lbzip2(AutotoolsPackage):
     homepage = "https://github.com/kjn/lbzip2/"
     url = "https://github.com/kjn/lbzip2/archive/refs/tags/v2.5.tar.gz"
 
+    depends_on("c", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     version(
         "2.5",
         sha256="7be69ece83ecdc8f12b9201d838eee5cdb499f2fd68cffd2af58866076ccac43",

--- a/var/spack/repos/builtin/packages/lbzip2/package.py
+++ b/var/spack/repos/builtin/packages/lbzip2/package.py
@@ -9,7 +9,11 @@ class Lbzip2(AutotoolsPackage):
     """Multi-threaded compression utility with support for bzip2
     compressed file format"""
 
-    homepage = "https://lbzip2.org/"
-    url = "http://archive.lbzip2.org/lbzip2-2.5.tar.gz"
+    homepage = "https://github.com/kjn/lbzip2/"
+    url = "https://github.com/kjn/lbzip2/archive/refs/tags/v2.5.tar.gz"
 
-    version("2.5", sha256="46c75ee93cc95eedc6005625442b2b8e59a2bef3ba80987d0491f055185650e9")
+    version(
+        "2.5",
+        sha256="46c75ee93cc95eedc6005625442b2b8e59a2bef3ba80987d0491f055185650e9",
+        deprecated=True
+    )

--- a/var/spack/repos/builtin/packages/lbzip2/package.py
+++ b/var/spack/repos/builtin/packages/lbzip2/package.py
@@ -14,6 +14,6 @@ class Lbzip2(AutotoolsPackage):
 
     version(
         "2.5",
-        sha256="46c75ee93cc95eedc6005625442b2b8e59a2bef3ba80987d0491f055185650e9",
-        deprecated=True
+        sha256="7be69ece83ecdc8f12b9201d838eee5cdb499f2fd68cffd2af58866076ccac43",
+        deprecated=True,
     )


### PR DESCRIPTION
As pointed out in #49608, the `lbzip2` URL does not resolve and the homepage points to domain squatters. This changes the URL to a non-authoritative source and marks the only version as deprecated.

This fails to build since it needs `gnulib` (which we don't package in spack). But the whole point of this PR is to deprecate the package, so I don't want to spend too much time on it.