### PR TITLE
libcerf: Add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -4,23 +4,49 @@
 
 
 from spack.package import *
+from spack.build_systems.autotools import AutotoolsBuilder
+from spack.build_systems.cmake import CMakeBuilder
 
-
-class Libcerf(AutotoolsPackage, SourceforgePackage):
+class Libcerf(AutotoolsPackage, CMakePackage):
     """A self-contained C library providing complex error functions, based
     on Faddeeva's plasma dispersion function w(z). Also provides Dawson's
     integral and Voigt's convolution of a Gaussian and a Lorentzian
 
     """
 
-    homepage = "https://sourceforge.net/projects/libcerf/"
-    sourceforge_mirror_path = "libcerf/libcerf-1.3.tgz"
+    homepage = "https://jugit.fz-juelich.de/mlz/libcerf/"
+    url = "https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v2.4/libcerf-v2.4.tar.gz"
 
-    version("1.3", sha256="d7059e923d3f370c89fb4d19ed4f827d381bc3f0e36da5595a04aeaaf3e6a859")
+    license("MIT")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    version("2.4", sha256="080b30ae564c3dabe3b89264522adaf5647ec754021572bee54929697b276cdc")
+    version("2.3", sha256="cceefee46e84ce88d075103390b4f9d04c34e4bc3b96d733292c36836d4f7065")
+    version("1.3", sha256="d7059e923d3f370c89fb4d19ed4f827d381bc3f0e36da5595a04aeaaf3e6a859",
+            url="https://sourceforge.net/projects/libcerf/files/libcerf-1.3.tgz")
 
+    variant("cpp", default=False, when="@2:", description="Compile source as C++")
+
+    # Build system
+    build_system(
+        conditional("cmake", when="@2:"),
+        conditional("autotools", when="@=1.3"),
+        default="cmake",
+    )
+
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+
+
+class CMakeBuilder(CMakeBuilder):
+    def cmake_args(self):
+        args = []
+
+        args.append(self.define_from_variant("CERF_CPP", "cpp"))
+
+        return args
+
+
+class AutotoolsBuilder(AutotoolsBuilder):
     def configure_args(self):
         spec = self.spec
         options = []

--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -11,9 +11,7 @@ from spack.package import *
 class Libcerf(AutotoolsPackage, CMakePackage):
     """A self-contained C library providing complex error functions, based
     on Faddeeva's plasma dispersion function w(z). Also provides Dawson's
-    integral and Voigt's convolution of a Gaussian and a Lorentzian
-
-    """
+    integral and Voigt's convolution of a Gaussian and a Lorentzian"""
 
     homepage = "https://jugit.fz-juelich.de/mlz/libcerf/"
     url = "https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v2.4/libcerf-v2.4.tar.gz"

--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.package import *
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.cmake import CMakeBuilder
+from spack.package import *
+
 
 class Libcerf(AutotoolsPackage, CMakePackage):
     """A self-contained C library providing complex error functions, based
@@ -21,16 +22,17 @@ class Libcerf(AutotoolsPackage, CMakePackage):
 
     version("2.4", sha256="080b30ae564c3dabe3b89264522adaf5647ec754021572bee54929697b276cdc")
     version("2.3", sha256="cceefee46e84ce88d075103390b4f9d04c34e4bc3b96d733292c36836d4f7065")
-    version("1.3", sha256="d7059e923d3f370c89fb4d19ed4f827d381bc3f0e36da5595a04aeaaf3e6a859",
-            url="https://sourceforge.net/projects/libcerf/files/libcerf-1.3.tgz")
+    version(
+        "1.3",
+        sha256="d7059e923d3f370c89fb4d19ed4f827d381bc3f0e36da5595a04aeaaf3e6a859",
+        url="https://sourceforge.net/projects/libcerf/files/libcerf-1.3.tgz",
+    )
 
     variant("cpp", default=False, when="@2:", description="Compile source as C++")
 
     # Build system
     build_system(
-        conditional("cmake", when="@2:"),
-        conditional("autotools", when="@=1.3"),
-        default="cmake",
+        conditional("cmake", when="@2:"), conditional("autotools", when="@=1.3"), default="cmake"
     )
 
     depends_on("c", type="build")

--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -20,6 +20,8 @@ class Libcerf(AutotoolsPackage, CMakePackage):
 
     license("MIT")
 
+    maintainers("white238")
+
     version("2.4", sha256="080b30ae564c3dabe3b89264522adaf5647ec754021572bee54929697b276cdc")
     version("2.3", sha256="cceefee46e84ce88d075103390b4f9d04c34e4bc3b96d733292c36836d4f7065")
     version(


### PR DESCRIPTION
They moved URLs and build systems a while back apparently. This PR keeps old functionality but swaps to new for the newer versions. I only added the newest version, 2.4, and the one I needed for a project, 2.3.

