### PR TITLE
Fix dependency on C compiler for some packages to pass cmake or configure stage

### DIFF
--- a/var/spack/repos/builtin/packages/bdsim/package.py
+++ b/var/spack/repos/builtin/packages/bdsim/package.py
@@ -28,6 +28,7 @@ class Bdsim(CMakePackage):
     version("1.6.0", sha256="c0149a68d3c2436e036e8f71a13a251a2d88afe51e4387fe43ebd31a96bb3d7d")
 
     depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("cmake")
     depends_on("geant4")

--- a/var/spack/repos/builtin/packages/cppunit/package.py
+++ b/var/spack/repos/builtin/packages/cppunit/package.py
@@ -41,6 +41,7 @@ class Cppunit(AutotoolsPackage):
     )
 
     depends_on("cxx", type="build")
+    depends_on("c", type="build")
 
     depends_on("autoconf", type="build", when="@master,1.15_20220904")
     depends_on("automake", type="build", when="@master,1.15_20220904")

--- a/var/spack/repos/builtin/packages/genfit/package.py
+++ b/var/spack/repos/builtin/packages/genfit/package.py
@@ -30,7 +30,8 @@ class Genfit(CMakePackage):
     version("b496504a", sha256="e1582b35782118ade08498adc03f3fda01979ff8bed61e0520edae46d7bfe477")
 
     depends_on("cxx", type="build")  # generated
-
+    depends_on("c", type="build")
+    
     depends_on("root")
     depends_on("root@:6.16.00", when="@b496504a")
     depends_on("eigen")

--- a/var/spack/repos/builtin/packages/genfit/package.py
+++ b/var/spack/repos/builtin/packages/genfit/package.py
@@ -31,7 +31,6 @@ class Genfit(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
     depends_on("c", type="build")
-    
     depends_on("root")
     depends_on("root@:6.16.00", when="@b496504a")
     depends_on("eigen")

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -19,6 +19,7 @@ class PyPyqt5(SIPPackage):
     version("5.15.9", sha256="dc41e8401a90dc3e2b692b411bd5492ab559ae27a27424eed4bd3915564ec4c0")
 
     depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
 
     # pyproject.toml
     depends_on("py-sip@6.6.2:6", type="build")

--- a/var/spack/repos/builtin/packages/vbfnlo/package.py
+++ b/var/spack/repos/builtin/packages/vbfnlo/package.py
@@ -44,6 +44,7 @@ class Vbfnlo(AutotoolsPackage):
 
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("hepmc")
     depends_on("gsl")


### PR DESCRIPTION
- `genfit` and `bdsim` do not specify `LANGUAGES` in their `project` declaration yet, so C is also required to pass the cmake stage.
- `cppunit` and `vbfnlo` both look for a C compiler at the `configure` stage
- `py-pyqt5` fails at build time (!) with the error below

```
2 errors found in build log:
     11167    cp -f libQtXmlPatterns.so QtXmlPatterns.abi3.so
     11168    make[1]: Leaving directory '/home/madlener/work/.spack/spack-stage/spack-stage-py-pyqt5-5.15.9-c2fyxxzwkbjqv2hv74rszwsu56p2qyky/spack-src/build/QtXmlPatterns'
     11169    cd Qt/ && ( test -e Makefile || /home/madlener/work/.spack/spackages/skylake-ubuntu24.04-gcc13.3.0/qt/5.15.15-y2t3mn/bin/qmake -o Makefile /home/madlener/work/.spack/spack-sta
              ge/spack-stage-py-pyqt5-5.15.9-c2fyxxzwkbjqv2hv74rszwsu56p2qyky/spack-src/build/Qt/Qt.pro ) && /home/madlener/work/.spack/spackages/skylake-ubuntu24.04-gcc13.3.0/gmake/4.4.1-n
              3szmh/bin/make -f Makefile
     11170    make[1]: Entering directory '/home/madlener/work/.spack/spack-stage/spack-stage-py-pyqt5-5.15.9-c2fyxxzwkbjqv2hv74rszwsu56p2qyky/spack-src/build/Qt'
     11171    cc -c -pipe -O2 -fno-exceptions -Wall -Wextra -D_REENTRANT -fPIC -DPy_LIMITED_API=0x03080000 -DSIP_PROTECTED_IS_PUBLIC -Dprotected=public -DQT_NO_EXCEPTIONS -DQT_NO_DEBUG -DQT
              _PLUGIN -I. -I. -I.. -I/home/madlener/work/.spack/spackages/skylake-ubuntu24.04-gcc13.3.0/python/3.11.11-vqwghg/include/python3.11 -I/home/madlener/work/.spack/spackages/skyla
              ke-ubuntu24.04-gcc13.3.0/qt/5.15.15-y2t3mn/mkspecs/linux-g++ -o sipQtcmodule.o sipQtcmodule.c
     11172    /home/madlener/work/.spack/spackages/skylake-ubuntu24.04-nonenone/compiler-wrapper/1.0-a3p23e/libexec/spack/cc: 1: eval: SPACK_CC_LINKER_ARG: ERROR: LINKER ARG WAS NOT SET, MA
              YBE THE PACKAGE DOES NOT DEPEND ON CC?
  >> 11173    make[1]: *** [Makefile:774: sipQtcmodule.o] Error 2
     11174    make[1]: Leaving directory '/home/madlener/work/.spack/spack-stage/spack-stage-py-pyqt5-5.15.9-c2fyxxzwkbjqv2hv74rszwsu56p2qyky/spack-src/build/Qt'
  >> 11175    make: *** [Makefile:1372: sub-Qt-make_first-ordered] Error 2

```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

