### PR TITLE
openldap: depends_on uuid

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/openldap/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openldap/package.py
@@ -51,6 +51,7 @@ class Openldap(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    depends_on("uuid")
     depends_on("icu4c", when="+icu")
 
     with when("~client_only"):


### PR DESCRIPTION
This PR adds to `openldap` the `uuid` [dependency](https://github.com/openldap/openldap/blob/7a8d72b02bcf8af4f056d66cac98ffafa21a5fdb/configure.ac#L1029). This fixes issues such as:
```
==> Installing openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li [319/639]
==> No binary for openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/2c/2cb7dc73e9c8340dff0d99357fbaa578abf30cc6619f0521972c555681e6b2ff.tgz
==> No patches needed for openldap
==> openldap: Executing phase: 'autoreconf'
==> openldap: Executing phase: 'configure'
==> openldap: Executing phase: 'build'
==> openldap: Executing phase: 'install'
==> Warning: bin/ldapcompare
        libldap.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/libldap.so.2
        liblber.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/liblber.so.2
        libsasl2.so.3 => /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z/lib/libsasl2.so.3
        libuuid.so.1 => not found
bin/ldapdelete
        libldap.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/libldap.so.2
        liblber.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/liblber.so.2
        libsasl2.so.3 => /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z/lib/libsasl2.so.3
        libuuid.so.1 => not found
bin/ldapexop
        libldap.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/libldap.so.2
        liblber.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/liblber.so.2
        libsasl2.so.3 => /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z/lib/libsasl2.so.3
        libuuid.so.1 => not found
bin/ldapmodify
        libldap.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/libldap.so.2
        liblber.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/liblber.so.2
        libsasl2.so.3 => /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z/lib/libsasl2.so.3
        libuuid.so.1 => not found
bin/ldapmodrdn
        libldap.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/libldap.so.2
        liblber.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/liblber.so.2
        libsasl2.so.3 => /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z/lib/libsasl2.so.3
        libuuid.so.1 => not found
bin/ldappasswd
        libldap.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/libldap.so.2
        liblber.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/liblber.so.2
        libsasl2.so.3 => /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z/lib/libsasl2.so.3
        libuuid.so.1 => not found
bin/ldapsearch
        libldap.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/libldap.so.2
        liblber.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/liblber.so.2
        libsasl2.so.3 => /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z/lib/libsasl2.so.3
        libuuid.so.1 => not found
bin/ldapvc
        libldap.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/libldap.so.2
        liblber.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/liblber.so.2
        libsasl2.so.3 => /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z/lib/libsasl2.so.3
        libuuid.so.1 => not found
bin/ldapwhoami
        libldap.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/libldap.so.2
        liblber.so.2 => /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li/lib/liblber.so.2
        libsasl2.so.3 => /opt/software/linux-skylake/cyrus-sasl-2.1.28-deqgowkz5npmwt7hekhh4umxv6zs525z/lib/libsasl2.so.3
        libuuid.so.1 => not found
==> openldap: Successfully installed openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li
  Stage: 0.65s.  Autoreconf: 0.01s.  Configure: 1m 4.44s.  Build: 44.65s.  Install: 46.59s.  Post-install: 1.34s.  Total: 2m 38.10s
[+] /opt/software/linux-skylake/openldap-2.6.9-4pxuc6zlc44rctrjadc5wyj2ahhvf3li
``` 