### PR TITLE
acts dependencies: new versions as of 2025/05/05

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/detray/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/detray/package.py
@@ -19,6 +19,7 @@ class Detray(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.95.0", sha256="86cc981eb0105143b971acea3544b9a668326e1027f317d77cf76918f766e7c4")
     version("0.94.0", sha256="a04e8193757846df50d0fbec858744dd66629a98be8ffc6faa04c2ab51770492")
     version("0.93.0", sha256="7d56771d213649de836905efbb21b5be59cc966b00417b0b1fa85bfe12ac92da")
     version("0.92.0", sha256="512669c1ea51936b0fe871fb5a33450b54161e811e48cc51445dc83fe3338c42")

--- a/var/spack/repos/spack_repo/builtin/packages/detray/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/detray/package.py
@@ -78,6 +78,7 @@ class Detray(CMakePackage):
     variant("vc", default=True, description="Enable the Vc math plugin")
 
     depends_on("cmake@3.11:", type="build")
+    depends_on("cmake@3.21:", type="build", when="@0.95:")
     depends_on("vecmem@1.6.0:")
     depends_on("vecmem@1.8.0:", when="@0.76:")
     depends_on("covfie@0.10.0:")

--- a/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
@@ -16,6 +16,7 @@ class Vecmem(CMakePackage, CudaPackage):
 
     license("MPL-2.0-no-copyleft-exception")
 
+    version("1.16.0", sha256="04da7077381e12c2b9bf869e1357105683596ed9105e3acff3c6d9214be04fbd")
     version("1.15.0", sha256="53e03599efd5a22284b62e10338b69345d8188182a12fefe228005069d1ddd74")
     version("1.14.0", sha256="3fac19e2766e5f997712b0799bd820f65c17ea9cddcb9e765cbdf214f41c4783")
     version("1.13.0", sha256="fc21cea04140e1210c83a32579b0a7194601889b6c895404214ac55ce547342b")


### PR DESCRIPTION
This commit adds v0.95.0 of detray and v1.16.0 of vecmem.