### PR TITLE
opencv: add pkgconfig dependency when +ffmpeg

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/opencv/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/opencv/package.py
@@ -238,6 +238,9 @@ class Opencv(CMakePackage, CudaPackage):
         depends_on("java")
         depends_on("ant")
 
+    with when("+ffmpeg"):
+        depends_on("pkgconfig")
+
     with when("+objc"):
         conflicts("~imgproc")
         conflicts("~objc_bindings_generator")

--- a/var/spack/repos/spack_repo/builtin/packages/opencv/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/opencv/package.py
@@ -239,7 +239,7 @@ class Opencv(CMakePackage, CudaPackage):
         depends_on("ant")
 
     with when("+ffmpeg"):
-        depends_on("pkgconfig")
+        depends_on("pkgconfig", type="build")
 
     with when("+objc"):
         conflicts("~imgproc")


### PR DESCRIPTION
OpenCV isn't able to find FFMPEG without pkgconfig:
https://github.com/opencv/opencv/blob/4.10.0/modules/videoio/cmake/detect_ffmpeg.cmake#L27

I was getting this error without the pkgconfig dependency:
 ```
>> 495    CMake Error at cmake/OpenCVUtils.cmake:797 (message):
     496      Some dependencies have not been found or have been forced, unset
     497      ENABLE_CONFIG_VERIFICATION option to ignore these failures or change
     498      following options:
     499
     500      WITH_FFMPEG
     501    Call Stack (most recent call first):
```