### PR TITLE
gtkplus-2: reviving deprecated cmake gtkplus@2

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/gtkplus_2/no-demos.patch
+++ b/var/spack/repos/spack_repo/builtin/packages/gtkplus_2/no-demos.patch
@@ -1,0 +1,15 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+--- a/Makefile.in    2017-02-21 12:18:44.774922978 -0800
++++ b/Makefile.in 2017-02-21 12:18:54.465965697 -0800
+@@ -564,7 +564,7 @@
+        || { echo "Gtk+Tests:ERROR: Failed to start Xvfb environment for X11 target tests."; exit 1; } \
+        && DISPLAY=:$$XID && export DISPLAY
+
+-SRC_SUBDIRS = gdk gtk modules demos tests perf
++SRC_SUBDIRS = gdk gtk modules tests perf
+ SUBDIRS = po po-properties $(SRC_SUBDIRS) docs m4macros build
+
+ # require automake 1.4

--- a/var/spack/repos/spack_repo/builtin/packages/gtkplus_2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gtkplus_2/package.py
@@ -1,0 +1,69 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+from spack.package import *
+
+
+class Gtkplus2(AutotoolsPackage):
+    """The GTK+ 2 package contains libraries used for creating graphical user
+    interfaces for applications."""
+
+    homepage = "http://www.gtk.org"
+    url = "http://ftp.gnome.org/pub/gnome/sources/gtk+/2.24/gtk+-2.24.31.tar.xz"
+    version("2.24.33", sha256="ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da")
+    version("2.24.32", sha256="b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e")
+    version("2.24.31", sha256="68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658")
+    version("2.24.25", sha256="38af1020cb8ff3d10dda2c8807f11e92af9d2fa4045de61c62eedb7fbc7ea5b3")
+
+    variant("cups", default="False", description="enable cups support")
+
+    depends_on("pkgconfig", type="build")
+
+    depends_on("atk")
+    depends_on("gdk-pixbuf")
+    depends_on("glib")
+    depends_on("shared-mime-info")
+    # Hardcode X11 support (former +X variant),
+    # see #6940 for rationale:
+    depends_on("pango+X")
+    depends_on("cairo+X+pdf+gobject")
+    depends_on("gobject-introspection")
+    depends_on("cups", when="+cups")
+
+    patch("no-demos.patch")
+
+    def url_for_version(self, version):
+        url = "http://ftp.gnome.org/pub/gnome/sources/gtk+"
+        return url + "/%s/gtk+-%s.tar.xz" % (version.up_to(2), version)
+
+    def patch(self):
+        # remove disable deprecated flag.
+        filter_file(
+            r'CFLAGS="-DGDK_PIXBUF_DISABLE_DEPRECATED $CFLAGS"', "", "configure", string=True
+        )
+
+    def setup_run_environment(self, env):
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
+
+    def configure_args(self):
+        args = []
+        # disable building of gtk-doc files following #9771
+        args.append("--disable-gtk-doc-html")
+        true = which("true")
+        args.append("GTKDOC_CHECK={0}".format(true))
+        args.append("GTKDOC_CHECK_PATH={0}".format(true))
+        args.append("GTKDOC_MKPDF={0}".format(true))
+        args.append("GTKDOC_REBASE={0}".format(true))
+        if "~cups" in self.spec:
+            args.append("--disable-cups")
+        return args


### PR DESCRIPTION
`gtkplus@2` deprecation is due to migration of build system to meson, still there are some GUI tools requiring it.
For example, these are not offered in `gtkplus@3`

```log
libgdk-x11-2.0.so.0
libgtk-x11-2.0.so.0
```

I suggest to revive the `@2` versions into this package independent of the current `gtkplus` package.

In this PR
- revived the files right before #21914 into new repo structure
- fixed build
