### PR TITLE
builtin: remove various redundant wildcard imports

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/paraconf/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/paraconf/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 

--- a/var/spack/repos/spack_repo/builtin/packages/pdi/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdi/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.hooks.sbang import sbang_shebang_line
 from spack.package import *
 

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_decl_hdf5/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_decl_hdf5/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 from ..pdi.package import Pdi

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_decl_netcdf/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_decl_netcdf/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 from ..pdi.package import Pdi

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_mpi/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_mpi/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 from ..pdi.package import Pdi

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_pycall/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_pycall/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 from ..pdi.package import Pdi

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_serialize/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_serialize/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 from ..pdi.package import Pdi

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_set_value/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_set_value/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 from ..pdi.package import Pdi

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_trace/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_trace/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 from ..pdi.package import Pdi

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_user_code/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_user_code/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 from ..pdi.package import Pdi

--- a/var/spack/repos/spack_repo/builtin/packages/zpp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/zpp/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.package import *
 
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
