### PR TITLE
RepoSplit/tests: add requires_builtin marker and use

### DIFF
--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -111,6 +111,7 @@ def split(output):
 pkg = spack.main.SpackCommand("pkg")
 
 
+@pytest.mark.requires_builtin("builtin repository path must exist")
 def test_builtin_repo():
     assert spack.repo.builtin_repo() is spack.repo.PATH.get_repo("builtin")
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2072,6 +2072,11 @@ def pytest_runtest_setup(item):
     if only_windows_marker and sys.platform != "win32":
         pytest.skip(*only_windows_marker.args)
 
+    # XFail test marked "requires_builtin" if builtin repo is required
+    requires_builtin_marker = item.get_closest_marker(name="requires_builtin")
+    if requires_builtin_marker and not os.path.exists(spack.paths.packages_path):
+        pytest.xfail(*requires_builtin_marker.args)
+
 
 def _sequential_executor(*args, **kwargs):
     return spack.util.parallel.SequentialExecutor()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2072,10 +2072,10 @@ def pytest_runtest_setup(item):
     if only_windows_marker and sys.platform != "win32":
         pytest.skip(*only_windows_marker.args)
 
-    # XFail test marked "requires_builtin" if builtin repo is required
+    # Skip tests marked "requires_builtin" if builtin repo is required
     requires_builtin_marker = item.get_closest_marker(name="requires_builtin")
     if requires_builtin_marker and not os.path.exists(spack.paths.packages_path):
-        pytest.xfail(*requires_builtin_marker.args)
+        pytest.skip(*requires_builtin_marker.args)
 
 
 def _sequential_executor(*args, **kwargs):

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,4 @@ markers =
   disable_clean_stage_check: avoid failing tests if there are leftover files in the stage area
   not_on_windows: mark tests that are skipped on Windows
   only_windows: mark tests that are skipped everywhere but Windows
+  requires_builtin: tests that require the builtin repository


### PR DESCRIPTION
This PR adds a `requires_builtin` marker that will ~raise `XFAIL`~ skip the test plus its use when a unit test requires the `builtin` repository but cannot be modified to use mock packages.