### PR TITLE
RepoSplit/tests: have test_list_with* ignore missing repo warning

### DIFF
--- a/lib/spack/spack/test/cmd/unit_test.py
+++ b/lib/spack/spack/test/cmd/unit_test.py
@@ -19,7 +19,7 @@ def test_list():
 
 def test_list_with_pytest_arg():
     output = spack_test("--list", cmd_test_py)
-    assert output.strip() == cmd_test_py
+    assert cmd_test_py in output.strip()
 
 
 def test_list_with_keywords():
@@ -27,7 +27,7 @@ def test_list_with_keywords():
     # since the behavior is inconsistent across different pytest
     # versions, see https://stackoverflow.com/a/48814787/771663
     output = spack_test("--list", "-k", "unit_test.py")
-    assert output.strip() == cmd_test_py
+    assert cmd_test_py in output.strip()
 
 
 def test_list_long(capsys):


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, commit https://github.com/spack/spack/pull/48930/commits/014e00810cc052dbe2f24f5f14aeebe13bbe711d

Switch checking of outputs to be consistent with other tests (i.e., check `in` instead of equality), which allows the two unit tests to ignore the missing repository warning (as occurs with other unit tests in the module).

Confirmed tests pass with and without access to the builtin repository.