### PR TITLE
netcdf-c: revert cxx removal in #50184

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -139,6 +139,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     variant("zstd", default=True, description="Enable Zstandard compression plugin")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build") # the cmake looks for c++ compiler
 
     with when("build_system=cmake"):
         # Based on the versions required by the root CMakeLists.txt:

--- a/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -139,7 +139,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     variant("zstd", default=True, description="Enable Zstandard compression plugin")
 
     depends_on("c", type="build")
-    depends_on("cxx", type="build") # the cmake looks for c++ compiler
+    depends_on("cxx", type="build")  # the cmake looks for c++ compiler
 
     with when("build_system=cmake"):
         # Based on the versions required by the root CMakeLists.txt:


### PR DESCRIPTION
PR https://github.com/spack/spack/pull/50184 removed `depends_on(cxx)`
>netcdf-c does not need cxx in any of the configurations we can build with Spack.

but `netcdf-c` cmake still looks for `cxx` compiler and will error out if it doesn't find it. 

This reverts that change.