### PR TITLE
rocm-examples: add cuda variant

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/hip/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hip/package.py
@@ -662,6 +662,8 @@ class Hip(CMakePackage):
                         f"-I{self.spec['xproto'].prefix.include}",
                     )
                 )
+            if self.spec.satisfies("@6.4.0:"):
+                args.append(self.define("clang", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang"))
 
         if self.spec.satisfies("+cuda"):
             args.append(self.define("HIP_PLATFORM", "nvidia"))
@@ -683,6 +685,4 @@ class Hip(CMakePackage):
             args.append(self.define("HIPCC_BIN_DIR", self.stage.source_path + "/hipcc/bin"))
         if self.spec.satisfies("@6.0:"):
             args.append(self.define("HIPCC_BIN_DIR", self.spec["hipcc"].prefix.bin))
-        if self.spec.satisfies("@6.4.0:"):
-            args.append(self.define("clang", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang"))
         return args

--- a/var/spack/repos/spack_repo/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipcub/package.py
@@ -99,7 +99,7 @@ class Hipcub(CMakePackage, CudaPackage, ROCmPackage):
         depends_on(f"hip +cuda@{ver}", when=f"+cuda @{ver}")
 
     # fix hardcoded search in /opt/rocm and broken config mode search
-    patch("find-hip-cuda-rocm-5.3.patch", when="@5.3: +cuda")
+    patch("find-hip-cuda-rocm-5.3.patch", when="@5.3:5.7 +cuda")
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("+rocm"):

--- a/var/spack/repos/spack_repo/builtin/packages/hiprand/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hiprand/package.py
@@ -124,7 +124,8 @@ class Hiprand(CMakePackage, CudaPackage, ROCmPackage):
         )
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        env.set("CXX", self.spec["hip"].hipcc)
+        if self.spec.satisfies("+rocm"):
+            env.set("CXX", self.spec["hip"].hipcc)
         if self.spec.satisfies("+asan"):
             self.asan_on(env)
 

--- a/var/spack/repos/spack_repo/builtin/packages/hiprand/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hiprand/package.py
@@ -147,6 +147,8 @@ class Hiprand(CMakePackage, CudaPackage, ROCmPackage):
             args.append(self.define("BUILD_WITH_LIB", "CUDA"))
             # FindHIP.cmake is used for +cuda
             args.append(self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip))
+            arch_str = ";".join(self.spec.variants["cuda_arch"].value)
+            args.append(self.define("NVGPU_TARGETS", arch_str))
         else:
             args.append(self.define("BUILD_WITH_LIB", "ROCM"))
 

--- a/var/spack/repos/spack_repo/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipsolver/package.py
@@ -170,7 +170,7 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
                     self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip)
                 )
         else:
-            self.define("ROCBLAS_PATH", self.spec["rocblas"].prefix)
+            args.append(self.define("ROCBLAS_PATH", self.spec["rocblas"].prefix))
 
         if self.spec.satisfies("@5.2.0:6.3.1"):
             args.append(self.define("BUILD_FILE_REORG_BACKWARD_COMPATIBILITY", True))

--- a/var/spack/repos/spack_repo/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/hipsolver/package.py
@@ -159,7 +159,6 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
             self.define("BUILD_FORTRAN_BINDINGS", "OFF"),
             self.define("BUILD_CLIENTS_TESTS", self.run_tests),
             self.define("SUITE_SPARSE_PATH", self.spec["suite-sparse"].prefix),
-            self.define("ROCBLAS_PATH", self.spec["rocblas"].prefix),
         ]
 
         args.append(self.define_from_variant("USE_CUDA", "cuda"))
@@ -170,6 +169,8 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
                 args.append(
                     self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip)
                 )
+        else:
+            self.define("ROCBLAS_PATH", self.spec["rocblas"].prefix)
 
         if self.spec.satisfies("@5.2.0:6.3.1"):
             args.append(self.define("BUILD_FILE_REORG_BACKWARD_COMPATIBILITY", True))

--- a/var/spack/repos/spack_repo/builtin/packages/rocm_examples/add_hip_include_cuda.patch
+++ b/var/spack/repos/spack_repo/builtin/packages/rocm_examples/add_hip_include_cuda.patch
@@ -1,0 +1,13 @@
+diff --git a/Libraries/CMakeLists.txt b/Libraries/CMakeLists.txt
+index 67a86ce..a9d5e3e 100644
+--- a/Libraries/CMakeLists.txt
++++ b/Libraries/CMakeLists.txt
+@@ -26,6 +26,8 @@ include(CTest)
+ 
+ file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
++find_package(HIP MODULE REQUIRED)
++include_directories("${HIP_ROOT_DIR}/include")
+ 
+ # CMake configuration files for CUDA versions of HIP libraries are not yet
+ # included under the HIP SDK for Windows.

--- a/var/spack/repos/spack_repo/builtin/packages/rocm_examples/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rocm_examples/package.py
@@ -98,6 +98,7 @@ class RocmExamples(CMakePackage):
             args.append(self.define("ROCM_ROOT", self.spec["hip"].prefix))
             args.append(self.define("HIP_ROOT_DIR", self.spec["hip"].prefix))
             args.append(self.define("CUDA_DRIVER_LIB", f"{self.spec['cuda'].prefix}/targets/x86_64-linux/lib/stubs/libcuda.so"))
+            #TODO: enable reduction for +cuda
             args.append(self.define("REDUCTION_BUILD_EXAMPLES", False))
             args.append(self.define("REDUCTION_BUILD_TESTING", False))
             args.append(self.define("REDUCTION_BUILD_BENCHMARKS", False))

--- a/var/spack/repos/spack_repo/builtin/packages/rocm_examples/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rocm_examples/package.py
@@ -29,7 +29,7 @@ class RocmExamples(CMakePackage):
     version("6.2.1", sha256="2e426572aa5f5b44c7893ea256945c8733b79db39cca84754380f40c8b44a563")
     version("6.2.0", sha256="6fb1f954ed32b5c4085c7f071058d278c2e1e8b7b71118ee5e85cf9bbc024df0")
 
-    variant("rocm", default=True, description="Build with CUDA")
+    variant("rocm", default=True, description="Build with ROCm")
     variant("cuda", default=False, description="Build with CUDA")
 
     conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")

--- a/var/spack/repos/spack_repo/builtin/packages/rocm_examples/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rocm_examples/package.py
@@ -97,8 +97,13 @@ class RocmExamples(CMakePackage):
             args.append(self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip))
             args.append(self.define("ROCM_ROOT", self.spec["hip"].prefix))
             args.append(self.define("HIP_ROOT_DIR", self.spec["hip"].prefix))
-            args.append(self.define("CUDA_DRIVER_LIB", f"{self.spec['cuda'].prefix}/targets/x86_64-linux/lib/stubs/libcuda.so"))
-            #TODO: enable reduction for +cuda
+            args.append(
+                self.define(
+                    "CUDA_DRIVER_LIB",
+                    f"{self.spec['cuda'].prefix}/targets/x86_64-linux/lib/stubs/libcuda.so",
+                )
+            )
+            # TODO: enable reduction for +cuda
             args.append(self.define("REDUCTION_BUILD_EXAMPLES", False))
             args.append(self.define("REDUCTION_BUILD_TESTING", False))
             args.append(self.define("REDUCTION_BUILD_BENCHMARKS", False))

--- a/var/spack/repos/spack_repo/builtin/packages/rocm_examples/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/rocm_examples/package.py
@@ -29,6 +29,12 @@ class RocmExamples(CMakePackage):
     version("6.2.1", sha256="2e426572aa5f5b44c7893ea256945c8733b79db39cca84754380f40c8b44a563")
     version("6.2.0", sha256="6fb1f954ed32b5c4085c7f071058d278c2e1e8b7b71118ee5e85cf9bbc024df0")
 
+    variant("rocm", default=True, description="Build with CUDA")
+    variant("cuda", default=False, description="Build with CUDA")
+
+    conflicts("+cuda +rocm", msg="CUDA and ROCm support are mutually exclusive")
+    conflicts("~cuda ~rocm", msg="CUDA or ROCm support is required")
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
@@ -38,17 +44,30 @@ class RocmExamples(CMakePackage):
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"hipify-clang@{ver}", when=f"@{ver}")
         depends_on(f"hipcub@{ver}", when=f"@{ver}")
-        depends_on(f"hiprand@{ver}", when=f"@{ver}")
         depends_on(f"hipsolver@{ver}", when=f"@{ver}")
-        depends_on(f"rocblas@{ver}", when=f"@{ver}")
-        depends_on(f"rocthrust@{ver}", when=f"@{ver}")
         depends_on(f"hipblas@{ver}", when=f"@{ver}")
-        depends_on(f"rocsparse@{ver}", when=f"@{ver}")
-        depends_on(f"rocsolver@{ver}", when=f"@{ver}")
+        depends_on(f"hiprand@{ver}", when=f"@{ver} +rocm")
+        depends_on(f"rocblas@{ver}", when=f"@{ver} +rocm")
+        depends_on(f"rocthrust@{ver}", when=f"@{ver} +rocm")
+        depends_on(f"rocsparse@{ver}", when=f"@{ver} +rocm")
+        depends_on(f"rocsolver@{ver}", when=f"@{ver} +rocm")
 
     for ver in ["6.4.0", "6.3.3", "6.3.2", "6.3.1", "6.3.0"]:
         depends_on(f"hipfft@{ver}", when=f"@{ver}")
-        depends_on(f"rocfft@{ver}", when=f"@{ver}")
+        depends_on(f"rocfft@{ver}", when=f"@{ver} +rocm")
+
+    depends_on("hip+cuda", when="+cuda")
+    depends_on("hipcub+cuda", when="+cuda")
+    depends_on("hipsolver+cuda", when="+cuda")
+    depends_on("hipblas+cuda", when="+cuda")
+    depends_on("hipfft+cuda", when="@6.3: +cuda")
+
+    patch(
+        "https://github.com/ROCm/rocm-examples/commit/669fc3e90ce95567464e80d7925f45cb525c81db.patch?full_index=1",
+        sha256="ee0eec2140732513d077cca2a46a8257ed785315208dd3e917e4c8e424cfa63e",
+        when="@6.4+cuda",
+    )
+    patch("add_hip_include_cuda.patch", when="@6.4+cuda")
 
     def patch(self):
         filter_file(
@@ -60,16 +79,26 @@ class RocmExamples(CMakePackage):
 
     def cmake_args(self):
         args = []
-        args.append(
-            self.define(
-                "OFFLOAD_BUNDLER_COMMAND",
-                f"{self.spec['llvm-amdgpu'].prefix}/bin/clang-offload-bundler",
+        if self.spec.satisfies("+cuda"):
+            args.append(
+                self.define(
+                    "OFFLOAD_BUNDLER_COMMAND",
+                    f"{self.spec['llvm-amdgpu'].prefix}/bin/clang-offload-bundler",
+                )
             )
-        )
-        args.append(
-            self.define("LLVM_MC_COMMAND", f"{self.spec['llvm-amdgpu'].prefix}/bin/llvm-mc")
-        )
-        args.append(
-            self.define("LLVM_DIS_COMMAND", f"{self.spec['llvm-amdgpu'].prefix}/bin/llvm-dis")
-        )
+            args.append(
+                self.define("LLVM_MC_COMMAND", f"{self.spec['llvm-amdgpu'].prefix}/bin/llvm-mc")
+            )
+            args.append(
+                self.define("LLVM_DIS_COMMAND", f"{self.spec['llvm-amdgpu'].prefix}/bin/llvm-dis")
+            )
+        if self.spec.satisfies("+cuda"):
+            args.append(self.define("GPU_RUNTIME", "CUDA"))
+            args.append(self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip))
+            args.append(self.define("ROCM_ROOT", self.spec["hip"].prefix))
+            args.append(self.define("HIP_ROOT_DIR", self.spec["hip"].prefix))
+            args.append(self.define("CUDA_DRIVER_LIB", f"{self.spec['cuda'].prefix}/targets/x86_64-linux/lib/stubs/libcuda.so"))
+            args.append(self.define("REDUCTION_BUILD_EXAMPLES", False))
+            args.append(self.define("REDUCTION_BUILD_TESTING", False))
+            args.append(self.define("REDUCTION_BUILD_BENCHMARKS", False))
         return args


### PR DESCRIPTION
add a cuda variant for rocm-examples and fix +cuda builds for hip, hiprand, hipcub and hipsolver
