### PR TITLE
Update mdspan recipe

### DIFF
--- a/var/spack/repos/builtin/packages/mdspan/package.py
+++ b/var/spack/repos/builtin/packages/mdspan/package.py
@@ -26,15 +26,12 @@ class Mdspan(CMakePackage):
     depends_on("googletest@main", when="+tests")
 
     def cmake_args(self):
-        args = []
-
-        if self.spec.satisfies("+tests"):
-            args.append("-DMDSPAN_ENABLE_TESTS=ON")
-            args.append("-DMDSPAN_USE_SYSTEM_GTEST=ON")
-        if self.spec.satisfies("+benchmarks"):
-            args.append("-DMDSPAN_ENABLE_BENCHMARKS=ON")
-        if self.spec.satisfies("+examples"):
-            args.append("-DMDSPAN_ENABLE_EXAMPLES=ON")
+        args = [
+            self.define_from_variant("MDSPAN_ENABLE_TESTS", "tests"),
+            self.define_from_variant("MDSPAN_USE_SYSTEM_GTEST", "tests"),
+            self.define_from_variant("MDSPAN_ENABLE_BENCHMARKS", "benchmarks"),
+            self.define_from_variant("MDSPAN_ENABLE_EXAMPLES", "examples"),
+        ]
 
         args.append("-DCMAKE_CXX_STANDARD=17")
         args.append("-DMDSPAN_CXX_STANDARD=17")

--- a/var/spack/repos/builtin/packages/mdspan/package.py
+++ b/var/spack/repos/builtin/packages/mdspan/package.py
@@ -26,7 +26,7 @@ class Mdspan(CMakePackage):
     )
 
     depends_on("benchmark", when="+benchmarks")
-    depends_on("googletest@main", when="+tests")
+    depends_on("googletest@1.14:1", when="+tests")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/mdspan/package.py
+++ b/var/spack/repos/builtin/packages/mdspan/package.py
@@ -39,7 +39,5 @@ class Mdspan(CMakePackage):
         args.append("-DCMAKE_CXX_FLAGS='-Wall -Wextra -pedantic'")
         args.append("-DCMAKE_CXX_STANDARD=17")
         args.append("-DMDSPAN_CXX_STANDARD=17")
-        args.append("-DCMAKE_CXX_COMPILER=g++")
-        args.append("-DCMAKE_CXX_EXTENSIONS=OFF")
 
         return args

--- a/var/spack/repos/builtin/packages/mdspan/package.py
+++ b/var/spack/repos/builtin/packages/mdspan/package.py
@@ -21,6 +21,9 @@ class Mdspan(CMakePackage):
     variant("examples", default=True, description="Enable examples")
     variant("tests", default=False, description="Enable tests")
     variant("benchmarks", default=False, description="Enable benchmarks")
+    variant(
+        "cxxstd", default="17", values=["14", "17", "20"], multi=False, description="C++ standard"
+    )
 
     depends_on("benchmark", when="+benchmarks")
     depends_on("googletest@main", when="+tests")
@@ -31,9 +34,8 @@ class Mdspan(CMakePackage):
             self.define_from_variant("MDSPAN_USE_SYSTEM_GTEST", "tests"),
             self.define_from_variant("MDSPAN_ENABLE_BENCHMARKS", "benchmarks"),
             self.define_from_variant("MDSPAN_ENABLE_EXAMPLES", "examples"),
+            self.define_from_variant("MDSPAN_CXX_STANDARD", "cxxstd"),
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
-
-        args.append("-DCMAKE_CXX_STANDARD=17")
-        args.append("-DMDSPAN_CXX_STANDARD=17")
 
         return args

--- a/var/spack/repos/builtin/packages/mdspan/package.py
+++ b/var/spack/repos/builtin/packages/mdspan/package.py
@@ -36,7 +36,6 @@ class Mdspan(CMakePackage):
         if self.spec.satisfies("+examples"):
             args.append("-DMDSPAN_ENABLE_EXAMPLES=ON")
 
-        args.append("-DCMAKE_CXX_FLAGS='-Wall -Wextra -pedantic'")
         args.append("-DCMAKE_CXX_STANDARD=17")
         args.append("-DMDSPAN_CXX_STANDARD=17")
 


### PR DESCRIPTION
Changes:
- Remove hard-coded `g++` compiler and extension
- Remove hard-coded compiler flags
- Simplify cmake definitions
- Add a `cxxstd` variant
- Rely on a not-too-old version of Google test instead of the main branch