### PR TITLE
test_package_audits: no longer xfail after api v2

### DIFF
--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -29,14 +29,7 @@ import spack.config
         # This package has a stand-alone test method in build-time callbacks
         (["fail-test-audit"], ["PKG-PROPERTIES"]),
         # This package implements and uses several deprecated stand-alone test methods
-        pytest.param(
-            ["fail-test-audit-deprecated"],
-            ["PKG-DEPRECATED-ATTRIBUTES"],
-            marks=pytest.mark.xfail(
-                reason="inspect.getsource() reads the source file, "
-                "which misses an injected import line"
-            ),
-        ),
+        (["fail-test-audit-deprecated"], ["PKG-DEPRECATED-ATTRIBUTES"]),
         # This package has stand-alone test methods without non-trivial docstrings
         (["fail-test-audit-docstring"], ["PKG-PROPERTIES"]),
         # This package has a stand-alone test method without an implementation


### PR DESCRIPTION
This test no longer fails thanks to after mock repos were upgraded to v2, which does not include the injected import lines, and hence no longer confuses inspect about line numbers.