### PR TITLE
neovim: add 0.10.3, 0.10.4 and 0.11 + drop old deps

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/neovim/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/neovim/package.py
@@ -151,6 +151,9 @@ class Neovim(CMakePackage):
         depends_on("cmake@3.16:", type="build")
         depends_on("utf8proc", type="link")
         depends_on("tree-sitter@0.25:", type="link")
+
+        # https://github.com/neovim/neovim/issues/33506#issuecomment-2812141484
+        conflicts("platform=darwin target=aarch64:")
     with when("@master"):
         pass
 

--- a/var/spack/repos/spack_repo/builtin/packages/neovim/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/neovim/package.py
@@ -18,6 +18,9 @@ class Neovim(CMakePackage):
 
     version("master", branch="master")
     version("stable", tag="stable", commit="d772f697a281ce9c58bf933997b87c7f27428a60")
+    version("0.11.0", sha256="6826c4812e96995d29a98586d44fbee7c9b2045485d50d174becd6d5242b3319")
+    version("0.10.4", sha256="10413265a915133f8a853dc757571334ada6e4f0aa15f4c4cc8cc48341186ca2")
+    version("0.10.3", sha256="39fab47d241da7b9418823cc563c689d522c1c4b2def04036393834f3f1ca94c")
     version("0.10.2", sha256="546cb2da9fffbb7e913261344bbf4cf1622721f6c5a67aa77609e976e78b8e89")
     version("0.10.0", sha256="372ea2584b0ea2a5a765844d95206bda9e4a57eaa1a2412a9a0726bab750f828")
     version("0.9.5", sha256="fe74369fc30a32ec7a086b1013acd0eacd674e7570eb1acc520a66180c9e9719")
@@ -105,11 +108,11 @@ class Neovim(CMakePackage):
     depends_on("lua-lpeg")
     depends_on("lua-mpack")
     depends_on("iconv", type="link")
-    depends_on("libtermkey", type="link")
+    depends_on("libtermkey", type="link", when="@:0.9")
     depends_on("libuv", type="link")
-    depends_on("libluv", type="link")
-    depends_on("libvterm", type="link")
-    depends_on("msgpack-c", type="link")
+    depends_on("libluv", type="link", when="@:0.9")
+    depends_on("libvterm", type="link", when="@:0.10")
+    depends_on("msgpack-c", type="link", when="@:0.10")
     depends_on("unibilium", type="link")
     depends_on("unibilium@:1.2.0", type="link", when="@0.2.0")
 
@@ -144,8 +147,12 @@ class Neovim(CMakePackage):
         depends_on("cmake@3.13:", type="build")
         depends_on("libvterm@0.3.3:")
         depends_on("tree-sitter@0.20.9:")
-    with when("@master"):
+    with when("@0.11:"):
+        depends_on("cmake@3.16:", type="build")
         depends_on("utf8proc", type="link")
+        depends_on("tree-sitter@0.25:", type="link")
+    with when("@master"):
+        pass
 
     # Support for `libvterm@0.2:` has been added in neovim@0.8.0
     # term: Add support for libvterm >= 0.2 (https://github.com/neovim/neovim/releases/tag/v0.8.0)

--- a/var/spack/repos/spack_repo/builtin/packages/neovim/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/neovim/package.py
@@ -17,7 +17,8 @@ class Neovim(CMakePackage):
     license("Apache-2.0 AND Vim")
 
     version("master", branch="master")
-    version("stable", tag="stable", commit="d772f697a281ce9c58bf933997b87c7f27428a60")
+    version("stable", tag="stable")
+    version("0.11.1", sha256="ffe7f9a7633ed895ff6adb1039af7516cd6453715c8889ad844b6fa39c3df443")
     version("0.11.0", sha256="6826c4812e96995d29a98586d44fbee7c9b2045485d50d174becd6d5242b3319")
     version("0.10.4", sha256="10413265a915133f8a853dc757571334ada6e4f0aa15f4c4cc8cc48341186ca2")
     version("0.10.3", sha256="39fab47d241da7b9418823cc563c689d522c1c4b2def04036393834f3f1ca94c")


### PR DESCRIPTION
Overall, it's not a bullet proof procedure, but ...

### Update dependencies/requirements

About cmake minimum version requirement https://github.com/neovim/neovim/commit/1d815acd78e5b961302985b80d2b625947902386

Then, about deps changes

```diff
➜  neovim.git git:(master) ✗ git diff v0.10.4..v0.11.0 -- src/nvim/CMakeLists.txt | head -n 30
diff --git a/src/nvim/CMakeLists.txt b/src/nvim/CMakeLists.txt
index 574344e4e0..2a60eefe7c 100644
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -30,19 +30,17 @@ target_link_libraries(main_lib INTERFACE ${LUV_LIBRARY})

 find_package(Iconv REQUIRED)
 find_package(Libuv 1.28.0 REQUIRED)
-find_package(Libvterm 0.3.3 REQUIRED)
 find_package(Lpeg REQUIRED)
-find_package(Msgpack 1.0.0 REQUIRED)
-find_package(Treesitter 0.20.9 REQUIRED)
+find_package(Treesitter 0.25.0 REQUIRED)
 find_package(Unibilium 2.0 REQUIRED)
+find_package(UTF8proc REQUIRED)

 target_link_libraries(main_lib INTERFACE
   iconv
-  libvterm
   lpeg
-  msgpack
   treesitter
-  unibilium)
+  unibilium
+  utf8proc)
 target_link_libraries(nlua0 PUBLIC lpeg)

 if(ENABLE_LIBINTL)
@@ -50,7 +48,11 @@ if(ENABLE_LIBINTL)
   target_link_libraries(main_lib INTERFACE libintl)
```

### Dropped dependencies

I took also the chance to mirror dependencies drop between 0.9 and 0.10.

```
git diff v0.9.5..v0.10.0 -- src/nvim/CMakeLists.txt | egrep -i "(libtermkey|libluv)"
-find_package(Libluv 1.43.0 REQUIRED)
-target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LIBLUV_INCLUDE_DIR})
-target_link_libraries(main_lib INTERFACE ${LIBLUV_LIBRARY})
-find_package(Libtermkey 0.22 REQUIRED)
-  libtermkey
```

## Problem on macOS/aarch64 with neovim@0.11

On macOS, neovim@0.11 does not build/work correctly due to some problems with `lua-jit` https://github.com/neovim/neovim/issues/33506. As can be seen in the issue, there is a solution, but `luajit` dependencies for the `darwin` platform have to be reworked a bit in spack.

I will do my best to do a follow up PR in order to fix it, but at the moment I'm evaluating to add a temporary conflict like

```
conflicts("target=aarch64: platform=darwin", when="@0.11:")
```