### PR TITLE
openblas: Fixes for Xcode 16.3

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/openblas-0.3.29-darwin-aarch64.patch
+++ b/var/spack/repos/builtin/packages/openblas/openblas-0.3.29-darwin-aarch64.patch
@@ -1,0 +1,84 @@
+diff --git a/Makefile.system b/Makefile.system
+index ac278bab1..a1059c224 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -434,6 +434,11 @@ ifeq (x$(XCVER), x 15)
+ CCOMMON_OPT += -Wl,-ld_classic
+ FCOMMON_OPT += -Wl,-ld_classic
+ endif
++ifeq (x$(XCVER), x 16)
++ifeq ($(F_COMPILER), GFORTRAN)
++override CEXTRALIB := $(filter-out(-lto_library, $(CEXTRALIB)))
++endif
++endif
+ endif
+ 
+ ifneq (,$(findstring $(OSNAME), FreeBSD OpenBSD DragonFly))
+diff --git a/ctest/Makefile b/ctest/Makefile
+index 877a190c1..e6f683bd8 100644
+--- a/ctest/Makefile
++++ b/ctest/Makefile
+@@ -235,18 +235,18 @@ FLDFLAGS = $(FFLAGS:-fPIC=) $(LDFLAGS)
+ ifeq ($(USE_OPENMP), 1)
+ ifeq ($(F_COMPILER), GFORTRAN)
+ ifeq ($(C_COMPILER), CLANG)
+-CEXTRALIB += -lomp
++EXTRALIB += -lomp
+ endif
+ endif
+ ifeq ($(F_COMPILER), NAG)
+-CEXTRALIB = -lgomp
++EXTRALIB = -lgomp
+ endif
+ ifeq ($(F_COMPILER), IBM)
+ ifeq ($(C_COMPILER), GCC)
+-CEXTRALIB += -lgomp
++EXTRALIB += -lgomp
+ endif
+ ifeq ($(C_COMPILER), CLANG)
+-CEXTRALIB += -lomp
++EXTRALIB += -lomp
+ endif
+ endif
+ endif
+diff --git a/test/Makefile b/test/Makefile
+index 65576d3dd..9ba88988b 100644
+--- a/test/Makefile
++++ b/test/Makefile
+@@ -299,18 +299,18 @@ CLDFLAGS = $(CFLAGS) $(LDFLAGS)
+ ifeq ($(USE_OPENMP), 1)
+ ifeq ($(F_COMPILER), GFORTRAN)
+ ifeq ($(C_COMPILER), CLANG)
+-CEXTRALIB += -lomp
++EXTRALIB += -lomp
+ endif
+ endif
+ ifeq ($(F_COMPILER), NAG)
+-CEXTRALIB = -lgomp
++EXTRALIB = -lgomp
+ endif
+ ifeq ($(F_COMPILER), IBM)
+ ifeq ($(C_COMPILER), GCC)
+-CEXTRALIB += -lgomp
++EXTRALIB += -lgomp
+ endif
+ ifeq ($(C_COMPILER), CLANG)
+-CEXTRALIB += -lomp
++EXTRALIB += -lomp
+ endif
+ endif
+ endif
+diff --git a/utest/test_potrs.c b/utest/test_potrs.c
+index 642ce1e37..bcb1f753b 100644
+--- a/utest/test_potrs.c
++++ b/utest/test_potrs.c
+@@ -32,7 +32,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **********************************************************************************/
+ 
+ #include "openblas_utest.h"
++#if defined(ARCH_LOONGARCH64)
+ #pragma GCC optimize("no-gcse")
++#endif
+ /*
+ void BLASFUNC(cpotrf)(char*, BLASINT*, complex float*, BLASINT*, BLASINT*);
+ void BLASFUNC(zpotrs_(char*, BLASINT*, BLASINT*, complex double*,

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -114,6 +114,9 @@ class Openblas(CMakePackage, MakefilePackage):
     # https://github.com/OpenMathLib/OpenBLAS/pull/4328
     patch("xcode15-fortran.patch", when="@0.3.25 %apple-clang@15:")
 
+    # https://github.com/OpenMathLib/OpenBLAS/issues/5202
+    patch("openblas-0.3.29-darwin-aarch64.patch", when="@0.3.29 platform=darwin")
+
     # https://github.com/xianyi/OpenBLAS/pull/2519/files
     patch("ifort-msvc.patch", when="%msvc")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR is based on https://github.com/OpenMathLib/OpenBLAS/pull/5207 by @martin-frbg . 

While that PR is to `develop` (--> 0.3.30), testing on my XCode 16.3 box with apple-clang/gfortran, gcc/gfortran, and apple-clang/nag seem to show it is necessary for 0.3.29 (at least).