### PR TITLE
RepoSplit/tests: info/list/style tests: use mock_packages fixture

### DIFF
--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -9,6 +9,8 @@ import pytest
 import spack.cmd.info
 from spack.main import SpackCommand
 
+pytestmark = [pytest.mark.usefixtures("mock_packages")]
+
 info = SpackCommand("info")
 
 
@@ -31,15 +33,12 @@ def print_buffer(monkeypatch):
     return buffer
 
 
-@pytest.mark.parametrize(
-    "pkg", ["openmpi", "trilinos", "boost", "python", "dealii", "xsdk", "gasnet", "warpx"]
-)
 @pytest.mark.parametrize("extra_args", [[], ["--variants-by-name"]])
-def test_it_just_runs(pkg, extra_args):
-    info(pkg, *extra_args)
+def test_it_just_runs(extra_args):
+    info("vtk-m", *extra_args)
 
 
-def test_info_noversion(mock_packages, print_buffer):
+def test_info_noversion(print_buffer):
     """Check that a mock package with no versions outputs None."""
     info("noversion")
 
@@ -58,7 +57,7 @@ def test_info_noversion(mock_packages, print_buffer):
 @pytest.mark.parametrize(
     "pkg_query,expected", [("zlib", "False"), ("find-externals1", "True (version)")]
 )
-def test_is_externally_detectable(mock_packages, pkg_query, expected, parser, print_buffer):
+def test_is_externally_detectable(pkg_query, expected, parser, print_buffer):
     args = parser.parse_args(["--detectable", pkg_query])
     spack.cmd.info.info(parser, args)
 
@@ -70,13 +69,7 @@ def test_is_externally_detectable(mock_packages, pkg_query, expected, parser, pr
 
 
 @pytest.mark.parametrize(
-    "pkg_query",
-    [
-        "hdf5",
-        "cloverleaf3d",
-        "trilinos",
-        "gcc",  # This should ensure --test's c_names processing loop covered
-    ],
+    "pkg_query", ["vtk-m", "gcc"]  # This should ensure --test's c_names processing loop covered
 )
 @pytest.mark.parametrize("extra_args", [[], ["--variants-by-name"]])
 def test_info_fields(pkg_query, extra_args, parser, print_buffer):

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -6,16 +6,20 @@ import os
 import sys
 from textwrap import dedent
 
+import pytest
+
 import spack.paths
 import spack.repo
 from spack.main import SpackCommand
+
+pytestmark = [pytest.mark.usefixtures("mock_packages")]
 
 list = SpackCommand("list")
 
 
 def test_list():
     output = list()
-    assert "cloverleaf3d" in output
+    assert "bzip2" in output
     assert "hdf5" in output
 
 
@@ -41,7 +45,7 @@ def test_list_cli_output_format(mock_tty_stdout):
     assert out == out_str
 
 
-def test_list_filter(mock_packages):
+def test_list_filter():
     output = list("py-*")
     assert "py-extension1" in output
     assert "py-extension2" in output
@@ -57,18 +61,18 @@ def test_list_filter(mock_packages):
     assert "mpich" not in output
 
 
-def test_list_search_description(mock_packages):
+def test_list_search_description():
     output = list("--search-description", "one build dependency")
     assert "depb" in output
 
 
-def test_list_format_name_only(mock_packages):
+def test_list_format_name_only():
     output = list("--format", "name_only")
     assert "zmpi" in output
     assert "hdf5" in output
 
 
-def test_list_format_version_json(mock_packages):
+def test_list_format_version_json():
     output = list("--format", "version_json")
     assert '{"name": "zmpi",' in output
     assert '{"name": "dyninst",' in output
@@ -77,7 +81,7 @@ def test_list_format_version_json(mock_packages):
     json.loads(output)
 
 
-def test_list_format_html(mock_packages):
+def test_list_format_html():
     output = list("--format", "html")
     assert '<div class="section" id="zmpi">' in output
     assert "<h1>zmpi" in output
@@ -86,7 +90,7 @@ def test_list_format_html(mock_packages):
     assert "<h1>hdf5" in output
 
 
-def test_list_update(tmpdir, mock_packages):
+def test_list_update(tmpdir):
     update_file = tmpdir.join("output")
 
     # not yet created when list is run
@@ -113,7 +117,7 @@ def test_list_update(tmpdir, mock_packages):
         assert f.read() == "empty\n"
 
 
-def test_list_tags(mock_packages):
+def test_list_tags():
     output = list("--tag", "tag1")
     assert "mpich" in output
     assert "mpich2" in output
@@ -127,7 +131,7 @@ def test_list_tags(mock_packages):
     assert "mpich2" in output
 
 
-def test_list_count(mock_packages):
+def test_list_count():
     output = list("--count")
     assert int(output.strip()) == len(spack.repo.all_package_names())
 
@@ -137,7 +141,6 @@ def test_list_count(mock_packages):
     )
 
 
-# def test_list_repos(mock_packages, builder_test_repository):
 def test_list_repos():
     with spack.repo.use_repositories(
         os.path.join(spack.paths.repos_path, "builtin.mock"),

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -116,7 +116,7 @@ def test_changed_no_base(git, tmpdir, capfd):
         assert "This repository does not have a 'foobar'" in err
 
 
-def test_changed_files_all_files():
+def test_changed_files_all_files(mock_packages):
     # it's hard to guarantee "all files", so do some sanity checks.
     files = set(
         [


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, commit https://github.com/spack/spack/pull/48930/commits/0f79e3f76d31d2acb030934a27892793c879cd7a

See https://github.com/spack/spack/pull/48930#discussion_r2072311497

Switch the unit tests for the three commands -- `info`, `list`, and `style` -- to use mock packages.