### PR TITLE
spack.package: re-export PackageBase, register_builder and Builder

### DIFF
--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -23,7 +23,7 @@ BUILDER_CLS: Dict[str, Type["Builder"]] = {}
 _BUILDERS: Dict[int, "Builder"] = {}
 
 
-def builder(build_system_name: str):
+def register_builder(build_system_name: str):
     """Class decorator used to register the default builder
     for a given build-system.
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -49,7 +49,7 @@ from llnl.util.filesystem import (
 from llnl.util.symlink import symlink
 
 from spack.build_environment import MakeExecutable
-from spack.builder import BaseBuilder
+from spack.builder import BaseBuilder, Builder, register_builder
 from spack.config import determine_number_of_jobs
 from spack.deptypes import ALL_TYPES as all_deptypes
 from spack.directives import (
@@ -81,7 +81,13 @@ from spack.install_test import (
 )
 from spack.mixins import filter_compiler_wrappers
 from spack.multimethod import default_args, when
-from spack.package_base import build_system_flags, env_flags, inject_flags, on_package_attributes
+from spack.package_base import (
+    PackageBase,
+    build_system_flags,
+    env_flags,
+    inject_flags,
+    on_package_attributes,
+)
 from spack.package_completions import (
     bash_completion_path,
     fish_completion_path,
@@ -216,6 +222,9 @@ __all__ = [
     "cd",
     "pwd",
     "tty",
+    "Builder",
+    "PackageBase",
+    "register_builder",
 ]
 
 # These are just here for editor support; they may be set when the build env is set up.

--- a/var/spack/repos/spack_repo/builtin/build_systems/_checks.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/_checks.py
@@ -6,13 +6,12 @@ from typing import List
 
 import llnl.util.lang
 
-import spack.builder
 import spack.relocate
 import spack.store
-from spack.package import InstallError, Spec, run_after
+from spack.package import Builder, InstallError, Spec, run_after
 
 
-def sanity_check_prefix(builder: spack.builder.Builder):
+def sanity_check_prefix(builder: Builder):
     """Check that specific directories and files are created after installation.
 
     The files to be checked are in the ``sanity_check_is_file`` attribute of the
@@ -43,7 +42,7 @@ def sanity_check_prefix(builder: spack.builder.Builder):
         raise InstallError(msg.format(pkg.name))
 
 
-def apply_macos_rpath_fixups(builder: spack.builder.Builder):
+def apply_macos_rpath_fixups(builder: Builder):
     """On Darwin, make installed libraries more easily relocatable.
 
     Some build systems (handrolled, autotools, makefiles) can set their own
@@ -97,7 +96,7 @@ def ensure_build_dependencies_or_raise(spec: Spec, dependencies: List[str], erro
     raise RuntimeError(msg)
 
 
-def execute_build_time_tests(builder: spack.builder.Builder):
+def execute_build_time_tests(builder: Builder):
     """Execute the build-time tests prescribed by builder.
 
     Args:
@@ -110,7 +109,7 @@ def execute_build_time_tests(builder: spack.builder.Builder):
     builder.pkg.tester.phase_tests(builder, "build", builder.build_time_test_callbacks)
 
 
-def execute_install_time_tests(builder: spack.builder.Builder):
+def execute_install_time_tests(builder: Builder):
     """Execute the install-time tests prescribed by builder.
 
     Args:
@@ -123,7 +122,7 @@ def execute_install_time_tests(builder: spack.builder.Builder):
     builder.pkg.tester.phase_tests(builder, "install", builder.install_time_test_callbacks)
 
 
-class BuilderWithDefaults(spack.builder.Builder):
+class BuilderWithDefaults(Builder):
     """Base class for all specific builders with common callbacks registered."""
 
     # Check that self.prefix is there after installation

--- a/var/spack/repos/spack_repo/builtin/build_systems/autotools.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/autotools.py
@@ -12,13 +12,13 @@ import llnl.util.tty as tty
 import spack.build_environment
 import spack.builder
 import spack.compilers.libraries
-import spack.package_base
 from spack.operating_systems.mac_os import macos_version
 from spack.package import (
     EnvironmentModifications,
     Executable,
     FileFilter,
     InstallError,
+    PackageBase,
     Prefix,
     Spec,
     Version,
@@ -31,6 +31,7 @@ from spack.package import (
     is_exe,
     keep_modification_time,
     mkdirp,
+    register_builder,
     run_after,
     run_before,
     when,
@@ -46,7 +47,7 @@ from ._checks import (
 )
 
 
-class AutotoolsPackage(spack.package_base.PackageBase):
+class AutotoolsPackage(PackageBase):
     """Specialized class for packages built using GNU Autotools."""
 
     #: This attribute is used in UI queries that need to know the build
@@ -91,7 +92,7 @@ class AutotoolsPackage(spack.package_base.PackageBase):
         return spack.builder.create(self).with_or_without(*args, **kwargs)
 
 
-@spack.builder.register_builder("autotools")
+@register_builder("autotools")
 class AutotoolsBuilder(BuilderWithDefaults):
     """The autotools builder encodes the default way of installing software built
     with autotools. It has four phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/autotools.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/autotools.py
@@ -91,7 +91,7 @@ class AutotoolsPackage(spack.package_base.PackageBase):
         return spack.builder.create(self).with_or_without(*args, **kwargs)
 
 
-@spack.builder.builder("autotools")
+@spack.builder.register_builder("autotools")
 class AutotoolsBuilder(BuilderWithDefaults):
     """The autotools builder encodes the default way of installing software built
     with autotools. It has four phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/bundle.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/bundle.py
@@ -22,7 +22,7 @@ class BundlePackage(spack.package_base.PackageBase):
     build_system("bundle")
 
 
-@spack.builder.builder("bundle")
+@spack.builder.register_builder("bundle")
 class BundleBuilder(spack.builder.Builder):
     phases = ("install",)
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/bundle.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/bundle.py
@@ -1,12 +1,10 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import spack.builder
-import spack.package_base
-from spack.package import Prefix, Spec, build_system
+from spack.package import Builder, PackageBase, Prefix, Spec, build_system, register_builder
 
 
-class BundlePackage(spack.package_base.PackageBase):
+class BundlePackage(PackageBase):
     """General purpose bundle, or no-code, package class."""
 
     #: This attribute is used in UI queries that require to know which
@@ -22,8 +20,8 @@ class BundlePackage(spack.package_base.PackageBase):
     build_system("bundle")
 
 
-@spack.builder.register_builder("bundle")
-class BundleBuilder(spack.builder.Builder):
+@register_builder("bundle")
+class BundleBuilder(Builder):
     phases = ("install",)
 
     def install(self, pkg: BundlePackage, spec: Spec, prefix: Prefix) -> None:

--- a/var/spack/repos/spack_repo/builtin/build_systems/cargo.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/cargo.py
@@ -32,7 +32,7 @@ class CargoPackage(spack.package_base.PackageBase):
         depends_on("rust", type="build")
 
 
-@spack.builder.builder("cargo")
+@spack.builder.register_builder("cargo")
 class CargoBuilder(BuilderWithDefaults):
     """The Cargo builder encodes the most common way of building software with
     a rust Cargo.toml file. It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/cargo.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/cargo.py
@@ -2,15 +2,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.builder
-import spack.package_base
 from spack.package import (
     EnvironmentModifications,
+    PackageBase,
     Prefix,
     Spec,
     build_system,
     depends_on,
     install_tree,
+    register_builder,
     run_after,
     when,
     working_dir,
@@ -19,7 +19,7 @@ from spack.package import (
 from ._checks import BuilderWithDefaults, execute_install_time_tests
 
 
-class CargoPackage(spack.package_base.PackageBase):
+class CargoPackage(PackageBase):
     """Specialized class for packages built using cargo."""
 
     #: This attribute is used in UI queries that need to know the build
@@ -32,7 +32,7 @@ class CargoPackage(spack.package_base.PackageBase):
         depends_on("rust", type="build")
 
 
-@spack.builder.register_builder("cargo")
+@register_builder("cargo")
 class CargoBuilder(BuilderWithDefaults):
     """The Cargo builder encodes the most common way of building software with
     a rust Cargo.toml file. It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/cmake.py
@@ -288,7 +288,7 @@ class CMakePackage(spack.package_base.PackageBase):
         return define_from_variant(self, cmake_var, variant)
 
 
-@spack.builder.builder("cmake")
+@spack.builder.register_builder("cmake")
 class CMakeBuilder(BuilderWithDefaults):
     """The cmake builder encodes the default way of building software with CMake. IT
     has three phases that can be overridden:

--- a/var/spack/repos/spack_repo/builtin/build_systems/cmake.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/cmake.py
@@ -12,17 +12,17 @@ from typing import Any, List, Optional, Tuple
 
 from llnl.util.lang import stable_partition
 
-import spack.builder
 import spack.deptypes as dt
-import spack.package_base
 from spack import traverse
 from spack.package import (
     InstallError,
+    PackageBase,
     Prefix,
     Spec,
     build_system,
     conflicts,
     depends_on,
+    register_builder,
     run_after,
     tty,
     variant,
@@ -46,7 +46,7 @@ def _extract_primary_generator(generator):
     return _primary_generator_extractor.match(generator).group(1)
 
 
-def _maybe_set_python_hints(pkg: spack.package_base.PackageBase, args: List[str]) -> None:
+def _maybe_set_python_hints(pkg: PackageBase, args: List[str]) -> None:
     """Set the PYTHON_EXECUTABLE, Python_EXECUTABLE, and Python3_EXECUTABLE CMake variables
     if the package has Python as build or link dep and ``find_python_hints`` is set to True. See
     ``find_python_hints`` for context."""
@@ -64,7 +64,7 @@ def _maybe_set_python_hints(pkg: spack.package_base.PackageBase, args: List[str]
     )
 
 
-def _supports_compilation_databases(pkg: spack.package_base.PackageBase) -> bool:
+def _supports_compilation_databases(pkg: PackageBase) -> bool:
     """Check if this package (and CMake) can support compilation databases."""
 
     # CMAKE_EXPORT_COMPILE_COMMANDS only exists for CMake >= 3.5
@@ -78,7 +78,7 @@ def _supports_compilation_databases(pkg: spack.package_base.PackageBase) -> bool
     return True
 
 
-def _conditional_cmake_defaults(pkg: spack.package_base.PackageBase, args: List[str]) -> None:
+def _conditional_cmake_defaults(pkg: PackageBase, args: List[str]) -> None:
     """Set a few default defines for CMake, depending on its version."""
     cmakes = pkg.spec.dependencies("cmake", dt.BUILD)
 
@@ -169,7 +169,7 @@ def generator(*names: str, default: Optional[str] = None) -> None:
         conflicts(f"generator={x}")
 
 
-def get_cmake_prefix_path(pkg: spack.package_base.PackageBase) -> List[str]:
+def get_cmake_prefix_path(pkg: PackageBase) -> List[str]:
     """Obtain the CMAKE_PREFIX_PATH entries for a package, based on the cmake_prefix_path package
     attribute of direct build/test and transitive link dependencies."""
     edges = traverse.traverse_topo_edges_generator(
@@ -190,7 +190,7 @@ def get_cmake_prefix_path(pkg: spack.package_base.PackageBase) -> List[str]:
     )
 
 
-class CMakePackage(spack.package_base.PackageBase):
+class CMakePackage(PackageBase):
     """Specialized class for packages built using CMake
 
     For more information on the CMake build system, see:
@@ -288,7 +288,7 @@ class CMakePackage(spack.package_base.PackageBase):
         return define_from_variant(self, cmake_var, variant)
 
 
-@spack.builder.register_builder("cmake")
+@register_builder("cmake")
 class CMakeBuilder(BuilderWithDefaults):
     """The cmake builder encodes the default way of building software with CMake. IT
     has three phases that can be overridden:
@@ -375,9 +375,7 @@ class CMakeBuilder(BuilderWithDefaults):
         return args
 
     @staticmethod
-    def std_args(
-        pkg: spack.package_base.PackageBase, generator: Optional[str] = None
-    ) -> List[str]:
+    def std_args(pkg: PackageBase, generator: Optional[str] = None) -> List[str]:
         """Computes the standard cmake arguments for a generic package"""
         default_generator = "Ninja" if sys.platform == "win32" else "Unix Makefiles"
         generator = generator or default_generator
@@ -425,11 +423,11 @@ class CMakeBuilder(BuilderWithDefaults):
         return args
 
     @staticmethod
-    def define_cuda_architectures(pkg: spack.package_base.PackageBase) -> str:
+    def define_cuda_architectures(pkg: PackageBase) -> str:
         return define_cuda_architectures(pkg)
 
     @staticmethod
-    def define_hip_architectures(pkg: spack.package_base.PackageBase) -> str:
+    def define_hip_architectures(pkg: PackageBase) -> str:
         return define_hip_architectures(pkg)
 
     @staticmethod
@@ -556,9 +554,7 @@ def define(cmake_var: str, value: Any) -> str:
     return "".join(["-D", cmake_var, ":", kind, "=", value])
 
 
-def define_from_variant(
-    pkg: spack.package_base.PackageBase, cmake_var: str, variant: Optional[str] = None
-) -> str:
+def define_from_variant(pkg: PackageBase, cmake_var: str, variant: Optional[str] = None) -> str:
     """Return a CMake command line argument from the given variant's value.
 
     The optional ``variant`` argument defaults to the lower-case transform
@@ -618,7 +614,7 @@ def define_from_variant(
     return define(cmake_var, value)
 
 
-def define_hip_architectures(pkg: spack.package_base.PackageBase) -> str:
+def define_hip_architectures(pkg: PackageBase) -> str:
     """Returns the str ``-DCMAKE_HIP_ARCHITECTURES:STRING=(expanded amdgpu_target)``.
 
     ``amdgpu_target`` is variant composed of a list of the target HIP
@@ -634,7 +630,7 @@ def define_hip_architectures(pkg: spack.package_base.PackageBase) -> str:
     return ""
 
 
-def define_cuda_architectures(pkg: spack.package_base.PackageBase) -> str:
+def define_cuda_architectures(pkg: PackageBase) -> str:
     """Returns the str ``-DCMAKE_CUDA_ARCHITECTURES:STRING=(expanded cuda_arch)``.
 
     ``cuda_arch`` is variant composed of a list of target CUDA architectures and

--- a/var/spack/repos/spack_repo/builtin/build_systems/compiler.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/compiler.py
@@ -11,14 +11,13 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 from llnl.util.lang import classproperty, memoized
 
 import spack.compilers.error
-import spack.package_base
-from spack.package import Executable, ProcessError, Spec, tty, which_string
+from spack.package import Executable, PackageBase, ProcessError, Spec, tty, which_string
 
 # Local "type" for type hints
 Path = Union[str, pathlib.Path]
 
 
-class CompilerPackage(spack.package_base.PackageBase):
+class CompilerPackage(PackageBase):
     """A Package mixin for all common logic for packages that implement compilers"""
 
     # TODO: how do these play nicely with other tags

--- a/var/spack/repos/spack_repo/builtin/build_systems/cuda.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/cuda.py
@@ -5,8 +5,7 @@
 import re
 from typing import Iterable, List
 
-from spack.package import any_combination_of, conflicts, depends_on, variant, when
-from spack.package_base import PackageBase
+from spack.package import PackageBase, any_combination_of, conflicts, depends_on, variant, when
 
 
 class CudaPackage(PackageBase):

--- a/var/spack/repos/spack_repo/builtin/build_systems/generic.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/generic.py
@@ -24,7 +24,7 @@ class Package(spack.package_base.PackageBase):
     build_system("generic")
 
 
-@spack.builder.builder("generic")
+@spack.builder.register_builder("generic")
 class GenericBuilder(BuilderWithDefaults):
     """A builder for a generic build system, that require packagers
     to implement an "install" phase.

--- a/var/spack/repos/spack_repo/builtin/build_systems/generic.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/generic.py
@@ -3,14 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from typing import Tuple
 
-import spack.builder
-import spack.package_base
-from spack.package import Prefix, Spec, build_system, run_after
+from spack.package import PackageBase, Prefix, Spec, build_system, register_builder, run_after
 
 from ._checks import BuilderWithDefaults, apply_macos_rpath_fixups, execute_install_time_tests
 
 
-class Package(spack.package_base.PackageBase):
+class Package(PackageBase):
     """General purpose class with a single ``install`` phase that needs to be
     coded by packagers.
     """
@@ -24,7 +22,7 @@ class Package(spack.package_base.PackageBase):
     build_system("generic")
 
 
-@spack.builder.register_builder("generic")
+@register_builder("generic")
 class GenericBuilder(BuilderWithDefaults):
     """A builder for a generic build system, that require packagers
     to implement an "install" phase.

--- a/var/spack/repos/spack_repo/builtin/build_systems/gnu.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/gnu.py
@@ -4,11 +4,11 @@
 
 from typing import Optional
 
-import spack.package_base
 import spack.util.url
+from spack.package import PackageBase
 
 
-class GNUMirrorPackage(spack.package_base.PackageBase):
+class GNUMirrorPackage(PackageBase):
     """Mixin that takes care of setting url and mirrors for GNU packages."""
 
     #: Path of the package in a GNU mirror

--- a/var/spack/repos/spack_repo/builtin/build_systems/go.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/go.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.builder
-import spack.package_base
 from spack.package import (
     EnvironmentModifications,
+    PackageBase,
     Prefix,
     Spec,
     build_system,
@@ -13,6 +12,7 @@ from spack.package import (
     install,
     join_path,
     mkdirp,
+    register_builder,
     run_after,
     when,
     working_dir,
@@ -21,7 +21,7 @@ from spack.package import (
 from ._checks import BuilderWithDefaults, execute_install_time_tests
 
 
-class GoPackage(spack.package_base.PackageBase):
+class GoPackage(PackageBase):
     """Specialized class for packages built using the Go toolchain."""
 
     #: This attribute is used in UI queries that need to know the build
@@ -37,7 +37,7 @@ class GoPackage(spack.package_base.PackageBase):
         depends_on("go", type="build")
 
 
-@spack.builder.register_builder("go")
+@register_builder("go")
 class GoBuilder(BuilderWithDefaults):
     """The Go builder encodes the most common way of building software with
     a golang go.mod file. It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/go.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/go.py
@@ -37,7 +37,7 @@ class GoPackage(spack.package_base.PackageBase):
         depends_on("go", type="build")
 
 
-@spack.builder.builder("go")
+@spack.builder.register_builder("go")
 class GoBuilder(BuilderWithDefaults):
     """The Go builder encodes the most common way of building software with
     a golang go.mod file. It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/lua.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/lua.py
@@ -5,21 +5,22 @@ import os
 
 from llnl.util.filesystem import find
 
-import spack.builder
-import spack.package_base
 from spack.package import (
+    Builder,
     EnvironmentModifications,
     Executable,
+    PackageBase,
     Prefix,
     Spec,
     build_system,
     depends_on,
     extends,
+    register_builder,
     when,
 )
 
 
-class LuaPackage(spack.package_base.PackageBase):
+class LuaPackage(PackageBase):
     """Specialized class for lua packages"""
 
     #: This attribute is used in UI queries that need to know the build
@@ -52,8 +53,8 @@ class LuaPackage(spack.package_base.PackageBase):
         return lr
 
 
-@spack.builder.register_builder("lua")
-class LuaBuilder(spack.builder.Builder):
+@register_builder("lua")
+class LuaBuilder(Builder):
     phases = ("unpack", "generate_luarocks_config", "preprocess", "install")
 
     #: Names associated with package methods in the old build-system format

--- a/var/spack/repos/spack_repo/builtin/build_systems/lua.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/lua.py
@@ -52,7 +52,7 @@ class LuaPackage(spack.package_base.PackageBase):
         return lr
 
 
-@spack.builder.builder("lua")
+@spack.builder.register_builder("lua")
 class LuaBuilder(spack.builder.Builder):
     phases = ("unpack", "generate_luarocks_config", "preprocess", "install")
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/makefile.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/makefile.py
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from typing import List
 
-import spack.builder
-import spack.package_base
 from spack.package import (
+    PackageBase,
     Prefix,
     Spec,
     build_system,
     conflicts,
     depends_on,
+    register_builder,
     run_after,
     when,
     working_dir,
@@ -24,7 +24,7 @@ from ._checks import (
 )
 
 
-class MakefilePackage(spack.package_base.PackageBase):
+class MakefilePackage(PackageBase):
     """Specialized class for packages built using Makefiles."""
 
     #: This attribute is used in UI queries that need to know the build
@@ -40,7 +40,7 @@ class MakefilePackage(spack.package_base.PackageBase):
         depends_on("gmake", type="build")
 
 
-@spack.builder.register_builder("makefile")
+@register_builder("makefile")
 class MakefileBuilder(BuilderWithDefaults):
     """The Makefile builder encodes the most common way of building software with
     Makefiles. It has three phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/makefile.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/makefile.py
@@ -40,7 +40,7 @@ class MakefilePackage(spack.package_base.PackageBase):
         depends_on("gmake", type="build")
 
 
-@spack.builder.builder("makefile")
+@spack.builder.register_builder("makefile")
 class MakefileBuilder(BuilderWithDefaults):
     """The Makefile builder encodes the most common way of building software with
     Makefiles. It has three phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/maven.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/maven.py
@@ -37,7 +37,7 @@ class MavenPackage(spack.package_base.PackageBase):
         depends_on("maven", type="build")
 
 
-@spack.builder.builder("maven")
+@spack.builder.register_builder("maven")
 class MavenBuilder(BuilderWithDefaults):
     """The Maven builder encodes the default way to build software with Maven.
     It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/maven.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/maven.py
@@ -1,14 +1,14 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import spack.builder
-import spack.package_base
 from spack.package import (
+    PackageBase,
     Prefix,
     Spec,
     build_system,
     depends_on,
     install_tree,
+    register_builder,
     when,
     which,
     working_dir,
@@ -17,7 +17,7 @@ from spack.package import (
 from ._checks import BuilderWithDefaults
 
 
-class MavenPackage(spack.package_base.PackageBase):
+class MavenPackage(PackageBase):
     """Specialized class for packages that are built using the
     Maven build system. See https://maven.apache.org/index.html
     for more information.
@@ -37,7 +37,7 @@ class MavenPackage(spack.package_base.PackageBase):
         depends_on("maven", type="build")
 
 
-@spack.builder.register_builder("maven")
+@register_builder("maven")
 class MavenBuilder(BuilderWithDefaults):
     """The Maven builder encodes the default way to build software with Maven.
     It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/meson.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/meson.py
@@ -70,7 +70,7 @@ class MesonPackage(spack.package_base.PackageBase):
         setattr(self, "meson_flag_args", [])
 
 
-@spack.builder.builder("meson")
+@spack.builder.register_builder("meson")
 class MesonBuilder(BuilderWithDefaults):
     """The Meson builder encodes the default way to build software with Meson.
     The builder has three phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/meson.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/meson.py
@@ -4,14 +4,14 @@
 import os
 from typing import List
 
-import spack.builder
-import spack.package_base
 from spack.package import (
+    PackageBase,
     Prefix,
     Spec,
     build_system,
     conflicts,
     depends_on,
+    register_builder,
     run_after,
     variant,
     when,
@@ -21,7 +21,7 @@ from spack.package import (
 from ._checks import BuilderWithDefaults, execute_build_time_tests
 
 
-class MesonPackage(spack.package_base.PackageBase):
+class MesonPackage(PackageBase):
     """Specialized class for packages built using Meson. For more information
     on the Meson build system, see https://mesonbuild.com/
     """
@@ -70,7 +70,7 @@ class MesonPackage(spack.package_base.PackageBase):
         setattr(self, "meson_flag_args", [])
 
 
-@spack.builder.register_builder("meson")
+@register_builder("meson")
 class MesonBuilder(BuilderWithDefaults):
     """The Meson builder encodes the default way to build software with Meson.
     The builder has three phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/msbuild.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/msbuild.py
@@ -28,7 +28,7 @@ class MSBuildPackage(spack.package_base.PackageBase):
         return define(msbuild_arg, value)
 
 
-@spack.builder.builder("msbuild")
+@spack.builder.register_builder("msbuild")
 class MSBuildBuilder(BuilderWithDefaults):
     """The MSBuild builder encodes the most common way of building software with
     Mircosoft's MSBuild tool. It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/msbuild.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/msbuild.py
@@ -5,14 +5,20 @@ from typing import List  # novm
 
 import llnl.util.filesystem as fs
 
-import spack.builder
-import spack.package_base
-from spack.package import Prefix, Spec, build_system, conflicts, working_dir
+from spack.package import (
+    PackageBase,
+    Prefix,
+    Spec,
+    build_system,
+    conflicts,
+    register_builder,
+    working_dir,
+)
 
 from ._checks import BuilderWithDefaults
 
 
-class MSBuildPackage(spack.package_base.PackageBase):
+class MSBuildPackage(PackageBase):
     """Specialized class for packages built using Visual Studio project files or solutions."""
 
     #: This attribute is used in UI queries that need to know the build
@@ -28,7 +34,7 @@ class MSBuildPackage(spack.package_base.PackageBase):
         return define(msbuild_arg, value)
 
 
-@spack.builder.register_builder("msbuild")
+@register_builder("msbuild")
 class MSBuildBuilder(BuilderWithDefaults):
     """The MSBuild builder encodes the most common way of building software with
     Mircosoft's MSBuild tool. It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/nmake.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/nmake.py
@@ -24,7 +24,7 @@ class NMakePackage(spack.package_base.PackageBase):
     conflicts("platform=darwin", when="build_system=nmake")
 
 
-@spack.builder.builder("nmake")
+@spack.builder.register_builder("nmake")
 class NMakeBuilder(BuilderWithDefaults):
     """The NMake builder encodes the most common way of building software with
     Mircosoft's NMake tool. It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/nmake.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/nmake.py
@@ -5,14 +5,20 @@ from typing import List  # novm
 
 import llnl.util.filesystem as fs
 
-import spack.builder
-import spack.package_base
-from spack.package import Prefix, Spec, build_system, conflicts, working_dir
+from spack.package import (
+    PackageBase,
+    Prefix,
+    Spec,
+    build_system,
+    conflicts,
+    register_builder,
+    working_dir,
+)
 
 from ._checks import BuilderWithDefaults
 
 
-class NMakePackage(spack.package_base.PackageBase):
+class NMakePackage(PackageBase):
     """Specialized class for packages built using a Makefiles."""
 
     #: This attribute is used in UI queries that need to know the build
@@ -24,7 +30,7 @@ class NMakePackage(spack.package_base.PackageBase):
     conflicts("platform=darwin", when="build_system=nmake")
 
 
-@spack.builder.register_builder("nmake")
+@register_builder("nmake")
 class NMakeBuilder(BuilderWithDefaults):
     """The NMake builder encodes the most common way of building software with
     Mircosoft's NMake tool. It has two phases that can be overridden, if need be:

--- a/var/spack/repos/spack_repo/builtin/build_systems/octave.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/octave.py
@@ -1,14 +1,21 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import spack.builder
-import spack.package_base
-from spack.package import EnvironmentModifications, Prefix, Spec, build_system, extends, when
+from spack.package import (
+    EnvironmentModifications,
+    PackageBase,
+    Prefix,
+    Spec,
+    build_system,
+    extends,
+    register_builder,
+    when,
+)
 
 from ._checks import BuilderWithDefaults
 
 
-class OctavePackage(spack.package_base.PackageBase):
+class OctavePackage(PackageBase):
     """Specialized class for Octave packages. See
     https://www.gnu.org/software/octave/doc/v4.2.0/Installing-and-Removing-Packages.html
     for more information.
@@ -26,7 +33,7 @@ class OctavePackage(spack.package_base.PackageBase):
         extends("octave")
 
 
-@spack.builder.register_builder("octave")
+@register_builder("octave")
 class OctaveBuilder(BuilderWithDefaults):
     """The octave builder provides the following phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/octave.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/octave.py
@@ -26,7 +26,7 @@ class OctavePackage(spack.package_base.PackageBase):
         extends("octave")
 
 
-@spack.builder.builder("octave")
+@spack.builder.register_builder("octave")
 class OctaveBuilder(BuilderWithDefaults):
     """The octave builder provides the following phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/perl.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/perl.py
@@ -94,7 +94,7 @@ class PerlPackage(spack.package_base.PackageBase):
                 assert "OK" in out
 
 
-@spack.builder.builder("perl")
+@spack.builder.register_builder("perl")
 class PerlBuilder(BuilderWithDefaults):
     """The perl builder provides four phases that can be overridden, if required:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/perl.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/perl.py
@@ -6,10 +6,9 @@ from typing import Iterable
 
 from llnl.util.lang import memoized
 
-import spack.builder
-import spack.package_base
 from spack.package import (
     Executable,
+    PackageBase,
     Prefix,
     SkipTest,
     Spec,
@@ -18,6 +17,7 @@ from spack.package import (
     extends,
     filter_file,
     find,
+    register_builder,
     run_after,
     test_part,
     when,
@@ -26,7 +26,7 @@ from spack.package import (
 from ._checks import BuilderWithDefaults, execute_build_time_tests
 
 
-class PerlPackage(spack.package_base.PackageBase):
+class PerlPackage(PackageBase):
     """Specialized class for packages that are built using Perl."""
 
     #: This attribute is used in UI queries that need to know the build
@@ -94,7 +94,7 @@ class PerlPackage(spack.package_base.PackageBase):
                 assert "OK" in out
 
 
-@spack.builder.register_builder("perl")
+@register_builder("perl")
 class PerlBuilder(BuilderWithDefaults):
     """The perl builder provides four phases that can be overridden, if required:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/python.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/python.py
@@ -15,11 +15,9 @@ import archspec
 import llnl.util.filesystem as fs
 from llnl.util.lang import ClassProperty, classproperty, match_predicate
 
-import spack.builder
 import spack.config
 import spack.deptypes as dt
 import spack.detection
-import spack.package_base
 import spack.platforms
 import spack.repo
 import spack.spec
@@ -29,6 +27,7 @@ from spack.package import (
     LibraryList,
     NoHeadersError,
     NoLibrariesError,
+    PackageBase,
     Prefix,
     Spec,
     build_system,
@@ -38,6 +37,7 @@ from spack.package import (
     find,
     find_all_headers,
     join_path,
+    register_builder,
     run_after,
     test_part,
     tty,
@@ -67,7 +67,7 @@ def _flatten_dict(dictionary: Mapping[str, object]) -> Iterable[str]:
             yield f"{key}={item}"
 
 
-class PythonExtension(spack.package_base.PackageBase):
+class PythonExtension(PackageBase):
     @property
     def import_modules(self) -> Iterable[str]:
         """Names of modules that the Python package provides.
@@ -437,7 +437,7 @@ class PythonPackage(PythonExtension):
         raise NoLibrariesError(msg.format(self.spec.name, platlib, purelib))
 
 
-@spack.builder.register_builder("python_pip")
+@register_builder("python_pip")
 class PythonPipBuilder(BuilderWithDefaults):
     phases = ("install",)
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/python.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/python.py
@@ -437,7 +437,7 @@ class PythonPackage(PythonExtension):
         raise NoLibrariesError(msg.format(self.spec.name, platlib, purelib))
 
 
-@spack.builder.builder("python_pip")
+@spack.builder.register_builder("python_pip")
 class PythonPipBuilder(BuilderWithDefaults):
     phases = ("install",)
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/qmake.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/qmake.py
@@ -29,7 +29,7 @@ class QMakePackage(spack.package_base.PackageBase):
     depends_on("gmake", type="build")
 
 
-@spack.builder.builder("qmake")
+@spack.builder.register_builder("qmake")
 class QMakeBuilder(BuilderWithDefaults):
     """The qmake builder provides three phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/qmake.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/qmake.py
@@ -3,14 +3,20 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from llnl.util.filesystem import working_dir
 
-import spack.builder
-import spack.package_base
-from spack.package import Prefix, Spec, build_system, depends_on, run_after
+from spack.package import (
+    PackageBase,
+    Prefix,
+    Spec,
+    build_system,
+    depends_on,
+    register_builder,
+    run_after,
+)
 
 from ._checks import BuilderWithDefaults, execute_build_time_tests
 
 
-class QMakePackage(spack.package_base.PackageBase):
+class QMakePackage(PackageBase):
     """Specialized class for packages built using qmake.
 
     For more information on the qmake build system, see:
@@ -29,7 +35,7 @@ class QMakePackage(spack.package_base.PackageBase):
     depends_on("gmake", type="build")
 
 
-@spack.builder.register_builder("qmake")
+@register_builder("qmake")
 class QMakeBuilder(BuilderWithDefaults):
     """The qmake builder provides three phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/racket.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/racket.py
@@ -51,7 +51,7 @@ class RacketPackage(PackageBase):
     homepage: ClassProperty[Optional[str]] = classproperty(_homepage)
 
 
-@spack.builder.builder("racket")
+@spack.builder.register_builder("racket")
 class RacketBuilder(spack.builder.Builder):
     """The Racket builder provides an ``install`` phase that can be overridden."""
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/racket.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/racket.py
@@ -6,10 +6,11 @@ from typing import Optional, Tuple
 
 from llnl.util.lang import ClassProperty, classproperty
 
-import spack.builder
 from spack.build_environment import SPACK_NO_PARALLEL_MAKE
 from spack.package import (
+    Builder,
     Executable,
+    PackageBase,
     Prefix,
     ProcessError,
     Spec,
@@ -17,10 +18,10 @@ from spack.package import (
     determine_number_of_jobs,
     extends,
     maintainers,
+    register_builder,
     tty,
     working_dir,
 )
-from spack.package_base import PackageBase
 from spack.util.environment import env_flag
 
 
@@ -51,8 +52,8 @@ class RacketPackage(PackageBase):
     homepage: ClassProperty[Optional[str]] = classproperty(_homepage)
 
 
-@spack.builder.register_builder("racket")
-class RacketBuilder(spack.builder.Builder):
+@register_builder("racket")
+class RacketBuilder(Builder):
     """The Racket builder provides an ``install`` phase that can be overridden."""
 
     phases = ("install",)

--- a/var/spack/repos/spack_repo/builtin/build_systems/rocm.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/rocm.py
@@ -78,12 +78,12 @@ import os
 
 from spack.package import (
     EnvironmentModifications,
+    PackageBase,
     any_combination_of,
     conflicts,
     depends_on,
     variant,
 )
-from spack.package_base import PackageBase
 
 
 class ROCmPackage(PackageBase):

--- a/var/spack/repos/spack_repo/builtin/build_systems/ruby.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/ruby.py
@@ -26,7 +26,7 @@ class RubyPackage(spack.package_base.PackageBase):
     extends("ruby", when="build_system=ruby")
 
 
-@spack.builder.builder("ruby")
+@spack.builder.register_builder("ruby")
 class RubyBuilder(BuilderWithDefaults):
     """The Ruby builder provides two phases that can be overridden if required:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/ruby.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/ruby.py
@@ -3,14 +3,20 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import glob
 
-import spack.builder
-import spack.package_base
-from spack.package import Prefix, Spec, build_system, extends, maintainers
+from spack.package import (
+    PackageBase,
+    Prefix,
+    Spec,
+    build_system,
+    extends,
+    maintainers,
+    register_builder,
+)
 
 from ._checks import BuilderWithDefaults
 
 
-class RubyPackage(spack.package_base.PackageBase):
+class RubyPackage(PackageBase):
     """Specialized class for building Ruby gems."""
 
     maintainers("Kerilk")
@@ -26,7 +32,7 @@ class RubyPackage(spack.package_base.PackageBase):
     extends("ruby", when="build_system=ruby")
 
 
-@spack.builder.register_builder("ruby")
+@register_builder("ruby")
 class RubyBuilder(BuilderWithDefaults):
     """The Ruby builder provides two phases that can be overridden if required:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/scons.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/scons.py
@@ -1,14 +1,20 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import spack.builder
-import spack.package_base
-from spack.package import Prefix, Spec, build_system, depends_on, run_after
+from spack.package import (
+    PackageBase,
+    Prefix,
+    Spec,
+    build_system,
+    depends_on,
+    register_builder,
+    run_after,
+)
 
 from ._checks import BuilderWithDefaults, execute_build_time_tests
 
 
-class SConsPackage(spack.package_base.PackageBase):
+class SConsPackage(PackageBase):
     """Specialized class for packages built using SCons.
 
     See http://scons.org/documentation.html for more information.
@@ -26,7 +32,7 @@ class SConsPackage(spack.package_base.PackageBase):
     depends_on("scons", type="build", when="build_system=scons")
 
 
-@spack.builder.register_builder("scons")
+@register_builder("scons")
 class SConsBuilder(BuilderWithDefaults):
     """The Scons builder provides the following phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/scons.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/scons.py
@@ -26,7 +26,7 @@ class SConsPackage(spack.package_base.PackageBase):
     depends_on("scons", type="build", when="build_system=scons")
 
 
-@spack.builder.builder("scons")
+@spack.builder.register_builder("scons")
 class SConsBuilder(BuilderWithDefaults):
     """The Scons builder provides the following phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/sip.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/sip.py
@@ -4,16 +4,16 @@
 import os
 import re
 
-import spack.builder
-import spack.package_base
 from spack.package import (
     Executable,
+    PackageBase,
     Prefix,
     Spec,
     build_system,
     depends_on,
     extends,
     find,
+    register_builder,
     run_after,
     test_part,
     tty,
@@ -24,7 +24,7 @@ from spack.package import (
 from ._checks import BuilderWithDefaults, execute_install_time_tests
 
 
-class SIPPackage(spack.package_base.PackageBase):
+class SIPPackage(PackageBase):
     """Specialized class for packages that are built using the
     SIP build system. See https://www.riverbankcomputing.com/software/sip/intro
     for more information.
@@ -109,7 +109,7 @@ class SIPPackage(spack.package_base.PackageBase):
                 self.python("-c", "import {0}".format(module))
 
 
-@spack.builder.register_builder("sip")
+@register_builder("sip")
 class SIPBuilder(BuilderWithDefaults):
     """The SIP builder provides the following phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/sip.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/sip.py
@@ -109,7 +109,7 @@ class SIPPackage(spack.package_base.PackageBase):
                 self.python("-c", "import {0}".format(module))
 
 
-@spack.builder.builder("sip")
+@spack.builder.register_builder("sip")
 class SIPBuilder(BuilderWithDefaults):
     """The SIP builder provides the following phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/sourceforge.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/sourceforge.py
@@ -4,11 +4,11 @@
 
 from typing import Optional
 
-import spack.package_base
 import spack.util.url
+from spack.package import PackageBase
 
 
-class SourceforgePackage(spack.package_base.PackageBase):
+class SourceforgePackage(PackageBase):
     """Mixin that takes care of setting url and mirrors for Sourceforge
     packages."""
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/sourceware.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/sourceware.py
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from typing import Optional
 
-import spack.package_base
 import spack.util.url
+from spack.package import PackageBase
 
 
-class SourcewarePackage(spack.package_base.PackageBase):
+class SourcewarePackage(PackageBase):
     """Mixin that takes care of setting url and mirrors for Sourceware.org
     packages."""
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/waf.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/waf.py
@@ -28,7 +28,7 @@ class WafPackage(spack.package_base.PackageBase):
     depends_on("python@2.5:", type="build", when="build_system=waf")
 
 
-@spack.builder.builder("waf")
+@spack.builder.register_builder("waf")
 class WafBuilder(BuilderWithDefaults):
     """The WAF builder provides the following phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/waf.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/waf.py
@@ -3,14 +3,20 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from llnl.util.filesystem import working_dir
 
-import spack.builder
-import spack.package_base
-from spack.package import Prefix, Spec, build_system, depends_on, run_after
+from spack.package import (
+    PackageBase,
+    Prefix,
+    Spec,
+    build_system,
+    depends_on,
+    register_builder,
+    run_after,
+)
 
 from ._checks import BuilderWithDefaults, execute_build_time_tests, execute_install_time_tests
 
 
-class WafPackage(spack.package_base.PackageBase):
+class WafPackage(PackageBase):
     """Specialized class for packages that are built using the
     Waf build system. See https://waf.io/book/ for more information.
     """
@@ -28,7 +34,7 @@ class WafPackage(spack.package_base.PackageBase):
     depends_on("python@2.5:", type="build", when="build_system=waf")
 
 
-@spack.builder.register_builder("waf")
+@register_builder("waf")
 class WafBuilder(BuilderWithDefaults):
     """The WAF builder provides the following phases that can be overridden:
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/xorg.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/xorg.py
@@ -4,11 +4,11 @@
 
 from typing import Optional
 
-import spack.package_base
 import spack.util.url
+from spack.package import PackageBase
 
 
-class XorgPackage(spack.package_base.PackageBase):
+class XorgPackage(PackageBase):
     """Mixin that takes care of setting url and mirrors for x.org
     packages."""
 

--- a/var/spack/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/compiler_wrapper/package.py
@@ -13,7 +13,6 @@ import archspec.cpu
 from llnl.util import lang
 
 import spack.compilers.libraries
-import spack.package_base
 from spack.package import *
 
 
@@ -279,7 +278,7 @@ class CompilerWrapper(Package):
         return "--enable-new-dtags"
 
 
-def _implicit_rpaths(pkg: spack.package_base.PackageBase) -> List[str]:
+def _implicit_rpaths(pkg: PackageBase) -> List[str]:
     detector = spack.compilers.libraries.CompilerPropertyDetector(pkg.spec)
     paths = detector.implicit_rpaths()
     return paths

--- a/var/spack/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/llvm/package.py
@@ -13,7 +13,7 @@ from llnl.util.lang import classproperty
 
 from spack.operating_systems.mac_os import macos_sdk_path
 from spack.package import *
-from spack.package_base import PackageBase
+from spack.package import PackageBase
 
 
 class LlvmDetection(PackageBase):

--- a/var/spack/repos/spack_repo/builtin/packages/llvm/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/llvm/package.py
@@ -13,7 +13,6 @@ from llnl.util.lang import classproperty
 
 from spack.operating_systems.mac_os import macos_sdk_path
 from spack.package import *
-from spack.package import PackageBase
 
 
 class LlvmDetection(PackageBase):

--- a/var/spack/repos/spack_repo/builtin/packages/mpich/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mpich/package.py
@@ -11,11 +11,10 @@ from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
 import spack.compilers.config
-import spack.package_base
 from spack.package import *
 
 
-class MpichEnvironmentModifications(spack.package_base.PackageBase):
+class MpichEnvironmentModifications(PackageBase):
     """Collects the environment modifications that are usually needed for the life-cycle of
     MPICH, and derivatives.
     """

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
@@ -78,7 +78,7 @@ class AutotoolsPackage(spack.package_base.PackageBase):
         return spack.builder.create(self).with_or_without(*args, **kwargs)
 
 
-@spack.builder.builder("autotools")
+@spack.builder.register_builder("autotools")
 class AutotoolsBuilder(BuilderWithDefaults):
     """The autotools builder encodes the default way of installing software built
     with autotools. It has four phases that can be overridden, if need be:

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/bundle.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/bundle.py
@@ -22,7 +22,7 @@ class BundlePackage(spack.package_base.PackageBase):
     spack.directives.build_system("bundle")
 
 
-@spack.builder.builder("bundle")
+@spack.builder.register_builder("bundle")
 class BundleBuilder(spack.builder.Builder):
     phases = ("install",)
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
@@ -283,7 +283,7 @@ class CMakePackage(spack.package_base.PackageBase):
         return define_from_variant(self, cmake_var, variant)
 
 
-@spack.builder.builder("cmake")
+@spack.builder.register_builder("cmake")
 class CMakeBuilder(BuilderWithDefaults):
     """The cmake builder encodes the default way of building software with CMake. IT
     has three phases that can be overridden:

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/generic.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/generic.py
@@ -27,7 +27,7 @@ class Package(spack.package_base.PackageBase):
     spack.directives.build_system("generic")
 
 
-@spack.builder.builder("generic")
+@spack.builder.register_builder("generic")
 class GenericBuilder(BuilderWithDefaults):
     """A builder for a generic build system, that require packagers
     to implement an "install" phase.

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
@@ -37,7 +37,7 @@ class MakefilePackage(spack.package_base.PackageBase):
         depends_on("gmake", type="build")
 
 
-@spack.builder.builder("makefile")
+@spack.builder.register_builder("makefile")
 class MakefileBuilder(BuilderWithDefaults):
     """The Makefile builder encodes the most common way of building software with
     Makefiles. It has three phases that can be overridden, if need be:

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
@@ -88,7 +88,7 @@ class PerlPackage(spack.package_base.PackageBase):
                 assert "OK" in out
 
 
-@spack.builder.builder("perl")
+@spack.builder.register_builder("perl")
 class PerlBuilder(BuilderWithDefaults):
     """The perl builder provides four phases that can be overridden, if required:
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
@@ -427,7 +427,7 @@ class PythonPackage(PythonExtension):
         raise NoLibrariesError(msg.format(self.spec.name, platlib, purelib))
 
 
-@spack.builder.builder("python_pip")
+@spack.builder.register_builder("python_pip")
 class PythonPipBuilder(BuilderWithDefaults):
     phases = ("install",)
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/py_test_callback/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/py_test_callback/package.py
@@ -35,7 +35,7 @@ class PyTestCallback(Python):
         print("PyTestCallback test")
 
 
-@spack.builder.builder("testcallback")
+@spack.builder.register_builder("testcallback")
 class MyBuilder(BuilderWithDefaults):
     phases = ("install",)
 


### PR DESCRIPTION
This adds some methods to the Spack v2.0 package API.