### PR TITLE
r: updates for compilers-as-nodes

### DIFF
--- a/var/spack/repos/builtin/packages/py-rpy2/package.py
+++ b/var/spack/repos/builtin/packages/py-rpy2/package.py
@@ -31,6 +31,9 @@ class PyRpy2(PythonPackage):
     variant("pandas", default=True, description="Pandas", when="@3.5.17:")
     variant("ipython", default=True, description="iPython", when="@3.5.17:")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     # many of the previous minor and patch versions change dependency versions so future updates
     # should be careful of that
     depends_on("python@3.8:", type=("build", "run"), when="@3.5.17:")
@@ -61,7 +64,7 @@ class PyRpy2(PythonPackage):
 
     depends_on("py-backports-zoneinfo", type=("build", "run"), when="@3.5.17: ^python@:3.8")
 
-    depends_on("iconv", type=("link"))
+    depends_on("iconv", type=("build", "link"))
 
     # These are from 2019 and predate the pyproject.toml config that currently exists
     with when("@3.0.0:3.0.4"):

--- a/var/spack/repos/builtin/packages/py-rpy2/package.py
+++ b/var/spack/repos/builtin/packages/py-rpy2/package.py
@@ -64,7 +64,7 @@ class PyRpy2(PythonPackage):
 
     depends_on("py-backports-zoneinfo", type=("build", "run"), when="@3.5.17: ^python@:3.8")
 
-    depends_on("iconv", type=("build", "link"))
+    depends_on("iconv")
 
     # These are from 2019 and predate the pyproject.toml config that currently exists
     with when("@3.0.0:3.0.4"):

--- a/var/spack/repos/builtin/packages/r-askpass/package.py
+++ b/var/spack/repos/builtin/packages/r-askpass/package.py
@@ -24,4 +24,7 @@ class RAskpass(RPackage):
     version("1.2.0", sha256="b922369781934d0ffc8d0c0177e8ace56796c2e6a726f65e460c16f792592cef")
     version("1.1", sha256="db40827d1bdbb90c0aa2846a2961d3bf9d76ad1b392302f9dd84cc2fd18c001f")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r-sys@2.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-backports/package.py
+++ b/var/spack/repos/builtin/packages/r-backports/package.py
@@ -28,4 +28,6 @@ class RBackports(RPackage):
     version("1.1.1", sha256="494e81a4829339c8f1cc3e015daa807e9138b8e21b929965fc7c00b1abbe8897")
     version("1.1.0", sha256="c5536966ed6ca93f20c9a21d4f569cc1c6865d3352445ea66448f82590349fcd")
 
+    depends_on("c", type="build")
+
     depends_on("r@3.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-cachem/package.py
+++ b/var/spack/repos/builtin/packages/r-cachem/package.py
@@ -20,6 +20,9 @@ class RCachem(RPackage):
     version("1.0.7", sha256="234fad2a947d1e1fb87d3fa92abf9197877772e31bc81ae5991ae69689b6320a")
     version("1.0.6", sha256="9a9452f7bcf3f79436c418b3c3290449fb8fd338714d9b992153754d112f1864")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r-rlang", type=("build", "run"))
     depends_on("r-fastmap", type=("build", "run"))
     depends_on("r-fastmap@1.2.0:", when="@1.1.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-cli/package.py
+++ b/var/spack/repos/builtin/packages/r-cli/package.py
@@ -33,6 +33,8 @@ class RCli(RPackage):
     version("1.0.1", sha256="ef80fbcde15760fd55abbf9413b306e3971b2a7034ab8c415fb52dc0088c5ee4")
     version("1.0.0", sha256="8fa3dbfc954ca61b8510f767ede9e8a365dac2ef95fe87c715a0f37d721b5a1d")
 
+    depends_on("c", type="build")
+
     depends_on("r@2.10:", type=("build", "run"))
     depends_on("r@3.4:", type=("build", "run"), when="@3.3.0:")
 

--- a/var/spack/repos/builtin/packages/r-curl/package.py
+++ b/var/spack/repos/builtin/packages/r-curl/package.py
@@ -61,6 +61,9 @@ class RCurl(RPackage):
         deprecated=True,
     )
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("curl", when="@4.3:")
     depends_on("curl@:7.63", when="@:4.0")

--- a/var/spack/repos/builtin/packages/r-data-table/package.py
+++ b/var/spack/repos/builtin/packages/r-data-table/package.py
@@ -39,6 +39,9 @@ class RDataTable(RPackage):
     version("1.9.8", sha256="dadb21a14a7f4d60955cdd8fb9779136833498be97b1625914e9a6b580646f4d")
     version("1.9.6", sha256="6f74c349c1731823aef6899edcf18418454167d04eba983e3a6fe17ee9fd236e")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("zlib-api")
     depends_on("llvm-openmp", when="platform=darwin %apple-clang", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-digest/package.py
+++ b/var/spack/repos/builtin/packages/r-digest/package.py
@@ -42,6 +42,9 @@ class RDigest(RPackage):
     version("0.6.11", sha256="edab2ca2a38bd7ee19482c9d2531cd169d5123cde4aa2a3dd65c0bcf3d1d5209")
     version("0.6.9", sha256="95fdc36011869fcfe21b40c3b822b931bc01f8a531e2c9260582ba79560dbe47")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@2.4.1:", type=("build", "run"))
     depends_on("r@3.1.0:", type=("build", "run"), when="@0.6.16:")
     depends_on("r@3.3.0:", type=("build", "run"), when="@0.6.27:")

--- a/var/spack/repos/builtin/packages/r-dplyr/package.py
+++ b/var/spack/repos/builtin/packages/r-dplyr/package.py
@@ -33,6 +33,9 @@ class RDplyr(RPackage):
     version("0.7.0", sha256="27b3593c09da5e99c0c4fb19ea826edd2cab619f8aaefd0cfd2a4140a0bd9410")
     version("0.5.0", sha256="93d3b829f1c2d38e14a4f2fa7d6398fc6c1a9e4189b3e78bc38a0eb0e864454f")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.1.2:", type=("build", "run"))
     depends_on("r@3.2.0:", type=("build", "run"), when="@0.8.1:")
     depends_on("r@3.3.0:", type=("build", "run"), when="@1.0.3:")

--- a/var/spack/repos/builtin/packages/r-fansi/package.py
+++ b/var/spack/repos/builtin/packages/r-fansi/package.py
@@ -27,4 +27,6 @@ class RFansi(RPackage):
     version("0.2.2", sha256="71dfdda467985a4d630ecf93d4bc60446a8a78d69dbd7ac24cc45822329d4bce")
     version("0.2.1", sha256="abe709d69ddd6610aaa24e049c7a97c16a2c2dbe0873d4e3b8af57e486ef05c5")
 
+    depends_on("c", type="build")
+
     depends_on("r@3.1.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-farver/package.py
+++ b/var/spack/repos/builtin/packages/r-farver/package.py
@@ -25,3 +25,6 @@ class RFarver(RPackage):
     version("2.1.0", sha256="e5c8630607049f682fb3002b99ca4f5e7c6b94f8b2a4342df594e7853b77cef4")
     version("2.0.3", sha256="0e1590df79ec6078f10426411b96216b70568a4eaf3ffd84ca723add0ed8e5cc")
     version("2.0.1", sha256="71473e21727357084c6aec4bb9bb258a6797a0f676b4b27504a03f16aa2f4e54")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")

--- a/var/spack/repos/builtin/packages/r-fastmap/package.py
+++ b/var/spack/repos/builtin/packages/r-fastmap/package.py
@@ -23,3 +23,6 @@ class RFastmap(RPackage):
     version("1.1.1", sha256="3623809dd016ae8abd235200ba7834effc4b916915a059deb76044137c5c7173")
     version("1.1.0", sha256="9113e526b4c096302cfeae660a06de2c4c82ae4e2d3d6ef53af6de812d4c822b")
     version("1.0.1", sha256="4778b05dfebd356f8df980dfeff3b973a72bca14898f870e5c40c1d84db9faec")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")

--- a/var/spack/repos/builtin/packages/r-fs/package.py
+++ b/var/spack/repos/builtin/packages/r-fs/package.py
@@ -21,6 +21,9 @@ class RFs(RPackage):
     version("1.5.0", sha256="36df1653571de3c628a4f769c4627f6ac53d0f9e4106d9d476afb22ae9603897")
     version("1.3.1", sha256="d6934dca8f835d8173e3fb9fd4d5e2740c8c04348dd2bcc57df1b711facb46bc")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.4:", type=("build", "run"), when="@1.6.2:")
     depends_on("r@3.6:", type=("build", "run"), when="@1.6.4:")

--- a/var/spack/repos/builtin/packages/r-glue/package.py
+++ b/var/spack/repos/builtin/packages/r-glue/package.py
@@ -29,6 +29,9 @@ class RGlue(RPackage):
     version("1.3.0", sha256="789e5a44c3635c3d3db26666e635e88adcf61cd02b75465125d95d7a12291cee")
     version("1.2.0", sha256="19275b34ee6a1bcad05360b7eb996cebaa1402f189a5dfb084e695d423f2296e")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.2:", type=("build", "run"), when="@1.4.2:")
     depends_on("r@3.4:", type=("build", "run"), when="@1.6.0:")

--- a/var/spack/repos/builtin/packages/r-htmltools/package.py
+++ b/var/spack/repos/builtin/packages/r-htmltools/package.py
@@ -23,6 +23,9 @@ class RHtmltools(RPackage):
     version("0.3.6", sha256="44affb82f9c2fd76c9e2b58f9229adb003217932b68c3fdbf1327c8d74c868a2")
     version("0.3.5", sha256="29fb7e075744bbffdff8ba4fce3860076de66f39a59a100ee4cfb4fc00722b49")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@2.14.1:", type=("build", "run"))
     depends_on("r-digest", type=("build", "run"))
     depends_on("r-base64enc", type=("build", "run"), when="@0.5.1:")

--- a/var/spack/repos/builtin/packages/r-lattice/package.py
+++ b/var/spack/repos/builtin/packages/r-lattice/package.py
@@ -26,5 +26,8 @@ class RLattice(RPackage):
     version("0.20-35", sha256="0829ab0f4dec55aac6a73bc3411af68441ddb1b5b078d680a7c2643abeaa965d")
     version("0.20-34", sha256="4a1a1cafa9c6660fb9a433b3a51898b8ec8e83abf143c80f99e3e4cf92812518")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@4.0.0:", type=("build", "run"), when="@0.21-8:")

--- a/var/spack/repos/builtin/packages/r-lubridate/package.py
+++ b/var/spack/repos/builtin/packages/r-lubridate/package.py
@@ -29,6 +29,8 @@ class RLubridate(RPackage):
     version("1.7.1", sha256="898c3f482ab8f5e5b415eecd13d1238769c88faed19b63fcb074ffe5ff57fb5f")
     version("1.5.6", sha256="9b1627ba3212e132ce2b9a29d7513e250cc682ab9b4069f6788a22e84bf8d2c4")
 
+    depends_on("c", type="build")
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.2:", type=("build", "run"), when="@1.7.9.2:")
     depends_on("r-generics", type=("build", "run"), when="@1.7.9.2:")

--- a/var/spack/repos/builtin/packages/r-mass/package.py
+++ b/var/spack/repos/builtin/packages/r-mass/package.py
@@ -25,6 +25,9 @@ class RMass(RPackage):
     version("7.3-51.3", sha256="5b0e0e7704d43a94b08dcc4b3fe600b9723d1b3e446dd393e82d39ddf66608b6")
     version("7.3-47", sha256="ed44cdabe84fff3553122267ade61d5cc68071c435f7645d36c8f2e4e9f9c6bf")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("r@3.3.0:", type=("build", "run"), when="@7.3-55:")
     depends_on("r@4.2.0:", type=("build", "run"), when="@7.3-59:")

--- a/var/spack/repos/builtin/packages/r-matrix/package.py
+++ b/var/spack/repos/builtin/packages/r-matrix/package.py
@@ -31,6 +31,9 @@ class RMatrix(RPackage):
     version("1.2-8", sha256="3cd2a187c45fc18a0766dc148b7f83dbf6f2163c256e887c41cbaa7c9a20dbb7")
     version("1.2-6", sha256="4b49b639b7bf612fa3d1c1b1c68125ec7859c8cdadae0c13f499f24099fd5f20")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.0.1:", type=("build", "run"))
     depends_on("r@3.2.0:", type=("build", "run"), when="@1.2-13:")
     depends_on("r@3.6.0:", type=("build", "run"), when="@1.3-2:")

--- a/var/spack/repos/builtin/packages/r-mgcv/package.py
+++ b/var/spack/repos/builtin/packages/r-mgcv/package.py
@@ -37,6 +37,8 @@ class RMgcv(RPackage):
     version("1.8-16", sha256="9266a0cbd783717fc6130db4e0034e69465d177397687f35daf6a8ccdb0b435e")
     version("1.8-13", sha256="74bc819708ef59da94b777a446ef00d7f14b428eec843533e824017c29cc524b")
 
+    depends_on("c", type="build")
+
     depends_on("r@2.14.0:", type=("build", "run"))
     depends_on("r@3.6.0:", type=("build", "run"), when="@1.8.34:")
     depends_on("r-nlme@3.1-64:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-nlme/package.py
+++ b/var/spack/repos/builtin/packages/r-nlme/package.py
@@ -28,6 +28,10 @@ class RNlme(RPackage):
     version("3.1-131", sha256="79daa167eb9bc7d8dba506da4b24b5250665b051d4e0a51dfccbb0087fdb564c")
     version("3.1-130", sha256="ec576bd906ef2e1c79b6a4382743d425846f63be2a43de1cce6aa397b40e290e")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@3.3.0:", type=("build", "run"), when="@3.1-131.1")
     depends_on("r@3.5.0:", type=("build", "run"), when="@3.1-134:3.1-135")

--- a/var/spack/repos/builtin/packages/r-openssl/package.py
+++ b/var/spack/repos/builtin/packages/r-openssl/package.py
@@ -37,6 +37,8 @@ class ROpenssl(RPackage):
     version("0.9.6", sha256="6dd6d1cade4004962d516ad761fff0812beec0232318b385d286761423a5dc39")
     version("0.9.4", sha256="cb7349defa5428acc0907629a4f53f82d2519af219e5d6a41f852cf55b1feb66")
 
+    depends_on("c", type="build")
+
     depends_on("r-askpass", type=("build", "run"), when="@1.2:")
     depends_on("openssl@1.0.1:")
     depends_on("openssl@1.0.2:", when="@2.0.2:")

--- a/var/spack/repos/builtin/packages/r-pbdzmq/package.py
+++ b/var/spack/repos/builtin/packages/r-pbdzmq/package.py
@@ -31,6 +31,9 @@ class RPbdzmq(RPackage):
     version("0.3-2", sha256="ece2a2881c662f77126e4801ba4e01c991331842b0d636ce5a2b591b9de3fc37")
     version("0.2-4", sha256="bfacac88b0d4156c70cf63fc4cb9969a950693996901a4fa3dcd59949ec065f6")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.0.0:", type=("build", "run"))
     depends_on("r@3.2.0:", type=("build", "run"), when="@0.2-6:")
     depends_on("r@3.5.0:", type=("build", "run"), when="@0.3-4:")

--- a/var/spack/repos/builtin/packages/r-processx/package.py
+++ b/var/spack/repos/builtin/packages/r-processx/package.py
@@ -34,6 +34,9 @@ class RProcessx(RPackage):
     version("2.0.0.1", sha256="8f61b2952d0f2d13c74465bfba174ce11eee559475c2f7b9be6bcb9e2e1d827b")
     version("2.0.0", sha256="8325b56a60a276909228756281523cda9256bc754c5f3ca03b41c5c17cc398ad")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.4.0:", type=("build", "run"), when="@3.5.3:")
     depends_on("r-ps@1.2.0:", type=("build", "run"), when="@3.2.0:")
     depends_on("r-r6", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-ps/package.py
+++ b/var/spack/repos/builtin/packages/r-ps/package.py
@@ -27,5 +27,7 @@ class RPs(RPackage):
     version("1.1.0", sha256="5d5240d5bf1d48c721b3fdf47cfc9dbf878e388ea1f057b764db05bffdc4a9fe")
     version("1.0.0", sha256="9bdaf64aaa44ae11866868402eb75bf56c2e3022100476d9b9dcd16ca784ffd8")
 
+    depends_on("c", type="build")
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.4:", type=("build", "run"), when="@1.7.0:")

--- a/var/spack/repos/builtin/packages/r-purrr/package.py
+++ b/var/spack/repos/builtin/packages/r-purrr/package.py
@@ -22,6 +22,9 @@ class RPurrr(RPackage):
     version("0.3.1", sha256="c2a3c9901192efd8a04976676f84885a005db88deb1432e4750900c7b3b7883b")
     version("0.2.4", sha256="ed8d0f69d29b95c2289ae52be08a0e65f8171abb6d2587de7b57328bf3b2eb71")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.2:", type=("build", "run"), when="@0.3.3:")
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.0.1:")

--- a/var/spack/repos/builtin/packages/r-ragg/package.py
+++ b/var/spack/repos/builtin/packages/r-ragg/package.py
@@ -22,6 +22,9 @@ class RRagg(RPackage):
     version("1.2.4", sha256="c547e5636a2eefaa0021a0d50fad1e813c2ce976ec0c9c3f796d38a110680dcd")
     version("1.2.3", sha256="976da0007ef0d4dbadda4734727b539671b65c1eff4ff392d734f4e2c846f2b2")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r-systemfonts@1.0.3:", type=("build", "run"))
     depends_on("r-textshaping@0.3.0:", type=("build", "run"))
     depends_on("freetype")

--- a/var/spack/repos/builtin/packages/r-readr/package.py
+++ b/var/spack/repos/builtin/packages/r-readr/package.py
@@ -27,6 +27,9 @@ class RReadr(RPackage):
     version("1.3.1", sha256="33f94de39bb7f2a342fbb2bd4e5afcfec08798eac39672ee18042ac0b349e4f3")
     version("1.1.1", sha256="1a29b99009a06f2cee18d08bc6201fd4985b6d45c76cefca65084dcc1a2f7cb3")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@3.1:", type=("build", "run"), when="@1.3.0:")
     depends_on("r@3.4:", type=("build", "run"), when="@2.1.3:")

--- a/var/spack/repos/builtin/packages/r-readxl/package.py
+++ b/var/spack/repos/builtin/packages/r-readxl/package.py
@@ -26,6 +26,9 @@ class RReadxl(RPackage):
     version("1.1.0", sha256="b63d21fc6510acb373e96deaec45e966a523ec75cbec75a089529297ed443116")
     version("1.0.0", sha256="fbd62f07fed7946363698a57be88f4ef3fa254ecf456ef292535849c787fc7ad")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.4:", type=("build", "run"), when="@1.4.0:")
     depends_on("r@3.5:", type=("build", "run"), when="@1.4.2:")
     depends_on("r@3.6:", type=("build", "run"), when="@1.4.3:")

--- a/var/spack/repos/builtin/packages/r-rlang/package.py
+++ b/var/spack/repos/builtin/packages/r-rlang/package.py
@@ -36,6 +36,8 @@ class RRlang(RPackage):
     version("0.1.2", sha256="90cfcd88cae6fff044fca64b24a8e6bdc09fc276163b518ff2d90268b0c785f9")
     version("0.1.1", sha256="5901f95d68728a7d9bb1c2373a20ce6e4ad222f66e397e7735e9eff987c73c3f")
 
+    depends_on("c", type="build")
+
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("r@3.2.0:", type=("build", "run"), when="@0.4.0:")
     depends_on("r@3.3.0:", type=("build", "run"), when="@0.4.10:")

--- a/var/spack/repos/builtin/packages/r-sass/package.py
+++ b/var/spack/repos/builtin/packages/r-sass/package.py
@@ -23,6 +23,9 @@ class RSass(RPackage):
     version("0.4.1", sha256="850fcb6bd49085d5afd25ac18da0744234385baf1f13d8c0a320f4da2de608bb")
     version("0.4.0", sha256="7d06ca15239142a49e88bb3be494515abdd8c75f00f3f1b0ee7bccb55019bc2b")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r-fs", type=("build", "run"))
     depends_on("r-fs@1.2.4:", type=("build", "run"), when="@0.4.7:")
     depends_on("r-rlang@0.4.10:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-stringi/package.py
+++ b/var/spack/repos/builtin/packages/r-stringi/package.py
@@ -34,6 +34,9 @@ class RStringi(RPackage):
     version("1.1.2", sha256="e50b7162ceb7ebae403475f6f8a76a39532a2abc82112db88661f48aa4b9218e")
     version("1.1.1", sha256="243178a138fe68c86384feb85ead8eb605e8230113d638da5650bca01e24e165")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@2.14:", type=("build", "run"))
     depends_on("r@3.1:", type=("build", "run"), when="@1.6.1:")
     depends_on("r@3.4:", type=("build", "run"), when="@1.8.1:")

--- a/var/spack/repos/builtin/packages/r-sys/package.py
+++ b/var/spack/repos/builtin/packages/r-sys/package.py
@@ -23,6 +23,8 @@ class RSys(RPackage):
     version("3.4", sha256="17f88fbaf222f1f8fd07919461093dac0e7175ae3c3b3264b88470617afd0487")
     version("3.2", sha256="2819498461fe2ce83d319d1a47844e86bcea6d01d10861818dba289e7099bbcc")
 
+    depends_on("c", type="build")
+
     def flag_handler(self, name, flags):
         if name == "cflags":
             flags.append(self.compiler.c99_flag)

--- a/var/spack/repos/builtin/packages/r-systemfonts/package.py
+++ b/var/spack/repos/builtin/packages/r-systemfonts/package.py
@@ -25,6 +25,9 @@ class RSystemfonts(RPackage):
     version("1.0.3", sha256="647c99d5ea6f90a49768ea7b10b39816af6be85168475273369fd973a20dbbba")
     version("1.0.1", sha256="401db4d9e78e3a5e00b7a0b4fbad7fbb1c584734469b65fe5b7ebe1851c7a797")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-cpp11@0.2.1:", type=("build", "run"))
     depends_on("r-lifecycle", type=("build", "run"), when="@1.1.0:")

--- a/var/spack/repos/builtin/packages/r-textshaping/package.py
+++ b/var/spack/repos/builtin/packages/r-textshaping/package.py
@@ -20,6 +20,9 @@ class RTextshaping(RPackage):
     version("0.4.0", sha256="35e940786bb278560de61bb55d4f46f8c86c878d0461613ceb8c98ba9b239d7a")
     version("0.3.6", sha256="80e2c087962f55ce2811fbc798b09f5638c06c6b28c10cd3cb3827005b902ada")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-cpp11@0.2.1:", type=("build", "run"))
     depends_on("r-lifecycle", type=("build", "run"), when="@0.4.0:")

--- a/var/spack/repos/builtin/packages/r-tidyr/package.py
+++ b/var/spack/repos/builtin/packages/r-tidyr/package.py
@@ -31,6 +31,9 @@ class RTidyr(RPackage):
     version("0.7.2", sha256="062cea2e2b57fffd500e4ce31cba6d593e65684fc0897ea49ea38d257c76009c")
     version("0.5.1", sha256="dbab642ac7231cbfe3e2a0d4553fb4ffb3699c6d6b432be2bb5812dfbbdbdace")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.3.0:")
     depends_on("r@3.6:", type=("build", "run"), when="@1.3.1:")

--- a/var/spack/repos/builtin/packages/r-timechange/package.py
+++ b/var/spack/repos/builtin/packages/r-timechange/package.py
@@ -24,5 +24,8 @@ class RTimechange(RPackage):
     version("0.2.0", sha256="3d602008052123daef94a5c3f5154c5461b4ec0432ab70c37273d7ddd252f7f1")
     version("0.1.1", sha256="8503919d233d7d7b81fe47692f0f2d6742ff4cae7320a5522bf98f077f5d7f70")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.3:", type=("build", "run"))
     depends_on("r-cpp11@0.2.7:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-tzdb/package.py
+++ b/var/spack/repos/builtin/packages/r-tzdb/package.py
@@ -26,6 +26,9 @@ class RTzdb(RPackage):
     version("0.3.0", sha256="6099f0ec1fba692b51b4360aa776902a39f10dae815933c31994b8e4d4277038")
     version("0.2.0", sha256="c335905d452b400af7ed54b916b5246cb3f47ede0602911a2bcb25a1cf56d5a9")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.3:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@0.3.0:")
     depends_on("r@3.5.0:", type=("build", "run"), when="@0.4.0:")

--- a/var/spack/repos/builtin/packages/r-utf8/package.py
+++ b/var/spack/repos/builtin/packages/r-utf8/package.py
@@ -25,4 +25,6 @@ class RUtf8(RPackage):
     version("1.1.0", sha256="6a8ae2c452859800c3ef12993a55892588fc35df8fa1360f3d182ed97244dc4f")
     version("1.0.0", sha256="7562a80262cbc2017eee76c0d3c9575f240fab291f868a11724fa04a116efb80")
 
+    depends_on("c", type="build")
+
     depends_on("r@2.10:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-uuid/package.py
+++ b/var/spack/repos/builtin/packages/r-uuid/package.py
@@ -22,4 +22,5 @@ class RUuid(RPackage):
     version("0.1-4", sha256="98e0249dda17434bfa209c2058e9911e576963d4599be9f7ea946e664f8ca93e")
     version("0.1-2", sha256="dd71704dc336b0857981b92a75ed9877d4ca47780b1682def28839304cd3b1be")
 
+    depends_on("c", type="build")
     depends_on("r@2.9.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-vroom/package.py
+++ b/var/spack/repos/builtin/packages/r-vroom/package.py
@@ -24,6 +24,9 @@ class RVroom(RPackage):
     version("1.5.7", sha256="d087cb148f71c222fc89199d03df2502689149873414a6d89c2f006d3a109fde")
     version("1.5.5", sha256="1d45688c08f162a3300eda532d9e87d144f4bc686769a521bf9a12e3d3b465fe")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.1:", type=("build", "run"))
     depends_on("r@3.4:", type=("build", "run"), when="@1.6.0:")
     depends_on("r@3.6:", type=("build", "run"), when="@1.6.4:")

--- a/var/spack/repos/builtin/packages/r-xfun/package.py
+++ b/var/spack/repos/builtin/packages/r-xfun/package.py
@@ -25,4 +25,6 @@ class RXfun(RPackage):
     version("0.20", sha256="284239d12a3d5ea7d1ef8b1382fb0a7a4661af54c85510501279681871da7c10")
     version("0.8", sha256="c2f8ecf8b57ddec02f9be7f417d9e22fc1ae2c7db8d70aa703fc62bf4a5c5416")
 
+    depends_on("c", type="build")
+
     depends_on("r@3.2.0:", when="@0.47:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-xml2/package.py
+++ b/var/spack/repos/builtin/packages/r-xml2/package.py
@@ -22,6 +22,9 @@ class RXml2(RPackage):
     version("1.2.1", sha256="5615bbc94607efc3bc192551992b349091df802ae34b855cfa817733f2690605")
     version("1.1.1", sha256="00f3e3b66b76760c19da5f6dddc98e6f30de36a96b211e59e1a3f4ff58763116")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("r@3.1.0:", type=("build", "run"))
     depends_on("r@3.6.0:", type=("build", "run"), when="@1.3.6:")
     depends_on("libxml2")

--- a/var/spack/repos/builtin/packages/r-yaml/package.py
+++ b/var/spack/repos/builtin/packages/r-yaml/package.py
@@ -25,3 +25,5 @@ class RYaml(RPackage):
     version("2.1.19", sha256="e5db035693ac765e4b5fe1fc2e9711f8ca73e398e3f2bf27cc60def59ccd7f11")
     version("2.1.14", sha256="41a559846f6d44cc2dbcb3fc0becbc50d2766d3dc2aad7cfb97c1f9759ec0875")
     version("2.1.13", sha256="26f69aa2008bcacf3b2f95ef82a4667eaec2f2da8487646f71f1e2635d2d7fa2")
+
+    depends_on("c", type="build")


### PR DESCRIPTION
Updates to packages required for `r-tidyverse` and `py-rpy2`, to account for the new compilers-as-nodes spack 1.0 changes