### PR TITLE
trivy: add v0.62.0 and v0.62.1

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/trivy/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/trivy/package.py
@@ -20,6 +20,7 @@ class Trivy(GoPackage):
     version("0.61.1", sha256="f6ad43e008c008d67842c9e2b4af80c2e96854db8009fba48fc37b4f9b15f59b")
     version("0.61.0", sha256="1e97b1b67a4c3aee9c567534e60355033a58ce43a3705bdf198d7449d53b6979")
 
+    depends_on("go@1.24.2:", type="build", when="@0.62:")
     depends_on("go@1.24:", type="build")
 
     build_directory = "cmd/trivy"

--- a/var/spack/repos/spack_repo/builtin/packages/trivy/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/trivy/package.py
@@ -15,6 +15,8 @@ class Trivy(GoPackage):
 
     license("Apache-2.0", checked_by="RobertMaaskant")
 
+    version("0.62.1", sha256="1b8000f08876dd02203021414581275daa69db00fab731351dbcf2a008ebe82a")
+    version("0.62.0", sha256="2b0b4df4bbfebde00a14a0616f5013db4cbba0f021a780a7e3b717a2c2978493")
     version("0.61.1", sha256="f6ad43e008c008d67842c9e2b4af80c2e96854db8009fba48fc37b4f9b15f59b")
     version("0.61.0", sha256="1e97b1b67a4c3aee9c567534e60355033a58ce43a3705bdf198d7449d53b6979")
 


### PR DESCRIPTION
Release notes:
- https://github.com/aquasecurity/trivy/releases/tag/v0.62.1
- https://github.com/aquasecurity/trivy/releases/tag/v0.62.0

Diffs:
- https://github.com/aquasecurity/trivy/compare/v0.62.0...v0.62.1
- https://github.com/aquasecurity/trivy/compare/v0.61.1...v0.62.0