### PR TITLE
New version for openCARP packages, v18.0

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -17,6 +17,7 @@ class Meshtool(MakefilePackage):
     # Version to use with openCARP releases
     # It is possible that different openCARP releases rely on the same
     # meshtool version
+    version("oc18.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc16.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc15.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc13.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -51,6 +51,7 @@ class Opencarp(CMakePackage):
     version(
         "7.0", commit="78da91952738b45760bcbc34610814a83c8c6299", submodules=False, no_cache=True
     )
+    version("18.0", commit="c156a5a53e426608b4903e58b5dd0c2097f41da8", submodules=False, no_cache=True, preferred=True)
     version("master", branch="master", submodules=False, no_cache=True)
 
     variant("carputils", default=False, description="Installs the carputils framework")
@@ -74,7 +75,7 @@ class Opencarp(CMakePackage):
     depends_on("py-carputils", when="+carputils", type=("build", "run"))
     depends_on("meshtool", when="+meshtool", type=("build", "run"))
     # Use specific versions of carputils and meshtool for releases
-    for ver in ["16.0", "15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "8.1", "7.0"]:
+    for ver in ["18.0", "16.0", "15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "8.1", "7.0"]:
         depends_on("py-carputils@oc" + ver, when="@" + ver + " +carputils")
         depends_on("meshtool@oc" + ver, when="@" + ver + " +meshtool")
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -18,6 +18,7 @@ class PyCarputils(PythonPackage):
 
     version("master", branch="master")
     # Version to use with openCARP releases
+    version("oc18.0", commit="e66c3ca6c5016d12b651a4e58a54430af3b91a44")
     version("oc16.0", commit="c40783d884de5ad8ae1b5102b68013b28e14cbe4")
     version("oc15.0", commit="50e2580b3f75711388eb55982a9b43871c3201f3")
     version("oc13.0", commit="216c3802c2ac2d14c739164dcd57f2e59aa2ede3")


### PR DESCRIPTION
Add a new version for the packages of the openCARP ecosystem, opencarp, meshtool and py-carputils.