### PR TITLE
max 1 process for installs on windows

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1492,6 +1492,8 @@ class PackageInstaller:
         """
         if sys.platform == "win32":
             # No locks on Windows, we should always use 1 process
+            # TODO: perhaps raise an error instead and update cmd-line interface
+            # to omit this option on Windows for nwo
             concurrent_packages = 1
 
         if isinstance(explicit, bool):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1428,6 +1428,13 @@ class RewireTask(Task):
             self.record.fail(e)
 
 
+if sys.platform == "win32":
+    # No locks on Windows, we should always use 1 process
+    _default_concurrent_procs = 1
+else:
+    _default_concurrent_procs = 4
+
+
 class PackageInstaller:
     """
     Class for managing the install process for a Spack instance based on a bottom-up DAG approach.
@@ -1464,7 +1471,7 @@ class PackageInstaller:
         unsigned: Optional[bool] = None,
         use_cache: bool = False,
         verbose: bool = False,
-        concurrent_packages: int = 4,
+        concurrent_packages: int = _default_concurrent_procs,
     ) -> None:
         """
         Arguments:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1428,13 +1428,6 @@ class RewireTask(Task):
             self.record.fail(e)
 
 
-if sys.platform == "win32":
-    # No locks on Windows, we should always use 1 process
-    _default_concurrent_procs = 1
-else:
-    _default_concurrent_procs = 4
-
-
 class PackageInstaller:
     """
     Class for managing the install process for a Spack instance based on a bottom-up DAG approach.
@@ -1471,7 +1464,7 @@ class PackageInstaller:
         unsigned: Optional[bool] = None,
         use_cache: bool = False,
         verbose: bool = False,
-        concurrent_packages: int = _default_concurrent_procs,
+        concurrent_packages: int,
     ) -> None:
         """
         Arguments:
@@ -1497,6 +1490,10 @@ class PackageInstaller:
             verbose: Display verbose build output (by default, suppresses it)
             concurrent_packages: Max packages to be built concurrently
         """
+        if sys.platform == "win32":
+            # No locks on Windows, we should always use 1 process
+            concurrent_packages = 1
+
         if isinstance(explicit, bool):
             explicit = {pkg.spec.dag_hash() for pkg in packages} if explicit else set()
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1464,7 +1464,7 @@ class PackageInstaller:
         unsigned: Optional[bool] = None,
         use_cache: bool = False,
         verbose: bool = False,
-        concurrent_packages: int,
+        concurrent_packages: int = 4,
     ) -> None:
         """
         Arguments:


### PR DESCRIPTION
This was necessary for me in https://github.com/spack/spack/pull/47615

(update: this works now) ~However, @johnwparent is observing mixed output on windows that suggests it is still doing a concurrent install, so this is probably not sufficient to suppress it everywhere.~

