### PR TITLE
ci: allow skipping verify-checksums with pr description/commit message

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -65,7 +65,11 @@ jobs:
       python_version: '3.13'
 
   verify-checksums:
-    if: ${{ inputs.with_packages == 'true' }}
+    # do not run if the commit message or PR description contains [skip-verify-checksums]
+    if: >-
+      ${{ inputs.with_packages == 'true' &&
+      !contains(github.event.pull_request.body, '[skip-verify-checksums]') &&
+      !contains(github.event.head_commit.message, '[skip-verify-checksums]') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29


### PR DESCRIPTION
Sometimes I want to opt out of verify-checksums.

This can now be done with a PR description/commit message `[skip-verify-checksums]`.