### PR TITLE
blast-plus: set Python version to <=3.11

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/blast_plus/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/blast_plus/package.py
@@ -79,7 +79,7 @@ class BlastPlus(AutotoolsPackage):
     depends_on("lzo", when="+lzo")
     depends_on("pcre", when="+pcre")
 
-    depends_on("python", when="+python")
+    depends_on("python@:3.11", when="+python")
     depends_on("perl", when="+perl")
 
     depends_on("lmdb", when="@2.7.1:")


### PR DESCRIPTION
Since #45712 python is not setting a prefered version, and BLAST+ doesn't support 3.12 or higher.
This fixes that.