### PR TITLE
mgis: wrong version for tfel 5.0.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/mgis/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mgis/package.py
@@ -63,7 +63,7 @@ class Mgis(CMakePackage):
     depends_on("fortran", type="build")  # generated
 
     depends_on("tfel@5.0.1", when="@3.0.1")
-    depends_on("tfel@5.0.0", when="@3.0.0")
+    depends_on("tfel@5.0.0", when="@3.0")
     depends_on("tfel@4.2.3", when="@2.2.1")
     depends_on("tfel@4.2.0", when="@2.2.0")
     depends_on("tfel@4.1.0", when="@2.1")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Because mgis@3.0.0 doesn't exist (`Cannot satisfy 'mgis@3.0.0`)