### PR TITLE
detection: use the instance passed instead of the global

### DIFF
--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -339,7 +339,9 @@ class CompilerFactory:
             pattern = re.compile(r"|".join(finder.search_patterns(pkg=pkg_cls)))
             filtered_paths = [x for x in candidate_paths if pattern.search(os.path.basename(x))]
             try:
-                detected = finder.detect_specs(pkg=pkg_cls, paths=filtered_paths)
+                detected = finder.detect_specs(
+                    pkg=pkg_cls, paths=filtered_paths, repo_path=spack.repo.PATH
+                )
             except Exception:
                 warnings.warn(
                     f"[{__name__}] cannot detect {pkg_name} from the "

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -88,7 +88,7 @@ def compiler_spec_from_paths(*, pkg_name: str, compiler_paths: Iterable[str]) ->
     """Returns the external spec associated with a series of compilers, if any."""
     pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
     finder = ExecutablesFinder()
-    specs = finder.detect_specs(pkg=pkg_cls, paths=compiler_paths)
+    specs = finder.detect_specs(pkg=pkg_cls, paths=compiler_paths, repo_path=spack.repo.PATH)
 
     if not specs or len(specs) > 1:
         raise CrayCompilerDetectionError(

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -253,7 +253,7 @@ class Finder:
         raise NotImplementedError("must be implemented by derived classes")
 
     def detect_specs(
-        self, *, pkg: Type["spack.package_base.PackageBase"], paths: Iterable[str]
+        self, *, pkg: Type["spack.package_base.PackageBase"], paths: Iterable[str], repo_path
     ) -> List["spack.spec.Spec"]:
         """Given a list of files matching the search patterns, returns a list of detected specs.
 
@@ -268,8 +268,6 @@ class Finder:
                 f" of the package."
             )
             return []
-
-        from spack.repo import PATH as repo_path
 
         result = []
         for candidate_path, items_in_prefix in _group_by_prefix(
@@ -355,8 +353,7 @@ class Finder:
             initial_guess = self.default_path_hints()
             initial_guess.extend(common_windows_package_paths(pkg_cls))
         candidates = self.candidate_files(patterns=patterns, paths=initial_guess)
-        result = self.detect_specs(pkg=pkg_cls, paths=candidates)
-        return result
+        return self.detect_specs(pkg=pkg_cls, paths=candidates, repo_path=repository)
 
 
 class ExecutablesFinder(Finder):


### PR DESCRIPTION
Lazy initialization of `spack.repo.PATH` depends on `spack.config.CONFIG`, which in turn is initialized lazily, but differs from how `spack.main` does it, notably without environment config scopes.

What ends up happening is that sub-processes created on platforms that use spawn are missing repos defined in environments and extra command line scopes.