### PR TITLE
aocl-da & aocl-utils: fix missing compiler dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/aocl-da/package.py
+++ b/var/spack/repos/builtin/packages/aocl-da/package.py
@@ -53,6 +53,8 @@ class AoclDa(CMakePackage):
     )
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("cmake@3.22:", type="build")
     for vers in ["5.0"]:

--- a/var/spack/repos/builtin/packages/aocl-utils/package.py
+++ b/var/spack/repos/builtin/packages/aocl-utils/package.py
@@ -47,7 +47,8 @@ class AoclUtils(CMakePackage):
     variant("shared", default=True, when="@4.2:", description="build shared library")
     variant("examples", default=False, description="enable examples")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.22:", type="build")
     depends_on("doxygen", when="+doc")


### PR DESCRIPTION
Fix https://github.com/spack/spack/issues/50021
Fix https://github.com/spack/spack/issues/50024

This PR adds missing compiler dependencies to `aocl-da` and `aocl-utils` packages.
