### PR TITLE
py-gidgetlab: add v2.0.0, v2.0.1, v2.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-gidgetlab/package.py
+++ b/var/spack/repos/builtin/packages/py-gidgetlab/package.py
@@ -28,8 +28,8 @@ class PyGidgetlab(PythonPackage):
     )
 
     depends_on("py-setuptools@60:", type=("build", "run"), when="@2.0.0:")
-    depends_on("py-setuptools-scm@8.0:", type="build", when="@2.0.0:")
     depends_on("py-setuptools@45:", type=("build", "run"))
+    depends_on("py-setuptools-scm@8.0:", type="build", when="@2.0.0:")
     depends_on("py-setuptools-scm@6.2:", type="build")
 
     depends_on("py-aiohttp", type=("build", "run"), when="+aiohttp")

--- a/var/spack/repos/builtin/packages/py-gidgetlab/package.py
+++ b/var/spack/repos/builtin/packages/py-gidgetlab/package.py
@@ -18,12 +18,17 @@ class PyGidgetlab(PythonPackage):
     license("Apache-2.0")
 
     version("main", branch="main")
+    version("2.1.0", sha256="60c39516261b788e7643ae12fae106a79329450d908e821c9a591ab6c52ffe95")
+    version("2.0.1", sha256="bce8f8553c41823bff330eb9e1f0951f19feb7fc76a9effe3038f780377d984e")
+    version("2.0.0", sha256="f109c12a47c4b2cadd5485c6574d003807a07796585d75a21bd9e0d4ecd63c14")
     version("1.1.0", sha256="314ec2cddc898317ec45d99068665dbf33c0fee1f52df6671f28ad35bb51f902")
 
     variant(
         "aiohttp", default=False, description="Enable aiohttp functionality through dependency."
     )
 
+    depends_on("py-setuptools@60:", type=("build", "run"), when="@2.0.0:")
+    depends_on("py-setuptools-scm@8.0:", type="build", when="@2.0.0:")
     depends_on("py-setuptools@45:", type=("build", "run"))
     depends_on("py-setuptools-scm@6.2:", type="build")
 

--- a/var/spack/repos/builtin/packages/py-gidgetlab/package.py
+++ b/var/spack/repos/builtin/packages/py-gidgetlab/package.py
@@ -26,6 +26,7 @@ class PyGidgetlab(PythonPackage):
     variant(
         "aiohttp", default=False, description="Enable aiohttp functionality through dependency."
     )
+    depends_on("python@:3.12", type=("build", "run"), when="@:1")
 
     depends_on("py-setuptools@60:", type=("build", "run"), when="@2.0.0:")
     depends_on("py-setuptools@45:", type=("build", "run"))


### PR DESCRIPTION
1.1.0 doesn't work with Python 3.13.

See this commit (and the tags that contain it) for history on build deps:
https://gitlab.com/beenje/gidgetlab/-/commit/310bc109bad39957c9d1b4d4d19a380ee7b8b077.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
