### PR TITLE
Executable: don't re-add existing arg(s)

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -35,7 +35,11 @@ class Executable:
         self.ignore_quotes = False
 
     def add_default_arg(self, *args: str) -> None:
-        """Add default argument(s) to the command."""
+        """Add default argument(s) to the command if not already present."""
+        for i in range(len(self.exe) - len(args) + 1):
+            if self.exe[i : i + len(args)] == args:
+                return
+
         self.exe.extend(args)
 
     def with_default_args(self, *args: str) -> "Executable":


### PR DESCRIPTION
@becker33 

This PR only adds default arguments to the executable if they aren't already in the list.

Why does this matter? It ensures the same (set of) arguments are only added to the command once. In doing so, it avoids the annoying failure that I and others consistently encounter with `test_adhoc_version_submodules` when running `spack unit-test --showlocals -v` on Mac _or_ Linux (see output below).

```
...
>               raise ProcessError("Command exited with status %d:" % proc.returncode, long_msg)
E               spack.util.executable.ProcessError: Command exited with status 1:
E                   '/usr/bin/git' '-c' 'protocol.file.allow=always' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' '-c' 'advice.detachedHead=false' 'fetch' '--tags'
...
```