### PR TITLE
Update default build type for benchmark recipe

### DIFF
--- a/var/spack/repos/builtin/packages/benchmark/package.py
+++ b/var/spack/repos/builtin/packages/benchmark/package.py
@@ -45,7 +45,7 @@ class Benchmark(CMakePackage):
 
     variant(
         "build_type",
-        default="RelWithDebInfo",
+        default="Release",
         description="The build type to build",
         values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel", "Coverage"),
     )


### PR DESCRIPTION
Since Spack 0.20, the default CMake and Meson build types are now Release, this PR aligns the default build type with the rest of Spack recipes.