### PR TITLE
zfit: Remove version constraint on hatchling

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/py_zfit/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_zfit/package.py
@@ -47,7 +47,7 @@ class PyZfit(PythonPackage):
     depends_on("python@:3.11", type=("build", "run"), when="@:0.18")
     depends_on("python@:3.12", type=("build", "run"), when="@0.20:")
 
-    depends_on("py-hatchling@42:", type="build", when="@0.26:")
+    depends_on("py-hatchling", type="build", when="@0.26:")
     depends_on("py-hatch-vcs", type="build", when="@0.26:")
 
     depends_on("py-setuptools@42:", type="build", when="@:0.25")


### PR DESCRIPTION
#50774 Adds a new version of `zfit` and in doing so adds a version constrained dependency on `py-hatchling@42` which is not a version of `hatchling` that exists (`hatchling` latest is at 1.27).

This PR removes the constraint.

> [!NOTE] 
> #50774 breaks all audit checks on develop

cc @tldahlgren @jonas-eschle  