### PR TITLE
Update pynvml package

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
@@ -36,4 +36,12 @@ class PyNvidiaMlPy(PythonPackage):
     version("11.450.51", sha256="5aa6dd23a140b1ef2314eee5ca154a45397b03e68fd9ebc4f72005979f511c73")
 
     # pip silently replaces distutils with setuptools
+    
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/source/n/nvidia-ml-py/nvidia{0}ml{0}py-{1}.tar.gz"
+        if version > Version("12.560.30"):
+            sep = "_"
+        else:
+            sep = "-"
+        return url.format(sep, version)
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
@@ -44,4 +44,5 @@ class PyNvidiaMlPy(PythonPackage):
         else:
             sep = "-"
         return url.format(sep, version)
+
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
@@ -35,6 +35,8 @@ class PyNvidiaMlPy(PythonPackage):
     )
     version("11.450.51", sha256="5aa6dd23a140b1ef2314eee5ca154a45397b03e68fd9ebc4f72005979f511c73")
 
+    depends_on("py-setuptools", type="build")
+
     # pip silently replaces distutils with setuptools
 
     def url_for_version(self, version):
@@ -44,5 +46,3 @@ class PyNvidiaMlPy(PythonPackage):
         else:
             sep = "-"
         return url.format(sep, version)
-
-    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
@@ -19,14 +19,20 @@ class PyNvidiaMlPy(PythonPackage):
     version("12.560.30", sha256="f0254dc7400647680a072ee02509bfd46102b60bdfeca321576d4d4817e7fe97")
     version("12.555.43", sha256="e9e7f12ef1ec234bb0dc22d2bdc762ffafab394bdc472a07a4377c95bbf93afe")
     version("12.550.89", sha256="02f299a341db7f938883c9a1098d28396dc29d5bb6b0f2806833e7dafff071f1")
-    version("12.535.161", sha256="2bcc31ff7a0ea291ed8d7fc39b149391a42c2fb1cb4256c935e692de488b4d17")
-    version("11.525.150", sha256="50af55b99ea167781102345a7de29bac94a57c8f38de6757ef9f945dd137c90a")
+    version(
+        "12.535.161", sha256="2bcc31ff7a0ea291ed8d7fc39b149391a42c2fb1cb4256c935e692de488b4d17"
+    )
+    version(
+        "11.525.150", sha256="50af55b99ea167781102345a7de29bac94a57c8f38de6757ef9f945dd137c90a"
+    )
     version("11.515.75", sha256="e3c75f06d5a3201dc51136e00e58c5c132b3be5d604d86c143426adb4e41c490")
     version("11.510.69", sha256="f7e0cd3a266c7c88ae5467cc6b7dab13d26adfd6b8e4ec8c555a4cc9897ce907")
     version("11.495.46", sha256="8f68e1af274756067632c7e1b79fb1a93a8dddf1e04851fccaeb34adfa599625")
     version("11.470.66", sha256="20fff0dcd40b32fdc674cd98bc614bb8b6cc8d488687a55bf8c569eef39541f3")
     version("11.460.79", sha256="5b7c051cd55469848960bb9fde07dc8fd25d21853307eeba669bfe3c3ede11c5")
-    version("11.450.129", sha256="b0170a3f16efdd055c283d3b94c7d2d517f32456e84ad118d809396929fcad4f")
+    version(
+        "11.450.129", sha256="b0170a3f16efdd055c283d3b94c7d2d517f32456e84ad118d809396929fcad4f"
+    )
     version("11.450.51", sha256="5aa6dd23a140b1ef2314eee5ca154a45397b03e68fd9ebc4f72005979f511c73")
 
     # pip silently replaces distutils with setuptools

--- a/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
@@ -12,8 +12,21 @@ class PyNvidiaMlPy(PythonPackage):
     homepage = "https://www.nvidia.com/"
     pypi = "nvidia-ml-py/nvidia-ml-py-11.450.51.tar.gz"
 
-    license("Unlicense")
+    license("BSD-2-Clause")
 
+    version("12.575.51", sha256="6490e93fea99eb4e966327ae18c6eec6256194c921f23459c8767aee28c54581")
+    version("12.570.86", sha256="0508d4a0c7b6d015cf574530b95a62ed4fc89da3b8b47e1aefe6777db170ec8b")
+    version("12.560.30", sha256="f0254dc7400647680a072ee02509bfd46102b60bdfeca321576d4d4817e7fe97")
+    version("12.555.43", sha256="e9e7f12ef1ec234bb0dc22d2bdc762ffafab394bdc472a07a4377c95bbf93afe")
+    version("12.550.89", sha256="02f299a341db7f938883c9a1098d28396dc29d5bb6b0f2806833e7dafff071f1")
+    version("12.535.161", sha256="2bcc31ff7a0ea291ed8d7fc39b149391a42c2fb1cb4256c935e692de488b4d17")
+    version("11.525.150", sha256="50af55b99ea167781102345a7de29bac94a57c8f38de6757ef9f945dd137c90a")
+    version("11.515.75", sha256="e3c75f06d5a3201dc51136e00e58c5c132b3be5d604d86c143426adb4e41c490")
+    version("11.510.69", sha256="f7e0cd3a266c7c88ae5467cc6b7dab13d26adfd6b8e4ec8c555a4cc9897ce907")
+    version("11.495.46", sha256="8f68e1af274756067632c7e1b79fb1a93a8dddf1e04851fccaeb34adfa599625")
+    version("11.470.66", sha256="20fff0dcd40b32fdc674cd98bc614bb8b6cc8d488687a55bf8c569eef39541f3")
+    version("11.460.79", sha256="5b7c051cd55469848960bb9fde07dc8fd25d21853307eeba669bfe3c3ede11c5")
+    version("11.450.129", sha256="b0170a3f16efdd055c283d3b94c7d2d517f32456e84ad118d809396929fcad4f")
     version("11.450.51", sha256="5aa6dd23a140b1ef2314eee5ca154a45397b03e68fd9ebc4f72005979f511c73")
 
     # pip silently replaces distutils with setuptools

--- a/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_nvidia_ml_py/package.py
@@ -36,7 +36,7 @@ class PyNvidiaMlPy(PythonPackage):
     version("11.450.51", sha256="5aa6dd23a140b1ef2314eee5ca154a45397b03e68fd9ebc4f72005979f511c73")
 
     # pip silently replaces distutils with setuptools
-    
+
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/source/n/nvidia-ml-py/nvidia{0}ml{0}py-{1}.tar.gz"
         if version > Version("12.560.30"):

--- a/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
@@ -22,5 +22,5 @@ class PyPynvml(PythonPackage):
     version("8.0.4", sha256="c8d4eadc648c7e12a3c9182a9750afd8481b76412f83747bcc01e2aa829cde5d")
 
     depends_on("py-setuptools", type="build")
-    depends_on("python@3.6:3.11", when="@8.0.4", type=("build", "run"))
-    depends_on("python@3.6:", when="@11:", type=("build", "run"))
+    depends_on("python", when="@11:", type=("build", "run"))
+    depends_on("python@:3.11", when="@8.0.4", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
@@ -17,9 +17,9 @@ class PyPynvml(PythonPackage):
 
     license("Unlicense")
 
-    version("8.0.4", sha256="c8d4eadc648c7e12a3c9182a9750afd8481b76412f83747bcc01e2aa829cde5d")
-    version("11.5.3", sha256="183d223ae487e5f00402d8da06c68c978ef8a9295793ee75559839c6ade7b229")
     version("12.0.0", sha256="299ce2451a6a17e6822d6faee750103e25b415f06f59abb8db65d30f794166f5")
+    version("11.5.3", sha256="183d223ae487e5f00402d8da06c68c978ef8a9295793ee75559839c6ade7b229")
+    version("8.0.4", sha256="c8d4eadc648c7e12a3c9182a9750afd8481b76412f83747bcc01e2aa829cde5d")
 
     depends_on("py-setuptools", type="build")
     depends_on("python@3.6:3.11", when="@8.0.4", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
@@ -19,6 +19,7 @@ class PyPynvml(PythonPackage):
 
     version("8.0.4", sha256="c8d4eadc648c7e12a3c9182a9750afd8481b76412f83747bcc01e2aa829cde5d")
     version("11.5.3", sha256="183d223ae487e5f00402d8da06c68c978ef8a9295793ee75559839c6ade7b229")
+    version("12.0.0", sha256="299ce2451a6a17e6822d6faee750103e25b415f06f59abb8db65d30f794166f5")
 
     depends_on("py-setuptools", type="build")
     depends_on("python@3.6:3.11", when="@8.0.4", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
@@ -23,5 +23,6 @@ class PyPynvml(PythonPackage):
     version("8.0.4", sha256="c8d4eadc648c7e12a3c9182a9750afd8481b76412f83747bcc01e2aa829cde5d")
 
     depends_on("py-setuptools", type="build")
+    depends_on("python@3.9:", when="@12:", type=("build", "run"))
     depends_on("python", when="@11:", type=("build", "run"))
     depends_on("python@:3.11", when="@8.0.4", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
@@ -18,6 +18,8 @@ class PyPynvml(PythonPackage):
     license("Unlicense")
 
     version("8.0.4", sha256="c8d4eadc648c7e12a3c9182a9750afd8481b76412f83747bcc01e2aa829cde5d")
+    version("11.5.3", sha256="183d223ae487e5f00402d8da06c68c978ef8a9295793ee75559839c6ade7b229")
 
     depends_on("py-setuptools", type="build")
     depends_on("python@3.6:3.11", when="@8.0.4", type=("build", "run"))
+    depends_on("python@3.6:", when="@11:", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
@@ -15,7 +15,8 @@ class PyPynvml(PythonPackage):
     homepage = "https://www.nvidia.com/"
     pypi = "pynvml/pynvml-8.0.4.tar.gz"
 
-    license("Unlicense")
+    license("BSD-3-Clause", when="@12:")
+    license("Unlicense", when="@:11")
 
     version("12.0.0", sha256="299ce2451a6a17e6822d6faee750103e25b415f06f59abb8db65d30f794166f5")
     version("11.5.3", sha256="183d223ae487e5f00402d8da06c68c978ef8a9295793ee75559839c6ade7b229")

--- a/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
@@ -22,6 +22,7 @@ class PyPynvml(PythonPackage):
     version("11.5.3", sha256="183d223ae487e5f00402d8da06c68c978ef8a9295793ee75559839c6ade7b229")
     version("8.0.4", sha256="c8d4eadc648c7e12a3c9182a9750afd8481b76412f83747bcc01e2aa829cde5d")
 
+    depends_on("py-nvidia-ml-py", when="@12:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("python@3.9:", when="@12:", type=("build", "run"))
     depends_on("python", when="@11:", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pynvml/package.py
@@ -20,4 +20,4 @@ class PyPynvml(PythonPackage):
     version("8.0.4", sha256="c8d4eadc648c7e12a3c9182a9750afd8481b76412f83747bcc01e2aa829cde5d")
 
     depends_on("py-setuptools", type="build")
-    depends_on("python@3.6:", type=("build", "run"))
+    depends_on("python@3.6:3.11", when="@8.0.4", type=("build", "run"))


### PR DESCRIPTION
The `py-pynvml` package currently only has one version, `8.0.4`, which is rather old (january 2020). This version uses the `SafeConfigParser` class, which is removed in Python 3.12. The `depends_on` clause was updated to force using a compatible Python version (e.g. 3.11).

Additionally, two other pynvml versions are added, the latest `11.x` release (`11.5.3`) and `12.0.0`. Both these versions successfully install using Python 3.9, 3.10, 3.11, 3.12 and 3.13 (all the 'safe' Python versions).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
