### PR TITLE
py-setuptools: add v78.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -19,6 +19,7 @@ class PySetuptools(Package, PythonExtension):
     # Requires railroad
     skip_modules = ["setuptools._vendor", "pkg_resources._vendor"]
 
+    version("78.1.1", sha256="c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561")
     version("78.1.0", sha256="3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8")
     version("78.0.2", sha256="4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d")
     version("78.0.1", sha256="1cc9b32ee94f93224d6c80193cbb768004667aa2f2732a473d6949b0236c1d4e")


### PR DESCRIPTION
Release notes: https://setuptools.pypa.io/en/latest/history.html#v78-1-1
Diff: https://github.com/pypa/setuptools/compare/v78.1.0...v78.1.1