### PR TITLE
go: ignore unresolved library

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -33,6 +33,7 @@ class Go(Package):
 
     extendable = True
     executables = ["^go$"]
+    unresolved_libraries = ["libtiff.so.*"]  # go/src/debug/elf/testdata/libtiffxx.so_
 
     maintainers("alecbcs")
 


### PR DESCRIPTION
This PR adds `libtiff.so` to the `unresolved_libraries` for `go` since a testdata library includes references to it. See also https://github.com/spack/spack/pull/50048#issuecomment-2806856869.