### PR TITLE
preCICE: fix incompatibility with libxml2 2.14.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/precice/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/precice/package.py
@@ -103,6 +103,7 @@ class Precice(CMakePackage):
 
     depends_on("libxml2")
     depends_on("libxml2@:2.11.99", type="build", when="@:2.5.0")
+    depends_on("libxml2@:2.13.99", type="build", when="@:3.2.0")
 
     depends_on("mpi", when="+mpi")
 


### PR DESCRIPTION
This PR fixes an incompatibility of preCICE 3.2.0 and before with libxml2 2.14.0 and later due to header changes.

While 2.14+ versions of libxml2 hasn't been added to spack yet, this issue starts appearing in distros that ship the newer libxml2.
