### PR TITLE
apache-tvm: add v0.19.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/apache_tvm/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/apache_tvm/package.py
@@ -13,13 +13,15 @@ class ApacheTvm(CMakePackage, CudaPackage):
     hardware backend."""
 
     homepage = "https://tvm.apache.org/"
-    url = "https://dlcdn.apache.org/tvm/tvm-v0.16.0/apache-tvm-src-v0.16.0.tar.gz"
 
     license("Apache-2.0", checked_by="alex391")
+    url = "https://github.com/apache/tvm/releases/download/v0.19.0/apache-tvm-src-v0.19.0.tar.gz"
 
+    version("0.19.0", sha256="13fd707eae37b9b2b77bccd39668764f61ae6824d50cd1ab8164df1c75565be1")
     version(
         "0.16.0",
         sha256="55e2629c39248ef3b1ee280e34a960182bd17bea7ae0d0fa132bbdaaf5aba1ac",
+        url="https://dlcdn.apache.org/tvm/tvm-v0.16.0/apache-tvm-src-v0.16.0.tar.gz",
         deprecated=True,
     )
 
@@ -28,10 +30,16 @@ class ApacheTvm(CMakePackage, CudaPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("cmake@3.18:", type="build")
-    depends_on("python@3.7:3.8", type=("build", "run"))
+
+    depends_on("python@3.7:", type=("build", "run"))
+    conflicts("^python@3.9.0:", when="@:0.16")
+
     depends_on("zlib-api", type=("link", "run"))
     depends_on("ncurses", type=("link", "run"))
-    depends_on("llvm@4:18.1.8", type="build", when="+llvm")
+
+    depends_on("llvm@4:", type="build", when="+llvm")
+    conflicts("^llvm@19.0.0:", when="@:0.16+llvm")
+
     depends_on("cuda@8:", when="+cuda")
 
     def cmake_args(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Note that `url = "https://dlcdn.apache.org/tvm/tvm-v0.16.0/apache-tvm-src-v0.16.0.tar.gz"` is invalid for v0.19.0. Use GitHub release instead.
