### PR TITLE
RepoSplit/tests: switch test/cmd/compiler.py tests to use mock packages

### DIFF
--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -15,6 +15,8 @@ import spack.version
 
 compiler = spack.main.SpackCommand("compiler")
 
+pytestmark = [pytest.mark.usefixtures("mock_packages")]
+
 
 @pytest.fixture
 def compilers_dir(mock_executable):
@@ -67,9 +69,7 @@ fi
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 @pytest.mark.regression("11678,13138")
-def test_compiler_find_without_paths(
-    mock_packages, no_packages_yaml, working_env, mock_executable
-):
+def test_compiler_find_without_paths(no_packages_yaml, working_env, mock_executable):
     """Tests that 'spack compiler find' looks into PATH by default, if no specific path
     is given.
     """
@@ -82,7 +82,7 @@ def test_compiler_find_without_paths(
 
 
 @pytest.mark.regression("37996")
-def test_compiler_remove(mutable_config, mock_packages):
+def test_compiler_remove(mutable_config):
     """Tests that we can remove a compiler from configuration."""
     assert any(
         compiler.satisfies("gcc@=9.4.0") for compiler in spack.compilers.config.all_compilers()
@@ -95,7 +95,7 @@ def test_compiler_remove(mutable_config, mock_packages):
 
 
 @pytest.mark.regression("37996")
-def test_removing_compilers_from_multiple_scopes(mutable_config, mock_packages):
+def test_removing_compilers_from_multiple_scopes(mutable_config):
     # Duplicate "site" scope into "user" scope
     site_config = spack.config.get("packages", scope="site")
     spack.config.set("packages", site_config, scope="user")
@@ -111,7 +111,7 @@ def test_removing_compilers_from_multiple_scopes(mutable_config, mock_packages):
 
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
-def test_compiler_add(mock_packages, mutable_config, mock_executable):
+def test_compiler_add(mutable_config, mock_executable):
     """Tests that we can add a compiler to configuration."""
     expected_version = "4.5.3"
     gcc_path = mock_executable(
@@ -147,9 +147,7 @@ done
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 @pytest.mark.regression("17590")
-def test_compiler_find_prefer_no_suffix(
-    mock_packages, no_packages_yaml, working_env, compilers_dir
-):
+def test_compiler_find_prefer_no_suffix(no_packages_yaml, working_env, compilers_dir):
     """Ensure that we'll pick 'clang' over 'clang-gpu' when there is a choice."""
     clang_path = compilers_dir / "clang"
     shutil.copy(clang_path, clang_path.parent / "clang-gpu")
@@ -170,7 +168,7 @@ def test_compiler_find_prefer_no_suffix(
 
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
-def test_compiler_find_path_order(mock_packages, no_packages_yaml, working_env, compilers_dir):
+def test_compiler_find_path_order(no_packages_yaml, working_env, compilers_dir):
     """Ensure that we look for compilers in the same order as PATH, when there are duplicates"""
     new_dir = compilers_dir / "first_in_path"
     new_dir.mkdir()
@@ -193,12 +191,12 @@ def test_compiler_find_path_order(mock_packages, no_packages_yaml, working_env, 
     }
 
 
-def test_compiler_list_empty(no_packages_yaml, working_env, compilers_dir):
+def test_compiler_list_empty(no_packages_yaml, compilers_dir, monkeypatch):
     """Spack should not automatically search for compilers when listing them and none are
     available. And when stdout is not a tty like in tests, there should be no output and
     no error exit code.
     """
-    os.environ["PATH"] = str(compilers_dir)
+    monkeypatch.setenv("PATH", str(compilers_dir), prepend=":")
     out = compiler("list")
     assert not out
     assert compiler.returncode == 0
@@ -236,7 +234,7 @@ def test_compiler_list_empty(no_packages_yaml, working_env, compilers_dir):
     ],
 )
 def test_compilers_shows_packages_yaml(
-    mock_packages, external, expected, no_packages_yaml, working_env, compilers_dir
+    external, expected, no_packages_yaml, working_env, compilers_dir
 ):
     """Spack should see a single compiler defined from packages.yaml"""
     external["prefix"] = external["prefix"].format(prefix=os.path.dirname(compilers_dir))

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -67,7 +67,9 @@ fi
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 @pytest.mark.regression("11678,13138")
-def test_compiler_find_without_paths(no_packages_yaml, working_env, mock_executable):
+def test_compiler_find_without_paths(
+    mock_packages, no_packages_yaml, working_env, mock_executable
+):
     """Tests that 'spack compiler find' looks into PATH by default, if no specific path
     is given.
     """
@@ -109,7 +111,7 @@ def test_removing_compilers_from_multiple_scopes(mutable_config, mock_packages):
 
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
-def test_compiler_add(mutable_config, mock_executable):
+def test_compiler_add(mock_packages, mutable_config, mock_executable):
     """Tests that we can add a compiler to configuration."""
     expected_version = "4.5.3"
     gcc_path = mock_executable(
@@ -145,7 +147,9 @@ done
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 @pytest.mark.regression("17590")
-def test_compiler_find_prefer_no_suffix(no_packages_yaml, working_env, compilers_dir):
+def test_compiler_find_prefer_no_suffix(
+    mock_packages, no_packages_yaml, working_env, compilers_dir
+):
     """Ensure that we'll pick 'clang' over 'clang-gpu' when there is a choice."""
     clang_path = compilers_dir / "clang"
     shutil.copy(clang_path, clang_path.parent / "clang-gpu")
@@ -166,7 +170,7 @@ def test_compiler_find_prefer_no_suffix(no_packages_yaml, working_env, compilers
 
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
-def test_compiler_find_path_order(no_packages_yaml, working_env, compilers_dir):
+def test_compiler_find_path_order(mock_packages, no_packages_yaml, working_env, compilers_dir):
     """Ensure that we look for compilers in the same order as PATH, when there are duplicates"""
     new_dir = compilers_dir / "first_in_path"
     new_dir.mkdir()
@@ -232,7 +236,7 @@ def test_compiler_list_empty(no_packages_yaml, working_env, compilers_dir):
     ],
 )
 def test_compilers_shows_packages_yaml(
-    external, expected, no_packages_yaml, working_env, compilers_dir
+    mock_packages, external, expected, no_packages_yaml, working_env, compilers_dir
 ):
     """Spack should see a single compiler defined from packages.yaml"""
     external["prefix"] = external["prefix"].format(prefix=os.path.dirname(compilers_dir))

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4286,7 +4286,7 @@ def test_env_include_packages_url(
     """Test inclusion of a (GitHub) URL."""
     develop_url = "https://github.com/fake/fake/blob/develop/"
     default_packages = develop_url + "etc/fake/defaults/packages.yaml"
-    sha256 = "8b69d9c6e983dfb8bac2ddc3910a86265cffdd9c85f905c716d426ec5b0d9847"
+    sha256 = "6a1b26c857ca7e5bcd7342092e2f218da43d64b78bd72771f603027ea3c8b4af"
     spack_yaml = tmpdir.join("spack.yaml")
     with spack_yaml.open("w") as f:
         f.write(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -759,7 +759,7 @@ class TestConcretize:
     @pytest.mark.parametrize(
         "spec_str,expected,not_expected",
         [
-            # clang only provides C, and C++ compilers, while gcc has also fortran
+            # clang (llvm~flang) only provides C, and C++ compilers, while gcc has also fortran
             #
             # If we ask mpileaks%clang, then %gcc must be used for fortran, and since
             # %gcc is preferred to clang in config, it will be used for most nodes

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -759,22 +759,19 @@ class TestConcretize:
     @pytest.mark.parametrize(
         "spec_str,expected,not_expected",
         [
-            # TODO/TBD: This doesn't appear to be the case anymore with llvm, which
-            # TODO/TBD: is what gets picked now for mpileaks.
-            # TODO/TBD: Should mpileaks be dropped or replaced?
             # clang only provides C, and C++ compilers, while gcc has also fortran
             #
             # If we ask mpileaks%clang, then %gcc must be used for fortran, and since
             # %gcc is preferred to clang in config, it will be used for most nodes
             (
                 "mpileaks %clang",
-                {"mpileaks": "%clang", "libdwarf": "%clang", "libelf": "%clang"},
-                {"libdwarf": "%gcc", "libelf": "%gcc"},
+                {"mpileaks": "%clang", "libdwarf": "%gcc", "libelf": "%gcc"},
+                {"libdwarf": "%clang", "libelf": "%clang"},
             ),
             (
                 "mpileaks %clang@:15.0.0",
-                {"mpileaks": "%clang", "libdwarf": "%clang", "libelf": "%clang"},
-                {"libdwarf": "%gcc", "libelf": "%gcc"},
+                {"mpileaks": "%clang", "libdwarf": "%gcc", "libelf": "%gcc"},
+                {"libdwarf": "%clang", "libelf": "%clang"},
             ),
             (
                 "mpileaks %gcc",
@@ -1393,7 +1390,7 @@ class TestConcretize:
         assert root.dag_hash() != new_root_without_reuse.dag_hash()
 
     @pytest.mark.regression("43663")
-    def test_no_reuse_when_variant_condition_does_not_hold(self, mutable_database):
+    def test_no_reuse_when_variant_condition_does_not_hold(self, mutable_database, mock_packages):
         spack.config.set("concretizer:reuse", True)
 
         # Install a spec for which the `version_based` variant condition does not hold

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -759,19 +759,22 @@ class TestConcretize:
     @pytest.mark.parametrize(
         "spec_str,expected,not_expected",
         [
+            # TODO/TBD: This doesn't appear to be the case anymore with llvm, which
+            # TODO/TBD: is what gets picked now for mpileaks.
+            # TODO/TBD: Should mpileaks be dropped or replaced?
             # clang only provides C, and C++ compilers, while gcc has also fortran
             #
             # If we ask mpileaks%clang, then %gcc must be used for fortran, and since
             # %gcc is preferred to clang in config, it will be used for most nodes
             (
                 "mpileaks %clang",
-                {"mpileaks": "%clang", "libdwarf": "%gcc", "libelf": "%gcc"},
-                {"libdwarf": "%clang", "libelf": "%clang"},
+                {"mpileaks": "%clang", "libdwarf": "%clang", "libelf": "%clang"},
+                {"libdwarf": "%gcc", "libelf": "%gcc"},
             ),
             (
                 "mpileaks %clang@:15.0.0",
-                {"mpileaks": "%clang", "libdwarf": "%gcc", "libelf": "%gcc"},
-                {"libdwarf": "%clang", "libelf": "%clang"},
+                {"mpileaks": "%clang", "libdwarf": "%clang", "libelf": "%clang"},
+                {"libdwarf": "%gcc", "libelf": "%gcc"},
             ),
             (
                 "mpileaks %gcc",
@@ -1390,7 +1393,7 @@ class TestConcretize:
         assert root.dag_hash() != new_root_without_reuse.dag_hash()
 
     @pytest.mark.regression("43663")
-    def test_no_reuse_when_variant_condition_does_not_hold(self, mutable_database, mock_packages):
+    def test_no_reuse_when_variant_condition_does_not_hold(self, mutable_database):
         spack.config.set("concretizer:reuse", True)
 
         # Install a spec for which the `version_based` variant condition does not hold

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -887,6 +887,7 @@ def no_packages_yaml(mutable_config):
         compilers_yaml = local_config.get_section_filename("packages")
         if os.path.exists(compilers_yaml):
             os.remove(compilers_yaml)
+    mutable_config.clear_caches()
     return mutable_config
 
 

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -81,7 +81,7 @@ packages:
             fortran: /path/bin/gfortran-10
   llvm:
     externals:
-      - spec: "llvm@15.0.0 +clang os={linux_os.name}{linux_os.version} target={target}"
+      - spec: "llvm@15.0.0 +clang~flang os={linux_os.name}{linux_os.version} target={target}"
         prefix: /path
         extra_attributes:
           compilers:

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -52,7 +52,7 @@ def test_rfc_remote_local_path_no_dest():
 
 
 packages_yaml_sha256 = (
-    "8b69d9c6e983dfb8bac2ddc3910a86265cffdd9c85f905c716d426ec5b0d9847"
+    "6a1b26c857ca7e5bcd7342092e2f218da43d64b78bd72771f603027ea3c8b4af"
     if sys.platform != "win32"
     else "182a5cdfdd88f50be23e55607b46285854c664c064e5a9f3f1e0200ebca6a1db"
 )

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -54,7 +54,7 @@ def test_rfc_remote_local_path_no_dest():
 packages_yaml_sha256 = (
     "6a1b26c857ca7e5bcd7342092e2f218da43d64b78bd72771f603027ea3c8b4af"
     if sys.platform != "win32"
-    else "182a5cdfdd88f50be23e55607b46285854c664c064e5a9f3f1e0200ebca6a1db"
+    else "ae3239d769f9e6dc137a998489b0d44c70b03e21de4ecd6a623a3463a1a5c3f4"
 )
 
 

--- a/var/spack/test_repos/builtin.mock/packages/llvm/package.py
+++ b/var/spack/test_repos/builtin.mock/packages/llvm/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+import re
 
 from spack.package import *
 
@@ -12,20 +13,75 @@ class Llvm(Package, CompilerPackage):
     homepage = "http://www.example.com"
     url = "http://www.example.com/gcc-1.0.tar.gz"
 
+    tags = ["compiler"]
+
     version("18.1.8", md5="0123456789abcdef0123456789abcdef")
 
     variant(
         "clang", default=True, description="Build the LLVM C/C++/Objective-C compiler frontend"
     )
+    variant(
+        "flang",
+        default=False,
+        description="Build the LLVM Fortran compiler frontend "
+        "(experimental - parser only, needs GCC)",
+    )
     variant("lld", default=True, description="Build the LLVM linker")
 
     provides("c", "cxx", when="+clang")
+    provides("fortran", when="+flang")
 
     depends_on("c")
 
+    compiler_version_argument = "--version"
     c_names = ["clang"]
     cxx_names = ["clang++"]
-    fortran_names = ["flang"]
+
+    clang_and_friends = "(?:clang|flang|flang-new)"
+
+    compiler_version_regex = (
+        # Normal clang compiler versions are left as-is
+        rf"{clang_and_friends} version ([^ )\n]+)-svn[~.\w\d-]*|"
+        # Don't include hyphenated patch numbers in the version
+        # (see https://github.com/spack/spack/pull/14365 for details)
+        rf"{clang_and_friends} version ([^ )\n]+?)-[~.\w\d-]*|"
+        rf"{clang_and_friends} version ([^ )\n]+)|"
+        # LLDB
+        r"lldb version ([^ )\n]+)|"
+        # LLD
+        r"LLD ([^ )\n]+) \(compatible with GNU linkers\)"
+    )
+    fortran_names = ["flang", "flang-new"]
+
+    @classmethod
+    def determine_version(cls, exe):
+        try:
+            compiler = Executable(exe)
+            output = compiler(cls.compiler_version_argument, output=str, error=str)
+            if "Apple" in output:
+                return None
+            if "AMD" in output:
+                return None
+            match = re.search(cls.compiler_version_regex, output)
+            if match:
+                return match.group(match.lastindex)
+        except ProcessError:
+            pass
+        except Exception as e:
+            tty.debug(e)
+
+        return None
+
+    @classmethod
+    def filter_detected_exes(cls, prefix, exes_in_prefix):
+        # Executables like lldb-vscode-X are daemon listening on some port and would hang Spack
+        # during detection. clang-cl, clang-cpp, etc. are dev tools that we don't need to test
+        reject = re.compile(
+            r"-(vscode|cpp|cl|ocl|gpu|tidy|rename|scan-deps|format|refactor|offload|"
+            r"check|query|doc|move|extdef|apply|reorder|change-namespace|"
+            r"include-fixer|import-test|dap|server|PerfectShuffle)"
+        )
+        return [x for x in exes_in_prefix if not reject.search(x)]
 
     def install(self, spec, prefix):
         # Create the minimal compiler that will fool `spack compiler find`

--- a/var/spack/test_repos/builtin.mock/packages/mpileaks/package.py
+++ b/var/spack/test_repos/builtin.mock/packages/mpileaks/package.py
@@ -25,6 +25,8 @@ class Mpileaks(Package):
     depends_on("callpath")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     # Will be used to try raising an exception
     libs = None

--- a/var/spack/test_repos/builtin.mock/packages/mpileaks/package.py
+++ b/var/spack/test_repos/builtin.mock/packages/mpileaks/package.py
@@ -25,8 +25,6 @@ class Mpileaks(Package):
     depends_on("callpath")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build")
-    depends_on("fortran", type="build")
 
     # Will be used to try raising an exception
     libs = None


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, replaces commits:
- https://github.com/spack/spack/commit/0871469c197778cda0b0c2ef0f2f91ec11aa9243
- https://github.com/spack/spack/commit/db69acb55f908a3a14d3e7397c9bdd47e63b7b50
- https://github.com/spack/spack/commit/c0bc5764ae339cf1e22e3f3b99c396c786dd6b05
- https://github.com/spack/spack/commit/12280729b44bc2d8232f9756b6795d3d8e45a4db
- https://github.com/spack/spack/commit/b73fcfbb21f0fdb213b32f3b9b971ff2b470fed8
- https://github.com/spack/spack/commit/3a5e4c7963fbf93aef59435d40ee692e805f1a20
- https://github.com/spack/spack/commit/c45c42a8861ebe52c48d28c59024416d0591ae16 (remove unused import; not merged)
- https://github.com/spack/spack/commit/b0b4317949bb476490832b9edaf241ba05826b89

There are 5 `test/cmd/compiler.py` tests that will fail without any access to the builtin repository and with the symlinks for gcc-runtime and compiler-wrapper. Those falling tests are:

```
FAILED lib/spack/spack/test/cmd/compiler.py::test_compiler_find_without_paths - assert 'gcc' in "==> Warning: Failed to initialize repository: ... 
FAILED lib/spack/spack/test/cmd/compiler.py::test_compiler_add - assert 0 == 1
FAILED lib/spack/spack/test/cmd/compiler.py::test_compiler_find_prefer_no_suffix - AssertionError: assert 'llvm@11.0.0' in '==> Found no new co...
FAILED lib/spack/spack/test/cmd/compiler.py::test_compiler_find_path_order - assert 0 == 2
FAILED lib/spack/spack/test/cmd/compiler.py::test_compilers_shows_packages_yaml[external0-gcc@7.7.7 languages=c,cxx,fortran os=foobar target=x86_64:\n  paths:\n    cc = /path/to/fake/gcc\n    cxx = /path/to/fake/g++\n\t\tf77 = /path/to/fake/gfortran\n\t\tfc = /path/to/fake/gfortran\n\tflags:\n\t\tfflags = ['-ffree-form']\n\tmodules  = ['gcc/7.7.7', 'foobar']\n\toperating system  = foobar\n]
```

UPDATE: With the changes to `llvm` and the rebase, `test/concretization/core.py` no longer yields the same results for `mpileaks%clang` even after adding the `fortran` dependency to the mock `mpileaks` package. The failures were:

```
FAILED lib/spack/spack/test/concretization/core.py::TestConcretize::test_compiler_inheritance[mpileaks %clang-expected0-not_expected0] - Asserti...
FAILED lib/spack/spack/test/concretization/core.py::TestConcretize::test_compiler_inheritance[mpileaks %clang@:15.0.0-expected1-not_expected1]
```

because `llvm` (not `gcc`) is now selected as the compiler for the dependencies.

TODO:

- [ ] `test_compiler_inheritance ` Remove the `mpileaks` tests (since no longer add value) or replace