### PR TITLE
[Tau package] patch for rocm 6.2, do not configure for rocprofiler by default, only if enabled with +rocprofiler

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/tau/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/tau/package.py
@@ -210,7 +210,7 @@ class Tau(Package):
     # https://github.com/UO-OACISS/tau2/commit/1d2cb6b
     patch("tau-rocm-disable-llvm-plugin.patch", when="@2.33.2 +rocm")
     # https://github.com/UO-OACISS/tau2/commit/523df968dd17ffad74f0d944ecbb958ba0e8c6e8
-    patch("tau-rocm-disable-rocprofiler-default.patch", when="@2.34 +rocm")    
+    patch("tau-rocm-disable-rocprofiler-default.patch", when="@2.34 +rocm")
 
     filter_compiler_wrappers("Makefile", relative_root="include")
     filter_compiler_wrappers("Makefile.tau*", relative_root="lib")

--- a/var/spack/repos/spack_repo/builtin/packages/tau/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/tau/package.py
@@ -209,6 +209,8 @@ class Tau(Package):
 
     # https://github.com/UO-OACISS/tau2/commit/1d2cb6b
     patch("tau-rocm-disable-llvm-plugin.patch", when="@2.33.2 +rocm")
+    # https://github.com/UO-OACISS/tau2/commit/523df968dd17ffad74f0d944ecbb958ba0e8c6e8
+    patch("tau-rocm-disable-rocprofiler-default.patch", when="@2.34 %rocm@6.2:")    
 
     filter_compiler_wrappers("Makefile", relative_root="include")
     filter_compiler_wrappers("Makefile.tau*", relative_root="lib")

--- a/var/spack/repos/spack_repo/builtin/packages/tau/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/tau/package.py
@@ -210,7 +210,7 @@ class Tau(Package):
     # https://github.com/UO-OACISS/tau2/commit/1d2cb6b
     patch("tau-rocm-disable-llvm-plugin.patch", when="@2.33.2 +rocm")
     # https://github.com/UO-OACISS/tau2/commit/523df968dd17ffad74f0d944ecbb958ba0e8c6e8
-    patch("tau-rocm-disable-rocprofiler-default.patch", when="@2.34 %rocm@6.2:")    
+    patch("tau-rocm-disable-rocprofiler-default.patch", when="@2.34 +rocm")    
 
     filter_compiler_wrappers("Makefile", relative_root="include")
     filter_compiler_wrappers("Makefile.tau*", relative_root="lib")

--- a/var/spack/repos/spack_repo/builtin/packages/tau/tau-rocm-disable-rocprofiler-default.patch
+++ b/var/spack/repos/spack_repo/builtin/packages/tau/tau-rocm-disable-rocprofiler-default.patch
@@ -1,0 +1,21 @@
+spack-src/configure spack-src-patched/configurediff -ruN
+--- spack-src/configure 2024-11-05 17:07:38.000000000 -0800
++++ spack-src-patched/configure  2025-05-19 08:56:22.311253328 -0700
+@@ -3191,7 +3191,7 @@
+             #fixmakeargs="$fixmakeargs rocmdir=$rocmdir ROCM ROCPROFILER"
+             fixmakeargs="$fixmakeargs rocmdir=$rocmdir ROCM"
+             rocm=yes
+-            rocprofiler=yes
++            #rocprofiler=yes
+             tauoptions="${tauoptions}-rocm"
+             pthread=yes
+             shift
+@@ -3207,7 +3207,7 @@
+               rocm=yes
+             fi
+             #fixmakeargs="$fixmakeargs ROCPROFILER"
+-            rocprofiler=yes
++            #rocprofiler=yes
+             tauoptions="${tauoptions}-rocm"
+             pthread=yes
+             shift


### PR DESCRIPTION
Rocprofiler is being build by default with +rocm.

This is commited into TAU, but not for the current release, the patch removes "rocprofiler=yes" when TAU configures with the rocm flag. `rocprofiler=yes` is only set when rocprofiler is used

