### PR TITLE
RepoSplit/test: do not use relative imports of spack.enums

### DIFF
--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -32,8 +32,7 @@ import spack.spec
 import spack.store
 import spack.util.path as spack_path
 import spack.util.spack_yaml as syaml
-
-from ..enums import ConfigScopePriority
+from spack.enums import ConfigScopePriority
 
 # sample config data
 config_low = {

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -68,13 +68,12 @@ import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web
 import spack.version
+from spack.enums import ConfigScopePriority
 from spack.fetch_strategy import URLFetchStrategy
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
 from spack.util.pattern import Bunch
 from spack.util.remote_file_cache import raw_github_gitlab_url
-
-from ..enums import ConfigScopePriority
 
 mirror_cmd = SpackCommand("mirror")
 


### PR DESCRIPTION
Of the seven unit test files importing `enums`, these are the only two that use a relative import. This PR resolves that inconsistency in part to facilitate testing the packages repository.

Before this PR:
```
$ git grep enums
cmd/deprecate.py:from spack.enums import InstallRecordStatus
cmd/find.py:from spack.enums import InstallRecordStatus
cmd/reindex.py:from spack.enums import InstallRecordStatus
cmd/uninstall.py:from spack.enums import InstallRecordStatus
config.py:from ..enums import ConfigScopePriority
conftest.py:from ..enums import ConfigScopePriority
database.py:from spack.enums import InstallRecordStatus
```