### PR TITLE
docs: build should check out the local spack repo

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -50,6 +50,11 @@ sys.path[0:0] = [
     os.path.abspath(".spack/spack-packages/repos"),
 ]
 
+# Ensure that spack.repo.PATH is initialized
+import spack.repo
+
+spack.repo.PATH.repos
+
 # Generate a command index if an update is needed -- this also clones the package repository.
 subprocess.call(
     [


### PR DESCRIPTION
Documentation builds are failing because the repository isn't getting cloned automatically into `lib/spack/docs/.spack`.

- [x] fix this by referring to `spack.repo.PATH` in `conf.py`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
