### PR TITLE
spack.repo.PATH: fix lazy constructor

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -13,6 +13,7 @@ import llnl.util.tty as tty
 from llnl.util.tty import color
 
 import spack
+import spack.caches
 import spack.config
 import spack.repo
 import spack.util.executable
@@ -157,7 +158,7 @@ def _add_repo(
     )
     descriptor.initialize(git=spack.util.executable.which("git"))
 
-    packages_repos = descriptor.construct()
+    packages_repos = descriptor.construct(cache=spack.caches.MISC_CACHE)
 
     usable_repos: Dict[str, spack.repo.Repo] = {}
 
@@ -220,7 +221,7 @@ def repo_remove(args):
             # hence "all" and not "any". We can improve this later if needed.
             if all(
                 r.namespace == namespace_or_path or r.root == canon_path
-                for r in descriptor.construct().values()
+                for r in descriptor.construct(cache=spack.caches.MISC_CACHE).values()
                 if isinstance(r, spack.repo.Repo)
             ):
                 key = name
@@ -246,7 +247,7 @@ def repo_list(args):
 
     for name, descriptor in descriptors.items():
         descriptor.initialize(fetch=False)
-        repos_for_descriptor = descriptor.construct()
+        repos_for_descriptor = descriptor.construct(cache=spack.caches.MISC_CACHE)
         for path, maybe_repo in repos_for_descriptor.items():
             if isinstance(maybe_repo, spack.repo.Repo):
                 color.cprint(
@@ -268,7 +269,7 @@ def _get_repo(name_or_path: str) -> Optional[spack.repo.Repo]:
         spack.repo.package_repository_lock(), spack.config.CONFIG
     )
 
-    repo_path, _ = descriptors.construct(fetch=False)
+    repo_path, _ = descriptors.construct(cache=spack.caches.MISC_CACHE, fetch=False)
 
     for repo in repo_path.repos:
         if repo.namespace == name_or_path:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -562,18 +562,7 @@ def setup_main_options(args):
         spack.config.add(fullpath=config_var, scope="command_line")
 
     # In the main function we automatically fetch remote package repositories if necessary
-    repo_descriptors = spack.repo.RepoDescriptors.from_config(
-        lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG
-    )
-
-    repo_path, errors = repo_descriptors.construct(fetch=True)
-
-    # Merely warn if package repositories from config could not be constructed.
-    if errors:
-        for path, error in errors.items():
-            tty.warn(f"Error constructing repository '{path}': {error}")
-
-    spack.repo.enable_repo(repo_path)
+    spack.repo.enable_repo(spack.repo.RepoPath.from_config(spack.config.CONFIG))
 
     # On Windows10 console handling for ASCI/VT100 sequences is not
     # on by default. Turn on before we try to write to console

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -260,10 +260,10 @@ class MockDescriptor(spack.repo.RepoDescriptor):
         self.to_construct = to_construct
         self.initialized = False
 
-    def initialize(self, git):
+    def initialize(self, fetch=True, git=None) -> None:
         self.initialized = True
 
-    def construct(self):
+    def construct(self, cache, overrides=None):
         assert self.initialized, "MockDescriptor must be initialized before construction"
         return self.to_construct
 


### PR DESCRIPTION
Fixes two regressions introduced in #50650.

#### Regression 1

`spack.repo.PATH` is constructed either in `spack.main` or through a singleton in `spack.repo`. Those initialization functions were out of sync; the latter used a named constructor that was not updated as part of #50650. That broke Spack on macOS where sub-processes instantiate `spack.repo.PATH` with the singleton.

Now both `spack.main` and `spack.repo` use `RepoPath.from_config` consistently.

#### Regression 2

When `spack.repo.PATH` was instantiated from `spack.main` it no longer received `overrides` from packages.yaml config.

---

Additionally, allow Spack to be run without any package repo configured, this is at least useful this week.