### PR TITLE
r: add v4.5.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/r/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/r/package.py
@@ -25,6 +25,7 @@ class R(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("4.5.0", sha256="3b33ea113e0d1ddc9793874d5949cec2c7386f66e4abfb1cef9aec22846c3ce1")
     version("4.4.3", sha256="0d93d224442dea253c2b086f088db6d0d3cfd9b592cd5496e8cb2143e90fc9e8")
     version("4.4.2", sha256="1578cd603e8d866b58743e49d8bf99c569e81079b6a60cf33cdf7bdffeb817ec")
     version("4.4.1", sha256="b4cb675deaaeb7299d3b265d218cde43f192951ce5b89b7bb1a5148a36b2d94d")
@@ -98,6 +99,7 @@ class R(AutotoolsPackage):
     depends_on("which", type=("build", "run"))
     depends_on("zlib-api")
     depends_on("zlib@1.2.5:", when="^[virtuals=zlib-api] zlib")
+    depends_on("zstd", when="@4.5:")
     depends_on("texinfo", type="build")
     depends_on("gettext")
 


### PR DESCRIPTION
This PR adds `r`, v4.5.0, which adds `zstd` support (as flagged by missing libraries).

Announcement with new features at https://stat.ethz.ch/pipermail/r-announce/2025/000710.html. This defaults to c++23, where supported. I didn't see any other major changes.

Test build (before explicitly adding `zstd`):
```
==> Installing r-4.5.0-xcavp6kddcyb3yoxxyhfl3nfvj3a5vf6 [112/130]
==> No binary for r-4.5.0-xcavp6kddcyb3yoxxyhfl3nfvj3a5vf6 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/3b/3b33ea113e0d1ddc9793874d5949cec2c7386f66e4abfb1cef9aec22846c3ce1.tar.gz
==> Applied patch /home/wdconinc/git/spack/var/spack/repos/spack_repo/builtin/packages/r/relocate-which.patch
==> r: Executing phase: 'autoreconf'
==> r: Executing phase: 'configure'
==> r: Executing phase: 'build'
==> r: Executing phase: 'install'
==> Warning: rlib/R/lib/libR.so
        libmkl_gf_lp64.so.2 => /opt/software/linux-skylake/intel-oneapi-mkl-2024.2.2-2uafnysjuwe2pcdrazt76b2icnrfdefg/mkl/2024.2/lib/libmkl_gf_lp64.so.2
        libmkl_sequential.so.2 => /opt/software/linux-skylake/intel-oneapi-mkl-2024.2.2-2uafnysjuwe2pcdrazt76b2icnrfdefg/mkl/2024.2/lib/libmkl_sequential.so.2
        libmkl_core.so.2 => /opt/software/linux-skylake/intel-oneapi-mkl-2024.2.2-2uafnysjuwe2pcdrazt76b2icnrfdefg/mkl/2024.2/lib/libmkl_core.so.2
        libintl.so.8 => /opt/software/linux-skylake/gettext-0.25-hbaf7rkkxvmfz6hpzg4qarogreqdi2co/lib/libintl.so.8
        libreadline.so.8 => /opt/software/linux-skylake/readline-8.2-kmroyytbmqkiffom2lrhcdkrh4tbcire/lib/libreadline.so.8
        libpcre2-8.so.0 => /opt/software/linux-skylake/pcre2-10.45-crqt5cldp3ojod5o4czgcpanngbfijyu/lib/libpcre2-8.so.0
        liblzma.so.5 => /opt/software/linux-skylake/xz-5.8.0-gl4ac26aw7vvz5bkdc4qhafay7fg7fkc/lib/liblzma.so.5
        libbz2.so.1.0 => /opt/software/linux-skylake/bzip2-1.0.8-ucjy5pzkgj5xcxkaslospgewqz5v6wkj/lib/libbz2.so.1.0
        libz.so.1 => /opt/software/linux-skylake/zlib-ng-2.2.4-3qemgnpurdgifazv65xo6cslkda55rpg/lib/libz.so.1
        libtirpc.so.3 => /opt/software/linux-skylake/libtirpc-1.3.3-fkz4wes32dppxe67uboyflkqdaugde4p/lib/libtirpc.so.3
        libiconv.so.2 => /opt/software/linux-skylake/libiconv-1.18-4ewsr4flntjrsercrq5p6kqmpmvsfp2q/lib/libiconv.so.2
        libicuuc.so.74 => /opt/software/linux-skylake/icu4c-74.2-ckypn5jpznunofuzc6kcb2hivq7z37lx/lib/libicuuc.so.74
        libicui18n.so.74 => /opt/software/linux-skylake/icu4c-74.2-ckypn5jpznunofuzc6kcb2hivq7z37lx/lib/libicui18n.so.74
        libzstd.so.1 => not found
==> r: Successfully installed r-4.5.0-xcavp6kddcyb3yoxxyhfl3nfvj3a5vf6
  Stage: 0.57s.  Autoreconf: 0.00s.  Configure: 28.86s.  Build: 2m 45.90s.  Install: 0.67s.  Post-install: 0.45s.  Total: 3m 19.89s
[+] /opt/software/linux-skylake/r-4.5.0-xcavp6kddcyb3yoxxyhfl3nfvj3a5vf6
```