### PR TITLE
Buildcache pruning

### DIFF
--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -48,6 +48,7 @@ def _prune_orphans(mirror: Mirror) -> int:
             cache_entry: Optional[URLBuildcacheEntry] = None
             try:
                 cache_entry = cast(URLBuildcacheEntry, read_fn(blob_name))
+                assert cache_entry.manifest is not None  #  to satisfy type checker
                 return {
                     cache_entry.get_blob_url(mirror_url=mirror.fetch_url, record=data): blob_name
                     for data in cache_entry.manifest.data
@@ -126,8 +127,8 @@ def _prune_orphans(mirror: Mirror) -> int:
         manifest_futures = [executor.submit(remove_manifest, url) for url in orphaned_manifests]
         blob_futures = [executor.submit(remove_blob, url) for url in orphaned_blobs]
 
-        for future in as_completed(manifest_futures + blob_futures):
-            pruned_objects += future.result()
+        for manifest_or_blob_future in as_completed(manifest_futures + blob_futures):
+            pruned_objects += manifest_or_blob_future.result()
 
     return pruned_objects
 

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -1,0 +1,134 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import tempfile
+from typing import Dict, Set
+
+import llnl.util.tty as tty
+
+import spack.binary_distribution as bindist
+import spack.stage
+import spack.util.url as url_util
+import spack.util.web as web_util
+
+from .mirrors.mirror import Mirror
+from .url_buildcache import URLBuildcacheEntry, get_entries_from_cache
+
+
+def _prune_orphans(mirror: Mirror) -> int:
+    """
+    Prune orphaned manifests and blobs from the buildcache.
+
+    This function crawls the buildcache for a given mirror and identifies orphaned
+    manifests and blobs. An "orphaned manifest" is one that references blobs that
+    are not present in the cache, while an "orphaned blob" is one that is present in
+    the cache but not referenced in any manifest.
+
+    It uses the following steps to identify and prune orphaned objects:
+
+    1. Fetch all the manifests in the cache and build up a list of all the blobs that they reference.
+    2. List all the blobs in the buildcache, resulting in a list of all the blobs that *actually* exist in the cache.
+    3. Compare the two lists and use the difference to determine which objects are orphaned.
+        - If a blob is listed in the cache but not in any manifest, that blob is orphaned.
+        - If a blob is listed in a manifest but not in the cache, that manifest is orphaned.
+    """
+
+    # As part of the pruning process, we need to keep track of the mapping between
+    # blob URLs and their corresponding manifest URLs. Once we start computing
+    # which blobs are referenced by a manifest but not present in the cache,
+    # we will need to know which manifest to prune.
+    blob_to_manifest_mapping: Dict[str, str] = {}
+
+    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
+        file_list, read_fn = get_entries_from_cache(url=mirror.fetch_url, tmpspecsdir=tmpspecsdir)
+        for blob_name in file_list:
+            try:
+                cache_entry: URLBuildcacheEntry = read_fn(manifest_url=blob_name)
+                for data in cache_entry.manifest.data:
+                    blob_url = cache_entry.get_blob_url(mirror_url=mirror.fetch_url, record=data)
+                    blob_to_manifest_mapping[blob_url] = blob_name
+
+            except Exception as e:
+                tty.warn(f"Unable to fetch spec for manifest {blob_name} due to: {e}")
+                continue
+
+    url_to_list = url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path())
+    tty.debug(f"Listing blobs in {url_to_list}")
+    blobs = web_util.list_url(url_to_list, recursive=True)
+    if not blobs:
+        tty.warn(f"Unable to list blobs in {url_to_list}")
+
+    # Blobs that are referenced in a manifest file (but not necessarily present in the cache)
+    blob_hashes_referenced_by_manifest = set(blob_to_manifest_mapping.keys())
+
+    # Blobs that are actually present in the cache (but not necessarily referenced in any manifest)
+    blob_hashes_present_in_cache: Set[str] = {
+        url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path(), blob_name)
+        for blob_name in blobs
+    }
+
+    # Compute set of blobs that are present in the cache but not referenced in any manifest
+    orphaned_blobs = blob_hashes_present_in_cache - blob_hashes_referenced_by_manifest
+
+    # Compute set of blobs that are referenced in a manifest but not present in the cache
+    nonexisting_referenced_blobs = (
+        blob_hashes_referenced_by_manifest - blob_hashes_present_in_cache
+    )
+
+    # Compute set of manifests that are orphaned (i.e., they reference blobs that are not present in the cache)
+    orphaned_manifests = {
+        blob_to_manifest_mapping[blob_url]
+        for blob_url in nonexisting_referenced_blobs
+    }
+
+    if not orphaned_blobs and not orphaned_manifests:
+        tty.info("No orphaned manifest(s) or blob(s) found")
+    else:
+        if orphaned_blobs:
+            tty.info(f"Found {len(orphaned_blobs)} blob(s) with no manifest")
+        if orphaned_manifests:
+            tty.info(f"Found {len(orphaned_manifests)} manifest(s) that are missing blobs")
+
+    pruned_objects = 0
+    tty.debug(f"Pruning {len(orphaned_manifests)} orphaned manifest(s)...")
+    for orphaned_manifest_url in orphaned_manifests:
+        # Get the manifest URL that references the non-existing blob
+        try:
+            web_util.remove_url(url=orphaned_manifest_url)
+            tty.info(f"Removed manifest {orphaned_manifest_url}")
+            pruned_objects += 1
+        except Exception as e:
+            tty.info(f"Unable to prune manifest {orphaned_manifest_url} due to: {e}")
+            continue
+
+    tty.debug(f"Pruning {len(orphaned_blobs)} orphaned blobs...")
+    for orphaned_blob_url in orphaned_blobs:
+        try:
+            web_util.remove_url(url=orphaned_blob_url)
+            tty.debug(f"Removed {orphaned_blob_url}")
+            pruned_objects += 1
+        except Exception as e:
+            tty.warn(f"Unable to prune blob {orphaned_blob_url} due to: {e}")
+            continue
+
+    return pruned_objects
+
+
+def prune(mirror: Mirror) -> None:
+    """
+    Execute the pruning process for a given mirror.
+
+    Currently, this function only performs the pruning of orphaned manifests and blobs.
+    """
+    tty.debug(f"Pruning mirror: {mirror.fetch_url}")
+
+    total_pruned = 0
+    while True:
+        # Continue pruning until no more orphaned objects are found
+        pruned = _prune_orphans(mirror)
+        if pruned == 0:
+            break
+        total_pruned += pruned
+
+    tty.debug(f"Pruned {total_pruned} orphaned objects from mirror: {mirror.fetch_url}")

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import tempfile
-from concurrent.futures import as_completed
+from concurrent.futures import Future, as_completed
 from contextlib import contextmanager
 from typing import Callable, Dict, Generator, List, Optional, Set, Tuple, cast
 
@@ -42,6 +42,19 @@ def _fetch_manifests(
         if not blobs:
             tty.warn(f"Unable to list blobs in {url_to_list}")
         yield file_list, read_fn, blobs
+
+
+def _delete_object(url: str, dry_run: bool) -> int:
+    if dry_run:
+        tty.info(f"Dry run: would remove object {url}")
+        return 1
+    try:
+        web_util.remove_url(url=url)
+        tty.info(f"Removed object {url}")
+        return 1
+    except Exception as e:
+        tty.warn(f"Unable to remove object {url} due to: {e}")
+        return 0
 
 
 def _prune_orphans(
@@ -127,42 +140,28 @@ def _prune_orphans(
         tty.info(f"Found {len(orphaned_manifests)} manifest(s) that are missing blobs")
 
     pruned_objects = 0
-
-    def remove_manifest(url: str) -> int:
-        if dry_run:
-            tty.info(f"Dry run: would remove manifest {url}")
-            return 1
-        try:
-            web_util.remove_url(url=url)
-            # Remove the manifest file from the local list of manifests.
-            # It may not be present in the local list if it was already removed
-            # during the pruning of another orphaned blob.
-            if url in manifests:
-                manifests.remove(url)
-            tty.info(f"Removed manifest {url}")
-            return 1
-        except Exception as e:
-            tty.warn(f"Unable to prune manifest {url} due to: {e}")
-            return 0
-
-    def remove_blob(url: str) -> int:
-        try:
-            if dry_run:
-                tty.info(f"Dry run: would remove blob {url}")
-                return 1
-            web_util.remove_url(url=url)
-            del blob_to_manifest_mapping[url]
-            tty.debug(f"Removed {url}")
-            return 1
-        except Exception as e:
-            tty.warn(f"Unable to prune blob {url} due to: {e}")
-            return 0
+    futures: List[Future] = []
 
     with spack.util.parallel.make_concurrent_executor() as executor:
-        manifest_futures = [executor.submit(remove_manifest, url) for url in orphaned_manifests]
-        blob_futures = [executor.submit(remove_blob, url) for url in orphaned_blobs]
+        for manifest in orphaned_manifests:
+            futures.append(executor.submit(_delete_object, manifest, dry_run))
+            try:
+                manifests.remove(manifest)
+            except ValueError:
+                # If the manifest was already removed during the pruning of another orphaned blob,
+                # it will not be in the list, so we can safely ignore this error.
+                pass
 
-        for manifest_or_blob_future in as_completed(manifest_futures + blob_futures):
+        for blob in orphaned_blobs:
+            futures.append(executor.submit(_delete_object, blob, dry_run))
+            try:
+                del blob_to_manifest_mapping[blob]
+            except KeyError:
+                # If the blob was already removed during the pruning of another orphaned manifest,
+                # it will not be in the list, so we can safely ignore this error.
+                pass
+
+        for manifest_or_blob_future in as_completed(futures):
             pruned_objects += manifest_or_blob_future.result()
 
     return pruned_objects

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -41,6 +41,10 @@ def _fetch_manifests(
         blobs = web_util.list_url(url_to_list, recursive=True) or []
         if not blobs:
             tty.warn(f"Unable to list blobs in {url_to_list}")
+        blobs = [
+            url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path(), blob_name)
+            for blob_name in blobs
+        ]
         yield file_list, read_fn, blobs
 
 
@@ -111,10 +115,7 @@ def _prune_orphans(
     blob_hashes_referenced_by_manifest = set(blob_to_manifest_mapping.keys())
 
     # Blobs that are actually present in the cache (but not necessarily referenced in any manifest)
-    blob_hashes_present_in_cache: Set[str] = {
-        url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path(), blob_name)
-        for blob_name in blobs
-    }
+    blob_hashes_present_in_cache: Set[str] = set(blobs)
 
     # Compute set of blobs that are present in the cache but not referenced in any manifest
     orphaned_blobs = blob_hashes_present_in_cache - blob_hashes_referenced_by_manifest
@@ -131,7 +132,6 @@ def _prune_orphans(
     }
 
     if not orphaned_blobs and not orphaned_manifests:
-        tty.info("No orphaned manifest(s) or blob(s) found")
         return 0
 
     if orphaned_blobs:
@@ -155,8 +155,9 @@ def _prune_orphans(
         for blob in orphaned_blobs:
             futures.append(executor.submit(_delete_object, blob, dry_run))
             try:
+                blobs.remove(blob)
                 del blob_to_manifest_mapping[blob]
-            except KeyError:
+            except (KeyError, ValueError):
                 # If the blob was already removed during the pruning of another orphaned manifest,
                 # it will not be in the list, so we can safely ignore this error.
                 pass
@@ -190,8 +191,7 @@ def prune(mirror: Mirror, dry_run: bool) -> None:
                 break
             total_pruned += pruned
 
-    tty.debug(
-        "Would have pruned"
-        if dry_run
-        else "Pruned" + f" {total_pruned} orphaned objects from mirror: {mirror.fetch_url}"
+    tty.info(
+        ("Would have pruned" if dry_run else "Pruned")
+        + f" {total_pruned} orphaned objects from mirror: {mirror.fetch_url}"
     )

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -4,7 +4,8 @@
 
 import tempfile
 from concurrent.futures import as_completed
-from typing import Dict, Optional, Set, cast
+from contextlib import contextmanager
+from typing import Callable, Dict, Generator, List, Optional, Set, Tuple, cast
 
 import llnl.util.tty as tty
 
@@ -18,7 +19,37 @@ from .mirrors.mirror import Mirror
 from .url_buildcache import URLBuildcacheEntry, get_entries_from_cache
 
 
-def _prune_orphans(mirror: Mirror) -> int:
+@contextmanager
+def _fetch_manifests(
+    mirror: Mirror,
+) -> Generator[Tuple[List[str], Callable[[str], URLBuildcacheEntry], List[str]], None, None]:
+    """
+    Fetch all manifests from the buildcache for a given mirror.
+
+    This function retrieves all the manifest files from the buildcache of the specified
+    mirror and returns a list of tuples containing the file names and a callable to read
+    each manifest.
+
+    :param mirror: The mirror from which to fetch the manifests.
+    :return: A list of tuples, each containing a list of file names and a callable to read
+             the manifest entries.
+    """
+    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
+        file_list, read_fn = get_entries_from_cache(url=mirror.fetch_url, tmpspecsdir=tmpspecsdir)
+        url_to_list = url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path())
+        tty.debug(f"Listing blobs in {url_to_list}")
+        blobs = web_util.list_url(url_to_list, recursive=True) or []
+        if not blobs:
+            tty.warn(f"Unable to list blobs in {url_to_list}")
+        yield file_list, read_fn, blobs
+
+
+def _prune_orphans(
+    mirror: Mirror,
+    manifests: List[str],
+    read_fn: Callable[[str], URLBuildcacheEntry],
+    blobs: List[str],
+) -> int:
     """
     Prune orphaned manifests and blobs from the buildcache.
 
@@ -44,36 +75,27 @@ def _prune_orphans(mirror: Mirror) -> int:
     # we will need to know which manifest to prune.
     blob_to_manifest_mapping: Dict[str, str] = {}
 
-    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
-        file_list, read_fn = get_entries_from_cache(url=mirror.fetch_url, tmpspecsdir=tmpspecsdir)
+    def process_manifest(blob_name: str) -> Dict[str, str]:
+        cache_entry: Optional[URLBuildcacheEntry] = None
+        try:
+            cache_entry = cast(URLBuildcacheEntry, read_fn(blob_name))
+            assert cache_entry.manifest is not None  # to satisfy type checker
+            return {
+                cache_entry.get_blob_url(mirror_url=mirror.fetch_url, record=data): blob_name
+                for data in cache_entry.manifest.data
+            }
+        except Exception as e:
+            tty.warn(f"Unable to fetch spec for manifest {blob_name} due to: {e}")
+            return {}
+        finally:
+            if cache_entry:
+                cache_entry.destroy()
 
-        def process_manifest(blob_name: str) -> Dict[str, str]:
-            cache_entry: Optional[URLBuildcacheEntry] = None
-            try:
-                cache_entry = cast(URLBuildcacheEntry, read_fn(blob_name))
-                assert cache_entry.manifest is not None  # to satisfy type checker
-                return {
-                    cache_entry.get_blob_url(mirror_url=mirror.fetch_url, record=data): blob_name
-                    for data in cache_entry.manifest.data
-                }
-            except Exception as e:
-                tty.warn(f"Unable to fetch spec for manifest {blob_name} due to: {e}")
-                return {}
-            finally:
-                if cache_entry:
-                    cache_entry.destroy()
-
-        with spack.util.parallel.make_concurrent_executor() as executor:
-            futures = {executor.submit(process_manifest, blob): blob for blob in file_list}
-            for future in as_completed(futures):
-                result = future.result()
-                blob_to_manifest_mapping.update(result)
-
-    url_to_list = url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path())
-    tty.debug(f"Listing blobs in {url_to_list}")
-    blobs = web_util.list_url(url_to_list, recursive=True)
-    if not blobs:
-        tty.warn(f"Unable to list blobs in {url_to_list}")
+    with spack.util.parallel.make_concurrent_executor() as executor:
+        futures = {executor.submit(process_manifest, blob): blob for blob in manifests}
+        for future in as_completed(futures):
+            result = future.result()
+            blob_to_manifest_mapping.update(result)
 
     # Blobs that are referenced in a manifest file (but not necessarily present in the cache)
     blob_hashes_referenced_by_manifest = set(blob_to_manifest_mapping.keys())
@@ -112,6 +134,11 @@ def _prune_orphans(mirror: Mirror) -> int:
     def remove_manifest(url: str) -> int:
         try:
             web_util.remove_url(url=url)
+            # Remove the manifest file from the local list of manifests.
+            # It may not be present in the local list if it was already removed
+            # during the pruning of another orphaned blob.
+            if url in manifests:
+                manifests.remove(url)
             tty.info(f"Removed manifest {url}")
             return 1
         except Exception as e:
@@ -121,6 +148,7 @@ def _prune_orphans(mirror: Mirror) -> int:
     def remove_blob(url: str) -> int:
         try:
             web_util.remove_url(url=url)
+            del blob_to_manifest_mapping[url]
             tty.debug(f"Removed {url}")
             return 1
         except Exception as e:
@@ -146,11 +174,14 @@ def prune(mirror: Mirror) -> None:
     tty.debug(f"Pruning mirror: {mirror.fetch_url}")
 
     total_pruned = 0
-    while True:
-        # Continue pruning until no more orphaned objects are found
-        pruned = _prune_orphans(mirror)
-        if pruned == 0:
-            break
-        total_pruned += pruned
+    with _fetch_manifests(mirror) as (manifest_list, read_fn, blob_list):
+        while True:
+            # Continue pruning until no more orphaned objects are found
+            pruned = _prune_orphans(
+                mirror=mirror, manifests=manifest_list, read_fn=read_fn, blobs=blob_list
+            )
+            if pruned == 0:
+                break
+            total_pruned += pruned
 
     tty.debug(f"Pruned {total_pruned} orphaned objects from mirror: {mirror.fetch_url}")

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -28,8 +28,10 @@ def _prune_orphans(mirror: Mirror) -> int:
 
     It uses the following steps to identify and prune orphaned objects:
 
-    1. Fetch all the manifests in the cache and build up a list of all the blobs that they reference.
-    2. List all the blobs in the buildcache, resulting in a list of all the blobs that *actually* exist in the cache.
+    1. Fetch all the manifests in the cache and build up a list of all the blobs that they
+       reference.
+    2. List all the blobs in the buildcache, resulting in a list of all the blobs that
+       *actually* exist in the cache.
     3. Compare the two lists and use the difference to determine which objects are orphaned.
         - If a blob is listed in the cache but not in any manifest, that blob is orphaned.
         - If a blob is listed in a manifest but not in the cache, that manifest is orphaned.
@@ -48,7 +50,7 @@ def _prune_orphans(mirror: Mirror) -> int:
             cache_entry: Optional[URLBuildcacheEntry] = None
             try:
                 cache_entry = cast(URLBuildcacheEntry, read_fn(blob_name))
-                assert cache_entry.manifest is not None  #  to satisfy type checker
+                assert cache_entry.manifest is not None  # to satisfy type checker
                 return {
                     cache_entry.get_blob_url(mirror_url=mirror.fetch_url, record=data): blob_name
                     for data in cache_entry.manifest.data
@@ -89,7 +91,8 @@ def _prune_orphans(mirror: Mirror) -> int:
         blob_hashes_referenced_by_manifest - blob_hashes_present_in_cache
     )
 
-    # Compute set of manifests that are orphaned (i.e., they reference blobs that are not present in the cache)
+    # Compute set of manifests that are orphaned (i.e., they reference blobs that are not
+    # present in the cache)
     orphaned_manifests = {
         blob_to_manifest_mapping[blob_url] for blob_url in nonexisting_referenced_blobs
     }

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import tempfile
-from typing import Dict, Set
-
+from typing import cast, Dict, Optional, Set
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import llnl.util.tty as tty
-
 import spack.binary_distribution as bindist
 import spack.stage
 import spack.util.url as url_util
@@ -42,16 +41,27 @@ def _prune_orphans(mirror: Mirror) -> int:
 
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
         file_list, read_fn = get_entries_from_cache(url=mirror.fetch_url, tmpspecsdir=tmpspecsdir)
-        for blob_name in file_list:
-            try:
-                cache_entry: URLBuildcacheEntry = read_fn(manifest_url=blob_name)
-                for data in cache_entry.manifest.data:
-                    blob_url = cache_entry.get_blob_url(mirror_url=mirror.fetch_url, record=data)
-                    blob_to_manifest_mapping[blob_url] = blob_name
 
+        def process_manifest(blob_name: str) -> Dict[str, str]:
+            cache_entry: Optional[URLBuildcacheEntry] = None
+            try:
+                cache_entry = cast(URLBuildcacheEntry, read_fn(blob_name))
+                return {
+                    cache_entry.get_blob_url(mirror_url=mirror.fetch_url, record=data): blob_name
+                    for data in cache_entry.manifest.data
+                }
             except Exception as e:
                 tty.warn(f"Unable to fetch spec for manifest {blob_name} due to: {e}")
-                continue
+                return {}
+            finally:
+                if cache_entry:
+                    cache_entry.destroy()
+
+        with ThreadPoolExecutor() as executor:
+            futures = {executor.submit(process_manifest, blob): blob for blob in file_list}
+            for future in as_completed(futures):
+                result = future.result()
+                blob_to_manifest_mapping.update(result)
 
     url_to_list = url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path())
     tty.debug(f"Listing blobs in {url_to_list}")
@@ -84,33 +94,39 @@ def _prune_orphans(mirror: Mirror) -> int:
 
     if not orphaned_blobs and not orphaned_manifests:
         tty.info("No orphaned manifest(s) or blob(s) found")
-    else:
-        if orphaned_blobs:
-            tty.info(f"Found {len(orphaned_blobs)} blob(s) with no manifest")
-        if orphaned_manifests:
-            tty.info(f"Found {len(orphaned_manifests)} manifest(s) that are missing blobs")
+        return 0
+
+    if orphaned_blobs:
+        tty.info(f"Found {len(orphaned_blobs)} blob(s) with no manifest")
+    if orphaned_manifests:
+        tty.info(f"Found {len(orphaned_manifests)} manifest(s) that are missing blobs")
 
     pruned_objects = 0
-    tty.debug(f"Pruning {len(orphaned_manifests)} orphaned manifest(s)...")
-    for orphaned_manifest_url in orphaned_manifests:
-        # Get the manifest URL that references the non-existing blob
-        try:
-            web_util.remove_url(url=orphaned_manifest_url)
-            tty.info(f"Removed manifest {orphaned_manifest_url}")
-            pruned_objects += 1
-        except Exception as e:
-            tty.info(f"Unable to prune manifest {orphaned_manifest_url} due to: {e}")
-            continue
 
-    tty.debug(f"Pruning {len(orphaned_blobs)} orphaned blobs...")
-    for orphaned_blob_url in orphaned_blobs:
+    def remove_manifest(url: str) -> int:
         try:
-            web_util.remove_url(url=orphaned_blob_url)
-            tty.debug(f"Removed {orphaned_blob_url}")
-            pruned_objects += 1
+            web_util.remove_url(url=url)
+            tty.info(f"Removed manifest {url}")
+            return 1
         except Exception as e:
-            tty.warn(f"Unable to prune blob {orphaned_blob_url} due to: {e}")
-            continue
+            tty.warn(f"Unable to prune manifest {url} due to: {e}")
+            return 0
+
+    def remove_blob(url: str) -> int:
+        try:
+            web_util.remove_url(url=url)
+            tty.debug(f"Removed {url}")
+            return 1
+        except Exception as e:
+            tty.warn(f"Unable to prune blob {url} due to: {e}")
+            return 0
+
+    with ThreadPoolExecutor() as executor:
+        manifest_futures = [executor.submit(remove_manifest, url) for url in orphaned_manifests]
+        blob_futures = [executor.submit(remove_blob, url) for url in orphaned_blobs]
+
+        for future in as_completed(manifest_futures + blob_futures):
+            pruned_objects += future.result()
 
     return pruned_objects
 

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -49,6 +49,7 @@ def _prune_orphans(
     manifests: List[str],
     read_fn: Callable[[str], URLBuildcacheEntry],
     blobs: List[str],
+    dry_run: bool,
 ) -> int:
     """
     Prune orphaned manifests and blobs from the buildcache.
@@ -132,6 +133,9 @@ def _prune_orphans(
     pruned_objects = 0
 
     def remove_manifest(url: str) -> int:
+        if dry_run:
+            tty.info(f"Dry run: would remove manifest {url}")
+            return 1
         try:
             web_util.remove_url(url=url)
             # Remove the manifest file from the local list of manifests.
@@ -147,6 +151,9 @@ def _prune_orphans(
 
     def remove_blob(url: str) -> int:
         try:
+            if dry_run:
+                tty.info(f"Dry run: would remove blob {url}")
+                return 1
             web_util.remove_url(url=url)
             del blob_to_manifest_mapping[url]
             tty.debug(f"Removed {url}")
@@ -165,23 +172,31 @@ def _prune_orphans(
     return pruned_objects
 
 
-def prune(mirror: Mirror) -> None:
+def prune(mirror: Mirror, dry_run: bool) -> None:
     """
     Execute the pruning process for a given mirror.
 
     Currently, this function only performs the pruning of orphaned manifests and blobs.
     """
-    tty.debug(f"Pruning mirror: {mirror.fetch_url}")
+    tty.debug(f"Pruning mirror: {mirror.fetch_url}" + (" (dry run)" if dry_run else ""))
 
     total_pruned = 0
     with _fetch_manifests(mirror) as (manifest_list, read_fn, blob_list):
         while True:
             # Continue pruning until no more orphaned objects are found
             pruned = _prune_orphans(
-                mirror=mirror, manifests=manifest_list, read_fn=read_fn, blobs=blob_list
+                mirror=mirror,
+                manifests=manifest_list,
+                read_fn=read_fn,
+                blobs=blob_list,
+                dry_run=dry_run,
             )
             if pruned == 0:
                 break
             total_pruned += pruned
 
-    tty.debug(f"Pruned {total_pruned} orphaned objects from mirror: {mirror.fetch_url}")
+    tty.debug(
+        "Would have pruned"
+        if dry_run
+        else "Pruned" + f" {total_pruned} orphaned objects from mirror: {mirror.fetch_url}"
+    )

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import tempfile
-from typing import cast, Dict, Optional, Set
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, Optional, Set, cast
+
 import llnl.util.tty as tty
+
 import spack.binary_distribution as bindist
 import spack.stage
 import spack.util.url as url_util
@@ -88,8 +90,7 @@ def _prune_orphans(mirror: Mirror) -> int:
 
     # Compute set of manifests that are orphaned (i.e., they reference blobs that are not present in the cache)
     orphaned_manifests = {
-        blob_to_manifest_mapping[blob_url]
-        for blob_url in nonexisting_referenced_blobs
+        blob_to_manifest_mapping[blob_url] for blob_url in nonexisting_referenced_blobs
     }
 
     if not orphaned_blobs and not orphaned_manifests:

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -268,7 +268,19 @@ def prune(mirror: Mirror, dry_run: bool) -> None:
                 break
             total_pruned += pruned
 
-        tty.info(
-            ("Would have pruned" if dry_run else "Pruned")
-            + f" {total_pruned} orphaned objects from mirror: {mirror.fetch_url}"
-        )
+        if dry_run:
+            tty.info(
+                f"Would have pruned {total_pruned} orphaned objects from mirror: "
+                + mirror.fetch_url
+            )
+        else:
+            tty.info(f"Pruned {total_pruned} orphaned objects from mirror: {mirror.fetch_url}")
+            if total_pruned > 0:
+                # If we pruned any objects, the buildcache index is likely out of date.
+                # Inform the user about this.
+                tty.info(
+                    "As a consequence of pruning, the buildcache index is now likely out of date."
+                )
+                tty.info(
+                    "Run `spack buildcache update-index` to update the index for this mirror."
+                )

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -37,10 +37,10 @@ def _fetch_manifests(
     each manifest.
 
     :param mirror: The mirror from which to fetch the manifests.
-    :return: A list of tuples, each containing a list of file names and a callable to read
-             the manifest entries.
+    :return: A tuple with three elements - a list of manifest files in the mirror, a
+             callable to read each manifest, and a list of blobs in the mirror.
     """
-    file_list, read_fn = get_entries_from_cache(url=mirror.fetch_url, tmpspecsdir=tmpspecsdir)
+    manifests, read_fn = get_entries_from_cache(url=mirror.fetch_url, tmpspecsdir=tmpspecsdir)
     url_to_list = url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path())
     tty.debug(f"Listing blobs in {url_to_list}")
     blobs = web_util.list_url(url_to_list, recursive=True) or []
@@ -50,7 +50,7 @@ def _fetch_manifests(
         url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path(), blob_name)
         for blob_name in blobs
     ]
-    return file_list, read_fn, blobs
+    return manifests, read_fn, blobs
 
 
 def _delete_manifests_from_cache_aws(

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -156,8 +156,7 @@ def _prune_orphans(
             futures.append(executor.submit(_delete_object, blob, dry_run))
             try:
                 blobs.remove(blob)
-                del blob_to_manifest_mapping[blob]
-            except (KeyError, ValueError):
+            except ValueError:
                 # If the blob was already removed during the pruning of another orphaned manifest,
                 # it will not be in the list, so we can safely ignore this error.
                 pass

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -76,27 +76,23 @@ def _prune_orphans(
     # we will need to know which manifest to prune.
     blob_to_manifest_mapping: Dict[str, str] = {}
 
-    def process_manifest(blob_name: str) -> Dict[str, str]:
+    for manifest in manifests:
         cache_entry: Optional[URLBuildcacheEntry] = None
         try:
-            cache_entry = cast(URLBuildcacheEntry, read_fn(blob_name))
+            cache_entry = cast(URLBuildcacheEntry, read_fn(manifest))
             assert cache_entry.manifest is not None  # to satisfy type checker
-            return {
-                cache_entry.get_blob_url(mirror_url=mirror.fetch_url, record=data): blob_name
-                for data in cache_entry.manifest.data
-            }
+            blob_to_manifest_mapping.update(
+                {
+                    cache_entry.get_blob_url(mirror_url=mirror.fetch_url, record=data): manifest
+                    for data in cache_entry.manifest.data
+                }
+            )
         except Exception as e:
-            tty.warn(f"Unable to fetch spec for manifest {blob_name} due to: {e}")
-            return {}
+            tty.warn(f"Unable to fetch spec for manifest {manifest} due to: {e}")
+            continue
         finally:
             if cache_entry:
                 cache_entry.destroy()
-
-    with spack.util.parallel.make_concurrent_executor() as executor:
-        futures = {executor.submit(process_manifest, blob): blob for blob in manifests}
-        for future in as_completed(futures):
-            result = future.result()
-            blob_to_manifest_mapping.update(result)
 
     # Blobs that are referenced in a manifest file (but not necessarily present in the cache)
     blob_hashes_referenced_by_manifest = set(blob_to_manifest_mapping.keys())

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+import pathlib
 import tempfile
 from concurrent.futures import Future, as_completed
-from contextlib import contextmanager
-from typing import Callable, Dict, Generator, List, Optional, Set, Tuple, cast
+from typing import Callable, Dict, List, Optional, Set, Tuple, cast
 
 import llnl.util.tty as tty
 
@@ -14,15 +15,20 @@ import spack.stage
 import spack.util.parallel
 import spack.util.url as url_util
 import spack.util.web as web_util
+from spack.util.executable import which
 
 from .mirrors.mirror import Mirror
-from .url_buildcache import URLBuildcacheEntry, get_entries_from_cache
+from .url_buildcache import (
+    CURRENT_BUILD_CACHE_LAYOUT_VERSION,
+    URLBuildcacheEntry,
+    get_entries_from_cache,
+    get_url_buildcache_class,
+)
 
 
-@contextmanager
 def _fetch_manifests(
-    mirror: Mirror,
-) -> Generator[Tuple[List[str], Callable[[str], URLBuildcacheEntry], List[str]], None, None]:
+    mirror: Mirror, tmpspecsdir: str
+) -> Tuple[List[str], Callable[[str], URLBuildcacheEntry], List[str]]:
     """
     Fetch all manifests from the buildcache for a given mirror.
 
@@ -34,24 +40,82 @@ def _fetch_manifests(
     :return: A list of tuples, each containing a list of file names and a callable to read
              the manifest entries.
     """
-    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
-        file_list, read_fn = get_entries_from_cache(url=mirror.fetch_url, tmpspecsdir=tmpspecsdir)
-        url_to_list = url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path())
-        tty.debug(f"Listing blobs in {url_to_list}")
-        blobs = web_util.list_url(url_to_list, recursive=True) or []
-        if not blobs:
-            tty.warn(f"Unable to list blobs in {url_to_list}")
-        blobs = [
-            url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path(), blob_name)
-            for blob_name in blobs
-        ]
-        yield file_list, read_fn, blobs
+    file_list, read_fn = get_entries_from_cache(url=mirror.fetch_url, tmpspecsdir=tmpspecsdir)
+    url_to_list = url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path())
+    tty.debug(f"Listing blobs in {url_to_list}")
+    blobs = web_util.list_url(url_to_list, recursive=True) or []
+    if not blobs:
+        tty.warn(f"Unable to list blobs in {url_to_list}")
+    blobs = [
+        url_util.join(mirror.fetch_url, bindist.buildcache_relative_blobs_path(), blob_name)
+        for blob_name in blobs
+    ]
+    return file_list, read_fn, blobs
 
 
-def _delete_object(url: str, dry_run: bool) -> int:
-    if dry_run:
-        tty.info(f"Dry run: would remove object {url}")
-        return 1
+def _delete_manifests_from_cache_aws(
+    url: str, tmpspecsdir: str, urls_to_delete: Set[str]
+) -> Optional[int]:
+    aws = which("aws")
+
+    if not aws:
+        tty.warn("AWS CLI not found, skipping deletion of cache entries.")
+        return None
+
+    cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
+
+    include_pattern = cache_class.get_buildcache_component_include_pattern()
+
+    file_count_before_deletion = len(list(pathlib.Path(tmpspecsdir).rglob(include_pattern)))
+
+    # Add file:// prefix to URLs so that they are deleted properly by web_util.remove_url
+    urls_to_delete = {url_util.path_to_file_url(url) for url in urls_to_delete}
+
+    tty.debug(f"Deleting {len(urls_to_delete)} entries from cache at {url}")
+    deleted = _delete_entries_from_cache_manual(tmpspecsdir, urls_to_delete)
+    tty.debug(f"Deleted {deleted} entries from cache at {url}")
+
+    sync_command_args = [
+        "s3",
+        "sync",
+        "--delete",
+        "--exclude",
+        "*",
+        "--include",
+        include_pattern,
+        tmpspecsdir,
+        url,
+    ]
+
+    try:
+        aws(*sync_command_args, output=os.devnull, error=os.devnull)
+        # `aws s3 sync` doesn't return the number of deleted files,
+        # but we can calculate it based on the local file count from
+        # before and after the deletion.
+        return file_count_before_deletion - len(
+            list(pathlib.Path(tmpspecsdir).rglob(include_pattern))
+        )
+    except Exception:
+        tty.warn("Failed to use aws s3 sync to delete specs, falling back to parallel deletion.")
+
+    return None
+
+
+def _delete_entries_from_cache_manual(url: str, urls_to_delete: Set[str]) -> int:
+    pruned_objects = 0
+    futures: List[Future] = []
+
+    with spack.util.parallel.make_concurrent_executor() as executor:
+        for url in urls_to_delete:
+            futures.append(executor.submit(_delete_object, url))
+
+        for manifest_or_blob_future in as_completed(futures):
+            pruned_objects += manifest_or_blob_future.result()
+
+    return pruned_objects
+
+
+def _delete_object(url: str) -> int:
     try:
         web_util.remove_url(url=url)
         tty.info(f"Removed object {url}")
@@ -66,6 +130,7 @@ def _prune_orphans(
     manifests: List[str],
     read_fn: Callable[[str], URLBuildcacheEntry],
     blobs: List[str],
+    tmpspecsdir: str,
     dry_run: bool,
 ) -> int:
     """
@@ -139,32 +204,43 @@ def _prune_orphans(
     if orphaned_manifests:
         tty.info(f"Found {len(orphaned_manifests)} manifest(s) that are missing blobs")
 
-    pruned_objects = 0
-    futures: List[Future] = []
-
-    with spack.util.parallel.make_concurrent_executor() as executor:
+    if dry_run:
+        pruned_object_count = len(orphaned_blobs) + len(orphaned_manifests)
         for manifest in orphaned_manifests:
-            futures.append(executor.submit(_delete_object, manifest, dry_run))
-            try:
-                manifests.remove(manifest)
-            except ValueError:
-                # If the manifest was already removed during the pruning of another orphaned blob,
-                # it will not be in the list, so we can safely ignore this error.
-                pass
-
+            manifests.remove(manifest)
         for blob in orphaned_blobs:
-            futures.append(executor.submit(_delete_object, blob, dry_run))
-            try:
-                blobs.remove(blob)
-            except ValueError:
-                # If the blob was already removed during the pruning of another orphaned manifest,
-                # it will not be in the list, so we can safely ignore this error.
-                pass
+            blobs.remove(blob)
+        return pruned_object_count
 
-        for manifest_or_blob_future in as_completed(futures):
-            pruned_objects += manifest_or_blob_future.result()
+    # Try to delete the orphaned manifests using the AWS CLI,
+    # if possible.
+    pruned_manifests: Optional[int] = None
+    if mirror.fetch_url.startswith("s3://"):
+        pruned_manifests = _delete_manifests_from_cache_aws(
+            url=mirror.fetch_url, tmpspecsdir=tmpspecsdir, urls_to_delete=orphaned_manifests
+        )
 
-    return pruned_objects
+    if pruned_manifests is None:
+        # If the AWS CLI deletion failed, we fall back to deleting both manifests
+        # and blobs with the fallback method.
+        orphans_to_delete = orphaned_blobs.union(orphaned_manifests)
+        pruned_object_count = 0
+    else:
+        # If the AWS CLI deletion succeeded, we only need to worry about
+        # deleting the blobs, since the manifests have already been deleted.
+        orphans_to_delete = orphaned_blobs
+        pruned_object_count = pruned_manifests
+
+    pruned_object_count += _delete_entries_from_cache_manual(
+        url=mirror.fetch_url, urls_to_delete=orphans_to_delete
+    )
+
+    for manifest in orphaned_manifests:
+        manifests.remove(manifest)
+    for blob in orphaned_blobs:
+        blobs.remove(blob)
+
+    return pruned_object_count
 
 
 def prune(mirror: Mirror, dry_run: bool) -> None:
@@ -176,7 +252,8 @@ def prune(mirror: Mirror, dry_run: bool) -> None:
     tty.debug(f"Pruning mirror: {mirror.fetch_url}" + (" (dry run)" if dry_run else ""))
 
     total_pruned = 0
-    with _fetch_manifests(mirror) as (manifest_list, read_fn, blob_list):
+    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
+        manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
         while True:
             # Continue pruning until no more orphaned objects are found
             pruned = _prune_orphans(
@@ -184,13 +261,14 @@ def prune(mirror: Mirror, dry_run: bool) -> None:
                 manifests=manifest_list,
                 read_fn=read_fn,
                 blobs=blob_list,
+                tmpspecsdir=tmpspecsdir,
                 dry_run=dry_run,
             )
             if pruned == 0:
                 break
             total_pruned += pruned
 
-    tty.info(
-        ("Would have pruned" if dry_run else "Pruned")
-        + f" {total_pruned} orphaned objects from mirror: {mirror.fetch_url}"
-    )
+        tty.info(
+            ("Would have pruned" if dry_run else "Pruned")
+            + f" {total_pruned} orphaned objects from mirror: {mirror.fetch_url}"
+        )

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -208,10 +208,10 @@ def _prune_orphans(
         pruned_object_count = len(orphaned_blobs) + len(orphaned_manifests)
         for manifest in orphaned_manifests:
             manifests.remove(manifest)
-            tty.info(f'  Would prune manifest: {manifest}')
+            tty.info(f"  Would prune manifest: {manifest}")
         for blob in orphaned_blobs:
             blobs.remove(blob)
-            tty.info(f'  Would prune blob: {blob}')
+            tty.info(f"  Would prune blob: {blob}")
         return pruned_object_count
 
     # Try to delete the orphaned manifests using the AWS CLI,

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -208,8 +208,10 @@ def _prune_orphans(
         pruned_object_count = len(orphaned_blobs) + len(orphaned_manifests)
         for manifest in orphaned_manifests:
             manifests.remove(manifest)
+            tty.info(f'  Would prune manifest: {manifest}')
         for blob in orphaned_blobs:
             blobs.remove(blob)
+            tty.info(f'  Would prune blob: {blob}')
         return pruned_object_count
 
     # Try to delete the orphaned manifests using the AWS CLI,

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import tempfile
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from typing import Dict, Optional, Set, cast
 
 import llnl.util.tty as tty
 
 import spack.binary_distribution as bindist
 import spack.stage
+import spack.util.parallel
 import spack.util.url as url_util
 import spack.util.web as web_util
 
@@ -62,7 +63,7 @@ def _prune_orphans(mirror: Mirror) -> int:
                 if cache_entry:
                     cache_entry.destroy()
 
-        with ThreadPoolExecutor() as executor:
+        with spack.util.parallel.make_concurrent_executor() as executor:
             futures = {executor.submit(process_manifest, blob): blob for blob in file_list}
             for future in as_completed(futures):
                 result = future.result()
@@ -126,7 +127,7 @@ def _prune_orphans(mirror: Mirror) -> int:
             tty.warn(f"Unable to prune blob {url} due to: {e}")
             return 0
 
-    with ThreadPoolExecutor() as executor:
+    with spack.util.parallel.make_concurrent_executor() as executor:
         manifest_futures = [executor.submit(remove_manifest, url) for url in orphaned_manifests]
         blob_futures = [executor.submit(remove_blob, url) for url in orphaned_blobs]
 

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -96,7 +96,9 @@ def _delete_manifests_from_cache_aws(
             list(pathlib.Path(tmpspecsdir).rglob(include_pattern))
         )
     except Exception:
-        tty.warn("Failed to use aws s3 sync to delete specs, falling back to parallel deletion.")
+        tty.warn(
+            "Failed to use aws s3 sync to delete manifests, falling back to parallel deletion."
+        )
 
     return None
 
@@ -170,7 +172,7 @@ def _prune_orphans(
                 }
             )
         except Exception as e:
-            tty.warn(f"Unable to fetch spec for manifest {manifest} due to: {e}")
+            tty.warn(f"Unable to fetch manifest {manifest} due to: {e}")
             continue
         finally:
             if cache_entry:

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -177,18 +177,16 @@ def _prune_orphans(
                 cache_entry.destroy()
 
     # Blobs that are referenced in a manifest file (but not necessarily present in the cache)
-    blob_hashes_referenced_by_manifest = set(blob_to_manifest_mapping.keys())
+    blob_urls_referenced_by_manifest = set(blob_to_manifest_mapping.keys())
 
     # Blobs that are actually present in the cache (but not necessarily referenced in any manifest)
-    blob_hashes_present_in_cache: Set[str] = set(blobs)
+    blob_urls_present_in_cache: Set[str] = set(blobs)
 
     # Compute set of blobs that are present in the cache but not referenced in any manifest
-    orphaned_blobs = blob_hashes_present_in_cache - blob_hashes_referenced_by_manifest
+    orphaned_blobs = blob_urls_present_in_cache - blob_urls_referenced_by_manifest
 
     # Compute set of blobs that are referenced in a manifest but not present in the cache
-    nonexisting_referenced_blobs = (
-        blob_hashes_referenced_by_manifest - blob_hashes_present_in_cache
-    )
+    nonexisting_referenced_blobs = blob_urls_referenced_by_manifest - blob_urls_present_in_cache
 
     # Compute set of manifests that are orphaned (i.e., they reference blobs that are not
     # present in the cache)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -213,7 +213,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
     download.set_defaults(func=download_fn)
 
     prune = subparsers.add_parser("prune", help=prune_fn.__doc__)
-    prune.add_argument("mirror", type=arguments.mirror_name, help="name of a configured mirror")
+    prune.add_argument(
+        "mirror", type=arguments.mirror_name_or_url, help="mirror name, path, or URL"
+    )
     prune.set_defaults(func=prune_fn)
 
     # Given the root spec, save the yaml of the dependent spec to a file

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -32,6 +32,7 @@ from spack.cmd.common import arguments
 from spack.spec import Spec, save_dependency_specfiles
 
 from ..buildcache_migrate import migrate
+from ..buildcache_prune import prune
 from ..enums import InstallRecordStatus
 from ..url_buildcache import (
     BuildcacheComponent,
@@ -210,6 +211,10 @@ def setup_parser(subparser: argparse.ArgumentParser):
         help="path to directory where tarball should be downloaded",
     )
     download.set_defaults(func=download_fn)
+
+    prune = subparsers.add_parser("prune", help=prune_fn.__doc__)
+    prune.add_argument("mirror", type=arguments.mirror_name, help="name of a configured mirror")
+    prune.set_defaults(func=prune_fn)
 
     # Given the root spec, save the yaml of the dependent spec to a file
     savespecfile = subparsers.add_parser("save-specfile", help=save_specfile_fn.__doc__)
@@ -818,6 +823,14 @@ def migrate_fn(args):
         tty.die("Migration aborted.")
 
     migrate(target_mirror, unsigned=unsigned, delete_existing=delete_existing)
+
+
+def prune_fn(args):
+    """prune stale buildcache entries from the mirror"""
+    mirror: spack.mirrors.mirror.Mirror = args.mirror
+    assert isinstance(mirror, spack.mirrors.mirror.Mirror)
+
+    prune(mirror)
 
 
 def buildcache(parser, args):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -216,6 +216,11 @@ def setup_parser(subparser: argparse.ArgumentParser):
     prune.add_argument(
         "mirror", type=arguments.mirror_name_or_url, help="mirror name, path, or URL"
     )
+    prune.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="do not actually delete anything from the buildcache, but log what would be deleted",
+    )
     prune.set_defaults(func=prune_fn)
 
     # Given the root spec, save the yaml of the dependent spec to a file
@@ -830,9 +835,10 @@ def migrate_fn(args):
 def prune_fn(args):
     """prune stale buildcache entries from the mirror"""
     mirror: spack.mirrors.mirror.Mirror = args.mirror
+    dry_run: bool = args.dry_run
     assert isinstance(mirror, spack.mirrors.mirror.Mirror)
 
-    prune(mirror)
+    prune(mirror, dry_run)
 
 
 def buildcache(parser, args):

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -23,10 +23,12 @@ import spack.main
 import spack.mirrors.mirror
 import spack.spec
 import spack.util.url as url_util
+import spack.util.web as web_util
 from spack.installer import PackageInstaller
 from spack.paths import test_path
 from spack.url_buildcache import (
     BuildcacheComponent,
+    BuildcacheEntryError,
     URLBuildcacheEntry,
     URLBuildcacheEntryV2,
     check_mirror_for_layout,
@@ -748,3 +750,86 @@ def test_migrate_requires_index(capsys, v2_buildcache_layout, mutable_config):
 
     # If the buildcache has no index, spack fails and explains why
     assert error.value.message == "Buildcache migration requires a buildcache index"
+
+
+def test_buildcache_prune_no_orphans(capsys, tmp_path, mutable_database, mock_gnupghome):
+    with capsys.disabled():
+        mirror("add", "--unsigned", "my-mirror", str(tmp_path))
+        spec = mutable_database.query_local("libelf", installed=True)[0]
+        buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
+
+    output = buildcache("prune", "my-mirror")
+
+    assert "No orphaned manifest(s) or blob(s) found" in output
+
+
+def test_buildcache_prune_orphaned_blobs(capsys, tmp_path, mutable_database, mock_gnupghome):
+    # Create a mirror and push a package to it
+    mirror_directory = str(tmp_path)
+
+    with capsys.disabled():
+        mirror("add", "--unsigned", "my-mirror", mirror_directory)
+        spec = mutable_database.query_local("libelf", installed=True)[0]
+        buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
+
+    cache_entry = URLBuildcacheEntry(
+        mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
+    )
+    cache_entry.fetch_metadata()
+
+    blob_urls = [
+        URLBuildcacheEntry.get_blob_url(mirror_url=f"file://{mirror_directory}", record=blob)
+        for blob in cache_entry.manifest.data
+    ]
+
+    # Remove the manifest from the cache, orphaning the blobs
+    manifest_url = URLBuildcacheEntry.get_manifest_url(
+        spec, mirror_url=f"file://{mirror_directory}"
+    )
+    web_util.remove_url(manifest_url)
+
+    # Ensure the blobs are still there before pruning
+    assert all(web_util.url_exists(blob_url) for blob_url in blob_urls)
+
+    output = buildcache("prune", "my-mirror")
+
+    # Ensure the blobs are gone after pruning
+    assert all(not web_util.url_exists(blob_url) for blob_url in blob_urls)
+
+    assert "Found 2 blob(s) with no manifest" in output
+
+    cache_entry.destroy()
+
+
+def test_buildcache_prune_orphaned_manifest(capsys, tmp_path, mutable_database, mock_gnupghome):
+    # Create a mirror and push a package to it
+    mirror_directory = str(tmp_path)
+
+    with capsys.disabled():
+        mirror("add", "--unsigned", "my-mirror", mirror_directory)
+        spec = mutable_database.query_local("libelf", installed=True)[0]
+        buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
+
+    # Create a cache entry and read the manifest, which should succeed
+    # as we haven't pruned anything yet
+    cache_entry = URLBuildcacheEntry(
+        mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
+    )
+    cache_entry.read_manifest()
+
+    # Remove the blobs from the cache, orphaning the manifest
+    for blob_file in cache_entry.read_manifest().data:
+        blob_url = cache_entry.get_blob_url(mirror_url=mirror_directory, record=blob_file)
+        web_util.remove_url(url=f"file://{blob_url}")
+
+    output = buildcache("prune", "my-mirror")
+
+    # Clear the local cache entry's manifest and try to read it again, which
+    # should raise an error because it has been pruned
+    with pytest.raises(BuildcacheEntryError):
+        cache_entry.manifest = None
+        cache_entry.read_manifest()
+
+    assert "Found 1 manifest(s) that are missing blobs" in output
+
+    cache_entry.destroy()

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -753,11 +753,10 @@ def test_migrate_requires_index(capsys, v2_buildcache_layout, mutable_config):
 
 
 @pytest.mark.parametrize("dry_run", [False, True])
-def test_buildcache_prune_no_orphans(capsys, tmp_path, mutable_database, mock_gnupghome, dry_run):
-    with capsys.disabled():
-        mirror("add", "--unsigned", "my-mirror", str(tmp_path))
-        spec = mutable_database.query_local("libelf", installed=True)[0]
-        buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
+def test_buildcache_prune_no_orphans(tmp_path, mutable_database, mock_gnupghome, dry_run):
+    mirror("add", "--unsigned", "my-mirror", str(tmp_path))
+    spec = mutable_database.query_local("libelf", installed=True)[0]
+    buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
     cmd_args = ["prune", "my-mirror"]
     if dry_run:
@@ -768,16 +767,13 @@ def test_buildcache_prune_no_orphans(capsys, tmp_path, mutable_database, mock_gn
 
 
 @pytest.mark.parametrize("dry_run", [False, True])
-def test_buildcache_prune_orphaned_blobs(
-    capsys, tmp_path, mutable_database, mock_gnupghome, dry_run
-):
+def test_buildcache_prune_orphaned_blobs(tmp_path, mutable_database, mock_gnupghome, dry_run):
     # Create a mirror and push a package to it
     mirror_directory = str(tmp_path)
 
-    with capsys.disabled():
-        mirror("add", "--unsigned", "my-mirror", mirror_directory)
-        spec = mutable_database.query_local("libelf", installed=True)[0]
-        buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+    spec = mutable_database.query_local("libelf", installed=True)[0]
+    buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
     cache_entry = URLBuildcacheEntry(
         mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
@@ -812,16 +808,13 @@ def test_buildcache_prune_orphaned_blobs(
 
 
 @pytest.mark.parametrize("dry_run", [False, True])
-def test_buildcache_prune_orphaned_manifest(
-    capsys, tmp_path, mutable_database, mock_gnupghome, dry_run
-):
+def test_buildcache_prune_orphaned_manifest(tmp_path, mutable_database, mock_gnupghome, dry_run):
     # Create a mirror and push a package to it
     mirror_directory = str(tmp_path)
 
-    with capsys.disabled():
-        mirror("add", "--unsigned", "my-mirror", mirror_directory)
-        spec = mutable_database.query_local("libelf", installed=True)[0]
-        buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+    spec = mutable_database.query_local("libelf", installed=True)[0]
+    buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
     # Create a cache entry and read the manifest, which should succeed
     # as we haven't pruned anything yet

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -777,11 +777,10 @@ def test_buildcache_prune_orphaned_blobs(tmp_path, mutable_database, mock_gnupgh
     cache_entry = URLBuildcacheEntry(
         mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
     )
-    cache_entry.fetch_metadata()
 
     blob_urls = [
         URLBuildcacheEntry.get_blob_url(mirror_url=f"file://{mirror_directory}", record=blob)
-        for blob in cache_entry.manifest.data
+        for blob in cache_entry.read_manifest().data
     ]
 
     # Remove the manifest from the cache, orphaning the blobs

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -764,7 +764,7 @@ def test_buildcache_prune_no_orphans(capsys, tmp_path, mutable_database, mock_gn
         cmd_args.append("--dry-run")
     output = buildcache(*cmd_args)
 
-    assert "No orphaned manifest(s) or blob(s) found" in output
+    assert "0 orphaned objects from mirror:" in output
 
 
 @pytest.mark.parametrize("dry_run", [False, True])
@@ -830,6 +830,8 @@ def test_buildcache_prune_orphaned_manifest(
     )
     cache_entry.read_manifest()
 
+    manifest_url = f"file://{cache_entry.get_manifest_url(spec=spec, mirror_url=mirror_directory)}"
+
     # Remove the blobs from the cache, orphaning the manifest
     for blob_file in cache_entry.read_manifest().data:
         blob_url = cache_entry.get_blob_url(mirror_url=mirror_directory, record=blob_file)
@@ -841,7 +843,7 @@ def test_buildcache_prune_orphaned_manifest(
     output = buildcache(*cmd_args)
 
     # Ensure the manifest is gone after pruning (or not if dry_run is True)
-    assert web_util.url_exists(cache_entry.mirror_url) == dry_run
+    assert web_util.url_exists(manifest_url) == dry_run
 
     if not dry_run:
         # Clear the local cache entry's manifest and try to read it again, which

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -821,12 +821,12 @@ def test_buildcache_prune_orphaned_manifest(tmp_path, mutable_database, mock_gnu
     cache_entry = URLBuildcacheEntry(
         mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
     )
-    cache_entry.read_manifest()
+    manifest = cache_entry.read_manifest()
 
     manifest_url = f"file://{cache_entry.get_manifest_url(spec=spec, mirror_url=mirror_directory)}"
 
     # Remove the blobs from the cache, orphaning the manifest
-    for blob_file in cache_entry.read_manifest().data:
+    for blob_file in manifest.data:
         blob_url = cache_entry.get_blob_url(mirror_url=mirror_directory, record=blob_file)
         web_util.remove_url(url=f"file://{blob_url}")
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -752,18 +752,25 @@ def test_migrate_requires_index(capsys, v2_buildcache_layout, mutable_config):
     assert error.value.message == "Buildcache migration requires a buildcache index"
 
 
-def test_buildcache_prune_no_orphans(capsys, tmp_path, mutable_database, mock_gnupghome):
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_buildcache_prune_no_orphans(capsys, tmp_path, mutable_database, mock_gnupghome, dry_run):
     with capsys.disabled():
         mirror("add", "--unsigned", "my-mirror", str(tmp_path))
         spec = mutable_database.query_local("libelf", installed=True)[0]
         buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
-    output = buildcache("prune", "my-mirror")
+    cmd_args = ["prune", "my-mirror"]
+    if dry_run:
+        cmd_args.append("--dry-run")
+    output = buildcache(*cmd_args)
 
     assert "No orphaned manifest(s) or blob(s) found" in output
 
 
-def test_buildcache_prune_orphaned_blobs(capsys, tmp_path, mutable_database, mock_gnupghome):
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_buildcache_prune_orphaned_blobs(
+    capsys, tmp_path, mutable_database, mock_gnupghome, dry_run
+):
     # Create a mirror and push a package to it
     mirror_directory = str(tmp_path)
 
@@ -791,17 +798,23 @@ def test_buildcache_prune_orphaned_blobs(capsys, tmp_path, mutable_database, moc
     # Ensure the blobs are still there before pruning
     assert all(web_util.url_exists(blob_url) for blob_url in blob_urls)
 
-    output = buildcache("prune", "my-mirror")
+    cmd_args = ["prune", "my-mirror"]
+    if dry_run:
+        cmd_args.append("--dry-run")
+    output = buildcache(*cmd_args)
 
-    # Ensure the blobs are gone after pruning
-    assert all(not web_util.url_exists(blob_url) for blob_url in blob_urls)
+    # Ensure the blobs are gone after pruning (or not if dry_run is True)
+    assert all(web_util.url_exists(blob_url) == dry_run for blob_url in blob_urls)
 
     assert "Found 2 blob(s) with no manifest" in output
 
     cache_entry.destroy()
 
 
-def test_buildcache_prune_orphaned_manifest(capsys, tmp_path, mutable_database, mock_gnupghome):
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_buildcache_prune_orphaned_manifest(
+    capsys, tmp_path, mutable_database, mock_gnupghome, dry_run
+):
     # Create a mirror and push a package to it
     mirror_directory = str(tmp_path)
 
@@ -822,13 +835,20 @@ def test_buildcache_prune_orphaned_manifest(capsys, tmp_path, mutable_database, 
         blob_url = cache_entry.get_blob_url(mirror_url=mirror_directory, record=blob_file)
         web_util.remove_url(url=f"file://{blob_url}")
 
-    output = buildcache("prune", "my-mirror")
+    cmd_args = ["prune", "my-mirror"]
+    if dry_run:
+        cmd_args.append("--dry-run")
+    output = buildcache(*cmd_args)
 
-    # Clear the local cache entry's manifest and try to read it again, which
-    # should raise an error because it has been pruned
-    with pytest.raises(BuildcacheEntryError):
-        cache_entry.manifest = None
-        cache_entry.read_manifest()
+    # Ensure the manifest is gone after pruning (or not if dry_run is True)
+    assert web_util.url_exists(cache_entry.mirror_url) == dry_run
+
+    if not dry_run:
+        # Clear the local cache entry's manifest and try to read it again, which
+        # should raise an error because it has been pruned
+        with pytest.raises(BuildcacheEntryError):
+            cache_entry.manifest = None
+            cache_entry.read_manifest()
 
     assert "Found 1 manifest(s) that are missing blobs" in output
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -28,7 +28,6 @@ from spack.installer import PackageInstaller
 from spack.paths import test_path
 from spack.url_buildcache import (
     BuildcacheComponent,
-    BuildcacheEntryError,
     URLBuildcacheEntry,
     URLBuildcacheEntryV2,
     check_mirror_for_layout,
@@ -837,13 +836,6 @@ def test_buildcache_prune_orphaned_manifest(tmp_path, mutable_database, mock_gnu
 
     # Ensure the manifest is gone after pruning (or not if dry_run is True)
     assert web_util.url_exists(manifest_url) == dry_run
-
-    if not dry_run:
-        # Clear the local cache entry's manifest and try to read it again, which
-        # should raise an error because it has been pruned
-        with pytest.raises(BuildcacheEntryError):
-            cache_entry.manifest = None
-            cache_entry.read_manifest()
 
     assert "Found 1 manifest(s) that are missing blobs" in output
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -623,7 +623,7 @@ _spack_buildcache_download() {
 _spack_buildcache_prune() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help --dry-run"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -563,7 +563,7 @@ _spack_buildcache() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="push create install list keys check download save-specfile sync update-index rebuild-index migrate"
+        SPACK_COMPREPLY="push create install list keys check download prune save-specfile sync update-index rebuild-index migrate"
     fi
 }
 
@@ -618,6 +618,15 @@ _spack_buildcache_check() {
 
 _spack_buildcache_download() {
     SPACK_COMPREPLY="-h --help -s --spec -p --path"
+}
+
+_spack_buildcache_prune() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        _mirrors
+    fi
 }
 
 _spack_buildcache_save_specfile() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -602,7 +602,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_enable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap enable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap disable
@@ -610,7 +610,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_disable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap disable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap reset
@@ -625,14 +625,14 @@ set -g __fish_spack_optspecs_spack_bootstrap_root h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap root' -f -a '(__fish_complete_directories)'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap list
 set -g __fish_spack_optspecs_spack_bootstrap_list h/help scope=
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap add
@@ -641,7 +641,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap add' -f -a '(__
 complete -c spack -n '__fish_spack_using_command_pos 1 bootstrap add' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -f -a trust
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -d 'enable the source immediately upon addition'
@@ -816,7 +816,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirro
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -d 'override any configured mirrors with this mirror URL'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -f -a output_file
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -d 'file where rebuild info should be written'
-complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -d 'configuration scope containing mirrors to check'
 
 # spack buildcache download
@@ -1090,7 +1090,7 @@ complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolcha
 complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1104,7 +1104,7 @@ complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchai
 complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1116,7 +1116,7 @@ complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -
 complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler rm
@@ -1126,21 +1126,21 @@ complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler list
 set -g __fish_spack_optspecs_spack_compiler_list h/help scope=
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
 
 # spack compiler ls
 set -g __fish_spack_optspecs_spack_compiler_ls h/help scope=
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
 
 # spack compiler info
@@ -1148,14 +1148,14 @@ set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope=
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -d 'configuration scope to read/modify'
 
 # spack concretize
@@ -1216,7 +1216,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a update -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a revert -d 'revert configuration files to their state before update'
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
@@ -1764,7 +1764,7 @@ complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -d 'one or more alternative search paths for finding externals'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
 complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
@@ -2340,7 +2340,7 @@ set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsig
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -f -a 'binary source'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -d 'specify the mirror type: for both binary and source use `--type binary --type source` (default)'
@@ -2380,7 +2380,7 @@ set -g __fish_spack_optspecs_spack_mirror_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror rm
@@ -2388,7 +2388,7 @@ set -g __fish_spack_optspecs_spack_mirror_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror set-url
@@ -2400,7 +2400,7 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -f -a p
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -d 'set only the URL used for uploading'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -f -a fetch
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -d 'set only the URL used for downloading'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2448,7 +2448,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2479,7 +2479,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-var
 set -g __fish_spack_optspecs_spack_mirror_list h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -d 'configuration scope to read from'
 
 # spack module
@@ -2787,7 +2787,7 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 set -g __fish_spack_optspecs_spack_repo_list h/help scope=
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
 
 # spack repo add
@@ -2799,7 +2799,7 @@ complete -c spack -n '__fish_spack_using_command repo add' -l name -r -f -a name
 complete -c spack -n '__fish_spack_using_command repo add' -l name -r -d 'config name for the package repository, defaults to the namespace of the repository'
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
@@ -2807,7 +2807,7 @@ set -g __fish_spack_optspecs_spack_repo_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
 
 # spack repo rm
@@ -2815,7 +2815,7 @@ set -g __fish_spack_optspecs_spack_repo_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
+complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
 
 # spack repo migrate

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -693,6 +693,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a list -d
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a keys -d 'get public keys available on mirrors'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a check -d 'check specs against remote binary mirror(s) to see if any need to be rebuilt'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a download -d 'download buildcache entry from a remote mirror to local folder'
+complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a prune -d 'prune stale buildcache entries from the mirror'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a save-specfile -d 'get full spec for dependencies and write them to files in the specified output directory'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a sync -d 'sync binaries (and associated metadata) from one mirror to another'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a update-index -d 'update a buildcache index'
@@ -826,6 +827,12 @@ complete -c spack -n '__fish_spack_using_command buildcache download' -s s -l sp
 complete -c spack -n '__fish_spack_using_command buildcache download' -s s -l spec -r -d 'download built tarball for spec from mirror'
 complete -c spack -n '__fish_spack_using_command buildcache download' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command buildcache download' -s p -l path -r -d 'path to directory where tarball should be downloaded'
+
+# spack buildcache prune
+set -g __fish_spack_optspecs_spack_buildcache_prune h/help
+
+complete -c spack -n '__fish_spack_using_command buildcache prune' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command buildcache prune' -s h -l help -d 'show this help message and exit'
 
 # spack buildcache save-specfile
 set -g __fish_spack_optspecs_spack_buildcache_save_specfile h/help root-spec= s/specs= specfile-dir=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -602,7 +602,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_enable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap enable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap disable
@@ -610,7 +610,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_disable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap disable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap reset
@@ -625,14 +625,14 @@ set -g __fish_spack_optspecs_spack_bootstrap_root h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap root' -f -a '(__fish_complete_directories)'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap list
 set -g __fish_spack_optspecs_spack_bootstrap_list h/help scope=
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap add
@@ -641,7 +641,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap add' -f -a '(__
 complete -c spack -n '__fish_spack_using_command_pos 1 bootstrap add' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -f -a trust
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -d 'enable the source immediately upon addition'
@@ -816,7 +816,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirro
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -d 'override any configured mirrors with this mirror URL'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -f -a output_file
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -d 'file where rebuild info should be written'
-complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -d 'configuration scope containing mirrors to check'
 
 # spack buildcache download
@@ -829,10 +829,12 @@ complete -c spack -n '__fish_spack_using_command buildcache download' -s p -l pa
 complete -c spack -n '__fish_spack_using_command buildcache download' -s p -l path -r -d 'path to directory where tarball should be downloaded'
 
 # spack buildcache prune
-set -g __fish_spack_optspecs_spack_buildcache_prune h/help
+set -g __fish_spack_optspecs_spack_buildcache_prune h/help dry-run
 
 complete -c spack -n '__fish_spack_using_command buildcache prune' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache prune' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command buildcache prune' -l dry-run -f -a dry_run
+complete -c spack -n '__fish_spack_using_command buildcache prune' -l dry-run -d 'do not actually delete anything from the buildcache, but log what would be deleted'
 
 # spack buildcache save-specfile
 set -g __fish_spack_optspecs_spack_buildcache_save_specfile h/help root-spec= s/specs= specfile-dir=
@@ -1088,7 +1090,7 @@ complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolcha
 complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1102,7 +1104,7 @@ complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchai
 complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1114,7 +1116,7 @@ complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -
 complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler rm
@@ -1124,21 +1126,21 @@ complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler list
 set -g __fish_spack_optspecs_spack_compiler_list h/help scope=
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
 
 # spack compiler ls
 set -g __fish_spack_optspecs_spack_compiler_ls h/help scope=
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
 
 # spack compiler info
@@ -1146,14 +1148,14 @@ set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope=
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -d 'configuration scope to read/modify'
 
 # spack concretize
@@ -1214,7 +1216,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a update -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a revert -d 'revert configuration files to their state before update'
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
@@ -1762,7 +1764,7 @@ complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -d 'one or more alternative search paths for finding externals'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
 complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
@@ -2338,7 +2340,7 @@ set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsig
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -f -a 'binary source'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -d 'specify the mirror type: for both binary and source use `--type binary --type source` (default)'
@@ -2378,7 +2380,7 @@ set -g __fish_spack_optspecs_spack_mirror_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror rm
@@ -2386,7 +2388,7 @@ set -g __fish_spack_optspecs_spack_mirror_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror set-url
@@ -2398,7 +2400,7 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -f -a p
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -d 'set only the URL used for uploading'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -f -a fetch
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -d 'set only the URL used for downloading'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2446,7 +2448,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2477,7 +2479,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-var
 set -g __fish_spack_optspecs_spack_mirror_list h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -d 'configuration scope to read from'
 
 # spack module
@@ -2785,7 +2787,7 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 set -g __fish_spack_optspecs_spack_repo_list h/help scope=
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
 
 # spack repo add
@@ -2797,7 +2799,7 @@ complete -c spack -n '__fish_spack_using_command repo add' -l name -r -f -a name
 complete -c spack -n '__fish_spack_using_command repo add' -l name -r -d 'config name for the package repository, defaults to the namespace of the repository'
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
@@ -2805,7 +2807,7 @@ set -g __fish_spack_optspecs_spack_repo_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
 
 # spack repo rm
@@ -2813,7 +2815,7 @@ set -g __fish_spack_optspecs_spack_repo_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:myenv command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
 
 # spack repo migrate


### PR DESCRIPTION
This PR implements buildcache pruning. The pruning logic is a modified version of the "Orphaned Pruning" algorithm described [here](https://github.com/spack/spack-infrastructure/tree/main/images/ci-prune-buildcache#orphan-pruning). It works as follows:
1. User runs `spack buildcache prune <mirror>`
2. Fetch all manifests and their associated metadata from the cache
3. Fetch a list of blobs present in the cache
4. Diff these two sets to identify manifests that reference non-existant blobs (**orphaned manifests**) and blobs that are not referenced by any manifests (**orphaned blobs**) and delete them
5. Repeat steps 2-4 until there are no orphaned manifests or blobs found

The `buildcache prune` command is intentionally barebones and not very configurable; the intent is to get a simple pruning approach implemented into spack for now, and follow up with more configuration options (allowing users to specify individual specs to prune, other pruning algorithms, etc.) later.