### PR TITLE
RepoSplit/tests: switch env.py to mock packages

### DIFF
--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -22,7 +22,10 @@ from spack.environment.environment import (
 )
 from spack.environment.list import UndefinedReferenceError
 
-pytestmark = pytest.mark.not_on_windows("Envs are not supported on windows")
+pytestmark = [
+    pytest.mark.not_on_windows("Envs are not supported on windows"),
+    pytest.mark.usefixtures("mock_packages"),
+]
 
 
 class TestDirectoryInitialization:
@@ -35,7 +38,7 @@ class TestDirectoryInitialization:
             ev.environment_dir_from_name("test", exists_ok=False)
 
 
-def test_hash_change_no_rehash_concrete(tmp_path, mock_packages, config):
+def test_hash_change_no_rehash_concrete(tmp_path, config):
     # create an environment
     env_path = tmp_path / "env_dir"
     env_path.mkdir(exist_ok=False)
@@ -65,7 +68,7 @@ def test_hash_change_no_rehash_concrete(tmp_path, mock_packages, config):
     assert read_in.specs_by_hash[read_in.concretized_order[0]]._hash == new_hash
 
 
-def test_env_change_spec(tmp_path, mock_packages, config):
+def test_env_change_spec(tmp_path, config):
     env_path = tmp_path / "env_dir"
     env_path.mkdir(exist_ok=False)
     env = ev.create_in_dir(env_path)
@@ -98,7 +101,7 @@ spack:
 """
 
 
-def test_env_change_spec_in_definition(tmp_path, mock_packages, mutable_mock_env_path):
+def test_env_change_spec_in_definition(tmp_path, mutable_mock_env_path):
     manifest_file = tmp_path / ev.manifest_name
     manifest_file.write_text(_test_matrix_yaml)
     e = ev.create("test", manifest_file)
@@ -121,7 +124,7 @@ def test_env_change_spec_in_definition(tmp_path, mock_packages, mutable_mock_env
     assert not any(x.intersects("mpileaks@2.1%gcc") for x in e.user_specs)
 
 
-def test_env_change_spec_in_matrix_raises_error(tmp_path, mock_packages, mutable_mock_env_path):
+def test_env_change_spec_in_matrix_raises_error(tmp_path, mutable_mock_env_path):
     manifest_file = tmp_path / ev.manifest_name
     manifest_file.write_text(_test_matrix_yaml)
     e = ev.create("test", manifest_file)
@@ -202,7 +205,7 @@ spack:
     unify: false"""
     ],
 )
-def test_roundtrip_spack_yaml_with_comments(original_content, mock_packages, config, tmp_path):
+def test_roundtrip_spack_yaml_with_comments(original_content, config, tmp_path):
     """Ensure that round-tripping a spack.yaml file doesn't change its content."""
     spack_yaml = tmp_path / "spack.yaml"
     spack_yaml.write_text(original_content)
@@ -242,7 +245,7 @@ def test_removing_from_non_existing_list_fails(tmp_path):
         (False, False),
     ],
 )
-def test_update_default_view(init_view, update_value, tmp_path, mock_packages, config):
+def test_update_default_view(init_view, update_value, tmp_path, config):
     """Tests updating the default view with different values."""
     env = ev.create_in_dir(tmp_path, with_view=init_view)
     env.update_default_view(update_value)
@@ -291,7 +294,7 @@ spack:
     ],
 )
 def test_update_default_complex_view(
-    initial_content, update_value, expected_view, tmp_path, mock_packages, config
+    initial_content, update_value, expected_view, tmp_path, config
 ):
     spack_yaml = tmp_path / "spack.yaml"
     spack_yaml.write_text(initial_content)
@@ -366,7 +369,7 @@ def test_error_on_nonempty_view_dir(tmpdir):
             _error_on_nonempty_view_dir("file")
 
 
-def test_can_add_specs_to_environment_without_specs_attribute(tmp_path, mock_packages, config):
+def test_can_add_specs_to_environment_without_specs_attribute(tmp_path, config):
     """Sometimes users have template manifest files, and save one line in the YAML file by
     removing the empty 'specs: []' attribute. This test ensures that adding a spec to an
     environment without the 'specs' attribute, creates the attribute first instead of returning
@@ -397,12 +400,12 @@ spack:
   # baz
   - zlib
 """,
-            "libpng",
+            "libdwarf",
             """spack:
   specs:
   # baz
   - zlib
-  - libpng
+  - libdwarf
 """,
         )
     ],
@@ -572,7 +575,7 @@ spack:
     ],
 )
 def test_conflicts_with_packages_that_are_not_dependencies(
-    spec_str, expected_raise, expected_spec, tmp_path, mock_packages, config
+    spec_str, expected_raise, expected_spec, tmp_path, config
 ):
     """Tests that we cannot concretize two specs together, if one conflicts with the other,
     even though they don't have a dependency relation.
@@ -601,9 +604,7 @@ spack:
 @pytest.mark.parametrize(
     "possible_mpi_spec,unify", [("mpich", False), ("mpich", True), ("zmpi", False), ("zmpi", True)]
 )
-def test_requires_on_virtual_and_potential_providers(
-    possible_mpi_spec, unify, tmp_path, mock_packages, config
-):
+def test_requires_on_virtual_and_potential_providers(possible_mpi_spec, unify, tmp_path, config):
     """Tests that in an environment we can add packages explicitly, even though they provide
     a virtual package, and we require the provider of the same virtual to be another package,
     if they are added explicitly by their name.
@@ -698,7 +699,7 @@ def test_removing_spec_from_manifest_with_exact_duplicates(
 
 
 @pytest.mark.regression("35298")
-def test_variant_propagation_with_unify_false(tmp_path, mock_packages, config):
+def test_variant_propagation_with_unify_false(tmp_path, config):
     """Spack distributes concretizations to different processes, when unify:false is selected and
     the number of roots is 2 or more. When that happens, the specs to be concretized need to be
     properly reconstructed on the worker process, if variant propagation was requested.
@@ -722,7 +723,7 @@ def test_variant_propagation_with_unify_false(tmp_path, mock_packages, config):
         assert node.satisfies("+foo")
 
 
-def test_env_with_include_defs(mutable_mock_env_path, mock_packages):
+def test_env_with_include_defs(mutable_mock_env_path):
     """Test environment with included definitions file."""
     env_path = mutable_mock_env_path
     env_path.mkdir()
@@ -756,7 +757,7 @@ def test_env_with_include_defs(mutable_mock_env_path, mock_packages):
         e.concretize()
 
 
-def test_env_with_include_def_missing(mutable_mock_env_path, mock_packages):
+def test_env_with_include_def_missing(mutable_mock_env_path):
     """Test environment with included definitions file that is missing a definition."""
     env_path = mutable_mock_env_path
     env_path.mkdir()
@@ -782,7 +783,7 @@ def test_env_with_include_def_missing(mutable_mock_env_path, mock_packages):
 
 
 @pytest.mark.regression("41292")
-def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, mock_packages):
+def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path):
     """Tests that, after having deconcretized a spec, we can reconcretize an environment which
     has 2 or more user specs mapping to the same concrete spec.
     """
@@ -811,7 +812,7 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, mock
 
 
 @pytest.mark.regression("44216")
-def test_root_version_weights_for_old_versions(mutable_mock_env_path, mock_packages):
+def test_root_version_weights_for_old_versions(mutable_mock_env_path):
     """Tests that, when we select two old versions of root specs that have the same version
     optimization penalty, both are considered.
     """
@@ -839,7 +840,7 @@ def test_root_version_weights_for_old_versions(mutable_mock_env_path, mock_packa
     assert gcc.satisfies("@=1.0")
 
 
-def test_env_view_on_empty_dir_is_fine(tmp_path, config, mock_packages, temporary_store):
+def test_env_view_on_empty_dir_is_fine(tmp_path, config, temporary_store):
     """Tests that creating a view pointing to an empty dir is not an error."""
     view_dir = tmp_path / "view"
     view_dir.mkdir()
@@ -851,7 +852,7 @@ def test_env_view_on_empty_dir_is_fine(tmp_path, config, mock_packages, temporar
     assert view_dir.is_symlink()
 
 
-def test_env_view_on_non_empty_dir_errors(tmp_path, config, mock_packages, temporary_store):
+def test_env_view_on_non_empty_dir_errors(tmp_path, config, temporary_store):
     """Tests that creating a view pointing to a non-empty dir errors."""
     view_dir = tmp_path / "view"
     view_dir.mkdir()
@@ -868,7 +869,7 @@ def test_env_view_on_non_empty_dir_errors(tmp_path, config, mock_packages, tempo
     "matrix_line", [("^zmpi", "^mpich"), ("~shared", "+shared"), ("shared=False", "+shared-libs")]
 )
 @pytest.mark.regression("40791")
-def test_stack_enforcement_is_strict(tmp_path, matrix_line, config, mock_packages):
+def test_stack_enforcement_is_strict(tmp_path, matrix_line, config):
     """Ensure that constraints in matrices are applied strictly after expansion, to avoid
     inconsistencies between abstract user specs and concrete specs.
     """
@@ -894,7 +895,7 @@ spack:
             e.concretize()
 
 
-def test_only_roots_are_explicitly_installed(tmp_path, mock_packages, config, temporary_store):
+def test_only_roots_are_explicitly_installed(tmp_path, config, temporary_store):
     """When installing specific non-root specs from an environment, we continue to mark them
     as implicitly installed. What makes installs explicit is that they are root of the env."""
     env = ev.create_in_dir(tmp_path)
@@ -908,7 +909,7 @@ def test_only_roots_are_explicitly_installed(tmp_path, mock_packages, config, te
     assert temporary_store.db.query(explicit=True) == [mpileaks]
 
 
-def test_environment_from_name_or_dir(mock_packages, mutable_mock_env_path, tmp_path):
+def test_environment_from_name_or_dir(mutable_mock_env_path, tmp_path):
     test_env = ev.create("test")
 
     name_env = ev.environment_from_name_or_dir(test_env.name)
@@ -923,7 +924,7 @@ def test_environment_from_name_or_dir(mock_packages, mutable_mock_env_path, tmp_
         _ = ev.environment_from_name_or_dir("fake-env")
 
 
-def test_env_include_configs(mutable_mock_env_path, mock_packages):
+def test_env_include_configs(mutable_mock_env_path):
     """check config and package values using new include schema"""
     env_path = mutable_mock_env_path
     env_path.mkdir()
@@ -970,9 +971,7 @@ spack:
         assert req_specs == set(["@3.11:"])
 
 
-def test_using_multiple_compilers_on_a_node_is_discouraged(
-    tmp_path, mutable_config, mock_packages
-):
+def test_using_multiple_compilers_on_a_node_is_discouraged(tmp_path, mutable_config):
     """Tests that when we specify %<compiler> Spack tries to use that compiler for all the
     languages needed by that node.
     """


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, commit https://github.com/spack/spack/commit/273774637e619477442f89ab672c30c6f4d3f33e (plus mock_pages module-wide)

Switched `test/env.py` to use mock-packages file- (or module-) wide. The changes from the #48930 commit were not sufficient if the built-in repository is not available as the following 17 tests would fail:

```
FAILED lib/spack/spack/test/env.py::test_hash_change_no_rehash_concrete - spack.repo.UnknownPackageError: Package 'spack.pkg.builtin.mock.compiler-wrapper' not found.
FAILED lib/spack/spack/test/env.py::test_env_change_spec_in_definition - RuntimeError: Package 'spack.pkg.builtin.mock.compiler-wrapper' not found.
FAILED lib/spack/spack/test/env.py::test_env_change_spec_in_matrix_raises_error - RuntimeError: Package 'spack.pkg.builtin.mock.compiler-wrapper' not found.
FAILED lib/spack/spack/test/env.py::test_conflicts_with_packages_that_are_not_dependencies[vendorsb-False-vendorsb@=1.0] - spack.repo.UnknownPackageError: Package ...
FAILED lib/spack/spack/test/env.py::test_conflicts_with_packages_that_are_not_dependencies[vendorsb@=1.1-True-None] - spack.repo.UnknownPackageError: Package 'spac...
FAILED lib/spack/spack/test/env.py::test_requires_on_virtual_and_potential_providers[mpich-False] - RuntimeError: Package 'spack.pkg.builtin.mock.compiler-wrapper'...
FAILED lib/spack/spack/test/env.py::test_requires_on_virtual_and_potential_providers[mpich-True] - spack.repo.UnknownPackageError: Package 'spack.pkg.builtin.mock....
FAILED lib/spack/spack/test/env.py::test_requires_on_virtual_and_potential_providers[zmpi-False] - RuntimeError: Package 'spack.pkg.builtin.mock.compiler-wrapper' ...
FAILED lib/spack/spack/test/env.py::test_requires_on_virtual_and_potential_providers[zmpi-True] - spack.repo.UnknownPackageError: Package 'spack.pkg.builtin.mock.c...
FAILED lib/spack/spack/test/env.py::test_variant_propagation_with_unify_false - RuntimeError: Package 'spack.pkg.builtin.mock.compiler-wrapper' not found.
FAILED lib/spack/spack/test/env.py::test_env_with_include_defs - RuntimeError: Package 'spack.pkg.builtin.mock.compiler-wrapper' not found.
FAILED lib/spack/spack/test/env.py::test_deconcretize_then_concretize_does_not_error - spack.repo.UnknownPackageError: Package 'spack.pkg.builtin.mock.compiler-wra...
FAILED lib/spack/spack/test/env.py::test_root_version_weights_for_old_versions - spack.repo.UnknownPackageError: Package 'spack.pkg.builtin.mock.compiler-wrapper' ...
FAILED lib/spack/spack/test/env.py::test_env_view_on_empty_dir_is_fine - spack.repo.UnknownPackageError: Package 'spack.pkg.builtin.mock.compiler-wrapper' not found.
FAILED lib/spack/spack/test/env.py::test_env_view_on_non_empty_dir_errors - spack.repo.UnknownPackageError: Package 'spack.pkg.builtin.mock.compiler-wrapper' not f...
FAILED lib/spack/spack/test/env.py::test_only_roots_are_explicitly_installed - spack.repo.UnknownPackageError: Package 'spack.pkg.builtin.mock.compiler-wrapper' no...
FAILED lib/spack/spack/test/env.py::test_using_multiple_compilers_on_a_node_is_discouraged - spack.repo.UnknownPackageError: Package 'spack.pkg.builtin.mock.compil...
```