### PR TITLE
RepoSplit/tests: switch test/cmd/versions to mock packages

### DIFF
--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -10,6 +10,9 @@ from spack.version import Version
 versions = SpackCommand("versions")
 
 
+pytestmark = [pytest.mark.usefixtures("mock_packages")]
+
+
 def test_safe_versions():
     """Only test the safe versions of a package."""
 
@@ -70,11 +73,11 @@ def test_no_unchecksummed_versions():
 def test_versions_no_url():
     """Test a package with versions but without a ``url`` attribute."""
 
-    versions("graphviz")
+    versions("attributes-foo-app")
 
 
 @pytest.mark.maybeslow
 def test_no_versions_no_url():
     """Test a package without versions or a ``url`` attribute."""
 
-    versions("opengl")
+    versions("no-url-or-version")

--- a/var/spack/repos/builtin.mock/packages/no-url-or-version/package.py
+++ b/var/spack/repos/builtin.mock/packages/no-url-or-version/package.py
@@ -1,0 +1,11 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class NoUrlOrVersion(Package):
+    """Mock package that has no url and no version."""
+
+    homepage = "https://example.com/"


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, commit c355765c3a738ca9a94e5fa628f6e061812e7449

Ensure the unit test uses mock packages including new `no-url-for-version`.