### PR TITLE
luajit: macOS / aarch64 problems

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/lua_luajit_openresty/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/lua_luajit_openresty/package.py
@@ -14,9 +14,11 @@ class LuaLuajitOpenresty(LuaImplPackage):
 
     homepage = "https://openresty.org/en/luajit.html"
     url = "https://github.com/openresty/luajit2/archive/refs/tags/v2.1-20230410.tar.gz"
+    git = "https://github.com/openresty/luajit2"
 
     license("MIT")
 
+    version("2.1-20250515", commit="eec7a8016c3381b949b5d84583800d05897fa960")
     version(
         "2.1-20240626", sha256="1e53822a1105df216b9657ccb0293a152ac5afd875abc848453bfa353ca8181b"
     )
@@ -39,6 +41,13 @@ class LuaLuajitOpenresty(LuaImplPackage):
     provides("luajit", "lua-lang", when="+lualinks")
     provides("lua-lang@5.1", when="+lualinks")
     lua_version_override = "5.1"
+
+    # https://github.com/neovim/neovim/issues/33506#issuecomment-2812141484
+    requires(
+        "@2.1-20250515:",
+        when="target=aarch64: platform=darwin",
+        msg="macOS / aarch64 require fixes from 2.1-20250515",
+    )
 
     @run_after("install")
     def install_links(self):

--- a/var/spack/repos/spack_repo/builtin/packages/neovim/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/neovim/package.py
@@ -154,9 +154,6 @@ class Neovim(CMakePackage):
         depends_on("cmake@3.16:", type="build")
         depends_on("utf8proc", type="link")
         depends_on("tree-sitter@0.25:", type="link")
-
-        # https://github.com/neovim/neovim/issues/33506#issuecomment-2812141484
-        conflicts("platform=darwin target=aarch64:")
     with when("@master"):
         pass
 


### PR DESCRIPTION
Follow up of `neovim` #50123 about "Problem on macOS/aarch64 with neovim@0.11".

As soon as this other PR gets merged, I will rebase this onto it
- [ ] #50577 

About `lua-luajit-openresty`:
- add "unofficial" `2.1-20250515` release named after the date of the selected commit
- add a requirement for `macOS` + `aarch64` (it might be needed also on non-`macOS`, but I haven't investigated)

`lua-luajit-openresty` on `develop` is currently the only `luajit` implementation supporting `macOS aarch64`. On this regard, I tried dropping the conflict in `lua-luajit` that was added in https://github.com/spack/spack/pull/30971, and I didn't get any problem. I'm not sure how safe it is to drop this conflict, I would probably do that and in case of a problem reproducer we can re-evaluate it.

Looking forward your comments.