### PR TITLE
netcdf_c: depends on cxx as well

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -139,6 +139,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     variant("zstd", default=True, description="Enable Zstandard compression plugin")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     with when("build_system=cmake"):
         # Based on the versions required by the root CMakeLists.txt:

--- a/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -139,7 +139,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     variant("zstd", default=True, description="Enable Zstandard compression plugin")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build")
+    depends_on("cxx", type="build", when="build_system=cmake")
 
     with when("build_system=cmake"):
         # Based on the versions required by the root CMakeLists.txt:


### PR DESCRIPTION
Configure fails without this.
