### PR TITLE
RepoSplit/tests: switch compilers/conversion.py to use mock packages

### DIFF
--- a/lib/spack/spack/test/compilers/conversion.py
+++ b/lib/spack/spack/test/compilers/conversion.py
@@ -35,7 +35,7 @@ def mock_compiler(mock_executable):
 #     extra_rpaths: []
 
 
-def test_basic_compiler_conversion(mock_packages, mock_compiler, tmp_path):
+def test_basic_compiler_conversion(mock_compiler, tmp_path):
     """Tests the conversion of a compiler using a single toolchain, with default options."""
     compilers = CompilerFactory.from_legacy_yaml(mock_compiler)
     compiler_spec = compilers[0]

--- a/lib/spack/spack/test/compilers/conversion.py
+++ b/lib/spack/spack/test/compilers/conversion.py
@@ -6,11 +6,11 @@ import pytest
 
 from spack.compilers.config import CompilerFactory
 
-pytestmark = [pytest.mark.usefixtures("mock_compilers")]
+pytestmark = [pytest.mark.usefixtures("config", "mock_packages")]
 
 
 @pytest.fixture()
-def legacy_compiler_yaml(mock_executable):
+def mock_compiler(mock_executable):
     gcc = mock_executable("gcc", "echo 13.2.0")
     gxx = mock_executable("g++", "echo 13.2.0")
     gfortran = mock_executable("gfortran", "echo 13.2.0")
@@ -35,9 +35,9 @@ def legacy_compiler_yaml(mock_executable):
 #     extra_rpaths: []
 
 
-def test_basic_compiler_conversion(mock_packages, legacy_compiler_yaml, tmp_path):
+def test_basic_compiler_conversion(mock_packages, mock_compiler, tmp_path):
     """Tests the conversion of a compiler using a single toolchain, with default options."""
-    compilers = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)
+    compilers = CompilerFactory.from_legacy_yaml(mock_compiler)
     compiler_spec = compilers[0]
     assert compiler_spec.satisfies("gcc@13.2.0 languages=c,c++,fortran")
     assert compiler_spec.external
@@ -47,55 +47,55 @@ def test_basic_compiler_conversion(mock_packages, legacy_compiler_yaml, tmp_path
         assert language in compiler_spec.extra_attributes["compilers"]
 
 
-def test_compiler_conversion_with_flags(legacy_compiler_yaml):
+def test_compiler_conversion_with_flags(mock_compiler):
     """Tests that flags are converted appropriately for external compilers"""
-    legacy_compiler_yaml["flags"] = {"cflags": "-O3", "cxxflags": "-O2 -g"}
-    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)[0]
+    mock_compiler["flags"] = {"cflags": "-O3", "cxxflags": "-O2 -g"}
+    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
     assert compiler_spec.external
     assert "flags" in compiler_spec.extra_attributes
     assert compiler_spec.extra_attributes["flags"]["cflags"] == "-O3"
     assert compiler_spec.extra_attributes["flags"]["cxxflags"] == "-O2 -g"
 
 
-def test_compiler_conversion_with_environment(legacy_compiler_yaml):
+def test_compiler_conversion_with_environment(mock_compiler):
     """Tests that custom environment modifications are converted appropriately
     for external compilers
     """
     mods = {"set": {"FOO": "foo", "BAR": "bar"}, "unset": ["BAZ"]}
-    legacy_compiler_yaml["environment"] = mods
-    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)[0]
+    mock_compiler["environment"] = mods
+    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
     assert compiler_spec.external
     assert "environment" in compiler_spec.extra_attributes
     assert compiler_spec.extra_attributes["environment"] == mods
 
 
-def test_compiler_conversion_extra_rpaths(legacy_compiler_yaml):
+def test_compiler_conversion_extra_rpaths(mock_compiler):
     """Tests that extra rpaths are converted appropriately for external compilers"""
-    legacy_compiler_yaml["extra_rpaths"] = ["/foo/bar"]
-    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)[0]
+    mock_compiler["extra_rpaths"] = ["/foo/bar"]
+    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
     assert compiler_spec.external
     assert "extra_rpaths" in compiler_spec.extra_attributes
     assert compiler_spec.extra_attributes["extra_rpaths"] == ["/foo/bar"]
 
 
-def test_compiler_conversion_modules(legacy_compiler_yaml):
+def test_compiler_conversion_modules(mock_compiler):
     """Tests that modules are converted appropriately for external compilers"""
     modules = ["foo/4.1.2", "bar/5.1.4"]
-    legacy_compiler_yaml["modules"] = modules
-    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)[0]
+    mock_compiler["modules"] = modules
+    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
     assert compiler_spec.external
     assert compiler_spec.external_modules == modules
 
 
 @pytest.mark.regression("49717")
-def test_compiler_conversion_corrupted_paths(legacy_compiler_yaml):
+def test_compiler_conversion_corrupted_paths(mock_compiler):
     """Tests that compiler entries with corrupted path do not raise"""
-    legacy_compiler_yaml["paths"] = {
+    mock_compiler["paths"] = {
         "cc": "gcc",
         "cxx": "g++",
         "fc": "gfortran",
         "f77": "gfortran",
     }
     # Test this call doesn't raise
-    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)
+    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)
     assert compiler_spec == []

--- a/lib/spack/spack/test/compilers/conversion.py
+++ b/lib/spack/spack/test/compilers/conversion.py
@@ -6,9 +6,11 @@ import pytest
 
 from spack.compilers.config import CompilerFactory
 
+pytestmark = [pytest.mark.usefixtures("mock_compilers")]
+
 
 @pytest.fixture()
-def mock_compiler(mock_executable):
+def legacy_compiler_yaml(mock_executable):
     gcc = mock_executable("gcc", "echo 13.2.0")
     gxx = mock_executable("g++", "echo 13.2.0")
     gfortran = mock_executable("gfortran", "echo 13.2.0")
@@ -33,9 +35,9 @@ def mock_compiler(mock_executable):
 #     extra_rpaths: []
 
 
-def test_basic_compiler_conversion(mock_compiler, tmp_path):
+def test_basic_compiler_conversion(mock_packages, legacy_compiler_yaml, tmp_path):
     """Tests the conversion of a compiler using a single toolchain, with default options."""
-    compilers = CompilerFactory.from_legacy_yaml(mock_compiler)
+    compilers = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)
     compiler_spec = compilers[0]
     assert compiler_spec.satisfies("gcc@13.2.0 languages=c,c++,fortran")
     assert compiler_spec.external
@@ -45,50 +47,55 @@ def test_basic_compiler_conversion(mock_compiler, tmp_path):
         assert language in compiler_spec.extra_attributes["compilers"]
 
 
-def test_compiler_conversion_with_flags(mock_compiler):
+def test_compiler_conversion_with_flags(legacy_compiler_yaml):
     """Tests that flags are converted appropriately for external compilers"""
-    mock_compiler["flags"] = {"cflags": "-O3", "cxxflags": "-O2 -g"}
-    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
+    legacy_compiler_yaml["flags"] = {"cflags": "-O3", "cxxflags": "-O2 -g"}
+    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)[0]
     assert compiler_spec.external
     assert "flags" in compiler_spec.extra_attributes
     assert compiler_spec.extra_attributes["flags"]["cflags"] == "-O3"
     assert compiler_spec.extra_attributes["flags"]["cxxflags"] == "-O2 -g"
 
 
-def tests_compiler_conversion_with_environment(mock_compiler):
+def test_compiler_conversion_with_environment(legacy_compiler_yaml):
     """Tests that custom environment modifications are converted appropriately
     for external compilers
     """
     mods = {"set": {"FOO": "foo", "BAR": "bar"}, "unset": ["BAZ"]}
-    mock_compiler["environment"] = mods
-    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
+    legacy_compiler_yaml["environment"] = mods
+    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)[0]
     assert compiler_spec.external
     assert "environment" in compiler_spec.extra_attributes
     assert compiler_spec.extra_attributes["environment"] == mods
 
 
-def tests_compiler_conversion_extra_rpaths(mock_compiler):
+def test_compiler_conversion_extra_rpaths(legacy_compiler_yaml):
     """Tests that extra rpaths are converted appropriately for external compilers"""
-    mock_compiler["extra_rpaths"] = ["/foo/bar"]
-    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
+    legacy_compiler_yaml["extra_rpaths"] = ["/foo/bar"]
+    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)[0]
     assert compiler_spec.external
     assert "extra_rpaths" in compiler_spec.extra_attributes
     assert compiler_spec.extra_attributes["extra_rpaths"] == ["/foo/bar"]
 
 
-def tests_compiler_conversion_modules(mock_compiler):
+def test_compiler_conversion_modules(legacy_compiler_yaml):
     """Tests that modules are converted appropriately for external compilers"""
     modules = ["foo/4.1.2", "bar/5.1.4"]
-    mock_compiler["modules"] = modules
-    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
+    legacy_compiler_yaml["modules"] = modules
+    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)[0]
     assert compiler_spec.external
     assert compiler_spec.external_modules == modules
 
 
 @pytest.mark.regression("49717")
-def tests_compiler_conversion_corrupted_paths(mock_compiler):
+def test_compiler_conversion_corrupted_paths(legacy_compiler_yaml):
     """Tests that compiler entries with corrupted path do not raise"""
-    mock_compiler["paths"] = {"cc": "gcc", "cxx": "g++", "fc": "gfortran", "f77": "gfortran"}
+    legacy_compiler_yaml["paths"] = {
+        "cc": "gcc",
+        "cxx": "g++",
+        "fc": "gfortran",
+        "f77": "gfortran",
+    }
     # Test this call doesn't raise
-    compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)
+    compiler_spec = CompilerFactory.from_legacy_yaml(legacy_compiler_yaml)
     assert compiler_spec == []

--- a/lib/spack/spack/test/compilers/conversion.py
+++ b/lib/spack/spack/test/compilers/conversion.py
@@ -90,12 +90,7 @@ def test_compiler_conversion_modules(mock_compiler):
 @pytest.mark.regression("49717")
 def test_compiler_conversion_corrupted_paths(mock_compiler):
     """Tests that compiler entries with corrupted path do not raise"""
-    mock_compiler["paths"] = {
-        "cc": "gcc",
-        "cxx": "g++",
-        "fc": "gfortran",
-        "f77": "gfortran",
-    }
+    mock_compiler["paths"] = {"cc": "gcc", "cxx": "g++", "fc": "gfortran", "f77": "gfortran"}
     # Test this call doesn't raise
     compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)
     assert compiler_spec == []

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2222,11 +2222,6 @@ def mock_runtimes(config, mock_packages):
 
 
 @pytest.fixture()
-def mock_compilers(config, mock_packages):
-    return mock_packages.packages_with_tags("compiler")
-
-
-@pytest.fixture()
 def write_config_file(tmpdir):
     """Returns a function that writes a config file."""
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2222,6 +2222,11 @@ def mock_runtimes(config, mock_packages):
 
 
 @pytest.fixture()
+def mock_compilers(config, mock_packages):
+    return mock_packages.packages_with_tags("compiler")
+
+
+@pytest.fixture()
 def write_config_file(tmpdir):
     """Returns a function that writes a config file."""
 

--- a/var/spack/test_repos/builtin.mock/packages/gcc/package.py
+++ b/var/spack/test_repos/builtin.mock/packages/gcc/package.py
@@ -31,6 +31,7 @@ class Gcc(CompilerPackage, Package):
     provides("fortran", when="languages=fortran")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     c_names = ["gcc"]
     cxx_names = ["g++"]
@@ -47,6 +48,19 @@ class Gcc(CompilerPackage, Package):
         "cxx": os.path.join("gcc", "g++"),
         "fortran": os.path.join("gcc", "gfortran"),
     }
+
+    implicit_rpath_libs = ["libgcc", "libgfortran"]
+
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        compilers = cls.determine_compiler_paths(exes=exes)
+
+        languages = set()
+        translation = {"cxx": "c++"}
+        for lang, compiler in compilers.items():
+            languages.add(translation.get(lang, lang))
+        variant_str = "languages={0}".format(",".join(languages))
+        return variant_str, {"compilers": compilers}
 
     def install(self, spec, prefix):
         # Create the minimal compiler that will fool `spack compiler find`


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, replaces commits:

- https://github.com/spack/spack/commit/62a4d00ec92beb893f9e177c7d8dbfc1bbf8fe1a
- https://github.com/spack/spack/commit/dc9370f2127395a1596a4b60ace452371b092e1e (mock gcc changes)
- https://github.com/spack/spack/commit/8a3f1355fdea738e7811002232f61a382805e0db (mock_gcc_yaml -> legacy_compiler_yaml; not pushed)

There are 5 `test/compilers/conversion.py` tests that error out without access to the builtin repository:

```
FAILED lib/spack/spack/test/compilers/conversion.py::test_basic_compiler_conversion - IndexError: list index out of range
FAILED lib/spack/spack/test/compilers/conversion.py::test_compiler_conversion_with_flags - IndexError: list index out of range
FAILED lib/spack/spack/test/compilers/conversion.py::tests_compiler_conversion_with_environment - IndexError: list index out of range
FAILED lib/spack/spack/test/compilers/conversion.py::tests_compiler_conversion_extra_rpaths - IndexError: list index out of range
FAILED lib/spack/spack/test/compilers/conversion.py::tests_compiler_conversion_modules - IndexError: list index out of range
```

TODO:

- [x] Determine which commit pulled in gcc since I thought that was for test/compilers/libraries.py
~- [ ] None of these changes resolve the errors when `builtin` isn't available so determine what else is needed here~