### PR TITLE
Remove runtime errors for Fortran compilers

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -120,7 +120,6 @@ class Adios(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        self.validate(spec)
 
         extra_args = [
             # required, otherwise building its python bindings will fail

--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -107,19 +107,6 @@ class Adios(AutotoolsPackage):
         sha256="aea47e56013b57c2d5d36e23e0ae6010541c3333a84003784437768c2e350b05",
     )
 
-    def validate(self, spec):
-        """Checks if incompatible variants have been activated at the same time
-
-        Args:
-            spec: spec of the package
-
-        Raises:
-            RuntimeError: in case of inconsistencies
-        """
-        if "+fortran" in spec and not self.compiler.fc:
-            msg = "cannot build a fortran variant without a fortran compiler"
-            raise RuntimeError(msg)
-
     def with_or_without_hdf5(self, activated):
         if activated:
             return f"--with-phdf5={self.spec['hdf5'].prefix}"

--- a/var/spack/repos/builtin/packages/cmor/package.py
+++ b/var/spack/repos/builtin/packages/cmor/package.py
@@ -48,12 +48,6 @@ class Cmor(AutotoolsPackage):
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-numpy", type=("build", "run"), when="+python")
 
-    @run_before("configure")
-    def validate(self):
-        if self.spec.satisfies("+fortran") and not self.compiler.fc:
-            msg = "cannot build a fortran variant without a fortran compiler"
-            raise RuntimeError(msg)
-
     def configure_args(self):
         spec = self.spec
         args = ["--disable-debug"]

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -305,11 +305,6 @@ class Eccodes(CMakePackage):
             msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
         )
 
-    @run_before("cmake")
-    def check_fortran(self):
-        if "+fortran" in self.spec and self.compiler.fc is None:
-            raise InstallError("Fortran interface requires a Fortran compiler!")
-
     def cmake_args(self):
         jp2k = self.spec.variants["jp2k"].value
 

--- a/var/spack/repos/builtin/packages/flibcpp/package.py
+++ b/var/spack/repos/builtin/packages/flibcpp/package.py
@@ -42,14 +42,6 @@ class Flibcpp(CMakePackage):
     depends_on("swig@4.0.2-fortran", type="build", when="+swig")
     depends_on("py-sphinx", type="build", when="+doc")
 
-    @run_before("cmake")
-    def die_without_fortran(self):
-        # Until we can pass compiler requirements through virtual
-        # dependencies, explicitly check for Fortran compiler instead of
-        # waiting for configure error.
-        if (self.compiler.f77 is None) or (self.compiler.fc is None):
-            raise InstallError("Flibcpp requires a Fortran compiler")
-
     def cmake_args(self):
         from_variant = self.define_from_variant
         fstd_key = (

--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -69,14 +69,6 @@ class Fortrilinos(CMakePackage):
         "trilinos+amesos2+anasazi+belos+kokkos+ifpack2+muelu+nox+tpetra" "+stratimikos", when="+hl"
     )
 
-    @run_before("cmake")
-    def die_without_fortran(self):
-        # Until we can pass variants such as +fortran through virtual
-        # dependencies, require Fortran compiler to
-        # avoid delayed build errors in dependents.
-        if (self.compiler.f77 is None) or (self.compiler.fc is None):
-            raise InstallError("ForTrilinos requires a Fortran compiler")
-
     def cmake_args(self):
         return [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),

--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -38,13 +38,6 @@ class H5hut(AutotoolsPackage):
     # install: .libs/libH5hut.a: No such file or directory
     parallel = False
 
-    @run_before("configure")
-    def validate(self):
-        """Checks if Fortran compiler is available."""
-
-        if self.spec.satisfies("+fortran") and not self.compiler.fc:
-            raise RuntimeError("Cannot build Fortran variant without a Fortran compiler.")
-
     def flag_handler(self, name, flags):
         build_system_flags = []
         if (

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -516,12 +516,6 @@ class Hdf5(CMakePackage):
         # LD_LIBRARY_PATH.
         env.append_path("LD_LIBRARY_PATH", self.prefix.lib)
 
-    @run_before("cmake")
-    def fortran_check(self):
-        if self.spec.satisfies("+fortran") and not self.compiler.fc:
-            msg = "cannot build a Fortran variant without a Fortran compiler"
-            raise RuntimeError(msg)
-
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -68,11 +68,6 @@ class GenericBuilder(GenericBuilder):
     def build_command_line(self):
         args = ["-noLogo"]
         ifort_bin = self.pkg.compiler.fc
-        if not ifort_bin:
-            raise InstallError(
-                "Cannot install MSMPI without fortran"
-                "please select a compiler with fortran support."
-            )
         args.append("/p:IFORT_BIN=%s" % os.path.dirname(ifort_bin))
         args.append("/p:VCToolsVersion=%s" % self.pkg.compiler.msvc_version)
         args.append("/p:WindowsTargetPlatformVersion=%s" % str(self.pkg.spec["wdk"].version))

--- a/var/spack/repos/builtin/packages/mvapich-plus/package.py
+++ b/var/spack/repos/builtin/packages/mvapich-plus/package.py
@@ -276,14 +276,6 @@ class MvapichPlus(AutotoolsPackage, CudaPackage, ROCmPackage):
             os.path.join(self.prefix.lib, f"libmpi.{dso_suffix}"),
         ]
 
-    @run_before("configure")
-    def die_without_fortran(self):
-        # Until we can pass variants such as +fortran through virtual
-        # dependencies depends_on('mpi'), require Fortran compiler to
-        # avoid delayed build errors in dependents.
-        if (self.compiler.f77 is None) or (self.compiler.fc is None):
-            raise InstallError("Mvapich requires both C and Fortran compilers!")
-
     def configure_args(self):
         spec = self.spec
         args = [

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -161,9 +161,6 @@ class Ncl(Package):
             )
 
     def install(self, spec, prefix):
-        if (self.compiler.fc is None) or (self.compiler.cc is None):
-            raise InstallError("NCL package requires both " "C and Fortran compilers.")
-
         self.prepare_site_config()
         self.prepare_install_config()
         self.prepare_src_tree()

--- a/var/spack/repos/builtin/packages/nek5000/package.py
+++ b/var/spack/repos/builtin/packages/nek5000/package.py
@@ -48,12 +48,6 @@ class Nek5000(Package):
 
     patch("add_fjfortran.patch", when="%fj")
 
-    @run_before("install")
-    def fortran_check(self):
-        if not self.compiler.f77:
-            msg = "Cannot build Nek5000 without a Fortran 77 compiler."
-            raise RuntimeError(msg)
-
     @run_after("install")
     def check_install(self):
         with working_dir("short_tests/eddy"):

--- a/var/spack/repos/builtin/packages/nekbone/package.py
+++ b/var/spack/repos/builtin/packages/nekbone/package.py
@@ -35,12 +35,6 @@ class Nekbone(Package):
 
     depends_on("mpi", when="+mpi")
 
-    @run_before("install")
-    def fortran_check(self):
-        if not self.compiler.fc:
-            msg = "Nekbone can not be built without a Fortran compiler."
-            raise RuntimeError(msg)
-
     def install(self, spec, prefix):
         mkdir(prefix.bin)
 

--- a/var/spack/repos/builtin/packages/nekcem/package.py
+++ b/var/spack/repos/builtin/packages/nekcem/package.py
@@ -34,12 +34,6 @@ class Nekcem(Package):
     depends_on("blas")
     depends_on("lapack")
 
-    @run_before("install")
-    def fortran_check(self):
-        if not self.compiler.fc:
-            msg = "NekCEM can not be built without a Fortran compiler."
-            raise RuntimeError(msg)
-
     @run_after("install")
     def check_install(self):
         nekcem_test = join_path(self.prefix.bin, "NekCEM", "tests", "2dboxpec")

--- a/var/spack/repos/builtin/packages/nektools/package.py
+++ b/var/spack/repos/builtin/packages/nektools/package.py
@@ -68,12 +68,6 @@ class Nektools(Package):
     depends_on("libxt", when="+postnek")
     depends_on("visit", when="+visit")
 
-    @run_before("install")
-    def fortran_check(self):
-        if not self.compiler.f77:
-            msg = "Cannot build Nek5000 without a Fortran 77 compiler."
-            raise RuntimeError(msg)
-
     def install(self, spec, prefix):
         tools_dir = "tools"
         bin_dir = "bin"

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -294,20 +294,6 @@ class Openblas(CMakePackage, MakefilePackage):
         # unclear whether setting `-j N` externally was supported before 0.3
         return self.spec.version >= Version("0.3.0")
 
-    @run_before("edit")
-    def check_compilers(self):
-        # As of 06/2016 there is no mechanism to specify that packages which
-        # depends on Blas/Lapack need C or/and Fortran symbols. For now
-        # require both.
-        # As of 08/2022 (0.3.21), we can build purely with a C compiler using
-        # a f2c translated LAPACK version
-        #   https://github.com/xianyi/OpenBLAS/releases/tag/v0.3.21
-        if self.compiler.fc is None and "~fortran" not in self.spec:
-            raise InstallError(
-                self.compiler.cc
-                + " has no Fortran compiler added in spack. Add it or use openblas~fortran!"
-            )
-
     @property
     def headers(self):
         # The only public headers for cblas and lapacke in

--- a/var/spack/repos/builtin/packages/openloops/package.py
+++ b/var/spack/repos/builtin/packages/openloops/package.py
@@ -277,8 +277,6 @@ class Openloops(Package):
             f.write("process_lib_dir = {0}\n".format(self.spec.prefix.proclib))
             f.write("cc = {0}\n".format(env["SPACK_CC"]))
             f.write("cxx = {0}\n".format(env["SPACK_CXX"]))
-            if not self.compiler.fc:
-                raise InstallError(f"{self.spec.compiler} has no Fortran compiler in spack!")
             f.write("fortran_compiler = {0}\n".format(env["SPACK_FC"]))
             if self.spec.satisfies("@1.3.1") and not is_intel:
                 f.write("gfortran_f_flags = -ffree-line-length-none\n")

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1013,14 +1013,6 @@ with '-Wl,-commons,use_dylibs' and without
             return "--without-tm"
         return f"--with-tm={self.spec['pbs'].prefix}"
 
-    @run_before("autoreconf")
-    def die_without_fortran(self):
-        # Until we can pass variants such as +fortran through virtual
-        # dependencies depends_on('mpi'), require Fortran compiler to
-        # avoid delayed build errors in dependents.
-        if (self.compiler.f77 is None) and (self.compiler.fc is None):
-            raise InstallError("OpenMPI requires both C and Fortran compilers!")
-
     @when("@main")
     def autoreconf(self, spec, prefix):
         perl = which("perl")

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -178,12 +178,6 @@ class Papi(AutotoolsPackage, ROCmPackage):
         return options
 
     @run_before("configure")
-    def fortran_check(self):
-        if not self.compiler.fc:
-            msg = "PAPI requires a Fortran compiler to build"
-            raise RuntimeError(msg)
-
-    @run_before("configure")
     def component_configure(self):
         configure_script = Executable("./configure")
         if "+lmsensors" in self.spec and self.version < Version("6"):

--- a/var/spack/repos/builtin/packages/petaca/package.py
+++ b/var/spack/repos/builtin/packages/petaca/package.py
@@ -52,12 +52,6 @@ class Petaca(CMakePackage):
 
     variant("std_name", default=False, description="enables std_mod_proc_name with intel")
 
-    # copied from openmpi/package.py to ensure fortran support
-    @run_before("cmake")
-    def die_without_fortran(self):
-        if (self.compiler.f77 is None) or (self.compiler.fc is None):
-            raise InstallError("petaca requires both C and Fortran compilers!")
-
     def cmake_args(self):
         return [
             self.define("ENABLE_TESTS", self.run_tests),

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -314,12 +314,6 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     filter_compiler_wrappers("petscvariables", "reconfigure*.py", relative_root="lib/petsc/conf")
     filter_compiler_wrappers("petsc.pc", "PETSc.pc", relative_root="lib/pkgconfig")
 
-    @run_before("configure")
-    def check_fortran_compiler(self):
-        # Raise error if +fortran and there isn't a fortran compiler!
-        if "+fortran" in self.spec and self.compiler.fc is None:
-            raise InstallError("+fortran requires a fortran compiler!")
-
     # temporary workaround Clang 8.1.0 with XCode 8.3 on macOS, see
     # https://bitbucket.org/petsc/petsc/commits/4f290403fdd060d09d5cb07345cbfd52670e3cbc
     # the patch is an adaptation of the original commit to 3.7.5

--- a/var/spack/repos/builtin/packages/pnmpi/package.py
+++ b/var/spack/repos/builtin/packages/pnmpi/package.py
@@ -32,15 +32,6 @@ class Pnmpi(CMakePackage):
     depends_on("doxygen")
     depends_on("mpi")
 
-    @run_before("cmake")
-    def check_fortran(self):
-        is_no_fortran_compiler = not self.compiler.f77 and not self.compiler.fc
-        if self.spec.satisfies("+fortran"):
-            if is_no_fortran_compiler:
-                raise InstallError(
-                    "pnmpi+fortran requires Fortran compiler " "but no Fortran compiler found!"
-                )
-
     def cmake_args(self):
         args = []
         spec = self.spec

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -230,11 +230,6 @@ class PyScipy(PythonPackage):
 
     @run_before("install")
     def set_fortran_compiler(self):
-        if self.compiler.f77 is None or self.compiler.fc is None:
-            raise InstallError(
-                "py-scipy requires Fortran compilers. Configure Fortran compiler to proceed."
-            )
-
         if self.spec.satisfies("%fj"):
             with open("setup.cfg", "w") as f:
                 f.write("[config_fc]\n")

--- a/var/spack/repos/builtin/packages/spherepack/package.py
+++ b/var/spack/repos/builtin/packages/spherepack/package.py
@@ -18,8 +18,6 @@ class Spherepack(Package):
     depends_on("gmake", type="build")
 
     def install(self, spec, prefix):
-        if self.compiler.fc is None:
-            raise InstallError("SPHEREPACK requires a Fortran 90 compiler")
         make("MAKE=make", "F90=f90 -O2 -fallow-argument-mismatch", "AR=ar", "libspherepack")
         make("MAKE=make", "F90=f90 -O2 -fallow-argument-mismatch", "AR=ar", "testspherepack")
         install_tree("lib", prefix.lib)

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -424,12 +424,6 @@ class Wrf(Package):
             )
             config.filter("^CC_TOOLS(.*?)=([^#\n\r]*)(.*)$", r"CC_TOOLS\1=\2 -fpermissive \3")
 
-    @run_before("configure")
-    def fortran_check(self):
-        if not self.compiler.fc:
-            msg = "cannot build WRF without a Fortran compiler"
-            raise RuntimeError(msg)
-
     def configure(self, spec, prefix):
         # Remove broken default options...
         self.do_configure_fixup()


### PR DESCRIPTION
Spack now has the ability to use `depends_on("fortran")` to assert that a Fortran compiler is available. This PR removes runtime checks and errors that are now handled by dependencies.