### PR TITLE
RepoSplit/tests: switch two tests to use mock_packages

### DIFF
--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -89,7 +89,7 @@ data_path = os.path.join(spack.paths.test_path, "data", "patch")
         (os.path.join(data_path, "foo.patch"), platform_url_sha, None),
     ],
 )
-def test_url_patch(mock_patch_stage, filename, sha256, archive_sha256, config):
+def test_url_patch(mock_packages, mock_patch_stage, filename, sha256, archive_sha256, config):
     # Make a patch object
     url = url_util.path_to_file_url(filename)
     s = spack.concretize.concretize_one("patch")
@@ -466,7 +466,7 @@ def test_equality():
     assert patch1 != "not a patch"
 
 
-def test_sha256_setter(mock_patch_stage, config):
+def test_sha256_setter(mock_packages, mock_patch_stage, config):
     path = os.path.join(data_path, "foo.patch")
     s = spack.concretize.concretize_one("patch")
     patch = spack.patch.FilePatch(s.package, path, level=1, working_dir=".")


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, replaces commit https://github.com/spack/spack/commit/5ac82da9f5e1e27f838aa1fe9b53e3c719d99900

The fixture is only really needed for the two tests that fail when the `builtin` repository is not available:

```
FAILED lib/spack/spack/test/patch.py::test_url_patch[/usr/WS1/dahlgren/spack/lib/spack/spack/test/data/patch/foo.tgz-252c0af58be3d90e5dc5e0d16658434c9efa5d20a5df6c10bf72c2d77f780866-4e8092a161ec6c3a1b5253176fcf33ce7ba23ee2ff27c75dbced589dabacd06e]
FAILED lib/spack/spack/test/patch.py::test_url_patch[/usr/WS1/dahlgren/spack/lib/spack/spack/test/data/patch/foo.patch-252c0af58be3d90e5dc5e0d16658434c9efa5d20a5df6c10bf72c2d77f780866-None]
FAILED lib/spack/spack/test/patch.py::test_sha256_setter - spack.solver.asp.UnsatisfiableSpecError: cannot concretize 'patch', since 'patch' does not exist
```