### PR TITLE
config: allow update of top level type

### DIFF
--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -158,6 +158,8 @@ def update(data):
     # root replaces install_tree, projections replace install_path_scheme
     changed = False
 
+    data = data["config"]
+
     install_tree = data.get("install_tree", None)
     if isinstance(install_tree, str):
         # deprecated short-form install tree

--- a/lib/spack/spack/schema/develop.py
+++ b/lib/spack/spack/schema/develop.py
@@ -20,10 +20,6 @@ properties: Dict[str, Any] = {
 }
 
 
-def update(data):
-    return False
-
-
 #: Full schema with metadata
 schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -104,6 +104,7 @@ schema = {
 
 
 def update(data):
+    data = data["mirrors"]
     errors = []
 
     def check_access_pair(name, section):

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -211,6 +211,7 @@ schema = {
 
 
 def update(data):
+    data = data["packages"]
     changed = False
     for key in data:
         version = data[key].get("version")

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -628,7 +628,7 @@ spack:
         )
 
     def update_config(data):
-        data["ccache"] = False
+        data["config"]["ccache"] = False
         return True
 
     monkeypatch.setattr(spack.schema.config, "update", update_config)


### PR DESCRIPTION
Currently you cannot change the type of config section from say list to dict, which we likely need to make the `repos` section more ergonomic for one-off changes in user config:

```yaml
repos:
- /path
```
to

```yaml
repos:
  name: /path
```

Also fixes two bugs in `spack config update <section>` :upside_down_face: 

1. It would list scopes multiple times if a new scope was added (e.g. with `spack -e . config update ...`)
2. If multiple scopes would be updated in one go, only one backup file would be used and overwritten, and the wrong paths of scopes to be updated would be printed.