### PR TITLE
Re::Solve: add c and fortran dependencies

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/resolve/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/resolve/package.py
@@ -34,7 +34,9 @@ class Resolve(CMakePackage, CudaPackage, ROCmPackage):
         description="Build the LUSOL Library. Requires fortran",
     )
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")
 
     depends_on("suite-sparse", when="+klu")
 


### PR DESCRIPTION
This add `c` and `fortran` dependencies to the Re::Solve package to work with the new compiler dependency handling in Spack.

cc @pelesh @shakedregev
