### PR TITLE
Win: Restore oneAPI env setup

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
@@ -158,6 +158,43 @@ class Msvc(Package, CompilerPackage):
         )
         self.vcvars_call = VCVarsInvocation(vcvars_script_path, arch, msvc_version)
         env_cmds.append(self.vcvars_call)
+
+
+        def get_oneapi_root(pth: str):
+                """From within a prefix known to be a oneAPI path
+                determine the oneAPI root path from arbitrary point
+                under root
+
+                Args:
+                    pth: path prefixed within oneAPI root
+                """
+                if not pth:
+                    return ""
+                while os.path.basename(pth) and os.path.basename(pth) != "oneAPI":
+                    pth = os.path.dirname(pth)
+                return pth
+
+        if self.fortran:
+            # If this found, it sets all the vars
+            oneapi_root = get_oneapi_root(self.fortran)
+            if not oneapi_root:
+                raise RuntimeError(f"Non-oneAPI Fortran compiler {self.fortran} assigned to MSVC")
+            oneapi_root_setvars = os.path.join(oneapi_root, "setvars.bat")
+            # some oneAPI exes return a version more precise than their
+            # install paths specify, so we determine path from
+            # the install path rather than the fc executable itself
+            numver = r"\d+\.\d+(?:\.\d+)?"
+            pattern = f"((?:{numver})|(?:latest))"
+            version_from_path = re.search(pattern, self.fortran).group(1)
+            oneapi_version_setvars = os.path.join(
+                oneapi_root, "compiler", version_from_path, "env", "vars.bat"
+            )
+            env_cmds.extend(
+                [
+                    VarsInvocation(oneapi_version_setvars),
+                    VarsInvocation(oneapi_root_setvars)
+                ]
+            )
         self.msvc_compiler_environment = CmdCall(*env_cmds)
 
     def _standard_flag(self, *, language: str, standard: str) -> str:

--- a/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
@@ -159,20 +159,19 @@ class Msvc(Package, CompilerPackage):
         self.vcvars_call = VCVarsInvocation(vcvars_script_path, arch, msvc_version)
         env_cmds.append(self.vcvars_call)
 
-
         def get_oneapi_root(pth: str):
-                """From within a prefix known to be a oneAPI path
-                determine the oneAPI root path from arbitrary point
-                under root
+            """From within a prefix known to be a oneAPI path
+            determine the oneAPI root path from arbitrary point
+            under root
 
-                Args:
-                    pth: path prefixed within oneAPI root
-                """
-                if not pth:
-                    return ""
-                while os.path.basename(pth) and os.path.basename(pth) != "oneAPI":
-                    pth = os.path.dirname(pth)
-                return pth
+            Args:
+                pth: path prefixed within oneAPI root
+            """
+            if not pth:
+                return ""
+            while os.path.basename(pth) and os.path.basename(pth) != "oneAPI":
+                pth = os.path.dirname(pth)
+            return pth
 
         if self.fortran:
             # If this found, it sets all the vars
@@ -190,10 +189,7 @@ class Msvc(Package, CompilerPackage):
                 oneapi_root, "compiler", version_from_path, "env", "vars.bat"
             )
             env_cmds.extend(
-                [
-                    VarsInvocation(oneapi_version_setvars),
-                    VarsInvocation(oneapi_root_setvars)
-                ]
+                [VarsInvocation(oneapi_version_setvars), VarsInvocation(oneapi_root_setvars)]
             )
         self.msvc_compiler_environment = CmdCall(*env_cmds)
 


### PR DESCRIPTION
oneAPI env setup was prematurely removed in compiler as nodes. Restore it.

Note: the choice to remove that functionality from the MSVC compiler class was not incorrect, just done too early.
This PR will eventually be reverted once installable oneAPI support is available on Windows (coming very soon)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
