### PR TITLE
Remove two unit tests, in favor of audits

### DIFF
--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -36,40 +36,6 @@ def define_plat_exe(exe):
     return exe
 
 
-def test_find_external_single_package(mock_executable):
-    cmake_path = mock_executable("cmake", output="echo cmake version 1.foo")
-    search_dir = cmake_path.parent.parent
-
-    specs_by_package = spack.detection.by_path(["cmake"], path_hints=[str(search_dir)])
-
-    assert len(specs_by_package) == 1 and "cmake" in specs_by_package
-    detected_spec = specs_by_package["cmake"]
-    assert len(detected_spec) == 1 and detected_spec[0] == Spec("cmake@1.foo")
-
-
-def test_find_external_two_instances_same_package(mock_executable):
-    # Each of these cmake instances is created in a different prefix
-    # In Windows, quoted strings are echo'd with quotes includes
-    # we need to avoid that for proper regex.
-    cmake1 = mock_executable("cmake", output="echo cmake version 1.foo", subdir=("base1", "bin"))
-    cmake2 = mock_executable("cmake", output="echo cmake version 3.17.2", subdir=("base2", "bin"))
-    search_paths = [str(cmake1.parent.parent), str(cmake2.parent.parent)]
-
-    finder = spack.detection.path.ExecutablesFinder()
-    detected_specs = finder.find(
-        pkg_name="cmake", initial_guess=search_paths, repository=spack.repo.PATH
-    )
-
-    assert len(detected_specs) == 2
-    spec_to_path = {s: s.external_path for s in detected_specs}
-    assert spec_to_path[Spec("cmake@1.foo")] == (
-        spack.detection.executable_prefix(str(cmake1.parent))
-    ), spec_to_path
-    assert spec_to_path[Spec("cmake@3.17.2")] == (
-        spack.detection.executable_prefix(str(cmake2.parent))
-    )
-
-
 def test_find_external_update_config(mutable_config):
     entries = [
         Spec.from_detection("cmake@1.foo", external_path="/x/y1"),

--- a/var/spack/repos/spack_repo/builtin/packages/gcc/detection_test.yaml
+++ b/var/spack/repos/spack_repo/builtin/packages/gcc/detection_test.yaml
@@ -119,3 +119,50 @@ paths:
       extra_attributes:
         compilers:
           c: ".*/bin/gcc-14$"
+
+# Tests having two versions of gcc in the same folder
+- layout:
+  - executables:
+    - "bin/gcc"
+    - "bin/g++"
+    script: |
+      if [ "$1" = "-dumpversion" ] ; then
+        echo "9"
+      elif [ "$1" = "-dumpfullversion" ] ; then
+        echo "9.4.0"
+      elif [ "$1" = "--version" ] ; then
+        echo "gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0"
+        echo "Copyright (C) 2019 Free Software Foundation, Inc."
+        echo "This is free software; see the source for copying conditions.  There is NO"
+        echo "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+      else
+        echo "mock executable got an unexpected flag: $1"
+        exit 1
+      fi
+  - executables:
+    - "bin/gcc-10"
+    script: |
+      if [ "$1" = "-dumpversion" ] ; then
+        echo "10"
+      elif [ "$1" = "-dumpfullversion" ] ; then
+        echo "10.5.0"
+      elif [ "$1" = "--version" ] ; then
+        echo "gcc-10 (Ubuntu 10.5.0-1ubuntu1~20.04) 10.5.0"
+        echo "Copyright (C) 2020 Free Software Foundation, Inc."
+        echo "This is free software; see the source for copying conditions.  There is NO"
+        echo "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+      else
+        echo "mock executable got an unexpected flag: $1"
+        exit 1
+      fi
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: "gcc@9.4.0 languages:=c,c++"
+    extra_attributes:
+      compilers:
+        c: ".*/bin/gcc"
+        cxx: ".*/bin/g\\+\\+"
+  - spec: "gcc@10.5.0 languages:=c"
+    extra_attributes:
+      compilers:
+        c: ".*/bin/gcc-10"


### PR DESCRIPTION
refers #50363

This PR removes two unit tests for:
```
$ spack external find ...
```
and replaces them with audits on the same functionality
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
