### PR TITLE
sst: update core, elements, macro to 15.0.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/sst_core/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/sst_core/package.py
@@ -13,12 +13,13 @@ class SstCore(AutotoolsPackage):
 
     homepage = "https://github.com/sstsimulator"
     git = "https://github.com/sstsimulator/sst-core.git"
-    url = "https://github.com/sstsimulator/sst-core/releases/download/v14.1.0_Final/sstcore-14.1.0.tar.gz"
+    url = "https://github.com/sstsimulator/sst-core/releases/download/v15.0.0_Final/sstcore-15.0.0.tar.gz"
 
     maintainers("berquist", "jmlapre", "naromero77")
 
     license("BSD-3-Clause")
 
+    version("15.0.0", sha256="ca2875fb36be069e34b10fd9b0ad756dd4c707795f824346aff9523a56f3840c")
     version("14.1.0", sha256="9d17c37d1ebdff8d8eb10ab0084eb901c78a7c5a76db15189e3d7fc318fd6f9d")
     version("14.0.0", sha256="fadc7ee99472ff3ac5d4b3f3e507123e32bd9fb89c4c6b48fbd2dca8aeb8b8d6")
     version("13.1.0", sha256="0a44c62ee0b18a20a3cb089f4e0d43e293dc5adc6c3fa7639d40986cf5b9854c")

--- a/var/spack/repos/spack_repo/builtin/packages/sst_elements/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/sst_elements/package.py
@@ -13,12 +13,13 @@ class SstElements(AutotoolsPackage):
 
     homepage = "https://github.com/sstsimulator"
     git = "https://github.com/sstsimulator/sst-elements.git"
-    url = "https://github.com/sstsimulator/sst-elements/releases/download/v14.1.0_Final/sstelements-14.1.0.tar.gz"
+    url = "https://github.com/sstsimulator/sst-elements/releases/download/v15.0.0_Final/sstelements-15.0.0.tar.gz"
 
     maintainers("berquist", "jmlapre", "naromero77")
 
     license("BSD-3-Clause")
 
+    version("15.0.0", sha256="98f7fbd4bce16f639616edb889fb3c6667b50899273114854e77fcdb26bcddd6")
     version("14.1.0", sha256="433994065810d3afee4e355173e781cd76171043cce8835bbc40887672a33350")
     version("14.0.0", sha256="68eab77febdd0138a497249d854e1cb0c3a67b1c56c4d51f1fe35df12dcd1b9c")
     version("13.1.0", sha256="ebda6ee5af858192dff8a7faf3125010001d5c439beec22afe5b9828a74adf1a")

--- a/var/spack/repos/spack_repo/builtin/packages/sst_macro/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/sst_macro/package.py
@@ -16,10 +16,11 @@ class SstMacro(AutotoolsPackage):
 
     homepage = "https://github.com/sstsimulator"
     git = "https://github.com/sstsimulator/sst-macro.git"
-    url = "https://github.com/sstsimulator/sst-macro/releases/download/v14.1.0_Final/sstmacro-14.1.0.tar.gz"
+    url = "https://github.com/sstsimulator/sst-macro/releases/download/v15.0.0_Final/sstmacro-15.0.0.tar.gz"
 
     maintainers("berquist", "jmlapre")
 
+    version("15.0.0", sha256="ce4bdb28b1500f2fd6875e3ff7a630e24ae381b58c72ae24a5157181d9546d53")
     version("14.1.0", sha256="241f42f5c460b0e7462592a7f412bda9c9de19ad7a4b62c22f35be4093b57014")
     version("14.0.0", sha256="3962942268dd9fe6ebd4462e2d6d305ab757f3f510487e84687146a8d461be13")
     version("13.1.0", sha256="022e39daae1067b56c0011dbe87e3234fee4587049fd53671e1ed6b23233f70e")


### PR DESCRIPTION
SST-{core,elements,macro} released 15.0.0 recently.  Update the corresponding packages.
