### PR TITLE
RepoSplit/tests: switch providers to mock packages

### DIFF
--- a/lib/spack/spack/test/cmd/providers.py
+++ b/lib/spack/spack/test/cmd/providers.py
@@ -7,6 +7,8 @@ import pytest
 
 from spack.main import SpackCommand
 
+pytestmark = [pytest.mark.usefixtures("mock_packages")]
+
 providers = SpackCommand("providers")
 
 
@@ -24,16 +26,28 @@ def test_it_just_runs(pkg):
         (
             ("mpi",),
             [
-                "mpich",
-                "mpilander",
-                "mvapich2",
-                "openmpi",
-                "openmpi@1.7.5:",
-                "openmpi@2.0.0:",
-                "spectrum-mpi",
+                "intel-parallel-studio",
+                "low-priority-provider",
+                "mpich@3:",
+                "mpich2",
+                "multi-provider-mpi@1.10.0",
+                "multi-provider-mpi@2.0.0",
+                "zmpi",
             ],
         ),
-        (("D", "awk"), ["ldc", "gawk", "mawk"]),  # Call 2 virtual packages at once
+        (
+            ("lapack", "something"),
+            [
+                "intel-parallel-studio",
+                "low-priority-provider",
+                "netlib-lapack",
+                "openblas-with-lapack",
+                "simple-inheritance",
+                "splice-a",
+                "splice-h",
+                "splice-vh",
+            ],
+        ),  # Call 2 virtual packages at once
     ],
 )
 def test_provider_lists(vpkg, provider_list):


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, commit https://github.com/spack/spack/pull/48930/commits/9dba2afba8b43a086e633475af10767a3832c0e9

Switch to use `mock_packages` and swap builtin packages for mock packages.

Confirmed tests pass with and without access to the builtin repository.