### PR TITLE
lammps: adding tbb dependency when +intel %oneapi

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/lammps/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/lammps/package.py
@@ -767,6 +767,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
     depends_on("llvm-amdgpu ", when="+rocm", type="build")
     depends_on("rocm-openmp-extras", when="+rocm +openmp", type="build")
     depends_on("gsl@2.6:", when="+rheo")
+    depends_on("tbb", when="+intel %oneapi")
 
     # propagate CUDA and ROCm architecture when +kokkos
     for arch in CudaPackage.cuda_arch_values:


### PR DESCRIPTION
Enabling tbb as dependency when `intel` variant is enabled and `oneapi` compiler is used.

doc reference:
https://github.com/lammps/lammps/blob/2744647c75f065f259845c3636182600c9ce00c9/doc/src/Speed_intel.rst?plain=1#L247

oneapi makefile reference:
https://github.com/lammps/lammps/blob/2744647c75f065f259845c3636182600c9ce00c9/src/MAKE/OPTIONS/Makefile.oneapi#L19


