### PR TITLE
package repos: store in $user_cache/package_repos

### DIFF
--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -101,6 +101,9 @@ default_monitor_path = os.path.join(reports_path, "monitor")
 #: git repositories fetched to compare commits to versions
 user_repos_cache_path = os.path.join(user_cache_path, "git_repos")
 
+#: default location where remote package repositories are cloned
+package_repos_path = os.path.join(user_cache_path, "package_repos")
+
 #: bootstrap store for bootstrapping clingo and other tools
 default_user_bootstrap_path = os.path.join(user_cache_path, "bootstrap")
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1843,7 +1843,7 @@ def parse_config_descriptor(
 
         if destination is None:  # use a default destination
             dir_name = spack.util.hash.b32_hash(repository)[-7:]
-            destination = os.path.join(spack.paths.user_repos_cache_path, dir_name)
+            destination = os.path.join(spack.paths.package_repos_path, dir_name)
         else:
             destination = spack.util.path.canonicalize_path(destination)
 


### PR DESCRIPTION
previous it was `$user_cache/git_repos`, but this dir was used for
package source downloads, which should be (although not implemented
currently) cleared by `spack clean` `--downloads`. Package repos
should not be removed of course.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
