### PR TITLE
mold: add 2.39.1

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/mold/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mold/package.py
@@ -15,6 +15,7 @@ class Mold(CMakePackage):
 
     license("MIT")
 
+    version("2.39.1", sha256="231ea3643a14fe5b88478c97b68b31f7c975b57b247a81356ffd889d015b5cc1")
     version("2.38.1", sha256="14bfb259fd7d0a1fdce9b66f8ed2dd0b134d15019cb359699646afeee1f18118")
     version("2.37.1", sha256="b8e36086c95bd51e9829c9755c138f5c4daccdd63b6c35212b84229419f3ccbe")
     version("2.37.0", sha256="28372bbc2ce069aa0362ba84ad5d1b0f2c0bcf84e95a0f533ecf79cb3aff232c")


### PR DESCRIPTION
Skipping 2.39.0 (https://github.com/rui314/mold/releases/tag/v2.39.0) in favour of 2.39.1 (https://github.com/rui314/mold/releases/tag/v2.39.1) which fixes a issue when building (linking) mold with LLVM and LTO.