### PR TITLE
Update netcdf variants for wgrib2

### DIFF
--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -57,6 +57,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     )
 
     version("develop", branch="develop")
+    version("3.6.0", sha256="55913cb58f2b329759de17f5a84dd97ad1844d7a93956d245ec94f4264d802be")
     version("3.5.0", sha256="b27b48228442a08bddc3d511d0c6335afca47252ae9f0e41ef6948f804afa3a1")
     version("3.4.0", sha256="ecbce2209c09bd63f1bca824f58a60aa89db6762603bda7d7d3fa2148b4a0536")
     version("3.3.0", sha256="010827fba9c31f05807e02375240950927e9e51379e1444388153284f08f58e2")
@@ -176,7 +177,8 @@ class Wgrib2(MakefilePackage, CMakePackage):
     depends_on("ip@5.1:", when="@3.5: +ipolates")
     depends_on("lapack", when="@3.5: +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
-    depends_on("netcdf-c", when="@3.2: +netcdf4")
+    depends_on("netcdf-c", when="+netcdf4")
+    depends_on("netcdf-c", when="+netcdf")
     depends_on("jasper@:2", when="@3.2:3.4 +jasper")
     depends_on("g2c", when="@3.5: +jasper")
     depends_on("zlib-api", when="@3.2: +png")

--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -97,16 +97,10 @@ class Wgrib2(MakefilePackage, CMakePackage):
         when="@:3.1",
     )
     variant(
-        "netcdf4",
-        default=False,
-        description="Link in netcdf4 library to write netcdf3/4 files",
-        when="@:3.3",
-    )
-    variant(
         "netcdf",
         default=False,
         description="Link in netcdf4 library to write netcdf3/4 files",
-        when="@3.4:",
+        when="@3.2:",
     )
     variant("ipolates", default=False, description="Use to interpolate to new grids")
     variant(
@@ -167,7 +161,6 @@ class Wgrib2(MakefilePackage, CMakePackage):
         "enable_docs", default=False, description="Build doxygen documentation", when="@3.4.0:"
     )
 
-    conflicts("+netcdf3", when="+netcdf4")
     conflicts("+netcdf3", when="+netcdf")
     conflicts("+openmp", when="%apple-clang")
 
@@ -177,7 +170,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     depends_on("ip@5.1:", when="@3.5: +ipolates")
     depends_on("lapack", when="@3.5: +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
-    depends_on("netcdf-c", when="+netcdf4")
+    depends_on("netcdf-c", when="+netcdf3")
     depends_on("netcdf-c", when="+netcdf")
     depends_on("jasper@:2", when="@3.2:3.4 +jasper")
     depends_on("g2c", when="@3.5: +jasper")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Prior to `v3.4.0`, `wgrib2` used conflicting configuration options `USE_NETCDF3` and `USE_NETCDF4`. The options were removed in `v3.4.0` and were replaced with `USE_NETCDF`.

The old options were used to determine if `netCDF` supports `HDF5`. `CMake` now checks for that in the `configure` phase.

Variant `+netcdf4` can be subsumed by variant `+netcdf` for `v3.2.0` and forward, as `+netcdf` will generate a concretization that yields a version of `netCDF` that supports `HDF5`.

The variant `+netcdf3` remains valid as specified.

Add version `wgrib2@3.6.0`