### PR TITLE
blis: remove unnecessary python runtime dependency

### DIFF
--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -17,7 +17,7 @@ class BlisBase(MakefilePackage):
 
     maintainers("jeffhammond")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
+    depends_on("python@2.7:2.8,3.4:", type="build")
 
     variant(
         "threads",


### PR DESCRIPTION
AFAICT, BLIS only needs python during build, to run the `flatten-headers.py` script.

@jeffhammond 