### PR TITLE
e2fsprogs: depends_on uuid

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/e2fsprogs/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/e2fsprogs/package.py
@@ -26,6 +26,7 @@ class E2fsprogs(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    depends_on("uuid")
     depends_on("texinfo", type="build")
     depends_on("fuse", when="+fuse2fs")
     depends_on("pkgconfig", when="+fuse2fs")


### PR DESCRIPTION
This PR adds to `e2fsprogs` the [dependency](https://github.com/tytso/e2fsprogs/blob/ff64357f839071968a727f8b5a08b0ddaedc5bbb/configure.ac#L476) on `uuid`. This avoids warnings like:
```
==> Installing e2fsprogs-1.47.1-hzpxp427bfyzss3o3ftqbz4sjy5oen2i [67/71]
==> No binary for e2fsprogs-1.47.1-hzpxp427bfyzss3o3ftqbz4sjy5oen2i found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/db/db95ff1cb6ef741c9aa8875d9f3f52a34168360febba765b6377b80bada09a8c.tar.gz
    [100%]   10.00 MB @   12.6 MB/s
==> No patches needed for e2fsprogs
==> e2fsprogs: Executing phase: 'autoreconf'
==> e2fsprogs: Executing phase: 'configure'
==> e2fsprogs: Executing phase: 'build'
==> e2fsprogs: Executing phase: 'install'
==> Warning: bin/fuse2fs
        libfuse3.so.4 => /opt/software/linux-skylake/libfuse-3.17.2-ldpdv7h753stpggudbzecqs5xeyojyir/lib/libfuse3.so.4
        libuuid.so.1 => not found
lib/e2initrd_helper
        libuuid.so.1 => not found
sbin/blkid
        libuuid.so.1 => not found
sbin/debugfs
        libuuid.so.1 => not found
sbin/dumpe2fs
        libuuid.so.1 => not found
sbin/e2fsck
        libuuid.so.1 => not found
sbin/e2image
        libuuid.so.1 => not found
sbin/e2label
        libuuid.so.1 => not found
sbin/e2mmpstatus
        libuuid.so.1 => not found
sbin/e4crypt
        libuuid.so.1 => not found
sbin/findfs
        libuuid.so.1 => not found
sbin/fsck
        libuuid.so.1 => not found
sbin/fsck.ext2
        libuuid.so.1 => not found
sbin/fsck.ext3
        libuuid.so.1 => not found
sbin/fsck.ext4
        libuuid.so.1 => not found
sbin/mke2fs
        libuuid.so.1 => not found
sbin/mkfs.ext2
        libuuid.so.1 => not found
sbin/mkfs.ext3
        libuuid.so.1 => not found
sbin/mkfs.ext4
        libuuid.so.1 => not found
sbin/tune2fs
        libuuid.so.1 => not found
==> e2fsprogs: Successfully installed e2fsprogs-1.47.1-hzpxp427bfyzss3o3ftqbz4sjy5oen2i
  Stage: 1.07s.  Autoreconf: 0.00s.  Configure: 9.84s.  Build: 22.60s.  Install: 0.64s.  Post-install: 0.34s.  Total: 34.54s
[+] /opt/software/linux-skylake/e2fsprogs-1.47.1-hzpxp427bfyzss3o3ftqbz4sjy5oen2i
```