### PR TITLE
hpx: disable HPX_WITH_PKGCONFIG

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -256,7 +256,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
             self.define("HPX_WITH_BOOST_ALL_DYNAMIC_LINK", True),
             self.define("BUILD_SHARED_LIBS", True),
             self.define("HPX_DATASTRUCTURES_WITH_ADAPT_STD_TUPLE", False),
-            self.define("HPX_WITH_PKGCONFIG", False)
+            self.define("HPX_WITH_PKGCONFIG", False),
         ]
 
         # Enable unity builds when available

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -256,6 +256,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
             self.define("HPX_WITH_BOOST_ALL_DYNAMIC_LINK", True),
             self.define("BUILD_SHARED_LIBS", True),
             self.define("HPX_DATASTRUCTURES_WITH_ADAPT_STD_TUPLE", False),
+            self.define("HPX_WITH_PKGCONFIG", False)
         ]
 
         # Enable unity builds when available

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -97,7 +97,6 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")
 
     depends_on("python", type=("build", "test", "run"))
-    depends_on("pkgconfig", type="build")
     depends_on("git", type="build")
     depends_on("cmake", type="build")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Since we only support cmake builds in spack, we should set HPX_WITH_PKGCONFIG to false. PKGconf results in various errors for some GPU types or on Arm. 