### PR TITLE
py-netcdf4: Add c dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -29,6 +29,7 @@ class PyNetcdf4(PythonPackage):
 
     depends_on("python", type=("build", "link", "run"))
     depends_on("python@3.8:", when="@1.7.1:", type=("build", "link", "run"))
+    depends_on("c", type="build")
     depends_on("py-cython@0.29:", when="@1.6.5:", type="build")
     depends_on("py-cython@0.19:", type="build")
     depends_on("py-setuptools@61:", when="@1.6.5:", type="build")


### PR DESCRIPTION
After https://github.com/spack/spack/pull/45189 _py-netcdf4_ was failing to build with cython complaining about missing mpi headers:
```
...
     246      /opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/gcc-13.3.0-xuubs
            5uokp4jiq2b5n7vv64auloqg2dt/bin/gcc -Wno-unused-result -Wsign-compa
            re -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -fPIC -DNPY_NO_DEPRECATED_AP
            I=NPY_1_7_API_VERSION -I/opt/pmapg_env/spack/opt/spack/linux-neover
            se_v2/netcdf-c-4.9.2-4hl3vsvbyhaugd4xrzjo3vlwkjjb6ghp/include -I/op
            t/pmapg_env/spack/opt/spack/linux-neoverse_v2/hdf5-1.14.6-j3z32t56w
            rn3oa3t46dkjtajy5tsm7gn/include -I/opt/pmapg_env/spack/opt/spack/li
            nux-neoverse_v2/py-numpy-1.26.4-53mel2qq2w7n62zv6a43ucb6qgrelvij/li
            b/python3.10/site-packages/numpy/core/include -I/opt/pmapg_env/spac
            k/opt/spack/linux-neoverse_v2/py-mpi4py-4.0.1-vola6vmyvpp7bz3kuxh5l
            ktf2yj5sk2s/lib/python3.10/site-packages/mpi4py/include -Iinclude -
            I/opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/python-venv-1.0-5
            l6hpb5vcuvxmvzkfu7hz4ubl4y2xcu5/include -I/opt/pmapg_env/spack/opt/
            spack/linux-neoverse_v2/python-3.10.16-zqadiu23bzlfcwi5nfapfcoiiepr
            uqzx/include/python3.10 -c src/netCDF4/_netCDF4.c -o build/temp.lin
            ux-aarch64-cpython-310/src/netCDF4/_netCDF4.o
     247      In file included from src/netCDF4/_netCDF4.c:1285:
  >> 248      /opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/hdf5-1.14.6-j3z3
            2t56wrn3oa3t46dkjtajy5tsm7gn/include/H5public.h:65:10: fatal error:
             mpi.h: No such file or directory
     249         65 | #include <mpi.h>
     250            |          ^~~~~~~
     251      compilation terminated.
...
```
After adding a dependency on `c`, cython uses the compiler wrapper again
```
...
  building 'netCDF4._netCDF4' extension
  creating build/temp.linux-aarch64-cpython-310/src/netCDF4
  /opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/compiler-wrapper-1.0-jdoyd74t4sisfjgl6kwfr2qskcvrhixs/libexec/spack/gcc/gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/netcdf-c-4.9.2-4hl3vsvbyhaugd4xrzjo3vlwkjjb6ghp/include -I/opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/hdf5-1.14.6-j3z32t56wrn3oa3t46dkjtajy5tsm7gn/include -I/opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/py-numpy-1.26.4-53mel2qq2w7n62zv6a43ucb6qgrelvij/lib/python3.10/site-packages/numpy/core/include -I/opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/py-mpi4py-4.0.1-vola6vmyvpp7bz3kuxh5lktf2yj5sk2s/lib/python3.10/site-packages/mpi4py/include -Iinclude -I/opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/python-venv-1.0-5l6hpb5vcuvxmvzkfu7hz4ubl4y2xcu5/include -I/opt/pmapg_env/spack/opt/spack/linux-neoverse_v2/python-3.10.16-zqadiu23bzlfcwi5nfapfcoiiepruqzx/include/python3.10 -c src/netCDF4/_netCDF4.c -o build/temp.linux-aarch64-cpython-310/src/netCDF4/_netCDF4.o
...
```
and everything builds alright.

Frankly I don't really know what I'm doing here. I tried compiling a simple `#include <mpi.h>` file using only the compiler wrapper without any include paths / additional args etc. and it compiled fine. Why does it find `mpi.h` and how does this fit with the instructions for the mpi compiler wrapper here https://spack.readthedocs.io/en/latest/packaging_guide.html#mpi-support-in-spack? Some hints would be appreciated for further fixes, otherwise I'm happy with a simple approval (assuming this is the right solution).