### PR TITLE
RepoSplit/tests: test_load_json_specfiles skip older spec versions

### DIFF
--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -14,7 +14,6 @@ import io
 import json
 import os
 import pickle
-import re
 
 import _vendoring.ruamel.yaml
 import pytest
@@ -389,8 +388,6 @@ ordered_spec = collections.OrderedDict(
     ]
 )
 
-specfile_version_regex = re.compile(r"specfiles/hdf5.([a-z0-9]*).*")
-
 
 @pytest.mark.parametrize(
     "specfile,expected_hash,reader_cls",
@@ -424,8 +421,7 @@ def test_load_json_specfiles(specfile, expected_hash, reader_cls):
     assert len(openmpi_edges) == 1
 
     # Check that virtuals have been reconstructed
-    match = re.search(specfile_version_regex, specfile)
-    if match.group(1) >= "v020":
+    if reader_cls.SPEC_VERSION >= spack.spec.SpecfileV4.SPEC_VERSION:
         assert "mpi" in openmpi_edges[0].virtuals
 
         # The virtuals attribute must be a tuple, when read from a

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -14,6 +14,7 @@ import io
 import json
 import os
 import pickle
+import re
 
 import _vendoring.ruamel.yaml
 import pytest
@@ -388,6 +389,8 @@ ordered_spec = collections.OrderedDict(
     ]
 )
 
+specfile_version_regex = re.compile(r"specfiles/hdf5.([a-z0-9]*).*")
+
 
 @pytest.mark.parametrize(
     "specfile,expected_hash,reader_cls",
@@ -421,12 +424,14 @@ def test_load_json_specfiles(specfile, expected_hash, reader_cls):
     assert len(openmpi_edges) == 1
 
     # Check that virtuals have been reconstructed
-    assert "mpi" in openmpi_edges[0].virtuals
+    match = re.search(specfile_version_regex, specfile)
+    if match.group(1) >= "v020":
+        assert "mpi" in openmpi_edges[0].virtuals
 
-    # The virtuals attribute must be a tuple, when read from a
-    # JSON or YAML file, not a list
-    for edge in s2.traverse_edges():
-        assert isinstance(edge.virtuals, tuple), edge
+        # The virtuals attribute must be a tuple, when read from a
+        # JSON or YAML file, not a list
+        for edge in s2.traverse_edges():
+            assert isinstance(edge.virtuals, tuple), edge
 
     # Ensure we can format {compiler} tokens
     assert s2.format("{compiler}") != "none"

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -420,7 +420,8 @@ def test_load_json_specfiles(specfile, expected_hash, reader_cls):
     openmpi_edges = s2.edges_to_dependencies(name="openmpi")
     assert len(openmpi_edges) == 1
 
-    # Check that virtuals have been reconstructed
+    # Check that virtuals have been reconstructed for specfiles conforming to
+    # version 4 on.
     if reader_cls.SPEC_VERSION >= spack.spec.SpecfileV4.SPEC_VERSION:
         assert "mpi" in openmpi_edges[0].virtuals
 


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, replaces commits:
- https://github.com/spack/spack/commit/d6d32cdf89dac01681b016cd6d5d25421dd49abd
- https://github.com/spack/spack/commit/11497f90b051ed45788036c18b34a9f4f96d8f87
- https://github.com/spack/spack/commit/00c4f11b03627a29aa0a798451bb92fb94e642ec

There are 18 `test/spec_yaml.py` tests that will fail without any access to the `builtin` repository. With the symlinks for gcc-runtime and compiler-wrapper, it drops to four tests:

```
FAILED lib/spack/spack/test/spec_yaml.py::test_load_json_specfiles[specfiles/hdf5.v013.json.gz-vglgw4reavn65vx5d4dlqn6rjywnq76d-SpecfileV1] - AssertionError: assert 'm...
FAILED lib/spack/spack/test/spec_yaml.py::test_load_json_specfiles[specfiles/hdf5.v016.json.gz-stp45yvzte43xdauknaj3auxlxb4xvzs-SpecfileV1] - AssertionError: assert 'm...
FAILED lib/spack/spack/test/spec_yaml.py::test_load_json_specfiles[specfiles/hdf5.v017.json.gz-xqh5iyjjtrp2jw632cchacn3l7vqzf3m-SpecfileV2] - AssertionError: assert 'm...
FAILED lib/spack/spack/test/spec_yaml.py::test_load_json_specfiles[specfiles/hdf5.v019.json.gz-iulacrbz7o5v5sbj7njbkyank3juh6d3-SpecfileV3] - AssertionError: assert 'm...
```

all of which are tied to `mpi` virtuals in the older specs, which was decided off-line as something we no longer need to care about from a testing standpoint.