### PR TITLE
gfe: protections for CMake 4.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/fargparse/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fargparse/package.py
@@ -35,7 +35,9 @@ class Fargparse(CMakePackage):
 
     depends_on("gftl-shared")
     depends_on("gftl")
-    depends_on("cmake@3.12:", type="build")
+
+    depends_on("cmake@3.12:3", type="build", when="@:1.9")
+    depends_on("cmake@3.24:", type="build", when="@1.10:")
 
     # fargparse only works with the Fujitsu compiler from 1.7.0 onwards
     conflicts(

--- a/var/spack/repos/spack_repo/builtin/packages/gftl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gftl/package.py
@@ -60,7 +60,9 @@ class Gftl(CMakePackage):
 
     depends_on("fortran", type="build")
 
-    depends_on("cmake@3.12:", type="build")
+    depends_on("cmake@3.12:3", type="build", when="@:1.15")
+    depends_on("cmake@3.24:", type="build", when="@1.16:")
+
     depends_on("m4", type="build")
 
     # gftl only works with the Fujitsu compiler from 1.12 onwards

--- a/var/spack/repos/spack_repo/builtin/packages/gftl_shared/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gftl_shared/package.py
@@ -46,7 +46,7 @@ class GftlShared(CMakePackage):
 
     depends_on("m4", type=("build", "run"))
 
-    depends_on("cmake@3.12:3", type="build", when=":@1.10")
+    depends_on("cmake@3.12:3", type="build", when="@:1.10")
     depends_on("cmake@3.24:", type="build", when="@1.11:")
 
     depends_on("gftl")

--- a/var/spack/repos/spack_repo/builtin/packages/gftl_shared/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gftl_shared/package.py
@@ -45,7 +45,10 @@ class GftlShared(CMakePackage):
     depends_on("fortran", type="build")
 
     depends_on("m4", type=("build", "run"))
-    depends_on("cmake@3.12:", type="build")
+
+    depends_on("cmake@3.12:3", type="build", when=":@1.10")
+    depends_on("cmake@3.24:", type="build", when="@1.11:")
+
     depends_on("gftl")
 
     # gftl-shared only works with the Fujitsu compiler from 1.8.0 onwards

--- a/var/spack/repos/spack_repo/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pflogger/package.py
@@ -74,7 +74,8 @@ class Pflogger(CMakePackage):
         msg="pFlogger only works with the Fujitsu compiler from version 1.13.0 onwards",
     )
 
-    depends_on("cmake@3.12:", type="build")
+    depends_on("cmake@3.12:3", type="build", when="@:1.16")
+    depends_on("cmake@3.24:", type="build", when="@1.17:")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/spack_repo/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pfunit/package.py
@@ -120,7 +120,10 @@ class Pfunit(CMakePackage):
     depends_on("m4", when="@4.1.5:", type="build")
     depends_on("fargparse@1.8.0:", when="@4.10.0:")
     depends_on("fargparse", when="@4:")
-    depends_on("cmake@3.12:", type="build")
+
+    depends_on("cmake@3.12:3", type="build", when="@:4.11")
+    depends_on("cmake@3.12:", type="build", when="@4.12")
+    depends_on("cmake@3.24:", type="build", when="@4.13:")
 
     # CMake 3.25.0 has an issue with pFUnit
     # https://gitlab.kitware.com/cmake/cmake/-/issues/24203

--- a/var/spack/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -54,7 +54,9 @@ class Yafyaml(CMakePackage):
 
     depends_on("gftl-shared")
     depends_on("gftl")
-    depends_on("cmake@3.12:", type="build")
+
+    depends_on("cmake@3.12:3", type="build", when="@:1.5")
+    depends_on("cmake@3.24:", type="build", when="@1.6:")
 
     # yafyaml only works with the Fujitsu compiler from 1.3.0 onwards
     conflicts(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Users recently found that the GFE libraries:

- gFTL
- gFTL-shared
- fArgParse
- pFUnit
- yaFyaml
- pFlogger

have some `cmake_minimum_required(VERSION 3.0)` calls in the CMake. With CMake 4, [this is now an error](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features).

Efforts are underway to update all the GFE libraries to use CMake 3.24 as a minimum (which is a version we use in codes that *use* GFE, so we are comfortable with it).

But until those versions can be tested and released, we need to protect spack users from having failing builds.

You'll note below that `pfunit` is a "special" case as a user already found this out and a version, 4.12, was released that can work with CMake 4:

```python
    depends_on("cmake@3.12:3", type="build", when="@:4.11")
    depends_on("cmake@3.12:", type="build", when="@4.12")
    depends_on("cmake@3.24:", type="build", when="@4.13:")
```

but with the upcoming 4.13 we'll move to CMake 3.24 as well.