### PR TITLE
apptainer: there is no --with-libsubid

### DIFF
--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -85,9 +85,7 @@ class Apptainer(SingularityBase):
         options = []
         if spec.satisfies("@1.1.0: +suid"):
             options.append("--with-suid")
-        if spec.satisfies("+libsubid"):
-            options.append("--with-libsubid")
-        else:
+        if spec.satisfies("@1.4: ~libsubid"):
             options.append("--without-libsubid")
         return options
 


### PR DESCRIPTION
This PR fixes #50180 by ensuring the non-existing `--with-libsubid` isn't passed.