### PR TITLE
e4s oneapi: build gromacs with libraries from oneAPI

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -84,7 +84,7 @@ spack:
   - globalarrays
   - gmp
   - gotcha
-  - gromacs +mpi +sycl ^[virtuals=fftw-api] intel-oneapi-mkl
+  - gromacs +mpi +sycl ^[virtuals=fftw-api] intel-oneapi-mkl ^[virtuals=lapack] intel-oneapi-mkl
   - h5bench
   - hdf5-vol-async
   - hdf5-vol-cache

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -84,7 +84,7 @@ spack:
   - globalarrays
   - gmp
   - gotcha
-  - gromacs
+  - gromacs +mpi +sycl ^intel-oneapi-mkl
   - h5bench
   - hdf5-vol-async
   - hdf5-vol-cache

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -84,7 +84,7 @@ spack:
   - globalarrays
   - gmp
   - gotcha
-  - gromacs +mpi +sycl ^intel-oneapi-mkl
+  - gromacs +mpi +sycl ^[virtuals=fftw-api] intel-oneapi-mkl
   - h5bench
   - hdf5-vol-async
   - hdf5-vol-cache


### PR DESCRIPTION
GROMACS, its spack recipe, and its support for Intel MPI, Intel MKL, and SYCL via oneapi is all fairly mature and good to test here.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
