### PR TITLE
cmake: Add versions 3.31.7, 4.0.1, 4.0.2

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/cmake/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cmake/package.py
@@ -32,12 +32,15 @@ class Cmake(Package):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("4.0.2", sha256="1c3a82c8ca7cf12e0b17178f9d0c32f7ac773bd5651a98fcfd80fbf4977f8d48")
+    version("4.0.1", sha256="d630a7e00e63e520b25259f83d425ef783b4661bdc8f47e21c7f23f3780a21e1")
     version("4.0.0", sha256="ddc54ad63b87e153cf50be450a6580f1b17b4881de8941da963ff56991a4083b")
     version(
-        "3.31.6",
-        sha256="653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0",
+        "3.31.7",
+        sha256="a6d2eb1ebeb99130dfe63ef5a340c3fdb11431cce3d7ca148524c125924cea68",
         preferred=True,
     )
+    version("3.31.6", sha256="653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0")
     version("3.31.5", sha256="66fb53a145648be56b46fa9e8ccade3a4d0dfc92e401e52ce76bdad1fea43d27")
     version("3.31.4", sha256="a6130bfe75f5ba5c73e672e34359f7c0a1931521957e8393a5c2922c8b0f7f25")
     version("3.31.3", sha256="fac45bc6d410b49b3113ab866074888d6c9e9dc81a141874446eb239ac38cb87")


### PR DESCRIPTION
@johnwparent reopened here. I see that `4.0.0` exists now, so I imagine it doesn't hurt to add the other minor versions now?