### PR TITLE
[TAU package] +rocprofiler-sdk variant

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/tau/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/tau/package.py
@@ -103,6 +103,12 @@ class Tau(Package):
         "rocprofv2", default=False, description="Activates ROCm rocprofiler support", when="@2.34:"
     )
     variant(
+        "rocprofiler-sdk",
+        default=False,
+        description="Activates ROCm rocprofiler-sdk support",
+        when="@2.34.1:",
+    )
+    variant(
         "salt", default=False, description="Activates SALT source instrumentation", when="@2.34:"
     )
     variant("opencl", default=False, description="Activates OpenCL support")
@@ -173,6 +179,10 @@ class Tau(Package):
     depends_on("hsa-rocr-dev", when="+rocm")
     depends_on("rocm-smi-lib", when="@2.32.1: +rocm")
     depends_on("rocm-core", when="@2.34: +rocm")
+    depends_on("rocprofiler-sdk@6.2.4:", when="+rocprofiler-sdk")
+    depends_on("hip", when="+rocprofiler-sdk")
+    depends_on("elfutils", when="+rocprofiler-sdk")
+    depends_on("comgr", when="+rocprofiler-sdk")
     depends_on("salt", when="+salt", type="run")
     depends_on("hip", when="@2.34: +roctracer")
     depends_on("java", type="run")  # for paraprof
@@ -192,19 +202,28 @@ class Tau(Package):
     conflicts("+disable-no-pie", when="@:2.33.2")
     patch("unwind.patch", when="@2.29.0")
 
-    conflicts("+rocprofiler", when="+roctracer", msg="Use either rocprofiler or roctracer")
-    conflicts("+rocprofv2", when="+rocprofiler", msg="Rocprofv2 does not need rocprofiler")
-    conflicts("+rocprofv2", when="+roctracer", msg="Rocprofv2 does not need roctracer")
+    conflicts("+rocprofiler", when="+rocprofv2", msg="Use either rocprofiler or rocprofv2")
+    conflicts(
+        "+rocprofiler", when="+rocprofiler-sdk", msg="Use either rocprofiler or rocprofiler-sdk"
+    )
+
+    conflicts("+roctracer", when="+rocprofv2", msg="Use either roctracer or rocprofv2")
+    conflicts("+roctracer", when="+rocprofiler-sdk", msg="Use either roctracer or rocprofiler-sdk")
+
+    conflicts("+rocprofv2", when="+rocprofiler-sdk", msg="Use either rocprofv2 or rocprofiler-sdk")
+
     requires("+rocm", when="+rocprofiler", msg="Rocprofiler requires ROCm")
     requires("+rocm", when="+roctracer", msg="Roctracer requires ROCm")
+    requires("+rocm", when="+rocprofiler-sdk", msg="Rocprofiler-sdk requires ROCm")
 
     requires(
         "+rocprofiler",
         "+roctracer",
         "+rocprofv2",
+        "+rocprofiler-sdk",
         policy="one_of",
         when="+rocm",
-        msg="Using ROCm, select either +rocprofiler, +roctracer or +rocprofv2",
+        msg="Using ROCm, select either +rocprofiler, +roctracer, +rocprofv2 or +rocprofiler-sdk",
     )
 
     # https://github.com/UO-OACISS/tau2/commit/1d2cb6b
@@ -380,6 +399,13 @@ class Tau(Package):
         if "+rocprofv2" in spec:
             options.append("-rocprofiler=%s" % spec["rocprofiler-dev"].prefix)
             options.append("-rocprofv2")
+
+
+        if "+rocprofiler-sdk" in spec:
+            options.append("-rocprofsdk=%s" % spec["rocprofiler-sdk"].prefix)
+            options.append("-elfutils=%s" % spec["elfutils"].prefix)
+            options.append("-hip=%s" % spec["hip"].prefix)
+            options.append("-comgr=%s" % spec["comgr"].prefix)
 
         if "+adios2" in spec:
             options.append("-adios=%s" % spec["adios2"].prefix)

--- a/var/spack/repos/spack_repo/builtin/packages/tau/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/tau/package.py
@@ -400,7 +400,6 @@ class Tau(Package):
             options.append("-rocprofiler=%s" % spec["rocprofiler-dev"].prefix)
             options.append("-rocprofv2")
 
-
         if "+rocprofiler-sdk" in spec:
             options.append("-rocprofsdk=%s" % spec["rocprofiler-sdk"].prefix)
             options.append("-elfutils=%s" % spec["elfutils"].prefix)


### PR DESCRIPTION
Adding rocprofiler-sdk variant.
@spackbot fix style

Tested with Odyssey (will test with omnia).

Should be tested with Frontier:
```
spack install tau+rocprofiler-sdk~papi~pdt
spack load tau
# Go to path shown with spack find -p tau+rocprofiler-sdk
cd examples/gpu/hip/add4
make
tau_exec -rocm ./gpu-stream-hip
```
```

# Check if output similar to:
NODE 0;CONTEXT 0;THREAD 0:
---------------------------------------------------------------------------------------
%Time    Exclusive    Inclusive       #Call      #Subrs  Inclusive Name
              msec   total msec                          usec/call
---------------------------------------------------------------------------------------
100.0          117        1,193           1           1    1193530 .TAU application
 90.2        1,076        1,076           1           0    1076360 taupreload_main

NODE 0;CONTEXT 0;THREAD 1:
---------------------------------------------------------------------------------------
%Time    Exclusive    Inclusive       #Call      #Subrs  Inclusive Name
              msec   total msec                          usec/call
---------------------------------------------------------------------------------------
100.0          621          878           1        1959     878448 .TAU application
  7.5           65           65           1           0      65976 hsa_queue_create
  7.3           64           64          12           0       5356 hsa_amd_memory_pool_allocate
  4.9           43           43         104           0        415 hsa_signal_wait_scacquire
  4.1           36           36          26           0       1402 hsa_executable_iterate_symbols
  3.2           28           28          56           0        506 hsa_amd_memory_async_copy_on_engine
  0.7            5            5          56           0        106 hsa_amd_memory_lock_to_pool
  0.5            4            4           5           0        945 hsa_amd_memory_pool_free
  0.3            2            2         195           0         15 hsa_agent_get_info
  0.3            2            2           2           0       1206 hsa_executable_freeze
  0.1            1            1           6           0        184 hsa_amd_agents_allow_access
  0.1        0.947        0.947           2           0        473 hsa_executable_load_agent_code_object
  0.0        0.404        0.404          88           0          5 hsa_signal_store_screlease
  0.0        0.193        0.193           2           0         96 hsa_code_object_reader_create_from_memory
  0.0        0.121        0.121          55           0          2 hsa_signal_create
  0.0        0.111        0.111          48           0          2 hsa_amd_signal_async_handler
  0.0       0.0663       0.0663         573           0          0 hsa_signal_load_relaxed
  0.0        0.066        0.066           8           0          8 hsa_isa_get_info_alt
  0.0        0.035        0.035           2           0         18 hsa_executable_create_alt
  0.0       0.0285       0.0285           1           0         28 hsa_iterate_agents
  0.0       0.0227       0.0227          56           0          0 hsa_amd_memory_unlock
  0.0       0.0198       0.0198           4           0          5 hsa_amd_agent_iterate_memory_pools
  0.0       0.0138       0.0138          16           0          1 hsa_amd_memory_copy_engine_status
  0.0       0.0132       0.0132          40           0          0 hsa_amd_pointer_info
  0.0       0.0105       0.0105         104           0          0 hsa_signal_silent_store_relaxed
  0.0       0.0095       0.0095          88           0          0 hsa_queue_add_write_index_screlease
  0.0       0.0085       0.0085          26           0          0 hsa_executable_get_symbol_by_name
  0.0      0.00625      0.00625          64           0          0 hsa_amd_signal_create
  0.0        0.006        0.006          88           0          0 hsa_queue_load_read_index_relaxed
  0.0      0.00575      0.00575          88           0          0 hsa_queue_load_read_index_scacquire
  0.0       0.0035       0.0035          60           0          0 hsa_amd_agent_memory_pool_get_info
  0.0        0.003        0.003          13           0          0 hsa_system_get_info
  0.0       0.0025       0.0025          52           0          0 hsa_executable_symbol_get_info
  0.0       0.0015       0.0015           4           0          0 hsa_agent_iterate_isas
  0.0       0.0015       0.0015           1           0          2 hsa_amd_profiling_set_profiler_enabled
  0.0       0.0005       0.0005          12           0          0 hsa_amd_memory_pool_get_info
  0.0      0.00025      0.00025           1           0          0 hsa_system_get_major_extension_table

NODE 0;CONTEXT 0;THREAD 2:
---------------------------------------------------------------------------------------
%Time    Exclusive    Inclusive       #Call      #Subrs  Inclusive Name
              msec   total msec                          usec/call
---------------------------------------------------------------------------------------
100.0          264        1,075           1         207    1075658 .TAU application
 37.2          399          399           8           0      49961 hipMemcpy
 19.5          209          209           1           0     209734 hipGetDeviceCount
  8.3           89           89          41           0       2188 hipDeviceSynchronize
  5.6           60           60           5           0      12112 hipMalloc
  4.3           46           46          40           0       1168 hipLaunchKernel
  0.4            4            4           5           0        962 hipFree
  0.0       0.0343       0.0343         103           0          0 hipGetLastError
  0.0       0.0145       0.0145           2           0          7 hipGetDevicePropertiesR0600
  0.0      0.00225      0.00225           1           0          2 hipSetDevice
  0.0       0.0015       0.0015           1           0          2 hipDriverGetVersion

NODE 0;CONTEXT 0;THREAD 3:
---------------------------------------------------------------------------------------
%Time    Exclusive    Inclusive       #Call      #Subrs  Inclusive Name
              msec   total msec                          usec/call
---------------------------------------------------------------------------------------
100.0          218          254           1          96     254134 .TAU application
  7.1           18           18          35           0        516 MEMORY_COPY_HOST_TO_DEVICE
  4.3           10           10          21           0        516 MEMORY_COPY_DEVICE_TO_HOST
  1.2            3            3          10           0        304 [ROCm Kernel] void add<double>(double const*, double const*, double const*, double const*, double*) [clone .kd]
  0.6            1            1          10           0        164 [ROCm Kernel] void triad<double>(double*, double const*, double const*) [clone .kd]
  0.4            1            1          10           0        109 [ROCm Kernel] void mul<double>(double*, double const*) [clone .kd]
  0.4            1            1          10           0        108 [ROCm Kernel] void copy<double>(double const*, double*) [clone .kd]
---------------------------------------------------------------------------------------



```