### PR TITLE
ci: Use explicit version of notary image

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -42,7 +42,7 @@ ci:
           aud: "${OIDC_TOKEN_AUDIENCE}"
 
   - signing-job:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+      image: { "name": "ghcr.io/spack/notary:0.0.1", "entrypoint": [""] }
       tags: ["aws"]
       script:
       - - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_BUILDCACHE_DESTINATION}/build_cache /tmp


### PR DESCRIPTION
It's a little unclear which image gets pulled when we use the `latest` tag, which hasn't caused any problems yet since we're still using the original version of the notary image.  Now that we're going to need to build and use a new one, it makes sense to start being explicit about which version to use.

This goes along with this spack-infrastructure [PR](https://github.com/spack/spack-infrastructure/pull/1091) to do the same, and this should not be merged until that has been merged and the new tag has been pushed.
