### PR TITLE
acts dependencies: new versions as of 2025/05/19

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/actsvg/package.py
@@ -19,6 +19,11 @@ class Actsvg(CMakePackage):
 
     license("MPL-2.0")
 
+    version("0.4.56", sha256="a850007036e992a2573e01bc32ee203bb3c146d124ec1135922272ba6a62008e")
+    version("0.4.55", sha256="31a95bd12d685b2f87eac4b9e5872f9fb4add5a5b2e826a8bd727d60a0ba601f")
+    version("0.4.54", sha256="204e4217936d0d6afb91f30c727e30b2a351d8ceddd9beca7550c40272a848fe")
+    version("0.4.53", sha256="c7ddec952e84c7b7b70c1e2e15b801675fe8a30d84cabdd3273ee9890dec04be")
+    version("0.4.52", sha256="3cee069bff266ad8ab7e12f1fefad7a825da6684185b8c5449d2f1dade004843")
     version("0.4.51", sha256="937385f7703c0d2d9c0af03bd5083d3f1fdac17ff573476a5fc5b1f8e3cd98b7")
     version("0.4.50", sha256="c97fb1cc75cbf23caebd3c6fb8716354bdbd0a77ad39dc43dae963692f3256e1")
     version("0.4.48", sha256="0f230c31c64b939e4d311afd997dbaa87a375454cf1595661a449b97943412c9")
@@ -54,6 +59,7 @@ class Actsvg(CMakePackage):
     depends_on("googletest", when="+examples")
     depends_on("python@3.8:", when="+python")
     depends_on("py-pybind11@2.10:", when="+python @0.4.42:")
+    depends_on("py-pybind11@2.13:", when="+python @0.4.53:")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/spack_repo/builtin/packages/detray/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/detray/package.py
@@ -19,6 +19,8 @@ class Detray(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.96.0", sha256="b009fad9780adf2bf8d683469d6167b37b4f682da0dbaf58f9f67166096f9bcc")
+    version("0.95.0", sha256="86cc981eb0105143b971acea3544b9a668326e1027f317d77cf76918f766e7c4")
     version("0.94.0", sha256="a04e8193757846df50d0fbec858744dd66629a98be8ffc6faa04c2ab51770492")
     version("0.93.0", sha256="7d56771d213649de836905efbb21b5be59cc966b00417b0b1fa85bfe12ac92da")
     version("0.92.0", sha256="512669c1ea51936b0fe871fb5a33450b54161e811e48cc51445dc83fe3338c42")
@@ -83,6 +85,7 @@ class Detray(CMakePackage):
     depends_on("nlohmann-json@3.11.0:", when="+json")
     depends_on("dfelibs@20211029:", when="@:0.88")
     depends_on("acts-algebra-plugins@0.18.0: +vecmem")
+    depends_on("acts-algebra-plugins@0.27.0: +vecmem", when="@0.95:")
     depends_on("acts-algebra-plugins +vc", when="+vc")
     depends_on("acts-algebra-plugins +eigen", when="+eigen")
     depends_on("acts-algebra-plugins +smatrix", when="+smatrix")

--- a/var/spack/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -17,6 +17,7 @@ class Geomodel(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.11.0", sha256="fc9fdd7d64b623586089949d9790182dcd93ebb35a05198c91eac8adbbbfd778")
     version("6.10.0", sha256="968a0f7c8108b14f22041ca0c6ae8a3293175131c6f61055527ecdefe8c7839a")
     version("6.9.0", sha256="ea34dad8a0cd392e06794b8a1b7407dd6ad617fefd19fb4cccdf36b154749793")
     version("6.8.0", sha256="4dfd5a932955ee2618a880bb210aed9ce7087cfadd31f23f92e5ff009c8384eb")
@@ -62,6 +63,9 @@ class Geomodel(CMakePackage):
         multi=False,
         description="Use the specified C++ standard when building",
     )
+
+    # GeoModel 6.11 drops support for C++17.
+    conflicts("cxxstd=20", when="@6.11:")
 
     conflicts("+fullsimlight", when="+fsl", msg="FSL triggers the build of the FullSimLight")
 

--- a/var/spack/repos/spack_repo/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/geomodel/package.py
@@ -17,6 +17,7 @@ class Geomodel(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.11.1", sha256="f7b47ff4ed264e1bfb013e6cdb724e7532109f1d58ab5774656e6ff871afb362")
     version("6.11.0", sha256="fc9fdd7d64b623586089949d9790182dcd93ebb35a05198c91eac8adbbbfd778")
     version("6.10.0", sha256="968a0f7c8108b14f22041ca0c6ae8a3293175131c6f61055527ecdefe8c7839a")
     version("6.9.0", sha256="ea34dad8a0cd392e06794b8a1b7407dd6ad617fefd19fb4cccdf36b154749793")
@@ -95,6 +96,7 @@ class Geomodel(CMakePackage):
         depends_on("coin3d")
         depends_on("soqt")
         depends_on("gl")
+    depends_on("googletest", when="@6.11:")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
@@ -16,6 +16,7 @@ class Vecmem(CMakePackage, CudaPackage):
 
     license("MPL-2.0-no-copyleft-exception")
 
+    version("1.17.0", sha256="6032279e8fc8bdb48d39c4ac19ffe561bcc53576e36f71ee2ed3ed75835f1af9")
     version("1.16.0", sha256="04da7077381e12c2b9bf869e1357105683596ed9105e3acff3c6d9214be04fbd")
     version("1.15.0", sha256="53e03599efd5a22284b62e10338b69345d8188182a12fefe228005069d1ddd74")
     version("1.14.0", sha256="3fac19e2766e5f997712b0799bd820f65c17ea9cddcb9e765cbdf214f41c4783")

--- a/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
@@ -16,6 +16,7 @@ class Vecmem(CMakePackage, CudaPackage):
 
     license("MPL-2.0-no-copyleft-exception")
 
+    version("1.16.0", sha256="04da7077381e12c2b9bf869e1357105683596ed9105e3acff3c6d9214be04fbd")
     version("1.15.0", sha256="53e03599efd5a22284b62e10338b69345d8188182a12fefe228005069d1ddd74")
     version("1.14.0", sha256="3fac19e2766e5f997712b0799bd820f65c17ea9cddcb9e765cbdf214f41c4783")
     version("1.13.0", sha256="fc21cea04140e1210c83a32579b0a7194601889b6c895404214ac55ce547342b")


### PR DESCRIPTION
This commit adds v1.16.0 of vecmem, v6.11.0 of geomodel, v0.95.0 and v0.96 of detray, and numerous new actsvg versions.