### PR TITLE
directives_meta.py: remove global decl

### DIFF
--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -144,7 +144,6 @@ class DirectiveMeta(type):
         Package class, and it's how Spack gets information from the
         packages to the core.
         """
-        global directive_names
 
         if isinstance(dicts, str):
             dicts = (dicts,)


### PR DESCRIPTION
flake8 complains about it, because it's never bound to another value, just "de-referenced".