### PR TITLE
dftbplus: backport "Fix logic for OMP target in exported dftbplus-config.cmake"

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dftbplus/package.py
@@ -158,6 +158,13 @@ class Dftbplus(CMakePackage, MakefilePackage):
     conflicts("+python", when="~shared")
     conflicts("-poisson", when="+transport")
 
+    # wrong logic in OMP detection in cmake config
+    patch(
+        "https://github.com/dftbplus/dftbplus/commit/9b9c29d28117ea54487e4384a24b58eb47f1f65c.patch?full_index=1",
+        sha256="f262c47ddce9695e15e7ae74b93aa19b4dfad91ba064e1534ea06bc1bc067135",
+        when="@22.2:24.1",
+    )
+
     # Extensions
     extends("python", when="+python")
 


### PR DESCRIPTION

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
