### PR TITLE
libiconv: add version 1.18

### DIFF
--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -14,6 +14,7 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("1.18", sha256="3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8")
     version("1.17", sha256="8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313")
     version("1.16", sha256="e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04")
     version("1.15", sha256="ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Update libiconv to make gcc-15.1 happy.
There are other packages like berkeley-db-18.1.40 and ncurses-6.5 fails at gcc-15.1 and have no new release available.