### PR TITLE
su2: capitalize a couple env vars required by SU2

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/su2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/su2/package.py
@@ -159,8 +159,8 @@ class Su2(MesonPackage):
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.set("SU2_RUN", self.prefix.bin)
         env.set("SU2_HOME", self.prefix)
-        env.prepend_path("path", self.prefix.bin)
-        env.prepend_path("pythonpath", self.prefix.bin)
+        env.prepend_path("PATH", self.prefix.bin)
+        env.prepend_path("PYTHONPATH", self.prefix.bin)
         if "+mpp" in self.spec:
-            env.set("mpp_data_directory", join_path(self.prefix, "mpp-data"))
-            env.prepend_path("ld_library_path", self.prefix.lib)
+            env.set("MPP_DATA_DIRECTORY", join_path(self.prefix, "mpp-data"))
+            env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)

--- a/var/spack/repos/spack_repo/builtin/packages/su2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/su2/package.py
@@ -157,8 +157,8 @@ class Su2(MesonPackage):
             )
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
-        env.set("su2_run", self.prefix.bin)
-        env.set("su2_home", self.prefix)
+        env.set("SU2_RUN", self.prefix.bin)
+        env.set("SU2_HOME", self.prefix)
         env.prepend_path("path", self.prefix.bin)
         env.prepend_path("pythonpath", self.prefix.bin)
         if "+mpp" in self.spec:


### PR DESCRIPTION
The updated names align with SU2's doc: https://github.com/su2code/SU2/blob/master/README.md?plain=1#L68-L87

Repro of the issue:

```
$ spack env activate /home/linsword_google_com/ramble/var/ramble/workspaces/su2/software/spack/su2
$ echo $su2_run
/home/linsword_google_com/ramble/var/ramble/workspaces/su2/software/spack/su2/ramble/bin
$ echo $SU2_RUN

$ parallel_computation.py -n 1 -f inv_channel.cfg
Traceback (most recent call last):
  File "/home/linsword_google_com/ramble/var/ramble/workspaces/su2/software/spack/su2/ramble/bin/parallel_computation.py", line 31, in <module>
    sys.path.append(os.environ["SU2_RUN"])
                    ~~~~~~~~~~^^^^^^^^^^^
  File "<frozen os>", line 679, in __getitem__
KeyError: 'SU2_RUN'
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
