### PR TITLE
nccl: add 2.24.3, 2.25.1, and 2.26.2

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/nccl/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/nccl/package.py
@@ -19,6 +19,9 @@ class Nccl(MakefilePackage, CudaPackage):
     maintainers("adamjstewart")
     libraries = ["libnccl.so"]
 
+    version("2.26.2-1", sha256="74c6ab40c864d79c2139508e9419de5970cb406ec85f001d5f834d5f5c0c4f3b")
+    version("2.25.1-1", sha256="7b154ad1f8ccafa795ed6696507d402b1b4ccac944c5fceb7f4e29b19a39cc47")
+    version("2.24.3-1", sha256="3028730b41e952d8e0441a2a62cf06a2267ec5a875c511a28c7904acc3d10b2a")
     version("2.23.4-1", sha256="6b946b70a9d2d01871842cbd15ec56488d358abe9a0f3767e372fddc3e241ba7")
     version("2.22.3-1", sha256="45151629a9494460e73375281e8b0fe379141528879301899ece9b776faca024")
     version("2.21.5-1", sha256="1923596984d85e310b5b6c52b2c72a1b93da57218f2bc5a5c7ac3d59297a3303")


### PR DESCRIPTION
Add the latest patch releases of the three latest missing minor releases.