### PR TITLE
elfutils: relax conflict with libarchive 3.8

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/elfutils/package.py
@@ -101,10 +101,10 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     provides("elf@1")
 
-    # libarchive with iconv doesn't configure (still broken as of libarchive@3.7.1)
+    # libarchive@:3.7 with iconv doesn't configure
     # see https://github.com/spack/spack/issues/36710
-    # and https://github.com/libarchive/libarchive/issues/1819
-    conflicts("^libarchive +iconv", when="+debuginfod")
+    # fix: https://github.com/libarchive/libarchive/pull/2611
+    conflicts("^libarchive@:3.7 +iconv", when="+debuginfod")
 
     # https://sourceware.org/bugzilla/show_bug.cgi?id=24964
     conflicts("%apple-clang")


### PR DESCRIPTION
I can now successfully build `elfutils +debuginfod ^libarchive@3.8: +iconv` on ubuntu 22.04 and 24.10.

In concretizations, `libarchive` can now keeps its default `+iconv` when `elfutils+debuginfod` is involved (`gdb`, etc.). FWIW, I didn't see any other unexpected changes in concretizations (`binutils`, `gdb`).

For the record:
- https://github.com/spack/spack/issues/36710#issuecomment-1501008041
  (The original `elfutils ^libarchive@3.6 +iconv` error. I checked, it still happens with `libarchive@3.7.9`)
- https://github.com/spack/spack/pull/36758 and https://github.com/spack/spack/pull/40314
- https://github.com/spack/spack/pull/50617
