### PR TITLE
vtk: Reallow more recent proj versions for vtk@9.1

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/vtk/package.py
@@ -198,8 +198,8 @@ class Vtk(CMakePackage):
     depends_on("gl2ps", when="@8.1:")
     depends_on("gl2ps@1.4.1:", when="@9:")
     # "8.2.1a" uses an internal proj so this special cases 8.2.1a
-    depends_on("proj@4:7", when="@:8.2.0, 9:9.1")
-    depends_on("proj@8:", when="@9.2:")
+    depends_on("proj@4:7", when="@:8.2.0, 9.0")
+    depends_on("proj@8:", when="@9.1:")
     depends_on("cgns@4.1.1:+mpi", when="@9.1: +mpi")
     depends_on("cgns@4.1.1:~mpi", when="@9.1: ~mpi")
 


### PR DESCRIPTION
vtk 9.1 compiles fine with recent proj releases.
