### PR TITLE
root: Change the default value of the runtime_cxxmodules option

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/root/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/root/package.py
@@ -768,7 +768,7 @@ class Root(CMakePackage):
             define("libcxx", False),
             define("roottest", False),
             define_from_variant("rpath"),
-            define("runtime_cxxmodules", False),
+            define("runtime_cxxmodules", False if self.spec.satisfies("@:6.18") else True),
             define("shared", True),
             define("soversion", True),
             define("testing", self.run_tests),


### PR DESCRIPTION
Since ROOT 6.20 the default (https://github.com/root-project/root/pull/4452) is to have `runtime_cxxmodules` ON and we have it OFF by default with no way of configuring it, so I propose to follow the default value and set it to ON. I have found that in our stack having this set to off causes some slow downs in some IO operations (https://github.com/key4hep/key4hep-spack/issues/743). The PCH option was removed in https://github.com/root-project/root/commit/898171f5a4619ac07245d70b7f8943da067516ba so I propose not to set it.