### PR TITLE
ci: remove ck from ML ROCm stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -19,6 +19,8 @@ spack:
       - +rocm
       - amdgpu_target=gfx90a
       - ~flash_attention
+    miopen-hip:
+      require: ~ck
 
   specs:
     # Horovod


### PR DESCRIPTION
Composable-Kernel is not able to build within the 6 hour limit and is causing ci failures:
https://gitlab.spack.io/spack/spack/-/jobs/16640490
