### PR TITLE
esmf: patch yaml-cpp for gcc@15

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/esmf/package.py
@@ -153,6 +153,10 @@ class Esmf(MakefilePackage, PythonExtension):
     # https://github.com/spack/spack/issues/35957
     patch("esmf_cpp_info.patch")
 
+    # Patch for yaml-cpp (https://github.com/esmf-org/esmf/pull/404)
+    # Needed for GCC 15, patch only works from 8.5 on, will be fixed in 8.9
+    patch("yaml_cpp.patch", when="@8.5:8.8 %gcc@15:")
+
     @when("+python")
     def patch(self):
         # The pyproject.toml file uses a dynamically generated version from git

--- a/var/spack/repos/spack_repo/builtin/packages/esmf/yaml_cpp.patch
+++ b/var/spack/repos/spack_repo/builtin/packages/esmf/yaml_cpp.patch
@@ -1,0 +1,8 @@
+diff --git before/src/prologue/yaml-cpp/src/emitterutils.cpp after/src/prologue/yaml-cpp/src/emitterutils.cpp
+index c6ad5e5d93..bac0458658 100644
+--- before/src/prologue/yaml-cpp/src/emitterutils.cpp
++++ after/src/prologue/yaml-cpp/src/emitterutils.cpp
+@@ -1,4 +1,5 @@
+ #include <algorithm>
++#include <cstdint>
+ #include <iomanip>


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds a patch for `esmf` when compiling with `%gcc@15`. The patch is applicable for esmf 8.5 to 8.8 (will be fixed in esmf 8.9, see https://github.com/esmf-org/esmf/pull/404). I'm only applying it for `%gcc@15` though I think it's safe for every compiler.

NOTE: I think this patch is not good for 8.4 and older, because the file in question, `src/prologue/yaml-cpp/src/emitterutils.cpp`, changed from 8.4 to 8.5. But a patch for older versions would be simple if needed. (But I'm not a `patch` expert so maybe it's smarter than I think.)