### PR TITLE
util/environment.py: require string values in env mods

### DIFF
--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -92,7 +92,7 @@ class Groff(AutotoolsPackage, GNUMirrorPackage):
     def setup_run_environment(self, env):
         if self.spec.satisfies("+x"):
             dir = join_path(self.prefix.lib, "X11", "app-defaults")
-            env.set_path("XFILESEARCHPATH", dir)
+            env.prepend_path("XFILESEARCHPATH", dir)
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":


### PR DESCRIPTION
* Remove the `system_env_normalize` decorator that leads to type erasure for mypy
* Warn about non-string values set as environment variables. This solves issues with e.g. `env.set("FLAG", 0xFF)` where you'd currently end up with `FLAG=255` whereas `"0xFF"` may have been intended.

Notice that we have a test which ensures `env.set("B", 3)` produces the value `str(3)`. At the same time our type hints suggest only `str` is supported.