### PR TITLE
RepoSplit/tests: compilers/libraries use mock packages

### DIFF
--- a/lib/spack/spack/test/compilers/libraries.py
+++ b/lib/spack/spack/test/compilers/libraries.py
@@ -28,11 +28,14 @@ def call_compiler(exe, *args, **kwargs):
 @pytest.fixture()
 def mock_gcc(config):
     compilers = spack.compilers.config.all_compilers_from(configuration=config)
+    assert compilers, "No compilers available"
+
     compilers.sort(key=lambda x: (x.name == "gcc", x.version))
     # Deepcopy is used to avoid more boilerplate when changing the "extra_attributes"
     return copy.deepcopy(compilers[-1])
 
 
+@pytest.mark.usefixtures("mock_packages")
 class TestCompilerPropertyDetector:
     @pytest.mark.parametrize(
         "language,flagname",


### PR DESCRIPTION
Source: https://github.com/spack/spack/pull/48930, replaces commits:

- https://github.com/spack/spack/commit/97e255f26cb1f3eaca06f2c93c3a2cbe15438fc0
- https://github.com/spack/spack/commit/c34b3e05c5f09a2e8aca02edd53298f42a5fb4da
- https://github.com/spack/spack/commit/bda99eb0d83d655b26de7607721eeab959b562da
- https://github.com/spack/spack/commit/10aaf0d3f48c8316d9bfad0b8c4ba880b659249a (remove unused variables; not pushed)

There are 10 `test/compilers/libraries.py` tests that will error without any access to the builtin repository:

```
ERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_compile_dummy_c_source[cxx-cxxflags] - IndexError: list index out of rangeERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_compile_dummy_c_source[cxx-cppflags] - IndexError: list index out of range
ERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_compile_dummy_c_source[cxx-ldflags] - IndexError: list index out of range
ERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_compile_dummy_c_source[c-cflags] - IndexError: list index out of range
ERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_compile_dummy_c_source[c-cppflags] - IndexError: list index out of range
ERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_compile_dummy_c_source_no_path - IndexError: list index out of range
ERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_compile_dummy_c_source_no_verbose_flags - IndexError: list index out of ...
ERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_compile_dummy_c_source_load_env - IndexError: list index out of range
ERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_implicit_rpaths - IndexError: list index out of range
ERROR lib/spack/spack/test/compilers/libraries.py::TestCompilerPropertyDetector::test_compiler_environment - IndexError: list index out of range
```
97e255f26cb1f3eaca06f2c93c3a2cbe15438fc0 c34b3e05c5f09a2e8aca02edd53298f42a5fb4da bda99eb0d83d655b26de7607721eeab959b562da 10aaf0d3f48c8316d9bfad0b8c4ba880b659249a