### PR TITLE
py-distributed, py-dask-expr: relax versioneer dependency

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_dask_expr/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_dask_expr/package.py
@@ -19,7 +19,7 @@ class PyDaskExpr(PythonPackage):
 
     depends_on("python@3.10:", type=("build", "run"))
     depends_on("py-setuptools@62.6:", type="build")
-    depends_on("py-versioneer@0.28+toml", type="build")
+    depends_on("py-versioneer@0.28:+toml", type="build")
 
     # Can't do circular run-time dependencies yet?
     # depends_on("py-dask@2024.7.1", type="run")

--- a/var/spack/repos/spack_repo/builtin/packages/py_distributed/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_distributed/package.py
@@ -46,7 +46,7 @@ class PyDistributed(PythonPackage):
     depends_on("python@:3.11", when="@:2022.6.0", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")
-    depends_on("py-versioneer@0.28+toml", type="build", when="@2023.4.1:")
+    depends_on("py-versioneer@0.28:+toml", type="build", when="@2023.4.1:")
 
     # In Spack py-dask+distributed depends on py-distributed, not the other way around.
     # Hence, no need for depends_on("py-dask", ...)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Other packages depend on py-versioneer@0.29:, and these packages are too strict on the version.

CC @theabm