### PR TITLE
Spack 1.0.0 amdlibm fix

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/amd_aocl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/amd_aocl/package.py
@@ -34,6 +34,9 @@ class AmdAocl(BundlePackage):
 
     variant("openmp", default=False, description="Enable OpenMP support.")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
     depends_on("scalapack")
     depends_on("lapack")
     depends_on("blas")

--- a/var/spack/repos/spack_repo/builtin/packages/amdlibm/libm-ose-SconsSpack-5.patch
+++ b/var/spack/repos/spack_repo/builtin/packages/amdlibm/libm-ose-SconsSpack-5.patch
@@ -1,11 +1,10 @@
 diff -Naru a/scripts/site_scons/alm/env.py b/scripts/site_scons/alm/env.py
---- a/scripts/site_scons/alm/env.py	2024-02-28 05:19:43.000000000 +0000
-+++ b/scripts/site_scons/alm/env.py	2025-05-12 17:46:19.299780124 +0000
-@@ -72,6 +72,9 @@
-                     'SPACK_LINKER_ARG',
+--- a/scripts/site_scons/alm/env.py	2024-10-11 04:15:23.000000000 +0000
++++ b/scripts/site_scons/alm/env.py	2025-05-12 18:17:06.390404980 +0000
+@@ -73,6 +73,8 @@
                      'SPACK_SHORT_SPEC',
                      'SPACK_SYSTEM_DIRS',
-+                    'SPACK_MANAGED_DIRS',
+                     'SPACK_MANAGED_DIRS',
 +                    'SPACK_COMPILER_WRAPPER_PATH',
 +                    'SPACK_CC_LINKER_ARG',
                  ]

--- a/var/spack/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -46,11 +46,11 @@ class Amdlibm(SConsPackage):
     variant("verbose", default=False, description="Building with verbosity", when="@:4.1")
 
     # Mandatory dependencies
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("python@3.6.1:", type=("build", "run"))
-    depends_on("scons@3.1.2:", type=("build"))
+    depends_on("scons@3.1.2:4.8.1", type=("build"))
     depends_on("mpfr", type=("link"))
     for vers in ["4.1", "4.2", "5.0"]:
         with when(f"@{vers}"):
@@ -58,10 +58,10 @@ class Amdlibm(SConsPackage):
 
     patch("0001-libm-ose-Scripts-cleanup-pyc-files.patch", when="@2.2")
     patch("0002-libm-ose-prevent-log-v3.c-from-building.patch", when="@2.2")
-    # Patch to update the SCons environment with
-    # the newly introduced 'SPACK_MANAGED_DIRS'
-    # build environment variable.
+    # Patch to update the SCons environment with newly introduced
+    # Spack build environment variables.
     patch("libm-ose-SconsSpack.patch", when="@3.1:4.2")
+    patch("libm-ose-SconsSpack-5.patch", when="@5.0")
 
     conflicts("%gcc@:9.1.0", msg="Minimum supported GCC version is 9.2.0")
     conflicts("%clang@:9.0", msg="Minimum supported Clang version is 9")


### PR DESCRIPTION
This PR fixes https://github.com/spack/spack/issues/50023. It contains the following:

* exclude the newer versions of `scons` as they contain flawed caching logic.
* patch the `scons` configuration to support Spack environmental variables newly introduced in https://github.com/spack/spack/pull/45189. This fix is very similar to https://github.com/spack/spack/pull/44054.
* additionally, the `amd_aocl` bundle package needs compiler dependencies to work.
