### PR TITLE
sst-core: depends on c

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/sst_core/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/sst_core/package.py
@@ -81,6 +81,7 @@ class SstCore(AutotoolsPackage):
     variant("profile", default=False, description="Enable performance profiling of core features")
 
     depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("python@:3.11", type=("build", "run", "link"))
     depends_on("mpi", when="+pdes_mpi")


### PR DESCRIPTION
Fix build issues that occur when `pdes_mpi` is false. 
