### PR TITLE
kokkos-kernels: add depends_on C and Fortran

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -182,7 +182,10 @@ class KokkosKernels(CMakePackage, CudaPackage):
         description="Scalars",
     )
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("kokkos")
     depends_on("kokkos@master", when="@master")
     depends_on("kokkos@develop", when="@develop")

--- a/var/spack/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/kokkos_kernels/package.py
@@ -181,10 +181,22 @@ class KokkosKernels(CMakePackage, CudaPackage):
         multi=True,
         description="Scalars",
     )
+    variant(
+        "fortran",
+        default=True,
+        when="+blas",
+        description="Require the Fortran compiler for builds",
+    )
+    variant(
+        "fortran",
+        default=True,
+        when="+lapack",
+        description="Require the fortran compiler for builds",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("fortran", type="build")
+    depends_on("fortran", type="build", when="+fortran")
 
     depends_on("kokkos")
     depends_on("kokkos@master", when="@master")


### PR DESCRIPTION
Added a dependency on C compiler when building Kokkos-Kernels and adds a conditional dependency on Fortran compilers

This is needed when blas and lapack TPLs are enabled.  When either of those variants are enabled, an optional (but default) dependence on Fortran is added.  Users who are sure that their BLAS and LAPACK implementations do not require Fortran can optionally disable the dependence by disabling the new variant.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
