### PR TITLE
Kokkos: Map more micro architectures to correct Kokkos architectures

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/kokkos/package.py
@@ -223,14 +223,10 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "westmere": "WSM",
         "ivybridge": "SNB",
         "broadwell": "BDW",
-        # @AndrewGaspar: Kokkos does not have an arch for plain-skylake - only
-        # for Skylake-X (i.e. Xeon). For now, I'm mapping this to Broadwell
-        # until Kokkos learns to optimize for SkyLake without the AVX-512
-        # extensions. SkyLake with AVX-512 will still be optimized using the
-        # separate `skylake_avx512` arch.
-        "skylake": "BDW",
-        "icelake": "SKX",
+        "skylake": "SKL",
+        "icelake": "ICL",
         "skylake_avx512": "SKX",
+        "sapphirerapids": "SPR",
     }
 
     spack_cuda_arch_map = {


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Fixes https://github.com/spack/spack/issues/50782. The `SKL` architecture was added in https://github.com/kokkos/kokkos/pull/5013 (Kokkos 3.7.00) and `SPR` was added in https://github.com/kokkos/kokkos/pull/5015 (Kokkos 3.7.00)
