### PR TITLE
Add C or C++ dependency for many packages

### DIFF
--- a/var/spack/repos/builtin/packages/3dtk/package.py
+++ b/var/spack/repos/builtin/packages/3dtk/package.py
@@ -21,6 +21,9 @@ class _3dtk(CMakePackage):
     version("trunk", svn="https://svn.code.sf.net/p/slam6d/code/trunk", preferred=True)
     version("1.2", svn="https://svn.code.sf.net/p/slam6d/code/branches/3dtk-release-1.2")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     variant("cgal", default=False, description="Compile with CGAL support")
     variant("opengl", default=True, description="Compile with OpenGL support")
     variant("opencv", default=True, description="Compile with OpenCV support")

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -46,6 +46,9 @@ class Actsvg(CMakePackage):
         "web", default=True, when="@0.4.36:", description="Build the webpage builder interface"
     )
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("boost +program_options", type="test")
     depends_on("boost +program_options", when="+examples")
     depends_on("googletest", when="+examples")

--- a/var/spack/repos/builtin/packages/ambertools/package.py
+++ b/var/spack/repos/builtin/packages/ambertools/package.py
@@ -20,6 +20,9 @@ class Ambertools(CMakePackage):
 
     version("22jlmrcc", sha256="1571d4e0f7d45b2a71dce5999fa875aea8c90ee219eb218d7916bf30ea229121")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("flex", type="build")
     depends_on("bison", type="build")
     depends_on("tcsh", type="build")

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -30,6 +30,9 @@ class Bcl2fastq2(Package):
 
     conflicts("platform=darwin", msg="malloc.h/etc requirements break build on macs")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("boost@1.54.0:1.55")
 
     # TODO: replace this with an explicit list of components of Boost,

--- a/var/spack/repos/builtin/packages/express/package.py
+++ b/var/spack/repos/builtin/packages/express/package.py
@@ -30,6 +30,8 @@ class Express(CMakePackage):
     )
     depends_on("bamtools")
     depends_on("zlib-api")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # patch from the debian package repo:
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811859

--- a/var/spack/repos/builtin/packages/gplates/package.py
+++ b/var/spack/repos/builtin/packages/gplates/package.py
@@ -21,6 +21,8 @@ class Gplates(CMakePackage):
 
     version("2.3.0", sha256="7d4be9d524d1fcbb6a81de29bd1d4b13133082db23f0808965c5efe30e9538ab")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("cmake@3.5:", when="@2.3:", type="build")
     depends_on("cmake@2.8.8:", when="@2.1", type="build")
     depends_on("cmake@2.6.2:", when="@2.0", type="build")

--- a/var/spack/repos/builtin/packages/hermes-shm/package.py
+++ b/var/spack/repos/builtin/packages/hermes-shm/package.py
@@ -41,6 +41,8 @@ class HermesShm(CMakePackage):
     depends_on("yaml-cpp")
     depends_on("doxygen@1.9.3:", type="build")
     depends_on("libelf")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # Machine variants
     variant("ares", default=False, description="Build in ares")

--- a/var/spack/repos/builtin/packages/log4cxx/package.py
+++ b/var/spack/repos/builtin/packages/log4cxx/package.py
@@ -50,6 +50,8 @@ class Log4cxx(CMakePackage):
     depends_on("expat")
     depends_on("zlib-api")
     depends_on("zip")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/nix/package.py
+++ b/var/spack/repos/builtin/packages/nix/package.py
@@ -72,6 +72,8 @@ class Nix(AutotoolsPackage):
     depends_on("openssl")
     depends_on("sqlite@3.6.19:")
     depends_on("xz")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # gcc 4.9+ and higher supported with c++14
     conflicts("%gcc@:4.8")

--- a/var/spack/repos/builtin/packages/paradiseo/package.py
+++ b/var/spack/repos/builtin/packages/paradiseo/package.py
@@ -36,6 +36,8 @@ class Paradiseo(CMakePackage):
 
     # Required dependencies
     depends_on("cmake@2.8:", type="build")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # Optional dependencies
     depends_on("mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/purify/package.py
+++ b/var/spack/repos/builtin/packages/purify/package.py
@@ -59,6 +59,8 @@ class Purify(CMakePackage):
     depends_on("py-onnxruntime@1.17.1:", when="+onnxrt")
     depends_on("hdf5+cxx", when="+hdf5")
     depends_on("highfive", when="+hdf5")
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/py-espresso/package.py
+++ b/var/spack/repos/builtin/packages/py-espresso/package.py
@@ -48,6 +48,9 @@ class PyEspresso(CMakePackage):
 
     variant("hdf5", default=True, description="Enable HDF5 backend")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("cmake@3.0:", type="build")
     depends_on("mpi")
     depends_on("boost+serialization+filesystem+system+python+mpi")

--- a/var/spack/repos/builtin/packages/r-rlas/package.py
+++ b/var/spack/repos/builtin/packages/r-rlas/package.py
@@ -24,3 +24,4 @@ class RRlas(RPackage):
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("r-data-table", type=("build", "run"))
     depends_on("boost@:1.84+filesystem+program_options+numpy+python+regex+serialization+thread")
+    depends_on("cxx", type="build")

--- a/var/spack/repos/builtin/packages/tecio/package.py
+++ b/var/spack/repos/builtin/packages/tecio/package.py
@@ -27,6 +27,9 @@ class Tecio(CMakePackage):
     depends_on("boost@1.69.0:+system", type="build")
     depends_on("mpi", when="+mpi")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     @property
     def root_cmakelists_dir(self):
         if self.spec.satisfies("+mpi"):


### PR DESCRIPTION
This resolves #49959 'cannot depend on gcc' error for these packages.

I tried to only add a dependency on 'c' where I was somewhat
confident, but it still might be overconstrained for some
packages.