### PR TITLE
fix: `spack compilers` lacks `--remote` argument

### DIFF
--- a/lib/spack/spack/cmd/compilers.py
+++ b/lib/spack/spack/cmd/compilers.py
@@ -16,6 +16,9 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "--scope", action=arguments.ConfigScope, help="configuration scope to read/modify"
     )
+    subparser.add_argument(
+        "--remote", action="store_true", help="list also compilers from registered buildcaches"
+    )
 
 
 def compilers(parser, args):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -816,7 +816,7 @@ _spack_compiler_info() {
 }
 
 _spack_compilers() {
-    SPACK_COMPREPLY="-h --help --scope"
+    SPACK_COMPREPLY="-h --help --scope --remote"
 }
 
 _spack_concretize() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1147,11 +1147,13 @@ complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
 
 # spack compilers
-set -g __fish_spack_optspecs_spack_compilers h/help scope=
+set -g __fish_spack_optspecs_spack_compilers h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -d 'configuration scope to read/modify'
+complete -c spack -n '__fish_spack_using_command compilers' -l remote -f -a remote
+complete -c spack -n '__fish_spack_using_command compilers' -l remote -d 'list also compilers from registered buildcaches'
 
 # spack concretize
 set -g __fish_spack_optspecs_spack_concretize h/help f/force test= q/quiet U/fresh reuse fresh-roots deprecated j/jobs=


### PR DESCRIPTION
This is expected by the common `compiler_list` function that is also called from `spack compiler list`.
I think `--remote` was introduced in https://github.com/spack/spack/pull/50682

Without this you get an error like

```console
$ spack compilers
==> Error: 'Namespace' object has no attribute 'remote'
```
