### PR TITLE
libogg: fix depends_on

### DIFF
--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -21,7 +21,8 @@ class Libogg(CMakePackage, AutotoolsPackage, Package):
     version("1.3.4", sha256="fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e")
     version("1.3.2", sha256="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("shared", default=True, description="Build shared library", when="build_system=cmake")
     variant(


### PR DESCRIPTION
Libogg tries to test for a `cxx` compiler. With compilers-as-nodes and `depends_on("cxx", type="build")` being required and missing, libogg fails.
This PR fixes that.

``` 
==> libogg: Executing phase: 'cmake'
==> [2025-04-17-21:59:22.740195] '/home/chm003/project/spack/opt/spack/linux-icelake/cmake-3.31.6-7xykgq2svhngvqp5j637m2yugmvgwfss/bin/cmake' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:STRING=/home/chm003/project/spack/opt/spack/linux-icelake/libogg-1.3.5-7iq27znuqrnpurpqva5dkwck3h6qykrb' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON' '-DCMAKE_INSTALL_RPATH:STRING=/home/chm003/project/spack/opt/spack/linux-icelake/libogg-1.3.5-7iq27znuqrnpurpqva5dkwck3h6qykrb/lib;/home/chm003/project/spack/opt/spack/linux-icelake/libogg-1.3.5-7iq27znuqrnpurpqva5dkwck3h6qykrb/lib64' '-DCMAKE_PREFIX_PATH:STRING=/home/chm003/project/spack/opt/spack/linux-icelake/cmake-3.31.6-7xykgq2svhngvqp5j637m2yugmvgwfss;/home/chm003/project/spack/opt/spack/linux-icelake/compiler-wrapper-1.0-kdgo3rcsfsxadycrds4ilitojdqew5mo;/home/chm003/project/spack/opt/spack/linux-rhel8-icelake/gcc-14.1.0/gcc-14.2.0-rf35r337eaoiy4icz3hvxoa553fu7f5n;/home/chm003/project/spack/opt/spack/linux-icelake/gcc-runtime-14.2.0-roghvvbyujiq5khb7rbdbs4w5qbggul2;/home/chm003/project/spack/opt/spack/linux-icelake/gmake-4.4.1-ft52nuwdsculbb2wqqrpdqwcqagxs44q' '-DCMAKE_BUILD_TYPE:STRING=Release' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF' '-DCMAKE_POLICY_DEFAULT_CMP0090:STRING=NEW' '-DCMAKE_FIND_USE_PACKAGE_REGISTRY:BOOL=OFF' '-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON' '-DBUILD_SHARED_LIBS:BOOL=ON' '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON' '/home/chm003/project/spack/stage/spack-stage-libogg-1.3.5-7iq27znuqrnpurpqva5dkwck3h6qykrb/spack-src'
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is unknown
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/chm003/project/spack/opt/spack/linux-icelake/compiler-wrapper-1.0-kdgo3rcsfsxadycrds4ilitojdqew5mo/libexec/spack/gcc/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - failed
-- Check for working CXX compiler: /home/chm003/project/spack/opt/spack/linux-icelake/compiler-wrapper-1.0-kdgo3rcsfsxadycrds4ilitojdqew5mo/libexec/spack/gcc/g++
-- Check for working CXX compiler: /home/chm003/project/spack/opt/spack/linux-icelake/compiler-wrapper-1.0-kdgo3rcsfsxadycrds4ilitojdqew5mo/libexec/spack/gcc/g++ - broken
CMake Error at /fs/site5/eccc/crd/ccrp/users/chm003/spack/opt/spack/linux-icelake/cmake-3.31.6-7xykgq2svhngvqp5j637m2yugmvgwfss/share/cmake-3.31/Modules/CMakeTestCXXCompiler.cmake:73 (message):
  The C++ compiler

    "/home/chm003/project/spack/opt/spack/linux-icelake/compiler-wrapper-1.0-kdgo3rcsfsxadycrds4ilitojdqew5mo/libexec/spack/gcc/g++"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: '/fs/site5/eccc/crd/ccrp/users/chm003/spack/stage/spack-stage-libogg-1.3.5-7iq27znuqrnpurpqva5dkwck3h6qykrb/spack-build-7iq27zn/CMakeFiles/CMakeScratch/TryCompile-8MOwdV'
    
    Run Build Command(s): /fs/site5/eccc/crd/ccrp/users/chm003/spack/opt/spack/linux-icelake/cmake-3.31.6-7xykgq2svhngvqp5j637m2yugmvgwfss/bin/cmake -E env VERBOSE=1 /home/chm003/project/spack/opt/spack/linux-icelake/gmake-4.4.1-ft52nuwdsculbb2wqqrpdqwcqagxs44q/bin/gmake -f Makefile cmTC_50959/fast
    /home/chm003/project/spack/opt/spack/linux-icelake/gmake-4.4.1-ft52nuwdsculbb2wqqrpdqwcqagxs44q/bin/gmake  -f CMakeFiles/cmTC_50959.dir/build.make CMakeFiles/cmTC_50959.dir/build
    gmake[1]: Entering directory '/fs/site5/eccc/crd/ccrp/users/chm003/spack/stage/spack-stage-libogg-1.3.5-7iq27znuqrnpurpqva5dkwck3h6qykrb/spack-build-7iq27zn/CMakeFiles/CMakeScratch/TryCompile-8MOwdV'
    Building CXX object CMakeFiles/cmTC_50959.dir/testCXXCompiler.cxx.o
    /home/chm003/project/spack/opt/spack/linux-icelake/compiler-wrapper-1.0-kdgo3rcsfsxadycrds4ilitojdqew5mo/libexec/spack/gcc/g++    -o CMakeFiles/cmTC_50959.dir/testCXXCompiler.cxx.o -c /fs/site5/eccc/crd/ccrp/users/chm003/spack/stage/spack-stage-libogg-1.3.5-7iq27znuqrnpurpqva5dkwck3h6qykrb/spack-build-7iq27zn/CMakeFiles/CMakeScratch/TryCompile-8MOwdV/testCXXCompiler.cxx
    /home/chm003/project/spack/opt/spack/linux-icelake/compiler-wrapper-1.0-kdgo3rcsfsxadycrds4ilitojdqew5mo/libexec/spack/gcc/g++: line 401: SPACK_CXX_LINKER_ARG: ERROR: LINKER ARG WAS NOT SET, MAYBE THE PACKAGE DOES NOT DEPEND ON CXX?
    gmake[1]: *** [CMakeFiles/cmTC_50959.dir/build.make:81: CMakeFiles/cmTC_50959.dir/testCXXCompiler.cxx.o] Error 1
    gmake[1]: Leaving directory '/fs/site5/eccc/crd/ccrp/users/chm003/spack/stage/spack-stage-libogg-1.3.5-7iq27znuqrnpurpqva5dkwck3h6qykrb/spack-build-7iq27zn/CMakeFiles/CMakeScratch/TryCompile-8MOwdV'
    gmake: *** [Makefile:134: cmTC_50959/fast] Error 2
    
    

  

  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:2 (project)


-- Configuring incomplete, errors occurred!

```