### PR TITLE
Sync CI Configs to spack-packages repo

### DIFF
--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -27,7 +27,10 @@ jobs:
     - name: Sync spack/spack-packages with spack/spack
       run: |
         cd spack-packages
-        git-filter-repo --quiet --source ../spack --subdirectory-filter var/spack/repos --refs develop
+        git-filter-repo --quiet --source ../spack \
+                        --subdirectory-filter var/spack/repos \
+                        --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
+                        --refs develop
     - name: Push
       run: |
         cd spack-packages


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Sync CI stuff to packages repo. Move gitlab CI to `share/spack/gitlab/cloud_pipelines/... -> .ci/gitlab/...`