### PR TITLE
bugfix: make `spack pkg grep` respect windows CLI limits

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -737,9 +737,9 @@ def group_arguments(
         max_group_length = 32768  # default to the Windows limit
         if hasattr(os, "sysconf"):  # sysconf is only on unix
             try:
+                # returns -1 if an option isn't present (soem older POSIXes)
                 sysconf_max = os.sysconf("SC_ARG_MAX")
-                if sysconf_max != -1:  # returns -1 if an option isn't present
-                    max_group_length = sysconf_max
+                max_group_length = sysconf_max if sysconf_max != -1 else max_group_length
             except (ValueError, OSError):
                 pass  # keep windows default if SC_ARG_MAX isn't in sysconf_names
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 from collections import Counter
-from typing import List, Optional, Union
+from typing import Generator, List, Optional, Sequence, Union
 
 import llnl.string
 import llnl.util.tty as tty
@@ -702,6 +702,57 @@ def find_environment(args):
 def first_line(docstring):
     """Return the first line of the docstring."""
     return docstring.split("\n")[0]
+
+
+def group_arguments(
+    args: Sequence[str], max_group_size: int = 500, max_group_len: Optional[int] = None
+) -> Generator[List[str], None, None]:
+    """Splits the supplied list of arguments into groups for passing to CLI tools.
+
+    When passing CLI arguments, we need to ensure that argument lists are no longer than
+    the system command line size limit, and we may also need to ensure that groups are
+    no more than some number of arguments long.
+
+    This returns an iterator over lists of arguments that meet these constraints.
+    Arguments are in the same order they appeared in the original argument list.
+
+    If any argument's length is greater than the max_group_length, this will raise a
+    ``ValueError``.
+
+    Arguments:
+        args: list of arguments to split into groups
+        max_group_size: max number of elements in any group (default 500)
+        max_group_len: max length of characters that if a group of args is joined by " "
+            On unix, ths defaults to SC_ARG_MAX from sysconf. On Windows the default is
+            the max usable for CreateProcess (32,768 chars)
+
+    """
+    if max_group_len is None:
+        max_group_len = 32768  # default to the Windows limit
+        if hasattr(os, "sysconf"):
+            # sysconf is only on unix and returns -1 if an option isn't present
+            sysconf_max = os.sysconf("SC_ARG_MAX")
+            if sysconf_max != -1:
+                max_group_len = sysconf_max
+
+    group: List[str] = []
+    grouplen, space = 0, 0
+    for i, arg in enumerate(args):
+        arglen = len(arg)
+        if arglen > max_group_len:
+            raise ValueError(f"Argument is longer than the maximum command line size: '{arg}'")
+
+        next_grouplen = grouplen + arglen + space
+        if len(group) == max_group_size or next_grouplen > max_group_len:
+            yield group
+            group, grouplen, space = [], 0, 0
+
+        group.append(arg)
+        grouplen += arglen + space
+        space = 1  # add a space for elements 1, 2, etc. but not 0
+
+    if group:
+        yield group
 
 
 class CommandNotFoundError(spack.error.SpackError):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -705,7 +705,11 @@ def first_line(docstring):
 
 
 def group_arguments(
-    args: Sequence[str], max_group_size: int = 500, max_group_len: Optional[int] = None
+    args: Sequence[str],
+    *,
+    max_group_size: int = 500,
+    prefix_length: int = 0,
+    max_group_length: Optional[int] = None,
 ) -> Generator[List[str], None, None]:
     """Splits the supplied list of arguments into groups for passing to CLI tools.
 
@@ -722,30 +726,32 @@ def group_arguments(
     Arguments:
         args: list of arguments to split into groups
         max_group_size: max number of elements in any group (default 500)
-        max_group_len: max length of characters that if a group of args is joined by " "
+        prefix_length: length of any additional arguments to be passed before the groups from args;
+            defaults to 0 characters.
+        max_group_length: max length of characters that if a group of args is joined by " "
             On unix, ths defaults to SC_ARG_MAX from sysconf. On Windows the default is
             the max usable for CreateProcess (32,768 chars)
 
     """
-    if max_group_len is None:
-        max_group_len = 32768  # default to the Windows limit
+    if max_group_length is None:
+        max_group_length = 32768  # default to the Windows limit
         if hasattr(os, "sysconf"):
             # sysconf is only on unix and returns -1 if an option isn't present
             sysconf_max = os.sysconf("SC_ARG_MAX")
             if sysconf_max != -1:
-                max_group_len = sysconf_max
+                max_group_length = sysconf_max
 
     group: List[str] = []
-    grouplen, space = 0, 0
+    grouplen, space = prefix_length, 0
     for i, arg in enumerate(args):
         arglen = len(arg)
-        if arglen > max_group_len:
+        if arglen > max_group_length:
             raise ValueError(f"Argument is longer than the maximum command line size: '{arg}'")
 
         next_grouplen = grouplen + arglen + space
-        if len(group) == max_group_size or next_grouplen > max_group_len:
+        if len(group) == max_group_size or next_grouplen > max_group_length:
             yield group
-            group, grouplen, space = [], 0, 0
+            group, grouplen, space = [], prefix_length, 0
 
         group.append(arg)
         grouplen += arglen + space

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -726,8 +726,8 @@ def group_arguments(
     Arguments:
         args: list of arguments to split into groups
         max_group_size: max number of elements in any group (default 500)
-        prefix_length: length of any additional arguments to be passed before the groups from args;
-            defaults to 0 characters.
+        prefix_length: length of any additional arguments (including spaces) to be passed before
+            the groups from args; default is 0 characters
         max_group_length: max length of characters that if a group of args is joined by " "
             On unix, ths defaults to SC_ARG_MAX from sysconf. On Windows the default is
             the max usable for CreateProcess (32,768 chars)
@@ -735,18 +735,22 @@ def group_arguments(
     """
     if max_group_length is None:
         max_group_length = 32768  # default to the Windows limit
-        if hasattr(os, "sysconf"):
-            # sysconf is only on unix and returns -1 if an option isn't present
-            sysconf_max = os.sysconf("SC_ARG_MAX")
-            if sysconf_max != -1:
-                max_group_length = sysconf_max
+        if hasattr(os, "sysconf"):  # sysconf is only on unix
+            try:
+                sysconf_max = os.sysconf("SC_ARG_MAX")
+                if sysconf_max != -1:  # returns -1 if an option isn't present
+                    max_group_length = sysconf_max
+            except (ValueError, OSError):
+                pass  # keep windows default if SC_ARG_MAX isn't in sysconf_names
 
     group: List[str] = []
     grouplen, space = prefix_length, 0
-    for i, arg in enumerate(args):
+    for arg in args:
         arglen = len(arg)
         if arglen > max_group_length:
-            raise ValueError(f"Argument is longer than the maximum command line size: '{arg}'")
+            raise ValueError(f"Argument is longer than max command line size: '{arg}'")
+        if arglen + prefix_length > max_group_length:
+            raise ValueError(f"Argument with prefix is longer than max command line size: '{arg}'")
 
         next_grouplen = grouplen + arglen + space
         if len(group) == max_group_size or next_grouplen > max_group_length:

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -185,8 +185,11 @@ def pkg_grep(args, unknown_args):
     if not all_paths:
         return 0  # no packages to search
 
+    # these args start every command invocation (grep arg1 arg2 ...)
+    all_prefix_args = grep.exe + args.grep_args + unknown_args
+    prefix_length = sum(len(arg) for arg in all_prefix_args) + len(all_prefix_args)
+
     # set up iterator and save the first group to ensure we don't end up with a group of size 1
-    prefix_length = len(" ".join(args.grep_args + unknown_args))
     groups = spack.cmd.group_arguments(all_paths, prefix_length=prefix_length)
 
     # You can force GNU grep to show filenames on every line with -H, but not POSIX grep.

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
-import itertools
 import os
 import sys
 
@@ -182,21 +181,19 @@ def pkg_grep(args, unknown_args):
     if "GNU" in grep("--version", output=str):
         grep.add_default_arg("--color=auto")
 
-    # determines number of files to grep at a time
-    grouper = lambda e: e[0] // 100
+    all_paths = spack.repo.PATH.all_package_paths()
+    if not all_paths:
+        return 0  # no packages to search
 
     # set up iterator and save the first group to ensure we don't end up with a group of size 1
-    groups = itertools.groupby(enumerate(spack.repo.PATH.all_package_paths()), grouper)
-    if not groups:
-        return 0  # no packages to search
+    groups = spack.cmd.group_arguments(all_paths)
 
     # You can force GNU grep to show filenames on every line with -H, but not POSIX grep.
     # POSIX grep only shows filenames when you're grepping 2 or more files.  Since we
     # don't know which one we're running, we ensure there are always >= 2 files by
     # saving the prior group of paths and adding it to a straggling group of 1 if needed.
     # This works unless somehow there is only one package in all of Spack.
-    _, first_group = next(groups)
-    prior_paths = [path for _, path in first_group]
+    prior_paths = next(groups)
 
     # grep returns 1 for nothing found, 0 for something found, and > 1 for error
     return_code = 1
@@ -207,9 +204,7 @@ def pkg_grep(args, unknown_args):
         grep(*all_args, fail_on_error=False)
         return grep.returncode
 
-    for _, group in groups:
-        paths = [path for _, path in group]  # extract current path group
-
+    for paths in groups:
         if len(paths) == 1:
             # Only the very last group can have length 1. If it does, combine
             # it with the prior group to ensure more than one path is grepped.

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -186,7 +186,8 @@ def pkg_grep(args, unknown_args):
         return 0  # no packages to search
 
     # set up iterator and save the first group to ensure we don't end up with a group of size 1
-    groups = spack.cmd.group_arguments(all_paths)
+    prefix_length = len(" ".join(args.grep_args + unknown_args))
+    groups = spack.cmd.group_arguments(all_paths, prefix_length=prefix_length)
 
     # You can force GNU grep to show filenames on every line with -H, but not POSIX grep.
     # POSIX grep only shows filenames when you're grepping 2 or more files.  Since we

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -322,24 +322,25 @@ group_args = [
 
 
 @pytest.mark.parametrize(
-    ["max_group_size", "prefix_length", "max_group_length", "lengths", "error"],
+    ["args", "max_group_size", "prefix_length", "max_group_length", "lengths", "error"],
     [
-        (3, 0, 1, None, ValueError),  # element too long
-        (3, 0, 13, None, ValueError),  # element too long
-        (3, 12, 25, None, ValueError),  # prefix and words too long
-        (3, 0, 25, [2, 1, 1, 1, 1, 1, 1, 1, 1], None),
-        (3, 0, 26, [2, 1, 1, 2, 1, 1, 2], None),
-        (3, 0, 40, [3, 3, 2, 2], None),
-        (3, 0, 43, [3, 3, 3, 1], None),
-        (4, 0, 54, [4, 3, 3], None),
-        (4, 0, 56, [4, 4, 2], None),
+        (group_args, 3, 0, 1, None, ValueError),  # element too long
+        (group_args, 3, 0, 13, None, ValueError),  # element too long
+        (group_args, 3, 12, 25, None, ValueError),  # prefix and words too long
+        (group_args, 3, 0, 25, [2, 1, 1, 1, 1, 1, 1, 1, 1], None),
+        (group_args, 3, 0, 26, [2, 1, 1, 2, 1, 1, 2], None),
+        (group_args, 3, 0, 40, [3, 3, 2, 2], None),
+        (group_args, 3, 0, 43, [3, 3, 3, 1], None),
+        (group_args, 4, 0, 54, [4, 3, 3], None),
+        (group_args, 4, 0, 56, [4, 4, 2], None),
+        ([], 500, 0, None, [], None),
     ],
 )
 def test_group_arguments(
-    mock_packages, max_group_size, prefix_length, max_group_length, lengths, error
+    mock_packages, args, max_group_size, prefix_length, max_group_length, lengths, error
 ):
     generator = spack.cmd.group_arguments(
-        group_args,
+        args,
         max_group_size=max_group_size,
         prefix_length=prefix_length,
         max_group_length=max_group_length,
@@ -352,7 +353,7 @@ def test_group_arguments(
         return
 
     groups = list(generator)
-    assert sum(groups, []) == group_args
+    assert sum(groups, []) == args
     assert [len(group) for group in groups] == lengths
     assert all(
         sum(len(elt) for elt in group) + (len(group) - 1) <= max_group_length for group in groups

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -322,7 +322,7 @@ group_args = [
 
 
 @pytest.mark.parametrize(
-    ["max_group_size", "max_group_len", "lengths", "error"],
+    ["max_group_size", "max_group_length", "lengths", "error"],
     [
         (3, 1, None, ValueError),
         (3, 13, None, ValueError),
@@ -334,9 +334,9 @@ group_args = [
         (4, 56, [4, 4, 2], None),
     ],
 )
-def test_group_arguments(mock_packages, max_group_size, max_group_len, lengths, error):
+def test_group_arguments(mock_packages, max_group_size, max_group_length, lengths, error):
     generator = spack.cmd.group_arguments(
-        group_args, max_group_size=max_group_size, max_group_len=max_group_len
+        group_args, max_group_size=max_group_size, max_group_length=max_group_length
     )
 
     # just check that error cases raise
@@ -349,7 +349,7 @@ def test_group_arguments(mock_packages, max_group_size, max_group_len, lengths, 
     assert sum(groups, []) == group_args
     assert [len(group) for group in groups] == lengths
     assert all(
-        sum(len(elt) for elt in group) + (len(group) - 1) <= max_group_len for group in groups
+        sum(len(elt) for elt in group) + (len(group) - 1) <= max_group_length for group in groups
     )
 
 

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -307,10 +307,56 @@ def test_pkg_hash(mock_packages):
     assert len(output) == 1 and all(len(elt) == 32 for elt in output)
 
 
+group_args = [
+    "/path/one.py",  # 12
+    "/path/two.py",  # 12
+    "/path/three.py",  # 14
+    "/path/four.py",  # 13
+    "/path/five.py",  # 13
+    "/path/six.py",  # 12
+    "/path/seven.py",  # 14
+    "/path/eight.py",  # 14
+    "/path/nine.py",  # 13
+    "/path/ten.py",  # 12
+]
+
+
+@pytest.mark.parametrize(
+    ["max_group_size", "max_group_len", "lengths", "error"],
+    [
+        (3, 1, None, ValueError),
+        (3, 13, None, ValueError),
+        (3, 25, [2, 1, 1, 1, 1, 1, 1, 1, 1], None),
+        (3, 26, [2, 1, 1, 2, 1, 1, 2], None),
+        (3, 40, [3, 3, 2, 2], None),
+        (3, 43, [3, 3, 3, 1], None),
+        (4, 54, [4, 3, 3], None),
+        (4, 56, [4, 4, 2], None),
+    ],
+)
+def test_group_arguments(mock_packages, max_group_size, max_group_len, lengths, error):
+    generator = spack.cmd.group_arguments(
+        group_args, max_group_size=max_group_size, max_group_len=max_group_len
+    )
+
+    # just check that error cases raise
+    if error:
+        with pytest.raises(ValueError):
+            list(generator)
+        return
+
+    groups = list(generator)
+    assert sum(groups, []) == group_args
+    assert [len(group) for group in groups] == lengths
+    assert all(
+        sum(len(elt) for elt in group) + (len(group) - 1) <= max_group_len for group in groups
+    )
+
+
 @pytest.mark.skipif(not spack.cmd.pkg.get_grep(), reason="grep is not installed")
 def test_pkg_grep(mock_packages, capfd):
     # only splice-* mock packages have the string "splice" in them
-    pkg("grep", "-l", "splice", output=str)
+    pkg("grep", "-l", "splice")
     output, _ = capfd.readouterr()
     assert output.strip() == "\n".join(
         spack.repo.PATH.get_pkg_class(name).module.__file__
@@ -330,12 +376,14 @@ def test_pkg_grep(mock_packages, capfd):
         ]
     )
 
-    # ensure that this string isn't fouhnd
-    pkg("grep", "abcdefghijklmnopqrstuvwxyz", output=str, fail_on_error=False)
+    # ensure that this string isn't found
+    with pytest.raises(spack.main.SpackCommandError):
+        pkg("grep", "abcdefghijklmnopqrstuvwxyz")
     assert pkg.returncode == 1
     output, _ = capfd.readouterr()
     assert output.strip() == ""
 
     # ensure that we return > 1 for an error
-    pkg("grep", "--foobarbaz-not-an-option", output=str, fail_on_error=False)
+    with pytest.raises(spack.main.SpackCommandError):
+        pkg("grep", "--foobarbaz-not-an-option")
     assert pkg.returncode == 2

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -322,21 +322,27 @@ group_args = [
 
 
 @pytest.mark.parametrize(
-    ["max_group_size", "max_group_length", "lengths", "error"],
+    ["max_group_size", "prefix_length", "max_group_length", "lengths", "error"],
     [
-        (3, 1, None, ValueError),
-        (3, 13, None, ValueError),
-        (3, 25, [2, 1, 1, 1, 1, 1, 1, 1, 1], None),
-        (3, 26, [2, 1, 1, 2, 1, 1, 2], None),
-        (3, 40, [3, 3, 2, 2], None),
-        (3, 43, [3, 3, 3, 1], None),
-        (4, 54, [4, 3, 3], None),
-        (4, 56, [4, 4, 2], None),
+        (3, 0, 1, None, ValueError),  # element too long
+        (3, 0, 13, None, ValueError),  # element too long
+        (3, 12, 25, None, ValueError),  # prefix and words too long
+        (3, 0, 25, [2, 1, 1, 1, 1, 1, 1, 1, 1], None),
+        (3, 0, 26, [2, 1, 1, 2, 1, 1, 2], None),
+        (3, 0, 40, [3, 3, 2, 2], None),
+        (3, 0, 43, [3, 3, 3, 1], None),
+        (4, 0, 54, [4, 3, 3], None),
+        (4, 0, 56, [4, 4, 2], None),
     ],
 )
-def test_group_arguments(mock_packages, max_group_size, max_group_length, lengths, error):
+def test_group_arguments(
+    mock_packages, max_group_size, prefix_length, max_group_length, lengths, error
+):
     generator = spack.cmd.group_arguments(
-        group_args, max_group_size=max_group_size, max_group_length=max_group_length
+        group_args,
+        max_group_size=max_group_size,
+        prefix_length=prefix_length,
+        max_group_length=max_group_length,
     )
 
     # just check that error cases raise

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -112,6 +112,36 @@ def test_which(tmpdir, monkeypatch):
         assert exe.path == path
 
 
+def make_script_exe(tmpdir, name, contents):
+    script = tmpdir / f"{name}.sh"
+    with script.open("w", encoding="utf-8") as f:
+        f.write("#!/bin/sh\n")
+        f.write(contents)
+        f.write("\n")
+    fs.set_executable(str(script))
+    return ex.Executable(str(script))
+
+
+def test_exe_fail(tmpdir):
+    fail = make_script_exe(tmpdir, "fail", "exit 107")
+    with pytest.raises(ex.ProcessError):
+        fail()
+    assert fail.returncode == 107
+
+
+def test_exe_success(tmpdir):
+    succeed = make_script_exe(tmpdir, "fail", "exit 0")
+    succeed()
+    assert succeed.returncode == 0
+
+
+def test_exe_timeout(tmpdir):
+    timeout = make_script_exe(tmpdir, "timeout", "sleep 100")
+    with pytest.raises(ex.ProcessError):
+        timeout(timeout=1)
+    assert timeout.returncode == 1
+
+
 def test_construct_from_pathlib(mock_executable):
     """Tests that we can construct an executable from a pathlib.Path object"""
     expected = "Hello world!"

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -112,34 +112,49 @@ def test_which(tmpdir, monkeypatch):
         assert exe.path == path
 
 
-def make_script_exe(tmpdir, name, contents):
-    script = tmpdir / f"{name}.sh"
-    with script.open("w", encoding="utf-8") as f:
-        f.write("#!/bin/sh\n")
-        f.write(contents)
-        f.write("\n")
-    fs.set_executable(str(script))
-    return ex.Executable(str(script))
+@pytest.fixture
+def make_script_exe(tmpdir):
+    if sys.platform == "win32":
+        pytest.skip("Can't test #!/bin/sh scripts on Windows.")
+
+    def make_script(name, contents):
+        script = tmpdir / f"{name}.sh"
+        with script.open("w", encoding="utf-8") as f:
+            f.write("#!/bin/sh\n")
+            f.write(contents)
+            f.write("\n")
+        fs.set_executable(str(script))
+
+        return ex.Executable(str(script))
+
+    return make_script
 
 
-def test_exe_fail(tmpdir):
-    fail = make_script_exe(tmpdir, "fail", "exit 107")
+def test_exe_fail(make_script_exe):
+    fail = make_script_exe("fail", "exit 107")
     with pytest.raises(ex.ProcessError):
         fail()
     assert fail.returncode == 107
 
 
-def test_exe_success(tmpdir):
-    succeed = make_script_exe(tmpdir, "fail", "exit 0")
+def test_exe_success(make_script_exe):
+    succeed = make_script_exe("fail", "exit 0")
     succeed()
     assert succeed.returncode == 0
 
 
-def test_exe_timeout(tmpdir):
-    timeout = make_script_exe(tmpdir, "timeout", "sleep 100")
+def test_exe_timeout(make_script_exe):
+    timeout = make_script_exe("timeout", "sleep 100")
     with pytest.raises(ex.ProcessError):
         timeout(timeout=1)
     assert timeout.returncode == 1
+
+
+def test_exe_not_exist(tmpdir):
+    fail = ex.Executable(str(tmpdir.join("foo")))  # doesn't exist
+    with pytest.raises(ex.ProcessError):
+        fail()
+    assert fail.returncode == 1
 
 
 def test_construct_from_pathlib(mock_executable):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -294,13 +294,6 @@ class Executable:
 
             raise ProcessError("%s: %s" % (self.exe[0], e.strerror), message)
 
-        except subprocess.CalledProcessError as e:
-            self.returncode = e.returncode
-            if fail_on_error:
-                raise ProcessError(
-                    str(e),
-                    f"\nExit status {e.returncode} when invoking command: {cmd_line_string}",
-                )
         except subprocess.TimeoutExpired as te:
             proc.kill()
             out, err = proc.communicate()

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -295,11 +295,11 @@ class Executable:
             raise ProcessError("%s: %s" % (self.exe[0], e.strerror), message)
 
         except subprocess.CalledProcessError as e:
+            self.returncode = e.returncode
             if fail_on_error:
                 raise ProcessError(
                     str(e),
-                    "\nExit status %d when invoking command: %s"
-                    % (proc.returncode, cmd_line_string),
+                    f"\nExit status {e.returncode} when invoking command: {cmd_line_string}",
                 )
         except subprocess.TimeoutExpired as te:
             proc.kill()

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -31,7 +31,7 @@ class Executable:
         self.exe = [file_path]
         self.default_env: Dict[str, str] = {}
         self.default_envmod = EnvironmentModifications()
-        self.returncode = 0
+        self.returncode = 1  # 1 until proven successful
         self.ignore_quotes = False
 
     def add_default_arg(self, *args: str) -> None:


### PR DESCRIPTION
`spack pkg grep` can construct command lines that are too long for Windows, i.e. command lines that are longer than 32768 characters.

This makes `spack pkg grep` respect the Windows limit by default, and gets the unix limit from `sysconfig`.

- [x] Add a new `spack.cmd.group_arguments` function to create CLI-safe arg groups
- [x] Default to max 500 elements or 32768 chars, whichever comes first
- [x] If sysconfig is available, get `SC_ARG_MAX` and use that for max chars
- [x] Add test for `group_arguments`