### PR TITLE
fmt: conflicts llvm@21: when @:11.0

### DIFF
--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -79,6 +79,8 @@ class Fmt(CMakePackage):
     # (https://github.com/fmtlib/fmt/issues/3028)
     conflicts("cxxstd=17", when="@9.0.0%intel")
     conflicts("cxxstd=17", when="@9.0.0%nvhpc")
+    # clang-21 requires fmt-11.1.0 (https://github.com/fmtlib/fmt/pull/4187)
+    conflicts("%llvm@21:", when="@:11.0")
 
     # Use CMAKE_CXX_STANDARD to define C++ flag, as in later versions
     patch("fmt-use-cmake-cxx-standard_3.0.0.patch", when="@3.0.0")

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -80,7 +80,7 @@ class Fmt(CMakePackage):
     conflicts("cxxstd=17", when="@9.0.0%intel")
     conflicts("cxxstd=17", when="@9.0.0%nvhpc")
     # clang-21 requires fmt-11.1.0 (https://github.com/fmtlib/fmt/pull/4187)
-    conflicts("%llvm@21:", when="@:11.0")
+    conflicts("%[virtuals=cxx] llvm@21:", when="@:11.0")
 
     # Use CMAKE_CXX_STANDARD to define C++ flag, as in later versions
     patch("fmt-use-cmake-cxx-standard_3.0.0.patch", when="@3.0.0")


### PR DESCRIPTION
This PR adds a conflict to `fmt` to reflect that clang-21 requires fmt-11.1 or newer. See https://github.com/fmtlib/fmt/pull/4187.