### PR TITLE
py-twine: add v6.1.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_twine/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_twine/package.py
@@ -12,6 +12,7 @@ class PyTwine(PythonPackage):
     pypi = "twine/twine-2.0.0.tar.gz"
     git = "https://github.com/pypa/twine.git"
 
+    version("6.1.0", sha256="be324f6272eff91d07ee93f251edf232fc647935dd585ac003539b42404a8dbd")
     version("6.0.1", sha256="36158b09df5406e1c9c1fb8edb24fc2be387709443e7376689b938531582ee27")
     version("4.0.2", sha256="9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8")
     version("4.0.1", sha256="96b1cf12f7ae611a4a40b6ae8e9570215daff0611828f5fe1f37a16255ab24a0")
@@ -24,8 +25,8 @@ class PyTwine(PythonPackage):
         depends_on("py-setuptools-scm+toml@6:", when="@3.4.2:")
 
     with default_args(type=("build", "run")):
-        depends_on("py-pkginfo@1.8.1:", when="@3.7:")
-        depends_on("py-pkginfo@1.4.2:")
+        depends_on("py-pkginfo@1.8.1:", when="@3.7:6.0.1")
+        depends_on("py-pkginfo@1.4.2:", when="@:3.6")
         depends_on("py-readme-renderer@35:", when="@4.0.1:")
         depends_on("py-readme-renderer@21.0:")
         depends_on("py-requests@2.20:")
@@ -36,7 +37,9 @@ class PyTwine(PythonPackage):
         depends_on("py-keyring@15.1:", when="@3:")
         depends_on("py-rfc3986@1.4:", when="@3.2:")
         depends_on("py-rich@12:", when="@4:")
-        depends_on("py-packaging", when="@6:")
+        depends_on("py-packaging@24:", when="@6:")
+        depends_on("py-packaging", when="@6.1:")
+        depends_on("py-id", when="@6.1:")
 
         # Historical Dependencies
         depends_on("py-tqdm@4.14:", when="@:3")

--- a/var/spack/repos/spack_repo/builtin/packages/py_twine/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_twine/package.py
@@ -41,5 +41,9 @@ class PyTwine(PythonPackage):
         depends_on("py-packaging", when="@6.1:")
         depends_on("py-id", when="@6.1:")
 
+        depends_on("python@3.8:", when="@5:")
+        depends_on("python@3.7:", when="@4:")
+        depends_on("python@3.6:", when="@2:")
+
         # Historical Dependencies
         depends_on("py-tqdm@4.14:", when="@:3")


### PR DESCRIPTION
Release notes: https://twine.readthedocs.io/en/stable/changelog.html#twine-6-1-0-2025-01-17
Diff: https://github.com/pypa/twine/compare/6.0.1...6.1.0