### PR TITLE
mailmap: add Kathleen Shea to mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -33,6 +33,7 @@ Ian Lee               <lee1001@llnl.gov>                Ian Lee                 
 James Wynne III       <wynnejr@ornl.gov>                James Riley Wynne III   <wynnejr@ornl.gov>
 James Wynne III       <wynnejr@ornl.gov>                James Wynne III         <wynnejr@gpujake.com>
 Joachim Protze        <protze@rz.rwth-aachen.de>        jprotze                 <protze@rz.rwth-aachen.de>
+Kathleen Shea         <shea9@llnl.gov>                  kshea21                 <k_shea@coloradocollege.edu>
 Kelly (KT) Thompson   <kgt@lanl.gov>                                            <kellyt@MENE.localdomain>
 Kelly (KT) Thompson   <kgt@lanl.gov>                    Kelly Thompson          <KineticTheory@users.noreply.github.com>
 Kevin Brandstatter    <kjbrandstatter@gmail.com>        Kevin Brandstatter      <kbrandst@hawk.iit.edu>


### PR DESCRIPTION
Map Kathleen's Colorado College email to her LLNL one.
