### PR TITLE
icu4c: add py installer to PATH

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1051,9 +1051,6 @@ class SetupContext:
             if os.path.isdir(pcdir):
                 env.prepend_path("PKG_CONFIG_PATH", pcdir)
 
-        if sys.platform == "win32":
-            env.prepend_path("PATH", dep.prefix)
-
     def _make_runnable(self, dep: spack.spec.Spec, env: EnvironmentModifications):
         if is_system_path(dep.prefix):
             return

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1051,6 +1051,9 @@ class SetupContext:
             if os.path.isdir(pcdir):
                 env.prepend_path("PKG_CONFIG_PATH", pcdir)
 
+        if sys.platform == "win32":
+            env.prepend_path("PATH", dep.prefix)
+
     def _make_runnable(self, dep: spack.spec.Spec, env: EnvironmentModifications):
         if is_system_path(dep.prefix):
             return

--- a/var/spack/repos/spack_repo/builtin/packages/python/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/python/package.py
@@ -622,7 +622,10 @@ class Python(Package):
         copy_tree(tools_dir, prefix.Tools)
         lib_dir = os.path.join(proj_root, "Lib")
         copy_tree(lib_dir, prefix.Lib)
-        pyconfig = os.path.join(proj_root, "PC", "pyconfig.h")
+        if self.spec.satisfies("@3.13:"):
+            pyconfig = os.path.join(pcbuild_root, platform.machine().lower(), "pyconfig.h")
+        else:
+            pyconfig = os.path.join(proj_root, "PC", "pyconfig.h")
         copy(pyconfig, prefix.include)
         shared_libraries = []
         shared_libraries.extend(glob.glob("%s\\*.exe" % build_root))

--- a/var/spack/repos/spack_repo/builtin/packages/python/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/python/package.py
@@ -1275,6 +1275,7 @@ print(json.dumps(config))
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.
         """
+        env.prepend_path("PATH", self.prefix)
         # The logic below is linux specific, and used to inject the compiler wrapper to
         # compile Python extensions. Thus, it is not needed on Windows.
         if sys.platform == "win32":
@@ -1348,6 +1349,7 @@ print(json.dumps(config))
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.
         """
+        env.prepend_path("PATH", self.prefix)
         if not dependent_spec.package.extends(self.spec) or dependent_spec.dependencies(
             "python-venv"
         ):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Adds py installer to PATH in order to resolve build failure for icu4c version 76.1