### PR TITLE
cyrus-sasl: depends_on krb5

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cyrus_sasl/package.py
@@ -41,3 +41,4 @@ class CyrusSasl(AutotoolsPackage):
     depends_on("groff", type="build")
     depends_on("openssl", type="link")
     depends_on("libxcrypt", type="link")
+    depends_on("krb5", type="link")


### PR DESCRIPTION
This PR ensures that `cyrus-sasl` depends on `krb5` (which is supported at https://github.com/cyrusimap/cyrus-sasl/blob/master/configure.ac#L462) so it does not lead to shared linking warnings like:
```
==> Installing cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z [298/639]
==> No binary for cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/3e/3e38933a30b9ce183a5488b4f6a5937a702549cde0d3287903d80968ad4ec341.tar.gz
==> Using cached archive: /opt/spack/cache/_source-cache/archive/81/819342fe68475ac1690136ff4ce9b73c028f433ae150898add36f724a8e2274b
==> Applied patch https://github.com/cyrusimap/cyrus-sasl/commit/266f0acf7f5e029afbb3e263437039e50cd6c262.patch?full_index=1
==> cyrus-sasl: Executing phase: 'autoreconf'
==> cyrus-sasl: Executing phase: 'configure'
==> cyrus-sasl: Executing phase: 'build'
==> cyrus-sasl: Executing phase: 'install'
==> Warning: lib/sasl2/libgs2.so.3.0.0
        libgssapi_krb5.so.2 => not found
lib/sasl2/libgssapiv2.so.3.0.0
        libgssapi_krb5.so.2 => not found
sbin/saslauthd
        libcrypt.so.2 => /opt/software/linux-skylake/libxcrypt-4.4.38-qwze5xsz2htjac74zcdoozyk6ievvh24/lib/libcrypt.so.2
        libkrb5.so.3 => not found
==> cyrus-sasl: Successfully installed cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z
  Stage: 0.28s.  Autoreconf: 18.17s.  Configure: 39.58s.  Build: 15.81s.  Install: 2.39s.  Post-install: 0.72s.  Total: 1m 17.21s
[+] /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z
```