### PR TITLE
spack cd/location --repo <namespace>

### DIFF
--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -48,7 +48,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--packages",
         "-P",
         nargs="?",
-        const=True,
         default=False,
         metavar="repo",
         help="package repository root (defaults to first configured repository)",
@@ -117,7 +116,7 @@ def location(parser, args):
         return
 
     if args.repo is not False:
-        if args.repo is True:
+        if args.repo is None:
             print(spack.repo.PATH.first_repo().root)
             return
         try:

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -43,7 +43,15 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="directory enclosing a spec's package.py file",
     )
     directories.add_argument(
-        "-P", "--packages", action="store_true", help="top-level packages directory for Spack"
+        "--repo",
+        # for backwards compatibility
+        "--packages",
+        "-P",
+        nargs="?",
+        const=True,
+        default=False,
+        metavar="repo",
+        help="package repository root (defaults to first configured repository)",
     )
     directories.add_argument(
         "-s", "--stage-dir", action="store_true", help="stage directory for a spec"
@@ -108,8 +116,14 @@ def location(parser, args):
         print(path)
         return
 
-    if args.packages:
-        print(spack.repo.PATH.first_repo().root)
+    if args.repo is not False:
+        if args.repo is True:
+            print(spack.repo.PATH.first_repo().root)
+            return
+        try:
+            print(spack.repo.PATH.get_repo(args.repo).root)
+        except spack.repo.UnknownNamespaceError:
+            tty.die(f"no such repository: '{args.repo}'")
         return
 
     if args.stages:

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import shutil
 
 import pytest
@@ -11,6 +12,7 @@ from llnl.util.filesystem import mkdirp
 import spack.concretize
 import spack.environment as ev
 import spack.paths
+import spack.repo
 import spack.stage
 from spack.main import SpackCommand, SpackCommandError
 
@@ -172,3 +174,24 @@ def test_location_stage_dir(mock_spec):
 def test_location_stages(mock_spec):
     """Tests spack location --stages."""
     assert location("--stages").strip() == spack.stage.get_stage_root()
+
+
+def test_location_specified_repo():
+    """Tests spack location --repo <repo>."""
+    with spack.repo.use_repositories(
+        os.path.join(spack.paths.test_repos_path, "spack_repo", "builtin_mock"),
+        os.path.join(spack.paths.test_repos_path, "spack_repo", "builder_test"),
+    ):
+        assert location("--repo").strip() == spack.repo.PATH.get_repo("builtin_mock").root
+        assert (
+            location("--repo", "builtin_mock").strip()
+            == spack.repo.PATH.get_repo("builtin_mock").root
+        )
+        assert (
+            location("--packages", "builder_test").strip()
+            == spack.repo.PATH.get_repo("builder_test").root
+        )
+        assert (
+            location("--repo", "nonexistent", fail_on_error=False).strip()
+            == "==> Error: no such repository: 'nonexistent'"
+        )

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -663,7 +663,7 @@ _spack_buildcache_migrate() {
 _spack_cd() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env --first"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir --repo --packages -P -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env --first"
     else
         _all_packages
     fi
@@ -1401,7 +1401,7 @@ _spack_load() {
 _spack_location() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env --first"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir --repo --packages -P -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env --first"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -875,7 +875,7 @@ complete -c spack -n '__fish_spack_using_command buildcache migrate' -s y -l yes
 complete -c spack -n '__fish_spack_using_command buildcache migrate' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack cd
-set -g __fish_spack_optspecs_spack_cd h/help m/module-dir r/spack-root i/install-dir p/package-dir P/packages s/stage-dir S/stages c/source-dir b/build-dir e/env= first
+set -g __fish_spack_optspecs_spack_cd h/help m/module-dir r/spack-root i/install-dir p/package-dir repo= s/stage-dir S/stages c/source-dir b/build-dir e/env= first
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 cd' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command cd' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command cd' -s h -l help -d 'show this help message and exit'
@@ -887,8 +887,8 @@ complete -c spack -n '__fish_spack_using_command cd' -s i -l install-dir -f -a i
 complete -c spack -n '__fish_spack_using_command cd' -s i -l install-dir -d 'install prefix for spec (spec need not be installed)'
 complete -c spack -n '__fish_spack_using_command cd' -s p -l package-dir -f -a package_dir
 complete -c spack -n '__fish_spack_using_command cd' -s p -l package-dir -d 'directory enclosing a spec'"'"'s package.py file'
-complete -c spack -n '__fish_spack_using_command cd' -s P -l packages -f -a packages
-complete -c spack -n '__fish_spack_using_command cd' -s P -l packages -d 'top-level packages directory for Spack'
+complete -c spack -n '__fish_spack_using_command cd' -l repo -l packages -s P -r -f -a repo
+complete -c spack -n '__fish_spack_using_command cd' -l repo -l packages -s P -r -d 'package repository root (defaults to first configured repository)'
 complete -c spack -n '__fish_spack_using_command cd' -s s -l stage-dir -f -a stage_dir
 complete -c spack -n '__fish_spack_using_command cd' -s s -l stage-dir -d 'stage directory for a spec'
 complete -c spack -n '__fish_spack_using_command cd' -s S -l stages -f -a stages
@@ -2189,7 +2189,7 @@ complete -c spack -n '__fish_spack_using_command load' -l list -f -a list
 complete -c spack -n '__fish_spack_using_command load' -l list -d 'show loaded packages: same as `spack find --loaded`'
 
 # spack location
-set -g __fish_spack_optspecs_spack_location h/help m/module-dir r/spack-root i/install-dir p/package-dir P/packages s/stage-dir S/stages c/source-dir b/build-dir e/env= first
+set -g __fish_spack_optspecs_spack_location h/help m/module-dir r/spack-root i/install-dir p/package-dir repo= s/stage-dir S/stages c/source-dir b/build-dir e/env= first
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 location' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command location' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command location' -s h -l help -d 'show this help message and exit'
@@ -2201,8 +2201,8 @@ complete -c spack -n '__fish_spack_using_command location' -s i -l install-dir -
 complete -c spack -n '__fish_spack_using_command location' -s i -l install-dir -d 'install prefix for spec (spec need not be installed)'
 complete -c spack -n '__fish_spack_using_command location' -s p -l package-dir -f -a package_dir
 complete -c spack -n '__fish_spack_using_command location' -s p -l package-dir -d 'directory enclosing a spec'"'"'s package.py file'
-complete -c spack -n '__fish_spack_using_command location' -s P -l packages -f -a packages
-complete -c spack -n '__fish_spack_using_command location' -s P -l packages -d 'top-level packages directory for Spack'
+complete -c spack -n '__fish_spack_using_command location' -l repo -l packages -s P -r -f -a repo
+complete -c spack -n '__fish_spack_using_command location' -l repo -l packages -s P -r -d 'package repository root (defaults to first configured repository)'
 complete -c spack -n '__fish_spack_using_command location' -s s -l stage-dir -f -a stage_dir
 complete -c spack -n '__fish_spack_using_command location' -s s -l stage-dir -d 'stage directory for a spec'
 complete -c spack -n '__fish_spack_using_command location' -s S -l stages -f -a stages


### PR DESCRIPTION
Closes #50819

```
spack location --packages
spack cd --packages
```

is replaced by

```
spack location --repo [repo]
spack cd --repo [repo]
```

where `[repo]` is optional. If not provided it will go to the top-level package repo.

The old `--packages` flag is an alias for `--repo` for backward compat. I just found `--packages` slightly confusing, given that a repo contains a packages dir, but the command shows the location of the root.