### PR TITLE
dcap: depends_on krb5

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/dcap/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dcap/package.py
@@ -26,6 +26,7 @@ class Dcap(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
+    depends_on("krb5")
     depends_on("openssl")
     depends_on("libxcrypt")
     depends_on("zlib-api")


### PR DESCRIPTION
This PR adds to `dcap` the [default enabled dependency](https://github.com/dCache/dcap/blob/master/configure.ac#L324) on `krb5`. If `krb5` is found, it is used. This ensures the version in spack is used.

This should avoid warnings like this:
```
==> Installing dcap-2.47.14-4zbw2ym6f7wukd2pig63yc2qdhcrzh2h [110/130]
==> No binary for dcap-2.47.14-4zbw2ym6f7wukd2pig63yc2qdhcrzh2h found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/dd/dda98990d93cded815ee425101674ad2f48438fff76b3d4d5d3f91e380e9cc49.tar.gz
==> Ran patch() for dcap
==> dcap: Executing phase: 'autoreconf'
==> dcap: Executing phase: 'configure'
==> dcap: Executing phase: 'build'
==> dcap: Executing phase: 'install'
==> Warning: lib/libgssTunnel.so
        libgssapi_krb5.so.2 => not found
==> dcap: Successfully installed dcap-2.47.14-4zbw2ym6f7wukd2pig63yc2qdhcrzh2h
  Stage: 0.01s.  Autoreconf: 1.86s.  Configure: 6.73s.  Build: 3.74s.  Install: 0.74s.  Post-install: 0.13s.  Total: 13.27s
```