### PR TITLE
solver: dedent blocks, rename a few facts

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2644,16 +2644,26 @@ class SpackSolverSetup:
                     concrete_build_deps=concrete_build_deps,
                     context=context,
                 )
-                if dspec.depflag == dt.BUILD:
-                    edge_clauses.append(fn.attr("depends_on", spec.name, dep.name, "build"))
-                    if body is False:
-                        for clause in dependency_clauses:
-                            clause.name = "build_requirement"
-                            edge_clauses.append(fn.attr("direct_dependency", spec.name, clause))
-                    else:
-                        edge_clauses.extend(dependency_clauses)
-                else:
+                ###
+                # Dependency expressed with "^"
+                ###
+                if not dspec.depflag == dt.BUILD:
                     edge_clauses.extend(dependency_clauses)
+                    continue
+
+                ###
+                # Direct dependencies expressed with "%"
+                ###
+                edge_clauses.append(fn.attr("depends_on", spec.name, dep.name, "build"))
+                # Body of a rule
+                if body is True:
+                    edge_clauses.extend(dependency_clauses)
+                    continue
+
+                # Head of a rule
+                for clause in dependency_clauses:
+                    clause.name = "build_requirement"
+                    edge_clauses.append(fn.attr("direct_dependency", spec.name, clause))
 
         clauses.extend(edge_clauses)
         return clauses

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2573,6 +2573,7 @@ class SpackSolverSetup:
         # add all clauses from dependencies
         if transitive:
             # TODO: Eventually distinguish 2 deps on the same pkg (build and link)
+            edge_clauses = []
             for dspec in spec.edges_to_dependencies():
                 dep = dspec.spec
 
@@ -2580,7 +2581,7 @@ class SpackSolverSetup:
                     # GCC runtime is solved again by clingo, even on concrete specs, to give
                     # the possibility to reuse specs built against a different runtime.
                     if dep.name == "gcc-runtime":
-                        clauses.append(
+                        edge_clauses.append(
                             fn.attr("compatible_runtime", spec.name, dep.name, f"{dep.version}:")
                         )
                         constraint_spec = spack.spec.Spec(f"{dep.name}@{dep.version}")
@@ -2590,10 +2591,10 @@ class SpackSolverSetup:
                     # libc is also solved again by clingo, but in this case the compatibility
                     # is not encoded in the parent node - so we need to emit explicit facts
                     if "libc" in dspec.virtuals:
-                        clauses.append(fn.attr("needs_libc", spec.name))
+                        edge_clauses.append(fn.attr("needs_libc", spec.name))
                         for libc in self.libcs:
                             if libc_is_compatible(libc, dep):
-                                clauses.append(
+                                edge_clauses.append(
                                     fn.attr("compatible_libc", spec.name, libc.name, libc.version)
                                 )
                         continue
@@ -2605,29 +2606,29 @@ class SpackSolverSetup:
                             continue
                         # skip build dependencies of already-installed specs
                         if concrete_build_deps or dtype != dt.BUILD:
-                            clauses.append(
+                            edge_clauses.append(
                                 fn.attr(
                                     "depends_on", spec.name, dep.name, dt.flag_to_string(dtype)
                                 )
                             )
                             for virtual_name in dspec.virtuals:
-                                clauses.append(
+                                edge_clauses.append(
                                     fn.attr("virtual_on_edge", spec.name, dep.name, virtual_name)
                                 )
-                                clauses.append(fn.attr("virtual_node", virtual_name))
+                                edge_clauses.append(fn.attr("virtual_node", virtual_name))
 
                     # imposing hash constraints for all but pure build deps of
                     # already-installed concrete specs.
                     if concrete_build_deps or dspec.depflag != dt.BUILD:
-                        clauses.append(fn.attr("hash", dep.name, dep.dag_hash()))
+                        edge_clauses.append(fn.attr("hash", dep.name, dep.dag_hash()))
                     elif not concrete_build_deps and dspec.depflag:
-                        clauses.append(
+                        edge_clauses.append(
                             fn.attr(
                                 "concrete_build_dependency", spec.name, dep.name, dep.dag_hash()
                             )
                         )
                         for virtual_name in dspec.virtuals:
-                            clauses.append(
+                            edge_clauses.append(
                                 fn.attr("virtual_on_build_edge", spec.name, dep.name, virtual_name)
                             )
 
@@ -2643,16 +2644,17 @@ class SpackSolverSetup:
                         context=context,
                     )
                     if dspec.depflag == dt.BUILD:
-                        clauses.append(fn.attr("depends_on", spec.name, dep.name, "build"))
+                        edge_clauses.append(fn.attr("depends_on", spec.name, dep.name, "build"))
                         if body is False:
                             for clause in dependency_clauses:
                                 clause.name = "build_requirement"
-                                clauses.append(fn.attr("direct_dependency", spec.name, clause))
+                                edge_clauses.append(fn.attr("direct_dependency", spec.name, clause))
                         else:
-                            clauses.extend(dependency_clauses)
+                            edge_clauses.extend(dependency_clauses)
                     else:
-                        clauses.extend(dependency_clauses)
+                        edge_clauses.extend(dependency_clauses)
 
+            clauses.extend(edge_clauses)
         return clauses
 
     def define_package_versions_and_validate_preferences(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2546,7 +2546,7 @@ class SpackSolverSetup:
                         )
                     )
 
-        # dependencies
+        # Hash for concrete specs
         if spec.concrete:
             # older specs do not have package hashes, so we have to do this carefully
             package_hash = getattr(spec, "_package_hash", None)
@@ -2555,7 +2555,7 @@ class SpackSolverSetup:
             clauses.append(fn.attr("hash", spec.name, spec.dag_hash()))
 
         edges = spec.edges_from_dependents()
-        virtuals = [x for x in itertools.chain.from_iterable([edge.virtuals for edge in edges])]
+        virtuals = sorted({x for x in itertools.chain.from_iterable([edge.virtuals for edge in edges])})
         if not body and not spec.concrete:
             for virtual in virtuals:
                 clauses.append(fn.attr("provider_set", spec.name, virtual))
@@ -2570,91 +2570,92 @@ class SpackSolverSetup:
             for libc in self.libcs:
                 clauses.append(fn.attr("compatible_libc", spec.name, libc.name, libc.version))
 
-        # add all clauses from dependencies
-        if transitive:
-            # TODO: Eventually distinguish 2 deps on the same pkg (build and link)
-            edge_clauses = []
-            for dspec in spec.edges_to_dependencies():
-                dep = dspec.spec
+        if not transitive:
+            return clauses
 
-                if spec.concrete:
-                    # GCC runtime is solved again by clingo, even on concrete specs, to give
-                    # the possibility to reuse specs built against a different runtime.
-                    if dep.name == "gcc-runtime":
-                        edge_clauses.append(
-                            fn.attr("compatible_runtime", spec.name, dep.name, f"{dep.version}:")
-                        )
-                        constraint_spec = spack.spec.Spec(f"{dep.name}@{dep.version}")
-                        self.spec_versions(constraint_spec)
-                        continue
+        # Dependencies
+        edge_clauses = []
+        for dspec in spec.edges_to_dependencies():
+            dep = dspec.spec
 
-                    # libc is also solved again by clingo, but in this case the compatibility
-                    # is not encoded in the parent node - so we need to emit explicit facts
-                    if "libc" in dspec.virtuals:
-                        edge_clauses.append(fn.attr("needs_libc", spec.name))
-                        for libc in self.libcs:
-                            if libc_is_compatible(libc, dep):
-                                edge_clauses.append(
-                                    fn.attr("compatible_libc", spec.name, libc.name, libc.version)
-                                )
-                        continue
+            if spec.concrete:
+                # GCC runtime is solved again by clingo, even on concrete specs, to give
+                # the possibility to reuse specs built against a different runtime.
+                if dep.name == "gcc-runtime":
+                    edge_clauses.append(
+                        fn.attr("compatible_runtime", spec.name, dep.name, f"{dep.version}:")
+                    )
+                    constraint_spec = spack.spec.Spec(f"{dep.name}@{dep.version}")
+                    self.spec_versions(constraint_spec)
+                    continue
 
-                    # We know dependencies are real for concrete specs. For abstract
-                    # specs they just mean the dep is somehow in the DAG.
-                    for dtype in dt.ALL_FLAGS:
-                        if not dspec.depflag & dtype:
-                            continue
-                        # skip build dependencies of already-installed specs
-                        if concrete_build_deps or dtype != dt.BUILD:
+                # libc is also solved again by clingo, but in this case the compatibility
+                # is not encoded in the parent node - so we need to emit explicit facts
+                if "libc" in dspec.virtuals:
+                    edge_clauses.append(fn.attr("needs_libc", spec.name))
+                    for libc in self.libcs:
+                        if libc_is_compatible(libc, dep):
                             edge_clauses.append(
-                                fn.attr(
-                                    "depends_on", spec.name, dep.name, dt.flag_to_string(dtype)
-                                )
+                                fn.attr("compatible_libc", spec.name, libc.name, libc.version)
                             )
-                            for virtual_name in dspec.virtuals:
-                                edge_clauses.append(
-                                    fn.attr("virtual_on_edge", spec.name, dep.name, virtual_name)
-                                )
-                                edge_clauses.append(fn.attr("virtual_node", virtual_name))
+                    continue
 
-                    # imposing hash constraints for all but pure build deps of
-                    # already-installed concrete specs.
-                    if concrete_build_deps or dspec.depflag != dt.BUILD:
-                        edge_clauses.append(fn.attr("hash", dep.name, dep.dag_hash()))
-                    elif not concrete_build_deps and dspec.depflag:
+                # We know dependencies are real for concrete specs. For abstract
+                # specs they just mean the dep is somehow in the DAG.
+                for dtype in dt.ALL_FLAGS:
+                    if not dspec.depflag & dtype:
+                        continue
+                    # skip build dependencies of already-installed specs
+                    if concrete_build_deps or dtype != dt.BUILD:
                         edge_clauses.append(
                             fn.attr(
-                                "concrete_build_dependency", spec.name, dep.name, dep.dag_hash()
+                                "depends_on", spec.name, dep.name, dt.flag_to_string(dtype)
                             )
                         )
                         for virtual_name in dspec.virtuals:
                             edge_clauses.append(
-                                fn.attr("virtual_on_build_edge", spec.name, dep.name, virtual_name)
+                                fn.attr("virtual_on_edge", spec.name, dep.name, virtual_name)
                             )
+                            edge_clauses.append(fn.attr("virtual_node", virtual_name))
 
-                # if the spec is abstract, descend into dependencies.
-                # if it's concrete, then the hashes above take care of dependency
-                # constraints, but expand the hashes if asked for.
-                if not spec.concrete or expand_hashes:
-                    dependency_clauses = self._spec_clauses(
-                        dep,
-                        body=body,
-                        expand_hashes=expand_hashes,
-                        concrete_build_deps=concrete_build_deps,
-                        context=context,
+                # imposing hash constraints for all but pure build deps of
+                # already-installed concrete specs.
+                if concrete_build_deps or dspec.depflag != dt.BUILD:
+                    edge_clauses.append(fn.attr("hash", dep.name, dep.dag_hash()))
+                elif not concrete_build_deps and dspec.depflag:
+                    edge_clauses.append(
+                        fn.attr(
+                            "concrete_build_dependency", spec.name, dep.name, dep.dag_hash()
+                        )
                     )
-                    if dspec.depflag == dt.BUILD:
-                        edge_clauses.append(fn.attr("depends_on", spec.name, dep.name, "build"))
-                        if body is False:
-                            for clause in dependency_clauses:
-                                clause.name = "build_requirement"
-                                edge_clauses.append(fn.attr("direct_dependency", spec.name, clause))
-                        else:
-                            edge_clauses.extend(dependency_clauses)
+                    for virtual_name in dspec.virtuals:
+                        edge_clauses.append(
+                            fn.attr("virtual_on_build_edge", spec.name, dep.name, virtual_name)
+                        )
+
+            # if the spec is abstract, descend into dependencies.
+            # if it's concrete, then the hashes above take care of dependency
+            # constraints, but expand the hashes if asked for.
+            if not spec.concrete or expand_hashes:
+                dependency_clauses = self._spec_clauses(
+                    dep,
+                    body=body,
+                    expand_hashes=expand_hashes,
+                    concrete_build_deps=concrete_build_deps,
+                    context=context,
+                )
+                if dspec.depflag == dt.BUILD:
+                    edge_clauses.append(fn.attr("depends_on", spec.name, dep.name, "build"))
+                    if body is False:
+                        for clause in dependency_clauses:
+                            clause.name = "build_requirement"
+                            edge_clauses.append(fn.attr("direct_dependency", spec.name, clause))
                     else:
                         edge_clauses.extend(dependency_clauses)
+                else:
+                    edge_clauses.extend(dependency_clauses)
 
-            clauses.extend(edge_clauses)
+        clauses.extend(edge_clauses)
         return clauses
 
     def define_package_versions_and_validate_preferences(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2555,7 +2555,9 @@ class SpackSolverSetup:
             clauses.append(fn.attr("hash", spec.name, spec.dag_hash()))
 
         edges = spec.edges_from_dependents()
-        virtuals = sorted({x for x in itertools.chain.from_iterable([edge.virtuals for edge in edges])})
+        virtuals = sorted(
+            {x for x in itertools.chain.from_iterable([edge.virtuals for edge in edges])}
+        )
         if not body and not spec.concrete:
             for virtual in virtuals:
                 clauses.append(fn.attr("provider_set", spec.name, virtual))
@@ -2608,9 +2610,7 @@ class SpackSolverSetup:
                     # skip build dependencies of already-installed specs
                     if concrete_build_deps or dtype != dt.BUILD:
                         edge_clauses.append(
-                            fn.attr(
-                                "depends_on", spec.name, dep.name, dt.flag_to_string(dtype)
-                            )
+                            fn.attr("depends_on", spec.name, dep.name, dt.flag_to_string(dtype))
                         )
                         for virtual_name in dspec.virtuals:
                             edge_clauses.append(
@@ -2624,9 +2624,7 @@ class SpackSolverSetup:
                     edge_clauses.append(fn.attr("hash", dep.name, dep.dag_hash()))
                 elif not concrete_build_deps and dspec.depflag:
                     edge_clauses.append(
-                        fn.attr(
-                            "concrete_build_dependency", spec.name, dep.name, dep.dag_hash()
-                        )
+                        fn.attr("concrete_build_dependency", spec.name, dep.name, dep.dag_hash())
                     )
                     for virtual_name in dspec.virtuals:
                         edge_clauses.append(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -305,7 +305,7 @@ def remove_build_deps(spec: spack.spec.Spec, facts: List[AspFunction]) -> List[A
         current_name = x.args[1]
         if current_name in build_deps:
             x.name = "build_requirement"
-            result.append(fn.attr("build_requirement", build_deps[current_name], x))
+            result.append(fn.attr("direct_dependency", build_deps[current_name], x))
             continue
 
         if x.args[0] == "depends_on":
@@ -2322,7 +2322,7 @@ class SpackSolverSetup:
                     for asp_fn in requirements:
                         if asp_fn.args[0] == "depends_on":
                             continue
-                        elif asp_fn.args[0] == "build_requirement":
+                        elif asp_fn.args[0] == "direct_dependency":
                             asp_fn.args = "external_build_requirement", *asp_fn.args[1:]
                         if asp_fn.args[1] != input_spec.name:
                             continue
@@ -2647,7 +2647,7 @@ class SpackSolverSetup:
                         if body is False:
                             for clause in dependency_clauses:
                                 clause.name = "build_requirement"
-                                clauses.append(fn.attr("build_requirement", spec.name, clause))
+                                clauses.append(fn.attr("direct_dependency", spec.name, clause))
                         else:
                             clauses.extend(dependency_clauses)
                     else:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -187,7 +187,7 @@ literal_node(Root, node(min_dupe_id, Root)) :-  mentioned_in_literal(Root, Root)
   literal_node(Root, LiteralNode),
   build(LiteralNode),
   not external(LiteralNode),
-  attr("build_requirement", LiteralNode, build_requirement("node", BuildDependency)).
+  attr("direct_dependency", LiteralNode, build_requirement("node", BuildDependency)).
 
 condition_set(node(min_dupe_id, Root), LiteralNode) :- literal_node(Root, LiteralNode).
 condition_set(LiteralNode, BuildNode) :- build_dependency_of_literal_node(LiteralNode, BuildNode).
@@ -512,62 +512,62 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
 % If the parent is built, then we have a build_requirement on another node. For concrete nodes,
 % or external nodes, we don't since we are trimming their build dependencies.
 1 { attr("depends_on",  node(X, Parent), node(0..Y-1, BuildDependency), "build") : max_dupes(BuildDependency, Y) } 1
-  :- attr("build_requirement", node(X, Parent), build_requirement("node", BuildDependency)),
+  :- attr("direct_dependency", node(X, Parent), build_requirement("node", BuildDependency)),
      build(node(X, Parent)),
      not external(node(X, Parent)).
 
 % Concrete nodes
-:- attr("build_requirement", ParentNode, build_requirement("node", BuildDependency)),
+:- attr("direct_dependency", ParentNode, build_requirement("node", BuildDependency)),
    concrete(ParentNode),
    not attr("concrete_build_dependency", ParentNode, BuildDependency, _).
 
-:- attr("build_requirement", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
+:- attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not 1 { pkg_fact(BuildDependency, version_satisfies(Constraint, Version)) : hash_attr(BuildDependencyHash, "version", BuildDependency, Version) } 1.
 
-:- attr("build_requirement", ParentNode, build_requirement("provider_set", BuildDependency, Virtual)),
+:- attr("direct_dependency", ParentNode, build_requirement("provider_set", BuildDependency, Virtual)),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    attr("virtual_on_build_edge", ParentNode, BuildDependency, Virtual),
    not 1 { pkg_fact(BuildDependency, version_satisfies(Constraint, Version)) : hash_attr(BuildDependencyHash, "version", BuildDependency, Version) } 1.
 
 error(100, "Cannot satisfy the request on {0} to have {1}={2}", BuildDependency, Variant, Value)
-:- attr("build_requirement", ParentNode, build_requirement("variant_set", BuildDependency, Variant, Value)),
+:- attr("direct_dependency", ParentNode, build_requirement("variant_set", BuildDependency, Variant, Value)),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not hash_attr(BuildDependencyHash, "variant_value", BuildDependency, Variant, Value).
 
 error(100, "Cannot satisfy the request on {0} to have the target set to {1}", BuildDependency, Target)
-:- attr("build_requirement", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
+:- attr("direct_dependency", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not hash_attr(BuildDependencyHash, "node_target", BuildDependency, Target).
 
 error(100, "Cannot satisfy the request on {0} to have the os set to {1}", BuildDependency, NodeOS)
-:- attr("build_requirement", ParentNode, build_requirement("node_os_set", BuildDependency, NodeOS)),
+:- attr("direct_dependency", ParentNode, build_requirement("node_os_set", BuildDependency, NodeOS)),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not hash_attr(BuildDependencyHash, "node_os", BuildDependency, NodeOS).
 
 error(100, "Cannot satisfy the request on {0} to have the platform set to {1}", BuildDependency, Platform)
-:- attr("build_requirement", ParentNode, build_requirement("node_platform_set", BuildDependency, Platform)),
+:- attr("direct_dependency", ParentNode, build_requirement("node_platform_set", BuildDependency, Platform)),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not hash_attr(BuildDependencyHash, "node_platform", BuildDependency, Platform).
 
 error(100, "Cannot satisfy the request on {0} to have the following hash {1}", BuildDependency, BuildHash)
-:- attr("build_requirement", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
+:- attr("direct_dependency", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
-   attr("build_requirement", ParentNode, build_requirement("hash", BuildDependency, BuildHash)),
+   attr("direct_dependency", ParentNode, build_requirement("hash", BuildDependency, BuildHash)),
    BuildHash != BuildDependencyHash.
 
 % External nodes
-:- attr("build_requirement", ParentNode, build_requirement("node", BuildDependency)),
+:- attr("direct_dependency", ParentNode, build_requirement("node", BuildDependency)),
    external(ParentNode),
    not attr("external_build_requirement", ParentNode, build_requirement("node", BuildDependency)).
 
 candidate_external_version(Constraint, BuildDependency, Version)
-  :- attr("build_requirement", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
+  :- attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
      external(ParentNode),
      pkg_fact(BuildDependency, version_satisfies(Constraint, Version)).
 
 error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, LiteralConstraint, ExternalConstraint)
-  :- attr("build_requirement", ParentNode, build_requirement("node_version_satisfies", BuildDependency, LiteralConstraint)),
+  :- attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, LiteralConstraint)),
      external(ParentNode),
      attr("external_build_requirement", ParentNode, build_requirement("node_version_satisfies", BuildDependency, ExternalConstraint)),
      not 1 { pkg_fact(BuildDependency, version_satisfies(ExternalConstraint, Version)) : candidate_external_version(LiteralConstraint, BuildDependency, Version) }.
@@ -575,13 +575,13 @@ error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, Lite
 
 % Asking for gcc@10 %gcc@9 shouldn't give us back an external gcc@10, just because of the hack
 % we have on externals
-:- attr("build_requirement", node(X, Parent), build_requirement("node", BuildDependency)),
+:- attr("direct_dependency", node(X, Parent), build_requirement("node", BuildDependency)),
    Parent == BuildDependency,
    external(node(X, Parent)).
 
 build_requirement(node(X, Parent), node(Y, BuildDependency)) :-
   attr("depends_on", node(X, Parent), node(Y, BuildDependency), "build"),
-  attr("build_requirement", node(X, Parent), build_requirement("node", BuildDependency)).
+  attr("direct_dependency", node(X, Parent), build_requirement("node", BuildDependency)).
 
 1 { virtual_build_requirement(ParentNode, node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1
   :- attr("dependency_holds", ParentNode, Virtual, "build"),
@@ -596,10 +596,10 @@ build_requirement(ParentNode, ProviderNode) :- virtual_build_requirement(ParentN
 %
 % root %gcc@12.0 ^dep %gcc@11.2
 %
-% Adding a "build_requirement" is a way to discriminate between the incompatible
+% Adding a "direct_dependency" is a way to discriminate between the incompatible
 % version constraints on "gcc" in the "imposed_constraint".
 attr("node_version_satisfies", node(X, BuildDependency), Constraint) :-
-  attr("build_requirement", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
+  attr("direct_dependency", ParentNode, build_requirement("node_version_satisfies", BuildDependency, Constraint)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 % Account for properties on the build requirements
@@ -607,30 +607,30 @@ attr("node_version_satisfies", node(X, BuildDependency), Constraint) :-
 % root %gcc@12.0 <properties for gcc> ^dep
 %
 attr("variant_set", node(X, BuildDependency), Variant, Value) :-
-  attr("build_requirement", ParentNode, build_requirement("variant_set", BuildDependency, Variant, Value)),
+  attr("direct_dependency", ParentNode, build_requirement("variant_set", BuildDependency, Variant, Value)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 attr("depends_on",  node(X, Parent), node(Y, BuildDependency), "build") :- build_requirement(node(X, Parent), node(Y, BuildDependency)).
 
 attr("node_target_set", node(X, BuildDependency), Target) :-
-  attr("build_requirement", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
+  attr("direct_dependency", ParentNode, build_requirement("node_target_set", BuildDependency, Target)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 attr("node_os_set", node(X, BuildDependency), NodeOS) :-
-  attr("build_requirement", ParentNode, build_requirement("node_os_set", BuildDependency, NodeOS)),
+  attr("direct_dependency", ParentNode, build_requirement("node_os_set", BuildDependency, NodeOS)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 attr("node_platform_set", node(X, BuildDependency), NodePlatform) :-
-  attr("build_requirement", ParentNode, build_requirement("node_platform_set", BuildDependency, NodePlatform)),
+  attr("direct_dependency", ParentNode, build_requirement("node_platform_set", BuildDependency, NodePlatform)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 attr("hash", node(X, BuildDependency), BuildHash) :-
-  attr("build_requirement", ParentNode, build_requirement("hash", BuildDependency, BuildHash)),
+  attr("direct_dependency", ParentNode, build_requirement("hash", BuildDependency, BuildHash)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 
 1 { attr("provider_set", node(X, BuildDependency), node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1 :-
-  attr("build_requirement", ParentNode, build_requirement("provider_set", BuildDependency, Virtual)),
+  attr("direct_dependency", ParentNode, build_requirement("provider_set", BuildDependency, Virtual)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
 % Reconstruct virtual dependencies for reused specs
@@ -1013,7 +1013,7 @@ requirement_weight(node(ID, Package), Group, W) :-
   requirement_policy(Package, Group, "one_of"),
   requirement_group_satisfied(node(ID, Package), Group).
 
- { attr("build_requirement", node(ID, Package), BuildRequirement) : condition_requirement(TriggerID, "build_requirement", Package, BuildRequirement) } :-
+ { attr("direct_dependency", node(ID, Package), BuildRequirement) : condition_requirement(TriggerID, "direct_dependency", Package, BuildRequirement) } :-
   pkg_fact(Package, condition_trigger(ConditionID, TriggerID)),
   requirement_group_member(ConditionID, Package, Group),
   activate_requirement(node(ID, Package), Group),


### PR DESCRIPTION
Extracted from #50565

Refactors to improve code quality:
- [x] De-dented a few blocks of code in `asp.py`
- [x] Renamed `build_requirement` -> `direct_dependency`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
