### PR TITLE
Remote package repositories

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -561,7 +561,19 @@ def setup_main_options(args):
     for config_var in args.config_vars or []:
         spack.config.add(fullpath=config_var, scope="command_line")
 
-    spack.repo.enable_repo(spack.repo.RepoPath.from_config(spack.config.CONFIG))
+    # In the main function we automatically fetch remote package repositories if necessary
+    repo_descriptors = spack.repo.RepoDescriptors.from_config(
+        lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG
+    )
+
+    repo_path, errors = repo_descriptors.construct(fetch=True)
+
+    # Merely warn if package repositories from config could not be constructed.
+    if errors:
+        for path, error in errors.items():
+            tty.warn(f"Error constructing repository '{path}': {error}")
+
+    spack.repo.enable_repo(repo_path)
 
     # On Windows10 console handling for ASCI/VT100 sequences is not
     # on by default. Turn on before we try to write to console

--- a/lib/spack/spack/schema/repos.py
+++ b/lib/spack/spack/schema/repos.py
@@ -14,7 +14,7 @@ properties: Dict[str, Any] = {
     "repos": {
         "oneOf": [
             {
-                # old format: array of paths
+                # old format: array of strings
                 "type": "array",
                 "items": {
                     "type": "string",
@@ -22,11 +22,27 @@ properties: Dict[str, Any] = {
                 },
             },
             {
-                # new format: dict of namespace => path
+                # new format: object with named repositories
                 "type": "object",
                 "additionalProperties": {
-                    "type": "string",
-                    "description": "Path to a Spack package repository directory",
+                    "oneOf": [
+                        {
+                            # local path
+                            "type": "string",
+                            "description": "Path to a Spack package repository directory",
+                        },
+                        {
+                            # remote git repository
+                            "type": "object",
+                            "properties": {
+                                "git": {"type": "string"},
+                                "destination": {"type": "string"},
+                                "paths": {"type": "array", "items": {"type": "string"}},
+                            },
+                            "required": ["git"],
+                            "additionalProperties": False,
+                        },
+                    ]
                 },
             },
         ],

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1813,7 +1813,7 @@ _spack_repo_list() {
 _spack_repo_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --name --path --scope"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2759,7 +2759,7 @@ complete -c spack -n '__fish_spack_using_command rm' -s f -l force -d 'remove co
 set -g __fish_spack_optspecs_spack_repo h/help
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a create -d 'create a new package repository'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a list -d 'show registered repositories and their namespaces'
-complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a add -d 'add a package source to Spack'"'"'s configuration'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a add -d 'add package repositories to Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a rm -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a migrate -d 'migrate a package repository to the latest Package API'
@@ -2782,10 +2782,14 @@ complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
 
 # spack repo add
-set -g __fish_spack_optspecs_spack_repo_add h/help scope=
-complete -c spack -n '__fish_spack_using_command_pos 0 repo add' -f -a '(__fish_complete_directories)'
+set -g __fish_spack_optspecs_spack_repo_add h/help name= path= scope=
+
 complete -c spack -n '__fish_spack_using_command repo add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo add' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command repo add' -l name -r -f -a name
+complete -c spack -n '__fish_spack_using_command repo add' -l name -r -d 'config name for the package repository, defaults to the namespace of the repository'
+complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
+complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
 


### PR DESCRIPTION
Adds support for Spack package repositories from external git repos.

```yaml
repos:
  my_repo:
    git: https://example.com/example/example.git
    destination: ~/example  # optional
    paths:  # optional
    - subdir/spack_repo/example/x
    - subdir/spack_repo/example/y
```

---

If `destination` is not configured, Spack clones the git repo to `~/.spack/git_repos/{hash(repository)}`.

---

Package repositories can put a file `spack-repo-index.yaml` in their root with relative paths to roots of package repositories (i.e. directories that contain `repo.yaml`):

```yaml
repo_index:
  paths:
  - subdir/spack_repo/example/x
  - subdir/spack_repo/example/y
```

so users don't have to put that under `paths` in config. The `spack-repo-index.yaml` is simply a list of paths under `repo_index`. The idea is to avoid duplicating data such as "namespace" already specified in `<git repo>/<repo path>/repo.yaml`, to avoid that there are two sources of truth that go out of sync.

Further, `paths` in user config takes precedence, which allows users to enable specific package repositories in case the git monorepo provides multiple.

---

Remote package repositories are cloned/initialized in:
* `spack.main`
* `spack repo add`

This is process safe due to the lock in `$SPACK_USER_CACHE_PATH/package-repository.lock`; only one process can clone at a time.

---

The `spack repo add` command has a few new flags and a new positional arg:

```
spack repo add [-h] [--name NAME] [--repo-path REPO_PATH] [--scope ...] path_or_repo [destination]
```

The signature is similar to the familiar `git clone <repository> <destination>`.

The `path_or_repo` argument is detected as a remote git repo if it contains a `:` not preceded by a `/`, which is what git does as well. If in the future we would support package repositories other than local file paths and remote git repos, we can resolve ambiguities with a new flag `[--git | --path | --<other-type>]`, but this is currently unnecessary.

The positional `destination` argument allows users to pick their own clone path, and only applies in case of git repos.

The flag `--repo-path` corresponds to `repos:<name>:paths` and can be repeated to select specific package repositories in a git monorepo, and is also required if the git repo does not provide a `spack-repo-index.yaml` file in its root. Spack will never scan for `repo.yaml` files recursively, it only relies on `spack-repo-index.yaml` and `--repo-path` for package repository roots inside a git repo.

The flag `--name` applies to the *config* name/key in `repos.yaml` under `repos:<name>`. This flag is optional in the common case of adding just one package repository: it is set to the package repository's namespace. In case of monorepos with multiple package repositories, the `--name` flag is required.