### PR TITLE
darshan-runtime,darshan-util,py-darshan: package updates for darshan 3.4.7 release

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/darshan_runtime/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/darshan_runtime/package.py
@@ -24,6 +24,7 @@ class DarshanRuntime(AutotoolsPackage):
     test_requires_compiler = True
 
     version("main", branch="main", submodules=True)
+    version("3.4.7", sha256="115a6d840b3bdb30751c271c0dec098b25bed2f8c77175125c133564d76afe5b")
     version("3.4.6", sha256="092b35e7af859af903dce0c51bcb5d3901dd0d9ad79d1b2f3282692407f032ee")
     version("3.4.5", sha256="1c017ac635fab5ee0e87a6b52c5c7273962813569495cb1dd3b7cfa6e19f6ed0")
     version("3.4.4", sha256="d9c9df5aca94dc5ca3d56fd763bec2f74771d35126d61cb897373d2166ccd867")
@@ -59,6 +60,7 @@ class DarshanRuntime(AutotoolsPackage):
     depends_on("hdf5", when="+hdf5")
     depends_on("parallel-netcdf", when="+parallel-netcdf")
     depends_on("lustre", when="+lustre")
+    depends_on("daos", when="+daos")
     depends_on("papi", when="+apxc")
     depends_on("autoconf", type="build", when="@main")
     depends_on("automake", type="build", when="@main")
@@ -78,6 +80,7 @@ class DarshanRuntime(AutotoolsPackage):
         when="@3.4.1:",
     )
     variant("lustre", default=False, description="Compile with Lustre module", when="@3.1:")
+    variant("daos", default=False, description="Compile with DAOS modules", when="@3.4.7:")
     variant("apmpi", default=False, description="Compile with AutoPerf MPI module", when="@3.3:")
     variant(
         "apmpi_sync",
@@ -131,6 +134,8 @@ class DarshanRuntime(AutotoolsPackage):
             extra_args.append("--enable-lustre-mod")
         else:
             extra_args.append("--disable-lustre-mod")
+        if spec.satisfies("+daos"):
+            extra_args.append("--enable-daos-mod")
         if spec.satisfies("+apmpi"):
             extra_args.append("--enable-apmpi-mod")
         if spec.satisfies("+apmpi_sync"):

--- a/var/spack/repos/spack_repo/builtin/packages/darshan_util/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/darshan_util/package.py
@@ -20,6 +20,7 @@ class DarshanUtil(AutotoolsPackage):
     tags = ["e4s"]
 
     version("main", branch="main", submodules="True")
+    version("3.4.7", sha256="115a6d840b3bdb30751c271c0dec098b25bed2f8c77175125c133564d76afe5b")
     version("3.4.6", sha256="092b35e7af859af903dce0c51bcb5d3901dd0d9ad79d1b2f3282692407f032ee")
     version("3.4.5", sha256="1c017ac635fab5ee0e87a6b52c5c7273962813569495cb1dd3b7cfa6e19f6ed0")
     version("3.4.4", sha256="d9c9df5aca94dc5ca3d56fd763bec2f74771d35126d61cb897373d2166ccd867")

--- a/var/spack/repos/spack_repo/builtin/packages/py_darshan/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_darshan/package.py
@@ -17,6 +17,7 @@ class PyDarshan(PythonPackage):
 
     # NOTE: don't forget to update the version array further down that sets the appropriate
     #       darshan-util dependency
+    version("3.4.7.0", sha256="e4e37c2707c5526a865bf4813b248ae4c327664538772e95c946f3b0079dc347")
     version("3.4.6.0", sha256="a105ec5c9bcd4a20469470ca51db8016336ede34a1c33f4488d1ba263a73c378")
     version("3.4.5.0", sha256="1419e246b2383d3e71da14942d6579a86fb298bf6dbbc3f507accefa614c6e50")
     version("3.4.4.0", sha256="2d218a1b2a450934698a78148c6603e453c246ec852679432bf217981668e56b")
@@ -41,6 +42,7 @@ class PyDarshan(PythonPackage):
     depends_on("py-seaborn", type=("build", "run"))
     depends_on("py-mako", type=("build", "run"))
     depends_on("py-humanize", when="@3.4.3.0:", type=("build", "run"))
+    depends_on("py-rich", when="@3.4.7.0:", type=("build", "run"))
     depends_on("py-pytest", type="test")
     depends_on("py-packaging", type="test")
     depends_on("py-lxml", type="test")
@@ -49,7 +51,7 @@ class PyDarshan(PythonPackage):
     # py-darshan depends on specific darshan-util versions corresponding
     # to the first 3 parts of the py-darshan version string
     # (i.e., py-darshan@3.4.3.0 requires darshan-util@3.4.3, etc.)
-    for v in ["3.4.0", "3.4.1", "3.4.2", "3.4.3", "3.4.4", "3.4.5", "3.4.6"]:
+    for v in ["3.4.0", "3.4.1", "3.4.2", "3.4.3", "3.4.4", "3.4.5", "3.4.6", "3.4.7"]:
         depends_on(f"darshan-util@{v}", when=f"@{v}", type=("build", "run"))
 
     @run_after("install")


### PR DESCRIPTION
Mostly this is just adding new checksums for this release.

Also added a new `+daos` variant for darshan-runtime that enables instrumentation of DAOS APIs.

Also, added `py-rich` as a proper dependency for `py-darshan` starting with this release.