### PR TITLE
test/cmd/maintainers.py: cleanup of mock_packages use

### DIFF
--- a/lib/spack/spack/test/cmd/maintainers.py
+++ b/lib/spack/spack/test/cmd/maintainers.py
@@ -9,6 +9,8 @@ import pytest
 import spack.main
 import spack.repo
 
+pytestmark = [pytest.mark.usefixtures("mock_packages")]
+
 maintainers = spack.main.SpackCommand("maintainers")
 
 MAINTAINED_PACKAGES = [
@@ -26,17 +28,17 @@ def split(output):
     return re.split(r"\s+", output) if output else []
 
 
-def test_maintained(mock_packages):
+def test_maintained():
     out = split(maintainers("--maintained"))
     assert out == MAINTAINED_PACKAGES
 
 
-def test_unmaintained(mock_packages):
+def test_unmaintained():
     out = split(maintainers("--unmaintained"))
     assert out == sorted(set(spack.repo.all_package_names()) - set(MAINTAINED_PACKAGES))
 
 
-def test_all(mock_packages, capfd):
+def test_all(capfd):
     with capfd.disabled():
         out = split(maintainers("--all"))
     assert out == [
@@ -63,7 +65,7 @@ def test_all(mock_packages, capfd):
     assert out == ["maintainers-1:", "user1,", "user2"]
 
 
-def test_all_by_user(mock_packages, capfd):
+def test_all_by_user(capfd):
     with capfd.disabled():
         out = split(maintainers("--all", "--by-user"))
     assert out == [
@@ -100,22 +102,22 @@ def test_all_by_user(mock_packages, capfd):
     ]
 
 
-def test_no_args(mock_packages):
+def test_no_args():
     with pytest.raises(spack.main.SpackCommandError):
         maintainers()
 
 
-def test_no_args_by_user(mock_packages):
+def test_no_args_by_user():
     with pytest.raises(spack.main.SpackCommandError):
         maintainers("--by-user")
 
 
-def test_mutex_args_fail(mock_packages):
+def test_mutex_args_fail():
     with pytest.raises(SystemExit):
         maintainers("--maintained", "--unmaintained")
 
 
-def test_maintainers_list_packages(mock_packages, capfd):
+def test_maintainers_list_packages(capfd):
     with capfd.disabled():
         out = split(maintainers("maintainers-1"))
     assert out == ["user1", "user2"]
@@ -129,13 +131,13 @@ def test_maintainers_list_packages(mock_packages, capfd):
     assert out == ["user2", "user3"]
 
 
-def test_maintainers_list_fails(mock_packages, capfd):
+def test_maintainers_list_fails(capfd):
     out = maintainers("pkg-a", fail_on_error=False)
     assert not out
     assert maintainers.returncode == 1
 
 
-def test_maintainers_list_by_user(mock_packages, capfd):
+def test_maintainers_list_by_user(capfd):
     with capfd.disabled():
         out = split(maintainers("--by-user", "user1"))
     assert out == ["maintainers-1", "maintainers-3", "py-extension1"]


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, commit https://github.com/spack/spack/pull/48930/commits/9ecd309bff8925fe0caee8d77d44e01f148e2464 (sans mock `cuda`)

The fixture should be specified module-wide versus on every test function.