### PR TITLE
rust: set stable release channel

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/rust/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rust/package.py
@@ -222,7 +222,7 @@ class Rust(Package):
         # by default a `-nightly` suffix we be applied even on
         # non-nightly stable builds
         if self.spec.version != Version("nightly"):
-            flags.append(f"--release-channel=stable")
+            flags.append("--release-channel=stable")
 
         configure(*flags)
 

--- a/var/spack/repos/spack_repo/builtin/packages/rust/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rust/package.py
@@ -219,6 +219,11 @@ class Rust(Package):
         # Compile tools into flag for configure.
         flags.append(f"--tools={','.join(tools)}")
 
+        # by default a `-nightly` suffix we be applied even on
+        # non-nightly stable builds
+        if self.spec.version != Version("nightly"):
+            flags.append(f"--release-channel=stable")
+
         configure(*flags)
 
     def build(self, spec, prefix):

--- a/var/spack/repos/spack_repo/builtin/packages/rust/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rust/package.py
@@ -221,7 +221,7 @@ class Rust(Package):
 
         # by default a `-nightly` suffix we be applied even on
         # non-nightly stable builds
-        if self.spec.version != Version("nightly"):
+        if not self.spec.satisfies("@=nightly"):
             flags.append("--release-channel=stable")
 
         configure(*flags)


### PR DESCRIPTION
Built from tarball, `rust` reports `-nightly` as part of its version string https://github.com/rust-lang/rust/issues/124618

```
$ rustc --version
rustc 1.85.0-nightly (4d91de4e4 2025-02-17) (built from a source tarball)
```

However the stable builds do not contain the nightly features, and tests against the version string will incorrectly determine that the compiler is nightly. This is problematic for tests[ like the following](https://github.com/pola-rs/polars/blob/py-1.29.0/crates/polars-ops/build.rs), which will incorrectly identify the compiler as having nightly feature sets.
```
    let channel = version_check::Channel::read().unwrap();
    if channel.is_nightly() {
        println!("cargo:rustc-cfg=feature=\"nightly\"");
    }
```

This sets `--release-channel=stable` for the stable builds as per https://github.com/rust-lang/rust/issues/124618#issuecomment-2092458937

```
$ rustc --version
rustc 1.85.0 (4d91de4e4 2025-02-17) (built from a source tarball)
```