### PR TITLE
New version for openCARP packages, v18.0

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -18,6 +18,7 @@ class Meshtool(MakefilePackage):
     # It is possible that different openCARP releases rely on the same
     # meshtool version
     version("oc18.0", commit="d6ab63fa6915995b203f4f6b278ed0c853ad15fa")
+    version("oc17.0", commit="d6ab63fa6915995b203f4f6b278ed0c853ad15fa")
     version("oc16.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc15.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc13.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")

--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -17,7 +17,7 @@ class Meshtool(MakefilePackage):
     # Version to use with openCARP releases
     # It is possible that different openCARP releases rely on the same
     # meshtool version
-    version("oc18.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
+    version("oc18.0", commit="d6ab63fa6915995b203f4f6b278ed0c853ad15fa")
     version("oc16.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc15.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc13.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")

--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -17,6 +17,7 @@ class Meshtool(MakefilePackage):
     # Version to use with openCARP releases
     # It is possible that different openCARP releases rely on the same
     # meshtool version
+    version("oc18.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc16.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc15.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc13.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -81,7 +81,7 @@ class Opencarp(CMakePackage):
     depends_on("py-carputils", when="+carputils", type=("build", "run"))
     depends_on("meshtool", when="+meshtool", type=("build", "run"))
     # Use specific versions of carputils and meshtool for releases
-        for ver in [
+    for ver in [
         "18.0",
         "17.0",
         "16.0",

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -25,6 +25,9 @@ class Opencarp(CMakePackage):
         preferred=True,
     )
     version(
+        "17.0", commit="537a359d49e976cc9f97042189fb9d3ba4e686c4", submodules=False, no_cache=True
+    )
+    version(
         "16.0", commit="295055b6a3859709730f62fc8d4fe0e87c4e20b9", submodules=False, no_cache=True
     )
     version(
@@ -80,6 +83,7 @@ class Opencarp(CMakePackage):
     # Use specific versions of carputils and meshtool for releases
         for ver in [
         "18.0",
+        "17.0",
         "16.0",
         "15.0",
         "13.0",

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -65,6 +65,7 @@ class Opencarp(CMakePackage):
 
     depends_on("git", type=("build", "run"))
     depends_on("petsc")
+    depends_on("petsc@:3.22.5", when="@:17.0")
     depends_on("binutils")
     depends_on("gengetopt")
     depends_on("pkgconfig")

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -51,6 +51,7 @@ class Opencarp(CMakePackage):
     version(
         "7.0", commit="78da91952738b45760bcbc34610814a83c8c6299", submodules=False, no_cache=True
     )
+    version("18.0", commit="ac4e96792db082958fa9a830341f6e0642cc6bb8", submodules=False, no_cache=True, preferred=True)
     version("master", branch="master", submodules=False, no_cache=True)
 
     variant("carputils", default=False, description="Installs the carputils framework")
@@ -74,7 +75,7 @@ class Opencarp(CMakePackage):
     depends_on("py-carputils", when="+carputils", type=("build", "run"))
     depends_on("meshtool", when="+meshtool", type=("build", "run"))
     # Use specific versions of carputils and meshtool for releases
-    for ver in ["16.0", "15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "8.1", "7.0"]:
+    for ver in ["18.0", "16.0", "15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "8.1", "7.0"]:
         depends_on("py-carputils@oc" + ver, when="@" + ver + " +carputils")
         depends_on("meshtool@oc" + ver, when="@" + ver + " +meshtool")
 

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -18,11 +18,14 @@ class Opencarp(CMakePackage):
     maintainers("MarieHouillon")
 
     version(
-        "16.0",
-        commit="295055b6a3859709730f62fc8d4fe0e87c4e20b9",
+        "18.0",
+        commit="ac4e96792db082958fa9a830341f6e0642cc6bb8",
         submodules=False,
         no_cache=True,
         preferred=True,
+    )
+    version(
+        "16.0", commit="295055b6a3859709730f62fc8d4fe0e87c4e20b9", submodules=False, no_cache=True
     )
     version(
         "15.0", commit="2271a3cccd7137f1e28c043c10adbd80480f1462", submodules=False, no_cache=True
@@ -51,7 +54,6 @@ class Opencarp(CMakePackage):
     version(
         "7.0", commit="78da91952738b45760bcbc34610814a83c8c6299", submodules=False, no_cache=True
     )
-    version("18.0", commit="ac4e96792db082958fa9a830341f6e0642cc6bb8", submodules=False, no_cache=True, preferred=True)
     version("master", branch="master", submodules=False, no_cache=True)
 
     variant("carputils", default=False, description="Installs the carputils framework")
@@ -76,7 +78,19 @@ class Opencarp(CMakePackage):
     depends_on("py-carputils", when="+carputils", type=("build", "run"))
     depends_on("meshtool", when="+meshtool", type=("build", "run"))
     # Use specific versions of carputils and meshtool for releases
-    for ver in ["18.0", "16.0", "15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "8.1", "7.0"]:
+        for ver in [
+        "18.0",
+        "16.0",
+        "15.0",
+        "13.0",
+        "12.0",
+        "11.0",
+        "10.0",
+        "9.0",
+        "8.2",
+        "8.1",
+        "7.0",
+    ]:
         depends_on("py-carputils@oc" + ver, when="@" + ver + " +carputils")
         depends_on("meshtool@oc" + ver, when="@" + ver + " +meshtool")
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -18,6 +18,7 @@ class PyCarputils(PythonPackage):
 
     version("master", branch="master")
     # Version to use with openCARP releases
+    version("oc18.0", commit="e66c3ca6c5016d12b651a4e58a54430af3b91a44")
     version("oc16.0", commit="c40783d884de5ad8ae1b5102b68013b28e14cbe4")
     version("oc15.0", commit="50e2580b3f75711388eb55982a9b43871c3201f3")
     version("oc13.0", commit="216c3802c2ac2d14c739164dcd57f2e59aa2ede3")

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -35,14 +35,51 @@ class PyCarputils(PythonPackage):
 
     depends_on("git", type=("build", "run"))
 
-    depends_on("py-numpy@1.14.5:", type=("build", "run"))
-    depends_on("py-setuptools@41.6.0:", type=("build", "run"))
-    depends_on("py-python-dateutil@2.8.1:", type=("build", "run"))
-    depends_on("py-scipy@1.5.0:", type=("build", "run"))
-    depends_on("py-matplotlib@3.0.0:", type=("build", "run"))
-    depends_on("py-pandas", type=("build", "run"))
-    depends_on("py-tables@3.8.0:", type=("build", "run"))
-    depends_on("py-six@1.12.0:", type=("build", "run"))
-    depends_on("py-pydoe@0.3.8", type=("build", "run"))
-    depends_on("py-ruamel-yaml@0.17.4:", type=("build", "run"))
-    depends_on("py-common", type=("build", "run"))
+    with when("@oc16.0:"):
+        depends_on("py-common@0.1.2", type=("build", "run"))
+        depends_on("py-ruamel-yaml@0.17.4:", type=("build", "run"))
+        depends_on("py-pydoe@0.3.8", type=("build", "run"))
+        depends_on("py-setuptools@41.6.0:", type=("build", "run"))
+
+        depends_on("py-scipy@1.11:", type=("build", "run"))
+        depends_on("py-scipy@1.11", when="^python@3.9:3.11", type=("build", "run"))
+        depends_on("py-scipy@1.9.2", when="^python@3.8", type=("build", "run"))
+        depends_on("py-scipy@1.7.3", when="^python@3.7", type=("build", "run"))
+        depends_on("py-scipy@1.5", when="^python@3.6", type=("build", "run"))
+        depends_on("py-scipy@1.4", when="^python@3.5", type=("build", "run"))
+        
+        depends_on("py-numpy@1.26:", type=("build", "run"))
+        depends_on("py-numpy@1.21.6:1.26", when="^python@3.9:3.11", type=("build", "run"))
+        depends_on("py-numpy@1.18.5:1.25", when="^python@3.8", type=("build", "run"))
+        depends_on("py-numpy@1.16.5:1.22", when="^python@3.7", type=("build", "run"))
+        depends_on("py-numpy@1.14.5:1.19.3", when="^python@3.6", type=("build", "run"))
+        depends_on("py-numpy@1.13.3:1.17.3", when="^python@3.5", type=("build", "run"))
+
+        depends_on("py-tables@3.9:", type=("build", "run"))
+        depends_on("py-tables@3.6.1", when="^python@:3.8", type=("build", "run"))
+
+        depends_on("py-pandas", type=("build", "run"))
+        depends_on("py-pandas@:1.1.4", when="^python@:3.9", type=("build", "run"))
+
+        depends_on("py-python-dateutil", type=("build", "run"))
+        depends_on("py-python-dateutil@2.8.1", when="^python@:3.9", type=("build", "run"))
+
+        depends_on("py-six@1.16", when="^python@3.12:", type=("build", "run"))
+        depends_on("py-six@1.14.0", when="^python@:3.11", type=("build", "run"))
+
+        depends_on("py-matplotlib", type=("build", "run"))
+        depends_on("py-matplotlib@:3.7", when="^python@:3.11", type=("build", "run"))
+
+    with when("@:oc15.0"):
+        # Historical dependencies
+        depends_on("py-numpy@1.14.5:", type=("build", "run"))
+        depends_on("py-setuptools@41.6.0:", type=("build", "run"))
+        depends_on("py-python-dateutil@2.8.1:", type=("build", "run"))
+        depends_on("py-scipy@1.5.0:", type=("build", "run"))
+        depends_on("py-matplotlib@3.0.0:", type=("build", "run"))
+        depends_on("py-pandas", type=("build", "run"))
+        depends_on("py-tables@3.8.0:", type=("build", "run"))
+        depends_on("py-six@1.12.0:", type=("build", "run"))
+        depends_on("py-pydoe@0.3.8", type=("build", "run"))
+        depends_on("py-ruamel-yaml@0.17.4:", type=("build", "run"))
+        depends_on("py-common", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -47,7 +47,7 @@ class PyCarputils(PythonPackage):
         depends_on("py-scipy@1.7.3", when="^python@3.7", type=("build", "run"))
         depends_on("py-scipy@1.5", when="^python@3.6", type=("build", "run"))
         depends_on("py-scipy@1.4", when="^python@3.5", type=("build", "run"))
-        
+
         depends_on("py-numpy@1.26:", type=("build", "run"))
         depends_on("py-numpy@1.21.6:1.26", when="^python@3.9:3.11", type=("build", "run"))
         depends_on("py-numpy@1.18.5:1.25", when="^python@3.8", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -19,6 +19,7 @@ class PyCarputils(PythonPackage):
     version("master", branch="master")
     # Version to use with openCARP releases
     version("oc18.0", commit="e66c3ca6c5016d12b651a4e58a54430af3b91a44")
+    version("oc17.0", commit="0e837d925d3c75cee5d11d900fa65b79b1b25ba5")
     version("oc16.0", commit="c40783d884de5ad8ae1b5102b68013b28e14cbe4")
     version("oc15.0", commit="50e2580b3f75711388eb55982a9b43871c3201f3")
     version("oc13.0", commit="216c3802c2ac2d14c739164dcd57f2e59aa2ede3")


### PR DESCRIPTION
Add a new version for the packages of the openCARP ecosystem, opencarp, meshtool and py-carputils.