### PR TITLE
Virtual assignment

### DIFF
--- a/etc/spack/defaults/repos.yaml
+++ b/etc/spack/defaults/repos.yaml
@@ -11,5 +11,5 @@
 #   ~/.spack/repos.yaml
 # -------------------------------------------------------------------------
 repos:
-  builtin:
-    git: https://github.com/spack/spack-packages.git
+  builtin: /Users/gamblin2/src/spack-packages
+#    git: https://github.com/spack/spack-packages.git

--- a/etc/spack/defaults/repos.yaml
+++ b/etc/spack/defaults/repos.yaml
@@ -11,5 +11,5 @@
 #   ~/.spack/repos.yaml
 # -------------------------------------------------------------------------
 repos:
-  builtin: /Users/gamblin2/src/spack-packages
-#    git: https://github.com/spack/spack-packages.git
+  builtin:
+    git: https://github.com/spack/spack-packages.git

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1448,6 +1448,37 @@ class SpecAnnotations:
         return result
 
 
+def _anonymous_star(dep, dep_format):
+    """Determine if a spec needs a star to disambiguate it from an anonymous spec w/variants.
+
+    Returns:
+        "*" if a star is needed, "" otherwise
+    """
+    # named spec never needs star
+    if dep.spec.name:
+        return ""
+
+    # virtuals without a name always need *: %c=* @4.0 foo=bar
+    if dep.virtuals:
+        return "*"
+
+    # versions are first so checking for @ is faster than != VersionList(':')
+    if dep_format.startswith("@"):
+        return ""
+
+    # compiler flags are key-value pairs and can be ambiguous with virtual assignment
+    if dep.spec.compiler_flags:
+        return "*"
+
+    # booleans come first, and they don't need a star. key-value pairs do. If there are
+    # no key value pairs, we're left with either an empty spec, which needs * as in
+    # '^*', or we're left with arch, which is a key value pair, and needs a star.
+    if not any(v.type == spack.variant.VariantType.BOOL for v in dep.spec.variants.values()):
+        return "*"
+
+    return "*" if dep.spec.architecture else ""
+
+
 @lang.lazy_lexicographic_ordering(set_hash=False)
 class Spec:
     compiler = DeprecatedCompilerSpec()
@@ -2143,24 +2174,13 @@ class Spec:
                     edge_attributes += " "
             virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
 
-            spec_format = item.spec.format(format_string)
-
             # need a * for anonymous specs with key-value variants
-            star = (
-                "*"
-                if (
-                    not item.spec.name
-                    and not virtuals
-                    and not item.spec.version
-                    and any(v.variant_type != BOOL for v in item.spec.variants.values())
-                )
-                else "*"
-            )
-
-            ddep_string = f"%{edge_attributes}{star}{virtuals}{spec_format}"
+            dep_format = item.spec.format(format_string)
+            star = _anonymous_star(item, dep_format)
+            string = f"%{edge_attributes}{star}{virtuals}{dep_format}"
             if current_name is not None:
-                ddep_string = ddep_string.replace(current_name, new_name)
-            parts.append(ddep_string)
+                string = string.replace(current_name, new_name)
+            parts.append(string)
 
         for item in sorted(transitive, key=lambda x: x.spec.name):
             if not predicate(item):
@@ -2177,9 +2197,9 @@ class Spec:
             virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
 
             sigil = "%" if _force_direct else "^"  # hack until direct deps are represented better
-            spec_format = item.spec.format(format_string)
-            star = ""
-            parts.append(f"{sigil}{edge_attributes}{star}{virtuals}{spec_format}")
+            dep_format = item.spec.format(format_string)
+            star = _anonymous_star(item, dep_format)
+            parts.append(f"{sigil}{edge_attributes}{star}{virtuals}{dep_format}")
 
             # also recursively add any build dependencies of transitive dependencies
             if item.spec._dependencies:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2138,7 +2138,7 @@ class Spec:
 
         attrs = " ".join(s for s in (when_str, deptypes_str, virtuals_str) if s)
         if attrs:
-            attrs = f"[{attrs}]"
+            attrs = f"[{attrs}] "
 
         return attrs
 
@@ -2158,53 +2158,46 @@ class Spec:
             self.edges_to_dependencies(), predicate_fn=lambda x: x.direct
         )
 
-        for item in sorted(direct, key=lambda x: x.spec.name):
-            if not predicate(item):
+        def format_edge(edge, sigil, dep_spec=None):
+            dep_spec = dep_spec or edge.spec
+            dep_format = dep_spec.format(format_string)
+
+            edge_attributes = (
+                self._format_edge_attributes(edge, deptypes=deptypes, virtuals=False)
+                if edge.depflag or edge.when != Spec()
+                else ""
+            )
+            virtuals = f"{','.join(edge.virtuals)}=" if edge.virtuals else ""
+            star = _anonymous_star(edge, dep_format)
+            return f"{sigil}{edge_attributes}{star}{virtuals}{dep_format}"
+
+        # direct dependencies
+        for edge in sorted(direct, key=lambda x: x.spec.name):
+            if not predicate(edge):
                 continue
 
-            current_name = item.spec.name
-            new_name = spack.aliases.BUILTIN_TO_LEGACY_COMPILER.get(current_name, current_name)
+            # replace legacy compiler names
+            old_name = edge.spec.name
+            new_name = spack.aliases.BUILTIN_TO_LEGACY_COMPILER.get(old_name)
+            try:
+                # this is ugly but copies can be expensive
+                if new_name:
+                    edge.spec.name = new_name
+                parts.append(format_edge(edge, "%", edge.spec))
+            finally:
+                edge.spec.name = old_name
 
-            edge_attributes = ""
-            if item.when != Spec():
-                edge_attributes = self._format_edge_attributes(
-                    item, deptypes=deptypes, virtuals=False
-                )
-                if edge_attributes:
-                    edge_attributes += " "
-            virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
-
-            # need a * for anonymous specs with key-value variants
-            dep_format = item.spec.format(format_string)
-            star = _anonymous_star(item, dep_format)
-            string = f"%{edge_attributes}{star}{virtuals}{dep_format}"
-            if current_name is not None:
-                string = string.replace(current_name, new_name)
-            parts.append(string)
-
-        for item in sorted(transitive, key=lambda x: x.spec.name):
-            if not predicate(item):
+        # transitive dependencies (with any direct dependencies)
+        for edge in sorted(transitive, key=lambda x: x.spec.name):
+            if not predicate(edge):
                 continue
+            sigil = "%" if _force_direct else "^"  # hack til direct deps represented better
+            parts.append(format_edge(edge, sigil, edge.spec))
 
-            edge_attributes = ""
-            if item.depflag or item.when != Spec():
-                edge_attributes = self._format_edge_attributes(
-                    item, deptypes=deptypes, virtuals=False
-                )
-                if edge_attributes:
-                    edge_attributes += " "
-
-            virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
-
-            sigil = "%" if _force_direct else "^"  # hack until direct deps are represented better
-            dep_format = item.spec.format(format_string)
-            star = _anonymous_star(item, dep_format)
-            parts.append(f"{sigil}{edge_attributes}{star}{virtuals}{dep_format}")
-
-            # also recursively add any build dependencies of transitive dependencies
-            if item.spec._dependencies:
+            # also recursively add any direct dependencies of transitive dependencies
+            if edge.spec._dependencies:
                 parts.append(
-                    item.spec._format_dependencies(
+                    edge.spec._format_dependencies(
                         format_string=format_string,
                         predicate=predicate,
                         deptypes=deptypes,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2145,19 +2145,26 @@ class Spec:
     def _format_dependencies(
         self,
         format_string: str = DEFAULT_FORMAT,
-        predicate: Optional[Callable[[DependencySpec], bool]] = None,
+        include: Optional[Callable[[DependencySpec], bool]] = None,
         deptypes=True,
         _force_direct=False,
     ):
-        if predicate is None:
-            predicate = lambda dep: True
+        """Helper for formatting dependencies on specs.
 
+        Arguments:
+            format_string: format string to use for each dependency
+            include: predicate to select which dependencies to include
+            deptypes: whether to format deptypes
+            _force_direct: if True, print all dependencies as direct dependencies
+                (to be removed when we have this metadata on concrete edges)
+        """
+        include = include or (lambda dep: True)
         parts = []
-
         direct, transitive = lang.stable_partition(
             self.edges_to_dependencies(), predicate_fn=lambda x: x.direct
         )
 
+        # helper for direct and transitive loops below
         def format_edge(edge, sigil, dep_spec=None):
             dep_spec = dep_spec or edge.spec
             dep_format = dep_spec.format(format_string)
@@ -2169,11 +2176,12 @@ class Spec:
             )
             virtuals = f"{','.join(edge.virtuals)}=" if edge.virtuals else ""
             star = _anonymous_star(edge, dep_format)
+
             return f"{sigil}{edge_attributes}{star}{virtuals}{dep_format}"
 
         # direct dependencies
         for edge in sorted(direct, key=lambda x: x.spec.name):
-            if not predicate(edge):
+            if not include(edge):
                 continue
 
             # replace legacy compiler names
@@ -2189,7 +2197,7 @@ class Spec:
 
         # transitive dependencies (with any direct dependencies)
         for edge in sorted(transitive, key=lambda x: x.spec.name):
-            if not predicate(edge):
+            if not include(edge):
                 continue
             sigil = "%" if _force_direct else "^"  # hack til direct deps represented better
             parts.append(format_edge(edge, sigil, edge.spec))
@@ -2199,7 +2207,7 @@ class Spec:
                 parts.append(
                     edge.spec._format_dependencies(
                         format_string=format_string,
-                        predicate=predicate,
+                        include=include,
                         deptypes=deptypes,
                         _force_direct=_force_direct,
                     )

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1640,7 +1640,7 @@ class Spec:
 
     @property
     def edge_attributes(self) -> str:
-        """Helper method to print edge attributes in spec literals"""
+        """Helper method to print edge attributes in spec strings."""
         edges = self.edges_from_dependents()
         if not edges:
             return ""
@@ -2095,6 +2095,17 @@ class Spec:
             visited=visited,
         )
 
+    def _format_edge_attributes(self, dep: DependencySpec, virtuals=True):
+        deptypes_str = f"deptypes={','.join(dt.flag_to_tuple(dep.depflag))}" if dep.depflag else ""
+        when_str = f"when='{(dep.when)}'" if dep.when != Spec() else ""
+        virtuals_str = f"virtuals={','.join(dep.virtuals)}" if virtuals and dep.virtuals else ""
+
+        attrs = " ".join(s for s in (when_str, deptypes_str, virtuals_str) if s)
+        if attrs:
+            attrs = f"[{attrs}]"
+
+        return attrs
+
     @property
     def long_spec(self):
         """Returns a string of the spec with the dependencies completely
@@ -2103,21 +2114,28 @@ class Spec:
         direct, transitive = lang.stable_partition(
             self.edges_to_dependencies(), predicate_fn=lambda x: x.direct
         )
+
         for item in sorted(direct, key=lambda x: x.spec.name):
             current_name = item.spec.name
             new_name = spack.aliases.BUILTIN_TO_LEGACY_COMPILER.get(current_name, current_name)
-            # note: depflag not allowed, currently, on "direct" edges
-            edge_attributes = ""
-            if item.virtuals or item.when != Spec():
-                edge_attributes = item.spec.format("{edge_attributes}") + " "
 
-            parts.append(f"%{edge_attributes}{item.spec.format()}".replace(current_name, new_name))
+            edge_attributes = ""
+            if item.when != Spec():
+                edge_attributes = self._format_edge_attributes(item, virtuals=False) + " "
+            virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
+
+            parts.append(
+                f"%{edge_attributes}{virtuals}{item.spec.format()}".replace(current_name, new_name)
+            )
+
         for item in sorted(transitive, key=lambda x: x.spec.name):
             # Recurse to attach build deps in order
             edge_attributes = ""
-            if item.virtuals or item.depflag or item.when != Spec():
-                edge_attributes = item.spec.format("{edge_attributes}") + " "
-            parts.append(f"^{edge_attributes}{str(item.spec)}")
+            if item.depflag or item.when != Spec():
+                edge_attributes = self._format_edge_attributes(item, virtuals=False) + " "
+            virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
+
+            parts.append(f"^{edge_attributes}{virtuals}{str(item.spec)}")
         return " ".join(parts).strip()
 
     @property
@@ -3951,6 +3969,14 @@ class Spec:
     @property
     def namespace_if_anonymous(self):
         return self.namespace if not self.name else None
+
+    @property
+    def virtuals(self):
+        return "FOOBAR"
+
+    @property
+    def compilers(self):
+        return "COMPILERS"
 
     def format(self, format_string: str = DEFAULT_FORMAT, color: Optional[bool] = False) -> str:
         r"""Prints out attributes of a spec according to a format string.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -133,7 +133,7 @@ SPEC_FORMAT_RE = re.compile(
     r"|"  # or
     # OPTION 2: an actual format string
     r"{"  # non-escaped open brace {
-    r"([%@/]|[\w ][\w -]*=)?"  # optional sigil (or identifier or space) to print sigil in color
+    r"( ?[%@/]|[\w ][\w -]*=)?"  # optional sigil (or identifier or space) to print sigil in color
     r"(?:\^([^}\.]+)\.)?"  # optional ^depname. (to get attr from dependency)
     # after the sigil or depname, we can have a hash expression or another attribute
     r"(?:"  # one of
@@ -173,6 +173,7 @@ DEFAULT_FORMAT = (
 DISPLAY_FORMAT = (
     "{name}{@version}{compiler_flags}"
     "{variants}{ namespace=namespace_if_anonymous}{ arch=architecture}{/abstract_hash}"
+    "{compilers}"
 )
 
 #: Regular expression to pull spec contents out of clearsigned signature
@@ -2095,8 +2096,12 @@ class Spec:
             visited=visited,
         )
 
-    def _format_edge_attributes(self, dep: DependencySpec, virtuals=True):
-        deptypes_str = f"deptypes={','.join(dt.flag_to_tuple(dep.depflag))}" if dep.depflag else ""
+    def _format_edge_attributes(self, dep: DependencySpec, deptypes=True, virtuals=True):
+        deptypes_str = (
+            f"deptypes={','.join(dt.flag_to_tuple(dep.depflag))}"
+            if deptypes and dep.depflag
+            else ""
+        )
         when_str = f"when='{(dep.when)}'" if dep.when != Spec() else ""
         virtuals_str = f"virtuals={','.join(dep.virtuals)}" if virtuals and dep.virtuals else ""
 
@@ -2106,37 +2111,91 @@ class Spec:
 
         return attrs
 
-    @property
-    def long_spec(self):
-        """Returns a string of the spec with the dependencies completely
-        enumerated."""
-        parts = [self.format()]
+    def _format_dependencies(
+        self,
+        format_string: str = DEFAULT_FORMAT,
+        predicate: Optional[Callable[[DependencySpec], bool]] = None,
+        deptypes=True,
+        _force_direct=False,
+    ):
+        if predicate is None:
+            predicate = lambda dep: True
+
+        parts = []
+
         direct, transitive = lang.stable_partition(
             self.edges_to_dependencies(), predicate_fn=lambda x: x.direct
         )
 
         for item in sorted(direct, key=lambda x: x.spec.name):
+            if not predicate(item):
+                continue
+
             current_name = item.spec.name
             new_name = spack.aliases.BUILTIN_TO_LEGACY_COMPILER.get(current_name, current_name)
 
             edge_attributes = ""
             if item.when != Spec():
-                edge_attributes = self._format_edge_attributes(item, virtuals=False) + " "
+                edge_attributes = self._format_edge_attributes(
+                    item, deptypes=deptypes, virtuals=False
+                )
+                if edge_attributes:
+                    edge_attributes += " "
             virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
 
             parts.append(
-                f"%{edge_attributes}{virtuals}{item.spec.format()}".replace(current_name, new_name)
+                f"%{edge_attributes}{virtuals}{item.spec.format(format_string)}".replace(
+                    current_name, new_name
+                )
             )
 
         for item in sorted(transitive, key=lambda x: x.spec.name):
-            # Recurse to attach build deps in order
+            if not predicate(item):
+                continue
+
             edge_attributes = ""
             if item.depflag or item.when != Spec():
-                edge_attributes = self._format_edge_attributes(item, virtuals=False) + " "
+                edge_attributes = self._format_edge_attributes(
+                    item, deptypes=deptypes, virtuals=False
+                )
+                if edge_attributes:
+                    edge_attributes += " "
+
             virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
 
-            parts.append(f"^{edge_attributes}{virtuals}{str(item.spec)}")
+            sigil = "%" if _force_direct else "^"  # hack until direct deps are represented better
+            parts.append(f"{sigil}{edge_attributes}{virtuals}{item.spec.format(format_string)}")
+
+            # also recursively add any build dependencies of transitive dependencies
+            if item.spec._dependencies:
+                parts.append(
+                    item.spec._format_dependencies(
+                        format_string=format_string,
+                        predicate=predicate,
+                        deptypes=deptypes,
+                        _force_direct=_force_direct,
+                    )
+                )
+
         return " ".join(parts).strip()
+
+    @property
+    def compilers(self):
+        # TODO: get rid of the space here and make formatting smarter
+        return " " + self._format_dependencies(
+            "{name}{@version}",
+            predicate=lambda dep: any(lang in dep.virtuals for lang in ("c", "cxx", "fortran")),
+            deptypes=False,
+            _force_direct=True,
+        )
+
+    @property
+    def long_spec(self):
+        """Returns a string of the spec with the dependencies completely enumerated."""
+        string = self.format()
+        deps = self._format_dependencies()
+        string = f"{string} {deps}" if deps else string
+        return string.strip()
 
     @property
     def short_spec(self):
@@ -3970,14 +4029,6 @@ class Spec:
     def namespace_if_anonymous(self):
         return self.namespace if not self.name else None
 
-    @property
-    def virtuals(self):
-        return "FOOBAR"
-
-    @property
-    def compilers(self):
-        return "COMPILERS"
-
     def format(self, format_string: str = DEFAULT_FORMAT, color: Optional[bool] = False) -> str:
         r"""Prints out attributes of a spec according to a format string.
 
@@ -3993,6 +4044,7 @@ class Spec:
             name
             version
             compiler_flags
+            compilers
             variants
             architecture
             architecture.platform
@@ -4159,7 +4211,7 @@ class Spec:
                 color = ARCHITECTURE_COLOR
             elif "variants" in parts or sig.endswith("="):
                 color = VARIANT_COLOR
-            elif "compiler" in parts or "compiler_flags" in parts:
+            elif any(c in parts for c in ("compiler", "compilers", "compiler_flags")):
                 color = COMPILER_COLOR
             elif "version" in parts or "versions" in parts:
                 color = VERSION_COLOR

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2220,7 +2220,7 @@ class Spec:
         # TODO: get rid of the space here and make formatting smarter
         return " " + self._format_dependencies(
             "{name}{@version}",
-            predicate=lambda dep: any(lang in dep.virtuals for lang in ("c", "cxx", "fortran")),
+            include=lambda dep: any(lang in dep.virtuals for lang in ("c", "cxx", "fortran")),
             deptypes=False,
             _force_direct=True,
         )

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2228,10 +2228,7 @@ class Spec:
     @property
     def long_spec(self):
         """Returns a string of the spec with the dependencies completely enumerated."""
-        string = self.format()
-        deps = self._format_dependencies()
-        string = f"{string} {deps}" if deps else string
-        return string.strip()
+        return f"{self.format()} {self._format_dependencies()}".strip()
 
     @property
     def short_spec(self):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2143,11 +2143,24 @@ class Spec:
                     edge_attributes += " "
             virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
 
-            parts.append(
-                f"%{edge_attributes}{virtuals}{item.spec.format(format_string)}".replace(
-                    current_name, new_name
+            spec_format = item.spec.format(format_string)
+
+            # need a * for anonymous specs with key-value variants
+            star = (
+                "*"
+                if (
+                    not item.spec.name
+                    and not virtuals
+                    and not item.spec.version
+                    and any(v.variant_type != BOOL for v in item.spec.variants.values())
                 )
+                else "*"
             )
+
+            ddep_string = f"%{edge_attributes}{star}{virtuals}{spec_format}"
+            if current_name is not None:
+                ddep_string = ddep_string.replace(current_name, new_name)
+            parts.append(ddep_string)
 
         for item in sorted(transitive, key=lambda x: x.spec.name):
             if not predicate(item):
@@ -2164,7 +2177,9 @@ class Spec:
             virtuals = f"{','.join(item.virtuals)}=" if item.virtuals else ""
 
             sigil = "%" if _force_direct else "^"  # hack until direct deps are represented better
-            parts.append(f"{sigil}{edge_attributes}{virtuals}{item.spec.format(format_string)}")
+            spec_format = item.spec.format(format_string)
+            star = ""
+            parts.append(f"{sigil}{edge_attributes}{star}{virtuals}{spec_format}")
 
             # also recursively add any build dependencies of transitive dependencies
             if item.spec._dependencies:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -194,21 +194,23 @@ def parseable_tokens(text: str) -> Iterator[Token]:
 class TokenContext:
     """Token context passed around by parsers"""
 
-    __slots__ = "token_stream", "current_token", "next_token", "pushback_token"
+    __slots__ = "token_stream", "current_token", "next_token", "pushed_tokens"
 
     def __init__(self, token_stream: Iterator[Token]):
         self.token_stream = token_stream
         self.current_token = None
-        self.next_token = None
-        self.pushback_token = None
+        self.next_token = None  # the next token to be read
+
+        # if not empty, back of list is front of stream, and we pop from here instead.
+        self.pushed_tokens: Optional[List] = None
+
         self.advance()
 
     def advance(self):
         """Advance one token"""
         self.current_token = self.next_token
-        if self.pushback_token:
-            self.next_token = self.pushback_token
-            self.pushback_token = None
+        if self.pushed_tokens and self.pushed_tokens is not None:
+            self.next_token = self.pushed_tokens.pop()
         else:
             self.next_token = next(self.token_stream, None)
 
@@ -221,10 +223,12 @@ class TokenContext:
             return True
         return False
 
-    def push_back(self, token=Token):
-        """Push a token back onto the front of the stream. Enables a bit of lookahead."""
-        assert not self.pushback_token, "Parser error: Can only push one token back at a time!"
-        self.pushback_token = token
+    def push_front(self, token=Token):
+        """Push a token onto the front of the stream. Enables a bit of lookahead."""
+        if self.pushed_tokens is None:
+            self.pushed_tokens = []
+        self.pushed_tokens.append(self.next_token)  # back of list is front of stream
+        self.next_token = token
 
     def expect(self, *kinds: SpecTokens):
         return self.next_token and self.next_token.kind in kinds
@@ -293,6 +297,44 @@ class SpecParser:
         """
         return list(filter(lambda x: x.kind != SpecTokens.WS, tokenize(self.literal_str)))
 
+    def parse_virtual_assignment(self) -> Tuple[str]:
+        """Look at subvalues and, if present, extract virtual and a push a substitute token.
+
+        This handles things like:
+            * ^c=gcc
+            * ^c,cxx=gcc
+            * %[when=+bar] c=gcc
+            * %[when=+bar] c,cxx=gcc
+
+        Virtual assignment can happen anywhere a dependency node can appear. It is
+        shorthand for %[virtuals=c,cxx] gcc.
+
+        The virtuals=substitute key value pair appears in the subvalues of DEPENDENCY
+        and END_EDGE_PROPERTIES tokens. We extract the virutals and create a token from
+        the substitute, which is then pushed back on the parser stream so that the head
+        of the stream can be parsed like a regular node.
+
+        Returns:
+            the virtuals assigned, or None if there aren't any
+
+        """
+        subvalues = self.ctx.current_token.subvalues
+
+        virtuals = subvalues["virtuals"]
+        if not virtuals:
+            return ()
+
+        substitute = subvalues["substitute"]
+        token_type = SpecTokens.UNQUALIFIED_PACKAGE_NAME
+        if "." in substitute:
+            token_type = SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME
+
+        start = self.ctx.current_token.value.index(substitute)
+        token = Token(token_type, substitute, start, start + len(substitute))
+        self.ctx.push_front(token)
+
+        return tuple(virtuals.split(","))
+
     def next_spec(
         self, initial_spec: Optional["spack.spec.Spec"] = None
     ) -> Optional["spack.spec.Spec"]:
@@ -320,7 +362,7 @@ class SpecParser:
         current_spec = root_spec
         while True:
             if self.ctx.accept(SpecTokens.START_EDGE_PROPERTIES):
-                is_direct = self.ctx.current_token.value[0] == "%"
+                is_direct = self.ctx.current_token.value == "%"
 
                 edge_properties = EdgeAttributeParser(self.ctx, self.literal_str).parse()
                 edge_properties.setdefault("virtuals", ())
@@ -341,14 +383,12 @@ class SpecParser:
                 add_dependency(dependency, **edge_properties)
 
             elif self.ctx.accept(SpecTokens.DEPENDENCY):
-                print(self.ctx.current_token.subvalues)
+                is_direct = self.ctx.current_token.value == "%"
+                virtuals = self.parse_virtual_assignment()
 
-                # String replacement for toolchains
-                # Look ahead to match upcoming value to list of toolchains
-                if (
-                    self.ctx.current_token.value == "%"
-                    and self.ctx.next_token.value in self.toolchains
-                ):
+                # if no virtual assignment, check for a toolchain - look ahead to find the
+                # toolchain and substitute it
+                if not virtuals and is_direct and self.ctx.next_token.value in self.toolchains:
                     assert self.ctx.accept(SpecTokens.UNQUALIFIED_PACKAGE_NAME)
                     try:
                         self._apply_toolchain(current_spec, self.ctx.current_token.value)
@@ -356,12 +396,8 @@ class SpecParser:
                         raise SpecParsingError(str(e), self.ctx.current_token, self.literal_str)
                     continue
 
-                is_direct = self.ctx.current_token.value[0] == "%"
+                edge_properties = {"direct": is_direct, "virtuals": virtuals, "depflag": 0}
                 dependency, warnings = self._parse_node(root_spec)
-                edge_properties = {}
-                edge_properties["direct"] = is_direct
-                edge_properties["virtuals"] = tuple()
-                edge_properties.setdefault("depflag", 0)
 
                 if is_direct:
                     target_spec = current_spec

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -296,6 +296,8 @@ def parse_virtual_assignment(context: TokenContext) -> Tuple[str]:
         the virtuals assigned, or None if there aren't any
 
     """
+    assert context.current_token is not None
+
     subvalues = context.current_token.subvalues
     if not subvalues:
         return ()
@@ -427,7 +429,7 @@ class SpecParser:
             )
             raise SpecParsingError(msg, self.ctx.current_token, self.literal_str)
         if root_spec.concrete:
-            raise spack.spec.RedundantSpecError(root_spec, "^" + str(dependency))
+            raise spack.error.SpecError(root_spec, "^" + str(dependency))
         return dependency, parser_warnings
 
     def _apply_toolchain(self, spec: "spack.spec.Spec", name: str) -> None:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -202,14 +202,14 @@ class TokenContext:
         self.next_token = None  # the next token to be read
 
         # if not empty, back of list is front of stream, and we pop from here instead.
-        self.pushed_tokens: Optional[List] = None
+        self.pushed_tokens: List[Token] = []
 
         self.advance()
 
     def advance(self):
         """Advance one token"""
         self.current_token = self.next_token
-        if self.pushed_tokens and self.pushed_tokens is not None:
+        if self.pushed_tokens:
             self.next_token = self.pushed_tokens.pop()
         else:
             self.next_token = next(self.token_stream, None)
@@ -225,8 +225,6 @@ class TokenContext:
 
     def push_front(self, token=Token):
         """Push a token onto the front of the stream. Enables a bit of lookahead."""
-        if self.pushed_tokens is None:
-            self.pushed_tokens = []
         self.pushed_tokens.append(self.next_token)  # back of list is front of stream
         self.next_token = token
 

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -91,7 +91,7 @@ GIT_VERSION_PATTERN = rf"(?:(?:git\.(?:{GIT_REF}))|(?:{GIT_HASH}))"
 VIRTUAL_ASSIGNMENT = (
     r"(?:"
     rf"(?P<virtuals>{IDENTIFIER}(?:,{IDENTIFIER})*)"  # comma-separated virtuals
-    rf"=(?P<substitute>{IDENTIFIER}|{DOTTED_IDENTIFIER})"  # package to substitute
+    rf"=(?P<substitute>{DOTTED_IDENTIFIER}|{IDENTIFIER})"  # package to substitute
     r")"
 )
 
@@ -275,6 +275,45 @@ def _warn_about_variant_after_compiler(literal_str: str, issues: List[str]):
             return
 
 
+def parse_virtual_assignment(context: TokenContext) -> Tuple[str]:
+    """Look at subvalues and, if present, extract virtual and a push a substitute token.
+
+    This handles things like:
+        * ^c=gcc
+        * ^c,cxx=gcc
+        * %[when=+bar] c=gcc
+        * %[when=+bar] c,cxx=gcc
+
+    Virtual assignment can happen anywhere a dependency node can appear. It is
+    shorthand for %[virtuals=c,cxx] gcc.
+
+    The virtuals=substitute key value pair appears in the subvalues of DEPENDENCY
+    and END_EDGE_PROPERTIES tokens. We extract the virutals and create a token from
+    the substitute, which is then pushed back on the parser stream so that the head
+    of the stream can be parsed like a regular node.
+
+    Returns:
+        the virtuals assigned, or None if there aren't any
+
+    """
+    subvalues = context.current_token.subvalues
+    virtuals = subvalues["virtuals"]
+    if not virtuals:
+        return ()
+
+    # build a token for the substitute that we can put back on the stream
+    pkg = subvalues["substitute"]
+    token_type = SpecTokens.UNQUALIFIED_PACKAGE_NAME
+    if "." in pkg:
+        token_type = SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME
+    start = context.current_token.value.index(pkg)
+
+    token = Token(token_type, pkg, start, start + len(pkg))
+    context.push_front(token)
+
+    return tuple(virtuals.split(","))
+
+
 class SpecParser:
     """Parse text into specs"""
 
@@ -296,44 +335,6 @@ class SpecParser:
         filtered out.
         """
         return list(filter(lambda x: x.kind != SpecTokens.WS, tokenize(self.literal_str)))
-
-    def parse_virtual_assignment(self) -> Tuple[str]:
-        """Look at subvalues and, if present, extract virtual and a push a substitute token.
-
-        This handles things like:
-            * ^c=gcc
-            * ^c,cxx=gcc
-            * %[when=+bar] c=gcc
-            * %[when=+bar] c,cxx=gcc
-
-        Virtual assignment can happen anywhere a dependency node can appear. It is
-        shorthand for %[virtuals=c,cxx] gcc.
-
-        The virtuals=substitute key value pair appears in the subvalues of DEPENDENCY
-        and END_EDGE_PROPERTIES tokens. We extract the virutals and create a token from
-        the substitute, which is then pushed back on the parser stream so that the head
-        of the stream can be parsed like a regular node.
-
-        Returns:
-            the virtuals assigned, or None if there aren't any
-
-        """
-        subvalues = self.ctx.current_token.subvalues
-
-        virtuals = subvalues["virtuals"]
-        if not virtuals:
-            return ()
-
-        substitute = subvalues["substitute"]
-        token_type = SpecTokens.UNQUALIFIED_PACKAGE_NAME
-        if "." in substitute:
-            token_type = SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME
-
-        start = self.ctx.current_token.value.index(substitute)
-        token = Token(token_type, substitute, start, start + len(substitute))
-        self.ctx.push_front(token)
-
-        return tuple(virtuals.split(","))
 
     def next_spec(
         self, initial_spec: Optional["spack.spec.Spec"] = None
@@ -384,7 +385,7 @@ class SpecParser:
 
             elif self.ctx.accept(SpecTokens.DEPENDENCY):
                 is_direct = self.ctx.current_token.value == "%"
-                virtuals = self.parse_virtual_assignment()
+                virtuals = parse_virtual_assignment(self.ctx)
 
                 # if no virtual assignment, check for a toolchain - look ahead to find the
                 # toolchain and substitute it
@@ -649,6 +650,9 @@ class EdgeAttributeParser:
                     raise SpecParsingError(msg, self.ctx.current_token, self.literal_str)
             # TODO: Add code to accept bool variants here as soon as use variants are implemented
             elif self.ctx.accept(SpecTokens.END_EDGE_PROPERTIES):
+                virtuals = attributes.get("virtuals", ())
+                virtuals += parse_virtual_assignment(self.ctx)
+                attributes["virtuals"] = virtuals
                 break
             else:
                 msg = "unexpected token in edge attributes"

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -86,6 +86,17 @@ GIT_HASH = r"(?:[A-Fa-f0-9]{40})"
 GIT_REF = r"(?:[a-zA-Z_0-9][a-zA-Z_0-9./\-]*)"
 GIT_VERSION_PATTERN = rf"(?:(?:git\.(?:{GIT_REF}))|(?:{GIT_HASH}))"
 
+#: Substitute a package for a virtual, e.g., c,cxx=gcc.
+#: NOTE: Overlaps w/KVP; this should be first if matched in sequence.
+VIRTUAL_ASSIGNMENT = (
+    r"(?:"
+    rf"(?P<virtuals>{IDENTIFIER}(?:,{IDENTIFIER})*)"  # comma-separated virtuals
+    rf"=(?P<substitute>{IDENTIFIER}|{DOTTED_IDENTIFIER})"  # package to substitute
+    r")"
+)
+
+STAR = r"\*"
+
 NAME = r"[a-zA-Z_0-9][a-zA-Z_0-9\-.]*"
 
 HASH = r"[a-zA-Z_0-9]+"
@@ -116,33 +127,41 @@ NO_QUOTES_NEEDED = re.compile(r"^[a-zA-Z0-9,/_.\-\[\]]+$")
 
 
 class SpecTokens(TokenBase):
-    """Enumeration of the different token kinds in the spec grammar.
+    """Enumeration of the different token kinds of tokens in the spec grammar.
+
     Order of declaration is extremely important, since text containing specs is parsed with a
     single regex obtained by ``"|".join(...)`` of all the regex in the order of declaration.
     """
 
-    # Dependency
+    # Dependency, with optional virtual assignment specifier
     START_EDGE_PROPERTIES = r"(?:[\^%]\[)"
-    END_EDGE_PROPERTIES = r"(?:\])"
-    DEPENDENCY = r"(?:[\^\%])"
+    END_EDGE_PROPERTIES = rf"(?:\]\s*{VIRTUAL_ASSIGNMENT}?)"
+    DEPENDENCY = rf"(?:[\^\%]\s*{VIRTUAL_ASSIGNMENT}?)"
+
     # Version
     VERSION_HASH_PAIR = rf"(?:@(?:{GIT_VERSION_PATTERN})=(?:{VERSION}))"
     GIT_VERSION = rf"@(?:{GIT_VERSION_PATTERN})"
     VERSION = rf"(?:@\s*(?:{VERSION_LIST}))"
+
     # Variants
     PROPAGATED_BOOL_VARIANT = rf"(?:(?:\+\+|~~|--)\s*{NAME})"
     BOOL_VARIANT = rf"(?:[~+-]\s*{NAME})"
     PROPAGATED_KEY_VALUE_PAIR = rf"(?:{NAME}:?==(?:{VALUE}|{QUOTED_VALUE}))"
     KEY_VALUE_PAIR = rf"(?:{NAME}:?=(?:{VALUE}|{QUOTED_VALUE}))"
+
     # FILENAME
     FILENAME = rf"(?:{FILENAME})"
+
     # Package name
     FULLY_QUALIFIED_PACKAGE_NAME = rf"(?:{DOTTED_IDENTIFIER})"
-    UNQUALIFIED_PACKAGE_NAME = rf"(?:{IDENTIFIER})"
+    UNQUALIFIED_PACKAGE_NAME = rf"(?:{IDENTIFIER}|{STAR})"
+
     # DAG hash
     DAG_HASH = rf"(?:/(?:{HASH}))"
+
     # White spaces
     WS = r"(?:\s+)"
+
     # Unexpected character(s)
     UNEXPECTED = r"(?:.[\s]*)"
 
@@ -175,17 +194,23 @@ def parseable_tokens(text: str) -> Iterator[Token]:
 class TokenContext:
     """Token context passed around by parsers"""
 
-    __slots__ = "token_stream", "current_token", "next_token"
+    __slots__ = "token_stream", "current_token", "next_token", "pushback_token"
 
     def __init__(self, token_stream: Iterator[Token]):
         self.token_stream = token_stream
         self.current_token = None
         self.next_token = None
+        self.pushback_token = None
         self.advance()
 
     def advance(self):
         """Advance one token"""
-        self.current_token, self.next_token = self.next_token, next(self.token_stream, None)
+        self.current_token = self.next_token
+        if self.pushback_token:
+            self.next_token = self.pushback_token
+            self.pushback_token = None
+        else:
+            self.next_token = next(self.token_stream, None)
 
     def accept(self, kind: SpecTokens):
         """If the next token is of the specified kind, advance the stream and return True.
@@ -195,6 +220,11 @@ class TokenContext:
             self.advance()
             return True
         return False
+
+    def push_back(self, token=Token):
+        """Push a token back onto the front of the stream. Enables a bit of lookahead."""
+        assert not self.pushback_token, "Parser error: Can only push one token back at a time!"
+        self.pushback_token = token
 
     def expect(self, *kinds: SpecTokens):
         return self.next_token and self.next_token.kind in kinds
@@ -311,6 +341,8 @@ class SpecParser:
                 add_dependency(dependency, **edge_properties)
 
             elif self.ctx.accept(SpecTokens.DEPENDENCY):
+                print(self.ctx.current_token.subvalues)
+
                 # String replacement for toolchains
                 # Look ahead to match upcoming value to list of toolchains
                 if (
@@ -350,8 +382,8 @@ class SpecParser:
 
         return root_spec
 
-    def _parse_node(self, root_spec):
-        dependency, parser_warnings = SpecNodeParser(self.ctx, self.literal_str).parse()
+    def _parse_node(self, root_spec: "spack.spec.Spec", root: bool = True):
+        dependency, parser_warnings = SpecNodeParser(self.ctx, self.literal_str).parse(root=root)
         if dependency is None:
             msg = (
                 "the dependency sigil and any optional edge attributes must be followed by a "
@@ -412,12 +444,13 @@ class SpecNodeParser:
         self.has_version = False
 
     def parse(
-        self, initial_spec: Optional["spack.spec.Spec"] = None
+        self, initial_spec: Optional["spack.spec.Spec"] = None, root: bool = True
     ) -> Tuple["spack.spec.Spec", List[str]]:
         """Parse a single spec node from a stream of tokens
 
         Args:
             initial_spec: object to be constructed
+            root: True if we're parsing a root, False if dependency after ^ or %
 
         Return
             The object passed as argument
@@ -434,7 +467,9 @@ class SpecNodeParser:
         # If we start with a package name we have a named spec, we cannot
         # accept another package name afterwards in a node
         if self.ctx.accept(SpecTokens.UNQUALIFIED_PACKAGE_NAME):
-            initial_spec.name = self.ctx.current_token.value
+            # if name is '*', this is an anonymous spec
+            if self.ctx.current_token.value != "*":
+                initial_spec.name = self.ctx.current_token.value
 
         elif self.ctx.accept(SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME):
             parts = self.ctx.current_token.value.split(".")

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -135,8 +135,8 @@ class SpecTokens(TokenBase):
 
     # Dependency, with optional virtual assignment specifier
     START_EDGE_PROPERTIES = r"(?:[\^%]\[)"
-    END_EDGE_PROPERTIES = rf"(?:\]\s*{VIRTUAL_ASSIGNMENT}?)"
-    DEPENDENCY = rf"(?:[\^\%]\s*{VIRTUAL_ASSIGNMENT}?)"
+    END_EDGE_PROPERTIES = rf"(?:\](?:\s*{VIRTUAL_ASSIGNMENT})?)"
+    DEPENDENCY = rf"(?:[\^\%](?:\s*{VIRTUAL_ASSIGNMENT})?)"
 
     # Version
     VERSION_HASH_PAIR = rf"(?:@(?:{GIT_VERSION_PATTERN})=(?:{VERSION}))"
@@ -297,8 +297,7 @@ def parse_virtual_assignment(context: TokenContext) -> Tuple[str]:
 
     """
     subvalues = context.current_token.subvalues
-    virtuals = subvalues["virtuals"]
-    if not virtuals:
+    if not subvalues:
         return ()
 
     # build a token for the substitute that we can put back on the stream
@@ -311,7 +310,7 @@ def parse_virtual_assignment(context: TokenContext) -> Tuple[str]:
     token = Token(token_type, pkg, start, start + len(pkg))
     context.push_front(token)
 
-    return tuple(virtuals.split(","))
+    return tuple(subvalues["virtuals"].split(","))
 
 
 class SpecParser:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -363,7 +363,7 @@ class SpecParser:
         current_spec = root_spec
         while True:
             if self.ctx.accept(SpecTokens.START_EDGE_PROPERTIES):
-                is_direct = self.ctx.current_token.value == "%"
+                is_direct = self.ctx.current_token.value[0] == "%"
 
                 edge_properties = EdgeAttributeParser(self.ctx, self.literal_str).parse()
                 edge_properties.setdefault("virtuals", ())
@@ -384,7 +384,7 @@ class SpecParser:
                 add_dependency(dependency, **edge_properties)
 
             elif self.ctx.accept(SpecTokens.DEPENDENCY):
-                is_direct = self.ctx.current_token.value == "%"
+                is_direct = self.ctx.current_token.value[0] == "%"
                 virtuals = parse_virtual_assignment(self.ctx)
 
                 # if no virtual assignment, check for a toolchain - look ahead to find the

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -316,8 +316,9 @@ def specfile_for(default_mock_concretization):
             "y+a~b+c~d+e~f",
         ),
         # Things that evaluate to Spec()
-        ("@:", [Token(SpecTokens.VERSION, value="@:")], r"*"),
-        ("*", [Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="*")], r"*"),
+        # TODO: consider making these format to "*" instead of ""
+        ("@:", [Token(SpecTokens.VERSION, value="@:")], r""),
+        ("*", [Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="*")], r""),
         # virtual assignment on a dep of an anonymous spec (more of these later)
         (
             "%foo=bar",

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -582,7 +582,19 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="openmpi"),
             ],
-            "^[virtuals=mpi] openmpi",
+            "^mpi=openmpi",
+        ),
+        (
+            "^mpi=openmpi",
+            [
+                Token(
+                    SpecTokens.DEPENDENCY,
+                    value="^mpi=openmpi",
+                    virtuals="mpi",
+                    substitute="openmpi",
+                )
+            ],
+            "^mpi=openmpi",
         ),
         # Allow merging attributes, if deptypes match
         (
@@ -599,7 +611,21 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="openmpi"),
                 Token(SpecTokens.BOOL_VARIANT, value="+bar"),
             ],
-            "^[virtuals=lapack,mpi] openmpi+bar+foo",
+            "^lapack,mpi=openmpi+bar+foo",
+        ),
+        (
+            "^lapack,mpi=openmpi+foo+bar",
+            [
+                Token(
+                    SpecTokens.DEPENDENCY,
+                    value="^lapack,mpi=openmpi",
+                    virtuals="lapack,mpi",
+                    substitute="openmpi",
+                ),
+                Token(SpecTokens.BOOL_VARIANT, value="+foo"),
+                Token(SpecTokens.BOOL_VARIANT, value="+bar"),
+            ],
+            "^lapack,mpi=openmpi+bar+foo",
         ),
         (
             "^[deptypes=link,build] zlib",
@@ -668,7 +694,15 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
             ],
-            "zlib %[virtuals=c] gcc",
+            "zlib %c=gcc",
+        ),
+        (
+            "zlib %c=gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib"),
+                Token(SpecTokens.DEPENDENCY, value="%c=gcc", virtuals="c", substitute="gcc"),
+            ],
+            "zlib %c=gcc",
         ),
         (
             "zlib %[virtuals=c,cxx] gcc",
@@ -679,7 +713,17 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
             ],
-            "zlib %[virtuals=c,cxx] gcc",
+            "zlib %c,cxx=gcc",
+        ),
+        (
+            "zlib %c,cxx=gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib"),
+                Token(
+                    SpecTokens.DEPENDENCY, value="%c,cxx=gcc", virtuals="c,cxx", substitute="gcc"
+                ),
+            ],
+            "zlib %c,cxx=gcc",
         ),
         (
             "zlib %[virtuals=c,cxx] gcc@14.1",
@@ -691,7 +735,18 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
                 Token(SpecTokens.VERSION, value="@14.1"),
             ],
-            "zlib %[virtuals=c,cxx] gcc@14.1",
+            "zlib %c,cxx=gcc@14.1",
+        ),
+        (
+            "zlib %c,cxx=gcc@14.1",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib"),
+                Token(
+                    SpecTokens.DEPENDENCY, value="%c,cxx=gcc", virtuals="c,cxx", substitute="gcc"
+                ),
+                Token(SpecTokens.VERSION, value="@14.1"),
+            ],
+            "zlib %c,cxx=gcc@14.1",
         ),
         (
             "zlib %[virtuals=fortran] gcc@14.1 %[virtuals=c,cxx] clang",
@@ -707,7 +762,27 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="clang"),
             ],
-            "zlib %[virtuals=fortran] gcc@14.1 %[virtuals=c,cxx] clang",
+            "zlib %fortran=gcc@14.1 %c,cxx=clang",
+        ),
+        (
+            "zlib %fortran=gcc@14.1 %c,cxx=clang",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib"),
+                Token(
+                    SpecTokens.DEPENDENCY,
+                    value="%fortran=gcc",
+                    virtuals="fortran",
+                    substitute="gcc",
+                ),
+                Token(SpecTokens.VERSION, value="@14.1"),
+                Token(
+                    SpecTokens.DEPENDENCY,
+                    value="%c,cxx=clang",
+                    virtuals="c,cxx",
+                    substitute="clang",
+                ),
+            ],
+            "zlib %fortran=gcc@14.1 %c,cxx=clang",
         ),
         # test := and :== syntax for key value pairs
         (
@@ -740,6 +815,18 @@ def specfile_for(default_mock_concretization):
         ),
         # Test conditional dependencies
         (
+            "foo ^[when='%c' virtuals=c] gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "foo"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, "^["),
+                Token(SpecTokens.KEY_VALUE_PAIR, "when='%c'"),
+                Token(SpecTokens.KEY_VALUE_PAIR, "virtuals=c"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, "]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "gcc"),
+            ],
+            "foo ^[when='%c'] c=gcc",
+        ),
+        (
             "foo ^[when='%c' virtuals=c]gcc",
             [
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "foo"),
@@ -749,7 +836,17 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.END_EDGE_PROPERTIES, "]"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "gcc"),
             ],
-            "foo ^[when='%c' virtuals=c] gcc",
+            "foo ^[when='%c'] c=gcc",
+        ),
+        (
+            "foo ^[when='%c'] c=gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "foo"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, "^["),
+                Token(SpecTokens.KEY_VALUE_PAIR, "when='%c'"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, "] c=gcc", virtuals="c", substitute="gcc"),
+            ],
+            "foo ^[when='%c'] c=gcc",
         ),
     ],
 )
@@ -902,17 +999,28 @@ def test_cli_spec_roundtrip(args, expected):
         (
             "foo%my_toolchain",
             {"my_toolchain": "%[when='%c' virtuals=c]gcc"},
-            ["foo %[when='%c' virtuals=c] gcc"],
+            ["foo %[when='%c'] c=gcc"],
         ),
+        ("foo%my_toolchain", {"my_toolchain": "%[when='%c'] c=gcc"}, ["foo %[when='%c'] c=gcc"]),
         (
             "foo%my_toolchain",
             {"my_toolchain": "+bar cflags=baz %[when='%c' virtuals=c]gcc"},
-            ["foo cflags=baz +bar %[when='%c' virtuals=c] gcc"],
+            ["foo cflags=baz +bar %[when='%c'] c=gcc"],
+        ),
+        (
+            "foo%my_toolchain",
+            {"my_toolchain": "+bar cflags=baz %[when='%c']c=gcc"},
+            ["foo cflags=baz +bar %[when='%c'] c=gcc"],
         ),
         (
             "foo%my_toolchain2",
             {"my_toolchain2": "%[when='%c' virtuals=c]gcc %[when='+mpi' virtuals=mpi]mpich"},
-            ["foo %[when='%c' virtuals=c] gcc %[when='+mpi' virtuals=mpi] mpich"],
+            ["foo %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
+        ),
+        (
+            "foo%my_toolchain2",
+            {"my_toolchain2": "%[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"},
+            ["foo %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
         ),
         (
             "foo%my_toolchain bar%my_toolchain2",
@@ -920,10 +1028,15 @@ def test_cli_spec_roundtrip(args, expected):
                 "my_toolchain": "%[when='%c' virtuals=c]gcc",
                 "my_toolchain2": "%[when='%c' virtuals=c]gcc %[when='+mpi' virtuals=mpi]mpich",
             },
-            [
-                "foo %[when='%c' virtuals=c] gcc",
-                "bar %[when='%c' virtuals=c] gcc %[when='+mpi' virtuals=mpi] mpich",
-            ],
+            ["foo %[when='%c'] c=gcc", "bar %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
+        ),
+        (
+            "foo%my_toolchain bar%my_toolchain2",
+            {
+                "my_toolchain": "%[when='%c'] c=gcc",
+                "my_toolchain2": "%[when='%c'] c=gcc %[when='+mpi']mpi=mpich",
+            },
+            ["foo %[when='%c'] c=gcc", "bar %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
         ),
         (
             "foo%my_toolchain2",
@@ -933,12 +1046,27 @@ def test_cli_spec_roundtrip(args, expected):
                     {"spec": "%[virtuals=mpi]mpich", "when": "+mpi"},
                 ]
             },
-            ["foo %[when='%c' virtuals=c] gcc %[when='+mpi' virtuals=mpi] mpich"],
+            ["foo %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
+        ),
+        (
+            "foo%my_toolchain2",
+            {
+                "my_toolchain2": [
+                    {"spec": "%c=gcc", "when": "%c"},
+                    {"spec": "%mpi=mpich", "when": "+mpi"},
+                ]
+            },
+            ["foo %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
         ),
         (
             "foo%my_toolchain2",
             {"my_toolchain2": [{"spec": "%[virtuals=c]gcc %[virtuals=mpi]mpich", "when": "%c"}]},
-            ["foo %[when='%c' virtuals=c] gcc %[when='%c' virtuals=mpi] mpich"],
+            ["foo %[when='%c'] c=gcc %[when='%c'] mpi=mpich"],
+        ),
+        (
+            "foo%my_toolchain2",
+            {"my_toolchain2": [{"spec": "%c=gcc %mpi=mpich", "when": "%c"}]},
+            ["foo %[when='%c'] c=gcc %[when='%c'] mpi=mpich"],
         ),
         # Test that we don't get caching wrong in the parser
         (
@@ -950,8 +1078,21 @@ def test_cli_spec_roundtrip(args, expected):
                 ]
             },
             [
-                "foo %[when='%c' virtuals=c] gcc %[when='%mpi' virtuals=mpi] mpich "
-                "^bar %[when='%c' virtuals=c] gcc %[when='%mpi' virtuals=mpi] mpich"
+                "foo %[when='%c'] c=gcc %[when='%mpi'] mpi=mpich "
+                "^bar %[when='%c'] c=gcc %[when='%mpi'] mpi=mpich"
+            ],
+        ),
+        (
+            "foo %gcc-mpich ^bar%gcc-mpich",
+            {
+                "gcc-mpich": [
+                    {"spec": "%c=gcc", "when": "%c"},
+                    {"spec": "%mpi=mpich", "when": "%mpi"},
+                ]
+            },
+            [
+                "foo %[when='%c'] c=gcc %[when='%mpi'] mpi=mpich "
+                "^bar %[when='%c'] c=gcc %[when='%mpi'] mpi=mpich"
             ],
         ),
     ],

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -315,7 +315,76 @@ def specfile_for(default_mock_concretization):
             ],
             "y+a~b+c~d+e~f",
         ),
-        ("@:", [Token(SpecTokens.VERSION, value="@:")], r""),
+        # Things that evaluate to Spec()
+        ("@:", [Token(SpecTokens.VERSION, value="@:")], r"*"),
+        ("*", [Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="*")], r"*"),
+        # virtual assignment on a dep of an anonymous spec (more of these later)
+        (
+            "%foo=bar",
+            [Token(SpecTokens.DEPENDENCY, value="%foo=bar", virtuals="foo", substitute="bar")],
+            "%foo=bar",
+        ),
+        (
+            "^foo=bar",
+            [Token(SpecTokens.DEPENDENCY, value="^foo=bar", virtuals="foo", substitute="bar")],
+            "^foo=bar",
+        ),
+        # anonymous dependencies with variants
+        (
+            "^*foo=bar",
+            [
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="*"),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="foo=bar"),
+            ],
+            "^*foo=bar",
+        ),
+        (
+            "%*foo=bar",
+            [
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="*"),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="foo=bar"),
+            ],
+            "%*foo=bar",
+        ),
+        (
+            "^*+foo",
+            [
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="*"),
+                Token(SpecTokens.BOOL_VARIANT, value="+foo"),
+            ],
+            "^+foo",
+        ),
+        (
+            "^*~foo",
+            [
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="*"),
+                Token(SpecTokens.BOOL_VARIANT, value="~foo"),
+            ],
+            "^~foo",
+        ),
+        (
+            "%*+foo",
+            [
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="*"),
+                Token(SpecTokens.BOOL_VARIANT, value="+foo"),
+            ],
+            "%+foo",
+        ),
+        (
+            "%*~foo",
+            [
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="*"),
+                Token(SpecTokens.BOOL_VARIANT, value="~foo"),
+            ],
+            "%~foo",
+        ),
+        # version range and list
         ("@1.6,1.2:1.4", [Token(SpecTokens.VERSION, value="@1.6,1.2:1.4")], r"@1.2:1.4,1.6"),
         (
             r"os=fe",  # Various translations associated with the architecture

--- a/lib/spack/spack/tokenize.py
+++ b/lib/spack/spack/tokenize.py
@@ -28,13 +28,14 @@ class TokenBase(enum.Enum):
 class Token:
     """Represents tokens; generated from input by lexer and fed to parse()."""
 
-    __slots__ = "kind", "value", "start", "end"
+    __slots__ = "kind", "value", "start", "end", "subvalues"
 
     def __init__(self, kind: TokenBase, value: str, start: int = 0, end: int = 0):
         self.kind = kind
         self.value = value
         self.start = start
         self.end = end
+        self.subvalues = None
 
     def __repr__(self):
         return str(self)
@@ -43,13 +44,56 @@ class Token:
         return f"({self.kind}, {self.value})"
 
     def __eq__(self, other):
-        return (self.kind == other.kind) and (self.value == other.value)
+        return (
+            self.kind == other.kind
+            and self.value == other.value
+            and self.subvalues == other.subvalues
+        )
+
+
+def rewrite_subvalues(token: Token, regex: str):
+    """Extract named capture groups from the provided regex and prefix them with token name.
+
+    Returns:
+        The rewritten regex and a list of pairs mapping subvalue name to rewritten name.
+    """
+    pairs = []
+
+    def replace(m: MatchObject):
+        subvalue_name = m.group(1)
+        pairs.append((token.name, subvalue_name))
+        return f"(?P<{token.name}_{subvalue_name}>"
+
+    return re.sub(r"\(\?P<([^>]+)>", replace, token.regex), pairs
 
 
 class Tokenizer:
     def __init__(self, tokens: Type[TokenBase]):
         self.tokens = tokens
-        self.regex = re.compile("|".join(f"(?P<{token}>{token.regex})" for token in tokens))
+
+        # tokens can have named subexpressions, if their regexes define named capture groups.
+        # record this so we can associate them with the token
+        self.token_subvalues = {}
+
+        parts = []
+        for token in tokens:
+            regex = re.sub(
+                r"\(\?P<([^>]+)>",
+                lambda m: m.replace(m.group(1), f"{token.name}_{m.group(1)}", token.regex),
+            )
+
+            subgroups = re.findall(r"\(\?P<([^>]+)>", token.regex)
+
+            parts.append(f"(?P<{token}>{token.regex})")
+
+        for token in tokens:
+
+            if subgroups:
+                self.token_subvalues[token.name] = subgroups
+
+        print(self.token_subvalues)
+
+        self.regex = re.compile("|".join(parts))
 
     def tokenize(self, text: str) -> Generator[Token, None, None]:
         if not text:
@@ -64,4 +108,12 @@ class Tokenizer:
             )
             assert m is not None, msg
             assert m.lastgroup is not None, msg
-            yield Token(self.tokens.__members__[m.lastgroup], m.group(), m.start(), m.end())
+
+            token = Token(self.tokens.__members__[m.lastgroup], m.group(), m.start(), m.end())
+
+            # add any subvalues to the token
+            subvalues = self.token_subvalues.get(m.lastgroup)
+            if subvalues:
+                token.subvalues = {name: m.group(name) for name in subvalues}
+
+            yield token

--- a/lib/spack/spack/tokenize.py
+++ b/lib/spack/spack/tokenize.py
@@ -54,7 +54,7 @@ class Token:
         )
 
 
-def token_match_regex(token: Token):
+def token_match_regex(token: TokenBase):
     """Generate a regular expression that matches the provided token and its subvalues.
 
     This will extract named capture groups from the provided regex and prefix them with

--- a/lib/spack/spack/tokenize.py
+++ b/lib/spack/spack/tokenize.py
@@ -30,18 +30,21 @@ class Token:
 
     __slots__ = "kind", "value", "start", "end", "subvalues"
 
-    def __init__(self, kind: TokenBase, value: str, start: int = 0, end: int = 0):
+    def __init__(self, kind: TokenBase, value: str, start: int = 0, end: int = 0, **kwargs):
         self.kind = kind
         self.value = value
         self.start = start
         self.end = end
-        self.subvalues = None
+        self.subvalues = kwargs if kwargs else None
 
     def __repr__(self):
         return str(self)
 
     def __str__(self):
-        return f"({self.kind}, {self.value})"
+        parts = [self.kind, self.value]
+        if self.subvalues:
+            parts += [self.subvalues]
+        return f"({', '.join(f'`{p}`' for p in parts)})"
 
     def __eq__(self, other):
         return (
@@ -114,6 +117,9 @@ class Tokenizer:
             # add any subvalues to the token
             subvalues = self.token_subvalues.get(m.lastgroup)
             if subvalues:
-                token.subvalues = {subval: m.group(rewritten) for subval, rewritten in subvalues}
+                if any(m.group(rewritten) for subval, rewritten in subvalues):
+                    token.subvalues = {
+                        subval: m.group(rewritten) for subval, rewritten in subvalues
+                    }
 
             yield token

--- a/lib/spack/spack/tokenize.py
+++ b/lib/spack/spack/tokenize.py
@@ -51,20 +51,30 @@ class Token:
         )
 
 
-def rewrite_subvalues(token: Token, regex: str):
-    """Extract named capture groups from the provided regex and prefix them with token name.
+def token_match_regex(token: Token):
+    """Generate a regular expression that matches the provided token and its subvalues.
+
+    This will extract named capture groups from the provided regex and prefix them with
+    token name, so they can coexist together in a larger, joined regular expression.
 
     Returns:
-        The rewritten regex and a list of pairs mapping subvalue name to rewritten name.
+        A regex with a capture group for the token and rewritten capture groups for any subvalues.
+
     """
     pairs = []
 
-    def replace(m: MatchObject):
+    def replace(m):
         subvalue_name = m.group(1)
-        pairs.append((token.name, subvalue_name))
-        return f"(?P<{token.name}_{subvalue_name}>"
+        token_prefixed_subvalue_name = f"{token.name}_{subvalue_name}"
+        pairs.append((subvalue_name, token_prefixed_subvalue_name))
+        return f"(?P<{token_prefixed_subvalue_name}>"
 
-    return re.sub(r"\(\?P<([^>]+)>", replace, token.regex), pairs
+    # rewrite all subvalue capture groups so they're prefixed with the token name
+    rewritten_token_regex = re.sub(r"\(\?P<([^>]+)>", replace, token.regex)
+
+    # construct a regex that matches the token as a whole *and* the subvalue capture groups
+    token_regex = f"(?P<{token}>{rewritten_token_regex})"
+    return token_regex, pairs
 
 
 class Tokenizer:
@@ -77,27 +87,17 @@ class Tokenizer:
 
         parts = []
         for token in tokens:
-            regex = re.sub(
-                r"\(\?P<([^>]+)>",
-                lambda m: m.replace(m.group(1), f"{token.name}_{m.group(1)}", token.regex),
-            )
-
-            subgroups = re.findall(r"\(\?P<([^>]+)>", token.regex)
-
-            parts.append(f"(?P<{token}>{token.regex})")
-
-        for token in tokens:
-
-            if subgroups:
-                self.token_subvalues[token.name] = subgroups
-
-        print(self.token_subvalues)
+            token_regex, pairs = token_match_regex(token)
+            parts.append(token_regex)
+            if pairs:
+                self.token_subvalues[token.name] = pairs
 
         self.regex = re.compile("|".join(parts))
 
     def tokenize(self, text: str) -> Generator[Token, None, None]:
         if not text:
             return
+
         scanner = self.regex.scanner(text)  # type: ignore[attr-defined]
         m: Optional[Match] = None
         for m in iter(scanner.match, None):
@@ -114,6 +114,6 @@ class Tokenizer:
             # add any subvalues to the token
             subvalues = self.token_subvalues.get(m.lastgroup)
             if subvalues:
-                token.subvalues = {name: m.group(name) for name in subvalues}
+                token.subvalues = {subval: m.group(rewritten) for subval, rewritten in subvalues}
 
             yield token


### PR DESCRIPTION
This makes compiler dependencies much easier to read and understand.

## Motivation

This also allows users to see directly, in the output of `spack spec` and other commands, what compiler was used for a node. It can be extended later to show things like which MPI or other virtual was chosen for a given node in `spack spec` output.  This essentially restores `spack spec` output to where it was in 0.23, and will:
1. Allow users to see what compilers were chosen
2. Allow users to understand how to specify them. `%c=gcc`, vs.` %[virtuals=c] gcc` may not seem like much, but consider for mixed compilers that you are likely to be writing:
    ```
    %[virtuals=c,cxx] gcc %[virtuals=fortran] gfortran
    ```
    vs.:
    ```
    %c= gcc %fortran=gfortran
    ```
    The latter is easy enough to specify ad-hoc on the CLI and is much easier to remember and read.  Consider that users are likely to glance at this as part of `spack spec` output -- the former is very noisy in that context.
4. Allow users to specify toolchains more easily.

Without this, users are going to need to understand our edge attribute syntax, which is not something I think should be in day-to-day use. The intuition with the syntax here is that, and virtuals are interfaces where you choose an implementation to substitute.  Virtuals are also now a *very* common part of users' conception of packages in Spack, since we use them for languages: `c`, `cxx`, and `fortran`, and in others in the future.

## Changes
Three main changes:

1. You can now write virtuals on edges as, e.g.:
    ```
    %c=gcc
    %c,cxx=gcc
    ^mpi=mpich@3.1
    ```
    instead of:
    ```
    %[virtuals=c] gcc
    %[virtuals=c,cxx] gcc
    ^[virtuals=mpi] mpich
    ```
5. `spack spec`, `spack solve`, and other places that would've shown `%compiler@version` before will show the `c`, `cxx`, and `fortran` virtuals for specs. This can be expanded later to be more customizable (e.g. if you want to see the MPI on each node in `spack spec`) but for now it allows users to easily see what compiler each node is built with, as they did before compiler dependencies.

Example of (2):

<img width="883" alt="Screenshot 2025-06-07 at 6 14 06 PM" src="https://github.com/user-attachments/assets/6511cd5d-65ac-416a-b0da-016cefcfa4a8" />

## Breaking change

Previously, `^c=gcc` would've been "any spec that depends on something that has gcc as the value of the c variant". While this is an uncommon query, that meaning is still possible, but requires a wildcard, like this:
```
spack find "^* foo=bar"
```

A key value pair assignment immediately after a dependency or after an edge specifier, where the spec name would normally be, is considered virtual assignment. Examples:

```
^c=gcc
%c=gcc
%[when=%c] c=gcc
```

Note that because we support a wildcard, you can now parse `Spec()` on the CLI, where previously that wasn't possible. `Spec()` is just `*`.

- [x] parse virtual assignment syntax
- [x] output virtual assignment syntax in `str(spec)`, `long_spec`, etc.
- [x] print virtual assignment syntax in `DISPLAY_FORMAT` for compilers
- [x] add "{compilers}" spec format property for this
- [x] rework tests to account for new default output format