### PR TITLE
glib: set preferred version to v2.78.3

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/glib/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/glib/package.py
@@ -30,7 +30,11 @@ class Glib(MesonPackage):
     # Even minor versions are stable, odd minor versions are development, only add even numbers
     version("2.82.5", sha256="05c2031f9bdf6b5aba7a06ca84f0b4aced28b19bf1b50c6ab25cc675277cbc3f")
     version("2.82.2", sha256="ab45f5a323048b1659ee0fbda5cecd94b099ab3e4b9abf26ae06aeb3e781fd63")
-    version("2.78.3", sha256="609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21")
+    version(
+        "2.78.3",
+        sha256="609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21",
+        preferred=True,
+    )
     version("2.78.0", sha256="44eaab8b720877ce303c5540b657b126f12dc94972d9880b52959f43fb537b30")
     version("2.76.6", sha256="1136ae6987dcbb64e0be3197a80190520f7acab81e2bfb937dc85c11c8aa9f04")
     version("2.76.4", sha256="5a5a191c96836e166a7771f7ea6ca2b0069c603c7da3cba1cd38d1694a395dda")


### PR DESCRIPTION
Versions of glib above 2.78.3 don't build (https://github.com/spack/spack-packages/issues/381). Until this is fixed we should set preferred to a confirmed version per https://github.com/spack/spack-packages/issues/381.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
