### PR TITLE
HEP: add minimal darwin stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -703,25 +703,48 @@ ml-darwin-aarch64-mps-build:
 ########################################
 # High Energy Physics (HEP) - Linux x86_64 (CPU)
 ########################################
-.hep:
+.hep-x86_64_v3:
   extends: [ ".linux_x86_64_v3" ]
   variables:
-    SPACK_CI_STACK_NAME: hep
+    SPACK_CI_STACK_NAME: hep-x86_64_v3
 
-hep-generate:
-  extends: [ ".hep", ".generate-x86_64"]
+hep-x86_64_v3-generate:
+  extends: [ ".hep-x86_64_v3", ".generate-x86_64"]
   image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01
 
-hep-build:
-  extends: [ ".hep", ".build" ]
+hep-x86_64_v3-build:
+  extends: [ ".hep-x86_64_v3", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: hep-generate
+        job: hep-x86_64_v3-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: hep-generate
+      job: hep-x86_64_v3-generate
+
+########################################
+# High Energy Physics (HEP) - Linux x86_64 (CPU)
+########################################
+.hep-darwin:
+  extends: [ ".darwin_aarch64" ]
+  variables:
+    SPACK_CI_STACK_NAME: hep-darwin
+
+hep-darwin-generate:
+  tags: [ "macos-sequoia", "apple-clang-16", "aarch64-macos" ]
+  extends: [ ".hep-darwin", ".generate-x86_64"]
+
+hep-darwin-build:
+  extends: [ ".hep-darwin", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: hep-darwin-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: hep-darwin-generate
 
 ########################################
 # AWS ParallelCluster

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep-darwin/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep-darwin/spack.yaml
@@ -1,0 +1,34 @@
+spack:
+  view: false
+
+  concretizer:
+    reuse: false
+    unify: when_possible
+    static_analysis: true
+
+  packages:
+    all:
+      require:
+      - "%gcc"
+      - target=aarch64
+      providers:
+        blas: [openblas]
+        mpi: [mpich]
+        tbb: [intel-tbb]
+      variants: +mpi
+    root:
+      require: +arrow ~daos +davix +dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
+      # note: root cxxstd=20 not concretizable within sherpa
+
+  specs:
+  # CPU
+  - root ~cuda
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        variables:
+          CI_GPG_KEY_ROOT: /etc/protected-runner
+
+  cdash:
+    build-group: HEP darwin

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep-darwin/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep-darwin/spack.yaml
@@ -9,13 +9,7 @@ spack:
   packages:
     all:
       require:
-      - "%gcc"
       - target=aarch64
-      providers:
-        blas: [openblas]
-        mpi: [mpich]
-        tbb: [intel-tbb]
-      variants: +mpi
     root:
       require: +arrow ~daos +davix +dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
       # note: root cxxstd=20 not concretizable within sherpa

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep-darwin/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep-darwin/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
       - target=aarch64
     root:
-      require: +arrow ~daos +davix ~dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
+      require: +arrow ~daos +davix ~dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql ~opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
       # note: root cxxstd=20 not concretizable within sherpa
 
   specs:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep-darwin/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep-darwin/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
       - target=aarch64
     root:
-      require: +arrow ~daos +davix +dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
+      require: +arrow ~daos +davix ~dcache +emacs +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
       # note: root cxxstd=20 not concretizable within sherpa
 
   specs:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep-x86_64_v3/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep-x86_64_v3/spack.yaml
@@ -143,4 +143,4 @@ spack:
         image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01
 
   cdash:
-    build-group: HEP
+    build-group: HEP x86_64_v3


### PR DESCRIPTION
This PR adds a minimal HEP stack for darwin, with only ROOT as root (pun intended). The use case is making sure we don't accidentally break macOS systems, which many users have as development machines.