### PR TITLE
conquest: Fix usage of fftw-api

### DIFF
--- a/var/spack/repos/builtin/packages/conquest/package.py
+++ b/var/spack/repos/builtin/packages/conquest/package.py
@@ -75,7 +75,7 @@ class Conquest(MakefilePackage):
 
         lapack_ld = self.spec["lapack"].libs.ld_flags
         blas_ld = self.spec["blas"].libs.ld_flags
-        fftw_ld = self.spec["fftw"].libs.ld_flags
+        fftw_ld = self.spec["fftw-api"].libs.ld_flags
         libxc_ld = self.spec["libxc"].libs.ld_flags
 
         # Starting from 1.3 there's automated logic in the Makefile that picks


### PR DESCRIPTION
Allows compiling with another fftw-api provider than FFTW.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
