### PR TITLE
mapl: add cxx dependence

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -285,6 +285,7 @@ class Mapl(CMakePackage):
     conflicts("+extdata2g", when="@:2.40.3 %intel@2021.7:")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
     depends_on("cmake@3.24:", type="build", when="@2.51:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

As found by @wdconinc in #50128, spack now requires `mapl` to depend on C++ because our `project()` says we do. And testing has shown without this line, things do not build.

It isn't exactly true as MAPL has no C++ code, but we could only change this going forward. However, if you have C, you probably have C++ so I don't consider making `mapl` depend on C++ that much of a burden.

Plus, well, probably will be C++ in MAPL at some point. Such is the way of the world!