### PR TITLE
libceed: Add BLAS_DIR and link time blas dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libceed/package.py
+++ b/var/spack/repos/builtin/packages/libceed/package.py
@@ -141,9 +141,9 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
 
             if spec.satisfies("+magma"):
                 makeopts += ["MAGMA_DIR=%s" % spec["magma"].prefix]
-                
+
         makeopts += ["BLAS_LIB=%s" % spec["blas"].libs]
-        
+
         return makeopts
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libceed/package.py
+++ b/var/spack/repos/builtin/packages/libceed/package.py
@@ -41,6 +41,8 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
+    depends_on("blas", type="link")
+
     with when("+rocm"):
         depends_on("hip@3.8.0:", when="@0.8:")
         depends_on("hipblas@3.8.0:", when="@0.8:")
@@ -139,7 +141,9 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
 
             if spec.satisfies("+magma"):
                 makeopts += ["MAGMA_DIR=%s" % spec["magma"].prefix]
-
+                
+        makeopts += ["BLAS_LIB=%s" % spec["blas"].libs]
+        
         return makeopts
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libceed/package.py
+++ b/var/spack/repos/builtin/packages/libceed/package.py
@@ -41,8 +41,6 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("blas", type="link")
-
     with when("+rocm"):
         depends_on("hip@3.8.0:", when="@0.8:")
         depends_on("hipblas@3.8.0:", when="@0.8:")
@@ -57,6 +55,7 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
         depends_on("occa~cuda", when="~cuda")
 
     depends_on("libxsmm", when="+libxsmm")
+    depends_on("blas", when="+libxsmm", type="link")
 
     depends_on("magma", when="+magma")
 
@@ -138,11 +137,10 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
 
             if spec.satisfies("+libxsmm"):
                 makeopts += ["XSMM_DIR=%s" % spec["libxsmm"].prefix]
+                makeopts += ["BLAS_LIB=%s" % spec["blas"].libs]
 
             if spec.satisfies("+magma"):
                 makeopts += ["MAGMA_DIR=%s" % spec["magma"].prefix]
-
-        makeopts += ["BLAS_LIB=%s" % spec["blas"].libs]
 
         return makeopts
 


### PR DESCRIPTION
I found this was necessary, or else libceed would complain about `-lblas` not being found.

The alternative workaround was to `spack load blas` before building libceed, which isn't ideal. Perhaps this change is wrong though, and I was doing something wrong in building.