### PR TITLE
py-pillow: only configure variants if they exist

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -88,6 +88,11 @@ class PyPillowBase(PythonPackage):
         settings = {"parallel": make_jobs}
 
         for variant in self.VARIANTS:
+            try:
+                self.get_variant(variant)
+            except ValueError:
+                continue
+
             if spec.satisfies(f"+{variant}"):
                 settings[variant] = "enable"
             elif spec.satisfies(f"~{variant}"):
@@ -133,6 +138,10 @@ class PyPillowBase(PythonPackage):
             with open("setup.cfg", "a") as setup:
                 setup.write("[build_ext]\n")
                 for variant in self.VARIANTS:
+                    try:
+                        self.get_variant(variant)
+                    except ValueError:
+                        continue
                     setup.write(variant_to_cfg(variant))
 
                 setup.write("rpath={0}\n".format(":".join(self.rpath)))


### PR DESCRIPTION
Ran into an error when building `py-pillow@9.5.0` in https://github.com/spack/spack/pull/50146: `error: error in setup.cfg: command 'pil_build_ext' has no such option 'disable_avif'`. See https://gitlab.spack.io/spack/spack/-/jobs/16355566 for the details.

THe problem is that it does not exist for that version. Fixed it by checking the variant actually exists for the current version.

Validated by running:
```
$ python -m PIL
--------------------------------------------------------------------
Pillow 9.5.0
Python 3.11.11 (main, Apr 23 2025, 16:10:55) [GCC 14.2.0]
--------------------------------------------------------------------
Python modules loaded from /home/robert/code/github.com/spack/spack/opt/spack/linux-zen4/py-pillow-9.5.0-2qmor5sj6tq65j3wzwjkvgvuqcocnrs3/lib/python3.11/site-packages/PIL
Binary modules loaded from /home/robert/code/github.com/spack/spack/opt/spack/linux-zen4/py-pillow-9.5.0-2qmor5sj6tq65j3wzwjkvgvuqcocnrs3/lib/python3.11/site-packages/PIL
--------------------------------------------------------------------
--- PIL CORE support ok, compiled for 9.5.0
*** TKINTER support not installed
*** FREETYPE2 support not installed
*** LITTLECMS2 support not installed
*** WEBP support not installed
*** WEBP Transparency support not installed
*** WEBPMUX support not installed
*** WEBP Animation support not installed
--- JPEG support ok, compiled for libjpeg-turbo 3.0.4
*** OPENJPEG (JPEG2000) support not installed
--- ZLIB (PNG/ZIP) support ok, loaded 1.3.1.zlib-ng
*** LIBTIFF support not installed
*** RAQM (Bidirectional Text) support not installed
*** LIBIMAGEQUANT (Quantization method) support not installed
*** XCB (X protocol) support not installed
--------------------------------------------------------------------
...
```