### PR TITLE
RepoSplit/tests: switch test_concretization_cache_roundtrip to mock_packages

### DIFF
--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3105,7 +3105,9 @@ def test_spec_unification(unify, mutable_config, mock_packages):
         _ = spack.cmd.parse_specs([a_restricted, b], concretize=True)
 
 
-def test_concretization_cache_roundtrip(use_concretization_cache, monkeypatch, mutable_config):
+def test_concretization_cache_roundtrip(
+    mock_packages, use_concretization_cache, monkeypatch, mutable_config
+):
     """Tests whether we can write the results of a clingo solve to the cache
     and load the same spec request from the cache to produce identical specs"""
     # Force determinism:


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, commit 23d564d68e4bad935ffc6759521f212ec780198a

See https://github.com/spack/spack/pull/48930#discussion_r2072312682

Ensure the unit test uses mock packages.