### PR TITLE
Fix wrong default concretization behavior for compilers

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -617,6 +617,18 @@ error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, Lite
    Parent == BuildDependency,
    external(node(X, Parent)).
 
+% If a virtual is needed only to build a package, its provider can be considered a build requirement
+1 { virtual_build_requirement(ParentNode, node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1
+  :- attr("dependency_holds", ParentNode, Virtual, "build"),
+     not attr("dependency_holds", ParentNode, Virtual,"link"),
+     not attr("dependency_holds", ParentNode, Virtual,"run"),
+     virtual(Virtual).
+
+attr("virtual_node", VirtualNode)  :- virtual_build_requirement(ParentNode, VirtualNode).
+{ build_requirement(ParentNode, ProviderNode) } :-
+  virtual_build_requirement(ParentNode, VirtualNode),
+  provider(ProviderNode, VirtualNode).
+
 % From cli we can have literal expressions like:
 %
 % root %gcc@12.0 ^dep %gcc@11.2


### PR DESCRIPTION
fixes #50815

With this, on the reproducer:
```console
# spack solve gcc@14
[ ... ]
 -  gcc@14.3.0 [...] languages:='c,c++,fortran'
```
Unfortunately coming up with a concise unit test is hard, since the issue seems to depend on multiple directives and the compiler version used to compile `gcc@14`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
