### PR TITLE
rust: improve external detection

### DIFF
--- a/var/spack/repos/builtin/packages/rust/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/rust/detection_test.yaml
@@ -1,0 +1,55 @@
+paths:
+- layout:
+  - executables:
+    - "bin/rustc"
+    script: |
+      echo "rustc 1.75.0 (82e1608df 2023-12-21) (built from a source tarball)"
+  - executables:
+    - "bin/cargo"
+    script: |
+      echo "cargo 1.75.0"
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'rust@1.75.0'
+    extra_attributes:
+      compilers:
+        rust: ".*/bin/rustc"
+      cargo: ".*/bin/cargo"
+# If rustc is missing, then we don't detect specs
+- layout:
+  - executables:
+    - "bin/cargo"
+    script: |
+      echo "cargo 1.75.0"
+  platforms: ["darwin", "linux"]
+  results: []
+# Check we can detect 2 different versions in the same folder
+- layout:
+  - executables:
+    - "bin/rustc"
+    script: |
+      echo "rustc 1.75.0 (82e1608df 2023-12-21) (built from a source tarball)"
+  - executables:
+    - "bin/rustc-1.80"
+    script: |
+      echo "rustc 1.80.1 (3f5fd8dd4 2024-08-06) (built from a source tarball)"
+  - executables:
+    - "bin/cargo"
+    script: |
+      echo "cargo 1.75.0"
+  - executables:
+    - "bin/cargo-1.80"
+    script: |
+      echo "cargo 1.80.1 (376290515 2024-07-16)"
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'rust@1.75.0'
+    extra_attributes:
+      compilers:
+        rust: ".*/bin/rustc"
+      cargo: ".*/bin/cargo"
+  - spec: 'rust@1.80.1'
+    extra_attributes:
+      compilers:
+        rust: ".*/bin/rustc-1.80"
+      cargo: ".*/bin/cargo-1.80"


### PR DESCRIPTION
fixes #50079

Modifications
- [x] Fixes wrong prefix detection
- [x] Can detect exes with suffixed with `-<version>`
- [x] Adds detection tests for `rust`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
