### PR TITLE
allow user repo config without repeating `git` / make repo init lazy / improve `spack repo list`

### DIFF
--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -12,6 +12,7 @@ import sys
 import llnl.util.tty as tty
 
 import spack
+import spack.repo
 
 description = "launch an interpreter as spack would launch a command"
 section = "developer"
@@ -74,6 +75,9 @@ def python(parser, args, unknown_args):
     # Unexpected behavior from supplying both
     if args.python_command and args.python_args:
         tty.die("You can only specify a command OR script, but not both.")
+
+    # Ensure that spack.repo.PATH is initialized
+    spack.repo.PATH.repos
 
     # Run user choice of interpreter
     if args.python_interpreter == "ipython":

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -42,7 +42,6 @@ import spack.environment.environment
 import spack.error
 import spack.paths
 import spack.platforms
-import spack.repo
 import spack.solver.asp
 import spack.spec
 import spack.store
@@ -560,9 +559,6 @@ def setup_main_options(args):
     # Use the spack config command to handle parsing the config strings
     for config_var in args.config_vars or []:
         spack.config.add(fullpath=config_var, scope="command_line")
-
-    # In the main function we automatically fetch remote package repositories if necessary
-    spack.repo.enable_repo(spack.repo.RepoPath.from_config(spack.config.CONFIG))
 
     # On Windows10 console handling for ASCI/VT100 sequences is not
     # on by default. Turn on before we try to write to console

--- a/lib/spack/spack/schema/repos.py
+++ b/lib/spack/spack/schema/repos.py
@@ -39,7 +39,6 @@ properties: Dict[str, Any] = {
                                 "destination": {"type": "string"},
                                 "paths": {"type": "array", "items": {"type": "string"}},
                             },
-                            "required": ["git"],
                             "additionalProperties": False,
                         },
                     ]

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -631,6 +631,16 @@ def test_parse_config_descriptor_local(tmp_path: pathlib.Path):
     assert descriptor.path == str(tmp_path / "local_repo")
 
 
+def test_parse_config_descriptor_no_git(tmp_path: pathlib.Path):
+    """Test that we can parse a descriptor without a git key."""
+    with pytest.raises(RuntimeError, match="Invalid configuration for repository"):
+        spack.repo.parse_config_descriptor(
+            name="name",
+            descriptor={"destination": str(tmp_path / "some/destination"), "paths": ["some/path"]},
+            lock=spack.util.lock.Lock(str(tmp_path / "x"), enable=False),
+        )
+
+
 def test_repo_descriptors_construct(tmp_path: pathlib.Path):
     """Test the RepoDescriptors construct function. Ensure it does not raise when we cannot
     construct a Repo instance, e.g. due to missing repo.yaml file. Check that it parses the

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1793,7 +1793,7 @@ _spack_repo() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create list add remove rm migrate"
+        SPACK_COMPREPLY="create list add set remove rm migrate"
     fi
 }
 
@@ -1816,6 +1816,15 @@ _spack_repo_add() {
         SPACK_COMPREPLY="-h --help --name --path --scope"
     else
         SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_repo_set() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --destination --path --scope"
+    else
+        _repos
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2764,6 +2764,7 @@ set -g __fish_spack_optspecs_spack_repo h/help
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a create -d 'create a new package repository'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a list -d 'show registered repositories and their namespaces'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a add -d 'add package repositories to Spack'"'"'s configuration'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a set -d 'modify an existing repository configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a rm -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a migrate -d 'migrate a package repository to the latest Package API'
@@ -2796,6 +2797,18 @@ complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
+
+# spack repo set
+set -g __fish_spack_optspecs_spack_repo_set h/help destination= path= scope=
+
+complete -c spack -n '__fish_spack_using_command repo set' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command repo set' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -f -a destination
+complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -d 'destination to clone git repository into'
+complete -c spack -n '__fish_spack_using_command repo set' -l path -r -f -a path
+complete -c spack -n '__fish_spack_using_command repo set' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
 set -g __fish_spack_optspecs_spack_repo_remove h/help scope=


### PR DESCRIPTION
with this

* `~/.spack/repo.yaml` does not error if it is
   ```yaml
   repos:
     builtin:
      destination: ~/spack-packages
       # git: ... # no longer required by validator; validated at runtime.
   ```
* `spack.main` no longer inits `spack.repo.PATH` -- this is done lazily to avoid that `spack repo rm` and `spack config add` etc trigger a git clone of the repo that is being removed/modified
* `spack python` inits `spack.repo.PATH` so users can do `import spack_repo.*` directly.
* `spack repo list` shows a status for uninitialized package repos with ` - `
* `spack repo set --destination ~/spack-packages builtin` gives users a way to put the spack package repo in a location of choice