### PR TITLE
trilinos: patch stk to include cstddef for size_t error

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/16-1-0-stk-size_t.patch
+++ b/var/spack/repos/builtin/packages/trilinos/16-1-0-stk-size_t.patch
@@ -1,0 +1,19 @@
+diff --git a/packages/stk/stk_util/stk_util/parallel/ReceiveCounter.hpp b/packages/stk/stk_util/stk_util/parallel/ReceiveCounter.hpp
+index ad1232b5bf7..daf3329969b 100644
+--- a/packages/stk/stk_util/stk_util/parallel/ReceiveCounter.hpp
++++ b/packages/stk/stk_util/stk_util/parallel/ReceiveCounter.hpp
+@@ -36,6 +36,7 @@
+ #define stk_util_parallel_ReceiveCounter_hpp
+ 
+ #include <vector>
++#include <cstddef>
+ 
+ #include "stk_util/parallel/Parallel.hpp"   // for MPI
+ 
+@@ -92,4 +93,4 @@ std::vector<int>  get_send_counts(std::vector< std::vector<T> > sendLists, size_
+ }
+ 
+ }  // namespace
+-#endif
+\ No newline at end of file
++#endif

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -556,6 +556,9 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     # https://github.com/trilinos/Trilinos/pull/13921
     patch("16-1-0-stk-fpe-exceptions.patch", when="@=16.1.0 +stk platform=darwin")
+
+    # https://github.com/trilinos/Trilinos/issues/13916 and
+    # https://github.com/trilinos/Trilinos/pull/13921
     patch("16-1-0-stk-size_t.patch", when="@=16.1.0 +stk")
 
     def flag_handler(self, name, flags):

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -556,6 +556,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     # https://github.com/trilinos/Trilinos/pull/13921
     patch("16-1-0-stk-fpe-exceptions.patch", when="@=16.1.0 +stk platform=darwin")
+    patch("16-1-0-stk-size_t.patch", when="@=16.1.0 +stk")
 
     def flag_handler(self, name, flags):
         spec = self.spec


### PR DESCRIPTION
Add in a missing `#include <cstddef>`.