### PR TITLE
Add py cuda bindings package

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
@@ -2,76 +2,47 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 from spack.package import *
 
 _versions = [
     {
-        "package_version": "12.8.0",
-        "cuda_version": "12.8",
-        "python_version": "3.10",
         "sha256": "7167b0c4d872a7c0935a2ee4025eb1669702815366c2f0fb4c938fbd3dac09c7",
         "url": "https://files.pythonhosted.org/packages/f9/c4/0dac1eb970f94c5d180d724eac69394b5fdcb60f986f77d86030b0f510e5/cuda_bindings-12.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
     {
-        "package_version": "12.8.0",
-        "cuda_version": "12.8",
-        "python_version": "3.11",
         "sha256": "33182c8aadf1c4ecf5e2672b5f0023f3be06011c22c916663eae6f33b1af90ff",
         "url": "https://files.pythonhosted.org/packages/9a/cc/27485aa29bbaadcc9eca07aaea1198807d7c2171550c290533a039d4efee/cuda_bindings-12.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
     {
-        "package_version": "12.8.0",
-        "cuda_version": "12.8",
-        "python_version": "3.12",
         "sha256": "e0e6a889c87238e6cd55e9b25ce4fd1d90fe2d4169982860fed5f0bc3230795e",
         "url": "https://files.pythonhosted.org/packages/59/11/aee1afd60a5d6af67994dd88697912be22366a6e548e52e6cd2defdbe678/cuda_bindings-12.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
     {
-        "package_version": "12.8.0",
-        "cuda_version": "12.8",
-        "python_version": "3.13",
         "sha256": "099f27e79e754346fa51517168787cda395fb437b31fbf20771c002f30adc0c9",
         "url": "https://files.pythonhosted.org/packages/78/f2/b5c3f07f743e74c1f5c42bb2fc6e735f3adac8b526f60ef731d861663dd9/cuda_bindings-12.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
     {
-        "package_version": "12.8.0",
-        "cuda_version": "12.8",
-        "python_version": "3.9",
         "sha256": "df5929d82056891477bf1818241098b6289df6f43499f8683a40b9c220505a6b",
         "url": "https://files.pythonhosted.org/packages/85/29/862fa4541adf2cc96f87977116f9e71d3d8ee4dff0a3552117dc6ab7d0f6/cuda_bindings-12.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
     {
-        "package_version": "12.9.0",
-        "cuda_version": "12.9",
-        "python_version": "3.10",
         "sha256": "050e82a8d1ee4d8ac04fc56cf6f98cfea72225447f4a57e477fd455484b88818",
         "url": "https://files.pythonhosted.org/packages/03/30/f5f2da321f72c23af9bb9df947ef5f53a1efe536d8ec4ccdacdfac25174d/cuda_bindings-12.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
     {
-        "package_version": "12.9.0",
-        "cuda_version": "12.9",
-        "python_version": "3.11",
         "sha256": "f543acf44f1d119c148c49937810451541a8618b054cc779fb1fa21ab46da64c",
         "url": "https://files.pythonhosted.org/packages/49/0d/82de160bd477c1a51195a49476dd7e3b538432c8717fd636bffc9c806076/cuda_bindings-12.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
     {
-        "package_version": "12.9.0",
-        "cuda_version": "12.9",
-        "python_version": "3.12",
         "sha256": "ff0e28d1e34758654b9c961e1f55e4786e49aee6a4dbceaf3cc24c46c672df7e",
         "url": "https://files.pythonhosted.org/packages/e3/03/40fc1488727a8d72ecc35f58f9df4939277892a837614339c3366d520426/cuda_bindings-12.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
     {
-        "package_version": "12.9.0",
-        "cuda_version": "12.9",
-        "python_version": "3.13",
         "sha256": "f6d7314b2e5db025bb88ddba4df6db2127cc39610ccf4f74c0e1ead05241da29",
         "url": "https://files.pythonhosted.org/packages/01/fd/1c30778265488c6797c6c17a69c09ba5636df6dc6b0ebfc96d950be2f9e7/cuda_bindings-12.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
     {
-        "package_version": "12.9.0",
-        "cuda_version": "12.9",
-        "python_version": "3.9",
         "sha256": "98391b6c811dd6565a23b89dcd3d5a530c0d1557a37d3c915670931b6578052b",
         "url": "https://files.pythonhosted.org/packages/1a/47/9c16b088a9ed1d7f9b2c5a73866df41fe61eb460222bb75281a1159491fd/cuda_bindings-12.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
@@ -84,16 +55,26 @@ class PyCudaBindings(PythonPackage):
     homepage = "https://pypi.org/project/cuda-bindings/"
 
     for entry in _versions:
-        full_version = f"{entry['package_version']}-py{entry['python_version'].replace('.', '')}"
-        version_args = {"sha256": entry["sha256"], "url": entry["url"]}
+        url = entry["url"]
+        sha256 = entry["sha256"]
 
-        if entry["cuda_version"] == "12.8":
+        match = re.search(r"cuda_bindings-(\d+\.\d+\.\d+)-cp(\d)(\d+)", url)
+        if not match:
+            raise ValueError(f"Failed to parse version info from {url}")
+
+        package_version = match.group(1)
+        python_version = f"{match.group(2)}.{match.group(3)}"
+        cuda_version = ".".join(package_version.split(".")[:2])  # drop patch
+
+        full_version = f"{package_version}-py{python_version.replace('.', '')}"
+        version_args = {"sha256": sha256, "url": url}
+
+        if cuda_version == "12.8":
             version_args["preferred"] = True
 
         version(full_version, **version_args)
-
-        depends_on(f"python@{entry['python_version']}", when=f"@{full_version}")
-        depends_on(f"cuda@{entry['cuda_version']}", when=f"@{full_version}")
+        depends_on(f"python@{python_version}", when=f"@{full_version}")
+        depends_on(f"cuda@{cuda_version}", when=f"@{full_version}")
 
     conflicts("target=ppc64le:", msg="py-cuda-bindings is only available for x86_64")
     conflicts("target=aarch64:", msg="py-cuda-bindings is only available for x86_64")

--- a/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
+
 from spack.package import *
 
 _versions = [
@@ -50,7 +51,8 @@ _versions = [
 
 
 class PyCudaBindings(PythonPackage):
-    """cuda.bindings is a standard set of low-level interfaces, providing full coverage of and access to the CUDA host APIs from Python."""
+    """cuda.bindings is a standard set of low-level interfaces, providing
+    full coverage of and access to the CUDA host APIs from Python."""
 
     homepage = "https://pypi.org/project/cuda-bindings/"
 

--- a/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
@@ -27,26 +27,6 @@ _versions = [
         "sha256": "df5929d82056891477bf1818241098b6289df6f43499f8683a40b9c220505a6b",
         "url": "https://files.pythonhosted.org/packages/85/29/862fa4541adf2cc96f87977116f9e71d3d8ee4dff0a3552117dc6ab7d0f6/cuda_bindings-12.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     },
-    {
-        "sha256": "050e82a8d1ee4d8ac04fc56cf6f98cfea72225447f4a57e477fd455484b88818",
-        "url": "https://files.pythonhosted.org/packages/03/30/f5f2da321f72c23af9bb9df947ef5f53a1efe536d8ec4ccdacdfac25174d/cuda_bindings-12.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
-    {
-        "sha256": "f543acf44f1d119c148c49937810451541a8618b054cc779fb1fa21ab46da64c",
-        "url": "https://files.pythonhosted.org/packages/49/0d/82de160bd477c1a51195a49476dd7e3b538432c8717fd636bffc9c806076/cuda_bindings-12.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
-    {
-        "sha256": "ff0e28d1e34758654b9c961e1f55e4786e49aee6a4dbceaf3cc24c46c672df7e",
-        "url": "https://files.pythonhosted.org/packages/e3/03/40fc1488727a8d72ecc35f58f9df4939277892a837614339c3366d520426/cuda_bindings-12.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
-    {
-        "sha256": "f6d7314b2e5db025bb88ddba4df6db2127cc39610ccf4f74c0e1ead05241da29",
-        "url": "https://files.pythonhosted.org/packages/01/fd/1c30778265488c6797c6c17a69c09ba5636df6dc6b0ebfc96d950be2f9e7/cuda_bindings-12.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
-    {
-        "sha256": "98391b6c811dd6565a23b89dcd3d5a530c0d1557a37d3c915670931b6578052b",
-        "url": "https://files.pythonhosted.org/packages/1a/47/9c16b088a9ed1d7f9b2c5a73866df41fe61eb460222bb75281a1159491fd/cuda_bindings-12.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
 ]
 
 
@@ -70,9 +50,6 @@ class PyCudaBindings(PythonPackage):
 
         full_version = f"{package_version}-py{python_version.replace('.', '')}"
         version_args = {"sha256": sha256, "url": url}
-
-        if cuda_version == "12.8":
-            version_args["preferred"] = True
 
         version(full_version, **version_args)
         depends_on(f"python@{python_version}", when=f"@{full_version}")

--- a/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
@@ -20,15 +20,15 @@ class PyCudaBindings(PythonPackage):
     version("12.8.0", sha256="6cc8db1e65a1f995e289b64f9b9bff4362321d36ecf9b54eb192d0781475fbca")
     version("11.8.7", sha256="613ec6d0cde3db4d48074010ed6015ff60462f14c5fa7d8fe82fe7a7ecd5d1ac")
 
-    depends_on("python@3.9:", type=("build", "run"))
-    depends_on("py-cython", type="build")
-    depends_on("py-pyparsing", type="build")
-    depends_on("py-pyclibrary", type="build")
-    depends_on("py-setuptools", type="build")
-
     depends_on("cuda@12.9", when="@12.9.0")
     depends_on("cuda@12.8", when="@12.8.0")
     depends_on("cuda@11.8", when="@11.8.7")
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-cython", type="build")
+    depends_on("py-pyclibrary", type=("build", "run"))
+    depends_on("py-pywin32", when="platform=windows", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@77.0.0:", when="@12.9.0", type="build")
 
     build_directory = "cuda_bindings"
 

--- a/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
@@ -2,58 +2,37 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import re
+from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *
 
-_versions = [
-    {
-        "sha256": "7167b0c4d872a7c0935a2ee4025eb1669702815366c2f0fb4c938fbd3dac09c7",
-        "url": "https://files.pythonhosted.org/packages/f9/c4/0dac1eb970f94c5d180d724eac69394b5fdcb60f986f77d86030b0f510e5/cuda_bindings-12.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
-    {
-        "sha256": "33182c8aadf1c4ecf5e2672b5f0023f3be06011c22c916663eae6f33b1af90ff",
-        "url": "https://files.pythonhosted.org/packages/9a/cc/27485aa29bbaadcc9eca07aaea1198807d7c2171550c290533a039d4efee/cuda_bindings-12.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
-    {
-        "sha256": "e0e6a889c87238e6cd55e9b25ce4fd1d90fe2d4169982860fed5f0bc3230795e",
-        "url": "https://files.pythonhosted.org/packages/59/11/aee1afd60a5d6af67994dd88697912be22366a6e548e52e6cd2defdbe678/cuda_bindings-12.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
-    {
-        "sha256": "099f27e79e754346fa51517168787cda395fb437b31fbf20771c002f30adc0c9",
-        "url": "https://files.pythonhosted.org/packages/78/f2/b5c3f07f743e74c1f5c42bb2fc6e735f3adac8b526f60ef731d861663dd9/cuda_bindings-12.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
-    {
-        "sha256": "df5929d82056891477bf1818241098b6289df6f43499f8683a40b9c220505a6b",
-        "url": "https://files.pythonhosted.org/packages/85/29/862fa4541adf2cc96f87977116f9e71d3d8ee4dff0a3552117dc6ab7d0f6/cuda_bindings-12.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    },
-]
-
 
 class PyCudaBindings(PythonPackage):
-    """cuda.bindings is a standard set of low-level interfaces, providing
-    full coverage of and access to the CUDA host APIs from Python."""
+    """NVIDIA’s CUDA Python provides Cython bindings and Python wrappers for the
+    driver and runtime API for existing toolkits and libraries to simplify
+    GPU-based accelerated processing."""
 
-    homepage = "https://pypi.org/project/cuda-bindings/"
+    homepage = "https://github.com/NVIDIA/cuda-python"
+    git = "https://github.com/NVIDIA/cuda-python"
+    url = "https://github.com/NVIDIA/cuda-python/releases/download/v12.9.0/cuda-python-v12.9.0.tar.gz"
 
-    for entry in _versions:
-        url = entry["url"]
-        sha256 = entry["sha256"]
+    version("12.9.0", sha256="1fa57a9fad278256cbb3b6cf347d2b258a7f83bba2759257e54c9fabd0b07ce1")
+    version("12.8.0", sha256="6cc8db1e65a1f995e289b64f9b9bff4362321d36ecf9b54eb192d0781475fbca")
+    version("11.8.7", sha256="613ec6d0cde3db4d48074010ed6015ff60462f14c5fa7d8fe82fe7a7ecd5d1ac")
 
-        match = re.search(r"cuda_bindings-(\d+\.\d+\.\d+)-cp(\d)(\d+)", url)
-        if not match:
-            raise ValueError(f"Failed to parse version info from {url}")
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-cython", type="build")
+    depends_on("py-pyparsing", type="build")
+    depends_on("py-pyclibrary", type="build")
+    depends_on("py-setuptools", type="build")
 
-        package_version = match.group(1)
-        python_version = f"{match.group(2)}.{match.group(3)}"
-        cuda_version = ".".join(package_version.split(".")[:2])  # drop patch
+    depends_on("cuda@12.9", when="@12.9.0")
+    depends_on("cuda@12.8", when="@12.8.0")
+    depends_on("cuda@11.8", when="@11.8.7")
 
-        full_version = f"{package_version}-py{python_version.replace('.', '')}"
-        version_args = {"sha256": sha256, "url": url}
+    build_directory = "cuda_bindings"
 
-        version(full_version, **version_args)
-        depends_on(f"python@{python_version}", when=f"@{full_version}")
-        depends_on(f"cuda@{cuda_version}", when=f"@{full_version}")
-
-    conflicts("target=ppc64le:", msg="py-cuda-bindings is only available for x86_64")
-    conflicts("target=aarch64:", msg="py-cuda-bindings is only available for x86_64")
+    def setup_build_environment(self, env):
+        cuda_version = self.spec["cuda"].version
+        if cuda_version >= Version("12.9"):
+            env.append_path("LIBRARY_PATH", self.spec["cuda"].prefix.lib64)

--- a/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_cuda_bindings/package.py
@@ -1,0 +1,99 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+_versions = [
+    {
+        "package_version": "12.8.0",
+        "cuda_version": "12.8",
+        "python_version": "3.10",
+        "sha256": "7167b0c4d872a7c0935a2ee4025eb1669702815366c2f0fb4c938fbd3dac09c7",
+        "url": "https://files.pythonhosted.org/packages/f9/c4/0dac1eb970f94c5d180d724eac69394b5fdcb60f986f77d86030b0f510e5/cuda_bindings-12.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+    {
+        "package_version": "12.8.0",
+        "cuda_version": "12.8",
+        "python_version": "3.11",
+        "sha256": "33182c8aadf1c4ecf5e2672b5f0023f3be06011c22c916663eae6f33b1af90ff",
+        "url": "https://files.pythonhosted.org/packages/9a/cc/27485aa29bbaadcc9eca07aaea1198807d7c2171550c290533a039d4efee/cuda_bindings-12.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+    {
+        "package_version": "12.8.0",
+        "cuda_version": "12.8",
+        "python_version": "3.12",
+        "sha256": "e0e6a889c87238e6cd55e9b25ce4fd1d90fe2d4169982860fed5f0bc3230795e",
+        "url": "https://files.pythonhosted.org/packages/59/11/aee1afd60a5d6af67994dd88697912be22366a6e548e52e6cd2defdbe678/cuda_bindings-12.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+    {
+        "package_version": "12.8.0",
+        "cuda_version": "12.8",
+        "python_version": "3.13",
+        "sha256": "099f27e79e754346fa51517168787cda395fb437b31fbf20771c002f30adc0c9",
+        "url": "https://files.pythonhosted.org/packages/78/f2/b5c3f07f743e74c1f5c42bb2fc6e735f3adac8b526f60ef731d861663dd9/cuda_bindings-12.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+    {
+        "package_version": "12.8.0",
+        "cuda_version": "12.8",
+        "python_version": "3.9",
+        "sha256": "df5929d82056891477bf1818241098b6289df6f43499f8683a40b9c220505a6b",
+        "url": "https://files.pythonhosted.org/packages/85/29/862fa4541adf2cc96f87977116f9e71d3d8ee4dff0a3552117dc6ab7d0f6/cuda_bindings-12.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+    {
+        "package_version": "12.9.0",
+        "cuda_version": "12.9",
+        "python_version": "3.10",
+        "sha256": "050e82a8d1ee4d8ac04fc56cf6f98cfea72225447f4a57e477fd455484b88818",
+        "url": "https://files.pythonhosted.org/packages/03/30/f5f2da321f72c23af9bb9df947ef5f53a1efe536d8ec4ccdacdfac25174d/cuda_bindings-12.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+    {
+        "package_version": "12.9.0",
+        "cuda_version": "12.9",
+        "python_version": "3.11",
+        "sha256": "f543acf44f1d119c148c49937810451541a8618b054cc779fb1fa21ab46da64c",
+        "url": "https://files.pythonhosted.org/packages/49/0d/82de160bd477c1a51195a49476dd7e3b538432c8717fd636bffc9c806076/cuda_bindings-12.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+    {
+        "package_version": "12.9.0",
+        "cuda_version": "12.9",
+        "python_version": "3.12",
+        "sha256": "ff0e28d1e34758654b9c961e1f55e4786e49aee6a4dbceaf3cc24c46c672df7e",
+        "url": "https://files.pythonhosted.org/packages/e3/03/40fc1488727a8d72ecc35f58f9df4939277892a837614339c3366d520426/cuda_bindings-12.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+    {
+        "package_version": "12.9.0",
+        "cuda_version": "12.9",
+        "python_version": "3.13",
+        "sha256": "f6d7314b2e5db025bb88ddba4df6db2127cc39610ccf4f74c0e1ead05241da29",
+        "url": "https://files.pythonhosted.org/packages/01/fd/1c30778265488c6797c6c17a69c09ba5636df6dc6b0ebfc96d950be2f9e7/cuda_bindings-12.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+    {
+        "package_version": "12.9.0",
+        "cuda_version": "12.9",
+        "python_version": "3.9",
+        "sha256": "98391b6c811dd6565a23b89dcd3d5a530c0d1557a37d3c915670931b6578052b",
+        "url": "https://files.pythonhosted.org/packages/1a/47/9c16b088a9ed1d7f9b2c5a73866df41fe61eb460222bb75281a1159491fd/cuda_bindings-12.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    },
+]
+
+
+class PyCudaBindings(PythonPackage):
+    """cuda.bindings is a standard set of low-level interfaces, providing full coverage of and access to the CUDA host APIs from Python."""
+
+    homepage = "https://pypi.org/project/cuda-bindings/"
+
+    for entry in _versions:
+        full_version = f"{entry['package_version']}-py{entry['python_version'].replace('.', '')}"
+        version_args = {"sha256": entry["sha256"], "url": entry["url"]}
+
+        if entry["cuda_version"] == "12.8":
+            version_args["preferred"] = True
+
+        version(full_version, **version_args)
+
+        depends_on(f"python@{entry['python_version']}", when=f"@{full_version}")
+        depends_on(f"cuda@{entry['cuda_version']}", when=f"@{full_version}")
+
+    conflicts("target=ppc64le:", msg="py-cuda-bindings is only available for x86_64")
+    conflicts("target=aarch64:", msg="py-cuda-bindings is only available for x86_64")

--- a/var/spack/repos/spack_repo/builtin/packages/py_pyclibrary/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pyclibrary/package.py
@@ -1,0 +1,19 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyPyclibrary(PythonPackage):
+    """C parser and bindings automation for Python."""
+
+    homepage = "https://pyclibrary.readthedocs.io/en/latest/"
+    pypi = "pyclibrary/pyclibrary-0.2.2.tar.gz"
+
+    version("0.2.2", sha256="9902fffe361bb86f57ab62aa4195ec4dd382b63c5c6892be6d9784ec0a3575f7")
+
+    depends_on("py-setuptools", type=("build"))
+    depends_on("python", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_pyclibrary/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pyclibrary/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class PyPyclibrary(PythonPackage):
     """C parser and bindings automation for Python."""
 
-    homepage = "https://pyclibrary.readthedocs.io/en/latest/"
+    homepage = "https://pyclibrary.readthedocs.io"
     pypi = "pyclibrary/pyclibrary-0.2.2.tar.gz"
 
     version("0.2.2", sha256="9902fffe361bb86f57ab62aa4195ec4dd382b63c5c6892be6d9784ec0a3575f7")

--- a/var/spack/repos/spack_repo/builtin/packages/py_pyclibrary/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pyclibrary/package.py
@@ -15,5 +15,6 @@ class PyPyclibrary(PythonPackage):
 
     version("0.2.2", sha256="9902fffe361bb86f57ab62aa4195ec4dd382b63c5c6892be6d9784ec0a3575f7")
 
-    depends_on("py-setuptools", type=("build"))
+    depends_on("py-setuptools", type="build")
     depends_on("python", type=("build", "run"))
+    depends_on("py-pyparsing@2.3.1:3", type=("build", "run"))


### PR DESCRIPTION
This PR adds the `py-cuda-bindings` package to Spack. It provides low-level Python bindings to NVIDIA’s CUDA driver and runtime APIs, used by higher-level Python CUDA libraries.

A few notes:
- Builds from source tarballs published on GitHub
- Supports versions 11.8.7, 12.8.0, and 12.9.0
- Adds a new `py-pyclibrary` package for the `pyclibrary` build-time dependency
- Fixes a linking issue with `libcudart_static.a` in CUDA 12.9+ by conditionally appending to `LIBRARY_PATH` during the build