### PR TITLE
py-trove-classifiers: add v2025.4.11.15

### DIFF
--- a/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
+++ b/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
@@ -25,6 +25,8 @@ class PyTroveClassifiers(PythonPackage):
 
     def url_for_version(self, version):
         if version >= Version("2024.5.17"):
-            return f"https://files.pythonhosted.org/packages/source/t/trove_classifiers/trove_classifiers-{version}.tar.gz"
+            sep = "_"
         else:
-            return f"https://files.pythonhosted.org/packages/source/t/trove-classifiers/trove-classifiers-{version}.tar.gz"
+            sep = "-"
+
+        return f"https://files.pythonhosted.org/packages/source/t/trove{sep}classifiers/trove{sep}classifiers-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
+++ b/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
@@ -14,7 +14,9 @@ class PyTroveClassifiers(PythonPackage):
 
     license("Apache-2.0")
 
-    version("2025.4.11.15", sha256="634728aa6698dc1ae3db161da94d9e4c7597a9a5da2c4410211b36f15fed60fc")
+    version(
+        "2025.4.11.15", sha256="634728aa6698dc1ae3db161da94d9e4c7597a9a5da2c4410211b36f15fed60fc"
+    )
     version("2023.8.7", sha256="c9f2a0a85d545e5362e967e4f069f56fddfd91215e22ffa48c66fb283521319a")
     version("2023.3.9", sha256="ee42f2f8c1d4bcfe35f746e472f07633570d485fab45407effc0379270a3bb03")
 

--- a/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
+++ b/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
@@ -10,12 +10,19 @@ class PyTroveClassifiers(PythonPackage):
     on PyPI. Classifiers categorize projects per PEP 301."""
 
     homepage = "https://github.com/pypa/trove-classifiers"
-    pypi = "trove-classifiers/trove-classifiers-2023.3.9.tar.gz"
+    pypi = "trove_classifiers/trove_classifiers-2024.5.17.tar.gz"
 
     license("Apache-2.0")
 
+    version("2025.4.11.15", sha256="634728aa6698dc1ae3db161da94d9e4c7597a9a5da2c4410211b36f15fed60fc")
     version("2023.8.7", sha256="c9f2a0a85d545e5362e967e4f069f56fddfd91215e22ffa48c66fb283521319a")
     version("2023.3.9", sha256="ee42f2f8c1d4bcfe35f746e472f07633570d485fab45407effc0379270a3bb03")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-calver", type="build")
+
+    def url_for_version(self, version):
+        if version >= Version("2024.5.17"):
+            return f"https://files.pythonhosted.org/packages/source/t/trove_classifiers/trove_classifiers-{version}.tar.gz"
+        else:
+            return f"https://files.pythonhosted.org/packages/source/t/trove-classifiers/trove-classifiers-{version}.tar.gz"


### PR DESCRIPTION
Release notes: https://github.com/pypa/trove-classifiers/releases
Diff: https://github.com/pypa/trove-classifiers/compare/2023.8.7...2025.4.11.15