### PR TITLE
gitlab: config:shared_linking:missing_library_policy:error

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/config.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/config.yaml
@@ -1,7 +1,7 @@
 config:
   db_lock_timeout: 120
   shared_linking:
-    missing_library_policy: warn
+    missing_library_policy: error
   install_tree:
     root: /home/software/spack
     padded_length: 256


### PR DESCRIPTION
This PR is intended to surface the remaining missing library errors in a rebuild-all, and then as new packages are added (https://github.com/spack/spack/pull/48646#pullrequestreview-2562241346).