### PR TITLE
Package "global": update version and download URL

### DIFF
--- a/var/spack/repos/builtin/packages/global/package.py
+++ b/var/spack/repos/builtin/packages/global/package.py
@@ -11,12 +11,13 @@ class Global(Package):
     """The Gnu Global tagging system"""
 
     homepage = "https://www.gnu.org/software/global"
-    url = "http://tamacom.com/global/global-6.5.tar.gz"
+    url = "https://ftp.gnu.org/pub/gnu/global/global-6.5.tar.gz"
 
     maintainers("gaber")
 
     license("LGPL-3.0-only")
 
+    version("6.6.14", sha256="f6e7fd0b68aed292e85bb686616baf6551d5c9424adcddca11d808ba318cb320")
     version("6.6.7", sha256="69a0f77f53827c5568176c1d382166df361e74263a047f0b3058aa2f2ad58a3c")
     version("6.6.6", sha256="758078afff98d4c051c58785c7ada3ed1977fabb77f8897ff657b71cc62d4d5d")
     version("6.6.4", sha256="987e8cb956c53f8ebe4453b778a8fde2037b982613aba7f3e8e74bcd05312594")


### PR DESCRIPTION
The current download URL for the global package hasn't been updated since 2021 while there are new versions available on the (more authoritative) gnu.org ftp site. The new version is needed in order to be compatible with gcc version 14.

