### PR TITLE
Checks for databases and mirror indexes

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -192,19 +192,9 @@ class BinaryCacheIndex:
         # Each entry is a MirrorURLAndVersion.
         self._mirrors_for_spec: Dict[str, List[MirrorForSpec]] = {}
 
-    def _init_local_index_cache(self, ignore_file_presence=False):
+    def _init_local_index_cache(self):
         cache_key = self._index_contents_key
-        # Hypothesis: TODO for refactoring
-        #
-        # odd logic for bootstrapping where in memory the cache is getting populated
-        # but then the root is changed so the index file doesn't exist
-        # the goal of bootstrapping is to get info about the system from the pre-existing cache
-        # but then use a separate store for after it is establisihed
-        if ignore_file_presence:
-            self._index_file_cache.init_entry(cache_key)
-            exists = True
-        else:
-            exists = self._index_file_cache.init_entry(cache_key)
+        exists = self._index_file_cache.init_entry(cache_key)
 
         if not self._index_file_cache_initialized or not exists:
             cache_path = self._index_file_cache.cache_path(cache_key)
@@ -234,12 +224,12 @@ class BinaryCacheIndex:
         with self._index_file_cache.write_transaction(cache_key) as (old, new):
             json.dump(self._local_index_cache, new)
 
-    def regenerate_spec_cache(self, clear_existing=False, ignore_index_file_presence=False):
+    def regenerate_spec_cache(self, clear_existing=False):
         """Populate the local cache of concrete specs (``_mirrors_for_spec``)
         from the locally cached buildcache index files.  This is essentially a
         no-op if it has already been done, as we keep track of the index
         hashes for which we have already associated the built specs."""
-        self._init_local_index_cache(ignore_index_file_presence)
+        self._init_local_index_cache()
 
         if clear_existing:
             self._specs_already_associated = set()

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -194,9 +194,10 @@ class BinaryCacheIndex:
 
     def _init_local_index_cache(self):
         cache_key = self._index_contents_key
-        self._index_file_cache.init_entry(cache_key)
+        exists = self._index_file_cache.init_entry(cache_key)
 
-        if not self._index_file_cache_initialized:
+        if not self._index_file_cache_initialized or not exists:
+            self.clear()
             cache_path = self._index_file_cache.cache_path(cache_key)
 
             self._local_index_cache = {}

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -193,10 +193,16 @@ class BinaryCacheIndex:
         self._mirrors_for_spec: Dict[str, List[MirrorForSpec]] = {}
 
     def _init_local_index_cache(self):
-        cache_key = self._index_contents_key
-        exists = self._index_file_cache.init_entry(cache_key)
+        # seems logical but fails bootstrapping
+        # cache_key = self._index_contents_key
+        # exists = self._index_file_cache.init_entry(cache_key)
+        # cache_path = self._index_file_cache.cache_path(cache_key)
+        # if not exists and self._index_file_cache_initialized:
+        # raise FileNotFoundError(f"Missing {cache_path}")
 
-        if not self._index_file_cache_initialized or not exists:
+        if not self._index_file_cache_initialized:
+            cache_key = self._index_contents_key
+            self._index_file_cache.init_entry(cache_key)
             cache_path = self._index_file_cache.cache_path(cache_key)
 
             self._local_index_cache = {}
@@ -255,6 +261,11 @@ class BinaryCacheIndex:
             try:
                 cache_exists = self._index_file_cache.init_entry(cache_key)
                 cache_path = self._index_file_cache.cache_path(cache_key)
+                if not cache_exists:
+                    # recreate index if it is missing
+                    cache_entry = self._local_index_cache[cache_key]
+                    self._fetch_and_cache_index(url_and_version, cache_entry)
+                    cache_exists = self._index_file_cache.init_entry(cache_key)
                 if cache_exists:
                     with self._index_file_cache.read_transaction(cache_key):
                         db._read_from_file(cache_path)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -197,7 +197,6 @@ class BinaryCacheIndex:
         exists = self._index_file_cache.init_entry(cache_key)
 
         if not self._index_file_cache_initialized or not exists:
-            self.clear()
             cache_path = self._index_file_cache.cache_path(cache_key)
 
             self._local_index_cache = {}

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -259,14 +259,15 @@ class BinaryCacheIndex:
             db = BuildCacheDatabase(tmpdir)
 
             try:
-                cache_exists = self._index_file_cache.init_entry(cache_key)
-                cache_path = self._index_file_cache.cache_path(cache_key)
-                with self._index_file_cache.read_transaction(cache_key):
-                    if not cache_exists:
-                        # recreate index if it is missing
+                cache_file_exists = self._index_file_cache.init_entry(cache_key)
+                cache_file_path = self._index_file_cache.cache_path(cache_key)
+                if not cache_file_exists:
+                    # recreate index if it is missing
+                    with self._index_file_cache.write_transaction(cache_key):
                         cache_entry = self._local_index_cache[cache_key]
                         self._fetch_and_cache_index(url_and_version, cache_entry)
-                    db._read_from_file(cache_path)
+                with self._index_file_cache.read_transaction(cache_key):
+                    db._read_from_file(cache_file_path)
             except spack_db.InvalidDatabaseVersionError as e:
                 tty.warn(
                     "you need a newer Spack version to read the buildcache index "

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -266,8 +266,7 @@ class BinaryCacheIndex:
                         # recreate index if it is missing
                         cache_entry = self._local_index_cache[str(url_and_version)]
                         self._fetch_and_cache_index(url_and_version, cache_entry)
-                    with self._index_file_cache.read_transaction(cache_key):
-                        db._read_from_file(cache_file_path)
+                    db._read_from_file(cache_file_path)
             except spack_db.InvalidDatabaseVersionError as e:
                 tty.warn(
                     "you need a newer Spack version to read the buildcache index "

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -192,9 +192,19 @@ class BinaryCacheIndex:
         # Each entry is a MirrorURLAndVersion.
         self._mirrors_for_spec: Dict[str, List[MirrorForSpec]] = {}
 
-    def _init_local_index_cache(self):
+    def _init_local_index_cache(self, ignore_file_presence=False):
         cache_key = self._index_contents_key
-        exists = self._index_file_cache.init_entry(cache_key)
+        # Hypothesis: TODO for refactoring
+        #
+        # odd logic for bootstrapping where in memory the cache is getting populated
+        # but then the root is changed so the index file doesn't exist
+        # the goal of bootstrapping is to get info about the system from the pre-existing cache
+        # but then use a separate store for after it is establisihed
+        if ignore_file_presence:
+            self._index_file_cache.init_entry(cache_key)
+            exists = True
+        else:
+            exists = self._index_file_cache.init_entry(cache_key)
 
         if not self._index_file_cache_initialized or not exists:
             cache_path = self._index_file_cache.cache_path(cache_key)
@@ -224,12 +234,12 @@ class BinaryCacheIndex:
         with self._index_file_cache.write_transaction(cache_key) as (old, new):
             json.dump(self._local_index_cache, new)
 
-    def regenerate_spec_cache(self, clear_existing=False):
+    def regenerate_spec_cache(self, clear_existing=False, ignore_index_file_presence=False):
         """Populate the local cache of concrete specs (``_mirrors_for_spec``)
         from the locally cached buildcache index files.  This is essentially a
         no-op if it has already been done, as we keep track of the index
         hashes for which we have already associated the built specs."""
-        self._init_local_index_cache()
+        self._init_local_index_cache(ignore_index_file_presence)
 
         if clear_existing:
             self._specs_already_associated = set()

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -264,7 +264,7 @@ class BinaryCacheIndex:
                 if not cache_file_exists:
                     # recreate index if it is missing
                     with self._index_file_cache.write_transaction(cache_key):
-                        cache_entry = self._local_index_cache[cache_key]
+                        cache_entry = self._local_index_cache[str(url_and_version)]
                         self._fetch_and_cache_index(url_and_version, cache_entry)
                 with self._index_file_cache.read_transaction(cache_key):
                     db._read_from_file(cache_file_path)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -194,9 +194,9 @@ class BinaryCacheIndex:
 
     def _init_local_index_cache(self):
         cache_key = self._index_contents_key
-        file_exists = self._index_file_cache.init_entry(cache_key)
+        self._index_file_cache.init_entry(cache_key)
 
-        if not self._index_file_cache_initialized or not file_exists:
+        if not self._index_file_cache_initialized:
             cache_path = self._index_file_cache.cache_path(cache_key)
 
             self._local_index_cache = {}
@@ -211,6 +211,7 @@ class BinaryCacheIndex:
         clear associated data structures."""
         if self._index_file_cache:
             self._index_file_cache.destroy()
+            self._index_file_cache_initialized = False
             self._index_file_cache = file_cache.FileCache(self._index_cache_root)
         self._local_index_cache = {}
         self._specs_already_associated = set()

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -261,17 +261,12 @@ class BinaryCacheIndex:
             try:
                 cache_exists = self._index_file_cache.init_entry(cache_key)
                 cache_path = self._index_file_cache.cache_path(cache_key)
-                if not cache_exists:
-                    # recreate index if it is missing
-                    cache_entry = self._local_index_cache[cache_key]
-                    self._fetch_and_cache_index(url_and_version, cache_entry)
-                    cache_exists = self._index_file_cache.init_entry(cache_key)
-                if cache_exists:
-                    with self._index_file_cache.read_transaction(cache_key):
-                        db._read_from_file(cache_path)
-                else:
-                    # this is a logic bug, we should never hit this
-                    raise FileNotFoundError(f"cache index file missing: {cache_path}")
+                with self._index_file_cache.read_transaction(cache_key):
+                    if not cache_exists:
+                        # recreate index if it is missing
+                        cache_entry = self._local_index_cache[cache_key]
+                        self._fetch_and_cache_index(url_and_version, cache_entry)
+                    db._read_from_file(cache_path)
             except spack_db.InvalidDatabaseVersionError as e:
                 tty.warn(
                     "you need a newer Spack version to read the buildcache index "
@@ -556,7 +551,7 @@ class BinaryCacheIndex:
         # Persist new index.json
         url_hash = compute_hash(f"{mirror_url}/v{layout_version}")
         cache_key = "{}_{}.json".format(url_hash[:10], result.hash[:10])
-        pre_existing = self._index_file_cache.init_entry(cache_key)
+        self._index_file_cache.init_entry(cache_key)
         with self._index_file_cache.write_transaction(cache_key) as (old, new):
             new.write(result.data)
 
@@ -568,7 +563,7 @@ class BinaryCacheIndex:
 
         # clean up the old cache_key if necessary
         old_cache_key = cache_entry.get("index_path", None)
-        if old_cache_key and not pre_existing:
+        if old_cache_key and old_cache_key != cache_key:
             self._index_file_cache.remove(old_cache_key)
 
         # We fetched an index and updated the local index cache, we should

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -193,10 +193,10 @@ class BinaryCacheIndex:
         self._mirrors_for_spec: Dict[str, List[MirrorForSpec]] = {}
 
     def _init_local_index_cache(self):
-        if not self._index_file_cache_initialized:
-            cache_key = self._index_contents_key
-            self._index_file_cache.init_entry(cache_key)
+        cache_key = self._index_contents_key
+        file_exists = self._index_file_cache.init_entry(cache_key)
 
+        if not self._index_file_cache_initialized or not file_exists:
             cache_path = self._index_file_cache.cache_path(cache_key)
 
             self._local_index_cache = {}
@@ -252,10 +252,14 @@ class BinaryCacheIndex:
             db = BuildCacheDatabase(tmpdir)
 
             try:
-                self._index_file_cache.init_entry(cache_key)
+                cache_exists = self._index_file_cache.init_entry(cache_key)
                 cache_path = self._index_file_cache.cache_path(cache_key)
-                with self._index_file_cache.read_transaction(cache_key):
-                    db._read_from_file(pathlib.Path(cache_path))
+                if cache_exists:
+                    with self._index_file_cache.read_transaction(cache_key):
+                        db._read_from_file(cache_path)
+                else:
+                    # this is a logic bug, we should never hit this
+                    raise FileNotFoundError(f"cache index file missing: {cache_path}")
             except spack_db.InvalidDatabaseVersionError as e:
                 tty.warn(
                     "you need a newer Spack version to read the buildcache index "

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -545,7 +545,7 @@ class BinaryCacheIndex:
         # Persist new index.json
         url_hash = compute_hash(f"{mirror_url}/v{layout_version}")
         cache_key = "{}_{}.json".format(url_hash[:10], result.hash[:10])
-        self._index_file_cache.init_entry(cache_key)
+        pre_existing = self._index_file_cache.init_entry(cache_key)
         with self._index_file_cache.write_transaction(cache_key) as (old, new):
             new.write(result.data)
 
@@ -557,7 +557,7 @@ class BinaryCacheIndex:
 
         # clean up the old cache_key if necessary
         old_cache_key = cache_entry.get("index_path", None)
-        if old_cache_key:
+        if old_cache_key and not pre_existing:
             self._index_file_cache.remove(old_cache_key)
 
         # We fetched an index and updated the local index cache, we should

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -260,14 +260,14 @@ class BinaryCacheIndex:
 
             try:
                 cache_file_exists = self._index_file_cache.init_entry(cache_key)
-                cache_file_path = self._index_file_cache.cache_path(cache_key)
-                if not cache_file_exists:
-                    # recreate index if it is missing
-                    with self._index_file_cache.write_transaction(cache_key):
+                with self._index_file_cache.write_transaction(cache_key):
+                    cache_file_path = self._index_file_cache.cache_path(cache_key)
+                    if not cache_file_exists:
+                        # recreate index if it is missing
                         cache_entry = self._local_index_cache[str(url_and_version)]
                         self._fetch_and_cache_index(url_and_version, cache_entry)
-                with self._index_file_cache.read_transaction(cache_key):
-                    db._read_from_file(cache_file_path)
+                    with self._index_file_cache.read_transaction(cache_key):
+                        db._read_from_file(cache_file_path)
             except spack_db.InvalidDatabaseVersionError as e:
                 tty.warn(
                     "you need a newer Spack version to read the buildcache index "

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -203,7 +203,9 @@ class BuildcacheBootstrapper(Bootstrapper):
         with spack.config.override(self.mirror_scope):
             # This index is currently needed to get the compiler used to build some
             # specs that we know by dag hash.
-            spack.binary_distribution.BINARY_INDEX.regenerate_spec_cache()
+            spack.binary_distribution.BINARY_INDEX.regenerate_spec_cache(
+                ignore_index_file_presence=True
+            )
             index = spack.binary_distribution.update_cache_and_get_specs()
 
             if not index:

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -203,9 +203,7 @@ class BuildcacheBootstrapper(Bootstrapper):
         with spack.config.override(self.mirror_scope):
             # This index is currently needed to get the compiler used to build some
             # specs that we know by dag hash.
-            spack.binary_distribution.BINARY_INDEX.regenerate_spec_cache(
-                ignore_index_file_presence=True
-            )
+            spack.binary_distribution.BINARY_INDEX.regenerate_spec_cache()
             index = spack.binary_distribution.update_cache_and_get_specs()
 
             if not index:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -795,6 +795,9 @@ class Database:
 
         Does not do any locking.
         """
+        if not filename.is_file():
+            raise FileNotFoundError(f"database does not exist {filename}")
+
         try:
             # In the future we may use a stream of JSON objects, hence `raw_decode` for compat.
             fdata, _ = JSONDecoder().raw_decode(filename.read_text(encoding="utf-8"))

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -137,6 +137,7 @@ def default_config(tmp_path, config_directory, mock_packages_repo, install_mocke
             spack.config.set(
                 "config:build_stage", [str(mutable_dir / "build_stage")], scope="user"
             )
+        spack.config.set("config:misc_cache:", str(mutable_dir / "misc_cache"), scope="user")
         timeout = spack.config.get("config:connect_timeout")
         if not timeout:
             spack.config.set("config:connect_timeout", 10, scope="user")
@@ -325,6 +326,11 @@ def test_relative_rpaths_install_nondefault(temporary_mirror_dir):
     into the non-default directory layout scheme.
     """
     cspec = spack.concretize.concretize_one("corge")
+    # Install 'corge' without using a cache
+    install_cmd("--no-cache", cspec.name)
+    buildcache_cmd("push", "-u", temporary_mirror_dir, cspec.name)
+    buildcache_cmd("update-index", temporary_mirror_dir)
+    uninstall_cmd("-y", "--dependents", cspec.name)
 
     # Test install in non-default install path scheme and relative path
     buildcache_cmd("install", "-ufo", cspec.name)


### PR DESCRIPTION
Several bugs for the logic regarding cache indexes and `contents.json` have been exposed and tried to fix in this PR. It is currently hot-fix without added tests, but relevant to #47615 .

1.  If the index file gets garbage collected/removed, but still remains in the `contents.json`/objects memory, spack will try to open the file and fail. Add a check to re-create to try and recreate he index if it is missing, but should be there.
  
2. If the remote hash gets out of sync the code can get into a state where it thinks it should update the index, but then recomputes the same file name for the new index file. In this case it currently garbage collects itself. Added logic to skip if the new index file computed already exists since it does an overwrite in this case. 

3. Database reads don't use file-locks, but also have no check for existence of the database file pre-read attempt. Add an existence check for cleaner debugging. 

I think these are all valid bugs and fixes. It indicates that `binary_distribution.py` and the tests for it need a lot more attention/refactoring post 1.0 no matter what. Items 2 and 3 should not be required for #47615, but were helpful during debugging iterations. They are optional, but I think they should be added. Especially item 2.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
