### PR TITLE
RepoSplit/tests: add mock_packages to test_intersects_and_satisfies

### DIFF
--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1837,7 +1837,7 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         (Spec, "mpileaks ^callpath %gcc@5", "mpileaks ^callpath %gcc@5.4", (True, False, True)),
     ],
 )
-def test_intersects_and_satisfies(factory, lhs_str, rhs_str, results):
+def test_intersects_and_satisfies(mock_packages, factory, lhs_str, rhs_str, results):
     lhs = factory(lhs_str)
     rhs = factory(rhs_str)
 


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, replaces commit https://github.com/spack/spack/commit/ea906a3f4c4e25d2608e899e1b45523984157fae

Only needed to add `mock_packages` to one of the tests to support not having the `builtin` repository available.

```
FAILED lib/spack/spack/test/spec_semantics.py::test_intersects_and_satisfies[Spec-mpi-lapack-results17] - assert False is True
```