### PR TITLE
netlib-scalapack +ilp64 variant

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
@@ -1,4 +1,5 @@
-# Copyright Spack Project Developers. See COPYRIGHT file for details.
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -14,12 +15,14 @@ class ScalapackBase(CMakePackage):
 
     variant("shared", default=True, description="Build the shared library version")
     variant("pic", default=False, description="Build position independent code")
+    variant("ilp64", default=False, description="Build with 8-byte (long) integers rather than the regular 4-byte ones")
 
     provides("scalapack")
 
     depends_on("mpi")
     depends_on("lapack")
-    depends_on("blas")
+    depends_on("openblas")                                # virtuals and variants do not play well together
+    depends_on("openblas+ilp64", when="+ilp64")
     depends_on("cmake", when="@2.0.0:", type="build")
 
     # See: https://github.com/Reference-ScaLAPACK/scalapack/issues/9
@@ -41,8 +44,6 @@ class ScalapackBase(CMakePackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%cce"):
-                flags.append("-Wno-error=implicit-function-declaration")
             if self.spec.satisfies("%gcc@14:"):
                 # https://bugzilla.redhat.com/show_bug.cgi?id=2178710
                 flags.append("-std=gnu89")
@@ -57,6 +58,41 @@ class ScalapackBase(CMakePackage):
         # for 'libnetlib-scalapack.<suffix>'
         shared = True if "+shared" in self.spec else False
         return find_libraries("libscalapack", root=self.prefix, shared=shared, recursive=True)
+
+    # patching tests as described in https://github.com/Reference-ScaLAPACK/scalapack/blob/master/README#L147-L157
+    def patch(self):
+        spec = self.spec
+        if "+ilp64" in spec:
+            import os
+            file_list = []
+            for root, dirs, files in os.walk("TESTING/EIG/", topdown=True, onerror=None, followlinks=False):
+                print("Parsing", files)
+                for myfile in files:
+                    rel_dir  = os.path.relpath(root, os.getcwd())
+                    rel_file  = os.path.join(rel_dir, myfile)
+                    file_list.append(rel_file)
+            for root, dirs, files in os.walk("TESTING/LIN/", topdown=True, onerror=None, followlinks=False):
+                print("Parsing", files)
+                for myfile in files:
+                    rel_dir  = os.path.relpath(root, os.getcwd())
+                    rel_file  = os.path.join(rel_dir, myfile)
+                    file_list.append(rel_file)
+
+            # equivalent to sed -i 's/INTSZ = 4/INTSZ = 8/g'   TESTING/EIG/* TESTING/LIN/*
+            filter_file(
+                "(?i)INTSZ = 4",
+                "INTSZ = 8",
+                *file_list,
+                ignore_absent=True,
+            )
+
+            # equivalent to sed -i 's/INTGSZ = 4/INTGSZ = 8/g' TESTING/EIG/* TESTING/LIN/*
+            filter_file(
+                "(?i)INTGSZ = 4",
+                "INTGSZ = 8",
+                *file_list,
+                ignore_absent=True,
+            )
 
     def cmake_args(self):
         spec = self.spec
@@ -83,6 +119,15 @@ class ScalapackBase(CMakePackage):
             c_flags.append(self.compiler.cc_pic_flag)
             options.append("-DCMAKE_Fortran_FLAGS=%s" % self.compiler.fc_pic_flag)
 
+        # adding flags as describe at https://github.com/Reference-ScaLAPACK/scalapack/blob/master/README#L141-L147
+        if "+ilp64" in spec:
+            c_flags.append("-DInt=long")
+            try:
+                fflags
+            except NameError:
+                fflags = []
+            fflags.append("-fdefault-integer-8")
+
         # Work around errors of the form:
         #   error: implicit declaration of function 'BI_smvcopy' is
         #   invalid in C99 [-Werror,-Wimplicit-function-declaration]
@@ -91,8 +136,6 @@ class ScalapackBase(CMakePackage):
             or spec.satisfies("%apple-clang")
             or spec.satisfies("%oneapi")
             or spec.satisfies("%arm")
-            or spec.satisfies("%cce")
-            or spec.satisfies("%rocmcc")
         ):
             c_flags.append("-Wno-error=implicit-function-declaration")
 
@@ -113,17 +156,14 @@ class NetlibScalapack(ScalapackBase):
     """
 
     homepage = "https://www.netlib.org/scalapack/"
-    url = "https://github.com/Reference-ScaLAPACK/scalapack/archive/refs/tags/v2.2.2.tar.gz"
+    url = "https://www.netlib.org/scalapack/scalapack-2.0.2.tgz"
     git = "https://github.com/Reference-ScaLAPACK/scalapack"
     tags = ["e4s"]
 
-    maintainers("etiennemlb")
-
     license("BSD-3-Clause-Open-MPI")
 
-    version("2.2.2", sha256="a2f0c9180a210bf7ffe126c9cb81099cf337da1a7120ddb4cbe4894eb7b7d022")
-    version("2.2.0", sha256="8862fc9673acf5f87a474aaa71cd74ae27e9bbeee475dbd7292cec5b8bcbdcf3")
-    version("2.1.0", sha256="f03fda720a152030b582a237f8387014da878b84cbd43c568390e9f05d24617f")
+    version("2.2.0", sha256="40b9406c20735a9a3009d863318cb8d3e496fb073d201c5463df810e01ab2a57")
+    version("2.1.0", sha256="61d9216cf81d246944720cfce96255878a3f85dec13b9351f1fa0fd6768220a6")
     version("2.0.2", sha256="0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c")
     version("2.0.1", sha256="a9b34278d4e10b40cbe084c6d87d09af8845e874250719bfbbc497b2a88bfde1")
     version("2.0.0", sha256="e51fbd9c3ef3a0dbd81385b868e2355900148eea689bf915c5383d72daf73114")
@@ -133,9 +173,3 @@ class NetlibScalapack(ScalapackBase):
     depends_on("fortran", type="build")  # generated
     # versions before 2.0.0 are not using cmake and requires blacs as
     # a separated package
-
-    def url_for_version(self, version):
-        if self.spec.satisfies("@2.2:"):
-            return super().url_for_version(version)
-        url_fmt = "https://www.netlib.org/scalapack/scalapack-{0}.tgz"
-        return url_fmt.format(version)

--- a/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
@@ -1,5 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -44,6 +43,8 @@ class ScalapackBase(CMakePackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
+            if self.spec.satisfies("%cce"):
+                flags.append("-Wno-error=implicit-function-declaration")            
             if self.spec.satisfies("%gcc@14:"):
                 # https://bugzilla.redhat.com/show_bug.cgi?id=2178710
                 flags.append("-std=gnu89")
@@ -136,6 +137,8 @@ class ScalapackBase(CMakePackage):
             or spec.satisfies("%apple-clang")
             or spec.satisfies("%oneapi")
             or spec.satisfies("%arm")
+            or spec.satisfies("%cce")
+            or spec.satisfies("%rocmcc")
         ):
             c_flags.append("-Wno-error=implicit-function-declaration")
 
@@ -156,14 +159,17 @@ class NetlibScalapack(ScalapackBase):
     """
 
     homepage = "https://www.netlib.org/scalapack/"
-    url = "https://www.netlib.org/scalapack/scalapack-2.0.2.tgz"
+    url = "https://github.com/Reference-ScaLAPACK/scalapack/archive/refs/tags/v2.2.2.tar.gz"
     git = "https://github.com/Reference-ScaLAPACK/scalapack"
     tags = ["e4s"]
 
+    maintainers("etiennemlb")
+    
     license("BSD-3-Clause-Open-MPI")
 
-    version("2.2.0", sha256="40b9406c20735a9a3009d863318cb8d3e496fb073d201c5463df810e01ab2a57")
-    version("2.1.0", sha256="61d9216cf81d246944720cfce96255878a3f85dec13b9351f1fa0fd6768220a6")
+    version("2.2.2", sha256="a2f0c9180a210bf7ffe126c9cb81099cf337da1a7120ddb4cbe4894eb7b7d022")
+    version("2.2.0", sha256="8862fc9673acf5f87a474aaa71cd74ae27e9bbeee475dbd7292cec5b8bcbdcf3")
+    version("2.1.0", sha256="f03fda720a152030b582a237f8387014da878b84cbd43c568390e9f05d24617f")
     version("2.0.2", sha256="0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c")
     version("2.0.1", sha256="a9b34278d4e10b40cbe084c6d87d09af8845e874250719bfbbc497b2a88bfde1")
     version("2.0.0", sha256="e51fbd9c3ef3a0dbd81385b868e2355900148eea689bf915c5383d72daf73114")
@@ -173,3 +179,9 @@ class NetlibScalapack(ScalapackBase):
     depends_on("fortran", type="build")  # generated
     # versions before 2.0.0 are not using cmake and requires blacs as
     # a separated package
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@2.2:"):
+            return super().url_for_version(version)
+        url_fmt = "https://www.netlib.org/scalapack/scalapack-{0}.tgz"
+        return url_fmt.format(version)

--- a/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
@@ -142,7 +142,7 @@ class ScalapackBase(CMakePackage):
             c_flags.append("-Wno-error=implicit-function-declaration")
 
         options.append(self.define("CMAKE_C_FLAGS", " ".join(c_flags)))
-        options.append(self.define("CMAKE_FFLAGS", " ".join(fflags)))
+        options.append(self.define("CMAKE_Fortran_FLAGS", " ".join(fflags)))
 
         return options
 

--- a/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
@@ -44,7 +44,7 @@ class ScalapackBase(CMakePackage):
     def flag_handler(self, name, flags):
         if name == "cflags":
             if self.spec.satisfies("%cce"):
-                flags.append("-Wno-error=implicit-function-declaration")            
+                flags.append("-Wno-error=implicit-function-declaration")
             if self.spec.satisfies("%gcc@14:"):
                 # https://bugzilla.redhat.com/show_bug.cgi?id=2178710
                 flags.append("-std=gnu89")
@@ -164,7 +164,7 @@ class NetlibScalapack(ScalapackBase):
     tags = ["e4s"]
 
     maintainers("etiennemlb")
-    
+
     license("BSD-3-Clause-Open-MPI")
 
     version("2.2.2", sha256="a2f0c9180a210bf7ffe126c9cb81099cf337da1a7120ddb4cbe4894eb7b7d022")

--- a/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
@@ -14,14 +14,18 @@ class ScalapackBase(CMakePackage):
 
     variant("shared", default=True, description="Build the shared library version")
     variant("pic", default=False, description="Build position independent code")
-    variant("ilp64", default=False, description="Build with 8-byte (long) integers rather than the regular 4-byte ones")
+    variant(
+        "ilp64",
+        default=False,
+        description="Build with 8-byte (long) integers rather than the regular 4-byte ones",
+    )
 
     provides("scalapack")
 
     depends_on("mpi")
     depends_on("lapack")
     depends_on("blas")
-    depends_on("openblas+ilp64", when="+ilp64")              # virtuals and variants do not play well together
+    depends_on("openblas+ilp64", when="+ilp64")  # virtuals and variants do not play well together
     depends_on("cmake", when="@2.0.0:", type="build")
 
     # See: https://github.com/Reference-ScaLAPACK/scalapack/issues/9
@@ -65,35 +69,30 @@ class ScalapackBase(CMakePackage):
         spec = self.spec
         if "+ilp64" in spec:
             import os
+
             file_list = []
-            for root, dirs, files in os.walk("TESTING/EIG/", topdown=True, onerror=None, followlinks=False):
+            for root, dirs, files in os.walk(
+                "TESTING/EIG/", topdown=True, onerror=None, followlinks=False
+            ):
                 print("Parsing", files)
                 for myfile in files:
-                    rel_dir  = os.path.relpath(root, os.getcwd())
-                    rel_file  = os.path.join(rel_dir, myfile)
+                    rel_dir = os.path.relpath(root, os.getcwd())
+                    rel_file = os.path.join(rel_dir, myfile)
                     file_list.append(rel_file)
-            for root, dirs, files in os.walk("TESTING/LIN/", topdown=True, onerror=None, followlinks=False):
+            for root, dirs, files in os.walk(
+                "TESTING/LIN/", topdown=True, onerror=None, followlinks=False
+            ):
                 print("Parsing", files)
                 for myfile in files:
-                    rel_dir  = os.path.relpath(root, os.getcwd())
-                    rel_file  = os.path.join(rel_dir, myfile)
+                    rel_dir = os.path.relpath(root, os.getcwd())
+                    rel_file = os.path.join(rel_dir, myfile)
                     file_list.append(rel_file)
 
             # equivalent to sed -i 's/INTSZ = 4/INTSZ = 8/g'   TESTING/EIG/* TESTING/LIN/*
-            filter_file(
-                "(?i)INTSZ = 4",
-                "INTSZ = 8",
-                *file_list,
-                ignore_absent=True,
-            )
+            filter_file("(?i)INTSZ = 4", "INTSZ = 8", *file_list, ignore_absent=True)
 
             # equivalent to sed -i 's/INTGSZ = 4/INTGSZ = 8/g' TESTING/EIG/* TESTING/LIN/*
-            filter_file(
-                "(?i)INTGSZ = 4",
-                "INTGSZ = 8",
-                *file_list,
-                ignore_absent=True,
-            )
+            filter_file("(?i)INTGSZ = 4", "INTGSZ = 8", *file_list, ignore_absent=True)
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
@@ -20,8 +20,8 @@ class ScalapackBase(CMakePackage):
 
     depends_on("mpi")
     depends_on("lapack")
-    depends_on("openblas")                                # virtuals and variants do not play well together
-    depends_on("openblas+ilp64", when="+ilp64")
+    depends_on("blas")
+    depends_on("openblas+ilp64", when="+ilp64")              # virtuals and variants do not play well together
     depends_on("cmake", when="@2.0.0:", type="build")
 
     # See: https://github.com/Reference-ScaLAPACK/scalapack/issues/9

--- a/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netlib_scalapack/package.py
@@ -142,6 +142,7 @@ class ScalapackBase(CMakePackage):
             c_flags.append("-Wno-error=implicit-function-declaration")
 
         options.append(self.define("CMAKE_C_FLAGS", " ".join(c_flags)))
+        options.append(self.define("CMAKE_FFLAGS", " ".join(fflags)))
 
         return options
 


### PR DESCRIPTION
Trying to enable ilp64 as described at https://github.com/Reference-ScaLAPACK/scalapack/blob/master/README#L141-L157

Unfortunately on my machine the ilp64 tests with OpenMPI still fail, despite having followed the instructions from the link above (translating `sed` into `filter_file`). Other things appear to work, putting this out there for discussion

See also https://github.com/spack/spack/issues/49720 and please double check that for the non-ilp64 version everything works correctly in all circumstances.

@etiennemlb 

