### PR TITLE
wrf-io: remove check()

### DIFF
--- a/var/spack/repos/builtin/packages/wrf-io/package.py
+++ b/var/spack/repos/builtin/packages/wrf-io/package.py
@@ -32,6 +32,3 @@ class WrfIo(CMakePackage):
     def cmake_args(self):
         args = [self.define_from_variant("OPENMP", "openmp")]
         return args
-
-    def check(self):
-        make("test")


### PR DESCRIPTION
This PR removes the `check()` function from wrf-io because it doesn't have a test target...