### PR TITLE
Cmake 4.0: package updates

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/callpath/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/callpath/package.py
@@ -24,7 +24,7 @@ class Callpath(CMakePackage):
     depends_on("dyninst")
     depends_on("adept-utils")
     depends_on("mpi")
-    depends_on("cmake@2.8:", type="build")
+    depends_on("cmake@2.8:3", when="build_system=cmake", type="build")
 
     def cmake_args(self):
         # TODO: offer options for the walker used.

--- a/var/spack/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cmake/package.py
@@ -31,11 +31,7 @@ class Cmake(Package):
 
     version("master", branch="master")
     version("4.0.0", sha256="ddc54ad63b87e153cf50be450a6580f1b17b4881de8941da963ff56991a4083b")
-    version(
-        "3.31.6",
-        sha256="653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0",
-        preferred=True,
-    )
+    version("3.31.6", sha256="653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0")
     version("3.31.5", sha256="66fb53a145648be56b46fa9e8ccade3a4d0dfc92e401e52ce76bdad1fea43d27")
     version("3.31.4", sha256="a6130bfe75f5ba5c73e672e34359f7c0a1931521957e8393a5c2922c8b0f7f25")
     version("3.31.3", sha256="fac45bc6d410b49b3113ab866074888d6c9e9dc81a141874446eb239ac38cb87")

--- a/var/spack/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cmake/package.py
@@ -30,7 +30,12 @@ class Cmake(Package):
     license("BSD-3-Clause")
 
     version("master", branch="master")
-    version("3.31.6", sha256="653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0")
+    version("4.0.0", sha256="ddc54ad63b87e153cf50be450a6580f1b17b4881de8941da963ff56991a4083b")
+    version(
+        "3.31.6",
+        sha256="653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0",
+        preferred=True,
+    )
     version("3.31.5", sha256="66fb53a145648be56b46fa9e8ccade3a4d0dfc92e401e52ce76bdad1fea43d27")
     version("3.31.4", sha256="a6130bfe75f5ba5c73e672e34359f7c0a1931521957e8393a5c2922c8b0f7f25")
     version("3.31.3", sha256="fac45bc6d410b49b3113ab866074888d6c9e9dc81a141874446eb239ac38cb87")
@@ -387,6 +392,10 @@ class Cmake(Package):
     @property
     def headers(self):
         return HeaderList([])
+
+    @property
+    def archive_files(self):
+        return [join_path(self.stage.source_path, "Bootstrap.cmk", "cmake_bootstrap.log")]
 
     def run_version_check(self, bin):
         """Runs and checks output of the installed binary."""

--- a/var/spack/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -91,7 +91,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("cmake@3.13.4:", type="build")
+    depends_on("cmake@3.13.4:3", when="build_system=cmake", type="build")
     depends_on("python", type="build")
     depends_on("z3", type="link")
     depends_on("zlib-api", type="link")

--- a/var/spack/repos/spack_repo/builtin/packages/magma/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/magma/package.py
@@ -56,6 +56,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("rocm-core", when="@2.8.0: +rocm")
     depends_on("python", when="@master", type="build")
 
+    depends_on("cmake@:3", when="build_system=cmake", type="build")
     conflicts("~cuda", when="~rocm", msg="magma: Either CUDA or HIP support must be enabled")
     conflicts("+rocm", when="+cuda", msg="magma: CUDA must be disabled to support HIP (ROCm)")
     conflicts("+rocm", when="@:2.5.4", msg="magma: HIP support starts in version 2.6.0")

--- a/var/spack/repos/spack_repo/builtin/packages/opencl_clhpp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/opencl_clhpp/package.py
@@ -29,8 +29,6 @@ class OpenclClhpp(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    root_cmakelists_dir = "include"
-
     @run_after("install")
     def post_install(self):
         if sys.platform == "darwin":

--- a/var/spack/repos/spack_repo/builtin/packages/pandorasdk/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pandorasdk/package.py
@@ -33,6 +33,7 @@ class Pandorasdk(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
+    depends_on("cmake@:3", when="build_system=cmake", type="build")
     depends_on("pandorapfa")
 
     def cmake_args(self):

--- a/var/spack/repos/spack_repo/builtin/packages/plasma/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/plasma/package.py
@@ -41,6 +41,7 @@ class Plasma(CMakePackage):
         "17.1",
         sha256="d4b89f7c3d240a69dfe986284a14471eec4830b9e352ae902ea8861f15573dee",
         url="https://github.com/icl-utk-edu/plasma/releases/download/17.01/plasma-17.01.tar.gz",
+        deprecated=True,
     )
 
     build_system(
@@ -48,6 +49,7 @@ class Plasma(CMakePackage):
         conditional("cmake", when="@18.9:"),
         default="cmake",
     )
+    depends_on("cmake@:3", when="build_system=cmake", type="build")
 
     variant("shared", default=True, description="Build shared library (disables static library)")
     variant("lua", default=False, description="Build Lua support for tuning tile sizes")

--- a/var/spack/repos/spack_repo/builtin/packages/visit/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/visit/package.py
@@ -127,8 +127,8 @@ class Visit(CMakePackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("cmake@3.14.7:", type="build")
     depends_on("cmake@3.24:", type="build", when="@3.4:")
+    depends_on("cmake@3.14.7:3", when="build_system=cmake", type="build")
     depends_on("mpi", when="+mpi")
     conflicts("mpi", when="~mpi")
 


### PR DESCRIPTION
> [!NOTE]  
> This PR is based on #49731 as as such the diff includes those changes for pipeline purposes, but those will be landing separately 

https://github.com/spack/spack/pull/49731 Adds initial CMake 4.0 support but does not actually prefer CMake 4.0.

This PR:

* Prefers 4.0
* Updates relevant packages to be compatible with the new CMake version (or update constraints as appropriate)
* Fixes generally broken packages