### PR TITLE
py-netcdf4: enable non-MPI build agains MPI-enabled HDF5

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf4/disable_parallel_support.patch
+++ b/var/spack/repos/builtin/packages/py-netcdf4/disable_parallel_support.patch
@@ -1,3 +1,16 @@
+--- a/include/netCDF4.pxi
++++ b/include/netCDF4.pxi
+@@ -4,8 +4,8 @@
+     ctypedef long ptrdiff_t
+ 
+ # hdf5 version info.
+-cdef extern from "H5public.h":
+-    ctypedef int herr_t
++ctypedef int herr_t
++cdef extern \
+     int H5get_libversion( unsigned int *majnum, unsigned int *minnum, unsigned int *relnum ) nogil
+  
+ cdef extern from *:
 --- a/setup.py
 +++ b/setup.py
 @@ -392,7 +392,7 @@

--- a/var/spack/repos/builtin/packages/py-netcdf4/disable_parallel_support.patch
+++ b/var/spack/repos/builtin/packages/py-netcdf4/disable_parallel_support.patch
@@ -11,6 +11,17 @@
      int H5get_libversion( unsigned int *majnum, unsigned int *minnum, unsigned int *relnum ) nogil
   
  cdef extern from *:
+--- a/include/netcdf-compat.h
++++ b/include/netcdf-compat.h
+@@ -95,7 +95,7 @@
+ #define HAS_CDF5_FORMAT 0
+ #endif
+ 
+-#if defined(NC_HAS_PARALLEL) && NC_HAS_PARALLEL
++#if 0
+ #include <netcdf_par.h>
+ #define HAS_PARALLEL_SUPPORT 1
+ #else
 --- a/setup.py
 +++ b/setup.py
 @@ -392,7 +392,7 @@

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -55,8 +55,6 @@ class PyNetcdf4(PythonPackage):
     with when("+mpi"):
         depends_on("netcdf-c+mpi")
         depends_on("hdf5+mpi")
-    # We cannot build py-netcdf4~mpi ^netcdf-c~mpi ^hdf5+mpi
-    conflicts("hdf5+mpi", when="~mpi ^netcdf-c~mpi")
 
     # The installation script tries to find hdf5 using pkg-config. However, the
     # version of hdf5 installed with Spack does not have pkg-config files.
@@ -72,6 +70,7 @@ class PyNetcdf4(PythonPackage):
     # See also: https://github.com/Unidata/netcdf4-python/issues/1389
     with when("@1.7:~mpi"):
         patch("disable_parallel_support.patch", when="^netcdf-c+mpi")
+        patch("disable_parallel_support.patch", when="^hdf5+mpi")
 
     # https://github.com/Unidata/netcdf4-python/pull/1322
     patch(


### PR DESCRIPTION
This makes it possible to build:
- `py-netcdf4 ~mpi ^netcdf-c+mpi` when types declared in `mpi.h` (included by `netcdf_par.h`) are inconsistent with those in [`include/netcdf-compat.h`](https://github.com/Unidata/netcdf4-python/blob/395e21792795c95422acd1cdca27b2df1439f9ca/include/netcdf-compat.h#L103-L104) and the compiler in use is too picky to accept that (e.g. `%gcc@14.2.0 ^openmpi@5.0.7`);
- `py-netcdf4 ~mpi ^netcdf-c~mpi ^hdf5+mpi`.

Basically, we extend `disable_parallel_support.patch` to ensure that `mpi.h` is never included for `py-netcdf4 ~mpi`.