### PR TITLE
test_migrate_diff: mark xfail on Windows for now

### DIFF
--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -142,6 +142,7 @@ def test_repo_migrate(tmp_path: pathlib.Path, config):
     assert pkg_py_numpy_new.read_bytes() == NEW_NUMPY
 
 
+@pytest.mark.not_on_windows("Known failure on windows")
 def test_migrate_diff(git: Executable, tmp_path: pathlib.Path):
     root, _ = spack.repo.create_repo(str(tmp_path), "foo", package_api=(2, 0))
     r = pathlib.Path(root)


### PR DESCRIPTION
Following from https://github.com/spack/spack/pull/50507#issuecomment-2887014137
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
