### PR TITLE
The Cmake from spack needs c and cxx as dependency to work

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/brahma/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/brahma/package.py
@@ -30,6 +30,7 @@ class Brahma(CMakePackage):
 
     variant("mpi", default=False, description="Enable MPI support")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     depends_on("cpp-logger@0.0.1", when="@:0.0.1")

--- a/var/spack/repos/spack_repo/builtin/packages/cpp_logger/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/cpp_logger/package.py
@@ -23,4 +23,5 @@ class CppLogger(CMakePackage):
     version("0.0.2", tag="v0.0.2", commit="329a48401033d2d2a1f1196141763cab029220ae")
     version("0.0.1", tag="v0.0.1", commit="d48b38ab14477bb7c53f8189b8b4be2ea214c28a")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
