### PR TITLE
go: add v1.23.9 and v1.24.3

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/go/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/go/package.py
@@ -39,9 +39,11 @@ class Go(Package):
 
     license("BSD-3-Clause")
 
+    version("1.24.3", sha256="229c08b600b1446798109fae1f569228102c8473caba8104b6418cb5bc032878")
     version("1.24.2", sha256="9dc77ffadc16d837a1bf32d99c624cb4df0647cee7b119edd9e7b1bcc05f2e00")
     version("1.24.1", sha256="8244ebf46c65607db10222b5806aeb31c1fcf8979c1b6b12f60c677e9a3c0656")
     version("1.24.0", sha256="d14120614acb29d12bcab72bd689f257eb4be9e0b6f88a8fb7e41ac65f8556e5")
+    version("1.23.9", sha256="08f6419547563ed9e7037d12b9c8909677c72f75f62ef85887ed9dbf49b8d2dd")
     version("1.23.8", sha256="0ca1f1e37ea255e3ce283af3f4e628502fb444587da987a5bb96d6c6f15930d4")
     version("1.23.7", sha256="7cfabd46b73eb4c26b19d69515dd043d7183a6559acccd5cfdb25eb6b266a458")
     version("1.23.6", sha256="039c5b04e65279daceee8a6f71e70bd05cf5b801782b6f77c6e19e2ed0511222")


### PR DESCRIPTION
Release notes:
> go1.24.3 (released 2025-05-06) includes security fixes to the os package, as well as bug fixes to the runtime, the compiler, the linker, the go command, and the crypto/tls and os packages. See the [Go 1.24.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.3+label%3ACherryPickApproved) on our issue tracker for details.

> go1.23.9 (released 2025-05-06) includes fixes to the runtime and the linker. See the [Go 1.23.9 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.9+label%3ACherryPickApproved) on our issue tracker for details.