### PR TITLE
gsl-lite: remove unnecessary options, add versions 0.42.0, 0.43.0, 1.0.1

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/gsl_lite/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gsl_lite/package.py
@@ -19,6 +19,9 @@ class GslLite(CMakePackage):
 
     license("MIT")
 
+    version("1.0.1", commit="56dab5ce071c4ca17d3e0dbbda9a94bd5a1cbca1")
+    version("0.43.0", commit="ce82d30be6f76a38d90605694f0c8fa201723baf")
+    version("0.42.0", commit="21751fb0473473e27ffb1f280543885ed65447a8")
     version("0.41.0", sha256="4682d8a60260321b92555760be3b9caab60e2a71f95eddbdfb91e557ee93302a")
     version("0.40.0", commit="d6c8af99a1d95b3db36f26b4f22dc3bad89952de")
     version("0.39.0", commit="d0903fa87ff579c30f608bc363582e6563570342")

--- a/var/spack/repos/spack_repo/builtin/packages/gsl_lite/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gsl_lite/package.py
@@ -19,12 +19,12 @@ class GslLite(CMakePackage):
 
     license("MIT")
 
-    version("1.0.1", commit="56dab5ce071c4ca17d3e0dbbda9a94bd5a1cbca1")
-    version("0.43.0", commit="ce82d30be6f76a38d90605694f0c8fa201723baf")
-    version("0.42.0", commit="21751fb0473473e27ffb1f280543885ed65447a8")
+    version("1.0.1", sha256="063a0b4248a2afd8154b2b5fe9d64472868a166d3963682e823f81516194af79")
+    version("0.43.0", sha256="e48c3138648156d2b85905b1d280d661fad61524c5c0ca10d3857036ca3dd519")
+    version("0.42.0", sha256="54a1b6f9db72eab5d8dcaf06b36d32d4f5da3471d91dac71aba19fe15291a773")
     version("0.41.0", sha256="4682d8a60260321b92555760be3b9caab60e2a71f95eddbdfb91e557ee93302a")
-    version("0.40.0", commit="d6c8af99a1d95b3db36f26b4f22dc3bad89952de")
-    version("0.39.0", commit="d0903fa87ff579c30f608bc363582e6563570342")
+    version("0.40.0", sha256="65af4ec8a1050dac4f1ca4622881bb02a9c3978a9baec289fb56e25412d6cac7")
+    version("0.39.0", sha256="f80ec07d9f4946097a1e2554e19cee4b55b70b45d59e03a7d2b7f80d71e467e9")
     version("0.38.1", sha256="c2fa2315fff312f3897958903ed4d4e027f73fa44235459ecb467ad7b7d62b18")
     version("0.38.0", sha256="5d25fcd31ea66dac9e14da1cad501d95450ccfcb2768fffcd1a4170258fcbc81")
     version("0.37.0", sha256="a31d51b73742bb234acab8d2411223cf299e760ed713f0840ffed0dabe57ca38")

--- a/var/spack/repos/spack_repo/builtin/packages/gsl_lite/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/gsl_lite/package.py
@@ -9,8 +9,7 @@ from spack.package import *
 
 
 class GslLite(CMakePackage):
-    """A single-file header-only version of ISO C++ Guidelines Support Library
-    (GSL) for C++98, C++11, and later"""
+    """ISO C++ Core Guidelines Library implementation for C++98, C++11 up"""
 
     homepage = "https://github.com/gsl-lite/gsl-lite"
     git = "https://github.com/gsl-lite/gsl-lite.git"
@@ -30,41 +29,3 @@ class GslLite(CMakePackage):
     version("0.34.0", sha256="a7d5b2672b78704ca03df9ef65bc274d8f8cacad3ca950365eef9e25b50324c5")
 
     depends_on("cxx", type="build")  # generated
-
-    variant("tests", default=False, description="Build and perform gsl-lite tests")
-    variant("cuda_tests", default=False, description="Build and perform gsl-lite CUDA tests")
-    variant("examples", default=False, description="Build gsl-lite examples")
-    variant(
-        "static_analysis_demos",
-        default=False,
-        description="Build and perform gsl-lite static analysis demos",
-    )
-    variant(
-        "cmake_export_package_registry",
-        default=False,
-        description="Export build directory to CMake user package registry",
-    )
-    variant(
-        "compat_header", default=False, description="Install MS-GSL compatibility header <gsl/gsl>"
-    )
-    variant(
-        "legacy_headers",
-        default=False,
-        description="Install legacy headers <gsl.h>, <gsl.hpp>, <gsl/gsl-lite.h>",
-    )
-
-    def cmake_args(self):
-        args = [
-            self.define_from_variant("GSL_LITE_OPT_BUILD_TESTS", "tests"),
-            self.define_from_variant("GSL_LITE_OPT_BUILD_CUDA_TESTS", "cuda_tests"),
-            self.define_from_variant("GSL_LITE_OPT_BUILD_EXAMPLES", "examples"),
-            self.define_from_variant(
-                "GSL_LITE_LOPT_BUILD_STATIC_ANALYSIS_DEMOS", "static_analysis_demos"
-            ),
-            self.define_from_variant(
-                "CMAKE_EXPORT_PACKAGE_REGISTRY", "cmake_export_package_registry"
-            ),
-            self.define_from_variant("GSL_LITE_OPT_INSTALL_COMPAT_HEADER", "compat_header"),
-            self.define_from_variant("GSL_LITE_OPT_INSTALL_LEGACY_HEADERS", "legacy_headers"),
-        ]
-        return args


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Regarding the removed package options:
It does not make sense to expose any of these options via the package manager. Building tests, examples, or demos  is something a contributor would do, and of no value to a consumer of the package. Installation of compatibility and legacy header files should not be encouraged by exposing it as an option; moreover, these header files have been removed in gsl-lite v1.0 anyway.