### PR TITLE
Fix spack.repo.PATH initialization with envs

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -197,21 +197,27 @@ def activate(env, use_env_repo=False):
     if not isinstance(env, Environment):
         raise TypeError("`env` should be of type {0}".format(Environment.__name__))
 
-    # Check if we need to reinitialize the store due to pushing the configuration
-    # below.
+    # Check if we need to reinitialize spack.store.STORE and spack.repo.REPO due to config changes.
     install_tree_before = spack.config.get("config:install_tree")
     upstreams_before = spack.config.get("upstreams")
+    repos_before = spack.config.get("repos")
     env.manifest.prepare_config_scope()
     install_tree_after = spack.config.get("config:install_tree")
     upstreams_after = spack.config.get("upstreams")
+    repos_after = spack.config.get("repos")
+
     if install_tree_before != install_tree_after or upstreams_before != upstreams_after:
-        # Hack to store the state of the store before activation
-        env.store_token = spack.store.reinitialize()
+        setattr(env, "store_token", spack.store.reinitialize())
 
-    if use_env_repo:
-        spack.repo.PATH.put_first(env.repo)
+    if repos_before != repos_after:
+        setattr(env, "repo_token", spack.repo.PATH)
+        spack.repo.PATH.disable()
+        new_repo = spack.repo.create(spack.config.CONFIG)
+        if use_env_repo:
+            new_repo.put_first(env.repo)
+        spack.repo.enable_repo(new_repo)
 
-    tty.debug("Using environment '%s'" % env.name)
+    tty.debug(f"Using environment '{env.name}'")
 
     # Do this last, because setting up the config must succeed first.
     _active_environment = env
@@ -224,18 +230,21 @@ def deactivate():
     if not _active_environment:
         return
 
-    # If we attached a store token on activation, restore the previous state
-    # and consume the token
-    if hasattr(_active_environment, "store_token"):
-        spack.store.restore(_active_environment.store_token)
+    # If any config changes affected spack.store.STORE or spack.repo.PATH, undo them.
+    store = getattr(_active_environment, "store_token", None)
+    if store is not None:
+        spack.store.restore(store)
         delattr(_active_environment, "store_token")
+
+    repo = getattr(_active_environment, "repo_token", None)
+
+    if repo is not None:
+        spack.repo.PATH.disable()
+        spack.repo.enable_repo(repo)
+
     _active_environment.manifest.deactivate_config_scope()
 
-    # use _repo so we only remove if a repo was actually constructed
-    if _active_environment._repo:
-        spack.repo.PATH.remove(_active_environment._repo)
-
-    tty.debug("Deactivated environment '%s'" % _active_environment.name)
+    tty.debug(f"Deactivated environment '{_active_environment.name}'")
 
     _active_environment = None
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -193,34 +193,38 @@ def activate(env, use_env_repo=False):
     """
     global _active_environment
 
-    # Fail early to avoid ending in an invalid state
-    if not isinstance(env, Environment):
-        raise TypeError("`env` should be of type {0}".format(Environment.__name__))
+    try:
+        _active_environment = env
 
-    # Check if we need to reinitialize spack.store.STORE and spack.repo.REPO due to config changes.
-    install_tree_before = spack.config.get("config:install_tree")
-    upstreams_before = spack.config.get("upstreams")
-    repos_before = spack.config.get("repos")
-    env.manifest.prepare_config_scope()
-    install_tree_after = spack.config.get("config:install_tree")
-    upstreams_after = spack.config.get("upstreams")
-    repos_after = spack.config.get("repos")
+        # Fail early to avoid ending in an invalid state
+        if not isinstance(env, Environment):
+            raise TypeError("`env` should be of type {0}".format(Environment.__name__))
 
-    if install_tree_before != install_tree_after or upstreams_before != upstreams_after:
-        setattr(env, "store_token", spack.store.reinitialize())
+        # Check if we need to reinitialize spack.store.STORE and spack.repo.REPO due to
+        # config changes.
+        install_tree_before = spack.config.get("config:install_tree")
+        upstreams_before = spack.config.get("upstreams")
+        repos_before = spack.config.get("repos")
+        env.manifest.prepare_config_scope()
+        install_tree_after = spack.config.get("config:install_tree")
+        upstreams_after = spack.config.get("upstreams")
+        repos_after = spack.config.get("repos")
 
-    if repos_before != repos_after:
-        setattr(env, "repo_token", spack.repo.PATH)
-        spack.repo.PATH.disable()
-        new_repo = spack.repo.create(spack.config.CONFIG)
-        if use_env_repo:
-            new_repo.put_first(env.repo)
-        spack.repo.enable_repo(new_repo)
+        if install_tree_before != install_tree_after or upstreams_before != upstreams_after:
+            setattr(env, "store_token", spack.store.reinitialize())
 
-    tty.debug(f"Using environment '{env.name}'")
+        if repos_before != repos_after:
+            setattr(env, "repo_token", spack.repo.PATH)
+            spack.repo.PATH.disable()
+            new_repo = spack.repo.create(spack.config.CONFIG)
+            if use_env_repo:
+                new_repo.put_first(env.repo)
+            spack.repo.enable_repo(new_repo)
 
-    # Do this last, because setting up the config must succeed first.
-    _active_environment = env
+        tty.debug(f"Using environment '{env.name}'")
+    except Exception:
+        _active_environment = None
+        raise
 
 
 def deactivate():

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -181,8 +181,7 @@ def activate(
     # become PATH variables.
     #
 
-    with env.manifest.use_config():
-        env_vars_yaml = spack.config.get("env_vars", None)
+    env_vars_yaml = spack.config.get("env_vars", None)
     if env_vars_yaml:
         env_mods.extend(spack.schema.environment.parse(env_vars_yaml))
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -36,9 +36,10 @@ from llnl.util.tty.log import log_output
 import spack
 import spack.cmd
 import spack.config
+import spack.environment
 import spack.environment as ev
+import spack.environment.environment
 import spack.error
-import spack.modules
 import spack.paths
 import spack.platforms
 import spack.repo
@@ -951,7 +952,10 @@ def _main(argv=None):
         try:
             env = spack.cmd.find_environment(args)
             if env:
-                ev.activate(env, args.use_env_repo)
+                # do not call activate here, cause it has a lot of expensive function calls to deal
+                # with mutation of spack.config.CONFIG -- but we are still building the config.
+                env.manifest.prepare_config_scope()
+                spack.environment.environment._active_environment = env
         except spack.config.ConfigFormatError as e:
             # print the context but delay this exception so that commands like
             # `spack config edit` can still work with a bad environment.

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -685,7 +685,7 @@ class RepoPath:
         """Ensure we unwrap this object from any dynamic wrapper (like Singleton)"""
         return self
 
-    def put_first(self, repo: "Repo") -> None:
+    def put_first(self, repo: Union["Repo", "RepoPath"]) -> None:
         """Add repo first in the search path."""
         if isinstance(repo, RepoPath):
             for r in reversed(repo.repos):
@@ -1580,9 +1580,16 @@ def create(configuration: spack.config.Configuration) -> RepoPath:
     return RepoPath(*repo_dirs, cache=spack.caches.MISC_CACHE, overrides=overrides)
 
 
+def create_and_enable(configuration: spack.config.Configuration) -> RepoPath:
+    """Same as create, but calls enable() on the created repository."""
+    repo_path = create(configuration)
+    repo_path.enable()
+    return repo_path
+
+
 #: Global package repository instance.
 PATH: RepoPath = llnl.util.lang.Singleton(
-    lambda: create(configuration=spack.config.CONFIG)
+    lambda: create_and_enable(spack.config.CONFIG)
 )  # type: ignore[assignment]
 
 # Add the finder to sys.meta_path

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -526,24 +526,24 @@ def test_is_package_module():
     assert not spack.repo.is_package_module("spack.something.else")
 
 
-def test_environment_activation_updates_repo_path(tmp_path):
+def test_environment_activation_updates_repo_path(tmp_path: pathlib.Path):
     """Test that the environment activation updates the repo path correctly."""
-    repo_root, _ = spack.repo.create_repo(str(tmp_path / "my_repo"), namespace="my_repo")
+    repo_root, _ = spack.repo.create_repo(str(tmp_path / "foo"), namespace="bar")
     (tmp_path / "spack.yaml").write_text(
-        f"""
+        """\
 spack:
     repos:
-    - {repo_root}
+    - $env/foo/spack_repo/bar
 """
     )
     env = spack.environment.Environment(tmp_path)
 
     with env:
-        assert any(str(repo_root) in r.root for r in spack.repo.PATH.repos)
+        assert any(os.path.samefile(repo_root, r.root) for r in spack.repo.PATH.repos)
 
-    assert not any(str(repo_root) in r.root for r in spack.repo.PATH.repos)
+    assert not any(os.path.samefile(repo_root, r.root) for r in spack.repo.PATH.repos)
 
     with env:
-        assert any(str(repo_root) in r.root for r in spack.repo.PATH.repos)
+        assert any(os.path.samefile(repo_root, r.root) for r in spack.repo.PATH.repos)
 
-    assert not any(str(repo_root) in r.root for r in spack.repo.PATH.repos)
+    assert not any(os.path.samefile(repo_root, r.root) for r in spack.repo.PATH.repos)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -7,6 +7,7 @@ import pathlib
 import pytest
 
 import spack
+import spack.environment
 import spack.package_base
 import spack.paths
 import spack.repo
@@ -523,3 +524,26 @@ def test_is_package_module():
     assert spack.repo.is_package_module("spack_repo.foo.bar.baz.package")
     assert not spack.repo.is_package_module("spack_repo.builtin.build_systems.cmake")
     assert not spack.repo.is_package_module("spack.something.else")
+
+
+def test_environment_activation_updates_repo_path(tmp_path):
+    """Test that the environment activation updates the repo path correctly."""
+    repo_root, _ = spack.repo.create_repo(str(tmp_path / "my_repo"), namespace="my_repo")
+    (tmp_path / "spack.yaml").write_text(
+        f"""
+spack:
+    repos:
+    - {repo_root}
+"""
+    )
+    env = spack.environment.Environment(tmp_path)
+
+    with env:
+        assert any(str(repo_root) in r.root for r in spack.repo.PATH.repos)
+
+    assert not any(str(repo_root) in r.root for r in spack.repo.PATH.repos)
+
+    with env:
+        assert any(str(repo_root) in r.root for r in spack.repo.PATH.repos)
+
+    assert not any(str(repo_root) in r.root for r in spack.repo.PATH.repos)


### PR DESCRIPTION
* If an env is activated with `spack -e . <command>` *do not* call
  activate, but (a) just register the config scope as we are
  constructing spack.config.CONFIG and (b) set it directly as active
* If an env is dynamically activated with new config when
  spack.config.CONFIG is already initialized, then call activate and deal
  with changes to spack.repo.PATH from spack.config.CONFIG.
* In the shell activation code, do not temporarily use `use_config`,
  which is wrong anyways, but also redundant after the activate call on
  the env.
* Set `_active_environment` a bit earlier in activate, so that `$env`
   can be interpolated.

This should fix a few issues:

* Dynamic activation and deactivation of an env (as opposed to global
   activation in main) updates spack.repo.PATH properly
* There shouldn't be as many redundant re-initializations of Repo
   instances as before.
   