### PR TITLE
defaults/config.yaml: timeout at 30s by default

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -90,10 +90,9 @@ config:
   misc_cache: $user_cache_path/cache
 
 
-  # Timeout in seconds used for downloading sources etc. This only applies
-  # to the connection phase and can be increased for slow connections or
-  # servers. 0 means no timeout.
-  connect_timeout: 10
+  # Abort downloads after this many seconds if not data is received.
+  # Setting this to 0 will disable the timeout.
+  connect_timeout: 30
 
 
   # If this is false, tools like curl that use SSL will not verify


### PR DESCRIPTION
Fetching generated tarballs from github.com sometimes takes pauses for
more than 10 seconds, when the server is slow to put together the next
bits of the tarball. Default to 30s to avoid that issue.

This was noticed when fetching https://github.com/ROCm/hipBLASLt/archive/refs/tags/rocm-6.3.3.tar.gz, sometimes it takes 2s (probably cached tarball) sometimes it takes 90s with significant gaps which makes `socket.read()` timeout. I verified locally that `git archive -v --format=tar.gz -o /dev/null rocm-6.3.3` is indeed pretty slow (~37s for me or 2.2MB/s), although I don't see pauses.


![Screenshot from 2025-04-10 10-51-54](https://github.com/user-attachments/assets/11545ac6-8d70-48cb-a6b3-a6bc2c1c5cf8)
