### PR TITLE
iconv: add a strong preference on libiconv by default

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -92,6 +92,8 @@ packages:
     buildable: false
   hpcx-mpi:
     buildable: false
+  iconv:
+    prefer: [libiconv]
   mpt:
     buildable: false
   spectrum-mpi:


### PR DESCRIPTION
fixes #49971

This strong preference fixes a sporadic issue when concretizing environments with `unify:when_possible`.

In the first round of concretization, it is almost certain that glibc is installed, and that spec might provide iconv. In later rounds using that as a provider might be preferred, as it leads to less nodes to be "built".

To avoid duplication by default, prefer libiconv in a stronger way than default preferences. This setting can still be overridden by a `require:` in case `glibc` is wanted as a provider.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
