### PR TITLE
spack repo: add ls alias for list

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -46,7 +46,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     # List
-    list_parser = sp.add_parser("list", help=repo_list.__doc__)
+    list_parser = sp.add_parser("list", aliases=["ls"], help=repo_list.__doc__)
     list_parser.add_argument(
         "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
     )
@@ -423,6 +423,7 @@ def repo(parser, args):
     return {
         "create": repo_create,
         "list": repo_list,
+        "ls": repo_list,
         "add": repo_add,
         "set": repo_set,
         "remove": repo_remove,

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1793,7 +1793,7 @@ _spack_repo() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create list add set remove rm migrate"
+        SPACK_COMPREPLY="create list ls add set remove rm migrate"
     fi
 }
 
@@ -1807,6 +1807,10 @@ _spack_repo_create() {
 }
 
 _spack_repo_list() {
+    SPACK_COMPREPLY="-h --help --scope"
+}
+
+_spack_repo_ls() {
     SPACK_COMPREPLY="-h --help --scope"
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2763,6 +2763,7 @@ complete -c spack -n '__fish_spack_using_command rm' -s f -l force -d 'remove co
 set -g __fish_spack_optspecs_spack_repo h/help
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a create -d 'create a new package repository'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a list -d 'show registered repositories and their namespaces'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a ls -d 'show registered repositories and their namespaces'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a add -d 'add package repositories to Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a set -d 'modify an existing repository configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 'remove a repository from Spack'"'"'s configuration'
@@ -2785,6 +2786,13 @@ complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a h
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
+
+# spack repo ls
+set -g __fish_spack_optspecs_spack_repo_ls h/help scope=
+complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -d 'configuration scope to read from'
 
 # spack repo add
 set -g __fish_spack_optspecs_spack_repo_add h/help name= path= scope=


### PR DESCRIPTION
Fixing the last spot where you can't say `ls` to mean `list` in a subcommand.