### PR TITLE
chafa: add v1.16.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/chafa/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/chafa/package.py
@@ -77,10 +77,15 @@ class Chafa(AutotoolsPackage):
     @run_after("install")
     def install_completions(self):
         mkdirp(zsh_completion_path(self.prefix))
-        install("tools/completions/zsh-completion.zsh", zsh_completion_path(self.prefix) / "_chafa")
+        install(
+            "tools/completions/zsh-completion.zsh", zsh_completion_path(self.prefix) / "_chafa"
+        )
         if self.spec.satisfies("@master"):
             mkdirp(fish_completion_path(self.prefix))
-            install("tools/completions/fish-completion.fish", fish_completion_path(self.prefix) / "chafa.fish")
+            install(
+                "tools/completions/fish-completion.fish",
+                fish_completion_path(self.prefix) / "chafa.fish",
+            )
 
     @run_after("install", when="+man")
     def install_man(self):

--- a/var/spack/repos/spack_repo/builtin/packages/chafa/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/chafa/package.py
@@ -11,13 +11,14 @@ class Chafa(AutotoolsPackage):
     suitable for display in a terminal."""
 
     homepage = "https://hpjansson.org/chafa/"
-    url = "https://hpjansson.org/chafa/releases/chafa-1.14.5.tar.xz"
+    url = "https://hpjansson.org/chafa/releases/chafa-1.16.0.tar.xz"
     git = "https://github.com/hpjansson/chafa.git"
 
     license("LGPL-3.0-or-later", checked_by="Buldram")
     maintainers("Buldram")
 
     version("master", branch="master")
+    version("1.16.0", sha256="bf863e57b6200b696bde1742aa95d7feb8cd23b9df1e91e91859b2b1e54fd290")
     version("1.14.5", sha256="7b5b384d5fb76a641d00af0626ed2115fb255ea371d9bef11f8500286a7b09e5")
     version("1.14.4", sha256="d0708a63f05b79269dae862a42671e38aece47fbd4fc852904bca51a65954454")
     version("1.14.3", sha256="f3d5530a96c8e55eea180448896e973093e0302f4cbde45d028179af8cfd90f3")
@@ -72,6 +73,14 @@ class Chafa(AutotoolsPackage):
             *self.with_or_without("avif"),
             *self.with_or_without("jxl"),
         ]
+
+    @run_after("install")
+    def install_completions(self):
+        mkdirp(zsh_completion_path(self.prefix))
+        install("tools/completions/zsh-completion.zsh", zsh_completion_path(self.prefix) / "_chafa")
+        if self.spec.satisfies("@master"):
+            mkdirp(fish_completion_path(self.prefix))
+            install("tools/completions/fish-completion.fish", fish_completion_path(self.prefix) / "chafa.fish")
 
     @run_after("install", when="+man")
     def install_man(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://github.com/hpjansson/chafa/releases/tag/1.16.0
Also added zsh/fish completions install.