### PR TITLE
detect subprocess initialization issues

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -968,6 +968,9 @@ MAIN_WAS_RUN = False
 
 def _lazy():
     if not MAIN_WAS_RUN:
+        import traceback
+
+        traceback.print_stack()
         raise RuntimeError("spack.config.CONFIG is initialized lazily with wrong config.")
     return create_incremental()
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -963,8 +963,17 @@ def create() -> Configuration:
     return list(create_incremental())[-1]
 
 
+MAIN_WAS_RUN = False
+
+
+def _lazy():
+    if not MAIN_WAS_RUN:
+        raise RuntimeError("spack.config.CONFIG is initialized lazily with wrong config.")
+    return create_incremental()
+
+
 #: This is the singleton configuration instance for Spack.
-CONFIG: Configuration = lang.Singleton(create_incremental)  # type: ignore
+CONFIG: Configuration = lang.Singleton(_lazy)  # type: ignore
 
 
 def add_from_file(filename: str, scope: Optional[str] = None) -> None:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -42,6 +42,7 @@ import spack.environment.environment
 import spack.error
 import spack.paths
 import spack.platforms
+import spack.repo
 import spack.solver.asp
 import spack.spec
 import spack.store
@@ -1044,6 +1045,8 @@ def main(argv=None):
             the executable name. If None, parses from sys.argv.
 
     """
+    spack.config.MAIN_WAS_RUN = True
+    spack.repo.MAIN_WAS_RUN = True
     try:
         return _main(argv)
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1886,10 +1886,17 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
     return repo_path
 
 
+MAIN_WAS_RUN = False
+
+
+def _lazy():
+    if not MAIN_WAS_RUN:
+        raise RuntimeError("spack.repo.PATH is initialized lazily with wrong config.")
+    return create_and_enable(spack.config.CONFIG)
+
+
 #: Global package repository instance.
-PATH: RepoPath = llnl.util.lang.Singleton(
-    lambda: create_and_enable(spack.config.CONFIG)
-)  # type: ignore[assignment]
+PATH: RepoPath = llnl.util.lang.Singleton(_lazy)  # type: ignore[assignment]
 
 # Add the finder to sys.meta_path
 REPOS_FINDER = ReposFinder()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1891,6 +1891,9 @@ MAIN_WAS_RUN = False
 
 def _lazy():
     if not MAIN_WAS_RUN:
+        import traceback
+
+        traceback.print_stack()
         raise RuntimeError("spack.repo.PATH is initialized lazily with wrong config.")
     return create_and_enable(spack.config.CONFIG)
 


### PR DESCRIPTION
- **detection: use the instance passed instead of the global**
- **detect init issues with globals**

Spack's lazy init of `spack.repo.PATH` and others assume `spack.config.CONFIG` is set up correctly, but this is only the case if either (a) Spack's main function sets up spack.config.CONFIG, or (b) the build env is set up which (de)serializes spack.config.CONFIG set up by Spack's main function.

Any other subprocess that references spack.repo.PATH will use wrong config.

This is not a PR meant to be merged, just a commit to test for problems in spack/spack-packages