### PR TITLE
ci: import-check continue-on-error: true

### DIFF
--- a/.github/workflows/import-check.yaml
+++ b/.github/workflows/import-check.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   # Check we don't make the situation with circular imports worse
   import-check:
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
     - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Allow other CI checks to continue even if the circular import check fails.

Circular imports are often indicative of code that needs to be restructured, but there are still places where we need to add them. This allows CI to continue, so that if CI is passing *except* for a problematic import, we can still force merge and accept a bit of technical debt to admit a useful feature.  Also, this allows people to keep working while they fix their circular import issues, without being blind to CI results.

- [x] update ci workflow: import-check continue-on-error: true