### PR TITLE
esmf: test for mvapich2 script existence

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -200,7 +200,8 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     @run_before("build")
     def chmod_scripts(self):
         chmod = which("chmod")
-        chmod("+x", "scripts/libs.mvapich2f90")
+        if os.path.exists("scripts/libs.mvapich2f90"):
+            chmod("+x", "scripts/libs.mvapich2f90")
 
     def url_for_version(self, version):
         if version < Version("8.0.0"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds an existence test to `scripts/libs.mvapich2f90` in `esmf`. 

A recent merge into `develop` (https://github.com/esmf-org/esmf/pull/379) removed the script. However, a [build against `esmf@develop` found](https://github.com/GEOS-ESM/MAPL/actions/runs/14408148780/job/40409597568?pr=3531#step:13:171) that this:
```python
    # Make script from mvapich2.patch executable
    @when("@:7.0")
    @run_before("build")
    def chmod_scripts(self):
        chmod = which("chmod")
        chmod("+x", "scripts/libs.mvapich2f90")
```
code was run and failed because the script didn't exist:
```
==> Applied patch /home/runner/work/MAPL/MAPL/spack/var/spack/repos/builtin/packages/esmf/esmf_cpp_info.patch
==> esmf: Executing phase: 'edit'
==> esmf: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 1:
    '/usr/bin/chmod' '+x' 'scripts/libs.mvapich2f90'

1 error found in build log:
     2    ==> esmf: Executing phase: 'build'
     3    ==> [2025-04-11-16:58:02.582133] '/usr/bin/chmod' '+x' 'scripts/libs.
          mvapich2f90'
  >> 4    /usr/bin/chmod: cannot access 'scripts/libs.mvapich2f90': No such fil
          e or directory

See build log for details:
  /tmp/runner/spack-stage/spack-stage-esmf-develop-c4xm575vfezyew4ly2s3g7rzg7ylj4yb/spack-build-out.txt

==> Error: esmf-develop-c4xm575vfezyew4ly2s3g7rzg7ylj4yb: ProcessError: Command exited with status 1:
    '/usr/bin/chmod' '+x' 'scripts/libs.mvapich2f90'
==> Error: esmf-develop-c4xm575vfezyew4ly2s3g7rzg7ylj4yb: Package was not installed
==> Error: Installation request failed.  Refer to reported errors for failing package(s).

```

As I'm not sure how to say `@when("@:7.0") ... but not develop`, my next thought is to check for the script's existence.
