### PR TITLE
trivy: add v0.63.0

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/trivy/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/trivy/package.py
@@ -17,6 +17,7 @@ class Trivy(GoPackage):
 
     license("Apache-2.0", checked_by="RobertMaaskant")
 
+    version("0.63.0", sha256="ac26dcb16072e674b8a3bffa6fbd817ec5baa125660b5c49d9ad8659e14d0800")
     version("0.62.1", sha256="1b8000f08876dd02203021414581275daa69db00fab731351dbcf2a008ebe82a")
     version("0.62.0", sha256="2b0b4df4bbfebde00a14a0616f5013db4cbba0f021a780a7e3b717a2c2978493")
     version("0.61.1", sha256="f6ad43e008c008d67842c9e2b4af80c2e96854db8009fba48fc37b4f9b15f59b")


### PR DESCRIPTION
Release notes: https://github.com/aquasecurity/trivy/discussions/8945
Diff: https://github.com/aquasecurity/trivy/compare/v0.62.1...v0.63.0