### PR TITLE
Mirrors: check human readable path

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -487,6 +487,9 @@ class Stage(LockableStagingDir):
             for mirror in self.mirrors:
                 if mirror.fetch_url.startswith("oci://"):
                     continue
+                look_at = [self.mirror_layout.path]
+                if mirror.fetch_url.startswith("file://") and hasattr(self.mirror_layout, "alias"):
+                    look_at.append(self.mirror_layout.alias)
                 for rel_path in self.mirror_layout:
                     mirror_fetchers.append(
                         fs.from_url_scheme(

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -489,6 +489,8 @@ class Stage(LockableStagingDir):
                     continue
                 look_at = [self.mirror_layout.path]
                 if mirror.fetch_url.startswith("file://") and hasattr(self.mirror_layout, "alias"):
+                    # Local mirrors might be manually updated by a human,
+                    # so check the human-readable alias
                     look_at.append(self.mirror_layout.alias)
                 for rel_path in self.mirror_layout:
                     mirror_fetchers.append(

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -480,30 +480,33 @@ class Stage(LockableStagingDir):
             expand = True
             extension = None
 
-        # TODO: move mirror logic out of here and clean it up!
-        # TODO: Or @alalazo may have some ideas about how to use a
-        # TODO: CompositeFetchStrategy here.
+        mirror_fetchers = []
         if not self.default_fetcher_only and self.mirror_layout and self.mirrors:
             # Add URL strategies for all the mirrors with the digest
             # Insert fetchers in the order that the URLs are provided.
-            fetchers[:0] = (
-                fs.from_url_scheme(
-                    url_util.join(mirror.fetch_url, *self.mirror_layout.path.split(os.sep)),
-                    checksum=digest,
-                    expand=expand,
-                    extension=extension,
-                )
-                for mirror in self.mirrors
-                if not mirror.fetch_url.startswith("oci://")  # no support for mirrors yet
-            )
+            for mirror in self.mirrors:
+                if mirror.fetch_url.startswith("oci://"):
+                    continue
+                for rel_path in self.mirror_layout:
+                    mirror_fetchers.append(
+                        fs.from_url_scheme(
+                            url_util.join(mirror.fetch_url, *rel_path.split(os.sep)),
+                            checksum=digest,
+                            expand=expand,
+                            extension=extension,
+                        )
+                    )
 
         if not self.default_fetcher_only and self.mirror_layout and self.default_fetcher.cachable:
-            fetchers.insert(
+            mirror_fetchers.insert(
                 0,
                 spack.caches.FETCH_CACHE.fetcher(
                     self.mirror_layout.path, digest, expand=expand, extension=extension
                 ),
             )
+
+        # When mirrors are enabled they have precedence
+        fetchers[:0] = mirror_fetchers
 
         yield from fetchers
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -226,6 +226,17 @@ def test_cache_extra_sources(install_mockery, spec, sources, extras, expect):
     shutil.rmtree(os.path.dirname(source_path))
 
 
+def test_mirror_check_human_readable_format(mock_packages, mutable_config, tmpdir):
+    """Package base is ultimately responsible for """
+    import spack.config
+    s = spack.concretize.concretize_one("pkg-a@2.0")
+    spack.config.add(f'mirrors:{{"test": {tmpdir}}}')
+    human_readable_path = os.path.join(tmpdir, "pkg-a", "pkg-a-2.0.tar.gz")
+    x = list(s.package.stage[0]._generate_fetchers())
+    assert any(human_readable_path in getattr(f, "url", "")
+               for f in s.package.stage[0]._generate_fetchers())
+
+
 def test_cache_extra_sources_fails(install_mockery):
     s = spack.concretize.concretize_one("pkg-a")
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -227,14 +227,16 @@ def test_cache_extra_sources(install_mockery, spec, sources, extras, expect):
 
 
 def test_mirror_check_human_readable_format(mock_packages, mutable_config, tmpdir):
-    """Package base is ultimately responsible for """
+    """Package base is ultimately responsible for"""
     import spack.config
+
     s = spack.concretize.concretize_one("pkg-a@2.0")
     spack.config.add(f'mirrors:{{"test": {tmpdir}}}')
     human_readable_path = os.path.join(tmpdir, "pkg-a", "pkg-a-2.0.tar.gz")
-    x = list(s.package.stage[0]._generate_fetchers())
-    assert any(human_readable_path in getattr(f, "url", "")
-               for f in s.package.stage[0]._generate_fetchers())
+    assert any(
+        human_readable_path in getattr(f, "url", "")
+        for f in s.package.stage[0]._generate_fetchers()
+    )
 
 
 def test_cache_extra_sources_fails(install_mockery):

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -227,7 +227,10 @@ def test_cache_extra_sources(install_mockery, spec, sources, extras, expect):
 
 
 def test_mirror_check_human_readable_format(mock_packages, mutable_config, tmpdir):
-    """Package base is ultimately responsible for"""
+    """The package is responsible for attempting to download
+    a package version from a mirror path that a human could
+    reasonably construct, of the form
+    <package-name>/<package-name>-<package-version>.<archive-extension>"""
     import spack.config
 
     s = spack.concretize.concretize_one("pkg-a@2.0")


### PR DESCRIPTION
For a mirror at path `x` it was once possible for a person to put a file at `x/pkgname/pkgname-pkgversion.tar.gz` and spack would be able to find it. This was lost at some point, and this PR restores it. It only searches this path for local filesystem mirrors (to avoid would would almost always just be an extra failure on remote mirrors).