### PR TITLE
RepoSplit/tests: mv test_*builtin_repo from test/cmd/pkg.py to test/repo.py

### DIFF
--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -112,15 +112,6 @@ def split(output):
 pkg = spack.main.SpackCommand("pkg")
 
 
-@pytest.mark.requires_builtin("builtin repository path must exist")
-def test_builtin_repo():
-    assert spack.repo.builtin_repo() is spack.repo.PATH.get_repo("builtin")
-
-
-def test_mock_builtin_repo(mock_packages):
-    assert spack.repo.builtin_repo() is spack.repo.PATH.get_repo("builtin_mock")
-
-
 def test_pkg_add(git, mock_pkg_git_repo):
     with working_dir(mock_pkg_git_repo):
         mkdirp("mockpkg_e")

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -563,3 +563,12 @@ def test_repo_update(tmp_path: pathlib.Path):
         "foo": existing_root,
         # non-existing root is removed for simplicity; would be a warning otherwise.
     }
+
+
+@pytest.mark.requires_builtin("builtin repository path must exist")
+def test_builtin_repo():
+    assert spack.repo.builtin_repo() is spack.repo.PATH.get_repo("builtin")
+
+
+def test_mock_builtin_repo(mock_packages):
+    assert spack.repo.builtin_repo() is spack.repo.PATH.get_repo("builtin_mock")


### PR DESCRIPTION
This PR moves checks of the two main repository paths from `test/cmd/pkg.py` to `test/repo.py`.