### PR TITLE
fix spack.repo.is_package_module

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -55,7 +55,9 @@ _API_REGEX = re.compile(r"^v(\d+)\.(\d+)$")
 
 def is_package_module(fullname: str) -> bool:
     """Check if the given module is a package module."""
-    return fullname.startswith(PKG_MODULE_PREFIX_V1) or fullname.startswith(PKG_MODULE_PREFIX_V2)
+    return fullname.startswith(PKG_MODULE_PREFIX_V1) or (
+        fullname.startswith(PKG_MODULE_PREFIX_V2) and fullname.endswith(".package")
+    )
 
 
 def namespace_from_fullname(fullname: str) -> str:

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -523,3 +523,10 @@ def test_subdir_in_v2():
 
     with pytest.raises(spack.repo.BadRepoError, match="Must be a valid Python module name"):
         spack.repo._validate_and_normalize_subdir(subdir="123", root="root", package_api=(2, 0))
+
+
+def test_is_package_module():
+    assert spack.repo.is_package_module("spack.pkg.something.something")
+    assert spack.repo.is_package_module("spack_repo.foo.bar.baz.package")
+    assert not spack.repo.is_package_module("spack_repo.builtin.build_systems.cmake")
+    assert not spack.repo.is_package_module("spack.something.else")


### PR DESCRIPTION
Test also that `spack_repo.*` ends with `.package`.

That way `spack_repo.builtin.build_systems.foo` is not seen as a package module whereas `spack_repo.builtin.packages.foo.package` is.

Because the packages dir name is configurable, nothing else can be said statically.