### PR TITLE
RepoSplit/tests: sync a more minimal set of unit tests

### DIFF
--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -33,6 +33,7 @@ jobs:
                         --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
                         --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
                         --path lib/spack/spack/test/conftest.py --path-rename lib/spack/spack/test/conftest.py:repos/spack_repo/builtin/tests/conftest.py \
+                        --path lib/spack/spack/test/cmd/providers.py --path-rename lib/spack/spack/test/cmd/providers.py:repos/spack_repo/builtin/tests/cmd/providers.py \
                         --path .github/workflows/unit_tests.yaml \
                         --path pytest.ini \
                         --path .github/workflows/audit.yaml \

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -34,6 +34,7 @@ jobs:
                         --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
                         --path lib/spack/spack/test/conftest.py --path-rename lib/spack/spack/test/conftest.py:repos/spack_repo/builtin/tests/conftest.py \
                         --path lib/spack/spack/test/cmd/providers.py --path-rename lib/spack/spack/test/cmd/providers.py:repos/spack_repo/builtin/tests/cmd/providers.py \
+                        --path lib/spack/spack/test/bootstrap.py --path-rename lib/spack/spack/test/bootstrap.py:repos/spack_repo/builtin/tests/bootstrap.py \
                         --path lib/spack/spack/test/packages.py --path-rename lib/spack/spack/test/packages.py:repos/spack_repo/builtin/tests/packages.py \
                         --path .github/workflows/unit_tests.yaml \
                         --path pytest.ini \

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -34,6 +34,7 @@ jobs:
                         --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
                         --path lib/spack/spack/test/conftest.py --path-rename lib/spack/spack/test/conftest.py:repos/spack_repo/builtin/tests/conftest.py \
                         --path lib/spack/spack/test/bootstrap.py --path-rename lib/spack/spack/test/bootstrap.py:repos/spack_repo/builtin/tests/bootstrap.py \
+                        --path lib/spack/spack/test/build_system_guess.py --path-rename lib/spack/spack/test/build_system_guess.py:repos/spack_repo/builtin/tests/build_system_guess.py \
                         --path lib/spack/spack/test/cmd/providers.py --path-rename lib/spack/spack/test/cmd/providers.py:repos/spack_repo/builtin/tests/cmd/providers.py \
                         --path lib/spack/spack/test/repo.py --path-rename lib/spack/spack/test/repo.py:repos/spack_repo/builtin/tests/repo.py \
                         --path lib/spack/spack/test/packages.py --path-rename lib/spack/spack/test/packages.py:repos/spack_repo/builtin/tests/packages.py \

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -28,28 +28,24 @@ jobs:
       run: |
         cd spack-packages
         git-filter-repo --quiet --source ../spack \
-                        --path var/spack/repos/README.md --path-rename var/spack/repos/README.md:README.md \
-                        --path var/spack/repos/ --path-rename var/spack/repos/:repos/ \
-                        --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
-                        --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
-                        --path lib/spack/spack/test/__init__.py --path-rename lib/spack/spack/test/__init__.py:repos/spack_repo/builtin/tests/__init__.py \
-                        --path lib/spack/spack/test/conftest.py --path-rename lib/spack/spack/test/conftest.py:repos/spack_repo/builtin/tests/conftest.py \
-                        --path lib/spack/spack/test/bootstrap.py --path-rename lib/spack/spack/test/bootstrap.py:repos/spack_repo/builtin/tests/bootstrap.py \
-                        --path lib/spack/spack/test/build_system_guess.py --path-rename lib/spack/spack/test/build_system_guess.py:repos/spack_repo/builtin/tests/build_system_guess.py \
-                        --path lib/spack/spack/test/cmd/providers.py --path-rename lib/spack/spack/test/cmd/providers.py:repos/spack_repo/builtin/tests/cmd/providers.py \
-                        --path lib/spack/spack/test/repo.py --path-rename lib/spack/spack/test/repo.py:repos/spack_repo/builtin/tests/repo.py \
-                        --path lib/spack/spack/test/packages.py --path-rename lib/spack/spack/test/packages.py:repos/spack_repo/builtin/tests/packages.py \
-                        --path .github/workflows/unit_tests.yaml \
-                        --path pytest.ini \
+                        --path .github/CODE_OF_CONDUCT.md --path-rename .github/CODE_OF_CONDUCT.md:.github/CODE_OF_CONDUCT.md \
+                        --path .github/CONTRIBUTING.md --path-rename .github/CONTRIBUTING.md:.github/CONTRIBUTING.md \
+                        --path .github/ISSUE_TEMPLATE/ \
+                        --path .github/pull_request_template.md \
                         --path .github/workflows/audit.yaml \
                         --path .github/workflows/ci.yaml \
                         --path .github/workflows/prechecks.yml \
+                        --path .github/workflows/unit_tests.yaml \
+                        --path lib/spack/spack/test/__init__.py --path-rename lib/spack/spack/test/__init__.py:tests/__init__.py \
+                        --path lib/spack/spack/test/build_systems.py --path-rename lib/spack/spack/test/build_systems.py:tests/build_systems.py \
+                        --path lib/spack/spack/test/conftest.py --path-rename lib/spack/spack/test/conftest.py:tests/conftest.py \
+                        --path pytest.ini \
+                        --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
                         --path share/spack/qa/validate_last_exit.ps1 --path-rename share/spack/qa/validate_last_exit.ps1:.ci/validate_last_exit.ps1 \
                         --path share/spack/qa/windows_test_setup.ps1 --path-rename share/spack/qa/windows_test_setup.ps1:.ci/windows_test_setup.ps1 \
-                        --path .github/CODE_OF_CONDUCT.md --path-rename .github/CODE_OF_CONDUCT.md:.github/CODE_OF_CONDUCT.md \
-                        --path .github/CONTRIBUTING.md --path-rename .github/CONTRIBUTING.md:.github/CONTRIBUTING.md \
-                        --path .github/pull_request_template.md \
-                        --path .github/ISSUE_TEMPLATE/ \
+                        --path var/spack/repos/ --path-rename var/spack/repos/:repos/ \
+                        --path var/spack/repos/README.md --path-rename var/spack/repos/README.md:README.md \
+                        --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
                         --refs develop
     - name: Push
       run: |

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -32,7 +32,7 @@ jobs:
                         --path var/spack/repos/ --path-rename var/spack/repos/:repos/ \
                         --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
                         --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
-                        --path lib/spack/spack/test/ --path-rename lib/spack/spack/test/:repos/spack_repo/builtin/tests/ \
+                        --path lib/spack/spack/test/conftest.py --path-rename lib/spack/spack/test/conftest.py:repos/spack_repo/builtin/tests/conftest.py \
                         --path .github/workflows/unit_tests.yaml \
                         --path pytest.ini \
                         --path .github/workflows/audit.yaml \

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -32,6 +32,7 @@ jobs:
                         --path var/spack/repos/ --path-rename var/spack/repos/:repos/ \
                         --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
                         --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
+                        --path lib/spack/spack/test/__init__.py --path-rename lib/spack/spack/test/__init__.py:repos/spack_repo/builtin/tests/__init__.py \
                         --path lib/spack/spack/test/conftest.py --path-rename lib/spack/spack/test/conftest.py:repos/spack_repo/builtin/tests/conftest.py \
                         --path lib/spack/spack/test/bootstrap.py --path-rename lib/spack/spack/test/bootstrap.py:repos/spack_repo/builtin/tests/bootstrap.py \
                         --path lib/spack/spack/test/build_system_guess.py --path-rename lib/spack/spack/test/build_system_guess.py:repos/spack_repo/builtin/tests/build_system_guess.py \

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -34,6 +34,7 @@ jobs:
                         --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
                         --path lib/spack/spack/test/conftest.py --path-rename lib/spack/spack/test/conftest.py:repos/spack_repo/builtin/tests/conftest.py \
                         --path lib/spack/spack/test/cmd/providers.py --path-rename lib/spack/spack/test/cmd/providers.py:repos/spack_repo/builtin/tests/cmd/providers.py \
+                        --path lib/spack/spack/test/packages.py --path-rename lib/spack/spack/test/packages.py:repos/spack_repo/builtin/tests/packages.py \
                         --path .github/workflows/unit_tests.yaml \
                         --path pytest.ini \
                         --path .github/workflows/audit.yaml \

--- a/.github/workflows/sync-packages.yaml
+++ b/.github/workflows/sync-packages.yaml
@@ -33,8 +33,9 @@ jobs:
                         --path share/spack/gitlab/cloud_pipelines/ --path-rename share/spack/gitlab/cloud_pipelines/:.ci/gitlab/ \
                         --path var/spack/spack-repo-index.yaml --path-rename var/spack/spack-repo-index.yaml:spack-repo-index.yaml \
                         --path lib/spack/spack/test/conftest.py --path-rename lib/spack/spack/test/conftest.py:repos/spack_repo/builtin/tests/conftest.py \
-                        --path lib/spack/spack/test/cmd/providers.py --path-rename lib/spack/spack/test/cmd/providers.py:repos/spack_repo/builtin/tests/cmd/providers.py \
                         --path lib/spack/spack/test/bootstrap.py --path-rename lib/spack/spack/test/bootstrap.py:repos/spack_repo/builtin/tests/bootstrap.py \
+                        --path lib/spack/spack/test/cmd/providers.py --path-rename lib/spack/spack/test/cmd/providers.py:repos/spack_repo/builtin/tests/cmd/providers.py \
+                        --path lib/spack/spack/test/repo.py --path-rename lib/spack/spack/test/repo.py:repos/spack_repo/builtin/tests/repo.py \
                         --path lib/spack/spack/test/packages.py --path-rename lib/spack/spack/test/packages.py:repos/spack_repo/builtin/tests/packages.py \
                         --path .github/workflows/unit_tests.yaml \
                         --path pytest.ini \


### PR DESCRIPTION
The updated list of paths to sync with the packages repository is intended to reflect a near minimal set of relevant unit tests. The files are being pulled over in part to preserve their history. All of the files will require changes, in some cases to include dropping multiple/most tests, in a separate `spack/spack-packages` PR.

The test files added in this PR are primarily the result of reviewing PRs involving changing unit tests from relying on the `builtin` repository to the `builtin.mock` repository. A number of additional unit test files were reviewed to determine if they should also be included (e.g., build system, compiler, concretization, and command tests).

The reason for the sync and or purpose of the changes to each file are:
- `pytest.ini`: configuration options and markers will be customized for the new repo
- `test/__init__.py`
- `test/bootstrap.py`: use actual (not mock) packages path in `test_bootstrap_search_for_compilers_*`
- `test/build_system_guess.py`: run build system tests (IFF want to include it)
- `test/conftest.py`: test configuration fixtures, etc. will need to be reduced as needed for the new repo
- `test/cmd/providers.py`: IFF want to run `test_it_just_runs` using the original (builtin) providers
- `test/repo.py`: run `test_builtin_repo` to check the path as the test is flagged as requiring `builtin`
- `test/packages.py`: run `test_import_package` without the mock `_PrependFileLoader`