### PR TITLE
spack.repo.PATH: initialize lazily

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -41,7 +41,6 @@ import spack.error
 import spack.modules
 import spack.paths
 import spack.platforms
-import spack.repo
 import spack.solver.asp
 import spack.spec
 import spack.store
@@ -559,8 +558,6 @@ def setup_main_options(args):
     # Use the spack config command to handle parsing the config strings
     for config_var in args.config_vars or []:
         spack.config.add(fullpath=config_var, scope="command_line")
-
-    spack.repo.enable_repo(spack.repo.create(spack.config.CONFIG))
 
     # On Windows10 console handling for ASCI/VT100 sequences is not
     # on by default. Turn on before we try to write to console

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1580,9 +1580,16 @@ def create(configuration: spack.config.Configuration) -> RepoPath:
     return RepoPath(*repo_dirs, cache=spack.caches.MISC_CACHE, overrides=overrides)
 
 
+def create_and_enable(configuration: spack.config.Configuration) -> RepoPath:
+    """Same as create, but calls enable() on the created repository."""
+    repo_path = create(configuration)
+    repo_path.enable()
+    return repo_path
+
+
 #: Global package repository instance.
 PATH: RepoPath = llnl.util.lang.Singleton(
-    lambda: create(configuration=spack.config.CONFIG)
+    lambda: create_and_enable(spack.config.CONFIG)
 )  # type: ignore[assignment]
 
 # Add the finder to sys.meta_path


### PR DESCRIPTION
Fixes a bug where `spack env activate` cannot find a package repo defined in its own `spack.yaml` file.

In #50370 `spack.repo.PATH` is constructed in `main` from `spack.config.CONFIG`. However, `spack.config.CONFIG` is mutable and repos that are added to config later (for example due to env activate) are not picked up by `spack.repo.PATH`.

In the past this worked "by accident" in the sense that `spack.repo.PATH` was only ever accessed after all `spack.config.CONFIG` changes were made. This commit restores that behavior.

It does not attempt to fix the obvious bug that `spack.repo.PATH` goes out of sync with `spack.config.CONFIG`; the former global is always created from a snapshot at some arbitrary point in time of the latter.

Edit: it was made eager so that `import spack_repo.something` would work without invoking a method of `spack.repo.PATH`.