### PR TITLE
RepoSplit/tests: add cmd/commands.py::test_names command cleanup

### DIFF
--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -23,15 +23,19 @@ spack.main.add_all_commands(parser)
 
 def test_names():
     """Test default output of spack commands."""
-    out1 = commands().strip().split("\n")
+    def cleanup(commands):
+        """Format output and remove any non-command lines, e.g., repo warnings."""
+        return [cmd for cmd in commands.strip().split("\n") if " " not in cmd]
+
+    out1 = cleanup(commands())
     assert out1 == spack.cmd.all_commands()
     assert "rm" not in out1
 
-    out2 = commands("--aliases").strip().split("\n")
+    out2 = cleanup(commands("--aliases"))
     assert out1 != out2
     assert "rm" in out2
 
-    out3 = commands("--format=names").strip().split("\n")
+    out3 = cleanup(commands("--format=names"))
     assert out1 == out3
 
 

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -23,6 +23,7 @@ spack.main.add_all_commands(parser)
 
 def test_names():
     """Test default output of spack commands."""
+
     def cleanup(commands):
         """Format output and remove any non-command lines, e.g., repo warnings."""
         return [cmd for cmd in commands.strip().split("\n") if " " not in cmd]


### PR DESCRIPTION
Likely a controversial change that _may be moot post-split_, but the basic approaches of `SuppressOutput`, `output_filter`, and monkey patching tty didn't seem to work. 

The goal is to skip what is currently a 5-line warning about the missing builtin repository with instructions on removing it. This change leverages the facts that 1) there are no spaces in a spack (sub)command or its alias; and 2) any changes to the warning message are likely to contain spaces.