### PR TITLE
w3nco: Fix for gcc@14

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/w3nco/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/w3nco/package.py
@@ -30,7 +30,7 @@ class W3nco(CMakePackage):
                 self.spec.satisfies("%oneapi")
                 or self.spec.satisfies("%apple-clang")
                 or self.spec.satisfies("%clang")
-                or self.spec.satisfies("%gcc@14")
+                or self.spec.satisfies("%gcc@14:")
             ):
                 flags.append("-Wno-error=implicit-function-declaration")
         return (flags, None, None)

--- a/var/spack/repos/spack_repo/builtin/packages/w3nco/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/w3nco/package.py
@@ -30,6 +30,7 @@ class W3nco(CMakePackage):
                 self.spec.satisfies("%oneapi")
                 or self.spec.satisfies("%apple-clang")
                 or self.spec.satisfies("%clang")
+                or self.spec.satisfies("%gcc@14")
             ):
                 flags.append("-Wno-error=implicit-function-declaration")
         return (flags, None, None)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Testing with spack and GCC 14 found that `w3nco` was failing with:

```
  >> 177    /home/ubuntu/tmpdir/spack-stage/spack-stage-w3nco-2.4.1-f3akx5giiz5svjgkxq4vtv7d4uo7tgqz/spack-src/src/summary.c:259:13: error: implicit declaration of function 'times'; did you mean 'utime
            s'? [-Wimplicit-function-declaration]
     178      259 |       ret = times (&Time_buffer);
     179          |             ^~~~~
     180          |             utimes
```

Since the recipe puts `-Wno-error=implicit-function-declaration` for other compilers, I added `gcc@14:`

NOTE: It's possible older GCC might also need this, but I only have GCC 14 around to test.