### PR TITLE
podio: Make podio depend on fmt for newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -111,6 +111,7 @@ class Podio(CMakePackage):
     depends_on("py-pyyaml", type=("build", "run"))
     depends_on("py-jinja2@2.10.1:", type=("build", "run"))
     depends_on("sio", type=("build", "link"), when="+sio")
+    depends_on("fmt@9:", type=("build", "link"), when="@1.3:")
     depends_on("catch2@3.0.1:", type=("test"), when="@:0.16.5")
     depends_on("catch2@3.1:", type=("test"), when="@0.16.6:")
     depends_on("catch2@3.4:", type=("test"), when="@0.17.1: cxxstd=20")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

PR that introduced the dependency: https://github.com/AIDASoft/podio/pull/620. 1.3 will be the next tagged version of podio, so I chose that as minimal version for introducing the dependency.