### PR TITLE
gh: add v2.72.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/gh/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gh/package.py
@@ -15,6 +15,7 @@ class Gh(GoPackage):
 
     license("MIT")
 
+    version("2.72.0", sha256="5a2cd4f2601d254d11a55dab463849ccccb5fa4bdcaa72b792ea9c3bf8c67d23")
     version("2.70.0", sha256="9e2247e5b31131fd4ac63916b9483a065fcfb861ebb93588cf2ff42952ae08c5")
     version("2.69.0", sha256="e2deb3759bbe4da8ad4f071ca604fda5c2fc803fef8b3b89896013e4b1c1fe65")
     version("2.63.2", sha256="2578a8b1f00cb292a8094793515743f2a86e02b8d0b18d6b95959ddbeebd6b8d")


### PR DESCRIPTION
Release notes:
- https://github.com/cli/cli/releases/tag/v2.71.0
- https://github.com/cli/cli/releases/tag/v2.71.1
- https://github.com/cli/cli/releases/tag/v2.71.2
- https://github.com/cli/cli/releases/tag/v2.72.0