### PR TITLE
builtin: remove `spack.variant` imports

### DIFF
--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -208,7 +208,7 @@ class Variant:
         else:
             return VariantType.SINGLE
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"Variant('{self.name}', "
             f"default='{self.default}', "
@@ -493,7 +493,7 @@ class DisjointSetsOfValues(collections.abc.Sequence):
 
     _empty_set = {"none"}
 
-    def __init__(self, *sets):
+    def __init__(self, *sets: Tuple[str, ...]) -> None:
         self.sets = [set(_flatten(x)) for x in sets]
 
         # 'none' is a special value and can appear only in a set of

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -491,14 +491,14 @@ class DisjointSetsOfValues(collections.abc.Sequence):
         *sets (list): mutually exclusive sets of values
     """
 
-    _empty_set = set(("none",))
+    _empty_set = {"none"}
 
     def __init__(self, *sets):
         self.sets = [set(_flatten(x)) for x in sets]
 
         # 'none' is a special value and can appear only in a set of
         # a single element
-        if any("none" in s and s != set(("none",)) for s in self.sets):
+        if any("none" in s and s != {"none"} for s in self.sets):
             raise spack.error.SpecError(
                 "The value 'none' represents the empty set,"
                 " and must appear alone in a set. Use the "

--- a/var/spack/repos/spack_repo/builtin/packages/geant4/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/geant4/package.py
@@ -5,16 +5,10 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from spack.package import *
-from spack.variant import ConditionalVariantValues
 
 
 def _std_when(values):
-    for v in values:
-        if isinstance(v, ConditionalVariantValues):
-            for c in v:
-                yield (c.value, c.when)
-        else:
-            yield (v, "")
+    return [(c.value, c.when) for v in values for c in v]
 
 
 class Geant4(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipblas/package.py
@@ -8,7 +8,6 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.variant
 from spack.package import *
 
 
@@ -57,7 +56,7 @@ class Hipblas(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=disjoint_sets(("auto",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/spack_repo/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipcub/package.py
@@ -6,7 +6,6 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.variant
 from spack.package import *
 
 
@@ -50,7 +49,7 @@ class Hipcub(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=disjoint_sets(("auto",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/spack_repo/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipfft/package.py
@@ -7,7 +7,6 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.variant
 from spack.package import *
 
 
@@ -57,7 +56,7 @@ class Hipfft(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=disjoint_sets(("auto",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/spack_repo/builtin/packages/hiprand/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hiprand/package.py
@@ -8,7 +8,6 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.variant
 from spack.package import *
 
 
@@ -57,7 +56,7 @@ class Hiprand(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=disjoint_sets(("auto",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/spack_repo/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipsolver/package.py
@@ -9,7 +9,6 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.variant
 from spack.package import *
 
 
@@ -62,7 +61,7 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=disjoint_sets(("auto",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/spack_repo/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipsparse/package.py
@@ -8,7 +8,6 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.variant
 from spack.package import *
 
 
@@ -54,7 +53,7 @@ class Hipsparse(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=disjoint_sets(("auto",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/spack_repo/builtin/packages/hipsparselt/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipsparselt/package.py
@@ -6,7 +6,6 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-import spack.variant
 from spack.package import *
 
 
@@ -41,7 +40,7 @@ class Hipsparselt(CMakePackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=disjoint_sets(("auto",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/spack_repo/builtin/packages/mesa/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mesa/package.py
@@ -6,7 +6,6 @@ import sys
 from spack_repo.builtin.build_systems import meson
 from spack_repo.builtin.build_systems.meson import MesonPackage
 
-import spack.variant
 from spack.package import *
 
 
@@ -85,9 +84,7 @@ class Mesa(MesonPackage):
     #   @:21  - swr was removed in 22.0
     variant(
         "swr",
-        values=spack.variant.DisjointSetsOfValues(
-            ("none",), ("auto",), ("avx", "avx2", "knl", "skx")
-        )
+        values=disjoint_sets(("none",), ("auto",), ("avx", "avx2", "knl", "skx"))
         .with_non_feature_values("auto")
         .with_non_feature_values("none")
         .with_default("auto"),

--- a/var/spack/repos/spack_repo/builtin/packages/spack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/spack/package.py
@@ -5,7 +5,6 @@
 from spack_repo.builtin.build_systems.generic import Package
 
 from spack.package import *
-from spack.variant import DisjointSetsOfValues
 
 
 class Spack(Package):
@@ -48,17 +47,15 @@ class Spack(Package):
     variant("development_tools", default=False, description="Build development dependencies")
     variant(
         "fetchers",
-        # TODO: make Spack support default=... with any_combination_of :(
-        values=DisjointSetsOfValues(
-            ("none",), ("curl", "git", "mercurial", "subversion", "s3")
-        ).with_default("git"),
+        values=any_combination_of("curl", "git", "mercurial", "subversion", "s3").with_default(
+            "git"
+        ),
         description="Fetchers for sources and binaries. "
         "By default, urllib is used since Spack 0.17",
     )
     variant(
         "modules",
-        # TODO: make Spack support default=... with any_combination_of :(
-        values=DisjointSetsOfValues(("none",), ("environment-modules", "lmod")).with_default(
+        values=any_combination_of("environment-modules", "lmod").with_default(
             "environment-modules,lmod"
         ),
         description="This variant makes Spack install the specified module system; "

--- a/var/spack/repos/spack_repo/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/vecgeom/package.py
@@ -7,16 +7,15 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 from spack.package import *
-from spack.variant import ConditionalVariantValues
 
 
 def _std_when(values):
     for v in values:
-        if isinstance(v, ConditionalVariantValues):
-            for c in v:
-                yield (c.value, c.when)
-        else:
-            yield (v, "")
+        if isinstance(v, str):
+            yield v, ""
+            continue
+        for c in v:
+            yield c.value, c.when
 
 
 class Vecgeom(CMakePackage, CudaPackage):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
