### PR TITLE
seacas: bug fixes, new version

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -35,6 +35,9 @@ class Seacas(CMakePackage):
     # ###################### Versions ##########################
     version("master", branch="master")
     version(
+        "2025-04-29", sha256="2a3a1533a1fbff8e8b78814a3a45f6fadfb3f05b5d9d10a4f0452c7bb4d1aa2f"
+    )
+    version(
         "2025-04-14", sha256="7704fc27e4f0d283fd9272ea769dbeffd971315a982e265c0d7c99fc77186476"
     )
     version(


### PR DESCRIPTION
Fix to cpup for zone grid connectivity.  Previous versions broken for some meshes.

Database entity names (sets, blocks) are not lowercased by default.

Numbers code now partially handles tet meshes

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
