### PR TITLE
Fix allowing conditional link dependencies on a compiler

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3265,7 +3265,7 @@ class SpackSolverSetup:
                                 arg = ast_sym(ast_sym(term.atom).arguments[0])
                                 symbol = AspFunction(name)(arg.string)
                                 self.assumptions.append((parse_term(str(symbol)), True))
-                                self.gen.asp_problem.append(f"{symbol}.\n")
+                                self.gen.asp_problem.append(f"{{ {symbol} }}.\n")
 
         path = os.path.join(parent_dir, "concretize.lp")
         parse_files([path], visit)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -584,15 +584,6 @@ error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, Lite
    Parent == BuildDependency,
    external(node(X, Parent)).
 
-1 { virtual_build_requirement(ParentNode, node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1
-  :- attr("dependency_holds", ParentNode, Virtual, "build"),
-     not attr("dependency_holds", ParentNode, Virtual,"link"),
-     not attr("dependency_holds", ParentNode, Virtual,"run"),
-     virtual(Virtual).
-
-attr("virtual_node", VirtualNode)  :- virtual_build_requirement(ParentNode, VirtualNode).
-build_requirement(ParentNode, ProviderNode) :- virtual_build_requirement(ParentNode, VirtualNode), provider(ProviderNode, VirtualNode).
-
 % From cli we can have literal expressions like:
 %
 % root %gcc@12.0 ^dep %gcc@11.2

--- a/lib/spack/spack/solver/direct_dependency.lp
+++ b/lib/spack/spack/solver/direct_dependency.lp
@@ -43,7 +43,8 @@ attr("depends_on", node(X, Parent), node(Y, BuildDependency), "build") :-
 
 attr(AttributeName, node(X, ChildPackage), A1)
   :- runtime_requirement(ParentNode, node(X, ChildPackage)),
-     attr("direct_dependency", ParentNode, node_requirement(AttributeName, ChildPackage, A1)).
+     attr("direct_dependency", ParentNode, node_requirement(AttributeName, ChildPackage, A1)),
+     AttributeName != "provider_set".
 
 attr(AttributeName, node(X, ChildPackage), A1, A2)
   :- runtime_requirement(ParentNode, node(X, ChildPackage)),

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3734,6 +3734,10 @@ def test_use_compiler_by_hash(mock_packages, mutable_database, mutable_config):
             ],
             ["%mpich~debug"],
         ),
+        # Package that has a conditional link dependency on a compiler
+        ("emacs +native", ["%[virtuals=c deptypes=build,link] gcc"], []),
+        ("emacs +native %gcc", ["%[virtuals=c deptypes=build,link] gcc"], []),
+        ("emacs +native %[virtuals=c] gcc", ["%[virtuals=c deptypes=build,link] gcc"], []),
     ],
 )
 def test_specifying_direct_dependencies(

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/emacs/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/emacs/package.py
@@ -1,0 +1,20 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class Emacs(Package):
+    """Mock package to test adding a link dependency on a compiler, depending on a variant"""
+
+    homepage = "http://www.example.org"
+    url = "http://bowtie-1.2.2.tar.bz2"
+
+    version("1.4.0", md5="1c837ecd990bb022d07e7aab32b09847")
+
+    variant("native", default=False, description="adds a link dep on gcc")
+
+    depends_on("c", type="build")
+    depends_on("gcc", type="link", when="+native")


### PR DESCRIPTION
closes #50730

Also restores internal_error, which was unintentionally dropped in #50565

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
