### PR TITLE
lcio: add version 2.22.6

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/lcio/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/lcio/package.py
@@ -20,6 +20,7 @@ class Lcio(CMakePackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("2.22.6", sha256="69271f021198d15390a0134110ab5c1cbeea9a183cef3f94f0d1ee91fa4748bb")
     version("2.22.5", sha256="a756521a2419f8d25d4a4f1bab0008e16c9947020d015f2f6ce457ab0a0429bf")
     version("2.22.4", sha256="5d60eeb4df8611059f4bc839ac098f5d7e3608a662591e9cbae48aed07995514")
     version("2.22.3", sha256="5b9715786c5e953f8854881c5d0c4a48030a5491f1701232b82e960ac7980162")
@@ -66,7 +67,7 @@ class Lcio(CMakePackage):
     variant("rootdict", default=True, description="Turn on to build/install ROOT dictionary.")
     variant("examples", default=False, description="Turn on to build LCIO examples")
 
-    depends_on("c", type="build")
+    depends_on("c", type="build", when="@:2.22.5")
     depends_on("cxx", type="build")
 
     depends_on("sio@0.0.2:", when="@2.14:")


### PR DESCRIPTION
Fix dependency on "c" to previous versions as this has been fixed in the latest tag [as per the release notes](https://github.com/iLCSoft/LCIO/releases/tag/v02-22-06)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
