### PR TITLE
sync-packages: copy unit tests to packages repository

### DIFF
--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -32,6 +32,7 @@ jobs:
                         --path var/spack/repos/ --path-rename var/spack/repos/:repos/ \
                         --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
                         --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
+                        --path lib/spack/spack/test --path-rename lib/spack/spack/test:repos/spack_repo/builtin/tests/ \
                         --refs develop
     - name: Push
       run: |

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -37,15 +37,13 @@ jobs:
                         --path pytest.ini \
                         --path .github/workflows/audit.yaml \
                         --path .github/workflows/ci.yaml \
-                        --path .github/workflows/prechecks.yaml \
+                        --path .github/workflows/prechecks.yml \
                         --path share/spack/qa/validate_last_exit.ps1 --path-rename share/spack/qa/validate_last_exit.ps1:.ci/validate_last_exit.ps1 \
                         --path share/spack/qa/windows_test_setup.ps1 --path-rename share/spack/qa/windows_test_setup.ps1:.ci/windows_test_setup.ps1 \
                         --path .github/CODE_OF_CONDUCT.md --path-rename .github/CODE_OF_CONDUCT.md:spack/.github/CODE_OF_CONDUCT.md \
                         --path .github/CONTRIBUTING.md --path-rename .github/CONTRIBUTING.md:spack/.github/CONTRIBUTING.md \
                         --path .github/pull_request_template.md \
-                        --path .github/ISSUE_TEMPLATE/build_error.yml \
-                        --path .github/ISSUE_TEMPLATE/config.yml \
-                        --path .github/ISSUE_TEMPLATE/test_error.yml \
+                        --path .github/ISSUE_TEMPLATE/ \
                         --refs develop
     - name: Push
       run: |

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -40,8 +40,8 @@ jobs:
                         --path .github/workflows/prechecks.yml \
                         --path share/spack/qa/validate_last_exit.ps1 --path-rename share/spack/qa/validate_last_exit.ps1:.ci/validate_last_exit.ps1 \
                         --path share/spack/qa/windows_test_setup.ps1 --path-rename share/spack/qa/windows_test_setup.ps1:.ci/windows_test_setup.ps1 \
-                        --path .github/CODE_OF_CONDUCT.md --path-rename .github/CODE_OF_CONDUCT.md:spack/.github/CODE_OF_CONDUCT.md \
-                        --path .github/CONTRIBUTING.md --path-rename .github/CONTRIBUTING.md:spack/.github/CONTRIBUTING.md \
+                        --path .github/CODE_OF_CONDUCT.md --path-rename .github/CODE_OF_CONDUCT.md:.github/CODE_OF_CONDUCT.md \
+                        --path .github/CONTRIBUTING.md --path-rename .github/CONTRIBUTING.md:.github/CONTRIBUTING.md \
                         --path .github/pull_request_template.md \
                         --path .github/ISSUE_TEMPLATE/ \
                         --refs develop

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -33,6 +33,8 @@ jobs:
                         --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
                         --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
                         --path lib/spack/spack/test --path-rename lib/spack/spack/test:repos/spack_repo/builtin/tests/ \
+                        --path .github/workflows/unit_tests.yaml \
+                        --path pytest.ini \
                         --refs develop
     - name: Push
       run: |

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -35,6 +35,17 @@ jobs:
                         --path lib/spack/spack/test --path-rename lib/spack/spack/test:repos/spack_repo/builtin/tests/ \
                         --path .github/workflows/unit_tests.yaml \
                         --path pytest.ini \
+                        --path .github/workflows/audit.yaml \
+                        --path .github/workflows/ci.yaml \
+                        --path .github/workflows/prechecks.yaml \
+                        --path share/spack/qa/validate_last_exit.ps1 --path-rename share/spack/qa/validate_last_exit.ps1:.ci/validate_last_exit.ps1 \
+                        --path share/spack/qa/windows_test_setup.ps1 --path-rename share/spack/qa/windows_test_setup.ps1:.ci/windows_test_setup.ps1 \
+                        --path .github/CODE_OF_CONDUCT.md --path-rename .github/CODE_OF_CONDUCT.md:spack/.github/CODE_OF_CONDUCT.md \
+                        --path .github/CONTRIBUTING.md --path-rename .github/CONTRIBUTING.md:spack/.github/CONTRIBUTING.md \
+                        --path .github/pull_request_template.md \
+                        --path .github/ISSUE_TEMPLATE/build_error.yml \
+                        --path .github/ISSUE_TEMPLATE/config.yml \
+                        --path .github/ISSUE_TEMPLATE/test_error.yml \
                         --refs develop
     - name: Push
       run: |


### PR DESCRIPTION
Copy over all of the unit tests for cleanup later. Also copying over history for key pytest and unit test configuration.