### PR TITLE
libcxi: add dependencies for autoreconf phase

### DIFF
--- a/var/spack/repos/builtin/packages/libcxi/package.py
+++ b/var/spack/repos/builtin/packages/libcxi/package.py
@@ -23,6 +23,12 @@ class Libcxi(AutotoolsPackage):
 
     depends_on("c", type="build")
 
+    with default_args(type="build", when="@main"):
+        depends_on("autoconf")
+        depends_on("automake")
+        depends_on("libtool")
+        depends_on("pkgconfig")
+
     depends_on("cassini-headers")
     depends_on("cxi-driver")
 


### PR DESCRIPTION
When setting this up on a new system, I discovered that some build dependencies were missing.
This also aligns with the guidelines outlined on the Autotools build system [page](https://spack.readthedocs.io/en/latest/build_systems/autotoolspackage.html) in the documentation. `pkgconfig` is needed to solve the error described in this blog [post](https://ae1020.github.io/undefined-macro-pkg-config/).

