### PR TITLE
Add ls alias to spack {compiler, external}

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -63,7 +63,7 @@ def setup_parser(subparser):
     )
 
     # List
-    list_parser = sp.add_parser("list", help="list available compilers")
+    list_parser = sp.add_parser("list", aliases=["ls"], help="list available compilers")
     list_parser.add_argument(
         "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
     )
@@ -216,5 +216,6 @@ def compiler(parser, args):
         "rm": compiler_remove,
         "info": compiler_info,
         "list": compiler_list,
+        "ls": compiler_list,
     }
     action[args.compiler_command](args)

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -62,7 +62,7 @@ def setup_parser(subparser):
         "package Spack knows how to find."
     )
 
-    sp.add_parser("list", help="list detectable packages, by repository and name")
+    sp.add_parser("list", aliases=["ls"], help="list detectable packages, by repository and name")
 
     read_cray_manifest = sp.add_parser(
         "read-cray-manifest",
@@ -259,6 +259,7 @@ def external(parser, args):
     action = {
         "find": external_find,
         "list": external_list,
+        "ls": external_list,
         "read-cray-manifest": external_read_cray_manifest,
     }
     action[args.external_command](args)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -749,7 +749,7 @@ _spack_compiler() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="find add remove rm list info"
+        SPACK_COMPREPLY="find add remove rm list ls info"
     fi
 }
 
@@ -790,6 +790,10 @@ _spack_compiler_rm() {
 }
 
 _spack_compiler_list() {
+    SPACK_COMPREPLY="-h --help --scope"
+}
+
+_spack_compiler_ls() {
     SPACK_COMPREPLY="-h --help --scope"
 }
 
@@ -1173,7 +1177,7 @@ _spack_external() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="find list read-cray-manifest"
+        SPACK_COMPREPLY="find list ls read-cray-manifest"
     fi
 }
 
@@ -1187,6 +1191,10 @@ _spack_external_find() {
 }
 
 _spack_external_list() {
+    SPACK_COMPREPLY="-h --help"
+}
+
+_spack_external_ls() {
     SPACK_COMPREPLY="-h --help"
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1054,6 +1054,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 compiler' -f -a add -d 's
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler' -f -a remove -d 'remove compiler by spec'
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler' -f -a rm -d 'remove compiler by spec'
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler' -f -a list -d 'list available compilers'
+complete -c spack -n '__fish_spack_using_command_pos 0 compiler' -f -a ls -d 'list available compilers'
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler' -f -a info -d 'show compiler paths'
 complete -c spack -n '__fish_spack_using_command compiler' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler' -s h -l help -d 'show this help message and exit'
@@ -1112,6 +1113,13 @@ complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f 
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
+
+# spack compiler ls
+set -g __fish_spack_optspecs_spack_compiler_ls h/help scope=
+complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
 
 # spack compiler info
 set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
@@ -1707,6 +1715,7 @@ complete -c spack -n '__fish_spack_using_command extensions' -s s -l show -r -d 
 set -g __fish_spack_optspecs_spack_external h/help
 complete -c spack -n '__fish_spack_using_command_pos 0 external' -f -a find -d 'add external packages to packages.yaml'
 complete -c spack -n '__fish_spack_using_command_pos 0 external' -f -a list -d 'list detectable packages, by repository and name'
+complete -c spack -n '__fish_spack_using_command_pos 0 external' -f -a ls -d 'list detectable packages, by repository and name'
 complete -c spack -n '__fish_spack_using_command_pos 0 external' -f -a read-cray-manifest -d 'consume a Spack-compatible description of externally-installed packages, including dependency relationships'
 complete -c spack -n '__fish_spack_using_command external' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command external' -s h -l help -d 'show this help message and exit'
@@ -1735,6 +1744,11 @@ complete -c spack -n '__fish_spack_using_command external find' -s j -l jobs -r 
 set -g __fish_spack_optspecs_spack_external_list h/help
 complete -c spack -n '__fish_spack_using_command external list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command external list' -s h -l help -d 'show this help message and exit'
+
+# spack external ls
+set -g __fish_spack_optspecs_spack_external_ls h/help
+complete -c spack -n '__fish_spack_using_command external ls' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command external ls' -s h -l help -d 'show this help message and exit'
 
 # spack external read-cray-manifest
 set -g __fish_spack_optspecs_spack_external_read_cray_manifest h/help file= directory= ignore-default-dir dry-run fail-on-error


### PR DESCRIPTION
We have ls aliases for some of our subcommands, but not all of them. This adds a few additional aliases to improve our UX.