### PR TITLE
repo.py: improve constructor

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -21,7 +21,6 @@ from llnl.util.link_tree import ConflictingSpecsError
 from llnl.util.symlink import islink, readlink, symlink
 
 import spack
-import spack.caches
 import spack.concretize
 import spack.config
 import spack.deptypes as dt
@@ -216,7 +215,7 @@ def activate(env, use_env_repo=False):
         if repos_before != repos_after:
             setattr(env, "repo_token", spack.repo.PATH)
             spack.repo.PATH.disable()
-            new_repo = spack.repo.create(spack.config.CONFIG)
+            new_repo = spack.repo.RepoPath.from_config(spack.config.CONFIG)
             if use_env_repo:
                 new_repo.put_first(env.repo)
             spack.repo.enable_repo(new_repo)
@@ -2438,11 +2437,11 @@ def display_specs(specs):
 
 def make_repo_path(root):
     """Make a RepoPath from the repo subdirectories in an environment."""
-    repos = [
+    repos = (
         spack.repo.from_path(os.path.dirname(p))
         for p in glob.glob(os.path.join(root, "**", "repo.yaml"), recursive=True)
-    ]
-    return spack.repo.RepoPath(*repos, cache=spack.caches.MISC_CACHE)
+    )
+    return spack.repo.RepoPath(*repos)
 
 
 def manifest_file(env_name_or_dir):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -561,7 +561,7 @@ def setup_main_options(args):
     for config_var in args.config_vars or []:
         spack.config.add(fullpath=config_var, scope="command_line")
 
-    spack.repo.enable_repo(spack.repo.create(spack.config.CONFIG))
+    spack.repo.enable_repo(spack.repo.RepoPath.from_config(spack.config.CONFIG))
 
     # On Windows10 console handling for ASCI/VT100 sequences is not
     # on by default. Turn on before we try to write to console

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -112,7 +112,7 @@ class GlobalStateMarshaler:
 
     def restore(self):
         spack.config.CONFIG = self.config
-        spack.repo.enable_repo(spack.repo.create(self.config))
+        spack.repo.enable_repo(spack.repo.RepoPath.from_config(self.config))
         spack.platforms.host = self.platform
         spack.store.STORE = self.store
         self.test_patches.restore()

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -105,7 +105,7 @@ def config_directory(tmp_path_factory):
 
 
 @pytest.fixture(scope="function")
-def default_config(tmp_path, config_directory, mock_repo_path, install_mockery):
+def default_config(tmp_path, config_directory, mock_packages_repo, install_mockery):
     # This fixture depends on install_mockery to ensure
     # there is a clear order of initialization. The substitution of the
     # config scopes here is done on top of the substitution that comes with
@@ -140,7 +140,7 @@ def default_config(tmp_path, config_directory, mock_repo_path, install_mockery):
         timeout = spack.config.get("config:connect_timeout")
         if not timeout:
             spack.config.set("config:connect_timeout", 10, scope="user")
-        with spack.repo.use_repositories(mock_repo_path):
+        with spack.repo.use_repositories(mock_packages_repo):
             yield spack.config.CONFIG
 
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -471,8 +471,8 @@ def test_environment_with_version_range_in_compiler_doesnt_fail(tmp_path, mock_p
 def test_repo(mock_stage):
     with spack.repo.use_repositories(
         os.path.join(spack.paths.test_repos_path, "spack_repo", "find")
-    ) as mock_repo_path:
-        yield mock_repo_path
+    ) as mock_packages_repo:
+        yield mock_packages_repo
 
 
 def test_find_concretized_not_installed(

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -23,12 +23,12 @@ pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 #: make sure module files are generated for all the tests here
 @pytest.fixture(scope="module", autouse=True)
-def ensure_module_files_are_there(mock_repo_path, mock_store, mock_configuration_scopes):
+def ensure_module_files_are_there(mock_packages_repo, mock_store, mock_configuration_scopes):
     """Generate module files for module tests."""
     module = spack.main.SpackCommand("module")
     with spack.store.use_store(str(mock_store)):
         with spack.config.use_configuration(*mock_configuration_scopes):
-            with spack.repo.use_repositories(mock_repo_path):
+            with spack.repo.use_repositories(mock_packages_repo):
                 module("tcl", "refresh", "-y")
 
 

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -45,10 +45,9 @@ def mock_pkg_git_repo(git, tmp_path_factory):
     shutil.copytree(spack.paths.mock_packages_path, str(repo_dir))
 
     repo_cache = spack.util.file_cache.FileCache(root_dir / "cache")
-    mock_repo = spack.repo.RepoPath(str(repo_dir), cache=repo_cache)
-    mock_repo_packages = mock_repo.repos[0].packages_path
+    mock_repo = spack.repo.Repo(str(repo_dir), cache=repo_cache)
 
-    with working_dir(mock_repo_packages):
+    with working_dir(mock_repo.packages_path):
         git("init")
 
         # initial commit with mock packages
@@ -86,8 +85,8 @@ def mock_pkg_git_repo(git, tmp_path_factory):
             "change mockpkg-b, remove mockpkg-c, add mockpkg-d",
         )
 
-    with spack.repo.use_repositories(str(repo_dir)):
-        yield mock_repo_packages
+    with spack.repo.use_repositories(mock_repo):
+        yield mock_repo.packages_path
 
 
 @pytest.fixture(scope="module")

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -47,8 +47,8 @@ import spack.util.spack_yaml as syaml
 @pytest.fixture
 def test_repo(mutable_config, monkeypatch, mock_stage):
     repo_dir = pathlib.Path(spack.paths.test_repos_path) / "spack_repo" / "flags_test"
-    with spack.repo.use_repositories(str(repo_dir)) as mock_repo_path:
-        yield mock_repo_path
+    with spack.repo.use_repositories(str(repo_dir)) as mock_packages_repo:
+        yield mock_packages_repo
 
 
 def update_concretize_scope(conf_str, section):

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -161,14 +161,14 @@ class TestConcretizePreferences:
             ({}, "http://www.llnl.gov/mpileaks-2.3.tar.gz"),
         ],
     )
-    def test_config_set_pkg_property_url(self, update, expected, mock_repo_path):
+    def test_config_set_pkg_property_url(self, update, expected, mock_packages_repo):
         """Test setting an existing attribute in the package class"""
         update_packages("mpileaks", "package_attributes", update)
-        with spack.repo.use_repositories(mock_repo_path):
+        with spack.repo.use_repositories(mock_packages_repo):
             spec = concretize("mpileaks")
             assert spec.package.fetcher.url == expected
 
-    def test_config_set_pkg_property_new(self, mock_repo_path):
+    def test_config_set_pkg_property_new(self, mock_packages_repo):
         """Test that you can set arbitrary attributes on the Package class"""
         conf = syaml.load_config(
             """\
@@ -187,7 +187,7 @@ mpileaks:
 """
         )
         spack.config.set("packages", conf, scope="concretize")
-        with spack.repo.use_repositories(mock_repo_path):
+        with spack.repo.use_repositories(mock_packages_repo):
             spec = concretize("mpileaks")
             assert spec.package.v1 == 1
             assert spec.package.v2 is True
@@ -197,7 +197,7 @@ mpileaks:
             assert list(spec.package.v6) == [1, 2]
 
         update_packages("mpileaks", "package_attributes", {})
-        with spack.repo.use_repositories(mock_repo_path):
+        with spack.repo.use_repositories(mock_packages_repo):
             spec = concretize("mpileaks")
             with pytest.raises(AttributeError):
                 spec.package.v1

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -29,8 +29,8 @@ def update_packages_config(conf_str):
 @pytest.fixture
 def test_repo(mutable_config, monkeypatch, mock_stage):
     repo_dir = pathlib.Path(spack.paths.test_repos_path) / "spack_repo" / "requirements_test"
-    with spack.repo.use_repositories(str(repo_dir)) as mock_repo_path:
-        yield mock_repo_path
+    with spack.repo.use_repositories(str(repo_dir)) as mock_packages_repo:
+        yield mock_packages_repo
 
 
 def test_one_package_multiple_reqs(concretize_scope, test_repo):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -635,7 +635,7 @@ def _use_test_platform(test_platform):
 # Test-specific fixtures
 #
 @pytest.fixture(scope="session")
-def mock_repo_path():
+def mock_packages_repo():
     yield spack.repo.from_path(spack.paths.mock_packages_path)
 
 
@@ -652,20 +652,20 @@ def mock_pkg_install(monkeypatch):
 
 
 @pytest.fixture(scope="function")
-def mock_packages(mock_repo_path, mock_pkg_install, request):
+def mock_packages(mock_packages_repo, mock_pkg_install, request):
     """Use the 'builtin_mock' repository instead of 'builtin'"""
     ensure_configuration_fixture_run_before(request)
-    with spack.repo.use_repositories(mock_repo_path) as mock_repo:
+    with spack.repo.use_repositories(mock_packages_repo) as mock_repo:
         yield mock_repo
 
 
 @pytest.fixture(scope="function")
-def mutable_mock_repo(mock_repo_path, request):
+def mutable_mock_repo(mock_packages_repo, request):
     """Function-scoped mock packages, for tests that need to modify them."""
     ensure_configuration_fixture_run_before(request)
     mock_repo = spack.repo.from_path(spack.paths.mock_packages_path)
-    with spack.repo.use_repositories(mock_repo) as mock_repo_path:
-        yield mock_repo_path
+    with spack.repo.use_repositories(mock_repo) as mock_packages_repo:
+        yield mock_packages_repo
 
 
 @pytest.fixture()
@@ -948,7 +948,7 @@ def _store_dir_and_cache(tmpdir_factory):
 def mock_store(
     tmpdir_factory,
     mock_wsdk_externals,
-    mock_repo_path,
+    mock_packages_repo,
     mock_configuration_scopes,
     _store_dir_and_cache,
 ):
@@ -970,7 +970,7 @@ def mock_store(
     if not os.path.exists(str(store_cache.join(".spack-db"))):
         with spack.config.use_configuration(*mock_configuration_scopes):
             with spack.store.use_store(str(store_path)) as store:
-                with spack.repo.use_repositories(mock_repo_path):
+                with spack.repo.use_repositories(mock_packages_repo):
                     # make the DB filesystem writable only while we populate it
                     store_path.chmod(mode=0o755, rec=1)
                     _populate(store.db)

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -158,7 +158,7 @@ def test_handle_unknown_package(temporary_store, config, mock_packages, tmp_path
     layout = temporary_store.layout
 
     repo_cache = spack.util.file_cache.FileCache(tmp_path / "cache")
-    mock_db = spack.repo.RepoPath(spack.paths.mock_packages_path, cache=repo_cache)
+    mock_db = spack.repo.Repo(spack.paths.mock_packages_path, cache=repo_cache)
 
     not_in_mock = set.difference(
         set(spack.repo.all_package_names()), set(mock_db.all_package_names())

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -30,8 +30,8 @@ from spack.solver.input_analysis import NoStaticAnalysis, StaticAnalysis
 
 
 @pytest.fixture(scope="module")
-def compiler_names(mock_repo_path):
-    return [spec.name for spec in mock_repo_path.providers_for("c")]
+def compiler_names(mock_packages_repo):
+    return [spec.name for spec in mock_packages_repo.providers_for("c")]
 
 
 @pytest.fixture()


### PR DESCRIPTION
* Use dependency injection for the `RepoPath` constructor for `Repo` instances, which makes the constructor more clear (there was already a case where cache=... was redundantly passed).
* Rename `mock_repo_path` -> `mock_packages_repo` since it's not a RepoPath but Repo instance.

This PR doesn't attempt to fix the hard-coded dependency on `spack.config.MISC_CACHE` in `spack.repo`, which in turn depends on `spack.config.CONFIG`, etc.
