### PR TITLE
Revert "XorgPackage, glx: conflicts windows and darwin"

### DIFF
--- a/lib/spack/spack/build_systems/xorg.py
+++ b/lib/spack/spack/build_systems/xorg.py
@@ -6,16 +6,11 @@ from typing import Optional
 
 import spack.package_base
 import spack.util.url
-from spack.directives import conflicts
 
 
 class XorgPackage(spack.package_base.PackageBase):
     """Mixin that takes care of setting url and mirrors for x.org
     packages."""
-
-    # x.org packages are not supported on windows or darwin
-    conflicts("platform=windows")
-    conflicts("platform=darwin")
 
     #: Path of the package in a x.org mirror
     xorg_mirror_path: Optional[str] = None

--- a/var/spack/repos/builtin/packages/glx/package.py
+++ b/var/spack/repos/builtin/packages/glx/package.py
@@ -12,9 +12,6 @@ class Glx(BundlePackage):
 
     version("1.4")
 
-    conflicts("platform=windows")
-    conflicts("platform=darwin")
-
     depends_on("libglx")
     provides("gl@4.5")
 


### PR DESCRIPTION
Reverts spack/spack#50216. See discussion after merge there: too much breakage discovered on macOS for the HEP community.

It is possible that this is due to incorrectly marked dependencies (that shouldn't apply on macOS), but we need to fix those before breaking this for people.

@kwryankrattiger 