### PR TITLE
Backports: v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,1066 @@
+# v1.0.0 (2025-07-20)
+
+`v1.0.0` is a major feature release and a significant milestone. It introduces compiler
+dependencies, a foundational change that has been in development for almost seven years,
+and the project's first stable package API.
+
+If you are interested in more information, you can find more details on the road to
+v1.0, as well as its features, in talks from the 2025 Spack User Meeting. For example:
+* [State of the Spack Community](https://www.youtube.com/watch?v=4rInmUfuiZQ&list=PLRKq_yxxHw29-JcpG2CZ-xKK2U8Hw8O1t&index=2)
+* [Spack v1.0 overview](https://www.youtube.com/watch?v=nFksqSDNwQA&list=PLRKq_yxxHw29-JcpG2CZ-xKK2U8Hw8O1t&index=4)
+
+Introducing some of these features required us to make breaking changes. In most cases,
+we've also provided tools (in the form of Spack commands) that you can use to
+automatically migrate your packages and configuration.
+
+## Overview
+
+- [Overview](#overview)
+- [Stable Package API](#stable-package-api)
+    - [Separate Package Repository](#separate-package-repository)
+    - [Updating and Pinning Packages](#updating-and-pinning-packages)
+    - [Breaking changes related to package repositories](#breaking-changes-related-to-package-repositories)
+    - [Migrating to the new package API](#migrating-to-the-new-package-api)
+- [Compiler dependencies](#compiler-dependencies)
+    - [Compiler configuration](#compiler-configuration)
+    - [Languages are virtual dependencies](#languages-are-virtual-dependencies)
+    - [The meaning of % has changed](#the-meaning-of-%25-has-changed)
+    - [Virtual assignment syntax](#virtual-assignment-syntax)
+    - [Toolchains](#toolchains)
+    - [Ordering of variants and compilers now matters](#ordering-of-variants-and-compilers-now-matters)
+- [Additional Major Features](#additional-major-features)
+    - [Concurrent Package Builds](#concurrent-package-builds)
+    - [Content-addressed build caches](#content-addressed-build-caches)
+    - [Better provenance and mirroring for git](#better-provenance-and-mirroring-for-git)
+    - [Environment variables in environments](#environment-variables-in-environments)
+    - [Better include functionality](#better-include-functionality)
+- [New commands and options](#new-commands-and-options)
+- [Notable refactors](#notable-refactors)
+- [Documentation](#documentation)
+- [Notable Bugfixes](#notable-bugfixes)
+- [Additional deprecations, removals, and breaking changes](#additional-deprecations-removals-and-breaking-changes)
+- [Spack community stats](#spack-community-stats)
+
+## Stable Package API
+
+In Spack `v1.0`, the package repository is separate from the Spack tool, giving you more
+control over the versioning of package recipes. There is also a stable
+[Package API](https://spack.readthedocs.io/en/latest/package_api.html) that is versioned
+separately from Spack.
+
+This release of Spack supports package API from `v1.0` up to `v2.2`. The older `v1.0`
+package API is deprecated and may be removed in a future release, but we are
+guaranteeing that any Spack `v1.x` release will be backward compatible with Package API
+`v.2.x` -- i.e., it can execute code from the packages in *this* Spack release.
+
+See the
+[Package API Documentation](https://spack.readthedocs.io/en/latest/package_api.html) for
+full details on package versioning and compatibility. The high level details are:
+
+  1. The `spack.package` Python module defines the Package API;
+  2. The Package API *minor version* is incremented when new functions or classes are exported from `spack.package`; and
+  3. The major version is incremented when functions or classes are removed or have breaking changes to their signatures (a rare occurrence).
+
+This independent versioning allows package authors to utilize new Spack features without
+waiting for a new Spack release. Older Spack packages (API `v1.0`) may import code from
+outside of `spack.package`, e.g., from `spack.*` or `llnl.util.*`. This is deprecated
+and *not* included in the API guarantee. We will remove support for these packages in a
+future Spack release.
+
+### Separate Package Repository
+
+The Spack `builtin` package repository no longer lives in the Spack git repository. You
+can find it here:
+
+* https://github.com/spack/spack-packages
+
+Spack clones the package repository automatically when you first run, so you do not have
+to manage this manually. By default, Spack version `v1.0` uses the `v2025.07` release of
+`spack-packages`. You can find out more about it by looking at the
+[package releases](https://github.com/spack/spack-packages/releases).
+
+Downloaded package repos are stored by default within `~/.spack`, but the fetch
+destination can be configured. (#50650). If you want your package repository to live
+somewhere else, run, e.g.:
+
+```
+spack repo set --destination ~/spack-packages builtin
+```
+
+You can also configure your *own* package repositories to be fetched automatically from
+git urls, just as you can with `builtin`. See the
+[repository configuration docs](https://spack.readthedocs.io/en/latest/repositories.html)
+for details.
+
+### Updating and Pinning Packages
+
+You can tell Spack to update the core package repository from a branch. For example, on
+`develop` or on a release, you can run commands like:
+
+  ```shell
+  # pull the latest packages
+  spack repo update
+  ```
+or
+
+  ```shell
+  # check out a specific commit of the spack-packages repo
+  spack repo update --commit 2bf4ab9585c8d483cc8581d65912703d3f020393 builtin
+  ```
+
+which will set up your configuration like this:
+
+  ```yaml
+  repos:
+    builtin:
+      git: "https://github.com/spack/spack-packages.git"
+      commit: 2bf4ab9585c8d483cc8581d65912703d3f020393
+  ```
+
+You can use this within an environment to pin a specific version of its package files.
+See the
+[repository configuration docs](https://spack.readthedocs.io/en/latest/repositories.html)
+for more details (#50868, #50997, #51021).
+
+### Breaking changes related to package repositories
+
+1. The builtin repo now lives in `var/spack/repos/spack_repo/builtin` instead of
+   `var/spack/repos/builtin`, and it has a new layout, which you can learn about in the
+   [repo docs](https://spack.readthedocs.io/en/latest/repositories.html).
+
+2. The module `spack.package` no longer exports the following symbols, mostly related to
+   build systems: `AspellDictPackage`, `AutotoolsPackage`, `BundlePackage`,
+   `CachedCMakePackage`, `cmake_cache_filepath`, `cmake_cache_option`,
+   `cmake_cache_path`, `cmake_cache_string`, `CargoPackage`, `CMakePackage`,
+   `generator`, `CompilerPackage`, `CudaPackage`, `Package`, `GNUMirrorPackage`,
+   `GoPackage`, `IntelPackage`, `IntelOneApiLibraryPackageWithSdk`,
+   `IntelOneApiLibraryPackage`, `IntelOneApiStaticLibraryList`, `IntelOneApiPackage`,
+   `INTEL_MATH_LIBRARIES`, `LuaPackage`, `MakefilePackage`, `MavenPackage`,
+   `MesonPackage`, `MSBuildPackage`, `NMakePackage`, `OctavePackage`, `PerlPackage`,
+   `PythonExtension`, `PythonPackage`, `QMakePackage`, `RacketPackage`, `RPackage`,
+   `ROCmPackage`, `RubyPackage`, `SConsPackage`, `SIPPackage`, `SourceforgePackage`,
+   `SourcewarePackage`, `WafPackage`, `XorgPackage`
+
+   These are now part of the `builtin` package repository, not part of core spack or its
+   package API. When using repositories with package API `v2.0` and higher, *you must
+   explicitly import these package classes* from the appropriate module in
+   `spack_repo.builtin.build_systems` (see #50452 for more).
+
+   e.g., for `CMakePackage`, you would write:
+
+     ```python
+     from spack_repo.builtin.build_systems.cmake import CMakePackage
+     ```
+
+   Note that `GenericBuilder` and `Package` *are* part of the core package API. They are
+   currently re-exported from `spack_repo.builtin.build_systems.generic` for backward
+   compatibility but may be removed from the package repo. You should prefer to import
+   them from `spack.package`.
+
+   The original names will still work for old-style (`v1.0`) package repositories but
+   *not* in `v2.0` package repositories. Note that this means that the API stability
+   promise does *not* include old-style package repositories. They are deprecated and
+   will be removed in a future version. So, you should update as soon as you can.
+
+3. Package directory names within `v2.0` repositories are now valid Python modules
+
+    | Old                   | New                   | Description                         |
+    |-----------------------|-----------------------|-------------------------------------|
+    | `py-numpy/package.py` | `py_numpy/package.py` | hyphen is replaced by underscore.   |
+    | `7zip/package.py`     | `_7zip/package.py`    | leading digits now preceded by _    |
+    | `pass/package.py`     | `_pass/package.py`    | Python reserved words preceded by _ |
+
+
+4. Spack has historically injected `import` statements into package recipes, so there
+   was no need to use `from spack.package import *` (though we have included it in
+   `builtin` packages for years. `from spack.package import *` (or more specific
+   imports) will be necessary in packages. The magic we added in the early days of Spack
+   was causing IDEs, code editors, and other tools not to be able to understand Spack
+   packages. Now they use standard Python import semantics and should be compatible with
+   modern Python tooling. This change was also necessary to support Python 3.13. (see
+   #47947 for more details).
+
+### Migrating to the new package API
+
+Support will remain in place for the old repository layout for *at least a year*, so
+that you can continue to use old-style repos in conjunction with earlier versions. If
+you have custom repositories that need to migrate to the new layout, you can upgrade
+them to package API `v2.x` by running:
+
+```
+spack repo migrate
+```
+
+This will make the following changes to your repository:
+
+   1. If you used to import from `spack.pkg.builtin` in Python, you now need to import
+      from `spack_repo.builtin` instead:
+
+       ```python
+       # OLD: no longer supported
+       from spack.pkg.builtin.my_pkg import MyPackage
+
+       # NEW: spack_repo is a Python namespace package
+       from spack_repo.builtin.packages.my_pkg.package import MyPackage
+       ```
+   2. Normalized directory names for packages
+   3. New-style `spack.package` imports
+
+See #50507, #50579, and #50594 for more.
+
+## Compiler dependencies
+
+Prior to `v1.0`, compilers in Spack were attributes on nodes in the spec graph, with a
+name and a version (e.g., `gcc@12.0.0`). In `v1.0` compilers are packages like any other
+package in Spack (see #45189). This means that they can have variants, targets, and
+other attributes that regular nodes have.
+
+Here, we list the major changes that users should be aware of for this new model.
+
+### Compiler configuration
+
+In Spack `v1.0`, `compilers.yaml` is deprecated. `compilers.yaml` is still read by
+Spack, if present. We will continue to support this for at least a year, but we may
+remove it after that. Users are encouraged to migrate their configuration to use
+`packages.yaml` instead.
+
+Old style `compilers.yaml` specification:
+
+```yaml
+compilers:
+  - compiler:
+      spec: gcc@12.3.1
+      paths:
+         c: /usr/bin/gcc
+         cxx: /usr/bin/g++
+         fc: /usr/bin/gfortran
+       modules: [...]
+```
+
+New style `packages.yaml` compiler specification:
+
+```yaml
+packages:
+  gcc:
+    externals:
+    - spec: gcc@12.3.1+binutils
+      prefix: /usr
+      extra_attributes:
+        compilers:
+          c: /usr/bin/gcc
+          cxx: /usr/bin/g++
+          fc: /usr/bin/gfortran
+        modules: [...]
+```
+
+See
+[Configuring Compilers](https://spack.readthedocs.io/en/latest/configuring_compilers.html)
+for more details.
+
+
+### Languages are virtual dependencies
+
+Packages that need a C, C++, or Fortran compiler now **must** depend on `c`, `cxx`, or
+`fortran` as a build dependency, e.g.:
+
+```python
+class MyPackage(Package):
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+```
+
+Historically, Spack assumed that *every* package was compiled with C, C++, and Fortran.
+In Spack `v1.0`, we allow packages to simply not have a compiler if they do not need
+one. For example, pure Python packages would not depend on any of these, and you should
+not add these dependencies to packages that do not need them.
+
+[Spack `v0.23`](https://github.com/spack/spack/releases/tag/v0.23.0) introduced language
+virtual dependencies, and we have back-ported them to `0.21.3` and `v0.22.2`. In pre-1.0
+Spack releases, these are a no-op. They are present so that language dependencies do not
+cause an error. This allows you to more easily use older Spack versions together with
+`v1.0`.
+
+See #45217 for more details.
+
+### The meaning of `%` has changed
+
+In Spack `v0.x`, `%` specified a compiler with a name and an optional version. In Spack
+`v1.0`, it simply means "direct dependency". It is similar to the caret `^`, which means
+"direct *or* transitive dependency".
+
+Unlike `^`, which specifies a dependency that needs to be unified for the whole graph,
+`%` can specify direct dependencies of particular nodes. This means you can use it to
+mix and match compilers, or `cmake` versions, or any other package for which *multiple*
+versions of the same build dependency are needed in the same graph. For example, in this
+spec:
+
+```
+foo ^hdf5 %cmake@3.1.2 ^zlib-ng %cmake@3.2.4
+```
+
+`hdf5` and `zlib-ng` are both transitive dependencies of `foo`, but `hdf5` will be built
+with `cmake@3.1.2` and `zlib-ng` will be built with `%cmake@3.2.4`. This is similar to
+mixing compilers, but you can now use `%` with other types of build dependencies, as
+well. You can have multiple versions of packages in the same graph, as long as they are
+purely build dependencies.
+
+### Virtual assignment syntax
+
+You can still specify compilers with `foo %gcc`, in which case `gcc` will be used to
+satisfy any `c`, `cxx`, and `fortran` dependencies of `foo`, but you can also be
+specific about the compiler that should be used for each language. To mix, e.g., `clang`
+and `gfortran`, you can now use *virtual assignment* like so:
+
+```console
+spack install foo %c,cxx=gcc %fortran=gfortran
+```
+
+This says to use `gcc` for `c` and `cxx`, and `gfortran` for `fortran`.
+It is functionally equivalent to the already supported edge attribute syntax:
+
+```
+spack install foo %[virtuals=c,cxx] gcc %[virtuals=fortran] gfortran
+```
+
+But, virtual assignment is more legible. We use it as the default formatting for virtual
+edge attributes, and we print it in the output of `spack spec`, `spack find`, etc. For
+example:
+
+```console
+> spack spec zlib
+ -   zlib@1.3.1+optimize+pic+shared build_system=makefile arch=darwin-sequoia-m1 %c,cxx=apple-clang@16.0.0
+[e]      ^apple-clang@16.0.0 build_system=bundle arch=darwin-sequoia-m1
+ -       ^compiler-wrapper@1.0 build_system=generic arch=darwin-sequoia-m1
+[+]      ^gmake@4.4.1~guile build_system=generic arch=darwin-sequoia-m1 %c=apple-clang@16.0.0
+[+]          ^compiler-wrapper@1.0 build_system=generic arch=darwin-sequoia-m1
+```
+
+You can see above that only `zlib` and `gmake` are compiled, and `gmake` uses only `c`.
+The other nodes are either external, and we cannot detect the compiler (`apple-clang`)
+or they are not compiled (`compiler-wrapper` is a shell script).
+
+### Toolchains
+
+Spack now has a concept of a "toolchain", which can be configured in `toolchains.yaml`.
+A toolchain is an alias for common dependencies, flags, and other spec properties that
+you can attach to a node in a graph with `%`.
+
+Toolchains are versatile and composable as they are simply aliases for regular specs.
+You can use them to represent mixed compiler combinations, compiler/MPI/numerical
+library groups, particular runtime libraries, and flags -- all to be applied together.
+This allows you to do with compiler dependencies what we used to do with
+`compilers.yaml`, and more.
+
+Example mixed clang/gfortran toolchain:
+
+```yaml
+toolchains:
+  clang_gfortran:
+    - spec: %c=clang
+      when: %c
+    - spec: %cxx=clang
+      when: %cxx
+    - spec: %fortran=gcc
+      when: %fortran
+    - spec: cflags="-O3 -g"
+    - spec: cxxflags="-O3 -g"
+    - spec: fflags="-O3 -g"
+```
+
+This enables you to write `spack install foo %clang_gfortran`, and Spack will resolve
+the `%clang_gfortran` toolchain to include the dependencies and flags listed in
+`toolchains.yaml`.
+
+You could also couple the intel compilers with `mvapich2` like so:
+
+```yaml
+toolchains:
+  intel_mvapich2:
+    - spec: %c=intel-oneapi-compilers @2025.1.1
+      when: %c
+    - spec: %cxx=intel-oneapi-compilers @2025.1.1
+      when: %cxx
+    - spec: %fortran=intel-oneapi-compilers @2025.1.1
+      when: %fortran
+    - spec: %mpi=mvapich2 @2.3.7-1 +cuda
+      when: %mpi
+```
+
+The `when:` conditions here ensure that toolchain constraints are only applied when
+needed. See the
+[toolchains documentation](https://spack.readthedocs.io/en/latest/advanced_topics.html#defining-and-using-toolchains)
+or #50481 for details.
+
+### Ordering of variants and compilers now matters
+
+In Spack `v0.x`, these two specs parse the same:
+
+```
+pkg %gcc +foo
+pkg +foo %gcc
+```
+
+The `+foo` variant applies to `pkg` in either case. In Spack `v1.0`, there is a breaking
+change, and `+foo` in `pkg %gcc +foo` now applies to `gcc`, since `gcc` is a normal
+package. This ensures we have the following symmetry:
+
+```
+pkg +foo %dep +bar  # `pkg +foo` depends on `dep +bar` directly
+pkg +foo ^dep +bar  # `pkg +foo` depends on `dep +bar` directly or transitively
+```
+
+In Spack `v1.0` you may get errors at concretization time if `+foo` is not a variant of
+`gcc` in specs like`%pkg %gcc +foo`.
+
+You can use the `spack style --spec-strings` command to update `package.py` files,
+`spack.yaml` files:
+
+  ```shell
+  # dry run
+  spack style --spec-strings $(git ls-files)  # if you have a git repo
+  spack style --spec-strings spack.yaml  # environments
+  ```
+
+  ```shell
+  # use --fix to perform the changes listed by the dry run
+  spack style --fix --spec-strings $(git ls-files)
+  spack style --fix --spec-strings spack.yaml
+  ```
+
+  See #49808, #49438, #49439 for details.
+
+## Additional Major Features
+
+### Concurrent Package Builds
+
+This release has completely reworked Spack's build scheduler, and it adds a `-p`/
+`--concurrent-packages` argument to `spack install`, which can greatly accelerate builds
+with many packages. You can use it in combination with `spack install -j`. For example,
+this command:
+
+```
+spack install -p 4 -j 16
+```
+
+runs up to 4 package builds at once, each with up to 16 make jobs. The default for
+`--concurrent-packages` is currently 1, so you must enable this feature yourself, either
+on the command line or by setting `config:concurrent_packages` (#50856):
+
+```yaml
+config:
+  concurrent_packages: 1
+```
+
+As before, you can run `spack install` on multiple nodes in a cluster, if the filesystem
+where Spack's `install_tree` is located supports locking.
+
+We will make concurrent package builds the default in `1.1`, when we plan to include
+support for `gmake`'s jobserver protocol and for line-synced output. Currently, setting
+`-p` higher than 1 can make Spack's output difficult to read.
+
+### Content-addressed build caches
+
+Spack `v1.0` changes the format of build caches to address a number of scaling and
+consistency issues with our old (aging) buildcache layout. The new buildcache format is
+content-addressed and enables us to make many operations atomic (and therefore safer).
+It is also more extensible than the old buildcache format and can enable features like
+split debug info and different signing methods in the future. See #48713 for more
+details.
+
+Spack `v1.0` can still read, but not write to, the old build caches. The new build cache
+format is *not* backward compatible with the old format, *but* you can have a new build
+cache and an old build cache coexist beside each other. If you push to an old build
+cache, new binaries will start to show up in the new format.
+
+You can migrate an old buildcache to the new format using the `spack buildcache migrate`
+command. It is nondestructive and can migrate an old build cache to a new one in-place.
+That is, it creates the new buildcache within the same directory, alongside the old
+buildcache.
+
+As with other major changes, the old buildcache format is deprecated in `v1.0`, but will
+not be removed for at least a year.
+
+### Better provenance and mirroring for git
+
+Spack now resolves and preserves the commit of any git-based version at concretization
+time, storing the precise commit built on the Spec in a reserved `commit` variant. This
+allows us to better reproduce git builds. See #48702 for details.
+
+Historically, Spack has only stored the ref name, e.g. the branch or tag, for git
+versions that did not already contain full commits. Now we can know exactly what was
+built regardless of how it was fetched.
+
+As a consequence of this change, mirroring git repositories is also more robust. See
+#50604, #50906 for details.
+
+### Environment variables in environments
+
+You can now specify environment variables in your environment that should be set on
+activation (and unset on deactivation):
+
+```yaml
+spack:
+  specs:
+    - cmake%gcc
+  env_vars:
+    set:
+      MY_FAVORITE_VARIABLE: "TRUE"
+```
+
+The syntax allows the same modifications that are allowed for modules: `set:`, `unset:`,
+`prepend_path:`, `append_path:`, etc.
+
+See [the docs](https://spack.readthedocs.io/en/latest/env_vars_yaml.html or #47587 for more.
+
+### Better include functionality
+
+Spack allows you to include local or remote configuration files through `include.yaml`,
+and includes can be optional (i.e. include them only if they exist) or conditional (only
+include them under certain conditions:
+
+```yaml
+spack:
+  include:
+  - /path/to/a/required/config.yaml
+  - path: /path/to/$os/$target/config
+    optional: true
+  - path: /path/to/os-specific/config-dir
+    when: os == "ventura"
+```
+
+You can use this in an environment, or in an `include.yaml` in an existing configuration
+scope. Included configuration files are required *unless* they are explicitly optional
+or the entry's condition evaluates to `false`. Optional includes are specified with the
+`optional` clause and conditional ones with the ``when`` clause.
+
+Conditionals use the same syntax as
+[spec list references](https://spack.readthedocs.io/en/latest/environments.html#spec-list-references)
+The [docs on `include.yaml`](https://spack.readthedocs.io/en/latest/include_yaml.html)
+have more information. You can also look at #48784.
+
+
+## New commands and options
+* `spack repo update` will pull the latest packages (#50868, #50997)
+* `spack style --spec-strings` fixes old configuration file and packages (#49485)
+* `spack repo migrate`: migrates old repositories to the new layout (#50507)
+* `spack ci` no longer has a `--keep-stage` flag (#49467)
+* The new `spack config scopes` subcommand will list active configuration scopes (#41455, #50703)
+* `spack cd --repo <namespace>` (#50845)
+* `spack location --repo <namespace>` (#50845)
+* `--force` is now a common argument for all commands that do concretization (#48838)
+
+## Notable refactors
+
+* All of Spack is now in one top-level `spack` Python package
+  * The `spack_installable` package is gone as it's no longer needed (#50996)
+  * The top-level `llnl` package has been moved to `spack.llnl` and will likely be
+    refactored more later (#50989)
+  * Vendored dependencies that were previously in `_vendoring` are now in `spack.vendor` (#51005)
+
+* Increased determinism when generating inputs for the ASP solver, leading to more
+  consistent concretization results (#49471)
+
+* Added fast, stable spec comparison, which also increases determinism of concretizer
+  inputs, and more consistent results (#50625)
+
+* Test deps are now part of the DAG hash, so builds with tests enabled will (correctly)
+  have different hashes from builds without tests enabled (#48936)
+
+* `spack spec` in an environment or on the command line will show unified output with
+  the specs provided as roots (#47574)
+
+* users can now set a timeout in `concretizer.yaml` in case they frequently hit long
+  solves (#47661)
+
+* GoPackage: respect `-j`` concurrency (#48421)
+
+* We are using static analysis to speed up concretization (#48729)
+
+## Documentation
+
+We have overhauled a number of sections of the documentation.
+
+* The basics section of the documentation has been reorganized and updated (#50932)
+
+* The [packaging guide](https://spack.readthedocs.io/en/latest/packaging_guide_creation.html)
+  has been rewritten and broken into four separate, logically ordered sections (#50884).
+
+* As mentioned above the entire
+  [`spack.package` API](https://spack.readthedocs.io/en/latest/package_api.html) has
+  been documented and consolidated to one package (#51010)
+
+## Notable Bugfixes
+
+* A race that would cause timeouts in certain parallel builds has been fixed. Every
+  build now stages its own patches and cannot fight over them (causing a timeout) with
+  other builds (#50697)
+* The `command_line` scope is now *always* the top level. Previously environments could
+  override command line settings (#48255)
+* `setup-env.csh` is now hardened to avoid conflicts with user aliases (#49670)
+
+## Additional deprecations, removals, and breaking changes
+
+1. `spec["pkg"]` searches only direct dependencies and transitive link/run dependencies,
+   ordered by depth. This avoids situations where we pick up unwanted deps of build/test
+   deps. To reach those, you need to do `spec["build_dep"]["pkg"]` explicitly (#49016).
+
+2. `spec["mpi"]` no longer works to refer to `spec` itself on specs like `openmpi` and
+   `mpich` that could provide `mpi`. We only find `"mpi"` if it is provided by some
+   dependency (see #48984).
+
+3. We have removed some long-standing internal API methods on `spack.spec.Spec` so that
+   we can decouple internal modules in the Spack code. `spack.spec` was including too
+   many different parts of Spack.
+  * `Spec.concretize()` and `Spec.concretized()` have been removed. Use
+    `spack.concretize.concretize_one(spec)` instead (#47971, #47978)
+  * `Spec.is_virtual`` is now spack.repo.PATH.is_virtual (#48986)
+  * `Spec.virtual_dependencies` has been removed (#49079)
+
+4. #50603: Platform config scopes are now opt-in. If you want to use subdirectories like
+   `darwin` or `linux` in your scopes, you'll need to include them explicitly in an
+   `include.yaml` or in your `spack.yaml` file, like so:
+
+    ```yaml
+    include:
+      - include: "${platform}"
+        optional: true
+    ```
+
+5. #48488, #48502: buildcache entries created with Spack 0.19 and older using `spack
+   buildcache create --rel` will no longer be relocated upon install. These old binaries
+   should continue to work, except when they are installed with different
+   `config:install_tree:projections` compared to what they were built with. Similarly,
+   buildcache entries created with Spack 0.15 and older that contain long shebang lines
+   wrapped with sbang will no longer be relocated.
+
+6. #50462: the `package.py` globals `std_cmake_args`, `std_pip_args`, `std_meson_args`
+   were removed. They were deprecated in Spack 0.23. Use `CMakeBuilder.std_args(pkg)`,
+   `PythonPipBuilder.std_args(pkg)` and `MesonBuilder.std_args(pkg)` instead.
+
+7. #50605, #50616: If you were using `update_external_dependencies()` in your private
+   packages, note that it is going away in 1.0 to get it out of the package API. It is
+   instead being moved into the concretizer, where it can change in the future, when we
+   have a better way to deal with dependencies of externals, without breaking the
+   package API. We suspect that nobody was doing this, but it's technically a breaking
+   change.
+
+8. #48838: Two breaking command changes:
+    * `spack install` no longer has a `-f` / `--file` option --
+      write `spack install ./path/to/spec.json` instead.
+    * `spack mirror create` no longer has a short `-f` option --
+      use `spack mirror create --file` instead.
+
+9. We no longer support the PGI compilers. They have been replaced by `nvhpc` (#47195)
+
+10. Python 3.8 is deprecated in the Python package, as it is EOL (#46913)
+
+11. The `target=fe` / `target=frontend` and `target=be` / `target=backend` targets from
+    Spack's orignal compilation model for cross-compiled Cray and BlueGene systems are
+    now deprecated (#47756)
+
+## Spack community stats
+
+* 2,276 commits updated package recipes
+* 8,499 total packages, 214 new since v0.23.0
+* 372 people contributed to this release
+* 363 committers to packages
+* 63 committers to core
+
+
+# v0.23.1 (2025-02-19)
+
+## Bugfixes
+- Fix a correctness issue of `ArchSpec.intersects` (#48741)
+- Make `extra_attributes` order independent in Spec hashing (#48615, #48854)
+- Fix issue where system proxy settings were not respected in OCI build caches (#48783)
+- Fix an issue where the `--test` concretizer flag was not forwarded correctly (#48417)
+- Fix an issue where `codesign` and `install_name_tool` would not preserve hardlinks on
+  Darwin (#47808)
+- Fix an issue on Darwin where codesign would run on unmodified binaries (#48568)
+- Patch configure scripts generated with libtool < 2.5.4, to avoid redundant flags when
+  creating shared libraries on Darwin (#48671)
+- Fix issue related to mirror URL paths on Windows (#47898)
+- Esnure proper UTF-8 encoding/decoding in logging (#48005)
+- Fix issues related to `filter_file` (#48038, #48108)
+- Fix issue related to creating bootstrap source mirrors (#48235)
+- Fix issue where command line config arguments were not always top level (#48255)
+- Fix an incorrect typehint of `concretized()` (#48504)
+- Improve mention of next Spack version in warning (#47887)
+- Tests: fix forward compatibility with Python 3.13 (#48209)
+- Docs: encourage use of `--oci-username-variable` and `--oci-password-variable` (#48189)
+- Docs: ensure Getting Started has bootstrap list output in correct place (#48281)
+- CI: allow GitHub actions to run on forks of Spack with different project name (#48041)
+- CI: make unit tests work on Ubuntu 24.04 (#48151)
+- CI: re-enable cray pipelines (#47697)
+
+## Package updates
+- `qt-base`: fix rpath for dependents (#47424)
+- `gdk-pixbuf`: fix outdated URL (#47825)
+
+
+# v0.23.0 (2024-11-13)
+
+`v0.23.0` is a major feature release.
+
+We are planning to make this the last major release before Spack `v1.0`
+in June 2025. Alongside `v0.23`, we will be making pre-releases (alpha,
+beta, etc.)  of `v1.0`, and we encourage users to try them and send us
+feedback, either on GitHub or on Slack. You can track the road to
+`v1.0` here:
+
+  * https://github.com/spack/spack/releases
+  * https://github.com/spack/spack/discussions/30634
+
+## Features in this Release
+
+1. **Language virtuals**
+
+   Your packages can now explicitly depend on the languages they require.
+   Historically, Spack has considered C, C++, and Fortran compiler
+   dependencies to be implicit. In `v0.23`, you should ensure that
+   new packages add relevant C, C++, and Fortran dependencies like this:
+
+   ```python
+   depends_on("c", type="build")
+   depends_on("cxx", type="build")
+   depends_on("fortran", type="build")
+   ```
+
+   We encourage you to add these annotations to your packages now, to prepare
+   for Spack `v1.0.0`. In `v1.0.0`, these annotations will be necessary for
+   your package to use C, C++, and Fortran compilers. Note that you should
+   *not* add language dependencies to packages that don't need them, e.g.,
+   pure python packages.
+
+   We have already auto-generated these dependencies for packages in the
+   `builtin` repository (see #45217), based on the types of source files
+   present in each package's source code. We *may* have added too many or too
+   few language dependencies, so please submit pull requests to correct
+   packages if you find that the language dependencies are incorrect.
+
+   Note that we have also backported support for these dependencies to
+   `v0.21.3` and `v0.22.2`, to make all of them forward-compatible with
+   `v0.23`. This should allow you to move easily between older and newer Spack
+   releases without breaking your packages.
+
+2. **Spec splicing**
+
+   We are working to make binary installation more seamless in Spack. `v0.23`
+   introduces "splicing", which allows users to deploy binaries using local,
+   optimized versions of a binary interface, even if they were not built with
+   that interface. For example, this would allow you to build binaries in the
+   cloud using `mpich` and install them on a system using a local, optimized
+   version of `mvapich2` *without rebuilding*. Spack preserves full provenance
+   for the installed packages and knows that they were built one way but
+   deployed another.
+
+   Our intent is to leverage this across many key HPC binary packages,
+   e.g. MPI, CUDA, ROCm, and libfabric.
+
+   Fundamentally, splicing allows Spack to redeploy an existing spec with
+   different dependencies than how it was built. There are two interfaces to
+   splicing.
+
+   a. Explicit Splicing
+
+      #39136 introduced the explicit splicing interface. In the
+      concretizer config, you can specify a target spec and a replacement
+      by hash.
+
+      ```yaml
+      concretizer:
+        splice:
+          explicit:
+          - target: mpi
+            replacement: mpich/abcdef
+      ```
+
+      Here, every installation that would normally use the target spec will
+      instead use its replacement. Above, any spec using *any* `mpi` will be
+      spliced to depend on the specific `mpich` installation requested. This
+      *can* go wrong if you try to replace something built with, e.g.,
+      `openmpi` with `mpich`, and it is on the user to ensure ABI
+      compatibility between target and replacement specs. This currently
+      requires some expertise to use, but it will allow users to reuse the
+      binaries they create across more machines and environments.
+
+   b. Automatic Splicing (experimental)
+
+      #46729 introduced automatic splicing. In the concretizer config, enable
+      automatic splicing:
+
+      ```yaml
+      concretizer:
+        splice:
+          automatic: true
+      ```
+
+      or run:
+
+      ```console
+      spack config add concretizer:splice:automatic:true
+      ```
+
+      The concretizer will select splices for ABI compatibility to maximize
+      package reuse. Packages can denote ABI compatibility using the
+      `can_splice` directive. No packages in Spack yet use this directive, so
+      if you want to use this feature you will need to add `can_splice`
+      annotations to your packages. We are working on ways to add more ABI
+      compatibility information to the Spack package repository, and this
+      directive may change in the future.
+
+   See the documentation for more details:
+   * https://spack.readthedocs.io/en/latest/build_settings.html#splicing
+   * https://spack.readthedocs.io/en/latest/packaging_guide.html#specifying-abi-compatibility
+
+3. Broader variant propagation
+
+   Since #42931, you can specify propagated variants like `hdf5
+   build_type==RelWithDebInfo` or `trilinos ++openmp` to propagate a variant
+   to all dependencies for which it is relevant. This is valid *even* if the
+   variant does not exist on the package or its dependencies.
+
+   See https://spack.readthedocs.io/en/latest/basic_usage.html#variants.
+
+4. Query specs by namespace
+
+   #45416 allows a package's namespace (indicating the repository it came from)
+   to be treated like a variant. You can request packages from particular repos
+   like this:
+
+   ```console
+   spack find zlib namespace=builtin
+   spack find zlib namespace=myrepo
+   ```
+
+   Previously, the spec syntax only allowed namespaces to be prefixes of spec
+   names, e.g. `builtin.zlib`. The previous syntax still works.
+
+5. `spack spec` respects environment settings and `unify:true`
+
+   `spack spec` did not previously respect environment lockfiles or
+   unification settings, which made it difficult to see exactly how a spec
+   would concretize within an environment. Now it does, so the output you get
+   with `spack spec` will be *the same* as what your environment will
+   concretize to when you run `spack concretize`. Similarly, if you provide
+   multiple specs on the command line with `spack spec`, it will concretize
+   them together if `unify:true` is set.
+
+   See #47556 and #44843.
+
+6. Less noisy `spack spec` output
+
+   `spack spec` previously showed output like this:
+
+   ```console
+    > spack spec /v5fn6xo
+    Input spec
+    --------------------------------
+     -   /v5fn6xo
+
+    Concretized
+    --------------------------------
+    [+]  openssl@3.3.1%apple-clang@16.0.0~docs+shared arch=darwin-sequoia-m1
+    ...
+   ```
+
+   But the input spec is redundant, and we know we run `spack spec` to concretize
+   the input spec. `spack spec` now *only* shows the concretized spec. See #47574.
+
+7. Better output for `spack find -c`
+
+   In an environmnet, `spack find -c` lets you search the concretized, but not
+   yet installed, specs, just as you would the installed ones. As with `spack
+   spec`, this should make it easier for you to see what *will* be built
+   before building and installing it. See #44713.
+
+8. `spack -C <env>`: use an environment's configuration without activation
+
+   Spack environments allow you to associate:
+   1. a set of (possibly concretized) specs, and
+   2. configuration
+
+   When you activate an environment, you're using both of these. Previously, we
+   supported:
+   * `spack -e <env>` to run spack in the context of a specific environment, and
+   * `spack -C <directory>` to run spack using a directory with configuration files.
+
+   You can now also pass an environment to `spack -C` to use *only* the environment's
+   configuration, but not the specs or lockfile. See #45046.
+
+## New commands, options, and directives
+
+* The new `spack env track` command (#41897) takes a non-managed Spack
+  environment and adds a symlink to Spack's `$environments_root` directory, so
+  that it will be included for reference counting for commands like `spack
+  uninstall` and `spack gc`. If you use free-standing directory environments,
+  this is useful for preventing Spack from removing things required by your
+  environments. You can undo this tracking with the `spack env untrack`
+  command.
+
+* Add `-t` short option for `spack --backtrace` (#47227)
+
+  `spack -d / --debug` enables backtraces on error, but it can be very
+  verbose, and sometimes you just want the backtrace. `spack -t / --backtrace`
+  provides that option.
+
+* `gc`: restrict to specific specs (#46790)
+
+  If you only want to garbage-collect specific packages, you can now provide
+  them on the command line. This gives users finer-grained control over what
+  is uninstalled.
+
+* oci buildcaches now support `--only=package`. You can now push *just* a
+  package and not its dependencies to an OCI registry. This allows dependents
+  of non-redistributable specs to be stored in OCI registries without an
+  error. See #45775.
+
+## Notable refactors
+* Variants are now fully conditional
+
+  The `variants` dictionary on packages was previously keyed by variant name,
+  and allowed only one definition of any given variant. Spack is now smart
+  enough to understand that variants may have different values and defaults
+  for different versions. For example, `warpx` prior to `23.06` only supported
+  builds for one dimensionality, and newer `warpx` versions could be built
+  with support for many different dimensions:
+
+  ```python
+  variant(
+      "dims",
+      default="3",
+      values=("1", "2", "3", "rz"),
+      multi=False,
+      description="Number of spatial dimensions",
+      when="@:23.05",
+  )
+  variant(
+      "dims",
+      default="1,2,rz,3",
+      values=("1", "2", "3", "rz"),
+      multi=True,
+      description="Number of spatial dimensions",
+      when="@23.06:",
+  )
+  ```
+
+  Previously, the default for the old version of `warpx` was not respected and
+  had to be specified manually. Now, Spack will select the right variant
+  definition for each version at concretization time. This allows variants to
+  evolve more smoothly over time. See #44425 for details.
+
+## Highlighted bugfixes
+
+1. Externals no longer override the preferred provider (#45025).
+
+   External definitions could interfere with package preferences. Now, if
+   `openmpi` is the preferred `mpi`, and an external `mpich` is defined, a new
+   `openmpi` *will* be built if building it is possible. Previously we would
+   prefer `mpich` despite the preference.
+
+2. Composable `cflags` (#41049).
+
+   This release fixes a longstanding bug that concretization would fail if
+   there were different `cflags` specified in `packages.yaml`,
+   `compilers.yaml`, or on `the` CLI. Flags and their ordering are now tracked
+   in the concretizer and flags from multiple sources will be merged.
+
+3. Fix concretizer Unification for included environments (#45139).
+
+## Deprecations, removals, and syntax changes
+
+1. The old concretizer has been removed from Spack, along with the
+   `config:concretizer` config option. Spack will emit a warning if the option
+   is present in user configuration, since it now has no effect. Spack now
+   uses a simpler bootstrapping mechanism, where a JSON prototype is tweaked
+   slightly to get an initial concrete spec to download. See #45215.
+
+2. Best-effort expansion of spec matrices has been removed. This feature did
+   not work with the "new" ASP-based concretizer, and did not work with
+   `unify: True` or `unify: when_possible`. Use the
+   [exclude key](https://spack.readthedocs.io/en/latest/environments.html#spec-matrices)
+   for the environment to exclude invalid components, or use multiple spec
+   matrices to combine the list of specs for which the constraint is valid and
+   the list of specs for which it is not. See #40792.
+
+3. The old Cray `platform` (based on Cray PE modules) has been removed, and
+   `platform=cray` is no longer supported. Since `v0.19`, Spack has handled
+   Cray machines like Linux clusters with extra packages, and we have
+   encouraged using this option to support Cray. The new approach allows us to
+   correctly handle Cray machines with non-SLES operating systems, and it is
+   much more reliable than making assumptions about Cray modules. See the
+   `v0.19` release notes and #43796 for more details.
+
+4. The `config:install_missing_compilers` config option has been deprecated,
+   and it is a no-op when set in `v0.23`. Our new compiler dependency model
+   will replace it with a much more reliable and robust mechanism in `v1.0`.
+   See #46237.
+
+5. Config options that deprecated in `v0.21` have been removed in `v0.23`. You
+   can now only specify preferences for `compilers`, `targets`, and
+   `providers` globally via the `packages:all:` section. Similarly, you can
+   only specify `versions:` locally for a specific package. See #44061 and
+   #31261 for details.
+
+6. Spack's old test interface has been removed (#45752), having been
+   deprecated in `v0.22.0` (#34236). All `builtin` packages have been updated
+   to use the new interface. See the [stand-alone test documentation](
+   https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests)
+
+7. The `spack versions --safe-only` option, deprecated since `v0.21.0`, has
+   been removed. See #45765.
+
+* The `--dependencies` and `--optimize` arguments to `spack ci` have been
+  deprecated. See #45005.
+
+## Binary caches
+1. Public binary caches now include an ML stack for Linux/aarch64 (#39666)We
+   now build an ML stack for Linux/aarch64 for all pull requests and on
+   develop. The ML stack includes both CPU-only and CUDA builds for Horovod,
+   Hugging Face, JAX, Keras, PyTorch,scikit-learn, TensorBoard, and
+   TensorFlow, and related packages. The CPU-only stack also includes XGBoost.
+   See https://cache.spack.io/tag/develop/?stack=ml-linux-aarch64-cuda.
+
+2. There is also now an stack of developer tools for macOS (#46910), which is
+   analogous to the Linux devtools stack. You can use this to avoid building
+   many common build dependencies. See
+   https://cache.spack.io/tag/develop/?stack=developer-tools-darwin.
+
+## Architecture support
+* archspec has been updated to `v0.2.5`, with support for `zen5`
+* Spack's CUDA package now supports the Grace Hopper `9.0a` compute capability (#45540)
+
+## Windows
+* Windows bootstrapping: `file` and `gpg` (#41810)
+* `scripts` directory added to PATH on Windows for python extensions (#45427)
+* Fix `spack load --list` and `spack unload` on Windows (#35720)
+
+## Other notable changes
+* Bugfix: `spack find -x` in environments (#46798)
+* Spec splices are now robust to duplicate nodes with the same name in a spec (#46382)
+* Cache per-compiler libc calculations for performance (#47213)
+* Fixed a bug in external detection for openmpi (#47541)
+* Mirror configuration allows username/password as environment variables (#46549)
+* Default library search caps maximum depth (#41945)
+* Unify interface for `spack spec` and `spack solve` commands (#47182)
+* Spack no longer RPATHs directories in the default library search path (#44686)
+* Improved performance of Spack database (#46554)
+* Enable package reuse for packages with versions from git refs (#43859)
+* Improved handling for `uuid` virtual on macos (#43002)
+* Improved tracking of task queueing/requeueing in the installer (#46293)
+
+## Spack community stats
+
+* Over 2,000 pull requests updated package recipes
+* 8,307 total packages, 329 new since `v0.22.0`
+    * 140 new Python packages
+    * 14 new R packages
+* 373 people contributed to this release
+    * 357 committers to packages
+    * 60 committers to core
+
+
 # v0.22.2 (2024-09-21)
 
 ## Bugfixes
@@ -419,7 +1482,7 @@
 - spack graph: fix coloring with environments (#41240)
 - spack info: sort variants in --variants-by-name (#41389)
 - Spec.format: error on old style format strings (#41934)
-- ASP-based solver: 
+- ASP-based solver:
   - fix infinite recursion when computing concretization errors (#41061)
   - don't error for type mismatch on preferences (#41138)
   - don't emit spurious debug output (#41218)

--- a/etc/spack/defaults/repos.yaml
+++ b/etc/spack/defaults/repos.yaml
@@ -13,3 +13,4 @@
 repos:
   builtin:
     git: https://github.com/spack/spack-packages.git
+    branch: releases/v2025.07

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -10,7 +10,7 @@ import spack.paths
 import spack.util.git
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0"
 spack_version = __version__
 
 #: The current Package API version implemented by this version of Spack. The Package API defines


### PR DESCRIPTION
- [x] point packages to `v2025.07`
- [x] Set version to `v1.0.0` and update `CHANGELOG.md`