### PR TITLE
dd4hep: add v1.32

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -25,7 +25,7 @@ class Dd4hep(CMakePackage):
     license("LGPL-3.0-or-later")
 
     version("master", branch="master")
-    version("1.32", sha256="13fd48d76356c730fcc3cfa385bc428b540b661a139aaaf19779507e6f90d538")
+    version("1.32", sha256="8bde4eab9af9841e040447282ea7df3a16e4bcec587c3a1e32f41987da9b1b4d")
     version("1.31", sha256="9c06a1b4462fc1b51161404889c74b37350162d0b0ac2154db27e3f102670bd1")
     version("1.30", sha256="02de46151e945eff58cffd84b4b86d35051f4436608199c3efb4d2e1183889fe")
     version("1.29", sha256="435d25a7ef093d8bf660f288b5a89b98556b4c1c293c55b93bf641fb4cba77e9")

--- a/var/spack/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -154,7 +154,7 @@ class Dd4hep(CMakePackage):
         depends_on("podio@:0", when="@:1.29")
         depends_on("podio@0.16:", when="@1.24:")
         depends_on("podio@0.16.3:", when="@1.26:")
-        depends_on("podio@0.16.7:", when="@:")
+        depends_on("podio@0.16.7:", when="@1.31:")
 
     extends("python")
 

--- a/var/spack/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -25,6 +25,7 @@ class Dd4hep(CMakePackage):
     license("LGPL-3.0-or-later")
 
     version("master", branch="master")
+    version("1.32", sha256="13fd48d76356c730fcc3cfa385bc428b540b661a139aaaf19779507e6f90d538")
     version("1.31", sha256="9c06a1b4462fc1b51161404889c74b37350162d0b0ac2154db27e3f102670bd1")
     version("1.30", sha256="02de46151e945eff58cffd84b4b86d35051f4436608199c3efb4d2e1183889fe")
     version("1.29", sha256="435d25a7ef093d8bf660f288b5a89b98556b4c1c293c55b93bf641fb4cba77e9")
@@ -153,7 +154,7 @@ class Dd4hep(CMakePackage):
         depends_on("podio@:0", when="@:1.29")
         depends_on("podio@0.16:", when="@1.24:")
         depends_on("podio@0.16.3:", when="@1.26:")
-        depends_on("podio@0.16.7:", when="@1.31:")
+        depends_on("podio@0.16.7:", when="@:")
 
     extends("python")
 


### PR DESCRIPTION
I added a git hash for dd4hep v1.32, which introduces a couple of useful features including the support for the custom generator status ID for stable particles, see https://github.com/AIDASoft/DD4hep/pull/1447

The git hash points to https://github.com/AIDASoft/DD4hep/commit/f1d058c99cae20cf50c3c07932ef4691b28af7d5. I converted it to sha256 format with 
`echo -n "f1d058c99cae20cf50c3c07932ef4691b28af7d5" | openssl dgst -sha256` 
I didn't modify the edm4hep or podio dependence.

