### PR TITLE
berkeleygw: use pic flag when compiling

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/berkeleygw/package.py
@@ -182,7 +182,10 @@ class Berkeleygw(MakefilePackage):
             paraflags.append("-DMPI")
 
         # We need to copy fflags in case we append to it (#34019):
+        cflags = spec.compiler_flags["cflags"][:]
         fflags = spec.compiler_flags["fflags"][:]
+        cflags.append(self.compiler.cc_pic_flag)
+        fflags.append(self.compiler.fc_pic_flag)
         if spec.satisfies("+openmp"):
             paraflags.append("-DOMP")
             fflags.append(self.compiler.openmp_flag)
@@ -206,7 +209,7 @@ class Berkeleygw(MakefilePackage):
             buildopts.append("C_LINK=%s" % spack_cxx)
 
         buildopts.append("FOPTS=%s" % " ".join(fflags))
-        buildopts.append("C_OPTS=%s" % " ".join(spec.compiler_flags["cflags"]))
+        buildopts.append("C_OPTS=%s" % " ".join(cflags))
 
         mathflags = []
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Try to fix errors of the type
```
/tmp/spack/opt/spack/linux-debian12-sandybridge/gcc-13.2.0/binutils-2.40-g5jqiir3amzkpgcbz3q4izye3yqeowpi/bin/ld: /tmp/spack/opt/spack/linux-debian12-sandybridge/gcc-13.2.0/berkeleygw-3.1.0-3smxh377ctuk63ny73z2ibdn3jhpghin/lib/libBGW_wfn.a(wfn_rho_vxc_io.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/tmp/spack/opt/spack/linux-debian12-sandybridge/gcc-13.2.0/binutils-2.40-g5jqiir3amzkpgcbz3q4izye3yqeowpi/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
```