### PR TITLE
`spack compiler list`: show compilers in store and buildcaches

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -14,6 +14,7 @@ from llnl.util.tty.color import colorize
 import spack.compilers.config
 import spack.config
 import spack.spec
+import spack.store
 from spack.cmd.common import arguments
 
 description = "manage compilers"
@@ -170,7 +171,15 @@ def compiler_info(args):
 
 
 def compiler_list(args):
-    compilers = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
+    supported_compilers = spack.compilers.config.supported_compilers()
+
+    def _is_compiler(x):
+        return x.name in supported_compilers and x.package.supported_languages
+
+    compilers_from_store = [x for x in spack.store.STORE.db.query() if _is_compiler(x)]
+    compilers_from_yaml = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
+
+    compilers = compilers_from_yaml + compilers_from_store
 
     # If there are no compilers in any scope, and we're outputting to a tty, give a
     # hint to the user.
@@ -205,7 +214,10 @@ def compiler_list(args):
             os_str += f"-{target}"
         cname = f"{spack.spec.COMPILER_COLOR}{{{name}}} {os_str}"
         tty.hline(colorize(cname), char="-")
-        colify(reversed(sorted(c.format("{name}@{version}") for c in compilers)))
+        result = {
+            colorize(c.install_status().value) + c.format("{name}@{version}") for c in compilers
+        }
+        colify(reversed(sorted(result)))
 
 
 def compiler(parser, args):

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -185,7 +185,9 @@ def compiler_list(args):
     compilers = compilers_from_yaml + compilers_from_store
 
     if args.remote:
-        compilers.extend([x for x in spack.binary_distribution.update_cache_and_get_specs() if _is_compiler(x)])
+        compilers.extend(
+            [x for x in spack.binary_distribution.update_cache_and_get_specs() if _is_compiler(x)]
+        )
 
     # If there are no compilers in any scope, and we're outputting to a tty, give a
     # hint to the user.

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -11,6 +11,7 @@ from llnl.util.lang import index_by
 from llnl.util.tty.colify import colify
 from llnl.util.tty.color import colorize
 
+import spack.binary_distribution
 import spack.compilers.config
 import spack.config
 import spack.spec
@@ -67,6 +68,9 @@ def setup_parser(subparser):
     list_parser = sp.add_parser("list", aliases=["ls"], help="list available compilers")
     list_parser.add_argument(
         "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
+    )
+    list_parser.add_argument(
+        "--remote", action="store_true", help="list also compilers from registered buildcaches"
     )
 
     # Info
@@ -174,12 +178,14 @@ def compiler_list(args):
     supported_compilers = spack.compilers.config.supported_compilers()
 
     def _is_compiler(x):
-        return x.name in supported_compilers and x.package.supported_languages
+        return x.name in supported_compilers and x.package.supported_languages and not x.external
 
     compilers_from_store = [x for x in spack.store.STORE.db.query() if _is_compiler(x)]
     compilers_from_yaml = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
-
     compilers = compilers_from_yaml + compilers_from_store
+
+    if args.remote:
+        compilers.extend([x for x in spack.binary_distribution.update_cache_and_get_specs() if _is_compiler(x)])
 
     # If there are no compilers in any scope, and we're outputting to a tty, give a
     # hint to the user.

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -246,7 +246,7 @@ def name_os_target(spec: spack.spec.Spec) -> Tuple[str, str, str]:
         target = spec.architecture.target
         if not target:
             target = spack.platforms.host().target("default_target")
-        target = target
+        target = target.family
 
         operating_system = spec.os
         if not operating_system:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -799,11 +799,11 @@ _spack_compiler_rm() {
 }
 
 _spack_compiler_list() {
-    SPACK_COMPREPLY="-h --help --scope"
+    SPACK_COMPREPLY="-h --help --scope --remote"
 }
 
 _spack_compiler_ls() {
-    SPACK_COMPREPLY="-h --help --scope"
+    SPACK_COMPREPLY="-h --help --scope --remote"
 }
 
 _spack_compiler_info() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1121,18 +1121,22 @@ complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a 
 complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler list
-set -g __fish_spack_optspecs_spack_compiler_list h/help scope=
+set -g __fish_spack_optspecs_spack_compiler_list h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
+complete -c spack -n '__fish_spack_using_command compiler list' -l remote -f -a remote
+complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'list also compilers from registered buildcaches'
 
 # spack compiler ls
-set -g __fish_spack_optspecs_spack_compiler_ls h/help scope=
+set -g __fish_spack_optspecs_spack_compiler_ls h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -f -a remote
+complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -d 'list also compilers from registered buildcaches'
 
 # spack compiler info
 set -g __fish_spack_optspecs_spack_compiler_info h/help scope=


### PR DESCRIPTION
Starting from:
```console
$ spack find
==> In environment /home/culpo/opt/compilers
==> 3 root specs
[+] gcc@14+binutils  [+] gcc@15+binutils  [+] intel-oneapi-compilers

-- linux-ubuntu20.04-icelake / gcc@10.5.0 -----------------------
automake@1.16.5      binutils@2.44  diffutils@3.10    gawk@5.3.1  gcc@15.1.0  gettext@0.23.1  gmp@6.3.0      libsigsegv@2.14  libxml2@2.13.5  mpc@1.3.1   ncurses@6.5  pigz@2.8       readline@8.2  texinfo@7.1  zlib-ng@2.2.4
berkeley-db@18.1.40  bzip2@1.0.8    findutils@4.10.0  gcc@14.3.0  gdbm@1.23   gmake@4.4.1     libiconv@1.18  libtool@2.4.7    m4@1.4.19       mpfr@4.2.1  perl@5.40.0  pkgconf@2.3.0  tar@1.35      xz@5.6.3     zstd@1.5.7

-- linux-ubuntu20.04-icelake / no compiler ----------------------
autoconf@2.72  autoconf-archive@2023.02.20  compiler-wrapper@1.0  gcc@10.5.0  gcc@10.5.0  gcc-runtime@10.5.0  glibc@2.31  intel-oneapi-compilers@2025.1.1
==> 38 installed packages
==> 0 concretized packages to be installed (show with `spack find -c`)
$ spack mirror list
develop-2025-05-25-developer-tools-x86_64_v3-linux-gnu [sb] https://binaries.spack.io/develop-2025-05-25/developer-tools-x86_64_v3-linux-gnu
local                                                  [sb] file:///home/culpo/opt/compilers/mirror
spack-public                                           [s ] https://mirror.spack.io
```

**Before the PR**
```console
$ spack compiler list
==> Available compilers
-- gcc ubuntu20.04-x86_64 ---------------------------------------
gcc@10.5.0
```

**After the PR**
```console
$ spack compiler list
==> Available compilers
-- gcc ubuntu20.04-x86_64 ---------------------------------------
[e]  gcc@10.5.0  [+]  gcc@15.1.0  [+]  gcc@14.3.0

-- intel-oneapi-compilers ubuntu20.04-x86_64 --------------------
[+]  intel-oneapi-compilers@2025.1.1
$ spack compiler list --remote
==> Available compilers
-- gcc ubuntu20.04-x86_64 ---------------------------------------
[e]  gcc@10.5.0  [+]  gcc@15.1.0  [+]  gcc@14.3.0

-- intel-oneapi-compilers ubuntu20.04-x86_64 --------------------
[+]  intel-oneapi-compilers@2025.1.1

-- llvm centos7-x86_64 ------------------------------------------
 -   llvm@20.1.4
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
