### PR TITLE
intel-oneapi-mkl: add `include/fftw` to list of include directories

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/intel_oneapi_mkl/package.py
@@ -239,6 +239,12 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         else:
             return IntelOneApiStaticLibraryList(libs, system_libs)
 
+    @property
+    def headers(self):
+        headers = find_all_headers(self.component_prefix.include)
+        headers.directories = [self.component_prefix.include, self.component_prefix.include.fftw]
+        return headers
+
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:


### PR DESCRIPTION
When using MKL as FFTW provider, consumer packages need to manually add MKL's fftw directory to include dirs, which leads to special-casing like
https://github.com/spack/spack/blob/76d3bfe8665a32b737dc5171b074803f17bd2078/var/spack/repos/spack_repo/builtin/packages/quantum_espresso/package.py#L543-L545
https://github.com/spack/spack/blob/76d3bfe8665a32b737dc5171b074803f17bd2078/var/spack/repos/spack_repo/builtin/packages/hpcc/package.py#L129
I think Spack should automatically add fftw directory to the list of include dirs.

Before this PR:
```python
>>> spack.concretize.concretize_one(spack.spec.Spec('intel-oneapi-mkl'))['intel-oneapi-mkl'].headers.include_flags
''
```
after this PR:
```python
>>> spack.concretize.concretize_one(spack.spec.Spec('intel-oneapi-mkl'))['intel-oneapi-mkl'].headers.include_flags
'-I/home/mose/repo/spack/opt/spack/linux-skylake/intel-oneapi-mkl-2024.2.2-olsnfyvpenkfbyeawt6kxtvfsgysz55r/mkl/2024.2/include -I/home/mose/repo/spack/opt/spack/linux-skylake/intel-oneapi-mkl-2024.2.2-olsnfyvpenkfbyeawt6kxtvfsgysz55r/mkl/2024.2/include/fftw'
```

The only thing I'm not sure about is whether it's desirable to _always_ add the fftw directory to the list of headers dirs, but I don't think there's a way to query whether the package is providing fftw?