### PR TITLE
py-py-spy: fix linkage with libunwind

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_py_spy/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_py_spy/package.py
@@ -22,5 +22,6 @@ class PyPySpy(CargoPackage):
     # TODO: uses cargo to download and build dozens of dependencies.
     # Need to figure out how to manage these with Spack once we have a
     # CargoPackage base class.
+    depends_on("c")
     depends_on("unwind")
     depends_on("libunwind components=ptrace", when="^[virtuals=unwind] libunwind")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Builds fail with the following:

```
  >> 283      = note: rust-lld: error: unable to find library -lunwind
  >> 284              rust-lld: error: unable to find library -lunwind-ptrace
  >> 285              rust-lld: error: unable to find library -lunwind-x86_64
  >> 286              collect2: error: ld returned 1 exit status
```

I assume that adding `c` to the environment, propagates the proper link flags to the environment which are picked up by rustc.

Please let me know if there's a cleaner way to do it.