### PR TITLE
spack debug report: include builtin commit

### DIFF
--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -3,11 +3,17 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import os
 import platform
+import re
+from typing import Optional
 
 import spack
+import spack.config
 import spack.platforms
+import spack.repo
 import spack.spec
+import spack.util.git
 
 description = "debugging commands for troubleshooting Spack"
 section = "developer"
@@ -19,12 +25,48 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     sp.add_parser("report", help="print information useful for bug reports")
 
 
+def _get_builtin_repo_commit() -> Optional[str]:
+    """Get the builtin package repository git commit sha."""
+    # Get builtin from config
+    descriptors = spack.repo.RepoDescriptors.from_config(
+        spack.repo.package_repository_lock(), spack.config.CONFIG
+    )
+
+    if "builtin" not in descriptors:
+        return None
+
+    builtin = descriptors["builtin"]
+
+    if not isinstance(builtin, spack.repo.RemoteRepoDescriptor) or not builtin.fetched():
+        return None  # no git info
+
+    git = spack.util.git.git(required=False)
+    if not git:
+        return None
+
+    rev = git(
+        "-C",
+        builtin.destination,
+        "rev-parse",
+        "HEAD",
+        output=str,
+        error=os.devnull,
+        fail_on_error=False,
+    )
+    if git.returncode != 0:
+        return None
+
+    match = re.match(r"[a-f\d]{7,}$", rev)
+    return match.group(0) if match else None
+
+
 def report(args):
     host_platform = spack.platforms.host()
     host_os = host_platform.default_operating_system()
     host_target = host_platform.default_target()
     architecture = spack.spec.ArchSpec((str(host_platform), str(host_os), str(host_target)))
     print("* **Spack:**", spack.get_version())
+    print("* **Builtin repo:**", _get_builtin_repo_commit() or "not available")
     print("* **Python:**", platform.python_version())
     print("* **Platform:**", architecture)
 


### PR DESCRIPTION
For bug reports we now need to know two commits: spack and pkg repo.