### PR TITLE
podio, edm4hep: Add version 1.3 and 0.99.2 and ensure make sure EDM4hep still builds

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/edm4hep/package.py
@@ -20,6 +20,7 @@ class Edm4hep(CMakePackage):
     license("Apache-2.0")
 
     version("main", branch="main")
+    version("0.99.2", sha256="b3e7abb61fd969e4c9aef55dd6839a2186bf0b0d3801174fe6e0b9df8e0ebace")
     version("0.99.1", sha256="84d990f09dbd0ad2198596c0c51238a4b15391f51febfb15dd3d191dc7aae9f4")
     version("0.99", sha256="3636e8c14474237029bf1a8be11c53b57ad3ed438fd70a7e9b87c5d08f1f2ea6")
     version("0.10.5", sha256="003c8e0c8e1d1844592d43d41384f4320586fbfa51d4d728ae0870b9c4f78d81")
@@ -77,6 +78,7 @@ class Edm4hep(CMakePackage):
     depends_on("podio@1:", when="@0.99:")
     depends_on("podio@0.15:", when="@:0.10.5")
     depends_on("podio@:1.1", when="@:0.99.0")
+    depends_on("podio@1.3:", when="@0.99.2:")
     for _std in _cxxstd_values:
         for _v in _std:
             depends_on(f"podio cxxstd={_v.value}", when=f"cxxstd={_v.value}")

--- a/var/spack/repos/spack_repo/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/edm4hep/package.py
@@ -107,6 +107,8 @@ class Edm4hep(CMakePackage):
             self.define("BUILD_TESTING", self.run_tests),
             self.define_from_variant("EDM4HEP_WITH_JSON", "json"),
         ]
+        if self.spec.satisfies("@:0.99.1 ^podio@1.3:"):
+            args.append(self.define("PODIO_USE_CLANG_FORMAT", False))
         return args
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:

--- a/var/spack/repos/spack_repo/builtin/packages/podio/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/podio/package.py
@@ -19,6 +19,7 @@ class Podio(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version("master", branch="master")
+    version("1.3", sha256="7efdf049822f171f4da5e83a7101096c066679904e59e741f3c2833ccda5e363")
     version("1.2", sha256="bc97ba09ce908e55d4c5faa78d9739dde7daefd9337ae98351813b13708d0685")
     version("1.1", sha256="2cb5040761f3da4383e1f126da25d68e99ecd8398e0ff12e7475a3745a7030a6")
     version("1.0.1", sha256="915531a2bcf638011bb6cc19715bbc46d846ec8b985555a1afdcd6abc017e21b")

--- a/var/spack/repos/spack_repo/builtin/packages/podio/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/podio/package.py
@@ -103,6 +103,7 @@ class Podio(CMakePackage):
     depends_on("root@6.08.06: cxxstd=17", when="cxxstd=17")
     depends_on("root@6.14:", when="+datasource")
     depends_on("root@6.28.04: +root7", when="+rntuple")
+    depends_on("root@6.32: +root7", when="@1.3: +rntuple")
     depends_on("root@6.28:", when="@0.17:")
     for cxxstd in ("17", "20"):
         depends_on("root cxxstd={}".format(cxxstd), when="cxxstd={}".format(cxxstd))

--- a/var/spack/repos/spack_repo/builtin/packages/podio/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/podio/package.py
@@ -103,8 +103,8 @@ class Podio(CMakePackage):
     depends_on("root@6.08.06: cxxstd=17", when="cxxstd=17")
     depends_on("root@6.14:", when="+datasource")
     depends_on("root@6.28.04: +root7", when="+rntuple")
-    depends_on("root@6.32: +root7", when="@1.3: +rntuple")
     depends_on("root@6.28:", when="@0.17:")
+    depends_on("root@6.32: +root7", when="@1.3: +rntuple")
     for cxxstd in ("17", "20"):
         depends_on("root cxxstd={}".format(cxxstd), when="cxxstd={}".format(cxxstd))
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add podio version 1.3. This requires a few more tweaks
- The minimal ROOT version for building RNTuple support is now 6.32 (although we do recommend 6.34 for backwards compatibility)
- Switching to c++20 breaks the EDM4hep clang-format configuration, so we need to turn it off entirely for code generation until the next version of EDM4hep if we build with the latest version of podio

Also adding EDM4hep 0.99.2 in this PR since it is closely connected