### PR TITLE
py-numba: add 0.61.2 and fix numpy version constraints

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_numba/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_numba/package.py
@@ -16,6 +16,7 @@ class PyNumba(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("0.61.2", sha256="8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d")
     version("0.61.0", sha256="888d2e89b8160899e19591467e8fdd4970e07606e1fbc248f239c89818d5f925")
     version("0.60.0", sha256="5df6158e5584eece5fc83294b949fd30b9f1125df7708862205217e068aabf16")
     version("0.59.1", sha256="76f69132b96028d2774ed20415e8c528a34e3299a40581bae178f0994a2f370b")
@@ -57,7 +58,13 @@ class PyNumba(PythonPackage):
     depends_on("python@3.6:3.9", when="@0.53", type=("build", "run"))
     depends_on("python@3.6:3.8", when="@0.52", type=("build", "run"))
     depends_on("python@3.6:3.8", when="@0.48:0.51", type=("build", "run"))
-    depends_on("py-numpy@2.0:2.2", when="@0.60:", type=("build", "run"))
+
+    # max_numpy_run_version in setup.py is a non inclusive upper bound
+    # min_numpy_run_version < min_numpy_build_version and these ranges use
+    # min_numpy_build_version
+    depends_on("py-numpy@2.0:2.2", when="@0.61.2", type=("build", "run"))
+    depends_on("py-numpy@2.0:2.1", when="@0.61.0", type=("build", "run"))
+    depends_on("py-numpy@2.0", when="@0.60", type=("build", "run"))
     depends_on("py-numpy@1.22:1.26", when="@0.58.1:0.59", type=("build", "run"))
     depends_on("py-numpy@1.21:1.25", when="@0.58.0", type=("build", "run"))
     depends_on("py-numpy@1.21:1.24", when="@0.57", type=("build", "run"))


### PR DESCRIPTION
- adds `@0.61.2`
- fixes numpy version constraints that were incorrect and allowed concretization against incompatible numpy versions