### PR TITLE
RepoSplit/tests: convert repo initialization failure warning to debug

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -656,7 +656,7 @@ class RepoPath:
             try:
                 repos.append(Repo(p, cache=cache, overrides=overrides))
             except RepoError as e:
-                tty.warn(
+                tty.debug(
                     f"Failed to initialize repository: '{p}'.",
                     e.message,
                     "To remove the bad repository, run this command:",


### PR DESCRIPTION
Supersedes #50479 

@tgamblin You mentioned in a meeting this morning something along the lines of you'd prefer the warning be removed than for the `lib/spack/spack/test/cmd/commands.py::test_names` test to skip the warning output. 

This PR converts the initialization message from a warning to a failure. Without it, the unit test fails due to an equality comparison that is not expecting the following warning in the output:

```
==> Warning: Failed to initialize repository: '$spack/var/spack/repos/spack_repo/builtin'.
  No repo.yaml found in '$spack/var/spack/repos/spack_repo/builtin'
  To remove the bad repository, run this command:
      spack repo rm $spack/var/spack/repos/spack_repo/builtin
```