### PR TITLE
CI: switch ubi8 image to rockylinux

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -54,7 +54,7 @@ jobs:
   # Check that spack can bootstrap the development environment on Python 3.6 - RHEL8
   bootstrap-dev-rhel8:
     runs-on: ubuntu-latest
-    container: registry.access.redhat.com/ubi8/ubi
+    container: rockylinux:8
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -132,7 +132,7 @@ jobs:
   # only on PRs modifying core Spack
   rhel8-platform-python:
     runs-on: ubuntu-latest
-    container: registry.access.redhat.com/ubi8/ubi
+    container: rockylinux:8
     steps:
     - name: Install dependencies
       run: |


### PR DESCRIPTION
RHEL8 UBI tests started failing with some sort of repository issue with `glibc-devel`.

Try switching to Rocky Linux for now.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
