### PR TITLE
Generalize buildcache fetching

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -749,7 +749,9 @@ def _url_generate_package_index(url: str, tmpdir: str):
     """
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
         try:
-            file_list, read_fn = get_entries_from_cache(url, tmpspecsdir)
+            file_list, read_fn = get_entries_from_cache(
+                url, tmpspecsdir, component_type=BuildcacheComponent.SPEC
+            )
         except ListMirrorSpecsError as e:
             raise GenerateIndexError(f"Unable to generate package index: {e}") from e
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -92,6 +92,7 @@ from .url_buildcache import (
     BuildcacheEntryError,
     BuildcacheManifest,
     InvalidMetadataFile,
+    ListMirrorSpecsError,
     MirrorForSpec,
     MirrorURLAndVersion,
     URLBuildcacheEntry,
@@ -2955,10 +2956,6 @@ class UnsignedPackageException(spack.error.SpackError):
     Raised if installation of unsigned package is attempted without
     the use of ``--no-check-signature``.
     """
-
-
-class ListMirrorSpecsError(spack.error.SpackError):
-    """Raised when unable to retrieve list of specs from the mirror"""
 
 
 class GenerateIndexError(spack.error.SpackError):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -701,7 +701,7 @@ def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str):
 
 def _read_specs_and_push_index(
     file_list: List[str],
-    read_method: Callable,
+    read_method: Callable[[str], URLBuildcacheEntry],
     cache_prefix: str,
     db: BuildCacheDatabase,
     temp_dir: str,
@@ -717,11 +717,18 @@ def _read_specs_and_push_index(
         temp_dir: Location to write index.json and hash for pushing
     """
     for file in file_list:
+        cache_entry: Optional[URLBuildcacheEntry] = None
         try:
-            fetched_spec = spack.spec.Spec.from_dict(read_method(file))
+            cache_entry = read_method(file)
+            spec_dict = cache_entry.fetch_metadata()
+            cache_entry.destroy()
+            fetched_spec = spack.spec.Spec.from_dict(spec_dict)
         except Exception as e:
             tty.warn(f"Unable to fetch spec for manifest {file} due to: {e}")
             continue
+        finally:
+            if cache_entry:
+                cache_entry.destroy()
         db.add(fetched_spec)
         db.mark(fetched_spec, "in_buildcache", True)
 
@@ -746,13 +753,11 @@ def _specs_from_cache_aws_cli(url: str, tmpspecsdir: str):
         tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
         return file_list, read_fn
 
-    def file_read_method(manifest_path):
+    def file_read_method(manifest_path: str) -> URLBuildcacheEntry:
         cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
-        cache_entry = cache_class(url, allow_unsigned=True)
+        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
         cache_entry.read_manifest(manifest_url=f"file://{manifest_path}")
-        spec_dict = cache_entry.fetch_metadata()
-        cache_entry.destroy()
-        return spec_dict
+        return cache_entry
 
     url_to_list = url_util.join(url, buildcache_relative_specs_url())
     sync_command_args = [
@@ -791,13 +796,11 @@ def _specs_from_cache_fallback(url: str, tmpspecsdir: str):
     read_fn = None
     file_list = None
 
-    def url_read_method(manifest_url):
+    def url_read_method(manifest_url: str) -> URLBuildcacheEntry:
         cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
-        cache_entry = cache_class(url, allow_unsigned=True)
+        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
         cache_entry.read_manifest(manifest_url)
-        spec_dict = cache_entry.fetch_metadata()
-        cache_entry.destroy()
-        return spec_dict
+        return cache_entry
 
     try:
         url_to_list = url_util.join(url, buildcache_relative_specs_url())

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -723,7 +723,6 @@ def _read_specs_and_push_index(
         try:
             cache_entry = read_method(file)
             spec_dict = cache_entry.fetch_metadata()
-            cache_entry.destroy()
             fetched_spec = spack.spec.Spec.from_dict(spec_dict)
         except Exception as e:
             tty.warn(f"Unable to fetch spec for manifest {file} due to: {e}")

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -95,9 +95,9 @@ from .url_buildcache import (
     MirrorForSpec,
     MirrorURLAndVersion,
     URLBuildcacheEntry,
+    get_entries_from_cache,
     get_url_buildcache_class,
     get_valid_spec_file,
-    get_entries_from_cache,
 )
 
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -97,6 +97,7 @@ from .url_buildcache import (
     URLBuildcacheEntry,
     get_url_buildcache_class,
     get_valid_spec_file,
+    _spec_files_from_cache,
 )
 
 
@@ -733,117 +734,6 @@ def _read_specs_and_push_index(
         db.mark(fetched_spec, "in_buildcache", True)
 
     _push_index(db, temp_dir, cache_prefix)
-
-
-def _specs_from_cache_aws_cli(url: str, tmpspecsdir: str):
-    """Use aws cli to sync all the specs into a local temporary directory.
-
-    Args:
-        url: prefix of the build cache on s3
-        tmpspecsdir: path to temporary directory to use for writing files
-
-    Return:
-        List of the local file paths and a function that can read each one from the file system.
-    """
-    read_fn = None
-    file_list = None
-    aws = which("aws")
-
-    if not aws:
-        tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
-        return file_list, read_fn
-
-    def file_read_method(manifest_path: str) -> URLBuildcacheEntry:
-        cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
-        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
-        cache_entry.read_manifest(manifest_url=f"file://{manifest_path}")
-        return cache_entry
-
-    url_to_list = url_util.join(url, buildcache_relative_specs_url())
-    sync_command_args = [
-        "s3",
-        "sync",
-        "--exclude",
-        "*",
-        "--include",
-        "*.spec.manifest.json",
-        url_to_list,
-        tmpspecsdir,
-    ]
-
-    tty.debug(f"Using aws s3 sync to download manifests from {url_to_list} to {tmpspecsdir}")
-
-    try:
-        aws(*sync_command_args, output=os.devnull, error=os.devnull)
-        file_list = fsys.find(tmpspecsdir, ["*.spec.manifest.json"])
-        read_fn = file_read_method
-    except Exception:
-        tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
-
-    return file_list, read_fn
-
-
-def _specs_from_cache_fallback(url: str, tmpspecsdir: str):
-    """Use spack.util.web module to get a list of all the specs at the remote url.
-
-    Args:
-        cache_prefix (str): Base url of mirror (location of spec files)
-
-    Return:
-        The list of complete spec file urls and a function that can read each one from its
-            remote location (also using the spack.util.web module).
-    """
-    read_fn = None
-    file_list = None
-
-    def url_read_method(manifest_url: str) -> URLBuildcacheEntry:
-        cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
-        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
-        cache_entry.read_manifest(manifest_url)
-        return cache_entry
-
-    try:
-        url_to_list = url_util.join(url, buildcache_relative_specs_url())
-        file_list = [
-            url_util.join(url_to_list, entry)
-            for entry in web_util.list_url(url_to_list, recursive=True)
-            if entry.endswith("spec.manifest.json")
-        ]
-        read_fn = url_read_method
-    except Exception as err:
-        # If we got some kind of S3 (access denied or other connection error), the first non
-        # boto-specific class in the exception is Exception.  Just print a warning and return
-        tty.warn(f"Encountered problem listing packages at {url}: {err}")
-
-    return file_list, read_fn
-
-
-def _spec_files_from_cache(url: str, tmpspecsdir: str):
-    """Get a list of all the spec files in the mirror and a function to
-    read them.
-
-    Args:
-        url: Base url of mirror (location of spec files)
-        tmpspecsdir: Temporary location for writing files
-
-    Return:
-        A tuple where the first item is a list of absolute file paths or
-        urls pointing to the specs that should be read from the mirror,
-        and the second item is a function taking a url or file path and
-        returning the spec read from that location.
-    """
-    callbacks = []
-    if url.startswith("s3://"):
-        callbacks.append(_specs_from_cache_aws_cli)
-
-    callbacks.append(_specs_from_cache_fallback)
-
-    for specs_from_cache_fn in callbacks:
-        file_list, read_fn = specs_from_cache_fn(url, tmpspecsdir)
-        if file_list:
-            return file_list, read_fn
-
-    raise ListMirrorSpecsError("Failed to get list of specs from {0}".format(url))
 
 
 def _url_generate_package_index(url: str, tmpdir: str):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -97,7 +97,7 @@ from .url_buildcache import (
     URLBuildcacheEntry,
     get_url_buildcache_class,
     get_valid_spec_file,
-    _spec_files_from_cache,
+    get_entries_from_cache,
 )
 
 
@@ -749,7 +749,7 @@ def _url_generate_package_index(url: str, tmpdir: str):
     """
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
         try:
-            file_list, read_fn = _spec_files_from_cache(url, tmpspecsdir)
+            file_list, read_fn = get_entries_from_cache(url, tmpspecsdir)
         except ListMirrorSpecsError as e:
             raise GenerateIndexError(f"Unable to generate package index: {e}") from e
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1188,9 +1188,6 @@ def get_entries_from_cache(
         and the second item is a function taking a url or file path and
         returning the spec read from that location.
     """
-    # Import here to avoid circular dependency
-    from spack.binary_distribution import ListMirrorSpecsError
-
     callbacks: List[Callable] = []
     if url.startswith("s3://"):
         callbacks.append(_entries_from_cache_aws_cli)
@@ -1393,3 +1390,7 @@ class UnknownBuildcacheLayoutError(BuildcacheEntryError):
     """Raised when unrecognized buildcache layout version is encountered"""
 
     pass
+
+
+class ListMirrorSpecsError(spack.error.SpackError):
+    """Raised when unable to retrieve list of specs from the mirror"""

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -19,7 +19,6 @@ import _vendoring.jsonschema
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
 
-from spack.binary_distribution import ListMirrorSpecsError, buildcache_relative_specs_url
 from spack.util.executable import which
 import spack.config as config
 import spack.database
@@ -1061,6 +1060,9 @@ def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str):
     Return:
         List of the local file paths and a function that can read each one from the file system.
     """
+    # Import here to avoid circular dependency
+    from spack.binary_distribution import buildcache_relative_specs_url
+
     read_fn = None
     file_list = None
     aws = which("aws")
@@ -1109,6 +1111,9 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str):
         The list of complete spec file urls and a function that can read each one from its
             remote location (also using the spack.util.web module).
     """
+    # Import here to avoid circular dependency
+    from spack.binary_distribution import buildcache_relative_specs_url
+
     read_fn = None
     file_list = None
 
@@ -1148,6 +1153,9 @@ def get_entries_from_cache(url: str, tmpspecsdir: str):
         and the second item is a function taking a url or file path and
         returning the spec read from that location.
     """
+    # Import here to avoid circular dependency
+    from spack.binary_distribution import ListMirrorSpecsError
+
     callbacks: List[Callable] = []
     if url.startswith("s3://"):
         callbacks.append(_entries_from_cache_aws_cli)

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1080,7 +1080,7 @@ def check_mirror_for_layout(mirror: spack.mirrors.mirror.Mirror):
 def _entries_from_cache_aws_cli(
     url: str, tmpspecsdir: str, component_type: Optional[BuildcacheComponent] = None
 ):
-    """Use aws cli to sync all the specs into a local temporary directory.
+    """Use aws cli to sync all manifests into a local temporary directory.
 
     Args:
         url: prefix of the build cache on s3
@@ -1088,7 +1088,10 @@ def _entries_from_cache_aws_cli(
         component_type: type of buildcache component to sync (spec, index, key, etc.)
 
     Return:
-        List of the local file paths and a function that can read each one from the file system.
+        A tuple where the first item is a list of local file paths pointing
+        to the manifests that should be read from the mirror, and the
+        second item is a function taking a url or file path and returning
+        a `URLBuildcacheEntry` for that manifest.
     """
     read_fn = None
     file_list = None
@@ -1133,16 +1136,18 @@ def _entries_from_cache_aws_cli(
 def _entries_from_cache_fallback(
     url: str, tmpspecsdir: str, component_type: Optional[BuildcacheComponent] = None
 ):
-    """Use spack.util.web module to get a list of all the specs at the remote url.
+    """Use spack.util.web module to get a list of all the manifests at the remote url.
 
     Args:
-        url: Base url of mirror (location of spec files)
+        url: Base url of mirror (location of manifest files)
         tmpspecsdir: path to temporary directory to use for writing files
         component_type: type of buildcache component to sync (spec, index, key, etc.)
 
     Return:
-        The list of complete spec file urls and a function that can read each one from its
-            remote location (also using the spack.util.web module).
+        A tuple where the first item is a list of absolute file paths or
+        urls pointing to the manifests that should be read from the mirror,
+        and the second item is a function taking a url or file path of a manifest and
+        returning a `URLBuildcacheEntry` for that manifest.
     """
     read_fn = None
     file_list = None
@@ -1174,8 +1179,7 @@ def _entries_from_cache_fallback(
 def get_entries_from_cache(
     url: str, tmpspecsdir: str, component_type: Optional[BuildcacheComponent] = None
 ):
-    """Get a list of all the spec files in the mirror and a function to
-    read them.
+    """Get a list of all the manifests in the mirror and a function to read them.
 
     Args:
         url: Base url of mirror (location of spec files)
@@ -1184,9 +1188,9 @@ def get_entries_from_cache(
 
     Return:
         A tuple where the first item is a list of absolute file paths or
-        urls pointing to the specs that should be read from the mirror,
+        urls pointing to the manifests that should be read from the mirror,
         and the second item is a function taking a url or file path and
-        returning the spec read from that location.
+        returning a `URLBuildcacheEntry` for that manifest.
     """
     callbacks: List[Callable] = []
     if url.startswith("s3://"):
@@ -1199,7 +1203,7 @@ def get_entries_from_cache(
         if file_list:
             return file_list, read_fn
 
-    raise ListMirrorSpecsError("Failed to get list of specs from {0}".format(url))
+    raise ListMirrorSpecsError("Failed to get list of entries from {0}".format(url))
 
 
 def validate_checksum(file_path, checksum_algorithm, expected_checksum) -> None:

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -20,7 +20,6 @@ import _vendoring.jsonschema
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
 
-from spack.util.executable import which
 import spack.config as config
 import spack.database
 import spack.error
@@ -35,6 +34,7 @@ import spack.util.web as web_util
 from spack.schema.url_buildcache_manifest import schema as buildcache_manifest_schema
 from spack.util.archive import ChecksumWriter
 from spack.util.crypto import hash_fun_for_algo
+from spack.util.executable import which
 
 #: The build cache layout version that this version of Spack creates.
 #: Version 3: Introduces content-addressable tarballs
@@ -1130,7 +1130,9 @@ def _entries_from_cache_aws_cli(
     return file_list, read_fn
 
 
-def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: Optional[BuildcacheComponent] = None):
+def _entries_from_cache_fallback(
+    url: str, tmpspecsdir: str, component_type: Optional[BuildcacheComponent] = None
+):
     """Use spack.util.web module to get a list of all the specs at the remote url.
 
     Args:
@@ -1170,9 +1172,7 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: Opt
 
 
 def get_entries_from_cache(
-    url: str,
-    tmpspecsdir: str,
-    component_type: Optional[BuildcacheComponent] = None,
+    url: str, tmpspecsdir: str, component_type: Optional[BuildcacheComponent] = None
 ):
     """Get a list of all the spec files in the mirror and a function to
     read them.

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -12,13 +12,15 @@ import re
 import shutil
 from contextlib import closing, contextmanager
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import _vendoring.jsonschema
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
 
+from spack.binary_distribution import ListMirrorSpecsError, buildcache_relative_specs_url
+from spack.util.executable import which
 import spack.config as config
 import spack.database
 import spack.error
@@ -1047,6 +1049,117 @@ def check_mirror_for_layout(mirror: spack.mirrors.mirror.Mirror):
             "    in this mirror."
         )
         tty.warn(msg)
+
+
+def _specs_from_cache_aws_cli(url: str, tmpspecsdir: str):
+    """Use aws cli to sync all the specs into a local temporary directory.
+
+    Args:
+        url: prefix of the build cache on s3
+        tmpspecsdir: path to temporary directory to use for writing files
+
+    Return:
+        List of the local file paths and a function that can read each one from the file system.
+    """
+    read_fn = None
+    file_list = None
+    aws = which("aws")
+
+    if not aws:
+        tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
+        return file_list, read_fn
+
+    def file_read_method(manifest_path: str) -> URLBuildcacheEntry:
+        cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
+        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
+        cache_entry.read_manifest(manifest_url=f"file://{manifest_path}")
+        return cache_entry
+
+    url_to_list = url_util.join(url, buildcache_relative_specs_url())
+    sync_command_args = [
+        "s3",
+        "sync",
+        "--exclude",
+        "*",
+        "--include",
+        "*.spec.manifest.json",
+        url_to_list,
+        tmpspecsdir,
+    ]
+
+    tty.debug(f"Using aws s3 sync to download manifests from {url_to_list} to {tmpspecsdir}")
+
+    try:
+        aws(*sync_command_args, output=os.devnull, error=os.devnull)
+        file_list = fsys.find(tmpspecsdir, ["*.spec.manifest.json"])
+        read_fn = file_read_method
+    except Exception:
+        tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
+
+    return file_list, read_fn
+
+
+def _specs_from_cache_fallback(url: str, tmpspecsdir: str):
+    """Use spack.util.web module to get a list of all the specs at the remote url.
+
+    Args:
+        cache_prefix (str): Base url of mirror (location of spec files)
+
+    Return:
+        The list of complete spec file urls and a function that can read each one from its
+            remote location (also using the spack.util.web module).
+    """
+    read_fn = None
+    file_list = None
+
+    def url_read_method(manifest_url: str) -> URLBuildcacheEntry:
+        cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
+        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
+        cache_entry.read_manifest(manifest_url)
+        return cache_entry
+
+    try:
+        url_to_list = url_util.join(url, buildcache_relative_specs_url())
+        file_list = [
+            url_util.join(url_to_list, entry)
+            for entry in web_util.list_url(url_to_list, recursive=True)
+            if entry.endswith("spec.manifest.json")
+        ]
+        read_fn = url_read_method
+    except Exception as err:
+        # If we got some kind of S3 (access denied or other connection error), the first non
+        # boto-specific class in the exception is Exception.  Just print a warning and return
+        tty.warn(f"Encountered problem listing packages at {url}: {err}")
+
+    return file_list, read_fn
+
+
+def _spec_files_from_cache(url: str, tmpspecsdir: str):
+    """Get a list of all the spec files in the mirror and a function to
+    read them.
+
+    Args:
+        url: Base url of mirror (location of spec files)
+        tmpspecsdir: Temporary location for writing files
+
+    Return:
+        A tuple where the first item is a list of absolute file paths or
+        urls pointing to the specs that should be read from the mirror,
+        and the second item is a function taking a url or file path and
+        returning the spec read from that location.
+    """
+    callbacks: List[Callable] = []
+    if url.startswith("s3://"):
+        callbacks.append(_specs_from_cache_aws_cli)
+
+    callbacks.append(_specs_from_cache_fallback)
+
+    for specs_from_cache_fn in callbacks:
+        file_list, read_fn = specs_from_cache_fn(url, tmpspecsdir)
+        if file_list:
+            return file_list, read_fn
+
+    raise ListMirrorSpecsError("Failed to get list of specs from {0}".format(url))
 
 
 def validate_checksum(file_path, checksum_algorithm, expected_checksum) -> None:

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -4,6 +4,7 @@
 
 import codecs
 import enum
+import fnmatch
 import gzip
 import io
 import json
@@ -281,6 +282,23 @@ class URLBuildcacheEntry:
         return url_util.join(
             mirror_url, *path_components, spec.name, cls.get_manifest_filename(spec)
         )
+
+    @classmethod
+    def get_buildcache_component_include_pattern(
+        cls, buildcache_component: Optional[BuildcacheComponent] = None
+    ) -> str:
+        if buildcache_component is None:
+            return "*.manifest.json"
+        elif buildcache_component == BuildcacheComponent.SPEC:
+            return "*.spec.manifest.json"
+        elif buildcache_component == BuildcacheComponent.INDEX:
+            return ".*index.manifest.json"
+        elif buildcache_component == BuildcacheComponent.KEY:
+            return "*.key.manifest.json"
+        elif buildcache_component == BuildcacheComponent.KEY_INDEX:
+            return "keys.manifest.json"
+
+        raise BuildcacheEntryError(f"Not a manifest component: {buildcache_component}")
 
     @classmethod
     def component_to_media_type(cls, component: BuildcacheComponent) -> str:
@@ -945,6 +963,12 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
     def get_manifest_url(cls, spec: spack.spec.Spec, mirror_url: str) -> str:
         raise BuildcacheEntryError("v2 buildcache entries do not have a manifest url")
 
+    @classmethod
+    def get_buildcache_component_include_pattern(
+        cls, buildcache_component: Optional[BuildcacheComponent] = None
+    ) -> str:
+        raise BuildcacheEntryError("v2 buildcache entries do not have a manifest file")
+
     def read_manifest(self, manifest_url: Optional[str] = None) -> BuildcacheManifest:
         raise BuildcacheEntryError("v2 buildcache entries do not have a manifest file")
 
@@ -1050,50 +1074,52 @@ def check_mirror_for_layout(mirror: spack.mirrors.mirror.Mirror):
         tty.warn(msg)
 
 
-def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str):
+def _entries_from_cache_aws_cli(
+    url: str, tmpspecsdir: str, component_type: Optional[BuildcacheComponent] = None
+):
     """Use aws cli to sync all the specs into a local temporary directory.
 
     Args:
         url: prefix of the build cache on s3
         tmpspecsdir: path to temporary directory to use for writing files
+        component_type: type of buildcache component to sync (spec, index, key, etc.)
 
     Return:
         List of the local file paths and a function that can read each one from the file system.
     """
-    # Import here to avoid circular dependency
-    from spack.binary_distribution import buildcache_relative_specs_url
-
     read_fn = None
     file_list = None
     aws = which("aws")
+
+    cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
 
     if not aws:
         tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
         return file_list, read_fn
 
     def file_read_method(manifest_path: str) -> URLBuildcacheEntry:
-        cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
         cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
         cache_entry.read_manifest(manifest_url=f"file://{manifest_path}")
         return cache_entry
 
-    url_to_list = url_util.join(url, buildcache_relative_specs_url())
+    include_pattern = cache_class.get_buildcache_component_include_pattern(component_type)
+
     sync_command_args = [
         "s3",
         "sync",
         "--exclude",
         "*",
         "--include",
-        "*.spec.manifest.json",
-        url_to_list,
+        include_pattern,
+        url,
         tmpspecsdir,
     ]
 
-    tty.debug(f"Using aws s3 sync to download manifests from {url_to_list} to {tmpspecsdir}")
+    tty.debug(f"Using aws s3 sync to download manifests from {url} to {tmpspecsdir}")
 
     try:
         aws(*sync_command_args, output=os.devnull, error=os.devnull)
-        file_list = fsys.find(tmpspecsdir, ["*.spec.manifest.json"])
+        file_list = fsys.find(tmpspecsdir, [include_pattern])
         read_fn = file_read_method
     except Exception:
         tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
@@ -1101,7 +1127,7 @@ def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str):
     return file_list, read_fn
 
 
-def _entries_from_cache_fallback(url: str, tmpspecsdir: str):
+def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: Optional[BuildcacheComponent] = None):
     """Use spack.util.web module to get a list of all the specs at the remote url.
 
     Args:
@@ -1111,24 +1137,23 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str):
         The list of complete spec file urls and a function that can read each one from its
             remote location (also using the spack.util.web module).
     """
-    # Import here to avoid circular dependency
-    from spack.binary_distribution import buildcache_relative_specs_url
-
     read_fn = None
     file_list = None
 
+    cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
+
     def url_read_method(manifest_url: str) -> URLBuildcacheEntry:
-        cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
         cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
         cache_entry.read_manifest(manifest_url)
         return cache_entry
 
     try:
-        url_to_list = url_util.join(url, buildcache_relative_specs_url())
         file_list = [
-            url_util.join(url_to_list, entry)
-            for entry in web_util.list_url(url_to_list, recursive=True)
-            if entry.endswith("spec.manifest.json")
+            url_util.join(url, entry)
+            for entry in web_util.list_url(url, recursive=True)
+            if fnmatch.fnmatch(
+                entry, cache_class.get_buildcache_component_include_pattern(component_type)
+            )
         ]
         read_fn = url_read_method
     except Exception as err:
@@ -1139,7 +1164,11 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str):
     return file_list, read_fn
 
 
-def get_entries_from_cache(url: str, tmpspecsdir: str):
+def get_entries_from_cache(
+    url: str,
+    tmpspecsdir: str,
+    component_type: Optional[BuildcacheComponent] = None,
+):
     """Get a list of all the spec files in the mirror and a function to
     read them.
 
@@ -1163,7 +1192,7 @@ def get_entries_from_cache(url: str, tmpspecsdir: str):
     callbacks.append(_entries_from_cache_fallback)
 
     for specs_from_cache_fn in callbacks:
-        file_list, read_fn = specs_from_cache_fn(url, tmpspecsdir)
+        file_list, read_fn = specs_from_cache_fn(url, tmpspecsdir, component_type)
         if file_list:
             return file_list, read_fn
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -287,6 +287,9 @@ class URLBuildcacheEntry:
     def get_buildcache_component_include_pattern(
         cls, buildcache_component: Optional[BuildcacheComponent] = None
     ) -> str:
+        """Given a buildcache component, return the glob pattern that can be used
+        to match it in a directory listing.  If None is provided, return a catch-all
+        pattern that will match all buildcache components."""
         if buildcache_component is None:
             return "*.manifest.json"
         elif buildcache_component == BuildcacheComponent.SPEC:
@@ -1131,7 +1134,9 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: Opt
     """Use spack.util.web module to get a list of all the specs at the remote url.
 
     Args:
-        cache_prefix (str): Base url of mirror (location of spec files)
+        url: Base url of mirror (location of spec files)
+        tmpspecsdir: path to temporary directory to use for writing files
+        component_type: type of buildcache component to sync (spec, index, key, etc.)
 
     Return:
         The list of complete spec file urls and a function that can read each one from its
@@ -1175,6 +1180,7 @@ def get_entries_from_cache(
     Args:
         url: Base url of mirror (location of spec files)
         tmpspecsdir: Temporary location for writing files
+        component_type: type of buildcache component to sync (spec, index, key, etc.)
 
     Return:
         A tuple where the first item is a list of absolute file paths or

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1051,7 +1051,7 @@ def check_mirror_for_layout(mirror: spack.mirrors.mirror.Mirror):
         tty.warn(msg)
 
 
-def _specs_from_cache_aws_cli(url: str, tmpspecsdir: str):
+def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str):
     """Use aws cli to sync all the specs into a local temporary directory.
 
     Args:
@@ -1099,7 +1099,7 @@ def _specs_from_cache_aws_cli(url: str, tmpspecsdir: str):
     return file_list, read_fn
 
 
-def _specs_from_cache_fallback(url: str, tmpspecsdir: str):
+def _entries_from_cache_fallback(url: str, tmpspecsdir: str):
     """Use spack.util.web module to get a list of all the specs at the remote url.
 
     Args:
@@ -1134,7 +1134,7 @@ def _specs_from_cache_fallback(url: str, tmpspecsdir: str):
     return file_list, read_fn
 
 
-def _spec_files_from_cache(url: str, tmpspecsdir: str):
+def get_entries_from_cache(url: str, tmpspecsdir: str):
     """Get a list of all the spec files in the mirror and a function to
     read them.
 
@@ -1150,9 +1150,9 @@ def _spec_files_from_cache(url: str, tmpspecsdir: str):
     """
     callbacks: List[Callable] = []
     if url.startswith("s3://"):
-        callbacks.append(_specs_from_cache_aws_cli)
+        callbacks.append(_entries_from_cache_aws_cli)
 
-    callbacks.append(_specs_from_cache_fallback)
+    callbacks.append(_entries_from_cache_fallback)
 
     for specs_from_cache_fn in callbacks:
         file_list, read_fn = specs_from_cache_fn(url, tmpspecsdir)


### PR DESCRIPTION
This PR moves the functions responsible for retrieving blobs and manifests from a buildcache from `binary_distribution.py` into `url_buildcache.py` and generalizes the API so that any type of "buildcache component" (specs, blobs, indexes, keys, key indexes, tarballs, or layout JSONs) can be fetched. This refactor lays the groundwork for implementing buildcache analysis and pruning. 

## Changes
- The new `url_buildcache` functions `get_entries_from_cache`, `_entries_from_cache_aws_cli`, and `_entries_from_cache_fallback`  functions replace the old `binary_distribution` functions `_spec_files_from_cache`, `_specs_from_cache_fallback`, and `_specs_from_cache_aws_cli`, respectively.
- The APIs remain largely the same, except for these changes
	- Instead of constructing a `URLBuildcacheEntry`, fetching its manifest, and returning a `Spec`, the `url_buildcache` functions now simply construct and return the `URLBuildcacheEntry` directly. Callers can still get a `Spec` from the `URLBuildcacheEntry` themselves if needed. This change will allow this function to be used to fetch arbitrary objects from the buildcache instead of being limited to specs.
	- The functions now take an optional argument, `component_type`, to allow fetching of any component type (instead of just specs). This parameter defaults to `BuildcacheComponent.SPEC`, so existing usage of it does not have to change (aside from the function name).
- I also added some type annotations to assist with the refactor

## Future work
- Once this PR is finalized, I will follow up with another PR implementing buildcache pruning using these refactored APIs.