### PR TITLE
version_types.py: Version -> Union[StandardVersion, GitVersion]

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -149,12 +149,12 @@ def _getfqdn():
     return socket.getfqdn()
 
 
-def reader(version: vn.ConcreteVersion) -> Type["spack.spec.SpecfileReaderBase"]:
+def reader(version: vn.StandardVersion) -> Type["spack.spec.SpecfileReaderBase"]:
     reader_cls = {
-        vn.Version("5"): spack.spec.SpecfileV1,
-        vn.Version("6"): spack.spec.SpecfileV3,
-        vn.Version("7"): spack.spec.SpecfileV4,
-        vn.Version("8"): spack.spec.SpecfileV5,
+        vn.StandardVersion.from_string("5"): spack.spec.SpecfileV1,
+        vn.StandardVersion.from_string("6"): spack.spec.SpecfileV3,
+        vn.StandardVersion.from_string("7"): spack.spec.SpecfileV4,
+        vn.StandardVersion.from_string("8"): spack.spec.SpecfileV5,
     }
     return reader_cls[version]
 
@@ -824,7 +824,7 @@ class Database:
         db = fdata["database"]
         check("version" in db, "no 'version' in JSON DB.")
 
-        self.db_version = vn.Version(db["version"])
+        self.db_version = vn.StandardVersion.from_string(db["version"])
         if self.db_version > _DB_VERSION:
             raise InvalidDatabaseVersionError(self, _DB_VERSION, self.db_version)
         elif self.db_version < _DB_VERSION:

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -1257,7 +1257,7 @@ def _prev_version(v: StandardVersion) -> StandardVersion:
     return StandardVersion("", (release, prerelease), separators)
 
 
-def Version(string: Union[str, int]) -> ConcreteVersion:
+def Version(string: Union[str, int]) -> Union[StandardVersion, GitVersion]:
     if not isinstance(string, (str, int)):
         raise TypeError(f"Cannot construct a version from {type(string)}")
     string = str(string)


### PR DESCRIPTION
ConcreteVersion is supposed to be an abstract base class but is missing the interface.

Instead of abstracting the interface just make `def Version` produce a union type instead of the common denominator. It's likely that GitVersion goes away, so not worth further refactor.