### PR TITLE
hpctoolkit: Fix smoke test to use compiler node

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -281,7 +281,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     def test_sort(self):
         """build and run selection sort unit test"""
         exe = "tst-sort"
-        cxx = which(os.environ["CXX"])
+        cxx = Executable(self["cxx"].cxx)
         cxx(self.test_suite.current_test_data_dir.join("sort.cpp"), "-o", exe)
 
         hpcrun = which("hpcrun")


### PR DESCRIPTION
With the new compilers-as-nodes changes, the `hpctoolkit` smoke test can no longer compile the test program. This PR updates the logic to acquire the compiler to match the new changes in Spack code.

Inspired by the discussion and suggestion here: https://github.com/spack/spack/pull/50001#issuecomment-2819012196