### PR TITLE
mapl: add v2.56.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mapl/package.py
@@ -173,13 +173,13 @@ class Mapl(CMakePackage):
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.62.1",
-        when="@2.56",
+        when="@2.56:",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.58.1",
-        when="@2.55:",
+        when="@2.55",
     )
     resource(
         name="esma_cmake",

--- a/var/spack/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mapl/package.py
@@ -39,6 +39,7 @@ class Mapl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("2.56.0", sha256="9efdbfb87b7ca8d31f4be241a9db260612310e01930681565bfdaf869090a7e8")
     version("2.55.1", sha256="eb8bbb42a9a488155bd38f9bc6f6863b8a0acb210852ee71834f160958500243")
     version("2.55.0", sha256="13ec3d81d53cf18aa18322b74b9a6990ad7e51224f1156be5d1f834ee826f95c")
     version("2.54.2", sha256="70b7be425d07a7be7d9bb0e53b93a372887a048caf23260e0ae602ca6e3670ed")
@@ -168,6 +169,12 @@ class Mapl(CMakePackage):
 
     # Versions later than 3.14 remove FindESMF.cmake
     # from ESMA_CMake.
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v3.62.1",
+        when="@2.56",
+    )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds [MAPL v2.56.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.56.0)