### PR TITLE
fms: both variants pic and shared are required for shared libraries

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/fms/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fms/package.py
@@ -71,6 +71,8 @@ class Fms(CMakePackage):
     )
 
     variant("shared", description="Build shared libraries", when="@2024.02:", default=False)
+    # To build a shared/dynamic library, both `pic` and `shared` are required:
+    requires("+pic", when="+shared", msg="The +shared variant requires +pic")
     # What the following patch is providing is available in version 2024.03
     # and newer so it is only needed to 2024.02
     patch(


### PR DESCRIPTION
This PR fixes the following error:
```
# spack install fms+shared %intel@2021.10.0 target=x86_64 

==> Installing fms-2024.02-s32ftpj4qspse2en2obz2pcfzqo355ur [43/43]
==> No binary for fms-2024.02-s32ftpj4qspse2en2obz2pcfzqo355ur found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/47/47e5740bb066f5eb032e1de163eb762c7258880a2932f4cc4e34e769e0cc2b0e.tar.gz
==> Fetching https://mirror.spack.io/_source-cache/archive/2b/2b12a6c35f357c3dddcfa5282576e56ab0e8e6c1ad1dab92a2c85ce3dfb815d4
==> Applied patch https://github.com/NOAA-GFDL/fms/pull/1559.patch?full_index=1
==> fms: Executing phase: 'cmake'
==> fms: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    '/opt/release/linux-rocky8-x86_64/intel-2021.10.0/gmake-4.4.1-wddaytwmhnkgazbydr6ra5utkqoq45ou/bin/make' '-j16'

4 errors found in build log:
     557    ld: CMakeFiles/fms_r4_f.dir/time_manager/time_manager.F90.o: reloca
            tion R_X86_64_32 against `__STRLITPACK_266' can not be used when ma
            king a shared object; recompile with -fPIC
     558    ld: CMakeFiles/fms_r4_f.dir/topography/gaussian_topog.F90.o: reloca
            tion R_X86_64_32 against `__STRLITPACK_17.0.2' can not be used when
             making a shared object; recompile with -fPIC
     559    ld: CMakeFiles/fms_r4_f.dir/topography/topography.F90.o: relocation
             R_X86_64_32 against `__STRLITPACK_76.0.5' can not be used when mak
            ing a shared object; recompile with -fPIC
     560    ld: CMakeFiles/fms_r4_f.dir/tracer_manager/tracer_manager.F90.o: re
            location R_X86_64_32S against undefined symbol `tracer_manager_mod_
            mp_tracers_' can not be used when making a shared object; recompile
             with -fPIC
     561    ld: CMakeFiles/fms_r4_f.dir/tridiagonal/tridiagonal.F90.o: relocati
            on R_X86_64_32 against `.data' can not be used when making a shared
             object; recompile with -fPIC
     562    ld: CMakeFiles/fms_r4_c.dir/fms/fms_stacksize.c.o: relocation R_X86
            _64_PC32 against symbol `getrlimit@@GLIBC_2.2.5' can not be used wh
            en making a shared object; recompile with -fPIC
  >> 563    ld: final link failed: Bad value
  >> 564    make[2]: *** [CMakeFiles/fms_r4.dir/build.make:312: libfms_r4.so] E
            rror 1
     565    make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-fms-2
            024.02-s32ftpj4qspse2en2obz2pcfzqo355ur/spack-build-s32ftpj'
  >> 566    make[1]: *** [CMakeFiles/Makefile2:143: CMakeFiles/fms_r4.dir/all] 
            Error 2
     567    make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-fms-2
            024.02-s32ftpj4qspse2en2obz2pcfzqo355ur/spack-build-s32ftpj'
  >> 568    make: *** [Makefile:139: all] Error 2

See build log for details:
  /tmp/root/spack-stage/spack-stage-fms-2024.02-s32ftpj4qspse2en2obz2pcfzqo355ur/spack-build-out.txt
```