### PR TITLE
stages: add unique patch stages per build

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2585,10 +2585,10 @@ class BuildProcessInstaller:
         stage = self.pkg.stage
         stage.keep = self.keep_stage
 
-        if self.restage:
-            stage.destroy()
-
         with stage:
+            if self.restage:
+                stage.destroy()
+
             self.timer.start("stage")
 
             if not self.fake:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1693,14 +1693,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     # get the path either from the stage where it was fetched, or from the Patch
                     if isinstance(patch, spack.patch.UrlPatch):
                         patch_stage = next(patch_stages)
-                        files = os.listdir(patch_stage.source_path)
-                        assert len(files) == 1, f"Expected one file in stage, found {files}"
-                        patch_path = os.path.join(patch_stage.source_path, files[0])
-
+                        patch_path = patch_stage.single_file
                     else:
                         patch_path = patch.path
-                        if not patch_path or not os.path.isfile(patch_path):
-                            raise spack.error.NoSuchPatchError(f"No such patch: {patch.path}")
 
                     spack.patch.apply_patch(
                         self.stage, patch_path, patch.level, patch.working_dir, patch.reverse

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -43,6 +43,7 @@ import spack.patch
 import spack.phase_callbacks
 import spack.repo
 import spack.spec
+import spack.stage as stg
 import spack.store
 import spack.url
 import spack.util.archive
@@ -58,7 +59,6 @@ from spack.error import InstallError, NoURLError, PackageError
 from spack.filesystem_view import YamlFilesystemView
 from spack.resource import Resource
 from spack.solver.version_order import concretization_version_order
-from spack.stage import DevelopStage, ResourceStage, Stage, StageComposite, compute_stage_name
 from spack.util.package_hash import package_hash
 from spack.util.typing import SupportsRichComparison
 from spack.version import GitVersion, StandardVersion, VersionError, is_git_version
@@ -743,7 +743,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             raise ValueError(msg.format(self))
 
         # init internal variables
-        self._stage: Optional[StageComposite] = None
+        self._stage: Optional[stg.StageComposite] = None
+        self._patch_stages = []  # need to track patch stages separately, in order to apply them
         self._fetcher = None
         self._tester: Optional[Any] = None
 
@@ -1170,7 +1171,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     def _make_resource_stage(self, root_stage, resource):
         pretty_resource_name = fsys.polite_filename(f"{resource.name}-{self.version}")
-        return ResourceStage(
+        return stg.ResourceStage(
             resource.fetcher,
             root=root_stage,
             resource=resource,
@@ -1195,8 +1196,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         )
         # Construct a path where the stage should build..
         s = self.spec
-        stage_name = compute_stage_name(s)
-        stage = Stage(
+        stage_name = stg.compute_stage_name(s)
+        stage = stg.Stage(
             fetcher,
             mirror_paths=mirror_paths,
             mirrors=spack.mirrors.mirror.MirrorCollection(source=True).values(),
@@ -1206,7 +1207,19 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         )
         return stage
 
-    def _make_stage(self):
+    def _make_stages(self) -> Tuple[stg.StageComposite, List[stg.Stage]]:
+        """Create stages for this package, its resources, and any patches to be applied.
+
+        Returns:
+            A StageComposite containing all stages created, as well as a list of patch stages for
+            any patches that need to be fetched remotely.
+
+        The StageComposite is used to manage (create destroy, etc.) the stages.
+
+        The list of patch stages will be in the same order that patches are to be applied
+        to the package's staged source code. This is needed in order to apply the patches later.
+
+        """
         # If it's a dev package (not transitively), use a DIY stage object
         dev_path_var = self.spec.variants.get("dev_path", None)
         if dev_path_var:
@@ -1215,31 +1228,56 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             if not link_format:
                 link_format = "build-{arch}-{hash:7}"
             stage_link = self.spec.format_path(link_format)
-            source_stage = DevelopStage(compute_stage_name(self.spec), dev_path, stage_link)
+            source_stage = stg.DevelopStage(
+                stg.compute_stage_name(self.spec), dev_path, stage_link
+            )
         else:
             source_stage = self._make_root_stage(self.fetcher)
 
         # all_stages is source + resources + patches
-        all_stages = StageComposite()
+        all_stages = stg.StageComposite()
         all_stages.append(source_stage)
         all_stages.extend(
             self._make_resource_stage(source_stage, r) for r in self._get_needed_resources()
         )
+
+        def make_patch_stage(patch: spack.patch.UrlPatch, uniqe_part: str):
+            # UrlPatches can make their own fetchers
+            fetcher = patch.fetcher()
+
+            # The same package can have multiple patches with the same name but
+            # with different contents, therefore apply a subset of the hash.
+            fetch_digest = patch.archive_sha256 or patch.sha256
+
+            name = f"{os.path.basename(patch.url)}-{fetch_digest[:7]}"
+            per_package_ref = os.path.join(patch.owner.split(".")[-1], name)
+            mirror_ref = spack.mirrors.layout.default_mirror_layout(fetcher, per_package_ref)
+
+            return stg.Stage(
+                fetcher,
+                name=f"{stg.stage_prefix}-{uniqe_part}-patch-{fetch_digest}",
+                mirror_paths=mirror_ref,
+                mirrors=spack.mirrors.mirror.MirrorCollection(source=True).values(),
+            )
+
         if self.spec.concrete:
-            all_stages.extend(
-                p.stage for p in self.spec.patches if isinstance(p, spack.patch.UrlPatch)
-            )
+            patches = self.spec.patches
+            uniqe_part = self.spec.dag_hash(7)
         else:
-            # The only code path that gets here is spack mirror create --all which just needs all
-            # matching patches.
-            all_stages.extend(
-                p.stage
-                for when_spec, patch_list in self.patches.items()
-                if self.spec.intersects(when_spec)
-                for p in patch_list
-                if isinstance(p, spack.patch.UrlPatch)
-            )
-        return all_stages
+            # The only code path that gets here is `spack mirror create --all`,
+            # which needs all matching patches.
+            patch_lists = [
+                plist for when, plist in self.patches.items() if self.spec.intersects(when)
+            ]
+            patches = sum(patch_lists, [])
+            uniqe_part = self.name
+
+        patch_stages = [
+            make_patch_stage(p, uniqe_part) for p in patches if isinstance(p, spack.patch.UrlPatch)
+        ]
+        all_stages.extend(patch_stages)
+
+        return all_stages, patch_stages
 
     @property
     def stage(self):
@@ -1252,11 +1290,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         if not self.spec.versions.concrete:
             raise ValueError("Cannot retrieve stage for package without concrete version.")
         if self._stage is None:
-            self._stage = self._make_stage()
+            self._stage, self._patch_stages = self._make_stages()
         return self._stage
 
     @stage.setter
-    def stage(self, stage: StageComposite):
+    def stage(self, stage: stg.StageComposite):
         """Allow a stage object to be set to override the default."""
         self._stage = stage
 
@@ -1645,15 +1683,32 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             return
 
         errors = []
-
         # Apply all the patches for specs that match this one
         patched = False
+        patch_stages = iter(self._patch_stages)
+
         for patch in patches:
             try:
                 with fsys.working_dir(self.stage.source_path):
-                    patch.apply(self.stage)
-                tty.msg("Applied patch {0}".format(patch.path_or_url))
+                    # get the path either from the stage where it was fetched, or from the Patch
+                    if isinstance(patch, spack.patch.UrlPatch):
+                        patch_stage = next(patch_stages)
+                        files = os.listdir(patch_stage.source_path)
+                        assert len(files) == 1, f"Expected one file in stage, found {files}"
+                        patch_path = os.path.join(patch_stage.source_path, files[0])
+
+                    else:
+                        patch_path = patch.path
+                        if not patch_path or not os.path.isfile(patch_path):
+                            raise spack.error.NoSuchPatchError(f"No such patch: {patch.path}")
+
+                    spack.patch.apply_patch(
+                        self.stage, patch_path, patch.level, patch.working_dir, patch.reverse
+                    )
+
+                tty.msg(f"Applied patch {patch.path_or_url}")
                 patched = True
+
             except spack.error.SpackError as e:
                 # Touch bad file if anything goes wrong.
                 fsys.touch(bad_file)

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -14,8 +14,6 @@ from llnl.url import allowed_archive
 import spack
 import spack.error
 import spack.fetch_strategy
-import spack.mirrors.layout
-import spack.mirrors.mirror
 import spack.repo
 import spack.stage
 import spack.util.spack_json as sjson
@@ -113,17 +111,6 @@ class Patch:
         # ordering_key is irrelevant. In that case, use a default value so we don't need to branch
         # on whether ordering_key is None where it's used, just to make static analysis happy.
         self.ordering_key: Tuple[str, int] = ordering_key or ("", 0)
-
-    def apply(self, stage: "spack.stage.Stage") -> None:
-        """Apply a patch to source in a stage.
-
-        Args:
-            stage: stage where source code lives
-        """
-        if not self.path or not os.path.isfile(self.path):
-            raise spack.error.NoSuchPatchError(f"No such patch: {self.path}")
-
-        apply_patch(stage, self.path, self.level, self.working_dir, self.reverse)
 
     # TODO: Use TypedDict once Spack supports Python 3.8+ only
     def to_dict(self) -> Dict[str, Any]:
@@ -277,7 +264,6 @@ class UrlPatch(Patch):
         super().__init__(pkg, url, level, working_dir, reverse, ordering_key)
 
         self.url = url
-        self._stage: Optional["spack.stage.Stage"] = None
 
         if allowed_archive(self.url) and not archive_sha256:
             raise spack.error.PatchDirectiveError(
@@ -290,58 +276,17 @@ class UrlPatch(Patch):
             raise spack.error.PatchDirectiveError("URL patches require a sha256 checksum")
         self.sha256 = sha256
 
-    def apply(self, stage: "spack.stage.Stage") -> None:
-        """Apply a patch to source in a stage.
-
-        Args:
-            stage: stage where source code lives
-        """
-        assert self.stage.expanded, "Stage must be expanded before applying patches"
-
-        # Get the patch file.
-        files = os.listdir(self.stage.source_path)
-        assert len(files) == 1, "Expected one file in stage source path, found %s" % files
-        self.path = os.path.join(self.stage.source_path, files[0])
-
-        return super().apply(stage)
-
-    @property
-    def stage(self) -> "spack.stage.Stage":
-        """The stage in which to download (and unpack) the URL patch.
-
-        Returns:
-            The stage object.
-        """
-        if self._stage:
-            return self._stage
-
-        fetch_digest = self.archive_sha256 or self.sha256
-
+    def fetcher(self) -> spack.fetch_strategy.FetchStrategy:
+        """Construct a fetcher that can download (and unpack) this patch."""
         # Two checksums, one for compressed file, one for its contents
         if self.archive_sha256 and self.sha256:
-            fetcher: spack.fetch_strategy.FetchStrategy = (
-                spack.fetch_strategy.FetchAndVerifyExpandedFile(
-                    self.url, archive_sha256=self.archive_sha256, expanded_sha256=self.sha256
-                )
+            return spack.fetch_strategy.FetchAndVerifyExpandedFile(
+                self.url, archive_sha256=self.archive_sha256, expanded_sha256=self.sha256
             )
         else:
-            fetcher = spack.fetch_strategy.URLFetchStrategy(
+            return spack.fetch_strategy.URLFetchStrategy(
                 url=self.url, sha256=self.sha256, expand=False
             )
-
-        # The same package can have multiple patches with the same name but
-        # with different contents, therefore apply a subset of the hash.
-        name = "{0}-{1}".format(os.path.basename(self.url), fetch_digest[:7])
-
-        per_package_ref = os.path.join(self.owner.split(".")[-1], name)
-        mirror_ref = spack.mirrors.layout.default_mirror_layout(fetcher, per_package_ref)
-        self._stage = spack.stage.Stage(
-            fetcher,
-            name=f"{spack.stage.stage_prefix}patch-{fetch_digest}",
-            mirror_paths=mirror_ref,
-            mirrors=spack.mirrors.mirror.MirrorCollection(source=True).values(),
-        )
-        return self._stage
 
     def to_dict(self) -> Dict[str, Any]:
         """Dictionary representation of the patch.

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -279,7 +279,7 @@ class UrlPatch(Patch):
             raise spack.error.PatchDirectiveError("URL patches require a sha256 checksum")
         self.sha256 = sha256
 
-    def fetcher(self) -> spack.fetch_strategy.FetchStrategy:
+    def fetcher(self) -> "spack.fetch_strategy.FetchStrategy":
         """Construct a fetcher that can download (and unpack) this patch."""
         # Two checksums, one for compressed file, one for its contents
         if self.archive_sha256 and self.sha256:

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -37,6 +37,9 @@ def apply_patch(
         working_dir: relative path *within* the stage to change to
         reverse: reverse the patch
     """
+    if not patch_path or not os.path.isfile(patch_path):
+        raise spack.error.NoSuchPatchError(f"No such patch: {patch_path}")
+
     git_utils_path = os.environ.get("PATH", "")
     if sys.platform == "win32":
         git = which_string("git")

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -465,6 +465,13 @@ class Stage(LockableStagingDir):
         """Returns the well-known source directory path."""
         return os.path.join(self.path, _source_path_subdir)
 
+    @property
+    def single_file(self):
+        assert self.expanded, "Must expand stage before calling single_file"
+        files = os.listdir(self.source_path)
+        assert len(files) == 1, f"Expected one file in stage, found {files}"
+        return os.path.join(self.source_path, files[0])
+
     def _generate_fetchers(self, mirror_only=False) -> Generator["fs.FetchStrategy", None, None]:
         fetchers: List[fs.FetchStrategy] = []
         if not mirror_only:

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -121,11 +121,14 @@ third line
                 )
         # apply the patch and compare files
         patch = spack.patch.UrlPatch(s.package, url, sha256=sha256, archive_sha256=archive_sha256)
-        with patch.stage:
-            patch.stage.create()
-            patch.stage.fetch()
-            patch.stage.expand_archive()
-            patch.apply(stage)
+        patch_stage = Stage(patch.fetcher())
+        with patch_stage:
+            patch_stage.create()
+            patch_stage.fetch()
+            patch_stage.expand_archive()
+            spack.patch.apply_patch(
+                stage, patch_stage.single_file, patch.level, patch.working_dir, patch.reverse
+            )
 
         with working_dir(stage.source_path):
             assert filecmp.cmp("foo.txt", "foo-expected.txt")
@@ -134,11 +137,14 @@ third line
         patch = spack.patch.UrlPatch(
             s.package, url, sha256=sha256, archive_sha256=archive_sha256, reverse=True
         )
-        with patch.stage:
-            patch.stage.create()
-            patch.stage.fetch()
-            patch.stage.expand_archive()
-            patch.apply(stage)
+        patch_stage = Stage(patch.fetcher())
+        with patch_stage:
+            patch_stage.create()
+            patch_stage.fetch()
+            patch_stage.expand_archive()
+            spack.patch.apply_patch(
+                stage, patch_stage.single_file, patch.level, patch.working_dir, patch.reverse
+            )
 
         with working_dir(stage.source_path):
             assert filecmp.cmp("foo.txt", "foo-original.txt")
@@ -431,7 +437,7 @@ def test_patch_no_file():
     patch = spack.patch.Patch(fp, "nonexistent_file", 0, "")
     patch.path = "test"
     with pytest.raises(spack.error.NoSuchPatchError, match="No such patch:"):
-        patch.apply("")
+        spack.patch.apply_patch(Stage("https://example.com/foo.patch"), patch.path)
 
 
 def test_patch_no_sha256():


### PR DESCRIPTION
Fixes #50696.
Fixes #50698.
Fixes #22386.

There were two problems with the way we were setting up patch stages:
1. Patch stages are not unique to the bulids they belong to, despite the fact that builds want to (exclusively) lock them; and
2. Locks were not being taken correctly on patch stages -- in particular, `restage()` was happening before locking, which would cause nasty races when many builds use the same patch.

This PR does two things:

1. Fix the broken locking in `installer.py` by restaging only after we have the lock:
    ```diff
    -        if self.restage:
    -            stage.destroy()
    -
             with stage:
    +            if self.restage:
    +                stage.destroy()
    ```
    
2. Refactor patches to be dumber.

   Previously, `Patch` objects knew how to apply themselves to a stage. To do that, a `UrlPatch` had to create their own stage *and* know where the downloaded file lived in it. This meant the stage had to be persisted on the `Patch` between `stage()` and `apply()`, but patches aren't persisted on the `Package` - they're created with every call to `Spec.patches`. Rather than involve the patches in the fetch/stage/patch/etc. lifecycle of the Stage, we should be handling all this in one place in `package_base.py`.

   So, patches are now dumb objects. They have a bit of metadata about where they can be found, and it's the build logic's job to find them. `patch.py` also provides an `apply_patch` method, but that's it -- the build logic has to put it all together.  This works out much cleaner, and the package can more explicitly store the stages at `do_stage()` time in a way they can be reused by `do_patch()`.

(1) was causing #50696, and (2) was causing #50698.

I was able to build 10 concurrent `bash` instances with the following environment:

```yaml
spack:
  # add package specs to the `specs` list
  specs:
    - bash@5.2 cppflags="-D SPACK_DUMMY_0"
    - bash@5.2 cppflags="-D SPACK_DUMMY_1"
    - bash@5.2 cppflags="-D SPACK_DUMMY_2"
    - bash@5.2 cppflags="-D SPACK_DUMMY_3"
    - bash@5.2 cppflags="-D SPACK_DUMMY_4"
    - bash@5.2 cppflags="-D SPACK_DUMMY_5"
    - bash@5.2 cppflags="-D SPACK_DUMMY_6"
    - bash@5.2 cppflags="-D SPACK_DUMMY_7"
    - bash@5.2 cppflags="-D SPACK_DUMMY_8"
    - bash@5.2 cppflags="-D SPACK_DUMMY_9"
  view: false
  concretizer:
    unify: false
```

Each of these will use 37 patches (because `bash` just has that many patches), so I'm reasonably sure that Spack builds will no longer fight over patches.