### PR TITLE
Fedora bootstrap ci job needs awk maybe

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -26,7 +26,7 @@ jobs:
           dnf install -y \
               bzip2 curl file gcc-c++ gcc gcc-gfortran git gzip \
               make patch unzip which xz python3 python3-devel tree \
-              cmake bison bison-devel libstdc++-static
+              cmake bison bison-devel libstdc++-static gawk
       - name: Setup OpenSUSE
         if: ${{ matrix.image == 'opensuse/leap:latest' }}
         run: |


### PR DESCRIPTION
Recent bootstrap CI job failure indicates awk may not be present on fedora

https://github.com/spack/spack/actions/runs/14479031845/job/40614906994

```
1 error found in build log:
     209    config.status: creating doc/Makefile
     210    ./config.status: line 1235: awk: command not found
     211    config.status: creating po/Makefile.in
     212    ./config.status: line 1235: awk: command not found
     213    config.status: creating src/config.h
     214    ./config.status: line 1262: awk: command not found
  >> 215    config.status: error: could not create src/config.h
```
