### PR TITLE
resolve binary provenance to version commit if specified

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1049,6 +1049,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             ref = self.spec.version.ref
         else:
             v_attrs = self.versions.get(self.spec.version, {})
+            if "commit" in v_attrs:
+                self.spec.variants["commit"] = spack.variant.SingleValuedVariant(
+                    "commit", v_attrs["commit"]
+                )
+                return
             ref = v_attrs.get("tag") or v_attrs.get("branch")
 
         if not ref:

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -332,6 +332,12 @@ def test_deserialize_preserves_package_attribute(default_mock_concretization):
     assert y.spec._package is y
 
 
+@pytest.mark.require_provenance
+def test_binary_provenance_commit_version(mock_packages):
+    spec = spack.concretize.concretize_one("git-ref-package@stable")
+    assert spec.satisfies(f"commit={'c' * 40}")
+
+
 @pytest.mark.parametrize("version", ("main", "tag"))
 @pytest.mark.parametrize("pre_stage", (True, False))
 @pytest.mark.require_provenance


### PR DESCRIPTION
Fixes a bug in #50604 related to versions specified with a commit but no tag nor branch.

Also improves performance for versions that specify tag+commit.
