### PR TITLE
GLEW: add patch needed for mesa >= 24.0.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/glew/mesa-24.0.0-osmesa.patch
+++ b/var/spack/repos/spack_repo/builtin/packages/glew/mesa-24.0.0-osmesa.patch
@@ -1,0 +1,57 @@
+diff -r -u a/src/glew.c b/src/glew.c
+--- a/src/glew.c	2020-03-15 04:53:59.000000000 -0700
++++ b/src/glew.c	2025-05-10 09:30:10.610259000 -0700
+@@ -38,7 +38,15 @@
+ 
+ #if defined(GLEW_OSMESA)
+ #  define GLAPI extern
++#  ifndef APIENTRY
++#    define APIENTRY
++#    define GLEW_APIENTRY_DEFINED
++#  endif
+ #  include <GL/osmesa.h>
++#  ifdef GLEW_APIENTRY_DEFINED
++#    undef APIENTRY
++#    undef GLEW_APIENTRY_DEFINED
++#  endif
+ #elif defined(GLEW_EGL)
+ #  include <GL/eglew.h>
+ #elif defined(_WIN32)
+diff -r -u a/src/glewinfo.c b/src/glewinfo.c
+--- a/src/glewinfo.c	2020-03-15 04:53:59.000000000 -0700
++++ b/src/glewinfo.c	2025-05-10 09:45:02.853885000 -0700
+@@ -38,7 +38,15 @@
+ #include <GL/eglew.h>
+ #elif defined(GLEW_OSMESA)
+ #define GLAPI extern
++#ifndef APIENTRY
++#  define APIENTRY
++#  define GLEW_APIENTRY_DEFINED
++#endif
+ #include <GL/osmesa.h>
++#ifdef GLEW_APIENTRY_DEFINED
++#  undef APIENTRY
++#  undef GLEW_APIENTRY_DEFINED
++#endif
+ #elif defined(_WIN32)
+ #include <GL/wglew.h>
+ #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
+diff -r -u a/src/visualinfo.c b/src/visualinfo.c
+--- a/src/visualinfo.c	2020-03-15 04:53:59.000000000 -0700
++++ b/src/visualinfo.c	2025-05-10 09:45:38.136185000 -0700
+@@ -36,7 +36,15 @@
+ #include <GL/glew.h>
+ #if defined(GLEW_OSMESA)
+ #define GLAPI extern
++#ifndef APIENTRY
++#  define APIENTRY
++#  define GLEW_APIENTRY_DEFINED
++#endif
+ #include <GL/osmesa.h>
++#ifdef GLEW_APIENTRY_DEFINED
++#  undef APIENTRY
++#  undef GLEW_APIENTRY_DEFINED
++#endif
+ #elif defined(GLEW_EGL)
+ #include <GL/eglew.h>
+ #elif defined(_WIN32)

--- a/var/spack/repos/spack_repo/builtin/packages/glew/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/glew/package.py
@@ -28,6 +28,8 @@ class Glew(CMakePackage):
     # glu is already forcibly disabled in the CMakeLists.txt.  This prevents
     # it from showing up in the .pc file
     patch("remove-pkgconfig-glu-dep.patch")
+    # fix a build issue with mesa >= 24.0.0, see
+    # https://github.com/spack/spack/pull/50401
     patch("mesa-24.0.0-osmesa.patch", when="^mesa@24.0.0:")
 
     def cmake_args(self):

--- a/var/spack/repos/spack_repo/builtin/packages/glew/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/glew/package.py
@@ -28,6 +28,11 @@ class Glew(CMakePackage):
     # glu is already forcibly disabled in the CMakeLists.txt.  This prevents
     # it from showing up in the .pc file
     patch("remove-pkgconfig-glu-dep.patch")
+    patch(
+        "https://github.com/nigels-com/glew/commit/c050e33aa0d5f97cc9d1bfc73224f6f6d977629f.patch?full_index=1",
+        when="^mesa@24.0.0:",
+        sha256="346b7efb0828e4eecaa4a5066e48a3b3e75066d05d9fdd220611c4ed706d2ac6",
+    )
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/spack_repo/builtin/packages/glew/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/glew/package.py
@@ -28,11 +28,7 @@ class Glew(CMakePackage):
     # glu is already forcibly disabled in the CMakeLists.txt.  This prevents
     # it from showing up in the .pc file
     patch("remove-pkgconfig-glu-dep.patch")
-    patch(
-        "https://github.com/nigels-com/glew/commit/c050e33aa0d5f97cc9d1bfc73224f6f6d977629f.patch?full_index=1",
-        when="^mesa@24.0.0:",
-        sha256="346b7efb0828e4eecaa4a5066e48a3b3e75066d05d9fdd220611c4ed706d2ac6",
-    )
+    patch("mesa-24.0.0-osmesa.patch", when="^mesa@24.0.0:")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/spack_repo/builtin/packages/glew/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/glew/package.py
@@ -28,8 +28,8 @@ class Glew(CMakePackage):
     # glu is already forcibly disabled in the CMakeLists.txt.  This prevents
     # it from showing up in the .pc file
     patch("remove-pkgconfig-glu-dep.patch")
-    # fix a build issue with mesa >= 24.0.0, see
-    # https://github.com/spack/spack/pull/50401
+    # Define APIENTRY in osmesa build if not defined, see
+    # https://github.com/nigels-com/glew/pull/407
     patch("mesa-24.0.0-osmesa.patch", when="^mesa@24.0.0:")
 
     def cmake_args(self):


### PR DESCRIPTION
Attempt to resolve Gitlab CI failures (see e.g. https://gitlab.spack.io/spack/spack/-/jobs/16526595) due to new MESA version when building GLEW with OSMESA.

Note: the commit used for the patch corresponds to https://github.com/nigels-com/glew/pull/407.

Edit: the PR patch from https://github.com/nigels-com/glew/pull/407 did not work with the `*.tar.gz` source, so I replaced it with a local patch.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
