### PR TITLE
builtin: remove llnl.util.tty import

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/cray_mpich/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cray_mpich/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-import llnl.util.tty as tty
-
 from spack.package import *
 from spack.util.module_cmd import get_path_args_from_module_line, module
 

--- a/var/spack/repos/spack_repo/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libcatalyst/package.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 
 import llnl.util.filesystem as fsys
-import llnl.util.tty as tty
 
 from spack.package import *
 

--- a/var/spack/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -7,8 +7,6 @@ import os
 import re
 import sys
 
-import llnl.util.tty as tty
-
 import spack.compilers.config
 from spack.package import *
 


### PR DESCRIPTION
`tty` is defined through `from spack.package import *`