### PR TITLE
[WIP] New command: `spack mirror add-archive`

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -262,6 +262,10 @@ def mirror_add_artifact(args):
             spack.util.crypto.hash_fun_for_algo("sha256"), args.artifact
         ),
     )
+
+    # Use the mirror layout to determine the relative digest path and
+    # turn that into a relative url: util.url does not do this for
+    # relative paths.
     layout = spack.mirrors.layout.default_mirror_layout(local_fetcher, "unknown")
     relative_digest_path = layout.digest_path
     tokenized_relpath = pathlib.PurePath(pathlib.PurePath(relative_digest_path).as_posix()).parts

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+import pathlib
 import sys
 
 import llnl.util.lang as lang
@@ -12,7 +14,10 @@ import spack.caches
 import spack.cmd
 import spack.concretize
 import spack.config
+import spack.fetch_strategy
+import spack.util.crypto
 import spack.environment as ev
+import spack.mirrors.layout
 import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.repo
@@ -237,12 +242,6 @@ def setup_parser(subparser):
 
 
 def mirror_add_artifact(args):
-    import os
-    import pathlib
-    import spack.fetch_strategy
-    import spack.mirrors.layout
-    import spack.util.crypto
-
     mirror_name = args.name
     mirrors = spack.config.get("mirrors")
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -254,7 +254,8 @@ def mirror_add_artifact(args):
     if mirror_name in mirrors:
         the_mirror = spack.mirrors.mirror.Mirror(mirrors[mirror_name], name=mirror_name)
     else:
-        raise ValueError(f"The mirror does not exist: {mirror_name}")
+        assumed_mirror_path = os.path.abspath(args.name)
+        the_mirror = spack.mirrors.mirror.Mirror.from_url(f"file://{assumed_mirror_path}")
 
     local_fetcher = spack.fetch_strategy.URLFetchStrategy(
         url=f"file://{os.path.abspath(args.artifact)}",

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -230,6 +230,48 @@ def setup_parser(subparser):
         "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
     )
 
+    # Add-artifact
+    add_artifact_parser = sp.add_parser("add-artifact", help=mirror_add.__doc__)
+    add_artifact_parser.add_argument("name", help="name of existing mirror, or a path", metavar="mirror")
+    add_artifact_parser.add_argument("artifact", help="path to the artifact you want to add", metavar="mirror")
+
+
+def mirror_add_artifact(args):
+    import os
+    import pathlib
+    import spack.fetch_strategy
+    import spack.mirrors.layout
+    import spack.util.crypto
+
+    mirror_name = args.name
+    mirrors = spack.config.get("mirrors")
+
+    if not os.path.exists(args.artifact):
+        raise ValueError(f"Artifact path does not exist: {args.artifact}")
+    if mirror_name in mirrors:
+        the_mirror = spack.mirrors.mirror.Mirror(mirrors[mirror_name], name=mirror_name)
+    else:
+        raise ValueError(f"The mirror does not exist: {mirror_name}")
+
+    local_fetcher = spack.fetch_strategy.URLFetchStrategy(
+        url=f"file://{os.path.abspath(args.artifact)}",
+        checksum=spack.util.crypto.checksum(
+            spack.util.crypto.hash_fun_for_algo("sha256"),
+            args.artifact
+        )
+    )
+    layout = spack.mirrors.layout.default_mirror_layout(
+        local_fetcher, "unknown"
+    )
+    relative_digest_path = layout.digest_path
+    tokenized_relpath = pathlib.PurePath(pathlib.PurePath(relative_digest_path).as_posix()).parts
+    if tokenized_relpath[0] == "./":
+        tokenized_relpath = tokenized_relpath[1:]
+    relative_url = "/".join(tokenized_relpath)
+
+    dest_url = "/".join([the_mirror.push_url, relative_url])
+    web_util.push_to_url(args.artifact, dest_url, keep_original=True)
+
 
 def _configure_access_pair(
     args, id_tok, id_variable_tok, secret_tok, secret_variable_tok, default=None
@@ -700,6 +742,7 @@ def mirror(parser, args):
         "set-url": mirror_set_url,
         "set": mirror_set,
         "list": mirror_list,
+        "add-artifact": mirror_add_artifact,
     }
 
     if args.no_checksum:

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -14,14 +14,14 @@ import spack.caches
 import spack.cmd
 import spack.concretize
 import spack.config
-import spack.fetch_strategy
-import spack.util.crypto
 import spack.environment as ev
+import spack.fetch_strategy
 import spack.mirrors.layout
 import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.repo
 import spack.spec
+import spack.util.crypto
 import spack.util.web as web_util
 from spack.cmd.common import arguments
 from spack.error import SpackError
@@ -237,8 +237,12 @@ def setup_parser(subparser):
 
     # Add-artifact
     add_artifact_parser = sp.add_parser("add-artifact", help=mirror_add.__doc__)
-    add_artifact_parser.add_argument("name", help="name of existing mirror, or a path", metavar="mirror")
-    add_artifact_parser.add_argument("artifact", help="path to the artifact you want to add", metavar="mirror")
+    add_artifact_parser.add_argument(
+        "name", help="name of existing mirror, or a path", metavar="mirror"
+    )
+    add_artifact_parser.add_argument(
+        "artifact", help="path to the artifact you want to add", metavar="mirror"
+    )
 
 
 def mirror_add_artifact(args):
@@ -255,13 +259,10 @@ def mirror_add_artifact(args):
     local_fetcher = spack.fetch_strategy.URLFetchStrategy(
         url=f"file://{os.path.abspath(args.artifact)}",
         checksum=spack.util.crypto.checksum(
-            spack.util.crypto.hash_fun_for_algo("sha256"),
-            args.artifact
-        )
+            spack.util.crypto.hash_fun_for_algo("sha256"), args.artifact
+        ),
     )
-    layout = spack.mirrors.layout.default_mirror_layout(
-        local_fetcher, "unknown"
-    )
+    layout = spack.mirrors.layout.default_mirror_layout(local_fetcher, "unknown")
     relative_digest_path = layout.digest_path
     tokenized_relpath = pathlib.PurePath(pathlib.PurePath(relative_digest_path).as_posix()).parts
     if tokenized_relpath[0] == "./":


### PR DESCRIPTION
Closes https://github.com/spack/spack/pull/50208

If you manually downloaded a source tarball and you want it to be available in a mirror, this is the new (and only straightforward) way to make that happen:

`spack mirror add-archive ./m1/ ~/Downloads/kokkos-4.6.01.tar.gz `

This determines the digest-based path reference for the archive, and places in the mirror so that if you add that path (for example) like

`` spack mirror add m1 `pwd`/m1 ``

That spack will be able to find that archive in the mirror if you e.g. `spack stage kokkos@4.6.01`

This approach only works for source tarballs with a known digest in the associated package.py. It does not work for:

* git anything
  * branch tips, which you can place in e.g. `kokkos/kokkos-develop.tar.gz` (i.e. there is a simple path, but no command support)
  * fixed commits, which have no recourse (i.e. no simple path, and no command support)

Assuming the general form of this command is agreeable for tarballs, it should be possible to simple it for `git` (although the point is the command needs explicit support for each type of thing and would need the user to say how they got it, e.g. that they created the tarball with `git`). 