### PR TITLE
trivy: v0.61.1

### DIFF
--- a/var/spack/repos/builtin/packages/trivy/package.py
+++ b/var/spack/repos/builtin/packages/trivy/package.py
@@ -15,6 +15,7 @@ class Trivy(GoPackage):
 
     license("Apache-2.0", checked_by="RobertMaaskant")
 
+    version("0.61.1", sha256="f6ad43e008c008d67842c9e2b4af80c2e96854db8009fba48fc37b4f9b15f59b")
     version("0.61.0", sha256="1e97b1b67a4c3aee9c567534e60355033a58ce43a3705bdf198d7449d53b6979")
 
     depends_on("go@1.24:", type="build")


### PR DESCRIPTION
Change log: https://github.com/aquasecurity/trivy/releases/tag/v0.61.1 
Diff: https://github.com/aquasecurity/trivy/compare/v0.61.0...v0.61.1