### PR TITLE
acts dependencies: new versions as of 2025/05/26

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/actsvg/package.py
@@ -21,6 +21,11 @@ class Actsvg(CMakePackage):
 
     license("MPL-2.0")
 
+    version("0.4.56", sha256="a850007036e992a2573e01bc32ee203bb3c146d124ec1135922272ba6a62008e")
+    version("0.4.55", sha256="31a95bd12d685b2f87eac4b9e5872f9fb4add5a5b2e826a8bd727d60a0ba601f")
+    version("0.4.54", sha256="204e4217936d0d6afb91f30c727e30b2a351d8ceddd9beca7550c40272a848fe")
+    version("0.4.53", sha256="c7ddec952e84c7b7b70c1e2e15b801675fe8a30d84cabdd3273ee9890dec04be")
+    version("0.4.52", sha256="3cee069bff266ad8ab7e12f1fefad7a825da6684185b8c5449d2f1dade004843")
     version("0.4.51", sha256="937385f7703c0d2d9c0af03bd5083d3f1fdac17ff573476a5fc5b1f8e3cd98b7")
     version("0.4.50", sha256="c97fb1cc75cbf23caebd3c6fb8716354bdbd0a77ad39dc43dae963692f3256e1")
     version("0.4.48", sha256="0f230c31c64b939e4d311afd997dbaa87a375454cf1595661a449b97943412c9")
@@ -56,6 +61,7 @@ class Actsvg(CMakePackage):
     depends_on("googletest", when="+examples")
     depends_on("python@3.8:", when="+python")
     depends_on("py-pybind11@2.10:", when="+python @0.4.42:")
+    depends_on("py-pybind11@2.13:", when="+python @0.4.53:")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/spack_repo/builtin/packages/detray/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/detray/package.py
@@ -21,6 +21,7 @@ class Detray(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.98.0", sha256="d90c70d2d4bdd9dbd09024ff6990d57f610947c9544afccadf611316de76b2d9")
     version("0.97.0", sha256="cddee6074b92da9823afe016949c023843d9bc079caddaa7f52900dbefdf64a7")
     version("0.96.0", sha256="b009fad9780adf2bf8d683469d6167b37b4f682da0dbaf58f9f67166096f9bcc")
     version("0.95.0", sha256="86cc981eb0105143b971acea3544b9a668326e1027f317d77cf76918f766e7c4")

--- a/var/spack/repos/spack_repo/builtin/packages/detray/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/detray/package.py
@@ -21,6 +21,8 @@ class Detray(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.97.0", sha256="cddee6074b92da9823afe016949c023843d9bc079caddaa7f52900dbefdf64a7")
+    version("0.96.0", sha256="b009fad9780adf2bf8d683469d6167b37b4f682da0dbaf58f9f67166096f9bcc")
     version("0.95.0", sha256="86cc981eb0105143b971acea3544b9a668326e1027f317d77cf76918f766e7c4")
     version("0.94.0", sha256="a04e8193757846df50d0fbec858744dd66629a98be8ffc6faa04c2ab51770492")
     version("0.93.0", sha256="7d56771d213649de836905efbb21b5be59cc966b00417b0b1fa85bfe12ac92da")
@@ -87,6 +89,7 @@ class Detray(CMakePackage):
     depends_on("nlohmann-json@3.11.0:", when="+json")
     depends_on("dfelibs@20211029:", when="@:0.88")
     depends_on("acts-algebra-plugins@0.18.0: +vecmem")
+    depends_on("acts-algebra-plugins@0.27.0: +vecmem", when="@0.95:")
     depends_on("acts-algebra-plugins +vc", when="+vc")
     depends_on("acts-algebra-plugins +eigen", when="+eigen")
     depends_on("acts-algebra-plugins +smatrix", when="+smatrix")

--- a/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
@@ -19,6 +19,7 @@ class Vecmem(CMakePackage, CudaPackage):
 
     license("MPL-2.0-no-copyleft-exception")
 
+    version("1.18.0", sha256="2b9e92d10f8883eafb45f48fd357ecaf7456badec11ccd375d3f2505e71aa9d2")
     version("1.17.0", sha256="6032279e8fc8bdb48d39c4ac19ffe561bcc53576e36f71ee2ed3ed75835f1af9")
     version("1.16.0", sha256="04da7077381e12c2b9bf869e1357105683596ed9105e3acff3c6d9214be04fbd")
     version("1.15.0", sha256="53e03599efd5a22284b62e10338b69345d8188182a12fefe228005069d1ddd74")

--- a/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/vecmem/package.py
@@ -19,6 +19,7 @@ class Vecmem(CMakePackage, CudaPackage):
 
     license("MPL-2.0-no-copyleft-exception")
 
+    version("1.17.0", sha256="6032279e8fc8bdb48d39c4ac19ffe561bcc53576e36f71ee2ed3ed75835f1af9")
     version("1.16.0", sha256="04da7077381e12c2b9bf869e1357105683596ed9105e3acff3c6d9214be04fbd")
     version("1.15.0", sha256="53e03599efd5a22284b62e10338b69345d8188182a12fefe228005069d1ddd74")
     version("1.14.0", sha256="3fac19e2766e5f997712b0799bd820f65c17ea9cddcb9e765cbdf214f41c4783")


### PR DESCRIPTION
This commit adds v1.16.0 and v1.17.0 of vecmem, v0.95.0, v0.96.0, and v0.97.0 of detray, and numerous new actsvg versions.