### PR TITLE
Don't discard deps based on conditional requirements

### DIFF
--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -85,8 +85,10 @@ class NoStaticAnalysis(PossibleDependencyGraph):
     def is_allowed_on_this_platform(self, *, pkg_name: str) -> bool:
         """Returns true if a package is allowed on the current host"""
         pkg_cls = self.repo.get_pkg_class(pkg_name)
+        no_condition = spack.spec.Spec()
         for when_spec, conditions in pkg_cls.requirements.items():
-            if not when_spec.intersects(self._platform_condition):
+            # Restrict analysis to unconditional requirements
+            if when_spec != no_condition:
                 continue
             for requirements, _, _ in conditions:
                 if not any(x.intersects(self._platform_condition) for x in requirements):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3366,3 +3366,17 @@ def test_reuse_when_requiring_build_dep(
     with spack.config.override("concretizer:reuse", True):
         result = spack.concretize.concretize_one("pkg-b")
         assert pkgb_old.dag_hash() == result.dag_hash(), result.tree()
+
+
+@pytest.mark.regression("50167")
+def test_input_analysis_and_conditional_requirements(default_mock_concretization):
+    """Tests that input analysis doesn't account for conditional requirement
+    to discard possible dependencies.
+
+    If the requirement is conditional, and impossible to achieve on the current
+    platform, the valid search space is still the complement of the condition that
+    activates the requirement.
+    """
+    libceed = default_mock_concretization("libceed")
+    assert libceed["libxsmm"].satisfies("@main")
+    assert libceed["libxsmm"].satisfies("platform=test")

--- a/var/spack/repos/builtin.mock/packages/libceed/package.py
+++ b/var/spack/repos/builtin.mock/packages/libceed/package.py
@@ -1,0 +1,18 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Libceed(Package):
+    """Package that has a dependency imposing conditional requirements on platforms"""
+
+    homepage = "https://github.com/CEED/libCEED"
+    url = "http://www.fake.com/libceed.tgz"
+
+    version("0.12.0", sha256="e491ccadebc5cdcd1fc08b5b4509a0aba4e2c096f53d7880062a66b82a0baf84")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("libxsmm")

--- a/var/spack/repos/builtin.mock/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin.mock/packages/libxsmm/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Libxsmm(Package):
+    """Package that imposes conditional requirements on platforms"""
+
+    homepage = "https://github.com/libxsmm/libxsmm"
+    url = "https://github.com/libxsmm/libxsmm/archive/1.17.tar.gz"
+    git = "https://github.com/libxsmm/libxsmm.git"
+
+    version("main", branch="main")
+    version("1.16.3", sha256="e491ccadebc5cdcd1fc08b5b4509a0aba4e2c096f53d7880062a66b82a0baf84")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    requires("platform=linux", "platform=test")
+    requires("platform=linux", when="@:1")


### PR DESCRIPTION
fixes #50167

If a requirement cannot be met on the current platform, and is conditional, the valid search space is restricted to the complement of the conditional.

Therefore, consider only unconditional requirement to discard possible dependencies.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
