### PR TITLE
Remove deprecated `make` and `ninja` global from package.py

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -587,13 +587,7 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
     jobs = spack.config.determine_number_of_jobs(parallel=pkg.parallel)
     module.make_jobs = jobs
 
-    module.make = DeprecatedExecutable(pkg.name, "make", "gmake")
-    module.gmake = DeprecatedExecutable(pkg.name, "gmake", "gmake")
-    module.ninja = DeprecatedExecutable(pkg.name, "ninja", "ninja")
-
     if sys.platform == "win32":
-        module.nmake = DeprecatedExecutable(pkg.name, "nmake", "msvc")
-        module.msbuild = DeprecatedExecutable(pkg.name, "msbuild", "msvc")
         # analog to configure for win32
         module.cscript = Executable("cscript")
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -10,7 +10,10 @@ packages.
 
 import base64
 import collections
+<<<<<<< HEAD
 import copy
+=======
+>>>>>>> 05703d29cd (style: remove unused import)
 import errno
 import functools
 import glob
@@ -65,9 +68,9 @@ from spack.llnl.util.filesystem import (
     symlink,
 )
 from spack.llnl.util.lang import ClassProperty, classproperty, memoized
-from spack.util.executable import Executable
 from spack.resource import Resource
 from spack.solver.versions import concretization_version_order
+from spack.util.executable import Executable
 from spack.util.package_hash import package_hash
 from spack.util.typing import SupportsRichComparison
 from spack.version import GitVersion, StandardVersion, VersionError, is_git_version

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -10,10 +10,6 @@ packages.
 
 import base64
 import collections
-<<<<<<< HEAD
-import copy
-=======
->>>>>>> 05703d29cd (style: remove unused import)
 import errno
 import functools
 import glob

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -65,6 +65,7 @@ from spack.llnl.util.filesystem import (
     symlink,
 )
 from spack.llnl.util.lang import ClassProperty, classproperty, memoized
+from spack.util.executable import Executable
 from spack.resource import Resource
 from spack.solver.versions import concretization_version_order
 from spack.util.package_hash import package_hash
@@ -1885,7 +1886,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             return False
 
         # Prevent altering LC_ALL for 'make' outside this function
-        make = copy.deepcopy(self.module.make)
+        make = Executable("make")
 
         # Use English locale for missing target message comparison
         make.add_default_env("LC_ALL", "C")
@@ -1936,7 +1937,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """
         if self._has_make_target(target):
             # Execute target
-            self.module.make(target, *args, **kwargs)
+            make = Executable("make")
+            make(target, *args, **kwargs)
 
     def _has_ninja_target(self, target):
         """Checks to see if 'target' is a valid target in a Ninja build script.
@@ -1947,7 +1949,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         Returns:
             bool: True if 'target' is found, else False
         """
-        ninja = self.module.ninja
+        ninja = Executable("ninja")
 
         # Check if we have a Ninja build script
         if not os.path.exists("build.ninja"):
@@ -1976,7 +1978,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """
         if self._has_ninja_target(target):
             # Execute target
-            self.module.ninja(target, *args, **kwargs)
+            ninja = Executable("ninja")
+            ninja(target, *args, **kwargs)
 
     def _get_needed_resources(self):
         # We use intersects here cause it would also work if self.spec is abstract

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -490,30 +490,6 @@ def test_setting_dtags_based_on_config(
         assert dtags_to_add.value == expected_flag
 
 
-def test_module_globals_available_at_setup_dependent_time(
-    monkeypatch, mutable_config, mock_packages, working_env
-):
-    """Spack built package externaltest depends on an external package
-    externaltool. Externaltool's setup_dependent_package needs to be able to
-    access globals on the dependent"""
-
-    def setup_dependent_package(module, dependent_spec):
-        # Make sure set_package_py_globals was already called on
-        # dependents
-        # ninja is always set by the setup context and is not None
-        dependent_module = dependent_spec.package.module
-        assert hasattr(dependent_module, "ninja")
-        assert dependent_module.ninja is not None
-        dependent_spec.package.test_attr = True
-
-    externaltool = spack.concretize.concretize_one("externaltest")
-    monkeypatch.setattr(
-        externaltool["externaltool"].package, "setup_dependent_package", setup_dependent_package
-    )
-    spack.build_environment.setup_package(externaltool.package, False)
-    assert externaltool.package.test_attr
-
-
 def test_build_jobs_sequential_is_sequential():
     assert (
         spack.config.determine_number_of_jobs(

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/mpich/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/mpich/package.py
@@ -32,6 +32,8 @@ class Mpich(Package):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
+    depends_on("make", type="build")    
+
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/mpich/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/mpich/package.py
@@ -32,8 +32,7 @@ class Mpich(Package):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
-    depends_on("make", type="build")    
-
+    depends_on("make", type="build")
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
Historically, Spack assumed that every package depended on an external make. That is no longer the case and the support for implicit external make has been deprecated since January 2025. 

This PR removes deprecated support in preparation for v1.0. 