### PR TITLE
RepoSplit/tests: switch test_config_audits to mock packages

### DIFF
--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -93,6 +93,7 @@ _double_compiler_definition = [
 ]
 
 
+# TODO/RepoSplit: Should this not rely on mock packages post split?
 @pytest.mark.parametrize(
     "config_section,data,failing_check",
     [
@@ -113,7 +114,7 @@ _double_compiler_definition = [
         ),
     ],
 )
-def test_config_audits(config_section, data, failing_check):
+def test_config_audits(config_section, data, failing_check, mock_packages):
     with spack.config.override(config_section, data):
         reports = spack.audit.run_group("configs")
         assert any((check == failing_check) and errors for check, errors in reports)

--- a/var/spack/repos/builtin.mock/packages/openssl/package.py
+++ b/var/spack/repos/builtin.mock/packages/openssl/package.py
@@ -1,0 +1,9 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Openssl(Package):
+    version("3.4.0")


### PR DESCRIPTION
Source: #48930, commit https://github.com/spack/spack/pull/48930/commits/268c51478e8e39d8a39e8a8daea2f84b6d7f2e43

Switch `test_config_audits` to rely on mock packages and add a TODO comment about whether `test_package_audits` post-split.