### PR TITLE
Follow symlinks in roots of tracked environments

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -260,7 +260,10 @@ def active_environment() -> Optional["Environment"]:
 def _root(name):
     """Non-validating version of root(), to be used internally."""
     path = os.path.join(env_root_path(), name)
-    return os.readlink(path) if islink(path) else path
+    try:
+        return os.readlink(path)
+    except OSError:
+        return path
 
 
 def root(name):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -259,7 +259,8 @@ def active_environment() -> Optional["Environment"]:
 
 def _root(name):
     """Non-validating version of root(), to be used internally."""
-    return os.path.join(env_root_path(), name)
+    path = os.path.join(env_root_path(), name)
+    return os.readlink(path) if islink(path) else path
 
 
 def root(name):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -6,6 +6,8 @@ import collections
 import getpass
 import io
 import os
+import pathlib
+import sys
 import tempfile
 from datetime import date
 
@@ -34,6 +36,8 @@ import spack.util.path as spack_path
 import spack.util.spack_yaml as syaml
 
 from ..enums import ConfigScopePriority
+
+IS_WINDOWS = sys.platform == "win32"
 
 # sample config data
 config_low = {
@@ -371,7 +375,8 @@ def test_substitute_config_variables(mock_low_high_config, monkeypatch):
     ) == os.sep + os.path.join("foo", "bar", "baz", "$env")
 
     # Fake an active environment and $env is replaced properly
-    fake_env_path = os.sep + os.path.join("quux", "quuux")
+    root_drive = f"{pathlib.Path.cwd().drive}\\" if IS_WINDOWS else os.sep
+    fake_env_path = os.path.join(root_drive, "quux", "quuux")
     monkeypatch.setattr(ev, "active_environment", lambda: MockEnv(fake_env_path))
     assert spack_path.canonicalize_path("$env/foo/bar/baz") == os.path.join(
         fake_env_path, os.path.join("foo", "bar", "baz")


### PR DESCRIPTION
When tracking an environment using `spack develop` relative paths using `..` were
previously miscomputed off of the symlink rather than the realpath of the environment
resulting in build failures when the source code was not found. 

For example,

```yaml
spack:
  specs:
  - py-repligit
  develop:
    py-repligit:
      spec: py-repligit@=main
      path: $env/../
```

Would concretize to

```
py-repligit@main ... dev_path=$spack/var/spack/environments
```

instead of

```
py-repligit@main ... dev_path=/Users/alec/src/llnl/repligit
```

This PR modifies the root path calculation for tracked environments so that `$env` is
always computed off of the followed symlink of an environment.

It does *not* modify the path calculation of any other types of environments, as we want to
respect paths containing symlinks if they are provided by a user.  Likewise, we *only* indirect 
symlinks from `config:environments_root`  -- we do not call `realpath`, just `readlink`.
