### PR TITLE
krb5: depends_on libedit

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/krb5/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/krb5/package.py
@@ -66,6 +66,7 @@ class Krb5(AutotoolsPackage):
     depends_on("openssl@:1", when="@:1.19")
     depends_on("openssl")
     depends_on("gettext")
+    depends_on("libedit")
     depends_on("perl", type="build")
     depends_on("findutils", type="build")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
This PR adds to `krb5` the [default enabled dependency](https://github.com/krb5/krb5/blob/master/src/configure.ac#L1349) on `libedit` to avoid missing library warnings.

This should avoid the issue observed below:
```
==> Installing krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy [95/130]
==> No binary for krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/b7/b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35.tar.gz
==> Ran patch() for krb5
==> krb5: Executing phase: 'autoreconf'
==> krb5: Executing phase: 'configure'
==> krb5: Executing phase: 'build'
==> krb5: Executing phase: 'install'
==> Warning: bin/kadmin
        libkadm5clnt_mit.so.12 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libkadm5clnt_mit.so.12
        libkrb5.so.3 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libkrb5.so.3
        libk5crypto.so.3 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libk5crypto.so.3
        libcom_err.so.3 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libcom_err.so.3
        libintl.so.8 => /opt/software/linux-skylake/gettext-0.25-hbaf7rkkxvmfz6hpzg4qarogreqdi2co/lib/libintl.so.8
        libedit.so.0 => not found
bin/ktutil
        libkrb5.so.3 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libkrb5.so.3
        libk5crypto.so.3 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libk5crypto.so.3
        libcom_err.so.3 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libcom_err.so.3
        libkrb5support.so.0 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libkrb5support.so.0
        libintl.so.8 => /opt/software/linux-skylake/gettext-0.25-hbaf7rkkxvmfz6hpzg4qarogreqdi2co/lib/libintl.so.8
        libedit.so.0 => not found
sbin/kadmin.local
        libkadm5srv_mit.so.12 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libkadm5srv_mit.so.12
        libkrb5.so.3 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libkrb5.so.3
        libk5crypto.so.3 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libk5crypto.so.3
        libcom_err.so.3 => /opt/software/linux-skylake/krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy/lib/libcom_err.so.3
        libintl.so.8 => /opt/software/linux-skylake/gettext-0.25-hbaf7rkkxvmfz6hpzg4qarogreqdi2co/lib/libintl.so.8
        libedit.so.0 => not found
==> krb5: Successfully installed krb5-1.21.3-4a5zsx3jz6dh5p4k6gvfp6nhqfgcqhqy
  Stage: 0.19s.  Autoreconf: 0.00s.  Configure: 12.65s.  Build: 25.56s.  Install: 1.08s.  Post-install: 0.19s.  Total: 39.72s
```