### PR TITLE
Fix equality for specs

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -777,6 +777,7 @@ class DependencySpec:
         yield self.spec.name if self.spec else None
         yield self.depflag
         yield self.virtuals
+        yield self.direct
 
     def __str__(self) -> str:
         parent = self.parent.name if self.parent else None
@@ -3970,6 +3971,7 @@ class Spec:
                         node_ids[id(edge.spec)],
                         edge.depflag,
                         edge.virtuals,
+                        edge.direct,
                     )
                 )
 
@@ -3980,7 +3982,7 @@ class Spec:
 
             # level 1 edges all start with zero
             for i, edge in enumerate(sorted_l1_edges, start=1):
-                yield (0, i, edge.depflag, edge.virtuals)
+                yield (0, i, edge.depflag, edge.virtuals, edge.direct)
 
             # yield remaining edges in the order they were encountered during traversal
             if edge_list:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2169,7 +2169,7 @@ EMPTY_FLG = Spec().compiler_flags
                     ("a", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                     ("b", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
-                ((0, 1, 0, ()),),
+                ((0, 1, 0, (), False),),
             ),
         ],
         # root with multiple deps
@@ -2182,7 +2182,7 @@ EMPTY_FLG = Spec().compiler_flags
                     ("c", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                     ("d", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
-                ((0, 1, 0, ()), (0, 2, 0, ()), (0, 3, 0, ())),
+                ((0, 1, 0, (), False), (0, 2, 0, (), False), (0, 3, 0, (), False)),
             ),
         ],
         # root with multiple build deps
@@ -2195,7 +2195,7 @@ EMPTY_FLG = Spec().compiler_flags
                     ("c", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                     ("d", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
-                ((0, 1, 0, ()), (0, 2, 0, ()), (0, 3, 0, ())),
+                ((0, 1, 0, (), True), (0, 2, 0, (), True), (0, 3, 0, (), True)),
             ),
         ],
         # dependencies with dependencies
@@ -2212,12 +2212,12 @@ EMPTY_FLG = Spec().compiler_flags
                     ("g", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
                 (
-                    (0, 1, 0, ()),
-                    (0, 2, 0, ()),
-                    (1, 3, 0, ()),
-                    (1, 4, 0, ()),
-                    (2, 5, 0, ()),
-                    (2, 6, 0, ()),
+                    (0, 1, 0, (), False),
+                    (0, 2, 0, (), False),
+                    (1, 3, 0, (), True),
+                    (1, 4, 0, (), True),
+                    (2, 5, 0, (), True),
+                    (2, 6, 0, (), True),
                 ),
             ),
         ],
@@ -2310,3 +2310,17 @@ def test_spec_format_with_compiler_adaptors(
     """Tests the output of spec format, when involving `Spec.compiler` adaptors"""
     s = default_mock_concretization(spec_str)
     assert s.format(spec_fmt) == expected
+
+
+@pytest.mark.parametrize(
+    "lhs,rhs,expected",
+    [
+        ("mpich %gcc", "mpich %gcc", True),
+        ("mpich %gcc", "mpich ^gcc", False),
+        ("mpich ^callpath %gcc", "mpich %gcc ^callpath", False),
+    ],
+)
+def test_specs_equality(lhs, rhs, expected):
+    """Tests the semantic of == for abstract specs"""
+    lhs, rhs = Spec(lhs), Spec(rhs)
+    assert (lhs == rhs) is expected


### PR DESCRIPTION
Before the `.direct` attribute of edges was not taken into account, therefore:
```
foo %gcc == foo ^gcc
```

This commit fixes the issue

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
