### PR TITLE
remove `spack.paths.packages_path`

### DIFF
--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -16,7 +16,6 @@ import spack.environment
 import spack.modules
 import spack.paths
 import spack.platforms
-import spack.repo
 import spack.spec
 import spack.store
 import spack.util.path
@@ -148,7 +147,7 @@ def _ensure_bootstrap_configuration() -> Generator:
     user_configuration = _read_and_sanitize_configuration()
     with spack.environment.no_active_environment(), spack.platforms.use_platform(
         spack.platforms.real_host()
-    ), spack.repo.use_repositories(spack.paths.packages_path), spack.config.use_configuration(
+    ), spack.config.use_configuration(
         # Default configuration scopes excluding command line and builtin
         *_bootstrap_config_scopes()
     ), spack.store.use_store(

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -140,4 +140,4 @@ def edit(parser, args):
         spack.util.editor.editor(*paths)
     else:
         # By default open the directory where packages live
-        spack.util.editor.editor(spack.paths.packages_path)
+        spack.util.editor.editor(spack.repo.PATH.repos[0].packages_path)

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -56,7 +56,6 @@ var_path = os.path.join(prefix, "var", "spack")
 # read-only things in $spack/var/spack
 repos_path = os.path.join(var_path, "repos")
 test_repos_path = os.path.join(var_path, "test_repos")
-packages_path = os.path.join(repos_path, "spack_repo", "builtin")
 mock_packages_path = os.path.join(test_repos_path, "spack_repo", "builtin_mock")
 
 #

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -10,7 +10,6 @@ import spack.bootstrap.core
 import spack.compilers.config
 import spack.config
 import spack.environment
-import spack.paths
 import spack.store
 import spack.util.path
 
@@ -132,9 +131,7 @@ def test_bootstrap_disables_modulefile_generation(mutable_config):
 
 @pytest.mark.regression("25992")
 @pytest.mark.requires_executables("gcc")
-def test_bootstrap_search_for_compilers_with_no_environment(no_packages_yaml, monkeypatch):
-    monkeypatch.setattr(spack.paths, "packages_path", spack.paths.mock_packages_path)
-
+def test_bootstrap_search_for_compilers_with_no_environment(no_packages_yaml, mock_packages):
     assert not spack.compilers.config.all_compilers(init_config=False)
     with spack.bootstrap.ensure_bootstrap_configuration():
         assert spack.compilers.config.all_compilers(init_config=False)
@@ -144,10 +141,8 @@ def test_bootstrap_search_for_compilers_with_no_environment(no_packages_yaml, mo
 @pytest.mark.regression("25992")
 @pytest.mark.requires_executables("gcc")
 def test_bootstrap_search_for_compilers_with_environment_active(
-    no_packages_yaml, active_mock_environment, monkeypatch
+    no_packages_yaml, active_mock_environment, mock_packages
 ):
-    monkeypatch.setattr(spack.paths, "packages_path", spack.paths.mock_packages_path)
-
     assert not spack.compilers.config.all_compilers(init_config=False)
     with spack.bootstrap.ensure_bootstrap_configuration():
         assert spack.compilers.config.all_compilers(init_config=False)

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -15,6 +15,9 @@ export SPACK_ROOT=$(realpath "$QA_DIR/../../..")
 # Source the setup script
 . "$SPACK_ROOT/share/spack/setup-env.sh"
 
+# Ensure that clingo is bootstrapped
+spack spec zlib > /dev/null
+
 # by default coverage is off.
 coverage=""
 coverage_run=""


### PR DESCRIPTION
`spack.paths.packages_path` is no longer a constant, and shouldn't be used.

I've removed `use_repositories(<builtin path>)` from bootstrap; I can something similar back later, but not now.

Notice that `spack --mock` now tries to bootstrap clingo from the mock repo, which fails ;)