### PR TITLE
audit.py: disallow patches coming from PRs

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -34,6 +34,7 @@ Calls to each of these functions are triggered by the ``run`` method of
 the decorator object, that will forward the keyword arguments passed
 as input.
 """
+
 import ast
 import collections
 import collections.abc
@@ -445,7 +446,7 @@ def _check_patch_urls(pkgs, error_cls):
     )
     github_pull_commits_re = (
         r"^https?://(?:patch-diff\.)?github(?:usercontent)?\.com/"
-        r".+/.+/pull/\d+/commits/[a-fA-F0-9]+\.(?:patch|diff)"
+        r".+/.+/pull/\d+(/commits/[a-fA-F0-9]+)?\.(?:patch|diff)"
     )
     # Only .diff URLs have stable/full hashes:
     # https://forum.gitlab.com/t/patches-with-full-index/29313
@@ -463,13 +464,10 @@ def _check_patch_urls(pkgs, error_cls):
                     continue
 
                 if re.match(github_pull_commits_re, patch.url):
-                    url = re.sub(r"/pull/\d+/commits/", r"/commit/", patch.url)
-                    url = re.sub(r"^(.*)(?<!full_index=1)$", r"\1?full_index=1", url)
                     errors.append(
                         error_cls(
                             f"patch URL in package {pkg_cls.name} "
-                            + "must not be a pull request commit; "
-                            + f"instead use {url}",
+                            + "must not come from a pull request. ",
                             [patch.url],
                         )
                     )

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -20,6 +20,8 @@ import spack.config
         (["wrong-variant-in-depends-on"], ["PKG-DIRECTIVES", "PKG-PROPERTIES"]),
         # This package has a GitHub pull request commit patch URL
         (["invalid-github-pull-commits-patch-url"], ["PKG-DIRECTIVES", "PKG-PROPERTIES"]),
+        # This package has a GitHub pull request patch URL
+        (["invalid-github-pull-request-patch-url"], ["PKG-DIRECTIVES", "PKG-PROPERTIES"]),
         # This package has a GitHub patch URL without full_index=1
         (["invalid-github-patch-url"], ["PKG-DIRECTIVES", "PKG-PROPERTIES"]),
         # This package has invalid GitLab patch URLs

--- a/var/spack/repos/builtin.mock/packages/invalid-github-pull-request-patch-url/package.py
+++ b/var/spack/repos/builtin.mock/packages/invalid-github-pull-request-patch-url/package.py
@@ -1,0 +1,19 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class InvalidGithubPullRequestPatchUrl(Package):
+    """Package that has a GitHub pull request patch URL that fails auditing."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/patch-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    patch(
+        "https://github.com/spack/spack/pull/1.patch?full_index=1",
+        sha256="eae9035b832792549fac00680db5f180a88ff79feb7d7a535b4fd71f9d885e73",
+    )


### PR DESCRIPTION
This pull request blankety disallows patches coming from upstream pull requests.