### PR TITLE
gha: disable pip cache due to slowness

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,6 @@ jobs:
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
       with:
         python-version: '3.11'
-        cache: 'pip'
 
     - name: Install python dependencies
       run: pip install -r .github/workflows/requirements/coverage/requirements.txt

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -24,8 +24,6 @@ jobs:
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
       with:
         python-version: '3.13'
-        cache: 'pip'
-        cache-dependency-path: '.github/workflows/requirements/style/requirements.txt'
     - name: Install Python Packages
       run: |
         pip install -r .github/workflows/requirements/style/requirements.txt
@@ -46,8 +44,6 @@ jobs:
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
       with:
         python-version: '3.13'
-        cache: 'pip'
-        cache-dependency-path: '.github/workflows/requirements/style/requirements.txt'
     - name: Install Python packages
       run: |
         pip install -r .github/workflows/requirements/style/requirements.txt


### PR DESCRIPTION
setup-python action is terribly slow (currently 8 mins overhead)

disable pip cache until it's fixed upstream
