### PR TITLE
RepoSplit/tests: switch test/cmd/config.py to mock packages

### DIFF
--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -20,6 +20,8 @@ import spack.util.spack_yaml as syaml
 config = spack.main.SpackCommand("config")
 env = spack.main.SpackCommand("env")
 
+pytestmark = pytest.mark.usefixtures("mock_packages")
+
 
 def _create_config(scope=None, data={}, section="packages"):
     scope = scope or spack.config.default_modify_scope()


### PR DESCRIPTION
Replaces commit c90ddd03f5c08a6a55d3fa81b53f76300b262665 change in https://github.com/spack/spack/pull/48930.

Switch `test/cmd/config.py` to ensure all tests use mock packages.