### PR TITLE
libxml2: Move cmake_args to package instead of CMakeBuilder so it act…

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libxml2/package.py
@@ -147,6 +147,16 @@ class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
             )
             filter_file("-Wno-long-long -Wno-format-extra-args", "", "configure")
 
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("LIBXML2_WITH_PYTHON", "python"),
+            self.define("LIBXML2_WITH_LZMA", True),
+            self.define("LIBXML2_WITH_ZLIB", True),
+            self.define("LIBXML2_WITH_TESTS", True),
+        ]
+        return args
+
     def test_import(self):
         """import module test"""
         if "+python" not in self.spec:
@@ -269,19 +279,6 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
         args.append("--without-pic")
 
         return args
-
-
-class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
-    def cmake_args(self):
-        args = [
-            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            self.define_from_variant("LIBXML2_WITH_PYTHON", "python"),
-            self.define("LIBXML2_WITH_LZMA", True),
-            self.define("LIBXML2_WITH_ZLIB", True),
-            self.define("LIBXML2_WITH_TESTS", True),
-        ]
-        return args
-
 
 class NMakeBuilder(AnyBuilder, nmake.NMakeBuilder):
     phases = ("configure", "build", "install")

--- a/var/spack/repos/spack_repo/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/libxml2/package.py
@@ -280,6 +280,7 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
 
         return args
 
+
 class NMakeBuilder(AnyBuilder, nmake.NMakeBuilder):
     phases = ("configure", "build", "install")
 


### PR DESCRIPTION
…ually gets called.

I was observing cmake configure failures for libxml2~python because the cmake_args were not actually getting set and the default behavior was to look for python.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
