### PR TITLE
solver: dump output specs to file if not satisfied

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -20,6 +20,7 @@ import shlex
 import signal
 import subprocess as sp
 import sys
+import tempfile
 import traceback
 import warnings
 from typing import List, Tuple
@@ -41,6 +42,7 @@ import spack.modules
 import spack.paths
 import spack.platforms
 import spack.repo
+import spack.solver.asp
 import spack.spec
 import spack.store
 import spack.util.debug
@@ -1046,6 +1048,10 @@ def main(argv=None):
     try:
         return _main(argv)
 
+    except spack.solver.asp.OutputDoesNotSatisfyInputError as e:
+        _handle_solver_bug(e)
+        return 1
+
     except spack.error.SpackError as e:
         tty.debug(e)
         e.die()  # gracefully die on any SpackErrors
@@ -1067,6 +1073,44 @@ def main(argv=None):
             raise
         tty.error(e)
         return 3
+
+
+def _handle_solver_bug(e: spack.solver.asp.OutputDoesNotSatisfyInputError) -> None:
+    # when the solver outputs specs that do not satisfy the input and spack is used as a command
+    # line tool, we dump the incorrect output specs to json so users can upload them in bug reports
+    wrong_output = [(input, output) for input, output in e.input_to_output if output is not None]
+    no_output = [input for input, output in e.input_to_output if output is None]
+    if no_output:
+        tty.error(
+            "internal solver error: the following specs were not solved:\n    - "
+            + "\n    - ".join(str(s) for s in no_output)
+        )
+    if wrong_output:
+        msg = (
+            "internal solver error: the following specs were concretized, but do not satisfy the "
+            "input:\n    - " + "\n    - ".join(str(s) for s, _ in wrong_output)
+        )
+        # try to write the input/output specs to a temporary directory for bug reports
+        try:
+            tmpdir = tempfile.mkdtemp(prefix="spack-asp-")
+            files = []
+            for i, (input, output) in enumerate(wrong_output, start=1):
+                in_file = os.path.join(tmpdir, f"input-{i}.json")
+                out_file = os.path.join(tmpdir, f"output-{i}.json")
+                files.append(in_file)
+                files.append(out_file)
+                with open(in_file, "w", encoding="utf-8") as f:
+                    input.to_json(f)
+                with open(out_file, "w", encoding="utf-8") as f:
+                    output.to_json(f)
+
+            msg += (
+                "\n    Please report a bug at https://github.com/spack/spack/issues and attach "
+                "the following files:\n    - " + "\n    - ".join(files)
+            )
+        except Exception:
+            msg += "\n    Please report a bug at https://github.com/spack/spack/issues."
+        tty.error(msg)
 
 
 class SpackCommandError(Exception):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -1075,7 +1075,9 @@ def main(argv=None):
         return 3
 
 
-def _handle_solver_bug(e: spack.solver.asp.OutputDoesNotSatisfyInputError) -> None:
+def _handle_solver_bug(
+    e: spack.solver.asp.OutputDoesNotSatisfyInputError, out=sys.stderr, root=None
+) -> None:
     # when the solver outputs specs that do not satisfy the input and spack is used as a command
     # line tool, we dump the incorrect output specs to json so users can upload them in bug reports
     wrong_output = [(input, output) for input, output in e.input_to_output if output is not None]
@@ -1083,16 +1085,19 @@ def _handle_solver_bug(e: spack.solver.asp.OutputDoesNotSatisfyInputError) -> No
     if no_output:
         tty.error(
             "internal solver error: the following specs were not solved:\n    - "
-            + "\n    - ".join(str(s) for s in no_output)
+            + "\n    - ".join(str(s) for s in no_output),
+            stream=out,
         )
     if wrong_output:
         msg = (
             "internal solver error: the following specs were concretized, but do not satisfy the "
-            "input:\n    - " + "\n    - ".join(str(s) for s, _ in wrong_output)
+            "input:\n    - "
+            + "\n    - ".join(str(s) for s, _ in wrong_output)
+            + "\n    Please report a bug at https://github.com/spack/spack/issues"
         )
         # try to write the input/output specs to a temporary directory for bug reports
         try:
-            tmpdir = tempfile.mkdtemp(prefix="spack-asp-")
+            tmpdir = tempfile.mkdtemp(prefix="spack-asp-", dir=root)
             files = []
             for i, (input, output) in enumerate(wrong_output, start=1):
                 in_file = os.path.join(tmpdir, f"input-{i}.json")
@@ -1104,13 +1109,10 @@ def _handle_solver_bug(e: spack.solver.asp.OutputDoesNotSatisfyInputError) -> No
                 with open(out_file, "w", encoding="utf-8") as f:
                     output.to_json(f)
 
-            msg += (
-                "\n    Please report a bug at https://github.com/spack/spack/issues and attach "
-                "the following files:\n    - " + "\n    - ".join(files)
-            )
+            msg += " and attach the following files:\n    - " + "\n    - ".join(files)
         except Exception:
-            msg += "\n    Please report a bug at https://github.com/spack/spack/issues."
-        tty.error(msg)
+            msg += "."
+        tty.error(msg, stream=out)
 
 
 class SpackCommandError(Exception):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1831,10 +1831,7 @@ class TestConcretize:
         monkeypatch.setattr(spack.solver.asp.Result, "unsolved_specs", simulate_unsolved_property)
         monkeypatch.setattr(spack.solver.asp.Result, "specs", list())
 
-        with pytest.raises(
-            spack.solver.asp.InternalConcretizerError,
-            match="a subset of input specs could not be solved for",
-        ):
+        with pytest.raises(spack.solver.asp.OutputDoesNotSatisfyInputError):
             list(solver.solve_in_rounds(specs))
 
     def test_coconcretize_reuse_and_virtuals(self):


### PR DESCRIPTION
When the solver produces specs that do not satisfy the input
constraints, dump both input and output specs as json in an temporary
dir and ask the user to upload these files in a bug report.

Handling this in Spack's `main` function, so it only happens when
Spack is used as an application.

Helps with issues like #50005 where the error is currently entirely
useless.