### PR TITLE
package_base.py: correctly compute package name

### DIFF
--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -121,6 +121,7 @@ def _create(pkg: spack.package_base.PackageBase) -> "Builder":
                 new_cls_name,
                 bases,
                 {
+                    "__module__": package_cls.__module__,
                     "run_tests": property(lambda x: x.wrapped_package_object.run_tests),
                     "test_requires_compiler": property(
                         lambda x: x.wrapped_package_object.test_requires_compiler
@@ -129,7 +130,6 @@ def _create(pkg: spack.package_base.PackageBase) -> "Builder":
                     "tester": property(lambda x: x.wrapped_package_object.tester),
                 },
             )
-            new_cls.__module__ = package_cls.__module__
             self.__class__ = new_cls
             self.__dict__.update(wrapped_pkg_object.__dict__)
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -5,7 +5,7 @@ import argparse
 import errno
 import os
 import re
-import sys
+from collections import defaultdict
 from typing import List, Optional, Set
 
 import llnl.util.tty as tty
@@ -17,7 +17,6 @@ import spack.config
 import spack.cray_manifest as cray_manifest
 import spack.detection
 import spack.error
-import spack.package_base
 import spack.repo
 import spack.spec
 from spack.cmd.common import arguments
@@ -246,13 +245,16 @@ def _collect_and_consume_cray_manifest_files(
 
 
 def external_list(args):
-    # Trigger a read of all packages, might take a long time.
-    list(spack.repo.PATH.all_package_classes())
     # Print all the detectable packages
     tty.msg("Detectable packages per repository")
-    for namespace, pkgs in sorted(spack.package_base.detectable_packages.items()):
+    repo_to_packages = defaultdict(list)
+    for fullname in spack.repo.PATH.packages_with_tags("detectable", full=True):
+        repo, _, pkg = fullname.rpartition(".")
+        repo_to_packages[repo].append(pkg)
+
+    for namespace in sorted(repo_to_packages):
         print("Repository:", namespace)
-        colify.colify(pkgs, indent=4, output=sys.stdout)
+        colify.colify(repo_to_packages[namespace], indent=4)
 
 
 def external(parser, args):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -831,13 +831,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     def fullnames(cls):
         """Fullnames for this package and any packages from which it inherits."""
         fullnames = []
-        for cls in cls.__mro__:
-            namespace = getattr(cls, "namespace", None)
-            if namespace:
-                fullnames.append("%s.%s" % (namespace, cls.name))
-            if namespace == "builtin":
-                # builtin packages cannot inherit from other repos
+        for base in cls.__mro__:
+            if not base.__module__.startswith(f"{spack.repo.ROOT_PYTHON_NAMESPACE}."):
                 break
+            fullnames.append(base.fullname)
         return fullnames
 
     @classproperty

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -850,15 +850,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     @classproperty
     def name(cls):
-        """The name of this package.
-
-        The name of a package is the name of its Python module, without
-        the containing module names.
-        """
+        """The canonical name of this package"""
         if cls._name is None:
-            cls._name = cls.module.__name__
-            if "." in cls._name:
-                cls._name = cls._name[cls._name.rindex(".") + 1 :]
+            cls._name = spack.repo.pkg_name_from_module(cls.__module__)
         return cls._name
 
     @classproperty

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -132,11 +132,6 @@ class WindowsRPath:
             win_rpath.establish_link()
 
 
-#: Registers which are the detectable packages, by repo and package name
-#: Need a pass of package repositories to be filled.
-detectable_packages = collections.defaultdict(list)
-
-
 class DetectablePackageMeta(type):
     """Check if a package is detectable and add default implementations
     for the detection function.
@@ -241,9 +236,6 @@ class DetectablePackageMeta(type):
             @classmethod
             def determine_variants(cls, objs, version_str):
                 return ""
-
-            # Register the class as a detectable package
-            detectable_packages[cls.namespace].append(cls.name)
 
             # Attach function implementations to the detectable class
             default = False

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -83,6 +83,21 @@ def namespace_from_fullname(fullname):
     return namespace
 
 
+def pkg_name_from_module(module_name: str) -> str:
+    """Return the actual package name from a module name.
+
+    For instance ``spack.pkg.builtin.num3dtk`` has package name ``3dtk``
+    and ``spack.pkg.builtin.py_numpy`` has package name ``py-numpy``
+    """
+    if not module_name.startswith(f"{ROOT_PYTHON_NAMESPACE}."):
+        raise ValueError(f"Module '{module_name}' is not a Spack package module")
+    namespace, _, import_name = module_name[len(ROOT_PYTHON_NAMESPACE) + 1 :].rpartition(".")
+    name = PATH.get_repo(namespace).real_name(import_name)
+    if name is None:
+        raise ValueError(f"Module '{module_name}' does not correspond to a known package")
+    return name
+
+
 class SpackNamespaceLoader:
     def create_module(self, spec):
         return SpackNamespace(spec.name)

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -9,6 +9,7 @@ static DSL metadata for packages.
 """
 
 import os
+import pathlib
 import shutil
 
 import pytest
@@ -22,6 +23,7 @@ import spack.error
 import spack.install_test
 import spack.package
 import spack.package_base
+import spack.repo
 import spack.spec
 import spack.store
 from spack.build_systems.generic import Package
@@ -245,23 +247,31 @@ def test_package_exes_and_libs():
             libraries = ["libFindMe.a"]
 
 
-def test_package_url_and_urls():
-    class URLsPackage(spack.package.Package):
-        url = "https://www.example.com/url-package-1.0.tgz"
-        urls = ["https://www.example.com/archive"]
+def test_package_url_and_urls(tmp_path: pathlib.Path):
+    repo_path = tmp_path / "test-repo"
+    spack.repo.create_repo(str(repo_path))
+    package_py = repo_path / "packages" / "urls-package" / "package.py"
+    package_py.parent.mkdir(parents=True)
+    package_py.write_text(
+        """\
+from spack.package import *
 
+class UrlsPackage(Package):
+    url = "https://www.example.com/url-package-1.0.tgz"
+    urls = ["https://www.example.com/archive"]
+"""
+    )
+
+    with spack.repo.use_repositories(str(repo_path)) as repo:
+        pkg_cls = repo.get_pkg_class("urls-package")
+        s = spack.spec.Spec("urls-package")
+        with pytest.raises(ValueError, match="defines both"):
+            pkg_cls(s)
+
+
+def test_package_license(mock_packages):
     s = spack.spec.Spec("pkg-a")
-    with pytest.raises(ValueError, match="defines both"):
-        URLsPackage(s)
-
-
-def test_package_license():
-    class LicensedPackage(spack.package.Package):
-        extendees = None  # currently a required attribute for is_extension()
-        license_files = None
-
-    s = spack.spec.Spec("pkg-a")
-    pkg = LicensedPackage(s)
+    pkg = spack.repo.PATH.get_pkg_class("pkg-a")(s)
     assert pkg.global_license_file is None
 
     pkg.license_files = ["license.txt"]

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import importlib
 import os
 
 import pytest
@@ -333,3 +334,8 @@ def test_package_can_have_sparse_checkout_properties(mock_packages, mock_fetch, 
     assert isinstance(fetcher, spack.fetch_strategy.GitFetchStrategy)
     assert hasattr(fetcher, "git_sparse_paths")
     assert fetcher.git_sparse_paths == pkg_cls.git_sparse_paths
+
+
+def test_package_name_from_class_type(mock_packages):
+    module = importlib.import_module("spack.pkg.builtin.mock.num7zip")
+    assert module._7zip.name == "7zip"


### PR DESCRIPTION
The value returned by `PackageBase.name` is wrong depending on the module name by which package module was imported.

There are many ways to refer to the same package.py module:

* The standard naming is `spack.pkg.builtin.py-numpy`, but it would be invalid as an import statement...
* ... so the alternative is `spack.pkg.builtin.py_numpy`.

But `spack.pkg.builtin.py_numpy.PyNumpy.name` reports `py_numpy` instead of `py-numpy`.

The only way to make this work is to ask the relevant repository what the `real_name` is given some module "alias", since the package name is queried in various directives which run upon import.