### PR TITLE
builtin: remove unnecessary use of `archspec.cpu`

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/blast2go/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/blast2go/package.py
@@ -4,23 +4,19 @@
 
 from spack_repo.builtin.build_systems.generic import Package
 
-import archspec
-
 from spack.package import *
 
 
 class Blast2go(Package):
     """Blast2GO is a bioinformatics platform for high-quality functional
-    annotation and analysis of genomic datasets."""
+    annotation and analysis of genomic datasets.
+    """
 
     homepage = "https://www.blast2go.com/"
 
     version("5.2.5", sha256="c37aeda25f96ac0553b52da6b5af3167d50671ddbfb3b39bcb11afe5d0643891")
 
-    for t in set(
-        [str(x.family) for x in archspec.cpu.TARGETS.values() if str(x.family) != "x86_64"]
-    ):
-        conflicts("target={0}:".format(t), msg="blast2go is available x86_64 only")
+    requires("target=x86_64:", msg="blast2go is available x86_64 only")
 
     depends_on("bash", type="build")
     depends_on("blast-plus", type="run")

--- a/var/spack/repos/spack_repo/builtin/packages/gcc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gcc/package.py
@@ -10,8 +10,6 @@ from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
 from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage
 
-import archspec.cpu
-
 from llnl.util.symlink import readlink
 
 import spack.platforms
@@ -773,7 +771,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         for uarch in microarchitectures:
             try:
                 return uarch.optimization_flags("gcc", str(spec.version))
-            except archspec.cpu.UnsupportedMicroarchitecture:
+            except ValueError:
                 pass
         # no arch specific flags in common, unlikely to happen.
         return ""

--- a/var/spack/repos/spack_repo/builtin/packages/iwyu/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/iwyu/package.py
@@ -6,8 +6,6 @@ import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 
-import archspec
-
 from spack.package import *
 
 
@@ -62,10 +60,7 @@ class Iwyu(CMakePackage):
     depends_on("llvm+clang@8.0:8", when="@0.12")
     depends_on("llvm+clang@7.0:7", when="@0.11")
 
-    # iwyu uses X86AsmParser so must have the x86 target on non-x86 arch
-    _arches = set(str(x.family) for x in archspec.cpu.TARGETS.values())
-    for _arch in _arches - set(["x86", "x86_64"]):
-        depends_on("llvm targets=x86", when=f"arch={_arch}:")
+    requires("llvm targets=all", "llvm targets=x86", msg="iwyu needs the X86AsmParser")
 
     patch("iwyu-013-cmake.patch", when="@0.13:0.14")
 

--- a/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
@@ -9,8 +9,6 @@ from spack_repo.builtin.build_systems import compiler
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
 from spack_repo.builtin.build_systems.generic import Package
 
-import archspec.cpu
-
 import spack.platforms
 from spack.package import *
 
@@ -150,7 +148,7 @@ class Msvc(Package, CompilerPackage):
         # get current platform architecture and format for vcvars argument
         arch = spack.platforms.real_host().default.lower()
         arch = arch.replace("-", "_")
-        if str(archspec.cpu.host().family) == "x86_64":
+        if self.spec.satisfies("target=x86_64:"):
             arch = "amd64"
 
         msvc_version = Version(re.search(Msvc.compiler_version_regex, self.cc).group(1))

--- a/var/spack/repos/spack_repo/builtin/packages/py_azureml_dataprep_rslex/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_azureml_dataprep_rslex/package.py
@@ -6,8 +6,6 @@ import sys
 
 from spack_repo.builtin.build_systems.python import PythonPackage
 
-import archspec
-
 from spack.package import *
 
 
@@ -71,9 +69,4 @@ class PyAzuremlDataprepRslex(PythonPackage):
     depends_on("python@3.9.0:3.9", when="@1.9.0-py3.9,1.8.0-py3.9", type=("build", "run"))
     depends_on("python@3.8.0:3.8", when="@1.9.0-py3.8,1.8.0-py3.8", type=("build", "run"))
 
-    for t in set(
-        [str(x.family) for x in archspec.cpu.TARGETS.values() if str(x.family) != "x86_64"]
-    ):
-        conflicts(
-            "target={0}:".format(t), msg="py-azureml-dataprep-rslex is available x86_64 only"
-        )
+    requires("target=x86_64:", msg="py-azureml-dataprep-rslex is available x86_64 only")

--- a/var/spack/repos/spack_repo/builtin/packages/py_itk/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_itk/package.py
@@ -6,8 +6,6 @@ import sys
 
 from spack_repo.builtin.build_systems.python import PythonPackage
 
-import archspec
-
 from spack.package import *
 
 
@@ -113,7 +111,4 @@ class PyItk(PythonPackage):
     depends_on("python@3.11.0:3.11", when="@5.3.0-cp311", type=("build", "run"))
     depends_on("py-setuptools", type="run")
 
-    for t in set(
-        [str(x.family) for x in archspec.cpu.TARGETS.values() if str(x.family) != "x86_64"]
-    ):
-        conflicts("target={0}:".format(t), msg="py-itk is available for x86_64 only")
+    requires("target=x86_64:", msg="py-itk is available for x86_64 only")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
