### PR TITLE
Update aws-pcluster-amazonlinux-2 stacks

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -728,7 +728,7 @@ hep-build:
 ########################################
 
 .aws-pcluster-generate:
-  image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07", "entrypoint": [""] }
+  image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:pr-62", "entrypoint": [""] }
 
 # X86_64_V4 (one pipeline per target)
 .aws-pcluster-x86_64_v4:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -17,15 +17,17 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: ['']}
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:pr-62, entrypoint: ['']}
         tags: [aarch64]
         before_script:
         - - . "./share/spack/setup-env.sh"
           - . /etc/profile.d/modules.sh
           - spack --version
           - spack arch
-          - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/binutils-2.37-2yxz3xsjfmesxujxtlrgcctxlyilynmp/bin:$PATH
+          - spack mirror add --signed boot /bootstrap-gcc-cache/
+          - spack buildcache keys --install --trust --force
           - spack -c "config:install_tree:root:/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh" reindex
+          - spack install --use-buildcache package:only gcc@12
     - signing-job:
         before_script:
             # Do not distribute Intel & ARM binaries
@@ -40,23 +42,12 @@ spack:
       missing_library_policy: ignore  # due to use of externals
 
   packages:
-    gcc:
-      externals:
-      - spec: gcc@=12.4.0
-        prefix: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b
-        extra_attributes:
-          compilers:
-            c: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gcc
-            cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/g++
-            fortran: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
     acfl:
       require:
-      - "%gcc"
       - "target=aarch64"
     gromacs:
       require:
       - gromacs@2024.3 ^armpl-gcc ^openmpi
-      - "%gcc"
       - target=neoverse_v1
     libfabric:
       buildable: true
@@ -99,7 +90,7 @@ spack:
       - target=neoverse_v1
     quantum-espresso:
       require:
-      - quantum-espresso@6.6 %gcc ^armpl-gcc
+      - quantum-espresso@6.6 ^armpl-gcc %gcc
       - target=neoverse_v1
     slurm:
       buildable: false
@@ -111,7 +102,6 @@ spack:
     all:
       target: ["neoverse_v1"]
       require:
-      - "%gcc"
       - "target=neoverse_v1"
       providers:
         blas: [armpl-gcc, openblas]

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -42,56 +42,59 @@ spack:
       missing_library_policy: ignore  # due to use of externals
 
   packages:
+    all:
+      permissions:
+        read: world
+        write: user
+      target: ["neoverse_v1"]
+      providers:
+        blas: [armpl-gcc, openblas]
+        fftw-api: [armpl-gcc, fftw]
+        mpi: [openmpi, mpich]
+        lapack: [armpl-gcc, openblas]
+        scalapack: [netlib-scalapack]
+        c: [gcc@12, acfl]
+        cxx: [gcc@12, acfl]
+        fortran: [gcc@12, acfl]
+    c:
+      require: gcc@12
     acfl:
       require:
       - "target=aarch64"
     gromacs:
-      require:
-      - gromacs@2024.3 ^armpl-gcc ^openmpi
-      - target=neoverse_v1
+      version: [2024.3]
     libfabric:
       buildable: true
       externals:
       - prefix: /opt/amazon/efa/
         spec: libfabric@1.17.0
-      require:
+      variants:
       - fabrics=shm,efa
-      - target=neoverse_v1
     llvm:
       variants: ~lldb
     mpas-model:
-      require:
-      - precision=single ^parallelio+pnetcdf
-      - "%gcc"
-      - target=neoverse_v1
+      variants:
+       - precision=single ^parallelio+pnetcdf
     mpich:
       require:
       - mpich pmi=pmi2 device=ch4 netmod=ofi +slurm
-      - target=neoverse_v1
     nvhpc:
       require:
       - "target=aarch64"
     openfoam:
       require:
       - openfoam ^scotch@6.0.9
-      - target=neoverse_v1
     openmpi:
       variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
       require:
       - '@4:'
-      - target=neoverse_v1
     # Palace does not build correctly with armpl until https://github.com/awslabs/palace/pull/207 is merged into a version.
     # palace:
     #   require:
     #     - one_of: ["palace cxxflags=\"-include cstdint\" ^fmt@9.1.0"]
     pmix:
       require:
-      - "pmix@3:"
-      - target=neoverse_v1
-    quantum-espresso:
-      require:
-      - quantum-espresso@6.6 ^armpl-gcc %gcc
-      - target=neoverse_v1
+      - '@3:'
     slurm:
       buildable: false
       externals:
@@ -99,16 +102,3 @@ spack:
         spec: slurm@22.05.8 +pmix
       require:
       - "+pmix"
-    all:
-      target: ["neoverse_v1"]
-      require:
-      - "target=neoverse_v1"
-      providers:
-        blas: [armpl-gcc, openblas]
-        fftw-api: [armpl-gcc, fftw]
-        lapack: [armpl-gcc, openblas]
-        mpi: [openmpi, mpich]
-        scalapack: [netlib-scalapack]
-      permissions:
-        read: world
-        write: user

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -32,6 +32,7 @@ spack:
           - spack buildcache keys --install --trust --force
           - spack -c "config:install_tree:root:/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh" reindex
           - spack install --use-buildcache package:only gcc@12
+          - spack install intel-oneapi-compilers target=x86_64_v3
     - signing-job:
         before_script:
             # Do not distribute Intel & ARM binaries
@@ -46,20 +47,6 @@ spack:
       missing_library_policy: ignore  # due to use of externals
 
   packages:
-    intel-oneapi-compilers:
-      externals:
-        - spec: intel-oneapi-compilers@=2024.1.0
-          prefix: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop
-          extra_attributes:
-            compilers:
-              c: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icx
-              cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icpx
-              fortran: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
-            extra_rpaths:
-              - /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/lib64
-    fortran:
-      require:
-      - "intel-oneapi-compilers"
     gettext:
       # Newer gettext cannot build with gcc@12 and old AL2 glibc headers
       # Older gettext versions do not build correctly with oneapi.
@@ -94,9 +81,6 @@ spack:
     mpich:
       require:
       - mpich pmi=pmi2 device=ch4 netmod=ofi +slurm
-    openfoam:
-      require:
-      - openfoam ^scotch@6.0.9 %gcc
     openmpi:
       variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
       require:
@@ -121,12 +105,13 @@ spack:
       require:
       - wrf@4 build_type=dm+sm
     all:
-      require:
-      - "%oneapi"
       permissions:
         read: world
         write: user
       providers:
+        c: [intel-oneapi-compilers, gcc]
+        cxx: [intel-oneapi-compilers, gcc]
+        fortran: [intel-oneapi-compilers, gcc]
         blas: [intel-oneapi-mkl]
         daal: [intel-oneapi-dal]
         fftw-api: [intel-oneapi-mkl]

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -22,14 +22,16 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: ['']}
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:pr-62, entrypoint: ['']}
         before_script:
         - - . "./share/spack/setup-env.sh"
           - . /etc/profile.d/modules.sh
           - spack --version
           - spack arch
-          - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/binutils-2.37-qvccg7zpskturysmr4bzbsfrx34kvazo/bin:$PATH
+          - spack mirror add --signed boot /bootstrap-gcc-cache/
+          - spack buildcache keys --install --trust --force
           - spack -c "config:install_tree:root:/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh" reindex
+          - spack install --use-buildcache package:only gcc@12
     - signing-job:
         before_script:
             # Do not distribute Intel & ARM binaries
@@ -44,15 +46,6 @@ spack:
       missing_library_policy: ignore  # due to use of externals
 
   packages:
-    gcc:
-      externals:
-        - spec: gcc@=12.4.0
-          prefix: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb
-          extra_attributes:
-            compilers:
-              c: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gcc
-              cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/g++
-              fortran: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
     intel-oneapi-compilers:
       externals:
         - spec: intel-oneapi-compilers@=2024.1.0
@@ -103,7 +96,7 @@ spack:
       - mpich pmi=pmi2 device=ch4 netmod=ofi +slurm
     openfoam:
       require:
-      - openfoam %gcc ^scotch@6.0.9
+      - openfoam ^scotch@6.0.9 %gcc
     openmpi:
       variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
       require:


### PR DESCRIPTION
These stacks start the build with gcc@12 installed from a local buildcache

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

DNM: this is still in testing, and uses a runner image from a PR rather than a tagged verison.