### PR TITLE
emacs: test +native in CI/CD after changes to core

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/emacs/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/emacs/package.py
@@ -165,7 +165,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
         """Runs and checks output of the installed binary."""
         exe_path = join_path(self.prefix.bin, bin)
         if not os.path.exists(exe_path):
-            raise SkipTest(f"{exe_path} is not installed")
+            raise SkipTest(f"{exe_path} is not installed. TEST.")
 
         exe = which(exe_path)
         out = exe("--version", output=str.split, error=str.split)


### PR DESCRIPTION
https://github.com/spack/spack/pull/50565 appears to break `emacs+native` builds on my laptop. Testing the core change in CI to see if it breaks here too, but was uncaught because we didn't rebuild everything in the PR.
