### PR TITLE
RepoSplit/tests: switch test_environment_with.. to use mock_packages

### DIFF
--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -448,7 +448,7 @@ def test_find_loaded(database, working_env):
 
 
 @pytest.mark.regression("37712")
-def test_environment_with_version_range_in_compiler_doesnt_fail(tmp_path):
+def test_environment_with_version_range_in_compiler_doesnt_fail(tmp_path, mock_packages):
     """Tests that having an active environment with a root spec containing a compiler constrained
     by a version range (i.e. @X.Y rather the single version than @=X.Y) doesn't result in an error
     when invoking "spack find".


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, commit https://github.com/spack/spack/commit/a8925f8dd818563d877fa7277415362245d36b07

There are 19 `test/cmd/find.py` tests that will fail without any access to the `builtin` repository. With the symlinks for `gcc-runtime` and `compiler-wrapper`, it drops to one test:

```
FAILED lib/spack/spack/test/cmd/find.py::test_environment_with_version_range_in_compiler_doesnt_fail - spack.environment.environment.SpackEnvironmentError: no such package: zlib
```

This PR adds use of `mock_packages` just on the one test in that file.