### PR TITLE
Spack-Snake: A stack for python

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/spack-snake/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/spack-snake/spack.yaml
@@ -1,0 +1,44 @@
+spack:
+  view: false
+
+  concretizer:
+    reuse: false
+    unify: false
+    static_analysis: true
+
+  packages:
+    all:
+      require:
+      - "%gcc"
+      - target=x86_64_v3
+      variants: +mpi
+    c:
+      require: gcc
+    cxx:
+      require: gcc
+    fortran:
+      require: gcc
+    mpi:
+      require:
+      - openmpi
+    blas:
+      require:
+      - openblas
+    lapack:
+      require:
+      - openblas
+  specs:
+  - python
+  - py-numpy
+  - py-scipy
+  - py-matplotlib
+  - py-pip
+  - py-mpi4py
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01
+
+  cdash:
+    build-group: spack-snake


### PR DESCRIPTION
Spack has the ability to provide a binary cache of python packages for general use in the scientific and data analytics communities. This PR is an effort to begin such a collection

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
