### PR TITLE
[Scorep] bugfix: do not require conflicting versions of cube for 9.0,…

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/gotcha/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gotcha/package.py
@@ -18,6 +18,7 @@ class Gotcha(CMakePackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("1.0.8", tag="1.0.8")
     version("1.0.7", tag="1.0.7", commit="ae053b77e6b2800188e2c4ddd17057c9b15f4adb")
     version("1.0.6", tag="1.0.6", commit="81401b939c23562728a27d7678505090463e5c03")
     version("1.0.5", tag="1.0.5", commit="e28f10c45a0cda0e1ec225eaea6abfe72c8353aa")

--- a/var/spack/repos/spack_repo/builtin/packages/scorep/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/scorep/package.py
@@ -129,8 +129,8 @@ class Scorep(AutotoolsPackage):
     # SCOREP 8
     depends_on("binutils", type="link", when="@8:")
     depends_on("otf2@3:", when="@8:")
-    depends_on("cubew@4.8.2:4.8", when="@8.3:")
-    depends_on("cubelib@4.8.2:4.8", when="@8.3:")
+    depends_on("cubew@4.8.2:4.8", when="@8.3:8")
+    depends_on("cubelib@4.8.2:4.8", when="@8.3:8")
     depends_on("cubew@4.8", when="@8:8.2")
     depends_on("cubelib@4.8", when="@8:8.2")
     # fall through to Score-P 7's OPARI2, no new release


### PR DESCRIPTION
… add gotcha 1.0.8. Both necessary for 9.0 to concretize in the wild.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
