### PR TITLE
config: CLI scopes should override environments

### DIFF
--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -19,6 +19,6 @@ class ConfigScopePriority(enum.IntEnum):
 
     BUILTIN = 0
     CONFIG_FILES = 1
-    CUSTOM = 2
-    ENVIRONMENT = 3
+    ENVIRONMENT = 2
+    CUSTOM = 3
     COMMAND_LINE = 4

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2952,11 +2952,11 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             ensure_no_disallowed_env_config_mods(self._env_config_scope)
         return self._env_config_scope
 
-    def prepare_config_scope(self) -> None:
+    def prepare_config_scope(
+        self, priority: ConfigScopePriority = ConfigScopePriority.ENVIRONMENT
+    ) -> None:
         """Add the manifest's scope to the global configuration search path."""
-        spack.config.CONFIG.push_scope(
-            self.env_config_scope, priority=ConfigScopePriority.ENVIRONMENT
-        )
+        spack.config.CONFIG.push_scope(self.env_config_scope, priority)
 
     def deactivate_config_scope(self) -> None:
         """Remove the manifest's scope from the global config path."""

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1351,8 +1351,8 @@ def test_env_activation_preserves_config_scopes(mutable_mock_env_path):
     custom_scope = spack.config.InternalConfigScope("custom_scope")
     spack.config.CONFIG.push_scope(custom_scope, priority=ConfigScopePriority.CUSTOM)
     expected_scopes_without_env = ["custom_scope", "command_line"]
-    expected_scopes_with_first_env = ["custom_scope", "env:test", "command_line"]
-    expected_scopes_with_second_env = ["custom_scope", "env:test-2", "command_line"]
+    expected_scopes_with_first_env = ["env:test", "custom_scope", "command_line"]
+    expected_scopes_with_second_env = ["env:test-2", "custom_scope", "command_line"]
 
     def highest_priority_scopes(config, *, nscopes):
         return list(config.scopes)[-nscopes:]

--- a/share/spack/qa/scopes/false/concretizer.yaml
+++ b/share/spack/qa/scopes/false/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  unify: false

--- a/share/spack/qa/scopes/true/spack.yaml
+++ b/share/spack/qa/scopes/true/spack.yaml
@@ -1,0 +1,3 @@
+spack:
+  concretizer:
+    unify: true

--- a/share/spack/qa/scopes/wp/concretizer.yaml
+++ b/share/spack/qa/scopes/wp/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  unify: "when_possible"

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -222,17 +222,51 @@ succeeds spack -c config:ccache:true python "$SHARE_DIR/qa/config_state.py"
 
 spack env deactivate
 
+
+# -----------------------------------------------------------------------
+# Make sure environments and custom scopes on the CLI have the right
+# precedence, based on order of appearance
+# -----------------------------------------------------------------------
 echo "Testing correct scope precedence on command line"
-contains 'unify: true' spack -e scopes/true config get concretizer
-contains 'unify: true' spack -D scopes/true config get concretizer
-contains 'unify: false' spack -C scopes/false config get concretizer
-contains 'unify: when_possible' spack -C scopes/wp config get concretizer
+contains 'unify: true' spack -e $QA_DIR/scopes/true config get concretizer
+contains 'unify: true' spack -D $QA_DIR/scopes/true config get concretizer
+contains 'unify: false' spack -C $QA_DIR/scopes/false config get concretizer
+contains 'unify: when_possible' spack -C $QA_DIR/scopes/wp config get concretizer
+contains 'unify: false' \
+         spack -C $QA_DIR/scopes/wp -C $QA_DIR/scopes/false config get concretizer
 
-contains 'unify: true' spack -C scopes/wp -C scopes/false -e scopes/true config get concretizer
-contains 'unify: false' spack -C scopes/wp -C scopes/false config get concretizer
-contains 'unify: when_possible' spack -C scopes/false -e scopes/true -C scopes/wp config get concretizer
-contains 'unify: false' spack -e scopes/true -C scopes/wp -C scopes/false config get concretizer
+contains 'unify: true' \
+         spack -C $QA_DIR/scopes/wp \
+               -C $QA_DIR/scopes/false \
+               -e $QA_DIR/scopes/true \
+               config get concretizer
 
-contains 'unify: true' spack -C scopes/wp -C scopes/false -D scopes/true config get concretizer
-contains 'unify: when_possible' spack -C scopes/false -D scopes/true -C scopes/wp config get concretizer
-contains 'unify: false' spack -D scopes/true -C scopes/wp -C scopes/false config get concretizer
+contains 'unify: when_possible' \
+         spack -C $QA_DIR/scopes/false \
+               -e $QA_DIR/scopes/true \
+               -C $QA_DIR/scopes/wp \
+               config get concretizer
+
+contains 'unify: false' \
+         spack -e $QA_DIR/scopes/true \
+               -C $QA_DIR/scopes/wp \
+               -C $QA_DIR/scopes/false \
+         config get concretizer
+
+contains 'unify: true' \
+         spack -C $QA_DIR/scopes/wp \
+               -C $QA_DIR/scopes/false \
+               -D $QA_DIR/scopes/true \
+         config get concretizer
+
+contains 'unify: when_possible' \
+         spack -C $QA_DIR/scopes/false \
+               -D $QA_DIR/scopes/true \
+               -C $QA_DIR/scopes/wp \
+               config get concretizer
+
+contains 'unify: false' \
+         spack -D $QA_DIR/scopes/true \
+               -C $QA_DIR/scopes/wp \
+               -C $QA_DIR/scopes/false \
+              config get concretizer

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -221,3 +221,18 @@ contains 'True' spack -c config:ccache:true python -c "import spack.config;print
 succeeds spack -c config:ccache:true python "$SHARE_DIR/qa/config_state.py"
 
 spack env deactivate
+
+echo "Testing correct scope precedence on command line"
+contains 'unify: true' spack -e scopes/true config get concretizer
+contains 'unify: true' spack -D scopes/true config get concretizer
+contains 'unify: false' spack -C scopes/false config get concretizer
+contains 'unify: when_possible' spack -C scopes/wp config get concretizer
+
+contains 'unify: true' spack -C scopes/wp -C scopes/false -e scopes/true config get concretizer
+contains 'unify: false' spack -C scopes/wp -C scopes/false config get concretizer
+contains 'unify: when_possible' spack -C scopes/false -e scopes/true -C scopes/wp config get concretizer
+contains 'unify: false' spack -e scopes/true -C scopes/wp -C scopes/false config get concretizer
+
+contains 'unify: true' spack -C scopes/wp -C scopes/false -D scopes/true config get concretizer
+contains 'unify: when_possible' spack -C scopes/false -D scopes/true -C scopes/wp config get concretizer
+contains 'unify: false' spack -D scopes/true -C scopes/wp -C scopes/false config get concretizer


### PR DESCRIPTION
> [!CAUTION]
> Requires https://github.com/spack/spack-packages/pull/119 to be merged first, or CI will break.

Currently, active environments, from the CLI or from `$SPACK_ENV`, will override configuration set on the command line. This is confusing, as users would normally expect command line options to override environment options (e.g. SPACK_ENV).

See [more discussion here](https://github.com/spack/spack/pull/49187#issuecomment-2682945937).

This PR changes how we process configuration options on the CLI so that:

1. Any CLI option overrides an active environment from `SPACK_ENV`
2. CLI options that add config scopes (`-D`, `-C`, and `-e`) are now considered for scope precedence in the order they appear on the CLI.

What this means is that if you write:
 * `spack -C config_dir`: `config_dir` will override any active enviornment.
 * `spack -C config_dir -e env`: `env` will override `config_dir`
 * `spack -e env -C config_dir -e env`: `config_dir` will override `env`

And similar for `-D`. This makes the order much more obvious.

This is a breaking change, in that historically environments have been higher precedence than config scopes.

- [x] rework scope adding in `main.py`
- [x] add an action to handle config from CLI
- [x] add shell tests and unit tests

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
