### PR TITLE
c23 standard typo

### DIFF
--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -140,7 +140,7 @@ class CompilerAdaptor:
     @property
     def c23_flag(self) -> str:
         return self.compilers[Languages.C].package.standard_flag(
-            language=Languages.C.value, standard="17"
+            language=Languages.C.value, standard="23"
         )
 
     @property


### PR DESCRIPTION
This standard may not exist or be supported by any compiler yet (e.g. `standard_flags` in `gcc` and `intel-oneapi-compilers` don't support c17 or c23), but I assume we should try to ask for it when users request `c23_flag` (no builtin packages do this as of now, where a few ask for `c11_flag`).