### PR TITLE
py-jaxlib: restrict ROCm version

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_jaxlib/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_jaxlib/package.py
@@ -107,6 +107,7 @@ class PyJaxlib(PythonPackage, CudaPackage, ROCmPackage):
     with when("+rocm"):
         for pkg_dep in rocm_dependencies:
             depends_on(f"{pkg_dep}@6:", when="@0.4.28:")
+            depends_on(f"{pkg_dep}@6.3:", when="@0.6:")
             depends_on(pkg_dep)
         depends_on("rocprofiler-register", when="^hip@6.2:")
         depends_on("hipblas-common", when="^hip@6.3:")


### PR DESCRIPTION
Currently getting a ci error for py-jaxlib:
https://gitlab.spack.io/spack/spack/-/jobs/16925764
```
external/xla/xla/stream_executor/rocm/hip_blas_lt.cc: In lambda function:
external/xla/xla/stream_executor/rocm/hip_blas_lt.cc:252:31: error: ‘HIP_R_8F_E5M2’ was not declared in this scope; did you mean ‘HIP_R_8F_E5M2_FNUZ’?
  252 |              layout.type() == HIP_R_8F_E5M2 || layout.type() == HIP_R_8F_E4M3;
      |                               ^~~~~~~~~~~~~
      |                               HIP_R_8F_E5M2_FNUZ
```

`HIP_R_8F_E5M2` was introduced in ROCm 6.3:
https://github.com/ROCm/hip/blob/amd-staging/include/hip/library_types.h#L62