### PR TITLE
py-shapely: add v2.1.1

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_shapely/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_shapely/package.py
@@ -20,6 +20,7 @@ class PyShapely(PythonPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
+    version("2.1.1", sha256="500621967f2ffe9642454808009044c21e5b35db89ce69f8a2042c2ffd0e2772")
     version("2.1.0", sha256="2cbe90e86fa8fc3ca8af6ffb00a77b246b918c7cf28677b7c21489b678f6b02e")
     version("2.0.7", sha256="28fe2997aab9a9dc026dc6a355d04e85841546b2a5d232ed953e3321ab958ee5")
     version("2.0.6", sha256="997f6159b1484059ec239cacaa53467fd8b5564dabe186cd84ac2944663b0bf6")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://github.com/shapely/shapely/releases/tag/2.1.1