### PR TITLE
oneapi: Move temporary home directory to stage

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -107,7 +107,7 @@ class IntelOneApiPackage(Package):
             bash = Executable("bash")
 
             # Installer writes files in ~/intel set HOME so it goes to prefix
-            bash.add_default_env("HOME", self.prefix)
+            bash.add_default_env("HOME", join_path(self.stage.path, "home"))
             # Installer checks $XDG_RUNTIME_DIR/.bootstrapper_lock_file as well
             bash.add_default_env("XDG_RUNTIME_DIR", join_path(self.stage.path, "runtime"))
 

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -106,7 +106,7 @@ class IntelOneApiPackage(Package):
 
             bash = Executable("bash")
 
-            # Installer writes files in ~/intel set HOME so it goes to prefix
+            # Installer writes files in ~/intel set HOME so it goes to staging directory
             bash.add_default_env("HOME", join_path(self.stage.path, "home"))
             # Installer checks $XDG_RUNTIME_DIR/.bootstrapper_lock_file as well
             bash.add_default_env("XDG_RUNTIME_DIR", join_path(self.stage.path, "runtime"))


### PR DESCRIPTION
When trying to use Spack to build Intel TBB on the EOS network file system we use at CERN, I am facing the following error:

```
Launching the installer...
Installation directory is not empty.
The product cannot be installed into nonempty directory
'/eos/home-s/sswatman/spack/opt/spack/linux-x86_64_v2/...
    intel-oneapi-tbb-2021.12.0-3jlx6hlr3z6di42f3qy35eizcse7u2tk'.
```

This error appears to happen because Spack tries to set `$HOME` to the prefix of the package, into which the Intel installer is also trying to install it's software. I've found that an easy fix is to set `$HOME` to a directory in the build stage instead, as this can be guaranteed to remain empty.