### PR TITLE
py-maturin: update rust dependency version

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_maturin/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_maturin/package.py
@@ -34,6 +34,7 @@ class PyMaturin(PythonPackage):
     with default_args(type=("build", "run")):
         depends_on("py-tomli@1.1:", when="^python@:3.10")
         for rust, maturin in [
+            ("1.74", "1.8"),
             ("1.70", "1.5.0"),
             ("1.64", "1.0.0"),
             ("1.62", "0.14.3"),


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

py-maturin@1.8 requires a higher version of rust than what specified in the package. Building it with rust@1.72 causes this error:

```
  cargo build --manifest-path Cargo.toml --message-format=json-render-diagnostics --release -v --no-default-features --locked
  error: package `clap_builder v4.5.7` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.72.0-nightly
  Either upgrade to rustc 1.74 or newer, or use
  cargo update -p clap_builder@4.5.7 --precise ver
  where `ver` is the latest version of `clap_builder` supporting rustc 1.72.0-nightly
  error: `cargo build --manifest-path Cargo.toml --message-format=json-render-diagnostics --release -v --no-default-features --locked` failed with code 101
  error: subprocess-exited-with-error
```