### PR TITLE
rsem: add zlib dependency

### DIFF
--- a/var/spack/repos/builtin/packages/rsem/package.py
+++ b/var/spack/repos/builtin/packages/rsem/package.py
@@ -18,15 +18,16 @@ class Rsem(MakefilePackage):
     version("1.3.1", sha256="93c749a03ac16e94b1aab94d032d4fd5687d3261316ce943ecb89d3ae3ec2e11")
     version("1.3.0", sha256="ecfbb79c23973e1c4134f05201f4bd89b0caf0ce4ae1ffd7c4ddc329ed4e05d2")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("r", type=("build", "run"))
     depends_on("perl", type=("build", "run"))
     depends_on("python", type=("build", "run"))
     depends_on("bowtie")
     depends_on("bowtie2")
     depends_on("star")
+    # The bundled version of samtools/htslib is not compatible with zlib-ng
+    depends_on("zlib")
 
     def install(self, spec, prefix):
         make("install", "DESTDIR=%s" % prefix, "prefix=")

--- a/var/spack/repos/builtin/packages/rsem/package.py
+++ b/var/spack/repos/builtin/packages/rsem/package.py
@@ -26,7 +26,8 @@ class Rsem(MakefilePackage):
     depends_on("bowtie")
     depends_on("bowtie2")
     depends_on("star")
-    # The bundled version of samtools/htslib is not compatible with zlib-ng
+    # The bundled samtools-1.3/htslib-1.3 is not compatible with zlib-ng
+    # https://github.com/samtools/htslib/issues/1257
     depends_on("zlib")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Adding a zlib dependency to the rsem package. rsem bundles an older version (1.3) of samtools/htslib that is not compatible with zlib-ng. For reference, this conflict is documented in the htslib package recipe: https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/htslib/package.py#L72