### PR TITLE
`config scopes`: show scopes/paths in columnar format

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -267,6 +267,8 @@ def config_scopes(args):
     )
     if args.included:
         scopes = (i for s in scopes for i in s.included_scopes)
+    if not scopes:
+        return
     info = list(_config_scope_info(args, s) for s in scopes)
     max_col1_width = max((len(x[0]) for x in info))
     for c1, c2 in info:

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -245,17 +245,16 @@ def config_list(args):
     print(" ".join(list(spack.config.SECTION_SCHEMAS)))
 
 
-def _config_scope_info_string(args, scope):
+def _config_scope_info(args, scope):
+    scope_path = None
     if (args.section or args.show_paths) and hasattr(scope, "path"):
         section_path = scope.get_section_filename(args.section) if args.section else None
-        path = (
+        scope_path = (
             section_path
             if section_path and os.path.exists(section_path)
             else f"{scope.path}{os.sep}"
         )
-        return f"{scope.name} ({path})"
-    else:
-        return scope.name
+    return (scope.name, scope_path)
 
 
 def config_scopes(args):
@@ -268,9 +267,10 @@ def config_scopes(args):
     )
     if args.included:
         scopes = (i for s in scopes for i in s.included_scopes)
-    info = (_config_scope_info_string(args, s) for s in scopes)
-
-    print(" ".join(info))
+    info = list(_config_scope_info(args, s) for s in scopes)
+    max_col1_width = max((len(x[0]) for x in info))
+    for c1, c2 in info:
+        print(f"{c1:{max_col1_width}}  {c2}" if c2 else c1)
 
 
 def config_add(args):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -10,6 +10,7 @@ from typing import List
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
+from llnl.util.tty.colify import colify_table
 
 import spack.config
 import spack.environment as ev
@@ -73,26 +74,25 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "scopes", help="list defined scopes in descending order of precedence"
     )
     scopes_parser.add_argument(
-        "-i", "--included", action="store_true", default=False, help="list only included scopes"
-    )
-    scopes_parser.add_argument(
         "-p",
-        "--path-scopes",
-        action="store_true",
-        default=False,
-        help="list only writable scopes with an associated path",
-    )
-    scopes_parser.add_argument(
-        "-s",
-        "--show-paths",
+        "--paths",
         action="store_true",
         default=False,
         help="show associated paths for appropriate scopes",
     )
     scopes_parser.add_argument(
+        "-t",
+        "--type",
+        default=["all"],
+        metavar="scope-type",
+        nargs="+",
+        choices=("all", "env", "include", "internal", "path"),
+        help="list only scopes of the specified type(s)\n\noptions: %(choices)s",
+    )
+    scopes_parser.add_argument(
         "section",
-        help="tailor scope path information to the specified section (implies -s|--show-paths)"
-        "\noptions: %(choices)s",
+        help="tailor scope path information to the specified section (implies -p|--paths)"
+        "\n\noptions: %(choices)s",
         metavar="section",
         nargs="?",
         choices=spack.config.SECTION_SCHEMAS,
@@ -247,32 +247,45 @@ def config_list(args):
 
 def _config_scope_info(args, scope):
     scope_path = None
-    if (args.section or args.show_paths) and hasattr(scope, "path"):
+    if (args.section or args.paths) and hasattr(scope, "path"):
         section_path = scope.get_section_filename(args.section) if args.section else None
         scope_path = (
             section_path
             if section_path and os.path.exists(section_path)
             else f"{scope.path}{os.sep}"
         )
-    return (scope.name, scope_path)
+    return (scope.name, scope_path or " ")
+
+
+def _config_basic_scope_types(scope):
+    types = []
+    if isinstance(scope, spack.config.InternalConfigScope):
+        types.append("internal")
+    elif hasattr(scope, "yaml_path") and scope.yaml_path == [spack.schema.env.TOP_LEVEL_KEY]:
+        types.append("env")
+    if hasattr(scope, "path"):
+        types.append("path")
+    return sorted(types)
 
 
 def config_scopes(args):
     """List configured scopes in descending order of precedence."""
 
-    scopes = (
-        spack.config.scopes().reversed_values()
-        if (args.included or not args.path_scopes)
-        else spack.config.writable_scopes()
+    included_scopes = list(
+        i.name for s in spack.config.scopes().reversed_values() for i in s.included_scopes
     )
-    if args.included:
-        scopes = (i for s in scopes for i in s.included_scopes)
-    if not scopes:
-        return
-    info = list(_config_scope_info(args, s) for s in scopes)
-    max_col1_width = max(list(len(x[0]) for x in info))
-    for c1, c2 in info:
-        print(f"{c1:{max_col1_width}}  {c2}" if c2 else c1)
+
+    scopes = list(
+        s
+        for s in spack.config.scopes().reversed_values()
+        if (
+            "included" in args.type
+            and s.name in included_scopes
+            or any(i in ("all", *_config_basic_scope_types(s)) for i in args.type)
+        )
+    )
+    if scopes:
+        colify_table([_config_scope_info(args, s) for s in scopes])
 
 
 def config_add(args):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -270,7 +270,7 @@ def config_scopes(args):
     if not scopes:
         return
     info = list(_config_scope_info(args, s) for s in scopes)
-    max_col1_width = max((len(x[0]) for x in info))
+    max_col1_width = max(list(len(x[0]) for x in info))
     for c1, c2 in info:
         print(f"{c1:{max_col1_width}}  {c2}" if c2 else c1)
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -279,7 +279,7 @@ def config_scopes(args):
         s
         for s in spack.config.scopes().reversed_values()
         if (
-            "included" in args.type
+            "include" in args.type
             and s.name in included_scopes
             or any(i in ("all", *_config_basic_scope_types(s)) for i in args.type)
         )

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -870,7 +870,7 @@ _spack_config_list() {
 _spack_config_scopes() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -i --included -p --path-scopes -s --show-paths"
+        SPACK_COMPREPLY="-h --help -p --paths -t --type"
     else
         _config_sections
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1236,16 +1236,14 @@ complete -c spack -n '__fish_spack_using_command config list' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command config list' -s h -l help -d 'show this help message and exit'
 
 # spack config scopes
-set -g __fish_spack_optspecs_spack_config_scopes h/help i/included p/path-scopes s/show-paths
+set -g __fish_spack_optspecs_spack_config_scopes h/help p/paths t/type=
 complete -c spack -n '__fish_spack_using_command_pos 0 config scopes' -f -a 'bootstrap cdash ci compilers concretizer config definitions develop env_vars include mirrors modules packages repos upstreams view'
 complete -c spack -n '__fish_spack_using_command config scopes' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config scopes' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config scopes' -s i -l included -f -a included
-complete -c spack -n '__fish_spack_using_command config scopes' -s i -l included -d 'list only included scopes'
-complete -c spack -n '__fish_spack_using_command config scopes' -s p -l path-scopes -f -a path_scopes
-complete -c spack -n '__fish_spack_using_command config scopes' -s p -l path-scopes -d 'list only writable scopes with an associated path'
-complete -c spack -n '__fish_spack_using_command config scopes' -s s -l show-paths -f -a show_paths
-complete -c spack -n '__fish_spack_using_command config scopes' -s s -l show-paths -d 'show associated paths for appropriate scopes'
+complete -c spack -n '__fish_spack_using_command config scopes' -s p -l paths -f -a paths
+complete -c spack -n '__fish_spack_using_command config scopes' -s p -l paths -d 'show associated paths for appropriate scopes'
+complete -c spack -n '__fish_spack_using_command config scopes' -s t -l type -r -f -a 'all env include internal path'
+complete -c spack -n '__fish_spack_using_command config scopes' -s t -l type -r -d 'list only scopes of the specified type(s)'
 
 # spack config add
 set -g __fish_spack_optspecs_spack_config_add h/help f/file=


### PR DESCRIPTION
Per @tgamblin suggestion/request.