### PR TITLE
py-pandas: arrow+parquet when +parquet

### DIFF
--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -209,3 +209,4 @@ class PyPandas(PythonPackage):
 
         with when("+parquet"):
             depends_on("py-pyarrow@10.0.1:")
+            depends_on("arrow+parquet")


### PR DESCRIPTION
I redesigned py-pyarrow to remove the variants, but we need to forward some of these if we truly want parquet support.