### PR TITLE
Code cleanup for #47590

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -286,8 +286,7 @@ class DirectoryLayout:
         path = self.path_for_spec(spec)
         assert path.startswith(
             self.root
-        ), "Attempted to remove a directory outside Spack's install tree."
-        f"PATH: {path}, ROOT: {self.root}"
+        ), f"Attempted to remove dir outside Spack's install tree. PATH: {path}, ROOT: {self.root}"
 
         if deprecated:
             if os.path.exists(path):

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1105,7 +1105,6 @@ def test_padded_install_runtests_root(install_mockery, mock_fetch):
     output = install(
         "--verbose", "--test=root", "--no-cache", "test-build-callbacks", fail_on_error=False
     )
-    print(output)
     assert output.count("method not implemented") == 1
 
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_a/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_a/package.py
@@ -12,8 +12,7 @@ from spack.package import *
 
 
 class ParallelPackageA(Package):
-    """This is a fake vtk-m package used to demonstrate virtual package providers
-    with dependencies."""
+    """Simple package with dependencies for testing parallel builds"""
 
     homepage = "http://www.example.com"
     has_code = False

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_b/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_b/package.py
@@ -12,8 +12,7 @@ from spack.package import *
 
 
 class ParallelPackageB(Package):
-    """This is a fake vtk-m package used to demonstrate virtual package providers
-    with dependencies."""
+    """Simple dependency package for testing parallel builds"""
 
     homepage = "http://www.example.com"
     has_code = False

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_c/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_c/package.py
@@ -12,8 +12,7 @@ from spack.package import *
 
 
 class ParallelPackageC(Package):
-    """This is a fake vtk-m package used to demonstrate virtual package providers
-    with dependencies."""
+    """Simple dependency package for testing parallel builds"""
 
     homepage = "http://www.example.com"
     has_code = False


### PR DESCRIPTION
This PR addresses the remaining review feedback for #47590.

Cleaned up docstrings, invalid multi-line assert, and removed leftover test print statement. 