### PR TITLE
Remove -d flag from pipeline generate job

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -136,7 +136,7 @@ default:
       --config-scope "${SPACK_CI_CONFIG_ROOT}/${SPACK_TARGET_PLATFORM}"
       --config-scope "${SPACK_CI_CONFIG_ROOT}/${SPACK_TARGET_PLATFORM}/${SPACK_TARGET_ARCH}"
       config blame > "${CI_PROJECT_DIR}/jobs_scratch_dir/spack.yaml.blame"
-    - spack -d -v --color=always
+    - spack -v --color=always
       --config-scope "${SPACK_CI_CONFIG_ROOT}"
       --config-scope "${SPACK_CI_CONFIG_ROOT}/${SPACK_TARGET_PLATFORM}"
       --config-scope "${SPACK_CI_CONFIG_ROOT}/${SPACK_TARGET_PLATFORM}/${SPACK_TARGET_ARCH}"


### PR DESCRIPTION
This was introduced in #50616, see https://github.com/spack/spack/pull/50616/files#r2110952843 for more context

Using the `-d` flag leads to unreadable, and possibly truncated, output in pipelines generate jobs. See:
- https://gitlab.spack.io/spack/spack/-/jobs/16901136

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
