### PR TITLE
hipsycl: add missing c dependency

### DIFF
--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -38,6 +38,7 @@ class Hipsycl(CMakePackage, ROCmPackage):
     variant("cuda", default=False, description="Enable CUDA backend for SYCL kernels")
     variant("rocm", default=False, description="Enable ROCM backend for SYCL kernels")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.5:", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

add `depends_on("c", type="build")` as some linker args are not set otherwise.

Without this change on a fresh ubuntu-24 docker i get the following:
```
3 errors found in build log:
     8     -- The C compiler identification is unknown
     9     -- The CXX compiler identification is GNU 13.2.0
     10    -- Detecting C compiler ABI info
     11    -- Detecting C compiler ABI info - failed
     12    -- Check for working C compiler: /opt/spack/opt/spack/linux-skylake/compiler-wrapper-1.0-jygwswpord52lcaxv3eva7
           4e25vx6esu/libexec/spack/cc
     13    -- Check for working C compiler: /opt/spack/opt/spack/linux-skylake/compiler-wrapper-1.0-jygwswpord52lcaxv3eva7
           4e25vx6esu/libexec/spack/cc - broken
  >> 14    CMake Error at /opt/spack/opt/spack/linux-skylake/cmake-3.31.6-aq4sww2g4p7yflc4elxtxzpsmk2ppexg/share/cmake-3.3
           1/Modules/CMakeTestCCompiler.cmake:67 (message):
     15      The C compiler
     16    
     17        "/opt/spack/opt/spack/linux-skylake/compiler-wrapper-1.0-jygwswpord52lcaxv3eva74e25vx6esu/libexec/spack/cc"
     18    
     19      is not able to compile a simple test program.
     20    

     ...

     25        Run Build Command(s): /opt/spack/opt/spack/linux-skylake/cmake-3.31.6-aq4sww2g4p7yflc4elxtxzpsmk2ppexg/bin/
           cmake -E env VERBOSE=1 /opt/spack/opt/spack/linux-skylake/gmake-4.4.1-oqfe5byyi73mdktymdbasjhmsa6lmtxu/bin/gmak
           e -f Makefile cmTC_595a0/fast
     26        /opt/spack/opt/spack/linux-skylake/gmake-4.4.1-oqfe5byyi73mdktymdbasjhmsa6lmtxu/bin/gmake  -f CMakeFiles/cm
           TC_595a0.dir/build.make CMakeFiles/cmTC_595a0.dir/build
     27        gmake[1]: Entering directory '/tmp/root/spack-stage/spack-stage-hipsycl-24.10.0-nofr3smvblojbrhyaypy65c2ksb
           nvac7/spack-build-nofr3sm/CMakeFiles/CMakeScratch/TryCompile-tkAJ2a'
     28        Building C object CMakeFiles/cmTC_595a0.dir/testCCompiler.c.o
     29        /opt/spack/opt/spack/linux-skylake/compiler-wrapper-1.0-jygwswpord52lcaxv3eva74e25vx6esu/libexec/spack/cc  
             -o CMakeFiles/cmTC_595a0.dir/testCCompiler.c.o -c /tmp/root/spack-stage/spack-stage-hipsycl-24.10.0-nofr3smvb
           lojbrhyaypy65c2ksbnvac7/spack-build-nofr3sm/CMakeFiles/CMakeScratch/TryCompile-tkAJ2a/testCCompiler.c
     30        /opt/spack/opt/spack/linux-skylake/compiler-wrapper-1.0-jygwswpord52lcaxv3eva74e25vx6esu/libexec/spack/cc: 
           1: eval: SPACK_CC_LINKER_ARG: ERROR: LINKER ARG WAS NOT SET, MAYBE THE PACKAGE DOES NOT DEPEND ON CC?
  >> 31    gmake[1]: *** [CMakeFiles/cmTC_595a0.dir/build.make:81: CMakeFiles/cmTC_595a0.dir/testCCompiler.c.o] Error 2
     32        gmake[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-hipsycl-24.10.0-nofr3smvblojbrhyaypy65c2ksbn
           vac7/spack-build-nofr3sm/CMakeFiles/CMakeScratch/TryCompile-tkAJ2a'
  >> 33        gmake: *** [Makefile:134: cmTC_595a0/fast] Error 2
     34    
     35    
     36    
     37    
     38    
     39      CMake will not be able to correctly generate this project.
```