### PR TITLE
Conquest: Explicitly configure the MPI compilers.

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/conquest/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/conquest/package.py
@@ -87,6 +87,8 @@ class Conquest(MakefilePackage):
         else:
             defs_file = FileFilter("./src/system.make")
 
+        defs_file.filter(".*FC=.*", f"FC={spec['mpi'].mpifc}")
+        defs_file.filter(".*F77=.*", f"F77={spec['mpi'].mpif77}")
         defs_file.filter(".*COMPFLAGS=.*", f"COMPFLAGS= {fflags}")
         defs_file.filter(".*LINKFLAGS=.*", f"LINKFLAGS= {ldflags}")
         defs_file.filter(".*BLAS=.*", f"BLAS= {lapack_ld} {blas_ld}")


### PR DESCRIPTION
We might not always want to use the default mpif90/mpif77 wrappers.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
