### PR TITLE
builtin: remove unused imports from build_systems

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/libmng/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libmng/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.build_systems
 import spack.build_systems.autotools
 import spack.build_systems.cmake
 from spack.package import *

--- a/var/spack/repos/spack_repo/builtin/packages/libuv/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libuv/package.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import sys
 
-import spack.build_systems
 import spack.build_systems.autotools
 from spack.package import *
 

--- a/var/spack/repos/spack_repo/builtin/packages/sccache/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/sccache/package.py
@@ -5,7 +5,6 @@
 import os
 import re
 
-import spack.build_systems
 import spack.build_systems.cargo
 from spack.package import *
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
