### PR TITLE
Do not attach dependency types to `%` by default

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -296,7 +296,7 @@ def _depends_on(
     dependency = deps_by_name.get(spec.name)
 
     edges = spec.edges_to_dependencies()
-    if edges and not all(x.depflag == dt.BUILD for x in edges):
+    if edges and not all(x.direct for x in edges):
         raise DirectiveError(
             f"the '^' sigil cannot be used in 'depends_on' directives. Please reformulate "
             f"the directive below as multiple directives:\n\n"

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1030,7 +1030,7 @@ class ErrorHandler:
         """
         seen.add(cause)
         parents = [c for e, c in condition_causes if e == cause and c not in seen]
-        local = "required because %s " % conditions[cause[0]]
+        local = f"required because {conditions[cause[0]]} "
 
         return [indent + local] + [
             c
@@ -1084,7 +1084,7 @@ class ErrorHandler:
         # Spec(...) with the string representation of the spec mentioned
         specs_to_construct = re.findall(r"Spec\(([^)]*)\)", msg)
         for spec_str in specs_to_construct:
-            msg = msg.replace("Spec(%s)" % spec_str, str(spack.spec.Spec(spec_str)))
+            msg = msg.replace(f"Spec({spec_str})", str(spack.spec.Spec(spec_str)))
 
         for cause in set(causes):
             for c in self.get_cause_tree(cause):
@@ -1625,7 +1625,7 @@ class SpackSolverSetup:
 
     def conflict_rules(self, pkg):
         for when_spec, conflict_specs in pkg.conflicts.items():
-            when_spec_msg = "conflict constraint %s" % str(when_spec)
+            when_spec_msg = f"conflict constraint {str(when_spec)}"
             when_spec_id = self.condition(when_spec, required_name=pkg.name, msg=when_spec_msg)
 
             for conflict_spec, conflict_msg in conflict_specs:
@@ -2944,7 +2944,7 @@ class SpackSolverSetup:
             elif isinstance(v, vn.VersionList):
                 return sum((versions_for(e) for e in v), [])
             else:
-                raise TypeError("expected version type, found: %s" % type(v))
+                raise TypeError(f"expected version type, found: {type(v)}")
 
         # define a set of synthetic possible versions for virtuals, so
         # that `version_satisfies(Package, Constraint, Version)` has the
@@ -3217,7 +3217,7 @@ class SpackSolverSetup:
 
         self.gen.h1("Package Constraints")
         for pkg in sorted(self.pkgs):
-            self.gen.h2("Package rules: %s" % pkg)
+            self.gen.h2(f"Package rules: {pkg}")
             self.pkg_rules(pkg, tests=self.tests)
             self.preferred_variants(pkg)
 
@@ -3228,7 +3228,7 @@ class SpackSolverSetup:
         self.gen.h1("Develop specs")
         # Inject dev_path from environment
         for ds in dev_specs:
-            self.condition(spack.spec.Spec(ds.name), ds, msg="%s is a develop spec" % ds.name)
+            self.condition(spack.spec.Spec(ds.name), ds, msg=f"{ds.name} is a develop spec")
             self.trigger_rules()
             self.effect_rules()
 
@@ -3291,9 +3291,10 @@ class SpackSolverSetup:
             # FIXME (compiler as nodes): think of using isinstance(compiler_cls, WrappedCompiler)
             # Add a dependency on the compiler wrapper
             for language in ("c", "cxx", "fortran"):
+                compiler_str = f"{compiler.name}@{compiler.versions}"
                 recorder("*").depends_on(
                     "compiler-wrapper",
-                    when=f"%[virtuals={language}] {compiler.name}@{compiler.versions}",
+                    when=f"%[deptypes=build virtuals={language}] {compiler_str}",
                     type="build",
                     description=f"Add the compiler wrapper when using {compiler} for {language}",
                 )
@@ -3313,13 +3314,13 @@ class SpackSolverSetup:
             if current_libc:
                 recorder("*").depends_on(
                     "libc",
-                    when=f"%{compiler.name}@{compiler.versions}",
+                    when=f"%[deptypes=build] {compiler_str}",
                     type="link",
                     description=f"Add libc when using {compiler}",
                 )
                 recorder("*").depends_on(
                     f"{current_libc.name}@={current_libc.version}",
-                    when=f"%{compiler.name}@{compiler.versions}",
+                    when=f"%[deptypes=build] {compiler_str}",
                     type="link",
                     description=f"Libc is {current_libc} when using {compiler}",
                 )
@@ -3329,7 +3330,7 @@ class SpackSolverSetup:
 
     def literal_specs(self, specs):
         for spec in sorted(specs):
-            self.gen.h2("Spec: %s" % str(spec))
+            self.gen.h2(f"Spec: {str(spec)}")
             condition_id = next(self._id_counter)
             trigger_id = next(self._id_counter)
 
@@ -3755,7 +3756,7 @@ class RuntimePropertyRecorder:
             self.reset()
             return
 
-        when_spec = spack.spec.Spec(f"% {spec}")
+        when_spec = spack.spec.Spec(f"%[deptypes=build] {spec}")
         body_str, node_variable = self.rule_body_from(when_spec)
 
         node_placeholder = "XXX"
@@ -4038,7 +4039,7 @@ class SpecBuilder:
                     extend_flag_list(ordered_flags, cmd_flags)
 
                 compiler_flags = spec.compiler_flags.get(flag_type, [])
-                msg = "%s does not equal %s" % (set(compiler_flags), set(ordered_flags))
+                msg = f"{set(compiler_flags)} does not equal {set(ordered_flags)}"
                 assert set(compiler_flags) == set(ordered_flags), msg
 
                 spec.compiler_flags.update({flag_type: ordered_flags})
@@ -4097,7 +4098,7 @@ class SpecBuilder:
 
             # print out unknown actions so we can display them for debugging
             if not action:
-                msg = 'UNKNOWN SYMBOL: attr("%s", %s)' % (name, ", ".join(str(a) for a in args))
+                msg = f'UNKNOWN SYMBOL: attr("{name}", {", ".join(str(a) for a in args)})'
                 tty.debug(msg)
                 continue
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3264,7 +3264,7 @@ class SpackSolverSetup:
                                 arg = ast_sym(ast_sym(term.atom).arguments[0])
                                 symbol = AspFunction(name)(arg.string)
                                 self.assumptions.append((parse_term(str(symbol)), True))
-                                self.gen.asp_problem.append(f"{{ {symbol} }}.\n")
+                                self.gen.asp_problem.append(f"{symbol}.\n")
 
         path = os.path.join(parent_dir, "concretize.lp")
         parse_files([path], visit)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -298,24 +298,6 @@ def remove_facts(
     return _remove
 
 
-def remove_build_deps(spec: spack.spec.Spec, facts: List[AspFunction]) -> List[AspFunction]:
-    build_deps = {x.args[2]: x.args[1] for x in facts if x.args[0] == "depends_on"}
-    result = []
-    for x in facts:
-        current_name = x.args[1]
-        if current_name in build_deps:
-            x.name = "node_requirement"
-            result.append(fn.attr("direct_dependency", build_deps[current_name], x))
-            continue
-
-        if x.args[0] == "depends_on":
-            continue
-
-        result.append(x)
-
-    return result
-
-
 def all_libcs() -> Set[spack.spec.Spec]:
     """Return a set of all libc specs targeted by any configured compiler. If none, fall back to
     libc determined from the current Python process if dynamically linked."""
@@ -1457,6 +1439,7 @@ class SourceContext:
         # (which means it isn't important to keep track of the source
         # in that case).
         self.source = "none" if source is None else source
+        self.wrap_node_requirement: Optional[bool] = None
 
 
 class ConditionIdContext(SourceContext):
@@ -1491,17 +1474,24 @@ class ConditionContext(SourceContext):
         # transformation applied to facts from the imposed spec. Defaults
         # to removing "node" and "virtual_node" facts.
         self.transform_imposed = None
+        # Whether to wrap direct dependency facts as node requirements,
+        # imposed by the parent. If None, the default is used, which is:
+        # - wrap head of rules
+        # - do not wrap body of rules
+        self.wrap_node_requirement: Optional[bool] = None
 
     def requirement_context(self) -> ConditionIdContext:
         ctxt = ConditionIdContext()
         ctxt.source = self.source
         ctxt.transform = self.transform_required
+        ctxt.wrap_node_requirement = self.wrap_node_requirement
         return ctxt
 
     def impose_context(self) -> ConditionIdContext:
         ctxt = ConditionIdContext()
         ctxt.source = self.source
         ctxt.transform = self.transform_imposed
+        ctxt.wrap_node_requirement = self.wrap_node_requirement
         return ctxt
 
 
@@ -2221,8 +2211,9 @@ class SpackSolverSetup:
                     context.source = ConstraintOrigin.append_type_suffix(
                         pkg_name, ConstraintOrigin.REQUIRE
                     )
+                    context.wrap_node_requirement = True
                     if not virtual:
-                        context.transform_required = remove_build_deps
+                        context.transform_required = remove_facts("depends_on")
                         context.transform_imposed = remove_facts(
                             "node", "virtual_node", "depends_on"
                         )
@@ -2676,13 +2667,20 @@ class SpackSolverSetup:
                 ###
                 # Direct dependencies expressed with "%"
                 ###
-                edge_clauses.append(fn.attr("depends_on", spec.name, dep.name, "build"))
-                # Body of a rule
-                if body is True:
+                for dependency_type in dt.flag_to_tuple(dspec.depflag):
+                    edge_clauses.append(
+                        fn.attr("depends_on", spec.name, dep.name, dependency_type)
+                    )
+
+                # By default, wrap head of rules, unless the context says otherwise
+                wrap_node_requirement = body is False
+                if context and context.wrap_node_requirement is not None:
+                    wrap_node_requirement = context.wrap_node_requirement
+
+                if not wrap_node_requirement:
                     edge_clauses.extend(dependency_clauses)
                     continue
 
-                # Head of a rule
                 for clause in dependency_clauses:
                     clause.name = "node_requirement"
                     edge_clauses.append(fn.attr("direct_dependency", spec.name, clause))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2669,7 +2669,7 @@ class SpackSolverSetup:
                 ###
                 # Dependency expressed with "^"
                 ###
-                if not dspec.depflag == dt.BUILD:
+                if not dspec.direct:
                     edge_clauses.extend(dependency_clauses)
                     continue
 
@@ -3755,7 +3755,7 @@ class RuntimePropertyRecorder:
             self.reset()
             return
 
-        when_spec = spack.spec.Spec(f"^[deptypes=build] {spec}")
+        when_spec = spack.spec.Spec(f"% {spec}")
         body_str, node_variable = self.rule_body_from(when_spec)
 
         node_placeholder = "XXX"

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -304,7 +304,7 @@ def remove_build_deps(spec: spack.spec.Spec, facts: List[AspFunction]) -> List[A
     for x in facts:
         current_name = x.args[1]
         if current_name in build_deps:
-            x.name = "build_requirement"
+            x.name = "node_requirement"
             result.append(fn.attr("direct_dependency", build_deps[current_name], x))
             continue
 
@@ -1183,7 +1183,7 @@ class PyclingoDriver:
         if sys.platform == "win32":
             tty.debug("Ensuring basic dependencies {win-sdk, wgl} available")
             spack.bootstrap.core.ensure_winsdk_external_or_raise()
-        control_files = ["concretize.lp", "heuristic.lp", "display.lp"]
+        control_files = ["concretize.lp", "heuristic.lp", "display.lp", "direct_dependency.lp"]
         if not setup.concretize_everything:
             control_files.append("when_possible.lp")
         if using_libc_compatibility():
@@ -2684,7 +2684,7 @@ class SpackSolverSetup:
 
                 # Head of a rule
                 for clause in dependency_clauses:
-                    clause.name = "build_requirement"
+                    clause.name = "node_requirement"
                     edge_clauses.append(fn.attr("direct_dependency", spec.name, clause))
 
         clauses.extend(edge_clauses)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -183,11 +183,12 @@ literal_node(Root, node(min_dupe_id, Root)) :-  mentioned_in_literal(Root, Root)
   mentioned_in_literal(Root, Mentioned), Mentioned != Root,
   internal_error("must have exactly one condition_set for literals").
 
-1 { build_dependency_of_literal_node(LiteralNode, node(0..Y-1, BuildDependency)) : max_dupes(BuildDependency, Y) } 1 :-
+build_dependency_of_literal_node(LiteralNode, node(X, BuildDependency)) :-
   literal_node(Root, LiteralNode),
   build(LiteralNode),
   not external(LiteralNode),
-  attr("direct_dependency", LiteralNode, build_requirement("node", BuildDependency)).
+  build_requirement(LiteralNode, node(X, BuildDependency)),
+  attr("direct_dependency", LiteralNode, node_requirement("node", BuildDependency)).
 
 condition_set(node(min_dupe_id, Root), LiteralNode) :- literal_node(Root, LiteralNode).
 condition_set(LiteralNode, BuildNode) :- build_dependency_of_literal_node(LiteralNode, BuildNode).
@@ -511,63 +512,67 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
 
 % If the parent is built, then we have a build_requirement on another node. For concrete nodes,
 % or external nodes, we don't since we are trimming their build dependencies.
-1 { attr("depends_on",  node(X, Parent), node(0..Y-1, BuildDependency), "build") : max_dupes(BuildDependency, Y) } 1
-  :- attr("direct_dependency", node(X, Parent), build_requirement("node", BuildDependency)),
-     build(node(X, Parent)),
-     not external(node(X, Parent)).
 
 % Concrete nodes
-:- attr("direct_dependency", ParentNode, build_requirement("node", BuildDependency)),
+:- attr("direct_dependency", ParentNode, node_requirement("node", BuildDependency)),
+   concrete_build_requirement(ParentNode, BuildDependency),
    concrete(ParentNode),
    not attr("concrete_build_dependency", ParentNode, BuildDependency, _).
 
-:- attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
+:- attr("direct_dependency", ParentNode, node_requirement("node_version_satisfies", BuildDependency, Constraint)),
+   concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not 1 { pkg_fact(BuildDependency, version_satisfies(Constraint, Version)) : hash_attr(BuildDependencyHash, "version", BuildDependency, Version) } 1.
 
-:- attr("direct_dependency", ParentNode, build_requirement("provider_set", BuildDependency, Virtual)),
+:- attr("direct_dependency", ParentNode, node_requirement("provider_set", BuildDependency, Virtual)),
+   concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    attr("virtual_on_build_edge", ParentNode, BuildDependency, Virtual),
    not 1 { pkg_fact(BuildDependency, version_satisfies(Constraint, Version)) : hash_attr(BuildDependencyHash, "version", BuildDependency, Version) } 1.
 
 error(100, "Cannot satisfy the request on {0} to have {1}={2}", BuildDependency, Variant, Value)
-:- attr("direct_dependency", ParentNode, build_requirement("variant_set", BuildDependency, Variant, Value)),
+:- attr("direct_dependency", ParentNode, node_requirement("variant_set", BuildDependency, Variant, Value)),
+   concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not hash_attr(BuildDependencyHash, "variant_value", BuildDependency, Variant, Value).
 
 error(100, "Cannot satisfy the request on {0} to have the target set to {1}", BuildDependency, Target)
-:- attr("direct_dependency", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
+:- attr("direct_dependency", ParentNode, node_requirement("node_target_set", BuildDependency, Target)),
+   concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not hash_attr(BuildDependencyHash, "node_target", BuildDependency, Target).
 
 error(100, "Cannot satisfy the request on {0} to have the os set to {1}", BuildDependency, NodeOS)
-:- attr("direct_dependency", ParentNode, build_requirement("node_os_set", BuildDependency, NodeOS)),
+:- attr("direct_dependency", ParentNode, node_requirement("node_os_set", BuildDependency, NodeOS)),
+   concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not hash_attr(BuildDependencyHash, "node_os", BuildDependency, NodeOS).
 
 error(100, "Cannot satisfy the request on {0} to have the platform set to {1}", BuildDependency, Platform)
-:- attr("direct_dependency", ParentNode, build_requirement("node_platform_set", BuildDependency, Platform)),
+:- attr("direct_dependency", ParentNode, node_requirement("node_platform_set", BuildDependency, Platform)),
+   concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not hash_attr(BuildDependencyHash, "node_platform", BuildDependency, Platform).
 
 error(100, "Cannot satisfy the request on {0} to have the following hash {1}", BuildDependency, BuildHash)
-:- attr("direct_dependency", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
+:- attr("direct_dependency", ParentNode, node_requirement("node_target_set", BuildDependency, Target)),
+   concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
-   attr("direct_dependency", ParentNode, build_requirement("hash", BuildDependency, BuildHash)),
+   attr("direct_dependency", ParentNode, node_requirement("hash", BuildDependency, BuildHash)),
    BuildHash != BuildDependencyHash.
 
 % External nodes
-:- attr("direct_dependency", ParentNode, build_requirement("node", BuildDependency)),
+:- attr("direct_dependency", ParentNode, node_requirement("node", BuildDependency)),
    external(ParentNode),
    not attr("external_build_requirement", ParentNode, node_requirement("node", BuildDependency)).
 
 candidate_external_version(Constraint, BuildDependency, Version)
-  :- attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
+  :- attr("direct_dependency", ParentNode, node_requirement("node_version_satisfies", BuildDependency, Constraint)),
      external(ParentNode),
      pkg_fact(BuildDependency, version_satisfies(Constraint, Version)).
 
 error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, LiteralConstraint, ExternalConstraint)
-  :- attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, LiteralConstraint)),
+  :- attr("direct_dependency", ParentNode, node_requirement("node_version_satisfies", BuildDependency, LiteralConstraint)),
      external(ParentNode),
      attr("external_build_requirement", ParentNode, node_requirement("node_version_satisfies", BuildDependency, ExternalConstraint)),
      not 1 { pkg_fact(BuildDependency, version_satisfies(ExternalConstraint, Version)) : candidate_external_version(LiteralConstraint, BuildDependency, Version) }.
@@ -575,7 +580,7 @@ error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, Lite
 
 % Asking for gcc@10 %gcc@9 shouldn't give us back an external gcc@10, just because of the hack
 % we have on externals
-:- attr("direct_dependency", node(X, Parent), build_requirement("node", BuildDependency)),
+:- attr("direct_dependency", node(X, Parent), node_requirement("node", BuildDependency)),
    Parent == BuildDependency,
    external(node(X, Parent)).
 
@@ -595,7 +600,7 @@ build_requirement(ParentNode, ProviderNode) :- virtual_build_requirement(ParentN
 % Adding a "direct_dependency" is a way to discriminate between the incompatible
 % version constraints on "gcc" in the "imposed_constraint".
 attr("node_version_satisfies", node(X, BuildDependency), Constraint) :-
-  attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
+  attr("direct_dependency", ParentNode, node_requirement("node_version_satisfies", BuildDependency, Constraint)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 % Account for properties on the build requirements
@@ -603,30 +608,30 @@ attr("node_version_satisfies", node(X, BuildDependency), Constraint) :-
 % root %gcc@12.0 <properties for gcc> ^dep
 %
 attr("variant_set", node(X, BuildDependency), Variant, Value) :-
-  attr("direct_dependency", ParentNode, build_requirement("variant_set", BuildDependency, Variant, Value)),
+  attr("direct_dependency", ParentNode, node_requirement("variant_set", BuildDependency, Variant, Value)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 attr("depends_on",  node(X, Parent), node(Y, BuildDependency), "build") :- build_requirement(node(X, Parent), node(Y, BuildDependency)).
 
 attr("node_target_set", node(X, BuildDependency), Target) :-
-  attr("direct_dependency", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
+  attr("direct_dependency", ParentNode, node_requirement("node_target_set", BuildDependency, Target)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 attr("node_os_set", node(X, BuildDependency), NodeOS) :-
-  attr("direct_dependency", ParentNode, build_requirement("node_os_set", BuildDependency, NodeOS)),
+  attr("direct_dependency", ParentNode, node_requirement("node_os_set", BuildDependency, NodeOS)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 attr("node_platform_set", node(X, BuildDependency), NodePlatform) :-
-  attr("direct_dependency", ParentNode, build_requirement("node_platform_set", BuildDependency, NodePlatform)),
+  attr("direct_dependency", ParentNode, node_requirement("node_platform_set", BuildDependency, NodePlatform)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 attr("hash", node(X, BuildDependency), BuildHash) :-
-  attr("direct_dependency", ParentNode, build_requirement("hash", BuildDependency, BuildHash)),
+  attr("direct_dependency", ParentNode, node_requirement("hash", BuildDependency, BuildHash)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 
 1 { attr("provider_set", node(X, BuildDependency), node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1 :-
-  attr("direct_dependency", ParentNode, build_requirement("provider_set", BuildDependency, Virtual)),
+  attr("direct_dependency", ParentNode, node_requirement("provider_set", BuildDependency, Virtual)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 % Reconstruct virtual dependencies for reused specs

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -559,7 +559,7 @@ error(100, "Cannot satisfy the request on {0} to have the following hash {1}", B
 % External nodes
 :- attr("direct_dependency", ParentNode, build_requirement("node", BuildDependency)),
    external(ParentNode),
-   not attr("external_build_requirement", ParentNode, build_requirement("node", BuildDependency)).
+   not attr("external_build_requirement", ParentNode, node_requirement("node", BuildDependency)).
 
 candidate_external_version(Constraint, BuildDependency, Version)
   :- attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
@@ -569,7 +569,7 @@ candidate_external_version(Constraint, BuildDependency, Version)
 error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, LiteralConstraint, ExternalConstraint)
   :- attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, LiteralConstraint)),
      external(ParentNode),
-     attr("external_build_requirement", ParentNode, build_requirement("node_version_satisfies", BuildDependency, ExternalConstraint)),
+     attr("external_build_requirement", ParentNode, node_requirement("node_version_satisfies", BuildDependency, ExternalConstraint)),
      not 1 { pkg_fact(BuildDependency, version_satisfies(ExternalConstraint, Version)) : candidate_external_version(LiteralConstraint, BuildDependency, Version) }.
 
 
@@ -968,13 +968,13 @@ attr("external_spec_selected", node(ID, Package), LocalIndex) :-
 
 % Account for compiler annotation on externals
 :- not attr("root", ExternalNode),
-   attr("external_build_requirement", ExternalNode, build_requirement("node", Compiler)),
+   attr("external_build_requirement", ExternalNode, node_requirement("node", Compiler)),
    not node_compiler(_, node(_, Compiler)).
 
 1 { attr("node_version_satisfies", node(X, Compiler), Constraint) : node_compiler(_, node(X, Compiler)) }
   :- not attr("root", ExternalNode),
-     attr("external_build_requirement", ExternalNode, build_requirement("node", Compiler)),
-     attr("external_build_requirement", ExternalNode, build_requirement("node_version_satisfies", Compiler, Constraint)).
+     attr("external_build_requirement", ExternalNode, node_requirement("node", Compiler)),
+     attr("external_build_requirement", ExternalNode, node_requirement("node_version_satisfies", Compiler, Constraint)).
 
 % it cannot happen that a spec is external, but none of the external specs
 % conditions hold.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -579,10 +579,6 @@ error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, Lite
    Parent == BuildDependency,
    external(node(X, Parent)).
 
-build_requirement(node(X, Parent), node(Y, BuildDependency)) :-
-  attr("depends_on", node(X, Parent), node(Y, BuildDependency), "build"),
-  attr("direct_dependency", node(X, Parent), build_requirement("node", BuildDependency)).
-
 1 { virtual_build_requirement(ParentNode, node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1
   :- attr("dependency_holds", ParentNode, Virtual, "build"),
      not attr("dependency_holds", ParentNode, Virtual,"link"),

--- a/lib/spack/spack/solver/direct_dependency.lp
+++ b/lib/spack/spack/solver/direct_dependency.lp
@@ -9,6 +9,13 @@
        not external(PackageNode),
        not concrete(PackageNode).
 
+1 {
+  concrete_build_requirement(PackageNode, DirectDependency)
+} 1 :- attr("direct_dependency", PackageNode, node_requirement("node", DirectDependency)),
+       concrete(PackageNode).
+
+% TODO: add a rule to allow only build requirements for externals
+
 %%%%
 % Build requirement
 %%%%
@@ -17,8 +24,3 @@
 attr("depends_on", node(X, Parent), node(Y, BuildDependency), "build") :-
  build_requirement(node(X, Parent), node(Y, BuildDependency)),
  build(node(X, Parent)).
-
-attr("direct_dependency", PackageNode, build_requirement(A1, A2)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2)).
-attr("direct_dependency", PackageNode, build_requirement(A1, A2, A3)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2, A3)).
-attr("direct_dependency", PackageNode, build_requirement(A1, A2, A3, A4)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2, A3, A4)).
-attr("direct_dependency", PackageNode, build_requirement(A1, A2, A3, A4, A5)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2, A3, A4, A5)).

--- a/lib/spack/spack/solver/direct_dependency.lp
+++ b/lib/spack/spack/solver/direct_dependency.lp
@@ -2,6 +2,22 @@
 %
 % SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+% A direct dependency is either a runtime requirement, or a build requirement
+1 {
+  build_requirement(PackageNode, node(0..X-1, DirectDependency)) : max_dupes(DirectDependency, X)
+} 1 :- attr("direct_dependency", PackageNode, node_requirement("node", DirectDependency)),
+       not external(PackageNode),
+       not concrete(PackageNode).
+
+%%%%
+% Build requirement
+%%%%
+
+% A build requirement that is not concrete has a "build" only dependency
+attr("depends_on", node(X, Parent), node(Y, BuildDependency), "build") :-
+ build_requirement(node(X, Parent), node(Y, BuildDependency)),
+ build(node(X, Parent)).
+
 attr("direct_dependency", PackageNode, build_requirement(A1, A2)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2)).
 attr("direct_dependency", PackageNode, build_requirement(A1, A2, A3)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2, A3)).
 attr("direct_dependency", PackageNode, build_requirement(A1, A2, A3, A4)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2, A3, A4)).

--- a/lib/spack/spack/solver/direct_dependency.lp
+++ b/lib/spack/spack/solver/direct_dependency.lp
@@ -1,0 +1,8 @@
+% Copyright Spack Project Developers. See COPYRIGHT file for details.
+%
+% SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+attr("direct_dependency", PackageNode, build_requirement(A1, A2)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2)).
+attr("direct_dependency", PackageNode, build_requirement(A1, A2, A3)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2, A3)).
+attr("direct_dependency", PackageNode, build_requirement(A1, A2, A3, A4)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2, A3, A4)).
+attr("direct_dependency", PackageNode, build_requirement(A1, A2, A3, A4, A5)) :- attr("direct_dependency", PackageNode, node_requirement(A1, A2, A3, A4, A5)).

--- a/lib/spack/spack/solver/direct_dependency.lp
+++ b/lib/spack/spack/solver/direct_dependency.lp
@@ -4,17 +4,17 @@
 
 % A direct dependency is either a runtime requirement, or a build requirement
 1 {
-  build_requirement(PackageNode, node(0..X-1, DirectDependency)) : max_dupes(DirectDependency, X)
+  build_requirement(PackageNode, node(0..X-1, DirectDependency)) : max_dupes(DirectDependency, X);
+  runtime_requirement(PackageNode, node(0..X-1, DirectDependency)) : max_dupes(DirectDependency, X)
 } 1 :- attr("direct_dependency", PackageNode, node_requirement("node", DirectDependency)),
        not external(PackageNode),
        not concrete(PackageNode).
 
 1 {
-  concrete_build_requirement(PackageNode, DirectDependency)
+  concrete_build_requirement(PackageNode, DirectDependency);
+  runtime_requirement(PackageNode, node(0..X-1, DirectDependency)) : max_dupes(DirectDependency, X)
 } 1 :- attr("direct_dependency", PackageNode, node_requirement("node", DirectDependency)),
        concrete(PackageNode).
-
-% TODO: add a rule to allow only build requirements for externals
 
 %%%%
 % Build requirement
@@ -24,3 +24,35 @@
 attr("depends_on", node(X, Parent), node(Y, BuildDependency), "build") :-
  build_requirement(node(X, Parent), node(Y, BuildDependency)),
  build(node(X, Parent)).
+
+% Any other dependency type is forbidden
+:- build_requirement(ParentNode, ChildNode),
+   build(ParentNode),
+   attr("depends_on", ParentNode, ChildNode, Type), Type != "build".
+
+:- concrete_build_requirement(ParentNode, ChildPackage),
+   concrete(ParentNode),
+   attr("depends_on", ParentNode, node(_, ChildPackage), _).
+
+%%%%
+% Runtime requirement
+%%%%
+
+:- runtime_requirement(ParentNode, ChildNode),
+   not 1 { attr("depends_on", ParentNode, ChildNode, "link"); attr("depends_on", ParentNode, ChildNode, "run") }.
+
+attr(AttributeName, node(X, ChildPackage), A1)
+  :- runtime_requirement(ParentNode, node(X, ChildPackage)),
+     attr("direct_dependency", ParentNode, node_requirement(AttributeName, ChildPackage, A1)).
+
+attr(AttributeName, node(X, ChildPackage), A1, A2)
+  :- runtime_requirement(ParentNode, node(X, ChildPackage)),
+     attr("direct_dependency", ParentNode, node_requirement(AttributeName, ChildPackage, A1, A2)).
+
+attr(AttributeName, node(X, ChildPackage), A1, A2, A3)
+  :- runtime_requirement(ParentNode, node(X, ChildPackage)),
+     attr("direct_dependency", ParentNode, node_requirement(AttributeName, ChildPackage, A1, A2, A3)).
+
+attr(AttributeName, node(X, ChildPackage), A1, A2, A3, A4)
+  :- runtime_requirement(ParentNode, node(X, ChildPackage)),
+     attr("direct_dependency", ParentNode, node_requirement(AttributeName, ChildPackage, A1, A2, A3, A4)).

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3430,11 +3430,15 @@ class Spec:
                         return False
 
                 else:
-                    candidates = current_node.dependencies(
-                        name=rhs_edge.spec.name,
-                        deptype=rhs_edge.depflag,
-                        virtuals=rhs_edge.virtuals or None,
+                    candidate_edges = current_node.edges_to_dependencies(
+                        name=rhs_edge.spec.name, virtuals=rhs_edge.virtuals or None
                     )
+                    # Select at least the deptypes on the rhs_edge
+                    candidates = [
+                        x.spec
+                        for x in candidate_edges
+                        if ((x.depflag & rhs_edge.depflag) ^ rhs_edge.depflag) == 0
+                    ]
                     if not candidates or not any(x.satisfies(rhs_edge.spec) for x in candidates):
                         return False
 

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -312,8 +312,6 @@ class SpecParser:
                     target_spec = root_spec
                     edge_properties.setdefault("depflag", 0)
 
-                # print(f"[{current_spec}], {target_spec}->{dependency} {is_direct}")
-
                 parser_warnings.extend(warnings)
                 add_dependency(dependency, **edge_properties)
 

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -278,21 +278,18 @@ class SpecParser:
                 edge_properties = EdgeAttributeParser(self.ctx, self.literal_str).parse()
                 edge_properties.setdefault("virtuals", ())
                 edge_properties["direct"] = is_direct
+                edge_properties.setdefault("depflag", 0)
 
                 dependency, warnings = self._parse_node(root_spec)
 
                 if is_direct:
                     target_spec = current_spec
-                    edge_properties.setdefault("depflag", spack.deptypes.BUILD)
                     if dependency.name in LEGACY_COMPILER_TO_BUILTIN:
                         dependency.name = LEGACY_COMPILER_TO_BUILTIN[dependency.name]
-
                 else:
                     current_spec = dependency
                     target_spec = root_spec
-                    edge_properties.setdefault("depflag", 0)
 
-                # print(f"[{current_spec}], {target_spec}->{dependency} {is_direct}")
                 parser_warnings.extend(warnings)
                 add_dependency(dependency, **edge_properties)
 
@@ -302,15 +299,15 @@ class SpecParser:
                 edge_properties = {}
                 edge_properties["direct"] = is_direct
                 edge_properties["virtuals"] = tuple()
+                edge_properties.setdefault("depflag", 0)
+
                 if is_direct:
                     target_spec = current_spec
-                    edge_properties.setdefault("depflag", spack.deptypes.BUILD)
                     if dependency.name in LEGACY_COMPILER_TO_BUILTIN:
                         dependency.name = LEGACY_COMPILER_TO_BUILTIN[dependency.name]
                 else:
                     current_spec = dependency
                     target_spec = root_spec
-                    edge_properties.setdefault("depflag", 0)
 
                 parser_warnings.extend(warnings)
                 add_dependency(dependency, **edge_properties)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -329,6 +329,12 @@ class TestSpecSemantics:
                     "ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2"
                 ),
             ),
+            # deptypes on direct deps
+            (
+                "mpileaks %[deptypes=build] mpich",
+                "mpileaks %[deptypes=link] mpich",
+                "mpileaks %[deptypes=build,link] mpich",
+            ),
         ],
     )
     def test_abstract_specs_can_constrain_each_other(self, lhs, rhs, expected):
@@ -775,6 +781,8 @@ class TestSpecSemantics:
             ("libelf^foo", "libelf^foo~debug"),
             ("libelf", "^foo"),
             ("mpileaks ^callpath %gcc@14", "mpileaks ^callpath %gcc@14.1"),
+            ("mpileaks %[deptypes=build] mpich", "mpileaks %[deptypes=link] mpich"),
+            ("mpileaks %mpich", "mpileaks %[deptypes=link] mpich"),
         ],
     )
     def test_lhs_is_changed_when_constraining(self, lhs, rhs):
@@ -809,6 +817,7 @@ class TestSpecSemantics:
             ("libelf^foo~debug", "libelf^foo~debug"),
             ('libelf^foo cppflags="-O3"', 'libelf^foo cppflags="-O3"'),
             ("mpileaks ^callpath %gcc@14.1", "mpileaks ^callpath %gcc@14"),
+            ("mpileaks %[deptypes=build] gcc@14.1", "mpileaks %gcc@14"),
         ],
     )
     def test_lhs_is_not_changed_when_constraining(self, lhs, rhs):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2120,7 +2120,7 @@ EMPTY_FLG = Spec().compiler_flags
                     ("c", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                     ("d", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
-                ((0, 1, dt.BUILD, ()), (0, 2, dt.BUILD, ()), (0, 3, dt.BUILD, ())),
+                ((0, 1, 0, ()), (0, 2, 0, ()), (0, 3, 0, ())),
             ),
         ],
         # dependencies with dependencies
@@ -2139,10 +2139,10 @@ EMPTY_FLG = Spec().compiler_flags
                 (
                     (0, 1, 0, ()),
                     (0, 2, 0, ()),
-                    (1, 3, dt.BUILD, ()),
-                    (1, 4, dt.BUILD, ()),
-                    (2, 5, dt.BUILD, ()),
-                    (2, 6, dt.BUILD, ()),
+                    (1, 3, 0, ()),
+                    (1, 4, 0, ()),
+                    (2, 5, 0, ()),
+                    (2, 6, 0, ()),
                 ),
             ),
         ],

--- a/var/spack/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gcc/package.py
@@ -1165,7 +1165,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         for language in ("c", "cxx", "fortran"):
             pkg("*").depends_on(
                 f"gcc-runtime@{spec.version}:",
-                when=f"%[virtuals={language}] {spec.name}@{spec.versions}",
+                when=f"%[deptypes=build virtuals={language}] {spec.name}@{spec.versions}",
                 type="link",
                 description=f"Inject gcc-runtime when gcc is used as a {language} compiler",
             )
@@ -1179,17 +1179,21 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         for fortran_virtual in ("fortran-rt", gfortran_str):
             pkg("*").depends_on(
                 fortran_virtual,
-                when=f"%[virtuals=fortran] {spec.name}@{spec.versions}",
+                when=f"%[deptypes=build virtuals=fortran] {spec.name}@{spec.versions}",
                 type="link",
                 description=f"Add a dependency on '{gfortran_str}' for nodes compiled with "
                 f"{spec} and using the 'fortran' language",
             )
         # The version of gcc-runtime is the same as the %gcc used to "compile" it
-        pkg("gcc-runtime").requires(f"@{spec.versions}", when=f"%{spec.name}@{spec.versions}")
+        pkg("gcc-runtime").requires(
+            f"@{spec.versions}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
+        )
 
         # If a node used %gcc@X.Y its dependencies must use gcc-runtime@:X.Y
         # (technically @:X is broader than ... <= @=X but this should work in practice)
-        pkg("*").propagate(f"gcc@:{spec.version}", when=f"%{spec.name}@{spec.versions}")
+        pkg("*").propagate(
+            f"gcc@:{spec.version}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
+        )
 
     def _post_buildcache_install_hook(self):
         if not self.spec.satisfies("platform=linux"):

--- a/var/spack/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -674,7 +674,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         for language in ("c", "cxx", "fortran"):
             pkg("*").depends_on(
                 f"intel-oneapi-runtime@{spec.version}:",
-                when=f"%[virtuals={language}] {spec.name}@{spec.versions}",
+                when=f"%[deptypes=build virtuals={language}] {spec.name}@{spec.versions}",
                 type="link",
                 description="Inject intel-oneapi-runtime when oneapi is used as "
                 f"a {language} compiler",
@@ -683,20 +683,21 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         for fortran_virtual in ("fortran-rt", "libifcore@5"):
             pkg("*").depends_on(
                 fortran_virtual,
-                when=f"%[virtuals=fortran] {spec.name}@{spec.versions}",
+                when=f"%[deptypes=build virtuals=fortran] {spec.name}@{spec.versions}",
                 type="link",
                 description="Add a dependency on 'libifcore' for nodes compiled with "
                 f"{spec.name}@{spec.versions} and using the 'fortran' language",
             )
         # The version of intel-oneapi-runtime is the same as the %oneapi used to "compile" it
         pkg("intel-oneapi-runtime").requires(
-            f"@{spec.versions}", when=f"%{spec.name}@{spec.versions}"
+            f"@{spec.versions}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
         )
 
         # If a node used %intel-oneapi-runtime@X.Y its dependencies must use @:X.Y
         # (technically @:X is broader than ... <= @=X but this should work in practice)
         pkg("*").propagate(
-            f"intel-oneapi-compilers@:{spec.version}", when=f"%{spec.name}@{spec.versions}"
+            f"intel-oneapi-compilers@:{spec.version}",
+            when=f"%[deptypes=build] {spec.name}@{spec.versions}",
         )
 
     def _cc_path(self):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
@@ -103,7 +103,7 @@ class Gcc(CompilerPackage, Package):
         for language in ("c", "cxx", "fortran"):
             pkg("*").depends_on(
                 f"gcc-runtime@{spec.version}:",
-                when=f"%[virtuals={language}] {spec.name}@{spec.versions}",
+                when=f"%[deptypes=build virtuals={language}] {spec.name}@{spec.versions}",
                 type="link",
                 description=f"Inject gcc-runtime when gcc is used as a {language} compiler",
             )
@@ -117,14 +117,18 @@ class Gcc(CompilerPackage, Package):
         for fortran_virtual in ("fortran-rt", gfortran_str):
             pkg("*").depends_on(
                 fortran_virtual,
-                when=f"%[virtuals=fortran] {spec.name}@{spec.versions}",
+                when=f"%[deptypes=build virtuals=fortran] {spec.name}@{spec.versions}",
                 type="link",
                 description=f"Add a dependency on '{gfortran_str}' for nodes compiled with "
                 f"{spec} and using the 'fortran' language",
             )
         # The version of gcc-runtime is the same as the %gcc used to "compile" it
-        pkg("gcc-runtime").requires(f"@{spec.versions}", when=f"%{spec.name}@{spec.versions}")
+        pkg("gcc-runtime").requires(
+            f"@{spec.versions}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
+        )
 
         # If a node used %gcc@X.Y its dependencies must use gcc-runtime@:X.Y
         # (technically @:X is broader than ... <= @=X but this should work in practice)
-        pkg("*").propagate(f"gcc@:{spec.version}", when=f"%{spec.name}@{spec.versions}")
+        pkg("*").propagate(
+            f"gcc@:{spec.version}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
+        )


### PR DESCRIPTION
Following #49808 this PR removes the default dependency type attached to the `%` sigil, so that `^` and `%` have a symmetric behavior.

Modifications:
- [x] Modify `Spec.satisfies` to account for different deptypes attached to `%`
- [x] Modify the solver to avoid assuming `%` refers to a "build only" deptype
- [x] Allow solving `%[deptypes=link] mpich` etc.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
