### PR TITLE
mdspan: add std header install option for stable

### DIFF
--- a/var/spack/repos/builtin/packages/mdspan/package.py
+++ b/var/spack/repos/builtin/packages/mdspan/package.py
@@ -24,7 +24,12 @@ class Mdspan(CMakePackage):
     variant(
         "cxxstd", default="17", values=["14", "17", "20"], multi=False, description="C++ standard"
     )
-    variant("stdheaders", default=False, when="@stable", description="Whether to install headers to emulate standard library headers and namespace")
+    variant(
+        "stdheaders",
+        default=False,
+        when="@stable",
+        description="Whether to install headers to emulate standard library headers and namespace",
+    )
 
     depends_on("benchmark", when="+benchmarks")
     depends_on("googletest@1.14:1", when="+tests")

--- a/var/spack/repos/builtin/packages/mdspan/package.py
+++ b/var/spack/repos/builtin/packages/mdspan/package.py
@@ -24,6 +24,7 @@ class Mdspan(CMakePackage):
     variant(
         "cxxstd", default="17", values=["14", "17", "20"], multi=False, description="C++ standard"
     )
+    variant("stdheaders", default=False, when="@stable", description="Whether to install headers to emulate standard library headers and namespace")
 
     depends_on("benchmark", when="+benchmarks")
     depends_on("googletest@1.14:1", when="+tests")
@@ -36,6 +37,7 @@ class Mdspan(CMakePackage):
             self.define_from_variant("MDSPAN_ENABLE_EXAMPLES", "examples"),
             self.define_from_variant("MDSPAN_CXX_STANDARD", "cxxstd"),
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+            self.define_from_variant("MDSPAN_INSTALL_STDMODE_HEADERS", "stdheaders"),
         ]
 
         return args


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Fixes #50100

This will have to be update also in the next mdspan release as no release has the std header option, only stable