### PR TITLE
paraview: fix qt bounds, fix hdf5 patch

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/paraview/package.py
@@ -238,6 +238,10 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("qt@:4", when="@:5.2.0+qt")
     depends_on("qt+sql", when="+qt")
+
+    # https://discourse.paraview.org/t/paraview-5-9-and-minimum-recommended-qt-version/5333
+    depends_on("qt@5.12:5 +sql", when="+qt @5.9:")
+
     with when("+qt"):
         depends_on("qt+opengl", when="@5.3.0:+opengl2")
         depends_on("qt~opengl", when="@5.3.0:~opengl2")
@@ -373,7 +377,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     patch("vtk-xdmf2-hdf51.13.2.patch", when="@5.8:5.11.0")
     # a patch with the same name is also applied to vtk
     # the two patches are the same but for the path to the files they patch
-    patch("vtk_alias_hdf5.patch", when="@5.9.0: platform=windows")
+    patch("vtk_alias_hdf5.patch", when="@5.9.0:")
 
     # Fix VTK to work with external freetype using CONFIG mode for find_package
     patch("FindFreetype.cmake.patch", when="@5.10.1:")

--- a/var/spack/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/paraview/package.py
@@ -236,15 +236,15 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
     conflicts("mpi", when="~mpi")
 
-    depends_on("qt@:4", when="@:5.2.0+qt")
+    depends_on("qt@:4", when="@:5.2.0 +qt")
     depends_on("qt+sql", when="+qt")
 
     # https://discourse.paraview.org/t/paraview-5-9-and-minimum-recommended-qt-version/5333
-    depends_on("qt@5.12:5 +sql", when="+qt @5.9:")
+    depends_on("qt@5.12:5 +sql", when="@5.9:5.13 +qt")
 
     with when("+qt"):
-        depends_on("qt+opengl", when="@5.3.0:+opengl2")
-        depends_on("qt~opengl", when="@5.3.0:~opengl2")
+        depends_on("qt+opengl", when="@5.3.0: +opengl2")
+        depends_on("qt~opengl", when="@5.3.0: ~opengl2")
 
     depends_on("gl@3.2:", when="+opengl2")
     depends_on("gl@1.2:", when="~opengl2")


### PR DESCRIPTION
- The patch developed in https://github.com/spack/spack/pull/43087 needs to be applied to non-Windows cases as well. Same as done in VTK. 
- The lower limit of `qt@5.12` is not enforced, allowing Paraview 5.x to concretize with `qt@3` which isn't supported and fails to compile.

Although not needed for this PR per se, I also needed to disable compilation of examples in `libtheora` (https://github.com/spack/spack/pull/50242) to get Paraview to fully compile