### PR TITLE
Various package updates from JCSDA spack-stack-dev: crtm, g2, grads, hdf, ip, met, metplus, py-kiwisolver, py-pyogrio, py-ruamel-yaml-clib, wgrib2

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/grads/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/grads/package.py
@@ -25,7 +25,7 @@ class Grads(AutotoolsPackage):
 
     variant("geotiff", default=True, description="Enable GeoTIFF support")
     variant("shapefile", default=True, description="Enable Shapefile support")
-    variant("grib2", default=True, description="Enable GRIB2 support")
+    variant("grib2", default=True, description="Enable GRIB2 support with the g2c library.")
     variant("dap", default=False, description="Enable DAP support")
 
     # TODO: This variant depends on the "simple X" library, which is no longer available
@@ -43,7 +43,7 @@ class Grads(AutotoolsPackage):
     depends_on("hdf5", when="+hdf5")
     depends_on("hdf", when="+hdf4")
     depends_on("netcdf-c", when="+netcdf")
-    depends_on("g2c", when="+grib2")
+    depends_on("g2c+pic", when="+grib2")
     depends_on("libgeotiff", when="+geotiff")
     depends_on("shapelib", when="+shapefile")
     depends_on("gadap", when="+dap")

--- a/var/spack/repos/spack_repo/builtin/packages/ip/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ip/package.py
@@ -17,6 +17,8 @@ class Ip(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
     version("develop", branch="develop")
+    version("5.3.0", sha256="17dfcb52bab58d3f1bcbbdda5e76430020d963097139e1ba240bfc5fb5c5a5d1")
+    version("5.2.0", sha256="2f7b44abcf24e448855f57d107db55d3d58cbc271164ba083491d0c07a7ea3d0")
     version("5.1.0", sha256="5279f11f4c12db68ece74cec392b7a2a6b5166bc505877289f34cc3149779619")
     version("5.0.0", sha256="54b2987bd4f94adc1f7595d2a384e646019c22d163bcd30840a916a6abd7df71")
     version("4.4.0", sha256="858d9201ce0bc4d16b83581ef94a4a0262f498ed1ea1b0535de2e575da7a8b8c")

--- a/var/spack/repos/spack_repo/builtin/packages/met/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/met/package.py
@@ -16,7 +16,7 @@ class Met(AutotoolsPackage):
     url = "https://github.com/dtcenter/MET/archive/refs/tags/v11.0.1.tar.gz"
     git = "https://github.com/dtcenter/MET"
 
-    maintainers("AlexanderRichert-NOAA")
+    maintainers("AlexanderRichert-NOAA", "climbfuji")
 
     version("develop", branch="develop")
     version("12.0.1", sha256="ef396a99ca6c2248855848cd194f9ceaf3b051fb5e8c01a0b0b2a00110b1fcfb")
@@ -67,10 +67,8 @@ class Met(AutotoolsPackage):
     patch("openmp_shape_patch.patch", when="@10.1.0")
 
     # https://github.com/JCSDA/spack-stack/issues/615
-    # TODO(srherbener) Apple clang 14.x is getting pickier! When these updates are
-    # merged into the MET code base, the following two patches can be removed.
-    patch("apple-clang-string-cast-operator.patch", when="@10.1.1: %apple-clang@14:")
-    patch("apple-clang-no-register.patch", when="@10.1.1: %apple-clang@14:")
+    patch("apple-clang-string-cast-operator.patch", when="@10.1.1:11.0 %apple-clang@14:")
+    patch("apple-clang-no-register.patch", when="@10.1.1:11.0 %apple-clang@14:")
 
     def url_for_version(self, version):
         if version < Version("11"):

--- a/var/spack/repos/spack_repo/builtin/packages/metplus/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/metplus/package.py
@@ -15,7 +15,7 @@ class Metplus(Package):
     url = "https://github.com/dtcenter/METplus/archive/refs/tags/v4.1.0.tar.gz"
     git = "https://github.com/dtcenter/METplus"
 
-    maintainers("AlexanderRichert-NOAA")
+    maintainers("AlexanderRichert-NOAA", "climbfuji")
 
     version("develop", branch="develop")
     version("6.0.0", sha256="e9358aede2fd2abecd81806227de7b165d68fdf2fc9defcbba24df229461b155")

--- a/var/spack/repos/spack_repo/builtin/packages/py_kiwisolver/macos-gcc.patch
+++ b/var/spack/repos/spack_repo/builtin/packages/py_kiwisolver/macos-gcc.patch
@@ -1,0 +1,15 @@
+--- a/setup.py	2022-04-19 20:56:49.000000000 -0600
++++ b/setup.py	2022-04-19 20:58:52.000000000 -0600
+@@ -54,9 +54,9 @@
+         for ext in self.extensions:
+             ext.include_dirs.insert(0, cppy.get_include())
+             ext.extra_compile_args = opts
+-            if sys.platform == 'darwin':
+-                ext.extra_compile_args += ['-stdlib=libc++']
+-                ext.extra_link_args += ['-stdlib=libc++']
++            #if sys.platform == 'darwin':
++            #    ext.extra_compile_args += ['-stdlib=libc++']
++            #    ext.extra_link_args += ['-stdlib=libc++']
+             if (ct == 'msvc' and os.environ.get('KIWI_DISABLE_FH4')):
+                 # Disable FH4 Exception Handling implementation so that we don't
+                 # require VCRUNTIME140_1.dll. For more details, see:

--- a/var/spack/repos/spack_repo/builtin/packages/py_kiwisolver/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_kiwisolver/package.py
@@ -38,3 +38,7 @@ class PyKiwisolver(PythonPackage):
     depends_on("py-cppy@1.2.0:", type="build", when="@1.4.4:")
     depends_on("py-cppy@1.3.0:", type="build", when="@1.4.8:")
     depends_on("py-typing-extensions", when="@1.4.4: ^python@:3.7", type=("build", "run"))
+
+    # https://github.com/spack/spack/issues/28522
+    # https://github.com/nucleic/kiwi/issues/126
+    patch("macos-gcc.patch", when="@:1.3.2 platform=darwin %gcc")

--- a/var/spack/repos/spack_repo/builtin/packages/py_pyogrio/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pyogrio/package.py
@@ -19,6 +19,8 @@ class PyPyogrio(PythonPackage):
     version("0.9.0", sha256="6a6fa2e8cf95b3d4a7c0fac48bce6e5037579e28d3eb33b53349d6e11f15e5a8")
 
     depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-wheel", type="build")
     depends_on("gdal@2.4:", type=("build", "link", "run"))
     depends_on("py-cython@0.29:", type="build")
     depends_on("py-versioneer@0.28 +toml", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/py_ruamel_yaml_clib/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_ruamel_yaml_clib/package.py
@@ -16,6 +16,7 @@ class PyRuamelYamlClib(PythonPackage):
 
     version("0.2.12", sha256="6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f")
     version("0.2.7", sha256="1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497")
+    version("0.2.4", sha256="f997f13fd94e37e8b7d7dbe759088bb428adc6570da06b64a913d932d891ac8d")
     with default_args(deprecated=True):
         version("0.2.0", sha256="b66832ea8077d9b3f6e311c4a53d06273db5dc2db6e8a908550f3c14d67e718c")
 

--- a/var/spack/repos/spack_repo/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/wgrib2/package.py
@@ -57,6 +57,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     )
 
     version("develop", branch="develop")
+    version("3.6.0", sha256="55913cb58f2b329759de17f5a84dd97ad1844d7a93956d245ec94f4264d802be")
     version("3.5.0", sha256="b27b48228442a08bddc3d511d0c6335afca47252ae9f0e41ef6948f804afa3a1")
     version("3.4.0", sha256="ecbce2209c09bd63f1bca824f58a60aa89db6762603bda7d7d3fa2148b4a0536")
     version("3.3.0", sha256="010827fba9c31f05807e02375240950927e9e51379e1444388153284f08f58e2")
@@ -192,7 +193,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     # Use Spack compiler wrapper flags
     def inject_flags(self, name, flags):
         if name == "cflags":
-            if self.spec.compiler.name == "apple-clang":
+            if self.spec.compiler.name in ["apple-clang", "clang"]:
                 flags.append("-Wno-error=implicit-function-declaration")
 
             # When mixing Clang/gfortran need to link to -lgfortran


### PR DESCRIPTION
## Description

This PR updates several packages from the JCSDA spack-stack-dev fork. The versions in this PR are used for installations on all our supported systems, with Intel Classic, Intel LLVM, GNU, Apple Clang.