### PR TITLE
Add a dependency of flex for openmpi's main build

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -625,6 +625,8 @@ with '-Wl,-commons,use_dylibs' and without
 
     depends_on("perl", type="build")
     depends_on("pkgconfig", type="build")
+    # Based on https://docs.open-mpi.org/en/v5.0.x/developers/prerequisites.html#flex
+    depends_on("flex@2.5.4:", type="build", when="@main")
 
     depends_on("hwloc@2:", when="@4: ~internal-hwloc")
     # ompi@:3.0.0 doesn't support newer hwloc releases:


### PR DESCRIPTION
Otherwise hit with the following error:

```
$ spack install openmpi@main
...
   1650    checking for flex... no
   1651    checking for lex... no
   1652    configure: WARNING: *** Could not find Flex on your system.
   1653    configure: WARNING: *** Flex is required for developer builds of Open MPI.
   1654    configure: WARNING: *** Other versions of Lex are not supported.
   1655    configure: WARNING: *** NOTE: If you are building a tarball downloaded from www.open-mpi.org, you do not need Flex
>> 1656    configure: error: Cannot continue
```

The `flex` dep is documented here:
https://docs.open-mpi.org/en/v5.0.x/developers/prerequisites.html#flex.

Verified the fix as below:
```
$ spack install openmpi@main
...
==> Installing openmpi-main-estnftkxdcu4svcbw6pxb3dj6u7qvbzd [40/40]
==> No binary for openmpi-main-estnftkxdcu4svcbw6pxb3dj6u7qvbzd found: installing from source
==> No patches needed for openmpi
==> openmpi: Executing phase: 'autoreconf'
==> openmpi: Executing phase: 'configure'
==> openmpi: Executing phase: 'build'
==> openmpi: Executing phase: 'install'
==> openmpi: Successfully installed openmpi-main-estnftkxdcu4svcbw6pxb3dj6u7qvbzd
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
