### PR TITLE
repo.py: enable search paths when spack.repo.PATH is assigned

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -550,7 +550,6 @@ def setup_main_options(args):
         spack.config.CONFIG.scopes["command_line"].sections["repos"] = syaml.syaml_dict(
             [(key, [spack.paths.mock_packages_path])]
         )
-        spack.repo.PATH = spack.repo.create(spack.config.CONFIG)
 
     # If the user asked for it, don't check ssl certs.
     if args.insecure:
@@ -560,6 +559,8 @@ def setup_main_options(args):
     # Use the spack config command to handle parsing the config strings
     for config_var in args.config_vars or []:
         spack.config.add(fullpath=config_var, scope="command_line")
+
+    spack.repo.enable_repo(spack.repo.create(spack.config.CONFIG))
 
     # On Windows10 console handling for ASCI/VT100 sequences is not
     # on by default. Turn on before we try to write to console

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -106,7 +106,7 @@ class GlobalStateMarshaler:
 
     def restore(self):
         spack.config.CONFIG = self.config
-        spack.repo.PATH = spack.repo.create(self.config)
+        spack.repo.enable_repo(spack.repo.create(self.config))
         spack.platforms.host = self.platform
         spack.store.STORE = self.store
         self.test_patches.restore()
@@ -129,7 +129,6 @@ class TestPatches:
 
 
 def store_patches():
-    global patches
     module_patches = list()
     class_patches = list()
     if not patches:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2028,13 +2028,12 @@ def test_ci_verify_versions_valid(
     tmpdir,
 ):
     repo, _, commits = mock_git_package_changes
-    spack.repo.PATH.put_first(repo)
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
 
-    monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
-
-    out = ci_cmd("verify-versions", commits[-1], commits[-3])
-    assert "Validated diff-test@2.1.5" in out
-    assert "Validated diff-test@2.1.6" in out
+        out = ci_cmd("verify-versions", commits[-1], commits[-3])
+        assert "Validated diff-test@2.1.5" in out
+        assert "Validated diff-test@2.1.6" in out
 
 
 def test_ci_verify_versions_standard_invalid(
@@ -2045,23 +2044,21 @@ def test_ci_verify_versions_standard_invalid(
     verify_git_versions_invalid,
 ):
     repo, _, commits = mock_git_package_changes
-    spack.repo.PATH.put_first(repo)
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
 
-    monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
-
-    out = ci_cmd("verify-versions", commits[-1], commits[-3], fail_on_error=False)
-    assert "Invalid checksum found diff-test@2.1.5" in out
-    assert "Invalid commit for diff-test@2.1.6" in out
+        out = ci_cmd("verify-versions", commits[-1], commits[-3], fail_on_error=False)
+        assert "Invalid checksum found diff-test@2.1.5" in out
+        assert "Invalid commit for diff-test@2.1.6" in out
 
 
 def test_ci_verify_versions_manual_package(monkeypatch, mock_packages, mock_git_package_changes):
     repo, _, commits = mock_git_package_changes
-    spack.repo.PATH.put_first(repo)
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
 
-    monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
+        pkg_class = spack.spec.Spec("diff-test").package_class
+        monkeypatch.setattr(pkg_class, "manual_download", True)
 
-    pkg_class = spack.spec.Spec("diff-test").package_class
-    monkeypatch.setattr(pkg_class, "manual_download", True)
-
-    out = ci_cmd("verify-versions", commits[-1], commits[-2])
-    assert "Skipping manual download package: diff-test" in out
+        out = ci_cmd("verify-versions", commits[-1], commits[-2])
+        assert "Skipping manual download package: diff-test" in out

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -312,7 +312,6 @@ class TestRepoPath:
     def test_creation_from_string(self, mock_test_cache):
         repo = spack.repo.RepoPath(spack.paths.mock_packages_path, cache=mock_test_cache)
         assert len(repo.repos) == 1
-        assert repo.repos[0]._finder is repo
         assert repo.by_namespace["builtin.mock"] is repo.repos[0]
 
     def test_get_repo(self, mock_test_cache):

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -40,9 +40,7 @@ spack -p --lines 20 spec mpileaks%gcc
 $coverage_run $(which spack) bootstrap status --dev --optional
 
 # Check that we can import Spack packages directly as a first import
-# TODO: this check is disabled, because sys.path is only updated once
-# spack.repo.PATH.get_pkg_class is called.
-# $coverage_run $(which spack) python -c "import spack.pkg.builtin.mpileaks; repr(spack.pkg.builtin.mpileaks.Mpileaks)"
+$coverage_run $(which spack) python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
 
 #-----------------------------------------------------------
 # Run unit tests with code coverage


### PR DESCRIPTION
Fixes a bug where `custom_repo.get_pkg_class("foo")` failed executing `import spack_repo.builtin` even if the builtin repo was configured globally.

The solution for now is to consider `spack.repo.PATH` a required global, even when you construct a single repo instance, since we don't specify dependencies across repo instances.

Instead of assignment of `spack.repo.PATH`, the `spack.repo.enable_repo` function now assigns and enables the repo, meaning that also Python module search paths are modified.