### PR TITLE
fenics-dolfinx: add missing "c" build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
@@ -30,6 +30,7 @@ class FenicsDolfinx(CMakePackage):
         multi=True,
     )
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     # Graph partitioner dependencies


### PR DESCRIPTION
building fenics-dolfinx resulted in the following error:

    ==> No patches needed for fenics-dolfinx
    ==> fenics-dolfinx: Executing phase: 'cmake'
    ==> Error: ProcessError: Command exited with status 1:


    3 errors found in build log:
         3     -- The C compiler identification is unknown
         4     -- The CXX compiler identification is GNU 12.2.0
         5     -- Detecting C compiler ABI info
         6     -- Detecting C compiler ABI info - failed
         7     -- Check for working C compiler: /opt/spack/[...]libexec/spack/cc
         8     -- Check for working C compiler: /opt/spack/[...]libexec/spack/cc - broken

      >> 9     CMake Error at /opt/spack/opt/spack/[...]/CMakeTestCCompiler.cmake:67 (message):
         10      The C compiler
         11
         12        "/opt/spack/opt/spack/[...]/libexec/spack/cc"
         13
         14      is not able to compile a simple test program.
         15

     ...

Thanks to @amd-toolchain-support issue #50021, this is easily fixed by adding the one-liner for the missing dependency for the C compiler.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
