### PR TITLE
seacas: add v2025-04-14

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -35,6 +35,9 @@ class Seacas(CMakePackage):
     # ###################### Versions ##########################
     version("master", branch="master")
     version(
+        "2025-04-14", sha256="7704fc27e4f0d283fd9272ea769dbeffd971315a982e265c0d7c99fc77186476"
+    )
+    version(
         "2025-03-13", sha256="406aff5b8908d6a3bf6687d825905990101caa9cf8c1213a508938eed2134d6d"
     )
     version(


### PR DESCRIPTION
* Kluge to support file-per-rank and multiple-rank-single-file read/write in CGNS, other CGNS-related changes.
* Catalyst changes
* Update to latest TriBITs
* Improved static library build
* EPU: Handle case where no elements, but add_processor_id specified
* CPUP: Handle decomp-created zgc between zones better
* IOSS: Add filessystem type function (lustre, gpfs, nfs, ...)
* CPUP: Fix handling of assemblies
* IOSS: fix io_shell compare of db with no changesets
* IOSS: Cgns - handle missing assemblies correctly
* IOSS: Clean up owning_processor calculation
* EXO2MAT: Add -i option to not transfer info records to mat file

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
