### PR TITLE
Remove Prolog so that GitHub detects Answer Set Programming

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 *.py diff=python
-*.lp linguist-language=Prolog
 lib/spack/external/* linguist-vendored
 *.bat text eol=crlf


### PR DESCRIPTION
This reverts a change made in #20639 to have GitHub recognize our ASP files as Prolog, the closest langauge supported by [Linguist](https://github.com/github-linguist/linguist) at the time.

Linguist has since [added support for ASP](https://github.com/github-linguist/linguist/pull/7184), so we no longer need to force Prolog detection -- our `.lp` files should be auto-detected as ASP.