### PR TITLE
clingo: upper bound on cmake version

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/clingo/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/clingo/package.py
@@ -49,6 +49,7 @@ class Clingo(CMakePackage):
     # See https://github.com/potassco/clingo/blob/v5.5.2/INSTALL.md
     depends_on("cmake@3.1:", type="build")
     depends_on("cmake@3.18:", type="build", when="@5.5:")
+    depends_on("cmake@:3", type="build", when="@:5.7")
 
     depends_on("doxygen", type="build", when="+docs")
 


### PR DESCRIPTION
`clingo@:5.7` cannot build with `cmake@4:`

This PR updates clingo to only build with cmake version 3 when at `:5.7`. 

