### PR TITLE
mepo: add v2.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/mepo/package.py
+++ b/var/spack/repos/builtin/packages/mepo/package.py
@@ -16,6 +16,7 @@ class Mepo(PythonPackage):
 
     license("Apache-2.0", checked_by="mathomp4")
 
+    version("2.3.1", sha256="76b7fe081de7b34e5680879352a070dd447e2b113f3e34e4ce20c02486c3c0d8")
     version("2.3.0", sha256="e80d7157553d33382ab0c399fcd5ec43ab5ff642504b07c8aef266165f9095d2")
     version("2.2.1", sha256="b691989bb762dc5944a2f13afd89666602fa7e40816f0cfb0278fe2164b34e30")
     version("2.2.0", sha256="d7cf2456ec2ae9e1724782152b6bf86e06cf071263dbe2eb8ad5b8765b419857")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds [mepo v2.3.1](https://github.com/GEOS-ESM/mepo/releases/tag/v2.3.1) which fixes a small bug