### PR TITLE
Fix parsing edge attributes

### DIFF
--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -111,7 +111,7 @@ FILENAME = WINDOWS_FILENAME if sys.platform == "win32" else UNIX_FILENAME
 STRIP_QUOTES = re.compile(r"^(['\"])(.*)\1$")
 
 #: Values that match this (e.g., variants, flags) can be left unquoted in Spack output
-NO_QUOTES_NEEDED = re.compile(r"^[a-zA-Z0-9,/_.-]+$")
+NO_QUOTES_NEEDED = re.compile(r"^[a-zA-Z0-9,/_.\-\[\]]+$")
 
 
 class SpecTokens(TokenBase):

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1443,3 +1443,34 @@ expected a single spec, but got more:
 
     with pytest.raises(ValueError, match="expected a single spec, but got none"):
         parse_one_or_raise("    ")
+
+
+@pytest.mark.parametrize(
+    "input_args,expected",
+    [
+        # mpileaks %[virtuals=c deptypes=build] gcc
+        (
+            ["mpileaks", "%[virtuals=c", "deptypes=build]", "gcc"],
+            ["mpileaks %[virtuals=c deptypes=build] gcc"],
+        ),
+        # mpileaks %[ virtuals=c deptypes=build] gcc
+        (
+            ["mpileaks", "%[", "virtuals=c", "deptypes=build]", "gcc"],
+            ["mpileaks %[virtuals=c deptypes=build] gcc"],
+        ),
+        # mpileaks %[ virtuals=c deptypes=build ] gcc
+        (
+            ["mpileaks", "%[", "virtuals=c", "deptypes=build", "]", "gcc"],
+            ["mpileaks %[virtuals=c deptypes=build] gcc"],
+        ),
+    ],
+)
+def test_parse_multiple_edge_attributes(input_args, expected):
+    """Tests that we can parse correctly multiple edge attributes within square brackets,
+    from the command line.
+
+    The input are strings as they would be parsed from argparse.REMAINDER
+    """
+    s, *_ = spack.cmd.parse_specs(input_args)
+    for c in expected:
+        assert s.satisfies(c)


### PR DESCRIPTION
Before the PR:
```console
$ spack -m spec mpileaks %[virtuals=c deptypes=build] gcc
==> Error: unexpected token in edge attributes
mpileaks %[virtuals=c deptypes='build]' gcc
```

After the PR:
```console
$ spack -m spec mpileaks %[virtuals=c deptypes=build] gcc
 -   mpileaks@2.3~debug~opt+shared+static build_system=generic arch=linux-ubuntu20.04-icelake
...
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
