### PR TITLE
julia: add `cpu_target` variant to let user customise `JULIA_CPU_TARGET`

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/julia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/julia/package.py
@@ -66,8 +66,11 @@ class Julia(MakefilePackage):
         default="auto",
         description=(
             "Machine architecture(s) for which to (pre)compile system and package "
-            + "images. Use pipe (|) instead of comma (,) as Spack does not support "
-            + "commas in variants"
+            "images. Use the value `auto` (the default) to let Spack automatically "
+            "determine the target architecture. Use pipe (|) instead of comma (,) "
+            "in variants as Spack does not support commas. E.g.: "
+            "`cpu_target='generic;sandybridge|-xsaveopt|clone_all;haswell|-rdrnd|base(1);"
+            "znver4|-rdrnd|base(1)'`."
         ),
         sticky=True,
     )

--- a/var/spack/repos/spack_repo/builtin/packages/julia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/julia/package.py
@@ -61,6 +61,12 @@ class Julia(MakefilePackage):
 
     variant("precompile", default=True, description="Improve julia startup time")
     variant("openlibm", default=True, description="Use openlibm instead of libm")
+    variant(
+        "cpu_target",
+        default="auto",
+        description="Machine architecture(s) for which to (pre)compile system and package images",
+        sticky=True,
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -376,7 +382,9 @@ class Julia(MakefilePackage):
         march = get_best_target(spec.target, spec.compiler.name, spec.compiler.version)
 
         # LLVM compatible name for the JIT
-        julia_cpu_target = get_best_target(spec.target, "clang", spec["llvm"].version)
+        julia_cpu_target = spec.variants["cpu_target"].value
+        if julia_cpu_target == "auto":
+            julia_cpu_target = get_best_target(spec.target, "clang", spec["llvm"].version)
 
         libuv = "libuv-julia" if "^libuv-julia" in spec else "libuv"
 

--- a/var/spack/repos/spack_repo/builtin/packages/julia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/julia/package.py
@@ -64,7 +64,11 @@ class Julia(MakefilePackage):
     variant(
         "cpu_target",
         default="auto",
-        description="Machine architecture(s) for which to (pre)compile system and package images",
+        description=(
+            "Machine architecture(s) for which to (pre)compile system and package "
+            + "images. Use pipe (|) instead of comma (,) as Spack does not support "
+            + "commas in variants"
+        ),
         sticky=True,
     )
 
@@ -382,7 +386,8 @@ class Julia(MakefilePackage):
         march = get_best_target(spec.target, spec.compiler.name, spec.compiler.version)
 
         # LLVM compatible name for the JIT
-        julia_cpu_target = spec.variants["cpu_target"].value
+        # Spack variants don't allow commas, so we use pipes and replace them to commas.
+        julia_cpu_target = spec.variants["cpu_target"].value.replace("|", ",")
         if julia_cpu_target == "auto":
             julia_cpu_target = get_best_target(spec.target, "clang", spec["llvm"].version)
 


### PR DESCRIPTION
This is useful when compiling julia on heterogeneous systems where we want to provide a single sysimage usable on different nodes.

Note that this currently doesn't work particularly well because values of variants don't seem to allow commas, and  [`JULIA_CPU_TARGET`](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_CPU_TARGET) ***needs*** commas to separate target features.