### PR TITLE
spack repo add: prepend

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -18,6 +18,7 @@ import spack.config
 import spack.repo
 import spack.util.executable
 import spack.util.path
+import spack.util.spack_yaml
 from spack.cmd.common import arguments
 from spack.error import SpackError
 
@@ -203,8 +204,8 @@ def _add_repo(
     if key in existing:
         raise SpackError(f"A repository with the name '{key}' already exists.")
 
-    existing[key] = entry
-    config.set("repos", existing, scope)
+    # Prepend the new repository
+    config.set("repos", spack.util.spack_yaml.syaml_dict({key: entry, **existing}), scope)
     return key
 
 

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -692,3 +692,35 @@ def test_repo_set_does_not_work_on_local_path(mutable_config):
     spack.config.set("repos", {"local-repo": "/local/path"}, scope="site")
     with pytest.raises(SpackError, match="is not a git repository"):
         repo("set", "--destination", "/some/path", "local-repo")
+
+
+def test_add_repo_prepends_instead_of_appends(monkeypatch):
+    """Test that newly added repositories are prepended to the configuration,
+    giving them higher priority than existing repositories."""
+    config = make_repo_config({"existing_repo": "/path/to/existing"})
+
+    def mock_parse_config_descriptor(name, entry, lock):
+        return MockDescriptor({"/new/path": MockRepo("new_repo")})
+
+    monkeypatch.setattr(spack.repo, "parse_config_descriptor", mock_parse_config_descriptor)
+
+    # Add a new repository
+    key = spack.cmd.repo._add_repo(
+        path_or_repo="/new/path",
+        name="new_repo",
+        scope=None,
+        paths=[],
+        destination=None,
+        config=config,
+    )
+
+    assert key == "new_repo"
+
+    # Check that the new repository is first in the configuration
+    repos_config = config.get("repos", scope=None)
+    repo_names = list(repos_config.keys())
+
+    # The new repository should be first (highest priority)
+    assert repo_names == ["new_repo", "existing_repo"]
+    assert repos_config["new_repo"] == "/new/path"
+    assert repos_config["existing_repo"] == "/path/to/existing"

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -694,19 +694,22 @@ def test_repo_set_does_not_work_on_local_path(mutable_config):
         repo("set", "--destination", "/some/path", "local-repo")
 
 
-def test_add_repo_prepends_instead_of_appends(monkeypatch):
+def test_add_repo_prepends_instead_of_appends(monkeypatch, tmp_path):
     """Test that newly added repositories are prepended to the configuration,
     giving them higher priority than existing repositories."""
-    config = make_repo_config({"existing_repo": "/path/to/existing"})
+    existing_path = str(tmp_path / "existing_repo")
+    new_path = str(tmp_path / "new_repo")
+
+    config = make_repo_config({"existing_repo": existing_path})
 
     def mock_parse_config_descriptor(name, entry, lock):
-        return MockDescriptor({"/new/path": MockRepo("new_repo")})
+        return MockDescriptor({new_path: MockRepo("new_repo")})
 
     monkeypatch.setattr(spack.repo, "parse_config_descriptor", mock_parse_config_descriptor)
 
     # Add a new repository
     key = spack.cmd.repo._add_repo(
-        path_or_repo="/new/path",
+        path_or_repo=new_path,
         name="new_repo",
         scope=None,
         paths=[],
@@ -722,5 +725,5 @@ def test_add_repo_prepends_instead_of_appends(monkeypatch):
 
     # The new repository should be first (highest priority)
     assert repo_names == ["new_repo", "existing_repo"]
-    assert repos_config["new_repo"] == "/new/path"
-    assert repos_config["existing_repo"] == "/path/to/existing"
+    assert repos_config["new_repo"] == new_path
+    assert repos_config["existing_repo"] == existing_path


### PR DESCRIPTION
After the `repos.yaml` format went from list to dict, we started erroneously appending repos upon `spack repo add`. This commit fixes that.