### PR TITLE
btop: add v1.4.3

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/btop/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/btop/package.py
@@ -20,6 +20,7 @@ class Btop(MakefilePackage, CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.4.3", sha256="81b133e59699a7fd89c5c54806e16452232f6452be9c14b3a634122e3ebed592")
     version("1.4.0", sha256="ac0d2371bf69d5136de7e9470c6fb286cbee2e16b4c7a6d2cd48a14796e86650")
     version("1.3.2", sha256="331d18488b1dc7f06cfa12cff909230816a24c57790ba3e8224b117e3f0ae03e")
     version("1.3.0", sha256="375e078ce2091969f0cd14030620bd1a94987451cf7a73859127a786006a32cf")
@@ -29,12 +30,13 @@ class Btop(MakefilePackage, CMakePackage):
 
     variant("gpu", default=False, description="Enable GPU support", when="build_system=cmake")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.24:", type="build", when="@1.3.0: build_system=cmake")
 
     # Fix linking GPU support, by adding an explicit "target_link_libraries" to ${CMAKE_DL_LIBS}
-    patch("link-dl.patch", when="+gpu")
+    patch("link-dl.patch", when="+gpu @:1.4.0")
 
     requires("%gcc@10:", "%clang@16:", policy="one_of", msg="C++ 20 is required")
 


### PR DESCRIPTION
Compiling with GPU support might need extra macro, for `asprintf` (`-D_GNU_SOURCE`). Will try to fix that in a following PR.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
