### PR TITLE
[WIP] CMakePackages: add required languages as per project()

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/accfft/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/accfft/package.py
@@ -20,6 +20,7 @@ class Accfft(CMakePackage, CudaPackage):
     variant("pnetcdf", default=True, description="Add support for parallel NetCDF")
     variant("shared", default=True, description="Enables the build of shared libraries")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     # See: http://accfft.org/articles/install/#installing-dependencies

--- a/var/spack/repos/spack_repo/builtin/packages/brigand/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/brigand/package.py
@@ -23,6 +23,7 @@ class Brigand(CMakePackage):
     version("1.1.0", sha256="afdcc6909ebff6994269d3039c31698c2b511a70280072f73382b26855221f64")
     version("1.0.0", sha256="8daf7686ff39792f851ef1977323808b80aab31c5f38ef0ba4e6a8faae491f8d")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     def cmake_args(self):

--- a/var/spack/repos/spack_repo/builtin/packages/camellia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/camellia/package.py
@@ -23,6 +23,7 @@ class Camellia(CMakePackage):
         description="Compile with MOAB to include support for reading standard mesh formats",
     )
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on(

--- a/var/spack/repos/spack_repo/builtin/packages/cotter/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cotter/package.py
@@ -14,6 +14,7 @@ class Cotter(CMakePackage):
     version("master", branch="master")
     version("20190205", commit="b7b07f3298a8d57b9dfff0b72fc21e68b23a42da")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("erfa")

--- a/var/spack/repos/spack_repo/builtin/packages/cpp_logger/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cpp_logger/package.py
@@ -21,4 +21,5 @@ class CppLogger(CMakePackage):
     version("0.0.2", tag="v0.0.2", commit="329a48401033d2d2a1f1196141763cab029220ae")
     version("0.0.1", tag="v0.0.1", commit="d48b38ab14477bb7c53f8189b8b4be2ea214c28a")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/spack_repo/builtin/packages/digitrounding/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/digitrounding/package.py
@@ -19,6 +19,7 @@ class Digitrounding(CMakePackage):
     version("2020-02-27", commit="7b18679aded7a85e6f221f7f5cd4f080f322bc33")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
 
     depends_on("zlib-api")
 

--- a/var/spack/repos/spack_repo/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ectrans/package.py
@@ -46,6 +46,7 @@ class Ectrans(CMakePackage):
     variant("transi", default=True, description="Compile TransI C-interface to trans")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
     depends_on("ecbuild", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/flcl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/flcl/package.py
@@ -22,6 +22,7 @@ class Flcl(CMakePackage):
     version("0.4.0", sha256="0fe327906a991262866b126a7d58098eb48297148f117fd59a2dbcc14e76f394")
     version("0.3", sha256="fc18c8fa3ae33db61203b647ad9025d894612b0faaf7fe07426aaa8bbfa9e703")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 

--- a/var/spack/repos/spack_repo/builtin/packages/hipace/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipace/package.py
@@ -40,6 +40,7 @@ class Hipace(CMakePackage):
         description="Floating point precision (single/double)",
     )
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.18.0:", type="build", when="@23.05:")

--- a/var/spack/repos/spack_repo/builtin/packages/jedi_cmake/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/jedi_cmake/package.py
@@ -22,4 +22,7 @@ class JediCmake(CMakePackage):
     )
     version("1.3.0", commit="729a9b2ec97a7e93cbc58213493f28ca11f08754")
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("cmake @3.10:", type=("build"))

--- a/var/spack/repos/spack_repo/builtin/packages/kumi/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/kumi/package.py
@@ -21,4 +21,5 @@ class Kumi(CMakePackage):
     version("2.0", sha256="c9f2d2014d3513c57db4457c5a678c7adce1fa9bd061ee008847876f06dac355")
     version("1.0", sha256="d28be244e326b1c9f1651b47728af74bb6be80a7accd39f07441a246d49220f5")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/spack_repo/builtin/packages/libevpath/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libevpath/package.py
@@ -26,6 +26,7 @@ class Libevpath(CMakePackage):
     variant("enet_transport", default=False, description="Build an ENET transport for EVpath")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
 
     depends_on("gtkorvo-enet", when="@4.4.0: +enet_transport")
     depends_on("gtkorvo-enet@1.3.13", when="@:4.2.4 +enet_transport")

--- a/var/spack/repos/spack_repo/builtin/packages/libfive/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libfive/package.py
@@ -19,6 +19,7 @@ class Libfive(CMakePackage):
     # and currently, all tags are from 2017:
     version("master", branch="master")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/mdspan/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mdspan/package.py
@@ -31,6 +31,8 @@ class Mdspan(CMakePackage):
         description="Whether to install headers to emulate standard library headers and namespace",
     )
 
+    depends_on("cxx", type="build")
+
     depends_on("benchmark", when="+benchmarks")
     depends_on("googletest@1.14:1", when="+tests")
 

--- a/var/spack/repos/spack_repo/builtin/packages/melissa_api/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/melissa_api/package.py
@@ -21,6 +21,7 @@ class MelissaApi(CMakePackage):
     version("develop", branch="develop")
 
     depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
     depends_on("cmake@3.7.2:", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/mpiwrapper/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mpiwrapper/package.py
@@ -38,6 +38,7 @@ class Mpiwrapper(CMakePackage):
     version("2.0.0", sha256="cdc81f3fae459569d4073d99d068810689a19cf507d9c4e770fa91e93650dbe4")
     version("1.0.1", sha256="29d5499a1a7a358d69dd744c581e57cac9223ebde94b52fa4a2b98c730ad47ff")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 

--- a/var/spack/repos/spack_repo/builtin/packages/opensubdiv/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/opensubdiv/package.py
@@ -32,6 +32,7 @@ class Opensubdiv(CMakePackage, CudaPackage):
     variant("tbb", default=False, description="Builds with Intel TBB support")
     variant("openmp", default=False, description="Builds with OpenMP support")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@2.8.6:", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/parsplice/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/parsplice/package.py
@@ -25,6 +25,7 @@ class Parsplice(CMakePackage):
     version("multisplice", branch="multisplice")
     version("1.1", sha256="a011c4d14f66e7cdbc151cc74b5d40dfeae19ceea033ef48185d8f3b1bc2f86b")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.1:", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/parthenon/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/parthenon/package.py
@@ -46,6 +46,7 @@ class Parthenon(CMakePackage):
     # Dependencies
     # ------------------------------------------------------------#
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.16:", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/srcml_identifier_getter_tool/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/srcml_identifier_getter_tool/package.py
@@ -15,6 +15,7 @@ class SrcmlIdentifierGetterTool(CMakePackage):
 
     version("2022-10-17", commit="01394c247ae6f61cc5864a9697e72e3623d8e7fb", submodules=True)
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("libxml2")

--- a/var/spack/repos/spack_repo/builtin/packages/templight_tools/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/templight_tools/package.py
@@ -15,6 +15,7 @@ class TemplightTools(CMakePackage):
 
     version("develop", branch="master")
 
+    depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake @2.8.7:", type="build")


### PR DESCRIPTION
The determination of languages was made a while ago based on which source files are in the projects. This has some deficiencies for CMake packages, since even without C source code, a `project(name)` clause in CMakeLists.txt will by default enable both C and CXX languages.

For all CMakePackages, this PR adds languages depending on whether the `project()` includes no languages or a language other than the one already found based on source code. This is largely automated, so it remains tagged as `generated`.