### PR TITLE
Add build dependencies for several packages

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/fixesproto/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fixesproto/package.py
@@ -20,6 +20,9 @@ class Fixesproto(AutotoolsPackage, XorgPackage):
 
     version("5.0", sha256="67865a0e3cdc7dec1fd676f0927f7011ad4036c18eb320a2b41dbd56282f33b8")
 
+    depends_on("c", type="build")
+
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
     depends_on("xextproto")
+

--- a/var/spack/repos/spack_repo/builtin/packages/fixesproto/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fixesproto/package.py
@@ -25,4 +25,3 @@ class Fixesproto(AutotoolsPackage, XorgPackage):
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
     depends_on("xextproto")
-

--- a/var/spack/repos/spack_repo/builtin/packages/fontsproto/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fontsproto/package.py
@@ -16,5 +16,8 @@ class Fontsproto(AutotoolsPackage, XorgPackage):
 
     version("2.1.3", sha256="72c44e63044b2b66f6fa112921621ecc20c71193982de4f198d9a29cda385c5e")
 
+    depends_on("c", type="build")
+
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
+

--- a/var/spack/repos/spack_repo/builtin/packages/fontsproto/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/fontsproto/package.py
@@ -20,4 +20,3 @@ class Fontsproto(AutotoolsPackage, XorgPackage):
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
-

--- a/var/spack/repos/spack_repo/builtin/packages/lua_lpeg/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/lua_lpeg/package.py
@@ -35,6 +35,8 @@ class LuaLpeg(LuaPackage):
         expand=False,
     )
 
+    depends_on("c", type="build")
+
     depends_on("lua-lang@:5.1.9", when="@:0.12.1 ^[virtuals=lua-lang] lua")
 
     @property

--- a/var/spack/repos/spack_repo/builtin/packages/madgraph5amc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/madgraph5amc/package.py
@@ -62,6 +62,8 @@ class Madgraph5amc(MakefilePackage):
 
     conflicts("%gcc@10:", when="@2.7.3")
 
+    depends_on("fortran", type="build")
+
     depends_on("syscalc")
     depends_on("gosam-contrib", when="+ninja")
     depends_on("collier", when="+collier")

--- a/var/spack/repos/spack_repo/builtin/packages/mkfontdir/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mkfontdir/package.py
@@ -24,5 +24,3 @@ class Mkfontdir(AutotoolsPackage, XorgPackage):
     depends_on("util-macros", type="build")
 
     depends_on("mkfontscale", type="run")
-
-

--- a/var/spack/repos/spack_repo/builtin/packages/mkfontdir/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/mkfontdir/package.py
@@ -18,7 +18,11 @@ class Mkfontdir(AutotoolsPackage, XorgPackage):
 
     version("1.0.7", sha256="bccc5fb7af1b614eabe4a22766758c87bfc36d66191d08c19d2fa97674b7b5b7")
 
-    depends_on("mkfontscale", type="run")
+    depends_on("c", type="build")
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
+
+    depends_on("mkfontscale", type="run")
+
+

--- a/var/spack/repos/spack_repo/builtin/packages/psimd/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/psimd/package.py
@@ -22,4 +22,6 @@ class Psimd(CMakePackage):
     version("2017-10-26", commit="4ac61b112252778b174575931c641bef661ab3cd")  # py-torch@0.4
 
     generator("ninja")
+
+    depends_on("c", type="build")
     depends_on("cmake@2.8.12:", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/r_rcpp/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/r_rcpp/package.py
@@ -52,6 +52,7 @@ class RRcpp(RPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("gmake", type="build")
 
     # leave the r dependency also for newer versions
     # (not listed in Description for @1.0.5:)

--- a/var/spack/repos/spack_repo/builtin/packages/r_rinside/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/r_rinside/package.py
@@ -36,5 +36,6 @@ class RRinside(RPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("gmake", type="build")
 
     depends_on("r-rcpp", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/recordproto/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/recordproto/package.py
@@ -23,4 +23,3 @@ class Recordproto(AutotoolsPackage, XorgPackage):
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
-

--- a/var/spack/repos/spack_repo/builtin/packages/recordproto/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/recordproto/package.py
@@ -19,5 +19,8 @@ class Recordproto(AutotoolsPackage, XorgPackage):
 
     version("1.14.2", sha256="485f792570dd7afe49144227f325bf2827bc7d87aae6a8ab6c1de2b06b1c68c5")
 
+    depends_on("c", type="build")
+
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
+

--- a/var/spack/repos/spack_repo/builtin/packages/xf86vidmodeproto/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/xf86vidmodeproto/package.py
@@ -23,4 +23,3 @@ class Xf86vidmodeproto(AutotoolsPackage, XorgPackage):
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
-

--- a/var/spack/repos/spack_repo/builtin/packages/xf86vidmodeproto/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/xf86vidmodeproto/package.py
@@ -19,5 +19,8 @@ class Xf86vidmodeproto(AutotoolsPackage, XorgPackage):
 
     version("2.3.1", sha256="c3512b11cefa7558576551f8582c6e7071c8a24d78176059d94b84b48b262979")
 
+    depends_on("c", type="build")
+
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
+

--- a/var/spack/repos/spack_repo/builtin/packages/xkeyboard_config/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/xkeyboard_config/package.py
@@ -21,6 +21,8 @@ class XkeyboardConfig(AutotoolsPackage, XorgPackage):
     version("2.34", sha256="a5882238b4199ca90428aea102790aaa847e6e214653d956bf2abba3027107ba")
     version("2.18", sha256="d5c511319a3bd89dc40622a33b51ba41a2c2caad33ee2bfe502363fcc4c3817d")
 
+    depends_on("c", type="build")
+
     depends_on("libx11@1.4.3:")
 
     depends_on("libxslt", type="build")


### PR DESCRIPTION
Trying to build on Alma 9 with GCC 14 (without a system compiler) and I got errors for all these packages, I guess due to https://github.com/spack/spack/pull/45189. Most of them don't have language dependencies and I just added it. I'm also compiling without make in the system and some packages fail because they call make but there wasn't a dependency on gmake. After these fixes, all these packages build fine for me.