### PR TITLE
amdlibm: fix cannot compile using amd aocc

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/amdlibm/0004-libm-ose-SconsSpack-fix-version.patch
+++ b/var/spack/repos/spack_repo/builtin/packages/amdlibm/0004-libm-ose-SconsSpack-fix-version.patch
@@ -1,0 +1,24 @@
+--- a/scripts/site_scons/site_tools/gitversion.py	2024-10-11 12:15:23.000000000 +0800
++++ b/scripts/site_scons/site_tools/gitversion.py	2025-05-16 22:34:52.650958864 +0800
+@@ -146,16 +146,17 @@
+     cc = env['CC']
+     import ntpath
+     import os
+-    # get compiler exe file from full path
+-    # we donot need full path string in the version
+-    if os.path.exists(os.path.dirname(cc)):
+-        cc = ntpath.basename(cc)
+     cc_ver = env['CCVERSION']
+ 
+     # if clang, fetch aocc release version too
+     if 'clang' in cc:
+         cc_ver += '-' + GetAOCCVersion(cc)
+ 
++    # get compiler exe file from full path
++    # we do not need full path string in the version
++    if os.path.exists(os.path.dirname(cc)):
++        cc = ntpath.basename(cc)
++
+     import platform
+     platform = platform.platform()
+     sys_details = '%s-%s-%s' % (cc, cc_ver, str(platform))

--- a/var/spack/repos/spack_repo/builtin/packages/amdlibm/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/amdlibm/package.py
@@ -49,7 +49,7 @@ class Amdlibm(SConsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("python@3.6.1:", type=("build", "run"))
+    depends_on("python@3.6.1:", type=("build"))
     depends_on("scons@3.1.2:", type=("build"))
     depends_on("mpfr", type=("link"))
     for vers in ["4.1", "4.2", "5.0"]:
@@ -62,6 +62,7 @@ class Amdlibm(SConsPackage):
     # the newly introduced 'SPACK_MANAGED_DIRS'
     # build environment variable.
     patch("libm-ose-SconsSpack.patch", when="@3.1:4.2")
+    patch("0004-libm-ose-SconsSpack-fix-version.patch", when="@4:5")
 
     conflicts("%gcc@:9.1.0", msg="Minimum supported GCC version is 9.2.0")
     conflicts("%clang@:9.0", msg="Minimum supported Clang version is 9")


### PR DESCRIPTION
2 fixes

- `amdlibm@4:5 %aocc@:` build would fail with error below
  ```log
     12    Checking for valid AOCL UTILS install path(cached) yes
     13    Running cmd: clang-17 --version
  >> 14    Error: Proc failed with retcode:
     15    127
     16    Error:/bin/sh: line 1: clang-17: command not found
     17    
     18    ====================== Configuration ======================
     19    
     20        BuildDir     : build/aocl-release
     ```
    Patched the Scons python code attempt to invoke `clang-17` _after dropping the base path from cc_, in new version `cc` is invoked _before_ dropping the base path.
- I cannot be 100% certain, but I strongly believe `libm` has no reason to depend on `python` at runtime, and here are all files after build success, doesn't look like anything related to python.
  ```log
  [kftse@cpu amdlibm-5.0-3dglpnvyt6z7bb4flowarvlz6ascxtkn]$ ls */ examples/src/
  examples/:
  Makefile  README  src
  
  examples/src/:
  main.c             use_ceil.c        use_exp.c          use_log.c           use_round.c
  use_acos.c         use_cexp.c        use_exp10.c        use_log10_avx512.c  use_sin.c
  use_add.c          use_clog.c        use_exp2.c         use_log1p.c         use_sincos.c
  use_asin.c         use_copysign.c    use_exp2_avx512.c  use_log2.c          use_sinh.c
  use_asin_avx512.c  use_cos.c         use_exp_avx512.c   use_log_avx512.c    use_sqrt.c
  use_asinh.c        use_cosh.c        use_fabs.c         use_mul.c           use_sub.c
  use_atan.c         use_cpow.c        use_fdim.c         use_nearbyint.c     use_tan.c
  use_atan2.c        use_div.c         use_fmax.c         use_pow.c           use_tanh.c
  use_atan_avx512.c  use_erf.c         use_fmin.c         use_pow_avx512.c    use_trunc.c
  use_cbrt.c         use_erf_avx512.c  use_hypot.c        use_remainder.c
  
  include/:
  amdlibm.h  amdlibm_vec.h
  
  lib/:
  libalm-glibc-compat.so  libalm.so     libalmfast.so  libamdlibm.so     libamdlibmfast.so
  libalm.a                libalmfast.a  libamdlibm.a   libamdlibmfast.a
  ```