### PR TITLE
Adding support for disabling view in temporary environments

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -331,7 +331,8 @@ def env_activate(args):
         env = create_temp_env_directory()
         env_path = os.path.abspath(env)
         short_name = os.path.basename(env_path)
-        ev.create_in_dir(env).write(regenerate=False)
+        view = not args.without_view
+        ev.create_in_dir(env, with_view=view).write(regenerate=False)
         _tty_info(f"Created and activated temporary environment in {env_path}")
 
     # Managed environment


### PR DESCRIPTION
The `--without-view` option is silently ignored when activating a temporary environment with `spack env activate --temp --without-view`.  This change will allow the view to be disabled in the temporary spack.yaml.  The default remains `view: true`.