### PR TITLE
mark glibc and musl as buildable false

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -90,9 +90,13 @@ packages:
     buildable: false
   fujitsu-ssl2:
     buildable: false
+  glibc:
+    buildable: false
   hpcx-mpi:
     buildable: false
   mpt:
+    buildable: false
+  musl:
     buildable: false
   spectrum-mpi:
     buildable: false


### PR DESCRIPTION
Based on https://github.com/spack/spack/issues/44352 musl and glibc should be marked as `buildable: false`.

If I understand the code correctly, this should also prevent CI from trying to build `musl`. This is not a theoretical situation. Running into CI trying to build `musl` in https://github.com/spack/spack/pull/49419.