### PR TITLE
Modules: Allow using config variables in template path

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -837,7 +837,7 @@ class BaseModuleFileWriter:
         # Filter out false-ish values
         choices = list(filter(lambda x: bool(x), choices))
         # ... and return the first match
-        return choices.pop(0)
+        return spack.util.path.canonicalize_path(choices.pop(0))
 
     def write(self, overwrite=False):
         """Writes the module file.


### PR DESCRIPTION
This allows using config variables like $spack when defining a template path in the modules configuration file.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
