### PR TITLE
dpdk: enable building on aarch64

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/dpdk/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/dpdk/package.py
@@ -32,8 +32,6 @@ class Dpdk(MakefilePackage, MesonPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    conflicts("target=aarch64:", msg="DPDK is not supported on aarch64.")
-
     # Build system
     build_system(
         conditional("meson", when="@22.11:"),
@@ -50,7 +48,10 @@ class Dpdk(MakefilePackage, MesonPackage):
 
 class MesonBuilder(MesonBuilder):
     def meson_args(self):
-        return ["--warnlevel=2"]
+        args = ["--warnlevel=2"]
+        if self.spec.satifies("target=aarch64:"):
+            args.append("-Dplatform=generic")
+        return args
 
 
 class MakefileBuilder(MakefileBuilder):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Enable building dpdk on aarch64.