### PR TITLE
ci: sync packages to python/spack_repo instead of spack_repo/

### DIFF
--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -28,7 +28,7 @@ jobs:
       run: |
         cd spack-packages
         git-filter-repo --quiet --source ../spack \
-                        --subdirectory-filter var/spack/repos \
+                        --path var/spack/repos/ --path-rename var/spack/repos/:python/ \
                         --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
                         --refs develop
     - name: Push


### PR DESCRIPTION
The idea is that the `python/` dir will be put in sys.path, so sys.path is not polluted by other files in the root of spack/spack-packages.