### PR TITLE
mold: add 2.38.1

### DIFF
--- a/var/spack/repos/builtin/packages/mold/package.py
+++ b/var/spack/repos/builtin/packages/mold/package.py
@@ -15,6 +15,7 @@ class Mold(CMakePackage):
 
     license("MIT")
 
+    version("2.38.1", sha256="14bfb259fd7d0a1fdce9b66f8ed2dd0b134d15019cb359699646afeee1f18118")
     version("2.37.1", sha256="b8e36086c95bd51e9829c9755c138f5c4daccdd63b6c35212b84229419f3ccbe")
     version("2.37.0", sha256="28372bbc2ce069aa0362ba84ad5d1b0f2c0bcf84e95a0f533ecf79cb3aff232c")
     version("2.36.0", sha256="3f57fe75535500ecce7a80fa1ba33675830b7d7deb1e5ee9a737e2bc43cdb1c7")


### PR DESCRIPTION
2.38.0 (https://github.com/rui314/mold/releases/tag/v2.38.0) was released just a day before 2.38.1 (https://github.com/rui314/mold/releases/tag/v2.38.1), so I'm including only the latter.