### PR TITLE
builtin: github url pull -> commit

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/adios/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/adios/package.py
@@ -102,7 +102,7 @@ class Adios(AutotoolsPackage):
 
     # Fix a bug in configure.ac that causes automake issues on RHEL 7.7
     patch(
-        "https://github.com/ornladios/ADIOS/pull/207.patch?full_index=1",
+        "https://github.com/ornladios/ADIOS/commit/17aee8aeed64612cd8cfa0b949147091a5525bbe.patch?full_index=1",
         when="@1.12.0: +mpi",
         sha256="aea47e56013b57c2d5d36e23e0ae6010541c3333a84003784437768c2e350b05",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/adios2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/adios2/package.py
@@ -232,7 +232,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     # Add missing include <memory>
     # https://github.com/ornladios/adios2/pull/2710
     patch(
-        "https://github.com/ornladios/adios2/pull/2710.patch?full_index=1",
+        "https://github.com/ornladios/adios2/commit/72363a5ed1015c2bbb1c057d4d6b2e5662de12ec.patch?full_index=1",
         when="@2.5:2.7.1",
         sha256="8221073d1b2f8944395a88a5d60a15c7370646b62f5fc6309867bbb6a8c2096c",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/ascent/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ascent/package.py
@@ -155,9 +155,9 @@ class Ascent(CMakePackage, CudaPackage, ROCmPackage):
     # patch for fix typo in coord_type
     # https://github.com/Alpine-DAV/ascent/pull/1408
     patch(
-        "https://github.com/Alpine-DAV/ascent/pull/1408.patch?full_index=1",
+        "https://github.com/Alpine-DAV/ascent/commit/21f33494eed2016f97a266b3c23f33ff1bf39619.patch?full_index=1",
         when="@0.9.3 %oneapi@2025:",
-        sha256="7de7f51e57f3d743c39ad80d8783a4eb482be1def51eb2d3f9259246c661f164",
+        sha256="0dc417d8a454d235cdeb9e0f0bb527dc3c42a1eb6ae80e8bd5b33ead19198329",
     )
 
     ##########################################################################

--- a/var/spack/repos/spack_repo/builtin/packages/assimp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/assimp/package.py
@@ -33,7 +33,7 @@ class Assimp(CMakePackage):
     version("4.0.1", sha256="60080d8ab4daaab309f65b3cffd99f19eb1af8d05623fff469b9b652818e286e")
 
     patch(
-        "https://patch-diff.githubusercontent.com/raw/assimp/assimp/pull/4203.patch?full_index=1",
+        "https://github.com/assimp/assimp/commit/92b5c284ce58fb64af2ee1f11e86aa8a65c78d03.patch?full_index=1",
         sha256="24135e88bcef205e118f7a3f99948851c78d3f3e16684104dc603439dd790d74",
         when="@5.1:5.2.2",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/bazel/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/bazel/package.py
@@ -189,8 +189,8 @@ class Bazel(Package):
 
     # https://github.com/bazelbuild/bazel/issues/18642
     patch(
-        "https://github.com/bazelbuild/bazel/pull/20785.patch?full_index=1",
-        sha256="85dde31d129bbd31e004c5c87f23cdda9295fbb22946dc6d362f23d83bae1fd8",
+        "https://github.com/bazelbuild/bazel/commit/fe9754f0c14e15bd02fb231995cba473278d853b.patch?full_index=1",
+        sha256="c2dd258f11786b32f75d91013a3ebd3d0876be2628acadb2ac8331e06fd2e657",
         when="@6.0:6.4",
     )
     conflicts("%gcc@13:", when="@:5")

--- a/var/spack/repos/spack_repo/builtin/packages/bufr_query/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/bufr_query/package.py
@@ -42,8 +42,8 @@ class BufrQuery(CMakePackage, PythonExtension):
 
     # Patches
     patch(
-        "https://github.com/NOAA-EMC/bufr-query/pull/20.patch?full_index=1",
-        sha256="3acf11082c9e76e64dbbda4f62ac0cbc234dca7e60c85a275e778417cfd65001",
+        "https://github.com/NOAA-EMC/bufr-query/commit/a27d75e0c2a7c1b819520154fb330af202d65dcf.patch?full_index=1",
+        sha256="6146db89605f24a92f75bd3bb7521e3fb545dd25d1f3bfc1d917b862e7f3c6c9",
         when="+python @:0.0.2",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/compadre/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/compadre/package.py
@@ -50,7 +50,7 @@ class Compadre(CMakePackage):
 
     # fixes duplicate symbol issue with static library build
     patch(
-        "https://patch-diff.githubusercontent.com/raw/sandialabs/Compadre/pull/286.patch?full_index=1",
+        "https://github.com/sandialabs/Compadre/commit/af91a6ee3831dc951445df76053ec6315c58cb45.patch?full_index=1",
         sha256="e267b74f8ecb8dd23970848ed919d29b7d442f619ce80983e02a19f1d9582c61",
         when="@1.5.0",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/conduit/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/conduit/package.py
@@ -214,9 +214,9 @@ class Conduit(CMakePackage):
     # Add missing include for numeric_limits
     # https://github.com/LLNL/conduit/pull/773
     patch(
-        "https://github.com/LLNL/conduit/pull/773.patch?full_index=1",
+        "https://github.com/LLNL/conduit/commit/eb7dfce2229aac3b9644d422a44948509034e3c6.patch?full_index=1",
         when="@:0.7.2",
-        sha256="784d74942a63acf698c31b39848b46b4b755bf06faa6aa6fb81be61783ec0c30",
+        sha256="379a1b68928d9078e7302efe694f43c51c8f2c26db4a58ab3fd753746b96b284",
     )
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:

--- a/var/spack/repos/spack_repo/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dd4hep/package.py
@@ -55,9 +55,9 @@ class Dd4hep(CMakePackage):
     patch("cmake_language.patch", when="@:1.17")
     # Fix missing SimCaloHits when using the LCIO format
     patch(
-        "https://patch-diff.githubusercontent.com/raw/AIDASoft/DD4hep/pull/1019.patch?full_index=1",
+        "https://github.com/AIDASoft/DD4hep/commit/2c77055fb05744a4d367123c634bcb42291df030.patch?full_index=1",
         when="@1.19:1.23",
-        sha256="6466719c82de830ce728db57004fb7db03983587a63b804f6dc95c6b92b3fc76",
+        sha256="7bac1e08d2f83edb467da7f950b841021ecc649cc4cf21fd9043bd6d757c4e05",
     )
 
     # variants for subpackages

--- a/var/spack/repos/spack_repo/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/edm4hep/package.py
@@ -96,9 +96,9 @@ class Edm4hep(CMakePackage):
     # Fix missing nljson import
     # NOTE that downstream packages (dd4hep) may fail for 0.99 and before
     patch(
-        "https://patch-diff.githubusercontent.com/raw/key4hep/EDM4hep/pull/379.patch?full_index=1",
+        "https://github.com/key4hep/EDM4hep/commit/18799dacfdaf5d746134c957de48607aa2665d75.patch?full_index=1",
         when="@0.99.1",
-        sha256="c4be2f27c7bda4d033f92fee14e48ddf59fbe606d208e8288d9bdb3dec5ad5c2",
+        sha256="374f0b7635c632e5a57d23ad163efab7370ab471c62e2713a41aa26e33d8f221",
     )
 
     def cmake_args(self):

--- a/var/spack/repos/spack_repo/builtin/packages/flatbuffers/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/flatbuffers/package.py
@@ -50,8 +50,8 @@ class Flatbuffers(CMakePackage):
     # https://github.com/google/flatbuffers/issues/5950
     # Possibly affects earlier releases but I haven't tried to apply it.
     patch(
-        "https://github.com/google/flatbuffers/pull/6020.patch?full_index=1",
-        sha256="579cb6fa4430d4304b93c7a1df7e922f3c3ec614c445032877ad328c209d5462",
+        "https://github.com/google/flatbuffers/commit/515a4052a750dfe6df8d143c8f23cd8aaf51f9d7.patch?full_index=1",
+        sha256="f76b8777d7e719834ba0d83535b35e7c17ce474cfbc1286671d936191f784dc1",
         when="@1.12.0:1%gcc@10:",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/flux_sched/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/flux_sched/package.py
@@ -115,7 +115,7 @@ class FluxSched(CMakePackage, AutotoolsPackage):
     patch("jobid-sign-compare-fix.patch", when="@:0.22.0")
 
     patch(
-        "https://github.com/flux-framework/flux-sched/pull/1338.patch?full_index=1",
+        "https://github.com/flux-framework/flux-sched/commit/da6156addab5ec127b36cdee03c5d1f3e458d363.patch?full_index=1",
         when="@0.42.2 %oneapi@2025:",
         sha256="b46579efa70176055f88493caa3fefbfea5a5663a33d9c561b71e83046f763c5",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/fms/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fms/package.py
@@ -74,8 +74,8 @@ class Fms(CMakePackage):
     # What the following patch is providing is available in version 2024.03
     # and newer so it is only needed to 2024.02
     patch(
-        "https://github.com/NOAA-GFDL/fms/pull/1559.patch?full_index=1",
-        sha256="2b12a6c35f357c3dddcfa5282576e56ab0e8e6c1ad1dab92a2c85ce3dfb815d4",
+        "https://github.com/NOAA-GFDL/fms/commit/361352e0b410373ba259259627f4b714b15cff57.patch?full_index=1",
+        sha256="6c085485919d493c350d1692ea0b6b403fca1246c0c4bde3b50b44a08d887694",
         when="@2024.02",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ftgl/package.py
@@ -35,7 +35,7 @@ class Ftgl(CMakePackage):
     # https://github.com/kraj/ftgl/commit/37ed7d606a0dfecdcb4ab0c26d1b0132cd96d5fa
     # freetype 2.13.3 changed the type of many external chars to unsigned char!
     patch(
-        "https://patch-diff.githubusercontent.com/raw/frankheckenbach/ftgl/pull/20.patch?full_index=1",
+        "https://github.com/frankheckenbach/ftgl/commit/21e050670bc7217a3f61b90cdab5b543e676380c.patch?full_index=1",
         sha256="e2a0810fbf68403931bef4fbfda22e010e01421c92eeaa45f62e4e47f2381ebd",
         when="^freetype@2.13.3:",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/gdal/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gdal/package.py
@@ -492,7 +492,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
 
     # https://github.com/OSGeo/gdal/issues/3782
     patch(
-        "https://github.com/OSGeo/gdal/pull/3786.patch?full_index=1",
+        "https://github.com/OSGeo/gdal/commit/b1a01a6790d428038e3c7cd81ca54d6d468b68b9.patch?full_index=1",
         when="@3.3.0",
         level=2,
         sha256="9f9824296e75b34b3e78284ec772a5ac8f8ba92c17253ea9ca242caf766767ce",
@@ -501,7 +501,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     # https://github.com/spack/spack/issues/41299
     # ensures the correct build specific libproj is used with cmake builds (gdal >=3.5.0)
     patch(
-        "https://patch-diff.githubusercontent.com/raw/OSGeo/gdal/pull/8964.patch?full_index=1",
+        "https://github.com/OSGeo/gdal/commit/cc1213052fbfc6aca8fd7268f39e84f38a7b4155.patch?full_index=1",
         when="@3.5:3.8",
         sha256="52459dc9903ced5005ba81515762a55cd829d8f5420607405c211c4a77c2bf79",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/genie/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/genie/package.py
@@ -61,7 +61,7 @@ class Genie(Package):
     # Disables this check.
     patch("genie_disable_gopt_with_compiler_check.patch", level=0, when="@2.11:")
     patch(
-        "https://patch-diff.githubusercontent.com/raw/GENIE-MC/Generator/pull/376.patch?full_index=1",
+        "https://github.com/GENIE-MC/Generator/commit/be723d688ea0e1070b972b9fc3b52a557cfe79b5.patch?full_index=1",
         sha256="7eca9bf44251cd99edd962483ca24c5072f8e2eee688f1e95b076425f2dc59f6",
         when="@3.4.2",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/geos/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/geos/package.py
@@ -82,7 +82,7 @@ class Geos(CMakePackage):
     variant("shared", default=True, description="Build shared library")
 
     patch(
-        "https://github.com/libgeos/geos/pull/461.patch?full_index=1",
+        "https://github.com/libgeos/geos/commit/cb127eeac823c8b48364c1b437844a5b65ff4748.patch?full_index=1",
         sha256="ab78db7ff2e8fc89e899b8233cf77d90b24d88940dd202c4219decba479c8d35",
         when="@3.8:3.9",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ginkgo/package.py
@@ -127,7 +127,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
     # Correctly find rocthrust through CMake
     patch(
-        "https://github.com/ginkgo-project/ginkgo/pull/1668.patch?full_index=1",
+        "https://github.com/ginkgo-project/ginkgo/commit/369b12a5f4431577d60a61e67f2b0537b428abca.patch?full_index=1",
         sha256="27d6ae6c87bec15464d20a963c336e89eac92625d07e3f9548e33cd7b952a496",
         when="+rocm @1.8.0",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/gnina/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gnina/package.py
@@ -80,12 +80,12 @@ class Gnina(CMakePackage, CudaPackage):
     depends_on("openblas~fortran", when="@:1.1")
 
     patch(
-        "https://patch-diff.githubusercontent.com/raw/gnina/gnina/pull/280.patch?full_index=1",
+        "https://github.com/gnina/gnina/commit/b59e958c5d02c9348b7d327fa54a4b1bae5d55c4.patch?full_index=1",
         when="@1.3",
         sha256="88d1760423cedfdb992409b0bfe3f9939ab5900f52074364db9ad8b87f4845d4",
     )
     patch(
-        "https://patch-diff.githubusercontent.com/raw/gnina/gnina/pull/282.patch?full_index=1",
+        "https://github.com/gnina/gnina/commit/c33e0ccff8a5a36053599509f394cc2b84311563.patch?full_index=1",
         when="@1.3",
         sha256="6a1db3d63039a11ecc6e753b325962773e0084673d54a0d93a503bca8b08fb9e",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/ispc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ispc/package.py
@@ -81,16 +81,16 @@ class Ispc(CMakePackage):
 
     # Fix build with Apple clang 15
     patch(
-        "https://github.com/ispc/ispc/pull/2785.patch?full_index=1",
+        "https://github.com/ispc/ispc/commit/a25cbdcdb86cb35ea40dcddeba03564128f83eca.patch?full_index=1",
         when="@1.22:1.23.0",
-        sha256="f6a413bf86e49d520d23df7132004d1f09caa512187f369549a4a783859fbc41",
+        sha256="fb807ff565f8b07e9517a57658fa434958ad53241ce84216b3490c91f9e937eb",
     )
 
     # Fix library lookup for NCurses in CMake
     patch(
-        "https://patch-diff.githubusercontent.com/raw/ispc/ispc/pull/2638.patch?full_index=1",
+        "https://github.com/ispc/ispc/commit/408f831b6200439c3bc3f98fb62066f4980c1271.patch?full_index=1",
         when="@1.18:1.20",
-        sha256="3f7dae8d4a683fca2a6157bbcb7cbe9692ff2094b0f4afaf29be121c02b0b3ad",
+        sha256="c4621feaa73c8cb6ee2bbcebe218bc0275517aaa5f8fc4a45a962c60a8168c95",
     )
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:

--- a/var/spack/repos/spack_repo/builtin/packages/julia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/julia/package.py
@@ -271,7 +271,7 @@ class Julia(MakefilePackage):
 
     # Fix libstdc++ not being found (https://github.com/JuliaLang/julia/issues/47987)
     patch(
-        "https://github.com/JuliaLang/julia/pull/48342.patch?full_index=1",
+        "https://github.com/JuliaLang/julia/commit/7d2499dd35bebfcd8419d2d51611ba4ac1a19a9c.patch?full_index=1",
         sha256="10f7cab89c8353b2648a968d2c8e8ed8bd90961df3227084f1d69d3d482933d7",
         when="@1.8.4:1.8.5",
     )
@@ -280,8 +280,8 @@ class Julia(MakefilePackage):
     # applicable to previous versions of the library too
     # (https://github.com/JuliaLang/julia/issues/49895).
     patch(
-        "https://github.com/JuliaLang/julia/pull/49909.patch?full_index=1",
-        sha256="7fa53516b97d83ccf06f6d387c04d337849808f7e8ee2bdc2e79894d84578afc",
+        "https://github.com/JuliaLang/julia/commit/5d43397ee52323f1c015513b2be3909078b646ef.patch?full_index=1",
+        sha256="15f9f2a7b6ae21aa5de8655970c673a953e1d46018e901f7fff98aead8e4a929",
         when="@1.6.4:1.9.0",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libzmq/package.py
@@ -82,7 +82,7 @@ class Libzmq(AutotoolsPackage):
 
     # Fix build issues with gcc-12
     patch(
-        "https://github.com/zeromq/libzmq/pull/4334.patch?full_index=1",
+        "https://github.com/zeromq/libzmq/commit/a01d259db372bff5e049aa966da4efce7259af67.patch?full_index=1",
         sha256="edca864cba914481a5c97d2e975ba64ca1d2fbfc0044e9a78c48f1f7b2bedb6f",
         when="@4.3.4",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/lua_sol2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/lua_sol2/package.py
@@ -35,9 +35,9 @@ class LuaSol2(CMakePackage):
     depends_on("lua", type=("link", "run"))
 
     patch(
-        "https://github.com/ThePhD/sol2/pull/1606.patch?full_index=1",
+        "https://github.com/ThePhD/sol2/commit/d805d027e0a0a7222e936926139f06e23828ce9f.patch?full_index=1",
         when="@3.3.0 %oneapi@2025:",
-        sha256="ed6c5924a0639fb1671e6d7dacbb88dce70aa006bcee2f380b6acd34da89664c",
+        sha256="ea7e30be5d6e0d71aded18d68b16725fa4e5f86f99757048fa18c7ece92417c5",
     )
 
     def cmake_args(self):

--- a/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mfem/package.py
@@ -507,7 +507,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     patch("mfem-4.5.patch", when="@4.5.0")
     patch("mfem-4.6.patch", when="@4.6.0")
     patch(
-        "https://github.com/mfem/mfem/pull/4005.patch?full_index=1",
+        "https://github.com/mfem/mfem/commit/0ddb7aba31a0161fca08ff9dd617e6d36a565366.patch?full_index=1",
         when="@4.6.0 +gslib+shared+miniapps",
         sha256="2a31682d876626529e2778a216d403648b83b90997873659a505d982d0e65beb",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/mongo_c_driver/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mongo_c_driver/package.py
@@ -45,8 +45,8 @@ class MongoCDriver(AutotoolsPackage, CMakePackage):
     variant("zstd", default=True, description="Enable zstd support.")
 
     patch(
-        "https://github.com/mongodb/mongo-c-driver/pull/466.patch?full_index=1",
-        sha256="d8802d91226c176ba46d5b82413757121331d556a3a3d57ab65b70e175cab296",
+        "https://github.com/mongodb/mongo-c-driver/commit/5d759ff62f0c1389075b8b40932b7fdc11b4e12d.patch?full_index=1",
+        sha256="d4b6be7e885ef3e2ce12811c307b8b22fa297bfb9ea97d8493eef1d053f206a4",
         when="@1.8.1",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -98,12 +98,12 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         # Fix headers
         # See https://github.com/Unidata/netcdf-c/pull/1505
         patch(
-            "https://github.com/Unidata/netcdf-c/pull/1505.patch?full_index=1",
+            "https://github.com/Unidata/netcdf-c/commit/cca9ae64f622bb2b7f164fa352c820b5fe4d132c.patch?full_index=1",
             sha256="495b3e5beb7f074625bcec2ca76aebd339e42719e9c5ccbedbdcc4ffb81a7450",
         )
         # See https://github.com/Unidata/netcdf-c/pull/1508
         patch(
-            "https://github.com/Unidata/netcdf-c/pull/1508.patch?full_index=1",
+            "https://github.com/Unidata/netcdf-c/commit/f0dc61a73c8a35432034c8d262f1893a0090c3ed.patch?full_index=1",
             sha256="19e7f31b96536928621b1c29bb6d1a57bcb7aa672cea8719acf9ac934cdd2a3e",
         )
 

--- a/var/spack/repos/spack_repo/builtin/packages/netlib_lapack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netlib_lapack/package.py
@@ -122,7 +122,7 @@ class NetlibLapack(CMakePackage):
 
     # renaming with _64 suffixes pushes code beyond fortran column 72
     patch(
-        "https://github.com/Reference-LAPACK/lapack/pull/1093.patch?full_index=1",
+        "https://github.com/Reference-LAPACK/lapack/commit/0799b59571a4bbb434c62ef2346146123aa19d8d.patch?full_index=1",
         sha256="b1af8b6ef2113a59aba006319ded0c1a282533c3815289e1c9e91185f63ee9fe",
         when="@3.6:3.12.1",
     )
@@ -132,7 +132,7 @@ class NetlibLapack(CMakePackage):
         when="@3.12:3.12.1",
     )
     patch(
-        "https://github.com/Reference-LAPACK/lapack/pull/1099.patch?full_index=1",
+        "https://github.com/Reference-LAPACK/lapack/commit/447fd4e7844b81e62deff09b6b2f7961eecc7590.patch?full_index=1",
         sha256="3059ebf898cbca5101db77b77c645ab144a3cecbe58dd2bb46d9b84e7debee92",
         when="@3.12:3.12.1",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ocaml/package.py
@@ -37,8 +37,8 @@ class Ocaml(Package):
     # constants.  Fixes compatibility with the integrated assembler in clang 11.0.0.
     # (Jacob Young, review by Nicolas Ojeda Bar)
     patch(
-        "https://github.com/ocaml/ocaml/pull/9981.patch?full_index=1",
-        sha256="12700c697f0d5227e8eddd62e4308ec3cd67c0a5a5a1b7eec376686a5fd63a5c",
+        "https://github.com/ocaml/ocaml/commit/8a46d76bf9359b5cc505b3f2f9c81eb624c631fa.patch?full_index=1",
+        sha256="805cdd458c3849e0050600bfeac7cbe4a1da78aae7b686b529a475e63948048f",
         when="@:4.11.0 %clang@11:",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/openmm/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openmm/package.py
@@ -47,8 +47,8 @@ class Openmm(CMakePackage, CudaPackage):
     # `openmm@7.5.1+cuda`, which is the version currently required by
     # `py-alphafold`.
     patch(
-        "https://github.com/openmm/openmm/pull/3154.patch?full_index=1",
-        sha256="90bc01b34cf998e90220669b3ed55cd3c42000ad364234033aac631ed754e9bd",
+        "https://github.com/openmm/openmm/commit/71bc7c8c70ffbccd82891dec7fd4f4deb99af64d.patch?full_index=1",
+        sha256="9562e03eb8d43ba4d8f0f7b2a3326cc464985fc148804cf9e4340fd7a87bb8e7",
         when="@7.5.1+cuda",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/openpmd_api/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openpmd_api/package.py
@@ -92,29 +92,29 @@ class OpenpmdApi(CMakePackage):
 
     # CMake: Fix Python Install Directory
     patch(
-        "https://github.com/openPMD/openPMD-api/pull/1393.patch?full_index=1",
-        sha256="b5cecbdbe16d98c0ba352fa861fcdf9d7c7cc85f21226fa03effa7d62a7cb276",
+        "https://github.com/openPMD/openPMD-api/commit/31e3c42eb6687269adfb0e63c35269db328ea6ec.patch?full_index=1",
+        sha256="e8b57bcdc965643f46280408244f4d574bff09d0c19c863f42395a7203a89385",
         when="@0.15.0",
     )
 
     # macOS AppleClang12 Fixes
     patch(
-        "https://github.com/openPMD/openPMD-api/pull/1395.patch?full_index=1",
-        sha256="791c0a9d1dc09226beb26e8e67824b3337d95f4a2a6e7e64637ea8f0d95eee61",
+        "https://github.com/openPMD/openPMD-api/commit/c9b0f70294ef8d9ac89018c9b439815be9e77b96.patch?full_index=1",
+        sha256="83714efc90fe6d4f909bdde1b0578a43e6a013a5db6b10e87466665122fd6b21",
         when="@0.15.0",
     )
 
     # forgot to bump version.hpp in 0.15.1
     patch(
-        "https://github.com/openPMD/openPMD-api/pull/1417.patch?full_index=1",
-        sha256="c306483f1f94b308775a401c9cd67ee549fac6824a2264f5985499849fe210d5",
+        "https://github.com/openPMD/openPMD-api/commit/b3d3057e141af3a40dde5f00262a5671979a95c7.patch?full_index=1",
+        sha256="f31d0adcd407d20d559aa67e5f6ec2d81c6579b8b0166918c5178c02af180fba",
         when="@0.15.1",
     )
 
     # fix superbuild control in 0.16.0
     patch(
-        "https://github.com/openPMD/openPMD-api/pull/1678.patch?full_index=1",
-        sha256="e49fe79691bbb5aae2224d218f29801630d33f3a923c518f6bfb39ec22fd6a72",
+        "https://github.com/openPMD/openPMD-api/commit/3dc3a463d18dd5f87c38ee64d93bc7814b1cbb5d.patch?full_index=1",
+        sha256="474a7ccf11f0892717271fe3974a6ee046c15187a6ba12c75085a0d092071c9c",
         when="@0.16.0",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/protobuf/package.py
@@ -109,9 +109,9 @@ class Protobuf(CMakePackage):
 
     # See https://github.com/protocolbuffers/protobuf/issues/9916
     patch(
-        "https://github.com/protocolbuffers/protobuf/pull/9936.patch?full_index=1",
+        "https://github.com/protocolbuffers/protobuf/commit/b180b2809f7e77fdf7dd075d26a7421085bac58f.patch?full_index=1",
         when="@3.20 %gcc@12.1.0",
-        sha256="fa1abf042eddc1b3b43875dc018c651c90cd1c0c5299975a818a1610bee54ab8",
+        sha256="135b59be7205e47cb9603936a0aa39ed8f06a14fd4558aefb1ec0c250426c6a5",
     )
 
     # fix build on Centos 8, see also https://github.com/protocolbuffers/protobuf/issues/5144

--- a/var/spack/repos/spack_repo/builtin/packages/py_dgl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_dgl/package.py
@@ -86,8 +86,8 @@ class PyDgl(CMakePackage, PythonExtension, CudaPackage):
     depends_on("cudnn", when="+cuda", type=("build", "run"))
 
     patch(
-        "https://patch-diff.githubusercontent.com/raw/dmlc/dgl/pull/5434.patch?full_index=1",
-        sha256="8c5f14784637a9bb3dd55e6104715d4a35b4e6594c99884aa19e67bc0544e91a",
+        "https://github.com/dmlc/dgl/commit/b1ec112eeb0e0633e57d89a60f6f80322cff0028.patch?full_index=1",
+        sha256="ae432af55650a3e69ab1c5e5d8c2bb3c3f1450bef7a0660c9d30b716fcb8652f",
         when="@1.0.1",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/py_dm_tree/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_dm_tree/package.py
@@ -46,7 +46,7 @@ class PyDmTree(PythonPackage):
     depends_on("abseil-cpp", when="@0.1.8:")
 
     patch(
-        "https://github.com/google-deepmind/tree/pull/73.patch?full_index=1",
+        "https://github.com/google-deepmind/tree/commit/63f25d4e05440ccbd4ba662be5f3f6eb460d29d8.patch?full_index=1",
         sha256="77dbd895611d412da99a5afbf312c3c49984ad02bd0e56ad342b2002a87d789c",
         when="@0.1.8",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/py_horovod/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_horovod/package.py
@@ -164,16 +164,16 @@ class PyHorovod(PythonPackage, CudaPackage):
     )
     # https://github.com/horovod/horovod/issues/3996
     patch(
-        "https://github.com/horovod/horovod/pull/3998.patch?full_index=1",
-        sha256="9ecd4e8e315764afab20f2086e24baccf8178779a3c663196b24dc55a23a6aca",
+        "https://github.com/horovod/horovod/commit/3a31d933a13c7c885b8a673f4172b17914ad334d.patch?full_index=1",
+        sha256="2c6f296c20abbe15208512c23fc557d3aa970cb6891f68eea3137a2498f722a3",
         when="@0.25:0.28.1",
     )
     conflicts("^py-torch@2.1:", when="@:0.24")
 
     # https://github.com/horovod/horovod/pull/3957
     patch(
-        "https://github.com/horovod/horovod/pull/3957.patch?full_index=1",
-        sha256="9e22e312c0cbf224b4135ba70bd4fd2e4170d8316c996643e360112abaac8f93",
+        "https://github.com/horovod/horovod/commit/ff4ca09d3996ca51de47c4021519e12876847120.patch?full_index=1",
+        sha256="d766be99070faf242e6aec6f9e42cfaaa18838237f8d4ff43f4e8a3b4586876c",
         when="@0.21:0.28.1",
     )
     conflicts("%gcc@13:", when="@:0.20")

--- a/var/spack/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -155,12 +155,12 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
         when="@0.4.36:0.4.38",
     )
     patch(
-        "https://github.com/jax-ml/jax/pull/25473.patch?full_index=1",
+        "https://github.com/jax-ml/jax/commit/7bbba40cd42aa47a6880308469b56294c1f3512c.patch?full_index=1",
         sha256="9d6977bc32046600bf8b15863251283fe7546896340367a7f14e3dccf418b4fe",
         when="@0.4.36:0.4.37",
     )
     patch(
-        "https://github.com/google/jax/pull/20101.patch?full_index=1",
+        "https://github.com/google/jax/commit/612d4d500132f8ae2fca313ec1f21acb18eae78e.patch?full_index=1",
         sha256="4dfb9f32d4eeb0a0fb3a6f4124c4170e3fe49511f1b768cd634c78d489962275",
         when="@:0.4.25",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/py_macs2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_macs2/package.py
@@ -24,7 +24,7 @@ class PyMacs2(PythonPackage):
 
     # patch to correctly identify python-3.10 as greater than required version
     patch(
-        "https://github.com/macs3-project/MACS/pull/497.patch?full_index=1",
+        "https://github.com/macs3-project/MACS/commit/291fae879f8f9014a8163126a80cc356878ae553.patch?full_index=1",
         sha256="eaff891b9b3c6a910bd5d454dcc6e21288c8d1ad4d6d6f77e370bc8f90921cbd",
         when="@2.2.7.1^python@3.10:",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/py_numpy/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_numpy/package.py
@@ -186,8 +186,8 @@ class PyNumpy(PythonPackage):
 
     # https://github.com/spack/spack/issues/49983
     patch(
-        "https://github.com/numpy/numpy/pull/28713.patch?full_index=1",
-        sha256="e80ed84d31a03ecdebcaa4acd9f725298633b8f2c254beb30e0d44c039921783",
+        "https://github.com/numpy/numpy/commit/7771624a4a4c662f936e07bbf74dd7d553225f23.patch?full_index=1",
+        sha256="1c9cb080017e21e25ca92b70ce10ccf8ef6fcfd30dc936d832611db2f20da4c6",
         when="@2.0:2.2",
     )
 
@@ -202,14 +202,14 @@ class PyNumpy(PythonPackage):
 
     # Backport bug fix for f2py's define for threading when building with Mingw
     patch(
-        "https://github.com/numpy/numpy/pull/20881.patch?full_index=1",
+        "https://github.com/numpy/numpy/commit/932202d24c399f46161caa7464446b55e27fa947.patch?full_index=1",
         sha256="802970a9034d40a8a8f49a03f489d5361d5eabf69249621e6757651448910f1a",
         when="@1.20.3:1.22.1",
     )
     # Patch to update compiler flags.
     # See https://github.com/spack/spack/issues/30373
     patch(
-        "https://github.com/numpy/numpy/pull/21448.patch?full_index=1",
+        "https://github.com/numpy/numpy/commit/fdb5393dc518d57de411db1c364ec36a7192a5a4.patch?full_index=1",
         sha256="e9508c3b3a1e1a24669014a0c1b9f3b009a149ea3886cf711eaef2a32b247fdb",
         when="@1.22.0:1.22.3",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/py_pycompadre/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pycompadre/package.py
@@ -50,7 +50,7 @@ class PyPycompadre(PythonPackage):
 
     # fixes duplicate symbol issue with static library build
     patch(
-        "https://patch-diff.githubusercontent.com/raw/sandialabs/Compadre/pull/286.patch?full_index=1",
+        "https://github.com/sandialabs/Compadre/commit/af91a6ee3831dc951445df76053ec6315c58cb45.patch?full_index=1",
         sha256="e267b74f8ecb8dd23970848ed919d29b7d442f619ce80983e02a19f1d9582c61",
         when="@1.5.0",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/py_scikits_odes/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_scikits_odes/package.py
@@ -39,8 +39,8 @@ class PyScikitsOdes(PythonPackage):
 
     # Remove numpy test runner imports to be compatible with py-numpy@1.25:
     patch(
-        "https://github.com/bmcage/odes/pull/153.patch?full_index=1",
-        sha256="8d05d7bcc3582b7c482a4393bf5a8c0460a58eb62d1e3c86339c95a0d4ce30ac",
+        "https://github.com/bmcage/odes/commit/57466a97a278f687a6b0a92343b767c495834b31.patch?full_index=1",
+        sha256="2316c08d2003d857a8b1e21df736a0fdf37a6d4595f1efa7a56e854b4a377d66",
     )
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:

--- a/var/spack/repos/spack_repo/builtin/packages/py_tensorboard_data_server/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_tensorboard_data_server/package.py
@@ -24,13 +24,13 @@ class PyTensorboardDataServer(PythonPackage):
 
     # https://github.com/tensorflow/tensorboard/issues/5713
     patch(
-        "https://github.com/tensorflow/tensorboard/pull/5715.patch?full_index=1",
-        sha256="878bbd60fd9c38216a372792f02a65c1b422b6c546050fdf335b264ab263cd8a",
+        "https://github.com/tensorflow/tensorboard/commit/b085eab93a689230f24d3bba6a8caf75b387f1b9.patch?full_index=1",
+        sha256="ce5d221a3302cba1ee7948d6c9e7d4ce053c392b3849a1290a5210905d8e8cbd",
         when="@0.6.1",
     )
     patch(
-        "https://github.com/tensorflow/tensorboard/pull/6101.patch?full_index=1",
-        sha256="4b3bcc2ed656699e9faad7937d013b65fa65fed58fbe58d2ae38e0e7b8006ad8",
+        "https://github.com/tensorflow/tensorboard/commit/1675de9a2c905ef6cc8ecaa59394cb2fb52489db.patch?full_index=1",
+        sha256="8cbd5feb7235d3944fd05ba1f3e16ed3fa0e2212680d6e060c19489be372d6c5",
         when="@0.6.1",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/py_tensorflow/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_tensorflow/package.py
@@ -503,7 +503,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     # See https://github.com/tensorflow/tensorflow/issues/57663
     # This is fixed for 2.11 but 2.10 needs the following patch.
     patch(
-        "https://github.com/tensorflow/tensorflow/pull/56691.patch?full_index=1",
+        "https://github.com/tensorflow/tensorflow/commit/cd8cb49c977d8a460884cbd24f4cb9c20e532f0d.patch?full_index=1",
         sha256="d635ea6d6c1571505871d0caba3e2cd939ea0f4aff972095d552913a8109def3",
         when="@2.10",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/py_torch_nvidia_apex/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_torch_nvidia_apex/package.py
@@ -86,8 +86,8 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
     )
 
     patch(
-        "https://github.com/NVIDIA/apex/pull/1855.patch?full_index=1",
-        sha256="8481b1234a9ce1e8bef4e57a259d8528107761e1843777489e815ec3727397fd",
+        "https://github.com/NVIDIA/apex/commit/e552ad997605dd883825106776eba230a6820345.patch?full_index=1",
+        sha256="cd024471dce5cb7cb84607595055375d97f84f81c76f1f469cf4c9eb11a9063e",
         when="@:24.10",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/qmcpack/package.py
@@ -197,17 +197,17 @@ class Qmcpack(CMakePackage, CudaPackage):
 
     # Backport several patches from recent versions of QMCPACK
     # The test_numerics unit test is broken prior to QMCPACK 3.3.0
-    patch_url = "https://github.com/QMCPACK/qmcpack/pull/621.patch?full_index=1"
+    patch_url = "https://github.com/QMCPACK/qmcpack/commit/26aac9a2adb9a688ab8fe2a9664450de97557cf9.patch?full_index=1"
     patch_checksum = "54484b722df264dae3fd0c1094883b17431617e278eeba2cffbd720b36c9e21a"
     patch(patch_url, sha256=patch_checksum, when="@3.1.0:3.3.0")
 
     # FindMKL.cmake has an issues prior to QMCPACK 3.3.0
-    patch_url = "https://github.com/QMCPACK/qmcpack/pull/623.patch?full_index=1"
+    patch_url = "https://github.com/QMCPACK/qmcpack/commit/9f4c5f58779cad3146e3dfef005acdead95aa46e.patch?full_index=1"
     patch_checksum = "9e444d627ab22ad5f31797aec0c0d662463055955eff1c84fbde274e0259db6b"
     patch(patch_url, sha256=patch_checksum, when="@3.1.0:3.3.0")
 
     # git-rev files for not git builds issues prior to QMCPACK 3.3.0
-    patch_url = "https://github.com/QMCPACK/qmcpack/pull/643.patch?full_index=1"
+    patch_url = "https://github.com/QMCPACK/qmcpack/commit/d59a2b3f07584f7a4665db908577110a866d7f1b.patch?full_index=1"
     patch_checksum = "d6410e7843f6c062bf9aa8ecf107e573b35c32022927d63f8cf5ad36ccf873c3"
     patch(patch_url, sha256=patch_checksum, when="@3.1.0:3.3.0")
 

--- a/var/spack/repos/spack_repo/builtin/packages/qt/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/qt/package.py
@@ -183,7 +183,7 @@ class Qt(Package):
     # https://github.com/Tencent/rapidjson/issues/2277
     # https://github.com/Tencent/rapidjson/pull/719
     patch(
-        "https://patch-diff.githubusercontent.com/raw/Tencent/rapidjson/pull/719.patch?full_index=1",
+        "https://github.com/Tencent/rapidjson/commit/9bd618f545ab647e2c3bcbf2f1d87423d6edf800.patch?full_index=1",
         sha256="ce341a69d6c17852fddd5469b6aabe995fd5e3830379c12746a18c3ae858e0e1",
         working_dir="qtlocation/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0",
         when="@5.9.2: %gcc@14:",

--- a/var/spack/repos/spack_repo/builtin/packages/raja/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/raja/package.py
@@ -181,7 +181,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     # Fix compilation issue reported by Intel from their new compiler version
     patch(
-        "https://github.com/LLNL/RAJA/pull/1668.patch?full_index=1",
+        "https://github.com/LLNL/RAJA/commit/3e831e034bd92daacf49f40b66459aefd6ea3972.patch?full_index=1",
         sha256="c0548fc5220f24082fb2592d5b4e8b7c8c783b87906d5f0950d53953d25161f6",
         when="@2024.02.1:2024.02.99 %oneapi@2025:",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/root/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/root/package.py
@@ -113,21 +113,21 @@ class Root(CMakePackage):
     patch("root7-webgui.patch", level=1, when="@6.16.00")
     # Missing includes in libcpp_string_view.h
     patch(
-        "https://github.com/root-project/root/pull/8289.patch?full_index=1",
-        sha256="5d91d78bcecd4fdbce9c829554a563234a9cb99eaf91dbc14fb85c3de33bac34",
+        "https://github.com/root-project/root/commit/a15e883277e51303a61baa3e6890f46b5bb4bfd7.patch?full_index=1",
+        sha256="12f4b5d47cca85871160b6772f2e0ebcf49de4e3294414411477f1ef44dd2e5b",
         when="@6.22:6.22.08",
     )
     # 6.26.00:6.26.06 can fail with empty string COMPILE_DEFINITIONS, which this patch
     # protects against
     patch(
-        "https://github.com/root-project/root/pull/11111.patch?full_index=1",
-        sha256="3115be912bd948979c9c2a3d89ffe6437fe17bd3b81396958c6cb6f51f64ae62",
+        "https://github.com/root-project/root/commit/08ab7e03061e551647d707637957252d121f9c39.patch?full_index=1",
+        sha256="943e361c85f133d252e35200b59ee3c260a5e74edecb8ea37a362b580bef81d1",
         when="@6.26:6.26.06",
     )
     # 6.26.00:6.26.06 fails for recent nlohmann-json single headers versions
     patch(
-        "https://github.com/root-project/root/pull/11225.patch?full_index=1",
-        sha256="397f2de7db95a445afdb311fc91c40725fcfad485d58b4d72e6c3cdd0d0c5de7",
+        "https://github.com/root-project/root/commit/26247b68b3aabad4aea5362bc5a8988103ce8038.patch?full_index=1",
+        sha256="8337fda2a964682422a11f32cd385104054e3ad112ec234be3f2bd88cea08fd9",
         when="@6.26:6.26.06 +root7 ^nlohmann-json@3.11:",
     )
     # Support recent versions of protobuf with their own CMake config
@@ -151,8 +151,8 @@ class Root(CMakePackage):
 
     # Fix TUri to be PCRE2 compatible
     patch(
-        "https://github.com/root-project/root/pull/15988.patch?full_index=1",
-        sha256="9de4aa66f791dc3a1b9521995552b2d28b57be88a96a2e9e369977e32da26eb0",
+        "https://github.com/root-project/root/commit/37f59306938f91f3ff2cce963ecbb041591dff43.patch?full_index=1",
+        sha256="a530978b5a9e9aa4a58958aed5b1d7c7d5e91f949ea04254bf0afa2000e1eee9",
         when="@6.32.0:6.32.02",
     )
 
@@ -165,13 +165,13 @@ class Root(CMakePackage):
         patch("root6-60606-mathmore.patch", when="@6.06.06")
         # Fix macOS build when cocoa is disabled:
         patch(
-            "https://github.com/root-project/root/pull/14387.patch?full_index=1",
+            "https://github.com/root-project/root/commit/ebcda91aa14a359f06fa1c50690d5be9e4c98b94.patch?full_index=1",
             sha256="559495f7bdd6b7674d3b1019da9b76e8b374f6dca3dbe72fb1320b0be2b00e53",
             when="@6.30:6.30.3 ~aqua",
         )
         # Fix build issues with libAfterImage for macOS
         patch(
-            "https://github.com/root-project/root/pull/15044.patch?full_index=1",
+            "https://github.com/root-project/root/commit/854cbc1af3eddf144aaa98b530103b229ab63ed3.patch?full_index=1",
             sha256="e68be5fe7b1ec873da134bd39c5c72730c4ca06d51b52eb436ae44fe81cd472d",
             when="@:6.30.04 +x",
         )

--- a/var/spack/repos/spack_repo/builtin/packages/thrift/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/thrift/package.py
@@ -89,8 +89,8 @@ class Thrift(CMakePackage, AutotoolsPackage):
         depends_on("py-six@1.7.2:", type=("build", "run"))
 
     patch(
-        "https://github.com/apache/thrift/pull/2511.patch?full_index=1",
-        sha256="8523c97eccb31b084241b4061db830c4ef940042b37ba8ddfdcdd23d92325b89",
+        "https://github.com/apache/thrift/commit/69b66a51f2d86746b78300fdf43dd098d6eac7cb.patch?full_index=1",
+        sha256="e3c8d43963e3fd0835f1a7a0014bedc4a17480651e9d86ce602466fa1cabfee5",
         when="@0.16.0",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -524,7 +524,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     patch("cray_secas_12_12_1.patch", when="@12.12.1%cce")
     patch("cray_secas.patch", when="@12.14.1:12%cce")
     patch(
-        "https://patch-diff.githubusercontent.com/raw/trilinos/Trilinos/pull/10545.patch?full_index=1",
+        "https://github.com/trilinos/Trilinos/commit/c8b788d7e6e213a2828201ebdc00cde181e3b71b.patch?full_index=1",
         sha256="62272054f7cc644583c269e692c69f0a26af19e5a5bd262db3ea3de3447b3358",
         when="@:13.4 +complex",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/ut/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ut/package.py
@@ -39,8 +39,8 @@ class Ut(CMakePackage):
 
     # 1.1.9 had the version set to 1.1.8. See: https://github.com/boost-ext/ut/pull/492.
     patch(
-        "https://github.com/boost-ext/ut/pull/492.patch?full_index=1",
-        sha256="1858aefec7e6adbb6130bf32a0343f9ddd173182f9dba3eb3d30523e11d26987",
+        "https://github.com/boost-ext/ut/commit/67b136c0267a54248d05fcba63905ff5e6abf0b7.patch?full_index=1",
+        sha256="0b7ad701a4f9bd6276f7d8b7c464d4ba98cc8c18d436f0eb769c639e67296a69",
         when="@1.1.9",
     )
 

--- a/var/spack/repos/spack_repo/builtin/packages/votca_tools/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/votca_tools/package.py
@@ -84,7 +84,7 @@ class VotcaTools(CMakePackage):
 
     # https://github.com/votca/tools/pull/229, fix mkl in exported target
     patch(
-        "https://github.com/votca/tools/pull/229.patch?full_index=1",
+        "https://github.com/votca/tools/commit/fb80f3eb7696b81633642285d4ba0638db605df1.patch?full_index=1",
         sha256="2a9ef179904d5057f36a5ce533c002d8f5880dc4b3eba569825f4a7e7f055eb1",
         when="@=1.6+mkl",
     )

--- a/var/spack/repos/spack_repo/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/xrootd/package.py
@@ -166,20 +166,20 @@ class Xrootd(CMakePackage):
     # Issue with _STAT_VER not being defined, fixed in 5.0.3
     patch(
         "https://github.com/xrootd/xrootd/commit/1f2d48fa23ba220ce92bf8ec6c15305ebbf19564.diff?full_index=1",
-        sha256="cfb5c2a13257012c6f117e8a1d0a3831b02586e910d845b5ff5e80d1ab2119bc",
+        sha256="792f4cd4c80018a2d031bbdcf3afe2d8b5bc669249740d669c0eedb8096dc18f",
         when="@4:5.0.2",
     )
     patch("python-support.patch", level=1, when="@:4.8+python")
     # https://github.com/xrootd/xrootd/pull/1805
     patch(
-        "https://patch-diff.githubusercontent.com/raw/xrootd/xrootd/pull/1805.patch?full_index=1",
+        "https://github.com/xrootd/xrootd/commit/c267103e3093d9fc1370d56eed7481dbc10eba7d.patch?full_index=1",
         sha256="2655e2d609d80bf9c9ab58557f4f6940408a1af9c686e7aa214ac0348c89c8fa",
         when="@5.5.1",
     )
     # https://github.com/xrootd/xrootd/pull/1930
     patch(
-        "https://patch-diff.githubusercontent.com/raw/xrootd/xrootd/pull/1930.patch?full_index=1",
-        sha256="969f8b07edff42449ad76b02f3e57d93b8d6c829be1ba14bccf831c27bc971e1",
+        "https://github.com/xrootd/xrootd/commit/984efbc72bdad86b43923569f4dfa707b7a287a2.patch?full_index=1",
+        sha256="13a4a3373268b137f8cea8d6e082db421d17175cef36bb53a2b939f697290f0e",
         when="@5.5.3",
     )
     # https://github.com/xrootd/xrootd/pull/2013


### PR DESCRIPTION
rate limits on github.com's pull/ urls are ~1 per minute, the rate
limits for merged commits are better and on top of that their
contents are not dynamic.

For verification `curl -H 'Cookie: ...' <url> | sha256` where the cookie
is copied from the browser avoids rate limits.