### PR TITLE
builtin: use absolute imports again

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/abyss/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/abyss/package.py
@@ -5,10 +5,9 @@
 import numbers
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 def is_multiple_32(x):

--- a/var/spack/repos/spack_repo/builtin/packages/akantu/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/akantu/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Akantu(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/amdblis/package.py
@@ -4,9 +4,9 @@
 
 import os
 
-from spack.package import *
+from spack_repo.builtin.packages.blis.package import BlisBase
 
-from ..blis.package import BlisBase
+from spack.package import *
 
 
 class Amdblis(BlisBase):

--- a/var/spack/repos/spack_repo/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/amdfftw/package.py
@@ -4,9 +4,9 @@
 
 import os
 
-from spack.package import *
+from spack_repo.builtin.packages.fftw.package import FftwBase
 
-from ..fftw.package import FftwBase
+from spack.package import *
 
 
 class Amdfftw(FftwBase):

--- a/var/spack/repos/spack_repo/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/amdlibflame/package.py
@@ -5,10 +5,9 @@
 
 from spack_repo.builtin.build_systems import autotools, cmake
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.packages.libflame.package import LibflameBase
 
 from spack.package import *
-
-from ..libflame.package import LibflameBase
 
 
 class Amdlibflame(CMakePackage, LibflameBase):

--- a/var/spack/repos/spack_repo/builtin/packages/amdscalapack/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/amdscalapack/package.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
+from spack_repo.builtin.packages.netlib_scalapack.package import ScalapackBase
 
-from ..netlib_scalapack.package import ScalapackBase
+from spack.package import *
 
 
 class Amdscalapack(ScalapackBase):

--- a/var/spack/repos/spack_repo/builtin/packages/amp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/amp/package.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Amp(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/aocc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/aocc/package.py
@@ -5,10 +5,9 @@ import os.path
 
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.llvm.package import LlvmDetection
 
 from spack.package import *
-
-from ..llvm.package import LlvmDetection
 
 
 class Aocc(Package, LlvmDetection, CompilerPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/aoflagger/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/aoflagger/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Aoflagger(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/apple_clang/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/apple_clang/package.py
@@ -5,10 +5,9 @@ import os
 
 from spack_repo.builtin.build_systems.bundle import BundlePackage
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
+from spack_repo.builtin.packages.llvm.package import LlvmDetection
 
 from spack.package import *
-
-from ..llvm.package import LlvmDetection
 
 
 class AppleClang(BundlePackage, LlvmDetection, CompilerPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/apple_glu/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/apple_glu/package.py
@@ -1,9 +1,9 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from spack.package import *
+from spack_repo.builtin.packages.apple_gl.package import AppleGlBase
 
-from ..apple_gl.package import AppleGlBase
+from spack.package import *
 
 
 class AppleGlu(AppleGlBase):

--- a/var/spack/repos/spack_repo/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/apptainer/package.py
@@ -6,9 +6,9 @@
 from glob import glob
 from os.path import basename
 
-from spack.package import *
+from spack_repo.builtin.packages.singularityce.package import SingularityBase
 
-from ..singularityce.package import SingularityBase
+from spack.package import *
 
 
 # Apptainer is the new name of Singularity, piggy-back on the original package

--- a/var/spack/repos/spack_repo/builtin/packages/augustus/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/augustus/package.py
@@ -5,10 +5,9 @@
 import glob
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Augustus(MakefilePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/automaded/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/automaded/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Automaded(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/bcl2fastq2/package.py
@@ -6,10 +6,9 @@ import glob
 import os
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 # This application uses cmake to build, but they wrap it with a

--- a/var/spack/repos/spack_repo/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/bohrium/package.py
@@ -6,11 +6,10 @@ import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
 from spack.package_test import compare_output
-
-from ..boost.package import Boost
 
 
 class Bohrium(CMakePackage, CudaPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/branson/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/branson/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Branson(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/cabana/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cabana/package.py
@@ -5,10 +5,9 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.kokkos.package import Kokkos
 
 from spack.package import *
-
-from ..kokkos.package import Kokkos
 
 
 class Cabana(CMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/caffe/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/caffe/package.py
@@ -4,10 +4,9 @@
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Caffe(CMakePackage, CudaPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/cantera/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cantera/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.scons import SConsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Cantera(SConsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/care/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/care/package.py
@@ -12,10 +12,9 @@ from spack_repo.builtin.build_systems.cached_cmake import (
 )
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.blt.package import llnl_link_helpers
 
 from spack.package import *
-
-from ..blt.package import llnl_link_helpers
 
 
 class Care(CachedCMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/cbtf_argonavis/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cbtf_argonavis/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class CbtfArgonavis(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/cbtf_argonavis_gui/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cbtf_argonavis_gui/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.qmake import QMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class CbtfArgonavisGui(QMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/chai/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/chai/package.py
@@ -12,10 +12,9 @@ from spack_repo.builtin.build_systems.cached_cmake import (
 )
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.blt.package import llnl_link_helpers
 
 from spack.package import *
-
-from ..blt.package import llnl_link_helpers
 
 
 class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/channelflow/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/channelflow/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Channelflow(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/cleverleaf/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cleverleaf/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Cleverleaf(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/clfft/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/clfft/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Clfft(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/clingo_bootstrap/package.py
@@ -4,11 +4,11 @@
 import glob
 import os
 
+from spack_repo.builtin.packages.clingo.package import Clingo
+
 import spack.paths
 import spack.user_environment
 from spack.package import *
-
-from ..clingo.package import Clingo
 
 
 class ClingoBootstrap(Clingo):

--- a/var/spack/repos/spack_repo/builtin/packages/cntk/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cntk/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Cntk(Package):

--- a/var/spack/repos/spack_repo/builtin/packages/coin3d/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/coin3d/package.py
@@ -5,10 +5,9 @@
 from spack_repo.builtin.build_systems import autotools, cmake
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Coin3d(AutotoolsPackage, CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/cray_mpich/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cray_mpich/package.py
@@ -7,11 +7,10 @@ import os
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.generic import Package
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 from spack.package import *
 from spack.util.module_cmd import get_path_args_from_module_line, module
-
-from ..mpich.package import MpichEnvironmentModifications
 
 
 class CrayMpich(MpichEnvironmentModifications, Package, CudaPackage, ROCmPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/cray_mvapich2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cray_mvapich2/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 from spack.package import *
-
-from ..mpich.package import MpichEnvironmentModifications
 
 
 class CrayMvapich2(MpichEnvironmentModifications, Package):

--- a/var/spack/repos/spack_repo/builtin/packages/dakota/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dakota/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 def submodules(package):

--- a/var/spack/repos/spack_repo/builtin/packages/dbow2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dbow2/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Dbow2(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/dealii/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dealii/package.py
@@ -6,10 +6,9 @@ import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Dealii(CMakePackage, CudaPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/dssp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dssp/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Dssp(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ecflow/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Ecflow(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/ethminer/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ethminer/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Ethminer(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/exaca/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/exaca/package.py
@@ -5,10 +5,9 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.kokkos.package import Kokkos
 
 from spack.package import *
-
-from ..kokkos.package import Kokkos
 
 
 class Exaca(CMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/extrae/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/extrae/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 # typical working line with extrae 3.0.1
 # ./configure

--- a/var/spack/repos/spack_repo/builtin/packages/fenics/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fenics/package.py
@@ -4,10 +4,9 @@
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.python import PythonPipBuilder
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Fenics(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/foam_extend/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/foam_extend/package.py
@@ -33,10 +33,14 @@ import os
 import re
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.openfoam.package import (
+    OpenfoamArch,
+    add_extra_files,
+    rewrite_environ_files,
+    write_environ,
+)
 
 from spack.package import *
-
-from ..openfoam.package import OpenfoamArch, add_extra_files, rewrite_environ_files, write_environ
 
 
 class FoamExtend(Package):

--- a/var/spack/repos/spack_repo/builtin/packages/foundationdb/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/foundationdb/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Foundationdb(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/fujitsu_fftw/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fujitsu_fftw/package.py
@@ -1,9 +1,9 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from spack.package import *
+from spack_repo.builtin.packages.fftw.package import FftwBase
 
-from ..fftw.package import FftwBase
+from spack.package import *
 
 
 class FujitsuFftw(FftwBase):

--- a/var/spack/repos/spack_repo/builtin/packages/fujitsu_frontistr/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fujitsu_frontistr/package.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.package import *
+from spack_repo.builtin.packages.frontistr.package import FrontistrBase
 
-from ..frontistr.package import FrontistrBase
+from spack.package import *
 
 
 class FujitsuFrontistr(FrontistrBase):

--- a/var/spack/repos/spack_repo/builtin/packages/gnuradio/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gnuradio/package.py
@@ -4,10 +4,9 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Gnuradio(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/gource/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gource/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Gource(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/graphblast/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/graphblast/package.py
@@ -4,10 +4,9 @@
 
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Graphblast(MakefilePackage, CudaPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/gromacs_chain_coordinate/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gromacs_chain_coordinate/package.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
+from spack_repo.builtin.packages.gromacs.package import CMakeBuilder as GromacsCMakeBuilder
+from spack_repo.builtin.packages.gromacs.package import Gromacs
 
-from ..gromacs.package import CMakeBuilder as GromacsCMakeBuilder
-from ..gromacs.package import Gromacs
+from spack.package import *
 
 
 class GromacsChainCoordinate(Gromacs):

--- a/var/spack/repos/spack_repo/builtin/packages/gromacs_swaxs/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gromacs_swaxs/package.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
+from spack_repo.builtin.packages.gromacs.package import CMakeBuilder as GromacsCMakeBuilder
+from spack_repo.builtin.packages.gromacs.package import Gromacs
 
-from ..gromacs.package import CMakeBuilder as GromacsCMakeBuilder
-from ..gromacs.package import Gromacs
+from spack.package import *
 
 
 class GromacsSwaxs(Gromacs):

--- a/var/spack/repos/spack_repo/builtin/packages/gunrock/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gunrock/package.py
@@ -4,10 +4,9 @@
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Gunrock(CMakePackage, CudaPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/helics/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/helics/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Helics(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/herwigpp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/herwigpp/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Herwigpp(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/highfive/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/highfive/package.py
@@ -4,10 +4,9 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Highfive(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/hisea/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hisea/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Hisea(MakefilePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/hpx/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hpx/package.py
@@ -8,10 +8,9 @@ import sys
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Hpx(CMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/hssp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hssp/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Hssp(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/hybrid_lambda/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hybrid_lambda/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class HybridLambda(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/ibmisc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/ibmisc/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Ibmisc(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/imp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/imp/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Imp(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
@@ -5,10 +5,9 @@ import os
 
 from spack_repo.builtin.build_systems.generic import Package
 from spack_repo.builtin.build_systems.oneapi import IntelOneApiPackage
+from spack_repo.builtin.packages.gcc_runtime.package import get_elf_libraries
 
 from spack.package import *
-
-from ..gcc_runtime.package import get_elf_libraries
 
 
 @IntelOneApiPackage.update_description

--- a/var/spack/repos/spack_repo/builtin/packages/jali/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/jali/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Jali(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/kea/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/kea/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Kea(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/kicad/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/kicad/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Kicad(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/lammps_example_plugin/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/lammps_example_plugin/package.py
@@ -5,10 +5,9 @@
 import datetime as dt
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.lammps.package import Lammps
 
 from spack.package import *
-
-from ..lammps.package import Lammps
 
 
 class LammpsExamplePlugin(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/libcudf/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libcudf/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Libcudf(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/libfive/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libfive/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Libfive(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/libint/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libint/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 TUNE_VARIANTS = (
     "none",

--- a/var/spack/repos/spack_repo/builtin/packages/libkml/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libkml/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Libkml(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libmesh/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Libmesh(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/libpulsar/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libpulsar/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Libpulsar(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/librom/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/librom/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Librom(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/llvm_amdgpu/package.py
@@ -7,10 +7,9 @@ import shutil
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack_repo.builtin.build_systems.compiler import CompilerPackage
+from spack_repo.builtin.packages.llvm.package import LlvmDetection
 
 from spack.package import *
-
-from ..llvm.package import LlvmDetection
 
 
 class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/lordec/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/lordec/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Lordec(MakefilePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/lua_luajit/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/lua_luajit/package.py
@@ -4,9 +4,9 @@
 
 import os
 
-from spack.package import *
+from spack_repo.builtin.packages.lua.package import LuaImplPackage
 
-from ..lua.package import LuaImplPackage
+from spack.package import *
 
 
 class LuaLuajit(LuaImplPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/lua_luajit_openresty/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/lua_luajit_openresty/package.py
@@ -4,9 +4,9 @@
 
 import os
 
-from spack.package import *
+from spack_repo.builtin.packages.lua.package import LuaImplPackage
 
-from ..lua.package import LuaImplPackage
+from spack.package import *
 
 
 class LuaLuajitOpenresty(LuaImplPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mallocmc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mallocmc/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Mallocmc(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mapnik/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mapnik/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Mapnik(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mariadb/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mariadb/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Mariadb(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/masurca/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/masurca/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Masurca(Package):

--- a/var/spack/repos/spack_repo/builtin/packages/meraculous/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/meraculous/package.py
@@ -4,10 +4,9 @@
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.sourceforge import SourceforgePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Meraculous(CMakePackage, SourceforgePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/metabat/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/metabat/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Metabat(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/metacarpa/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/metacarpa/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Metacarpa(MakefilePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/metall/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/metall/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Metall(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/miopen_hip/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/miopen_hip/package.py
@@ -5,10 +5,9 @@
 import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class MiopenHip(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/miopen_opencl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/miopen_opencl/package.py
@@ -5,10 +5,9 @@
 import re
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class MiopenOpencl(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mira/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mira/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Mira(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mrnet/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mrnet/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Mrnet(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mvapich/package.py
@@ -7,10 +7,9 @@ import re
 import sys
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 from spack.package import *
-
-from ..mpich.package import MpichEnvironmentModifications
 
 
 class Mvapich(MpichEnvironmentModifications, AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mvapich2/package.py
@@ -7,11 +7,10 @@ import re
 import sys
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 import spack.compilers.config
 from spack.package import *
-
-from ..mpich.package import MpichEnvironmentModifications
 
 
 class Mvapich2(MpichEnvironmentModifications, AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mvapich2_gdr/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mvapich2_gdr/package.py
@@ -5,10 +5,9 @@
 import sys
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 from spack.package import *
-
-from ..mpich.package import MpichEnvironmentModifications
 
 
 class Mvapich2Gdr(MpichEnvironmentModifications, AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mvapich2x/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mvapich2x/package.py
@@ -5,10 +5,9 @@
 import sys
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 from spack.package import *
-
-from ..mpich.package import MpichEnvironmentModifications
 
 
 class Mvapich2x(MpichEnvironmentModifications, AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/mysql/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mysql/package.py
@@ -6,10 +6,9 @@ import os
 import tempfile
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Mysql(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/n2p2/package.py
@@ -4,10 +4,9 @@
 import os
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class N2p2(MakefilePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/nix/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/nix/package.py
@@ -7,10 +7,9 @@ import stat
 import tempfile
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Nix(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/of_precice/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/of_precice/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.openfoam.package import add_extra_files
 
 from spack.package import *
-
-from ..openfoam.package import add_extra_files
 
 
 class OfPrecice(Package):

--- a/var/spack/repos/spack_repo/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openfoam/package.py
@@ -44,10 +44,9 @@ import os
 import re
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 # Not the nice way of doing things, but is a start for refactoring
 __all__ = [

--- a/var/spack/repos/spack_repo/builtin/packages/openfoam_org/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openfoam_org/package.py
@@ -39,16 +39,15 @@ import os
 import re
 
 from spack_repo.builtin.build_systems.generic import Package
-
-from spack.package import *
-
-from ..openfoam.package import (
+from spack_repo.builtin.packages.openfoam.package import (
     OpenfoamArch,
     add_extra_files,
     mplib_content,
     rewrite_environ_files,
     write_environ,
 )
+
+from spack.package import *
 
 
 class OpenfoamOrg(Package):

--- a/var/spack/repos/spack_repo/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openspeedshop/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Openspeedshop(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/openspeedshop_utils/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/openspeedshop_utils/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class OpenspeedshopUtils(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pagmo/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pagmo/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Pagmo(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/paradiseo/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/paradiseo/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Paradiseo(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/parquet_cpp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/parquet_cpp/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class ParquetCpp(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/parsplice/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/parsplice/package.py
@@ -4,10 +4,9 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Parsplice(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pcl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pcl/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Pcl(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_decl_hdf5/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_decl_hdf5/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.pdi.package import Pdi
 
 from spack.package import *
-
-from ..pdi.package import Pdi
 
 
 class PdipluginDeclHdf5(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_decl_netcdf/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_decl_netcdf/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.pdi.package import Pdi
 
 from spack.package import *
-
-from ..pdi.package import Pdi
 
 
 class PdipluginDeclNetcdf(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_mpi/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_mpi/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.pdi.package import Pdi
 
 from spack.package import *
-
-from ..pdi.package import Pdi
 
 
 class PdipluginMpi(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_pycall/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_pycall/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.pdi.package import Pdi
 
 from spack.package import *
-
-from ..pdi.package import Pdi
 
 
 class PdipluginPycall(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_serialize/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_serialize/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.pdi.package import Pdi
 
 from spack.package import *
-
-from ..pdi.package import Pdi
 
 
 class PdipluginSerialize(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_set_value/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_set_value/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.pdi.package import Pdi
 
 from spack.package import *
-
-from ..pdi.package import Pdi
 
 
 class PdipluginSetValue(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_trace/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_trace/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.pdi.package import Pdi
 
 from spack.package import *
-
-from ..pdi.package import Pdi
 
 
 class PdipluginTrace(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pdiplugin_user_code/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pdiplugin_user_code/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.pdi.package import Pdi
 
 from spack.package import *
-
-from ..pdi.package import Pdi
 
 
 class PdipluginUserCode(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/percept/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/percept/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Percept(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/percona_server/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/percona_server/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class PerconaServer(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/piranha/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/piranha/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Piranha(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/pktools/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/pktools/package.py
@@ -4,10 +4,9 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Pktools(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/polymake/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/polymake/package.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Polymake(Package):

--- a/var/spack/repos/spack_repo/builtin/packages/povray/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/povray/package.py
@@ -9,10 +9,9 @@ import getpass
 import socket
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Povray(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/py_espresso/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_espresso/package.py
@@ -4,10 +4,9 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class PyEspresso(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/py_fluidsim/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_fluidsim/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.python import PythonPackage
+from spack_repo.builtin.packages.py_fluidsim_core.package import PyFluidsimCore
 
 from spack.package import *
-
-from ..py_fluidsim_core.package import PyFluidsimCore
 
 
 class PyFluidsim(PythonPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/py_pillow_simd/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pillow_simd/package.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
+from spack_repo.builtin.packages.py_pillow.package import PyPillowBase
 
-from ..py_pillow.package import PyPillowBase
+from spack.package import *
 
 
 class PyPillowSimd(PyPillowBase):

--- a/var/spack/repos/spack_repo/builtin/packages/py_pycuda/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_pycuda/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.python import PythonPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class PyPycuda(PythonPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/py_python_mapnik/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_python_mapnik/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.python import PythonPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class PyPythonMapnik(PythonPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/py_quast/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_quast/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.python import PythonPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class PyQuast(PythonPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/qt_5compat/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/qt_5compat/package.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.package import *
+from spack_repo.builtin.packages.qt_base.package import QtBase, QtPackage
 
-from ..qt_base.package import QtBase, QtPackage
+from spack.package import *
 
 
 class Qt5compat(QtPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/qt_declarative/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/qt_declarative/package.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.package import *
+from spack_repo.builtin.packages.qt_base.package import QtBase, QtPackage
 
-from ..qt_base.package import QtBase, QtPackage
+from spack.package import *
 
 
 class QtDeclarative(QtPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/qt_quick3d/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/qt_quick3d/package.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.package import *
+from spack_repo.builtin.packages.qt_base.package import QtBase, QtPackage
 
-from ..qt_base.package import QtBase, QtPackage
+from spack.package import *
 
 
 class QtQuick3d(QtPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/qt_quicktimeline/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/qt_quicktimeline/package.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.package import *
+from spack_repo.builtin.packages.qt_base.package import QtBase, QtPackage
 
-from ..qt_base.package import QtBase, QtPackage
+from spack.package import *
 
 
 class QtQuicktimeline(QtPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/qt_shadertools/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/qt_shadertools/package.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.package import *
+from spack_repo.builtin.packages.qt_base.package import QtBase, QtPackage
 
-from ..qt_base.package import QtBase, QtPackage
+from spack.package import *
 
 
 class QtShadertools(QtPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/qt_svg/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/qt_svg/package.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.package import *
+from spack_repo.builtin.packages.qt_base.package import QtBase, QtPackage
 
-from ..qt_base.package import QtBase, QtPackage
+from spack.package import *
 
 
 class QtSvg(QtPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/qt_tools/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/qt_tools/package.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.package import *
+from spack_repo.builtin.packages.qt_base.package import QtBase, QtPackage
 
-from ..qt_base.package import QtBase, QtPackage
+from spack.package import *
 
 
 class QtTools(QtPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/r_phantompeakqualtools/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/r_phantompeakqualtools/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.r import RPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class RPhantompeakqualtools(RPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/raja/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/raja/package.py
@@ -12,10 +12,9 @@ from spack_repo.builtin.build_systems.cached_cmake import (
 )
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.blt.package import llnl_link_helpers
 
 from spack.package import *
-
-from ..blt.package import llnl_link_helpers
 
 
 # Starting with 2022.03.0, the only submodule we want to fetch is tpl/desul

--- a/var/spack/repos/spack_repo/builtin/packages/raja_perf/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/raja_perf/package.py
@@ -12,10 +12,9 @@ from spack_repo.builtin.build_systems.cached_cmake import (
 )
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.blt.package import llnl_link_helpers
 
 from spack.package import *
-
-from ..blt.package import llnl_link_helpers
 
 
 class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/revbayes/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/revbayes/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Revbayes(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/rocm_tensile/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rocm_tensile/package.py
@@ -4,10 +4,9 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class RocmTensile(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/rose/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rose/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Rose(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/rpp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rpp/package.py
@@ -4,10 +4,9 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Rpp(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/sailfish/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/sailfish/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Sailfish(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/samrai/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/samrai/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Samrai(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/scantailor/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/scantailor/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Scantailor(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/sgpp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/sgpp/package.py
@@ -6,10 +6,9 @@ import sys
 
 from spack_repo.builtin.build_systems.python import PythonPipBuilder
 from spack_repo.builtin.build_systems.scons import SConsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Sgpp(SConsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/shark/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/shark/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Shark(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/singularity/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/singularity/package.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
+from spack_repo.builtin.packages.singularityce.package import SingularityBase
 
-from ..singularityce.package import SingularityBase
+from spack.package import *
 
 
 class Singularity(SingularityBase):

--- a/var/spack/repos/spack_repo/builtin/packages/spot/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/spot/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Spot(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/stat/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/stat/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Stat(AutotoolsPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/symengine/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/symengine/package.py
@@ -5,10 +5,9 @@
 import sys
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Symengine(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/sympol/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/sympol/package.py
@@ -4,10 +4,9 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Sympol(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/trilinos/package.py
@@ -10,12 +10,11 @@ import sys
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.kokkos.package import Kokkos
 
 from spack.build_environment import dso_suffix
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *
-
-from ..kokkos.package import Kokkos
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:

--- a/var/spack/repos/spack_repo/builtin/packages/umpire/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/umpire/package.py
@@ -13,10 +13,9 @@ from spack_repo.builtin.build_systems.cached_cmake import (
 )
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
+from spack_repo.builtin.packages.blt.package import llnl_link_helpers
 
 from spack.package import *
-
-from ..blt.package import llnl_link_helpers
 
 
 class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/spack_repo/builtin/packages/vigra/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/vigra/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Vigra(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/votca_csg_tutorials/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/votca_csg_tutorials/package.py
@@ -4,10 +4,9 @@
 
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class VotcaCsgTutorials(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/vtk/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/vtk/package.py
@@ -7,10 +7,9 @@ import glob
 import os
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Vtk(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/wcs/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/wcs/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Wcs(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/wonton/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/wonton/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Wonton(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/wt/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/wt/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Wt(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/xdmf3/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/xdmf3/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Xdmf3(CMakePackage):

--- a/var/spack/repos/spack_repo/builtin/packages/xios/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/xios/package.py
@@ -5,10 +5,9 @@
 import os
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 
 class Xios(Package):

--- a/var/spack/repos/spack_repo/builtin/packages/yaml_cpp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/yaml_cpp/package.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.packages.boost.package import Boost
 
 from spack.package import *
-
-from ..boost.package import Boost
 
 yaml_cpp_tests_libcxx_error_msg = "yaml-cpp tests incompatible with libc++"
 


### PR DESCRIPTION
The idea is that absolute imports make it easier to copy a recipe into a
different repo, which is useful for people who build using package.py in their
package repository itself.

