### PR TITLE
Toolchains add tests for matrix interactions

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2727,7 +2727,7 @@ class Spec:
                 return name, depflag
 
             def spec_and_dependency_types(
-                s: Union[Spec, Tuple[Spec, str]],
+                s: Union[Spec, Tuple[Spec, str]]
             ) -> Tuple[Spec, dt.DepFlag]:
                 """Given a non-string key in the literal, extracts the spec
                 and its dependency types.

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -81,7 +81,7 @@ packages:
             fortran: /path/bin/gfortran-10
   llvm:
     externals:
-      - spec: "llvm@15.0.0 +clang~flang os={linux_os.name}{linux_os.version} target={target}"
+      - spec: "llvm@15.0.0 +clang+flang os={linux_os.name}{linux_os.version} target={target}"
         prefix: /path
         extra_attributes:
           compilers:

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -87,3 +87,4 @@ packages:
           compilers:
             c: /path/bin/clang
             cxx: /path/bin/clang++
+            fortran: /path/bin/flang

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1167,38 +1167,3 @@ spack:
         for x in e.concrete_roots():
             if x.name in ["dt-diamond-left", "dt-diamond-right"]:
                 assert x.satisfies("%[virtuals=fortran] gcc")
-
-
-# import spack_repo.builtin_mock.build_systems.compiler
-
-
-def _display_with_compilers(spec):
-    compilers = set()
-
-    for depth, dep_spec in traverse.traverse_tree(
-        [spec], deptype=("link", "run", "build"), depth_first=True
-    ):
-        node = dep_spec.spec
-        # if isinstance(node.package,
-        # spack_repo.builtin_mock.build_systems.compiler.CompilerPackage):
-        if node.name in ["llvm", "gcc"]:
-            compilers.add(node)
-        # elif node.name in ["llvm", "gcc"]:
-        #     import pdb; pdb.set_trace()
-        #     print('?')
-
-    for depth, dep_spec in traverse.traverse_tree(
-        [spec], deptype=("link", "run", "build"), depth_first=True
-    ):
-        node = dep_spec.spec
-        lang_to_comp = {}
-        for direct_dep_spec in node.edges_to_dependencies():
-            child = direct_dep_spec.spec
-            if child in compilers:
-                lang_to_comp[direct_dep_spec.virtuals] = child.name
-
-        line = "  " * depth + node.name
-        for lang, comp in sorted(lang_to_comp.items()):
-            langs_id = ",".join(lang)
-            line += f" [{langs_id}]={comp}"
-        print(line)

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -15,6 +15,7 @@ import spack.environment as ev
 import spack.platforms
 import spack.solver.asp
 import spack.spec
+import spack.traverse as traverse
 from spack.environment.environment import (
     EnvironmentManifestFile,
     SpackEnvironmentViewError,
@@ -1059,3 +1060,151 @@ def test_toolchain_definitions_are_allowed(
 
     for c in not_expected:
         assert not mpileaks.satisfies(c)
+
+
+def test_matrix_toolchains_basic(
+    tmp_path, mutable_config, mutable_mock_env_path, temporary_store, mock_packages
+):
+    """Can a toolchain be applied in a matrix
+    """
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(
+        """\
+spack:
+  specs:
+    - matrix:
+      - [dt-diamond-left,  dt-diamond-right]
+      - ["%mixed-toolchain"]
+  toolchains:
+    mixed-toolchain:
+    - spec: "%[virtuals=c] llvm"
+      when: "%c"
+    - spec: "%[virtuals=cxx] llvm"
+      when: "%cxx"
+    # This succeeds if I flip it to gcc, but that seems to be the built
+    # in preference (what is chosen if I force nothing). A more-robust
+    # test would try forcing several combinations and making sure they
+    # all are respected.
+    - spec: "%[virtuals=fortran] llvm"
+      when: "%fortran"
+  concretizer:
+    unify: true
+"""
+    )
+    with ev.Environment(tmp_path) as e:
+        e.concretize()
+        for x in e.concrete_roots():
+            if x.name in ["dt-diamond-left", "dt-diamond-right"]:
+                assert x.satisfies("%[virtuals=fortran] gcc")
+
+
+def test_matrix_toolchains_apply_both(
+    tmp_path, mutable_config, mutable_mock_env_path, temporary_store, mock_packages
+):
+    """Matrix that multiplies two conflicting toolchains with
+    two root specs.
+    """
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(
+        """\
+spack:
+  specs:
+    - matrix:
+      - [dt-diamond-left,  dt-diamond-right]
+      - ["%toolchain-1", "%toolchain-2"]
+  toolchains:
+    toolchain-1:
+    - spec: "%[virtuals=c] llvm"
+      when: "%c"
+    - spec: "%[virtuals=cxx] llvm"
+      when: "%cxx"
+    - spec: "%[virtuals=fortran] gcc"
+      when: "%fortran"
+    toolchain-2:
+    - spec: "%[virtuals=c] gcc"
+      when: "%c"
+    - spec: "%[virtuals=cxx] gcc"
+      when: "%cxx"
+    - spec: "%[virtuals=fortran] llvm"
+      when: "%fortran"
+  concretizer:
+    unify: when_possible
+"""
+    )
+    with ev.Environment(tmp_path) as e:
+        e.concretize()
+        for x in e.concrete_roots():
+            if x.name in ["dt-diamond-left", "dt-diamond-right"]:
+                if x.satisfies("%[virtuals=c] llvm"):
+                    assert x.satisfies("%[virtuals=fortran] gcc")
+                else:
+                    assert x.satisfies("%[virtuals=c] gcc")
+                    assert x.satisfies("%[virtuals=fortran] llvm")
+
+
+def test_matrix_toolchains_three_vector(
+    tmp_path, mutable_config, mutable_mock_env_path, temporary_store, mock_packages
+):
+    """Can a toolchain be applied in a matrix
+    """
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(
+        """\
+spack:
+  specs:
+    - matrix:
+      - [dt-diamond-left, dt-diamond-right]
+      - [^dt-diamond-bottom@0.9]
+      - ["%mixed-toolchain"]
+  toolchains:
+    mixed-toolchain:
+    - spec: "%[virtuals=c] llvm"
+      when: "%c"
+    - spec: "%[virtuals=cxx] llvm"
+      when: "%cxx"
+    - spec: "%[virtuals=fortran] llvm"
+      when: "%fortran"
+  concretizer:
+    unify: true
+"""
+    )
+    with ev.Environment(tmp_path) as e:
+        e.concretize()
+        for x in e.concrete_roots():
+            if x.name in ["dt-diamond-left", "dt-diamond-right"]:
+                assert x.satisfies("%[virtuals=fortran] llvm")
+
+
+# import spack_repo.builtin_mock.build_systems.compiler
+
+
+def _display_with_compilers(spec):
+    compilers = set()
+
+    for depth, dep_spec in traverse.traverse_tree(
+        [spec], deptype=("link", "run", "build"), depth_first=True
+    ):
+        node = dep_spec.spec
+        # if isinstance(node.package,
+        # spack_repo.builtin_mock.build_systems.compiler.CompilerPackage):
+        if node.name in ["llvm", "gcc"]:
+            compilers.add(node)
+        # elif node.name in ["llvm", "gcc"]:
+        #     import pdb; pdb.set_trace()
+        #     print('?')
+
+    for depth, dep_spec in traverse.traverse_tree(
+        [spec], deptype=("link", "run", "build"), depth_first=True
+    ):
+        node = dep_spec.spec
+        lang_to_comp = {}
+        for direct_dep_spec in node.edges_to_dependencies():
+            child = direct_dep_spec.spec
+            if child in compilers:
+                lang_to_comp[direct_dep_spec.virtuals] = child.name
+
+        line = "  " * depth + node.name
+        for lang, comp in sorted(lang_to_comp.items()):
+            langs_id = ",".join(lang)
+            line += f" [{langs_id}]={comp}"
+        print(line)

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -15,7 +15,6 @@ import spack.environment as ev
 import spack.platforms
 import spack.solver.asp
 import spack.spec
-import spack.traverse as traverse
 from spack.environment.environment import (
     EnvironmentManifestFile,
     SpackEnvironmentViewError,

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1065,8 +1065,7 @@ def test_toolchain_definitions_are_allowed(
 def test_matrix_toolchains_basic(
     tmp_path, mutable_config, mutable_mock_env_path, temporary_store, mock_packages
 ):
-    """Can a toolchain be applied in a matrix
-    """
+    """Can a toolchain be applied in a matrix"""
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(
         """\
@@ -1141,8 +1140,7 @@ spack:
 def test_matrix_toolchains_three_vector(
     tmp_path, mutable_config, mutable_mock_env_path, temporary_store, mock_packages
 ):
-    """Can a toolchain be applied in a matrix
-    """
+    """Can a toolchain be applied in a matrix"""
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(
         """\

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1081,10 +1081,6 @@ spack:
       when: "%c"
     - spec: "%[virtuals=cxx] llvm"
       when: "%cxx"
-    # This succeeds if I flip it to gcc, but that seems to be the built
-    # in preference (what is chosen if I force nothing). A more-robust
-    # test would try forcing several combinations and making sure they
-    # all are respected.
     - spec: "%[virtuals=fortran] llvm"
       when: "%fortran"
   concretizer:
@@ -1095,7 +1091,7 @@ spack:
         e.concretize()
         for x in e.concrete_roots():
             if x.name in ["dt-diamond-left", "dt-diamond-right"]:
-                assert x.satisfies("%[virtuals=fortran] gcc")
+                assert x.satisfies("%[virtuals=fortran] llvm")
 
 
 def test_matrix_toolchains_apply_both(
@@ -1162,7 +1158,7 @@ spack:
       when: "%c"
     - spec: "%[virtuals=cxx] llvm"
       when: "%cxx"
-    - spec: "%[virtuals=fortran] llvm"
+    - spec: "%[virtuals=fortran] gcc"
       when: "%fortran"
   concretizer:
     unify: true
@@ -1172,7 +1168,7 @@ spack:
         e.concretize()
         for x in e.concrete_roots():
             if x.name in ["dt-diamond-left", "dt-diamond-right"]:
-                assert x.satisfies("%[virtuals=fortran] llvm")
+                assert x.satisfies("%[virtuals=fortran] gcc")
 
 
 # import spack_repo.builtin_mock.build_systems.compiler

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1089,8 +1089,7 @@ spack:
     with ev.Environment(tmp_path) as e:
         e.concretize()
         for x in e.concrete_roots():
-            if x.name in ["dt-diamond-left", "dt-diamond-right"]:
-                assert x.satisfies("%[virtuals=fortran] llvm")
+            assert x.satisfies("%[virtuals=fortran] llvm")
 
 
 def test_matrix_toolchains_apply_both(
@@ -1129,12 +1128,11 @@ spack:
     with ev.Environment(tmp_path) as e:
         e.concretize()
         for x in e.concrete_roots():
-            if x.name in ["dt-diamond-left", "dt-diamond-right"]:
-                if x.satisfies("%[virtuals=c] llvm"):
-                    assert x.satisfies("%[virtuals=fortran] gcc")
-                else:
-                    assert x.satisfies("%[virtuals=c] gcc")
-                    assert x.satisfies("%[virtuals=fortran] llvm")
+            if x.satisfies("%[virtuals=c] llvm"):
+                assert x.satisfies("%[virtuals=fortran] gcc")
+            else:
+                assert x.satisfies("%[virtuals=c] gcc")
+                assert x.satisfies("%[virtuals=fortran] llvm")
 
 
 def test_matrix_toolchains_three_vector(
@@ -1165,5 +1163,4 @@ spack:
     with ev.Environment(tmp_path) as e:
         e.concretize()
         for x in e.concrete_roots():
-            if x.name in ["dt-diamond-left", "dt-diamond-right"]:
-                assert x.satisfies("%[virtuals=fortran] gcc")
+            assert x.satisfies("%[virtuals=fortran] gcc")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dt_diamond_bottom/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dt_diamond_bottom/package.py
@@ -14,7 +14,7 @@ class DtDiamondBottom(Package):
     url = "http://www.example.com/dt-diamond-bottom-1.0.tar.gz"
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
-    version("0.9", md5="a"*32)
+    version("0.9", md5="a" * 32)
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dt_diamond_bottom/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dt_diamond_bottom/package.py
@@ -14,5 +14,7 @@ class DtDiamondBottom(Package):
     url = "http://www.example.com/dt-diamond-bottom-1.0.tar.gz"
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
+    version("0.9", md5="a"*32)
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dt_diamond_left/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dt_diamond_left/package.py
@@ -17,3 +17,5 @@ class DtDiamondLeft(Package):
 
     depends_on("dt-diamond-bottom", type="build")
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dt_diamond_right/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dt_diamond_right/package.py
@@ -17,3 +17,5 @@ class DtDiamondRight(Package):
 
     depends_on("dt-diamond-bottom", type=("build", "link", "run"))
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")


### PR DESCRIPTION
PR on a PR (https://github.com/spack/spack/pull/50481)

These tests matrices in combination with toolchains. 2 of 3 pass. `matrix_toolchains_apply_both` fails with

`spack.solver.asp.OutputDoesNotSatisfyInputError: internal solver error: the solver completed but produced specs that do not satisfy the request`