### PR TITLE
Package.compiler: add support for opt_flags/debug_flags

### DIFF
--- a/lib/spack/spack/build_systems/compiler.py
+++ b/lib/spack/spack/build_systems/compiler.py
@@ -47,6 +47,11 @@ class CompilerPackage(spack.package_base.PackageBase):
     #: Relative path to compiler wrappers
     compiler_wrapper_link_paths: Dict[str, str] = {}
 
+    # Note: if these are not defined, then e.g. spec["c"].package.opt_flags will
+    # raise an error unless each compiler package defines these attributes
+    opt_flags = []
+    debug_flags = []
+
     def __init__(self, spec: "spack.spec.Spec"):
         super().__init__(spec)
         msg = f"Supported languages for {spec} are not a subset of possible supported languages"

--- a/lib/spack/spack/build_systems/compiler.py
+++ b/lib/spack/spack/build_systems/compiler.py
@@ -49,8 +49,8 @@ class CompilerPackage(spack.package_base.PackageBase):
 
     # Note: if these are not defined, then e.g. spec["c"].package.opt_flags will
     # raise an error unless each compiler package defines these attributes
-    opt_flags = []
-    debug_flags = []
+    opt_flags: Sequence[str] = []
+    debug_flags: Sequence[str] = []
 
     def __init__(self, spec: "spack.spec.Spec"):
         super().__init__(spec)

--- a/lib/spack/spack/build_systems/compiler.py
+++ b/lib/spack/spack/build_systems/compiler.py
@@ -47,9 +47,9 @@ class CompilerPackage(spack.package_base.PackageBase):
     #: Relative path to compiler wrappers
     compiler_wrapper_link_paths: Dict[str, str] = {}
 
-    # Note: if these are not defined, then e.g. spec["c"].package.opt_flags will
-    # raise an error unless each compiler package defines these attributes
+    #: Optimization flags
     opt_flags: Sequence[str] = []
+    #: Flags for generating debug information
     debug_flags: Sequence[str] = []
 
     def __init__(self, spec: "spack.spec.Spec"):

--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -21,6 +21,7 @@ class CompilerAdaptor:
     """Provides access to compiler attributes via `Package.compiler`. Useful for
     packages which do not yet access compiler properties via `self.spec[language]`.
     """
+
     def __init__(
         self, compiled_spec: spack.spec.Spec, compilers: Dict[Languages, spack.spec.Spec]
     ) -> None:

--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -79,15 +79,6 @@ class CompilerAdaptor:
             result.extend(CompilerPropertyDetector(compiler).implicit_rpaths())
         return result
 
-    def _one_compiler(self, for_name) -> spack.spec.Spec:
-        unique_compilers = list(lang.dedupe(self.compilers.values()))
-        if len(unique_compilers) > 1:
-            raise ValueError(
-                f"Property {for_name} is language-specific and the package has"
-                " more than 1 compiler"
-            )
-        return unique_compilers[0]
-
     def _first_defined(self, property):
         for language in [Languages.C, Languages.CXX, Languages.FORTRAN]:
             if language in self.compilers:

--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -85,13 +85,11 @@ class CompilerAdaptor:
 
     @property
     def opt_flags(self) -> List[str]:
-        first_compiler = next(iter(self.compilers.values())).package
-        return getattr(first_compiler, "opt_flags", [])
+        return next(iter(self.compilers.values())).package.opt_flags
 
     @property
     def debug_flags(self) -> List[str]:
-        first_compiler = next(iter(self.compilers.values())).package
-        return getattr(first_compiler, "debug_flags", [])
+        return next(iter(self.compilers.values())).package.debug_flags
 
     @property
     def openmp_flag(self) -> str:

--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -89,9 +89,9 @@ class CompilerAdaptor:
         return unique_compilers[0]
 
     def _first_defined(self, property):
-        for lang in [Languages.C, Languages.CXX, Languages.FORTRAN]:
-            if lang in self.compilers:
-                compiler_pkg = self.compilers[lang].package
+        for language in [Languages.C, Languages.CXX, Languages.FORTRAN]:
+            if language in self.compilers:
+                compiler_pkg = self.compilers[language].package
                 opt_flags = getattr(compiler_pkg, property, None)
                 if opt_flags:
                     return opt_flags

--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -79,6 +79,31 @@ class CompilerAdaptor:
             result.extend(CompilerPropertyDetector(compiler).implicit_rpaths())
         return result
 
+    def _one_compiler(self, for_name) -> spack.spec.Spec:
+        unique_compilers = list(lang.dedupe(self.compilers.values()))
+        if len(unique_compilers) > 1:
+            raise ValueError(
+                f"Property {for_name} is language-specific and the package has"
+                " more than 1 compiler"
+            )
+        return unique_compilers[0]
+
+    @property
+    def opt_flags(self) -> List[str]:
+        compiler_pkg = self._one_compiler("opt_flags").package
+        return getattr(compiler_pkg, "opt_flags", [])
+
+    @property
+    def debug_flags(self) -> List[str]:
+        compiler_pkg = self._one_compiler("debug_flags").package
+        return getattr(compiler_pkg, "debug_flags", [])
+
+    def opt_flags_for_language(self, lang: str) -> List[str]:
+        return getattr(self.compilers[Languages(lang)].package, "opt_flags", [])
+
+    def debug_flags_for_language(self, lang: str) -> List[str]:
+        return getattr(self.compilers[Languages(lang)].package, "debug_flags", [])
+
     @property
     def openmp_flag(self) -> str:
         return next(iter(self.compilers.values())).package.openmp_flag

--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -18,6 +18,9 @@ class Languages(enum.Enum):
 
 
 class CompilerAdaptor:
+    """Provides access to compiler attributes via `Package.compiler`. Useful for
+    packages which do not yet access compiler properties via `self.spec[language]`.
+    """
     def __init__(
         self, compiled_spec: spack.spec.Spec, compilers: Dict[Languages, spack.spec.Spec]
     ) -> None:
@@ -79,21 +82,15 @@ class CompilerAdaptor:
             result.extend(CompilerPropertyDetector(compiler).implicit_rpaths())
         return result
 
-    def _first_defined(self, property):
-        for language in [Languages.C, Languages.CXX, Languages.FORTRAN]:
-            if language in self.compilers:
-                compiler_pkg = self.compilers[language].package
-                opt_flags = getattr(compiler_pkg, property, None)
-                if opt_flags:
-                    return opt_flags
-
     @property
     def opt_flags(self) -> List[str]:
-        return self._first_defined("opt_flags") or []
+        first_compiler = next(iter(self.compilers.values())).package
+        return getattr(first_compiler, "opt_flags", [])
 
     @property
     def debug_flags(self) -> List[str]:
-        return self._first_defined("debug_flags") or []
+        first_compiler = next(iter(self.compilers.values())).package
+        return getattr(first_compiler, "debug_flags", [])
 
     @property
     def openmp_flag(self) -> str:

--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -88,21 +88,21 @@ class CompilerAdaptor:
             )
         return unique_compilers[0]
 
+    def _first_defined(self, property):
+        for lang in [Languages.C, Languages.CXX, Languages.FORTRAN]:
+            if lang in self.compilers:
+                compiler_pkg = self.compilers[lang].package
+                opt_flags = getattr(compiler_pkg, property, None)
+                if opt_flags:
+                    return opt_flags
+
     @property
     def opt_flags(self) -> List[str]:
-        compiler_pkg = self._one_compiler("opt_flags").package
-        return getattr(compiler_pkg, "opt_flags", [])
+        return self._first_defined("opt_flags") or []
 
     @property
     def debug_flags(self) -> List[str]:
-        compiler_pkg = self._one_compiler("debug_flags").package
-        return getattr(compiler_pkg, "debug_flags", [])
-
-    def opt_flags_for_language(self, lang: str) -> List[str]:
-        return getattr(self.compilers[Languages(lang)].package, "opt_flags", [])
-
-    def debug_flags_for_language(self, lang: str) -> List[str]:
-        return getattr(self.compilers[Languages(lang)].package, "debug_flags", [])
+        return self._first_defined("debug_flags") or []
 
     @property
     def openmp_flag(self) -> str:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1366,7 +1366,12 @@ class TestSpecSemantics:
             vt.splice(vh, transitive)
 
     def test_adaptor_optflags(self):
-        spec = spack.concretize.concretize_one(Spec("pkg-a"))
+        """Tests that we can obtain the list of optflags, and debugflags,
+        from the compiler adaptor, and that this list is taken from the
+        appropriate compiler package.
+        """
+        # pkg-a depends on c, so only the gcc compiler should be chosen
+        spec = spack.concretize.concretize_one(Spec("pkg-a %gcc"))
         assert "-Otestopt" in spec.package.compiler.opt_flags
         # This is not set, make sure we get an empty list
         for x in spec.package.compiler.debug_flags:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1365,6 +1365,13 @@ class TestSpecSemantics:
         with pytest.raises(spack.spec.SpliceError, match="virtual"):
             vt.splice(vh, transitive)
 
+    def test_adaptor_optflags(self):
+        spec = spack.concretize.concretize_one(Spec("pkg-a"))
+        assert "-Otestopt" in spec.package.compiler.opt_flags
+        # This is not set, make sure we get an empty list
+        for x in spec.package.compiler.debug_flags:
+            pass
+
     def test_spec_override(self):
         init_spec = Spec("pkg-a foo=baz foobar=baz cflags=-O3 cxxflags=-O1")
         change_spec = Spec("pkg-a foo=fee cflags=-O2")

--- a/var/spack/repos/builtin.mock/packages/gcc/package.py
+++ b/var/spack/repos/builtin.mock/packages/gcc/package.py
@@ -40,7 +40,7 @@ class Gcc(CompilerPackage, Package):
     compiler_version_regex = r"(?<!clang version)\s?([0-9.]+)"
     compiler_version_argument = ("-dumpfullversion", "-dumpversion")
 
-    opt_flags = opt_flags = ["-Otestopt"]
+    opt_flags = ["-Otestopt"]
 
     compiler_wrapper_link_paths = {
         "c": os.path.join("gcc", "gcc"),

--- a/var/spack/repos/builtin.mock/packages/gcc/package.py
+++ b/var/spack/repos/builtin.mock/packages/gcc/package.py
@@ -40,6 +40,8 @@ class Gcc(CompilerPackage, Package):
     compiler_version_regex = r"(?<!clang version)\s?([0-9.]+)"
     compiler_version_argument = ("-dumpfullversion", "-dumpversion")
 
+    opt_flags = opt_flags = ["-Otestopt"]
+
     compiler_wrapper_link_paths = {
         "c": os.path.join("gcc", "gcc"),
         "cxx": os.path.join("gcc", "g++"),

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -659,8 +659,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
 
         if cxxflags:
             # Add opt/debug flags if they are not present in global cxx flags
-            opt_flag_found = any(f in self.compiler.opt_flags for f in cxxflags)
-            debug_flag_found = any(f in self.compiler.debug_flags for f in cxxflags)
+            opt_flag_found = any(f in self["cxx"].opt_flags for f in cxxflags)
+            debug_flag_found = any(f in self["cxx"].debug_flags for f in cxxflags)
 
             if "+debug" in spec:
                 if not debug_flag_found:


### PR DESCRIPTION
See `mfem` for an example

```
opt_flag_found = any(f in self.compiler.opt_flags for f in cxxflags)
```

this wasn't working, so I added `opt_flags` to the compiler adaptor. `Package.compiler.opt_flags` will return the `opt_flags` for C, C++, *or* Fortran compiler, the first of whichever is defined (in that order). A test is added for this behavior.

`mfem` itself is refactored to use `spec["cxx"].opt_flags`, which is preferred (but the general change above is to support packages in other repos which may not have updated to this form yet).

This also adds a default empty `opt_flags`/`debug_flags` to `CompilerPackage`, so one can ask for `Spec["c"].opt_flags` regardless of what underlying compiler is in use.

~If the package only depends on one language, or uses the same compiler for c/c++, then you can ask for `compiler.opt_flags`; otherwise you ask for `compiler.opt_flags_for_lang(c)`.~