### PR TITLE
bugfix: add build system imports to new packages

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/cryoef/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cryoef/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
 from spack.package import *
 
 

--- a/var/spack/repos/spack_repo/builtin/packages/py_deprecat/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_deprecat/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.python import PythonPackage
+
 from spack.package import *
 
 


### PR DESCRIPTION
Since #50452, build systems are no longer in core and need their own imports.

Specifically, in addition to:

```python
from spack.package import *
```

you now also need, e.g.:

```python
from spack_repo.builtin.build_systems.python import PythonPackage
```

Or similar for other build systems, or things will break.

- [x] Fix `py-deprecat` package
- [x] Fix `cryoef` package

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
