### PR TITLE
spack repo set

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -82,6 +82,26 @@ def setup_parser(subparser: argparse.ArgumentParser):
         help="configuration scope to modify",
     )
 
+    # Set (modify existing repository configuration)
+    set_parser = sp.add_parser("set", help=repo_set.__doc__)
+    set_parser.add_argument("namespace", help="namespace of a Spack package repository")
+    set_parser.add_argument(
+        "--destination", help="destination to clone git repository into", action="store"
+    )
+    set_parser.add_argument(
+        "--path",
+        help="relative path to the Spack package repository inside a git repository. Can be "
+        "repeated to add multiple package repositories in case of a monorepo",
+        action="append",
+        default=[],
+    )
+    set_parser.add_argument(
+        "--scope",
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
+        help="configuration scope to modify",
+    )
+
     # Remove
     remove_parser = sp.add_parser("remove", help=repo_remove.__doc__, aliases=["rm"])
     remove_parser.add_argument(
@@ -347,11 +367,46 @@ def repo_migrate(args: Any) -> int:
     return exit_code
 
 
+def repo_set(args):
+    """modify an existing repository configuration"""
+    namespace = args.namespace
+
+    # First, check if the repository exists across all scopes for validation
+    all_repos: Dict[str, Any] = spack.config.get("repos", default={})
+
+    if namespace not in all_repos:
+        raise SpackError(f"No repository with namespace '{namespace}' found in configuration.")
+
+    # Validate that it's a git repository
+    if not isinstance(all_repos[namespace], dict):
+        raise SpackError(
+            f"Repository '{namespace}' is not a git repository. "
+            "The 'set' command only works with git repositories."
+        )
+
+    # Now get the repos for the specific scope we're modifying
+    scope_repos: Dict[str, Any] = spack.config.get("repos", default={}, scope=args.scope)
+
+    updated_entry = scope_repos[namespace] if namespace in scope_repos else {}
+
+    if args.destination:
+        updated_entry["destination"] = args.destination
+
+    if args.path:
+        updated_entry["paths"] = args.path
+
+    scope_repos[namespace] = updated_entry
+    spack.config.set("repos", scope_repos, args.scope)
+
+    tty.msg(f"Updated repo '{namespace}'")
+
+
 def repo(parser, args):
     return {
         "create": repo_create,
         "list": repo_list,
         "add": repo_add,
+        "set": repo_set,
         "remove": repo_remove,
         "rm": repo_remove,
         "migrate": repo_migrate,

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1793,7 +1793,7 @@ _spack_repo() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create list add remove rm migrate"
+        SPACK_COMPREPLY="create list add set remove rm migrate"
     fi
 }
 
@@ -1816,6 +1816,15 @@ _spack_repo_add() {
         SPACK_COMPREPLY="-h --help --name --path --scope"
     else
         SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_repo_set() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --destination --path --scope"
+    else
+        _repos
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2764,6 +2764,7 @@ set -g __fish_spack_optspecs_spack_repo h/help
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a create -d 'create a new package repository'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a list -d 'show registered repositories and their namespaces'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a add -d 'add package repositories to Spack'"'"'s configuration'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a set -d 'modify an existing repository configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a rm -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a migrate -d 'migrate a package repository to the latest Package API'
@@ -2796,6 +2797,18 @@ complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
+
+# spack repo set
+set -g __fish_spack_optspecs_spack_repo_set h/help destination= path= scope=
+
+complete -c spack -n '__fish_spack_using_command repo set' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command repo set' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -f -a destination
+complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -d 'destination to clone git repository into'
+complete -c spack -n '__fish_spack_using_command repo set' -l path -r -f -a path
+complete -c spack -n '__fish_spack_using_command repo set' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
 set -g __fish_spack_optspecs_spack_repo_remove h/help scope=


### PR DESCRIPTION
```
spack repo set [-h] [--destination DESTINATION] [--path PATH] [--scope SCOPE] namespace
```

allows users to run

```
spack repo set --destination ~/spack-packages builtin
```

i.e. it gives them a way to put the spack package repo in a location of choice