### PR TITLE
RepoSplit/tests: switch TestSpecList to use mock packages

### DIFF
--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -55,6 +55,7 @@ def parser_and_speclist():
     return parser, result
 
 
+@pytest.mark.usefixtures("mock_packages")
 class TestSpecList:
     @pytest.mark.regression("28749")
     @pytest.mark.parametrize(
@@ -88,7 +89,7 @@ class TestSpecList:
             ),
         ],
     )
-    def test_spec_list_constraint_ordering(self, mock_packages, specs, expected):
+    def test_spec_list_constraint_ordering(self, specs, expected):
         result = SpecListParser().parse_user_specs(name="specs", yaml_list=specs)
         assert result.specs == [Spec(x) for x in expected]
 
@@ -125,7 +126,7 @@ class TestSpecList:
         assert mock_list.specs_as_yaml_list == (DEFAULT_EXPANSION + other_list.specs_as_yaml_list)
         assert mock_list.specs == DEFAULT_SPECS + other_list.specs
 
-    def test_spec_list_nested_matrices(self, mock_packages, parser_and_speclist):
+    def test_spec_list_nested_matrices(self, parser_and_speclist):
         parser, _ = parser_and_speclist
 
         inner_matrix = [{"matrix": [["zlib", "libelf"], ["%gcc", "%intel"]]}]
@@ -158,7 +159,7 @@ class TestSpecList:
         assert result.specs == DEFAULT_SPECS
 
     @pytest.mark.regression("16841")
-    def test_spec_list_matrix_exclude(self, mock_packages):
+    def test_spec_list_matrix_exclude(self):
         parser = SpecListParser()
         result = parser.parse_user_specs(
             name="specs",

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -83,12 +83,12 @@ class TestSpecList:
             ),
             # A constraint affects both the root and a dependency
             (
-                [{"matrix": [["gromacs"], ["%gcc"], ["+plumed ^plumed%gcc"]]}],
-                ["gromacs+plumed%gcc ^plumed%gcc"],
+                [{"matrix": [["version-test-root"], ["%gcc"], ["^version-test-pkg%gcc"]]}],
+                ["version-test-root%gcc ^version-test-pkg%gcc"],
             ),
         ],
     )
-    def test_spec_list_constraint_ordering(self, specs, expected):
+    def test_spec_list_constraint_ordering(self, mock_packages, specs, expected):
         result = SpecListParser().parse_user_specs(name="specs", yaml_list=specs)
         assert result.specs == [Spec(x) for x in expected]
 
@@ -125,7 +125,7 @@ class TestSpecList:
         assert mock_list.specs_as_yaml_list == (DEFAULT_EXPANSION + other_list.specs_as_yaml_list)
         assert mock_list.specs == DEFAULT_SPECS + other_list.specs
 
-    def test_spec_list_nested_matrices(self, parser_and_speclist):
+    def test_spec_list_nested_matrices(self, mock_packages, parser_and_speclist):
         parser, _ = parser_and_speclist
 
         inner_matrix = [{"matrix": [["zlib", "libelf"], ["%gcc", "%intel"]]}]
@@ -171,7 +171,7 @@ class TestSpecList:
         )
         assert len(result.specs) == 1
 
-    def test_spec_list_exclude_with_abstract_hashes(self, mock_packages, install_mockery):
+    def test_spec_list_exclude_with_abstract_hashes(self, install_mockery):
         # Put mpich in the database so it can be referred to by hash.
         mpich_1 = spack.concretize.concretize_one("mpich+debug")
         mpich_2 = spack.concretize.concretize_one("mpich~debug")


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, replaces commit https://github.com/spack/spack/commit/eca1f623ce6bbeea27adf52801c1d343bd8d98c7 (with changes)

Ensure using mock packages where needed as indicated by the tests that fail when the builtin repository is not available:

```
FAILED lib/spack/spack/test/spec_list.py::TestSpecList::test_spec_list_constraint_ordering[specs0-expected0] - spack.repo.UnknownPackageError: Package 'hypre' not found.
FAILED lib/spack/spack/test/spec_list.py::TestSpecList::test_spec_list_nested_matrices - spack.repo.UnknownPackageError: Package 'zlib' not found.
FAILED lib/spack/spack/test/spec_list.py::TestSpecList::test_spec_list_matrix_exclude - spack.repo.UnknownPackageError: Package 'multivalue-variant' not found.
```

Note there is a fourth test that currently relies on the `gcc-runtime` symlink:
```
FAILED lib/spack/spack/test/spec_list.py::TestSpecList::test_spec_list_exclude_with_abstract_hashes - spack.repo.UnknownPackageError: Package 'fortran-rt' not found.
```