### PR TITLE
root: 6.34 included this patch

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -182,7 +182,7 @@ class Root(CMakePackage):
         patch(
             "https://github.com/root-project/root/pull/15925.diff?full_index=1",
             sha256="1937290a4d54cd2e3e8a8d23d93b8dedaca9ed8dcfdcfa2f0d16629ff53fb3b7",
-            when="@6.28: +python",
+            when="@6.28:6.32 +python",
         )
 
     # ###################### Variants ##########################

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -500,6 +500,7 @@ class Root(CMakePackage):
     # See https://github.com/root-project/root/issues/11135
     conflicts("+ipo", msg="LTO is not a supported configuration for building ROOT")
 
+    @when("+root7 +geom +webgui")
     def patch(self):
         filter_file(
             r"#include <sstream>",


### PR DESCRIPTION
This fixes the ROOT install on macos: a previous patch didn't have a "best before end". Also it increases granularity of a patch that changes a file referenced inside this cmake:
```cmake
if(webgui AND root7 AND geom)
  add_subdirectory(eve7) # special CMakeLists.txt
endif()
```