### PR TITLE
py-pyproject-hooks: add v1.1.0 and v1.2.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_pyproject_hooks/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pyproject_hooks/package.py
@@ -13,7 +13,10 @@ class PyPyprojectHooks(PythonPackage):
 
     license("MIT")
 
+    version("1.2.0", sha256="1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8")
+    version("1.1.0", sha256="4b37730834edbd6bd37f26ece6b44802fb1c1ee2ece0e54ddff8bfc06db86965")
     version("1.0.0", sha256="f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5")
 
     depends_on("py-flit-core@3.2:3", type="build")
-    depends_on("py-tomli@1.1:", when="^python@:3.10", type=("build", "run"))
+    depends_on("py-tomli@1.1:", when="@1.0.0 ^python@:3.10", type=("build", "run"))
+    depends_on("python@3.7:", type=("build", "run"))


### PR DESCRIPTION
Release notes:
- https://pyproject-hooks.readthedocs.io/en/latest/changelog.html#v1-1
- https://pyproject-hooks.readthedocs.io/en/latest/changelog.html#v1-2

Diffs:
- https://github.com/pypa/pyproject-hooks/compare/v1.0.0...v1.1.0
- https://github.com/pypa/pyproject-hooks/compare/v1.1.0...v1.2.0