### PR TITLE
actsvg: use Spack pybind11 package

### DIFF
--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -50,7 +50,7 @@ class Actsvg(CMakePackage):
     depends_on("boost +program_options", when="+examples")
     depends_on("googletest", when="+examples")
     depends_on("python@3.8:", when="+python")
-    depends_on("py-pybind11@2.10", when="+python @0.4.42:")
+    depends_on("py-pybind11@2.10:", when="+python @0.4.42:")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -50,6 +50,7 @@ class Actsvg(CMakePackage):
     depends_on("boost +program_options", when="+examples")
     depends_on("googletest", when="+examples")
     depends_on("python@3.8:", when="+python")
+    depends_on("py-pybind11@2.10", when="+python @0.4.42:")
 
     def cmake_args(self):
         args = [
@@ -58,5 +59,8 @@ class Actsvg(CMakePackage):
             self.define_from_variant("ACTSVG_BUILD_PYTHON_BINDINGS", "python"),
             self.define_from_variant("ACTSVG_BUILD_WEB", "web"),
             self.define("ACTSVG_BUILD_TESTING", self.run_tests),
+            self.define("ACTSVG_USE_SYSTEM_LIBS", True),
+            # The pybind11 loading does not respect `ACTSVG_USE_SYSTEM_LIBS`.
+            self.define("ACTSVG_USE_SYSTEM_PYBIND11", True),
         ]
         return args


### PR DESCRIPTION
This commit makes the actsvg package use the Spack-provided pybind11 package rather than having it download its own copy.