### PR TITLE
database: Improve DB migration message

### DIFF
--- a/lib/spack/spack/cmd/reindex.py
+++ b/lib/spack/spack/cmd/reindex.py
@@ -16,10 +16,16 @@ level = "long"
 
 def reindex(parser, args):
     current_index = spack.store.STORE.db._index_path
-    if os.path.isfile(current_index):
+    needs_backup = os.path.isfile(current_index)
+
+    if needs_backup:
         backup = f"{current_index}.bkp"
         shutil.copy(current_index, backup)
-        tty.msg(f"Created a back-up copy of the DB at {backup}")
+        tty.msg("Created a backup copy of the DB at", backup)
 
     spack.store.STORE.reindex()
-    tty.msg(f"The DB at {current_index} has been reindex to v{spack.database._DB_VERSION}")
+
+    extra = ["If you need to restore, replace it with the backup."] if needs_backup else []
+    tty.msg(
+        f"The DB at {current_index} has been reindexed to v{spack.database._DB_VERSION}", *extra
+    )

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -902,11 +902,22 @@ class Database:
         raise ExplicitDatabaseUpgradeError(
             f"database is v{self.db_version}, but Spack v{spack.__version__} needs v{_DB_VERSION}",
             long_message=(
-                f"\nChange config:install_tree:root to use a different store, or use `spack "
-                f"reindex` to migrate the store at {self.root} to version {_DB_VERSION}.\n\n"
-                f"If you decide to migrate the store, note that:\n"
-                f"1. The operation cannot be reverted, and\n"
-                f"2. Older Spack versions will not be able to read the store anymore\n"
+                f"You will need to either:"
+                f"\n"
+                f"\n  1. Migrate the database to v{_DB_VERSION}, or"
+                f"\n  2. Use a new database by changing config:install_tree:root."
+                f"\n"
+                f"\nTo migrate the database at {self.root} "
+                f"\nto version {_DB_VERSION}, run:"
+                f"\n"
+                f"\n    spack reindex"
+                f"\n"
+                f"\nNOTE that if you do this, older Spack versions will no longer"
+                f"\nbe able to read the database. However, `spack reindex` will create a backup,"
+                f"\nin case you want to revert."
+                f"\n"
+                f"\nIf you still need your old database, you can instead run"
+                f"\n`spack config edit config` and set install_tree:root to a new location."
             ),
         )
 


### PR DESCRIPTION
This makes the instructions for DB migration clearer and more consistent.

- [x] DB migration mentions spack reindex first and highlights its consequences.
- [x] Mention that the DB makes a backup and advise a little on how to restore it.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
