### PR TITLE
Add `spack repo update` command

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -290,7 +290,7 @@ def create_temp_env_directory():
 
 def _tty_info(msg):
     """tty.info like function that prints the equivalent printf statement for eval."""
-    decorated = f'{colorize("@*b{==>}")} {msg}\n'
+    decorated = f"{colorize('@*b{==>}')} {msg}\n"
     executor = "echo" if sys.platform == "win32" else "printf"
     print(f"{executor} {shlex.quote(decorated)};")
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -290,7 +290,7 @@ def create_temp_env_directory():
 
 def _tty_info(msg):
     """tty.info like function that prints the equivalent printf statement for eval."""
-    decorated = f"{colorize('@*b{==>}')} {msg}\n"
+    decorated = f'{colorize("@*b{==>}")} {msg}\n'
     executor = "echo" if sys.platform == "win32" else "printf"
     print(f"{executor} {shlex.quote(decorated)};")
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -485,7 +485,7 @@ def repo_update(args: Any) -> int:
     # Get the repos for the specific scope we're modifying
     scope_repos: Dict[str, Any] = spack.config.get("repos", default={}, scope=args.scope)
 
-    namespace_flags = ["commit", "tag", "branch", "remote"]
+    namespace_flags = ["commit", "tag", "branch"]
     active_flag = next((attr for attr in namespace_flags if getattr(args, attr)), None)
     if active_flag and len(args.namespaces) != 1:
         error_msg = (
@@ -528,7 +528,9 @@ def repo_update(args: Any) -> int:
         if descriptor.error:  # need to fix this / find a better way
             raise SpackError(descriptor.error)
 
-    spack.config.set("repos", scope_repos, args.scope)
+    if active_flag:
+        spack.config.set("repos", scope_repos, args.scope)
+
     return 0
 
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -138,7 +138,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
 
     # Update
     update_parser = sp.add_parser("update", help=repo_update.__doc__)
-    update_parser.add_argument("namespace", nargs="?", help="repository namespace to update")
+    update_parser.add_argument(
+        "namespaces", nargs="*", default=[], help="repository namespaces to update"
+    )
     update_parser.add_argument(
         "--remote",
         "-r",
@@ -476,24 +478,49 @@ def repo_update(args: Any) -> int:
     config = spack.config.CONFIG
     scope = args.scope
 
-    if args.namespace:
-        existing: Dict[str, Any] = config.get("repos", default={}, scope=scope)
-        if args.namespace not in existing:
-            raise SpackError(f"{args.namespace} is not a known repository namespace.")
+    descriptors = spack.repo.RepoDescriptors.from_config(
+        spack.repo.package_repository_lock(), config, scope=scope
+    )
 
-        entry = spack.util.path.canonicalize_path(args.namespace)
-        descriptors = {
-            args.namespace: spack.repo.parse_config_descriptor(
-                args.namespace or "<unnamed>", entry, lock=spack.repo.package_repository_lock()
-            )
-        }
-    else:
-        descriptors = spack.repo.RepoDescriptors.from_config(
-            spack.repo.package_repository_lock(), spack.config.CONFIG
+    # Get the repos for the specific scope we're modifying
+    scope_repos: Dict[str, Any] = spack.config.get("repos", default={}, scope=args.scope)
+
+    namespace_flags = ["commit", "tag", "branch", "remote"]
+    active_flag = next((attr for attr in namespace_flags if getattr(args, attr)), None)
+    if active_flag and len(args.namespaces) != 1:
+        error_msg = (
+            f"Unable to set --{active_flag} because more than one namespace was given."
+            if len(args.namespaces) > 1
+            else f"Unable to apply --{active_flag} without a namespace"
         )
+        raise SpackError(error_msg)
 
-    for _, descriptor in descriptors.items():
-        descriptor.update(git=spack.util.executable.which("git"))
+    if args.namespaces:
+        for namespace in args.namespaces:
+            if namespace not in descriptors:
+                raise SpackError(f"{namespace} is not a known repository namespace.")
+
+        # filter descriptors when namespaces are provided as arguments
+        descriptors = {
+            name: descriptor for name, descriptor in descriptors.items() if name in args.namespaces
+        }
+
+    for name, descriptor in descriptors.items():
+        if active_flag:
+            # update the git commit, tag, or branch of the descriptor
+            setattr(descriptor, active_flag, getattr(args, active_flag))
+
+            # prune previous values of git fields
+            for entry in {"commit", "tag", "branch"} - {active_flag}:
+                setattr(descriptor, entry, None)
+                scope_repos[namespace].pop(entry, None)
+
+            scope_repos[namespace][active_flag] = args.commit or args.tag or args.branch
+
+        descriptor.update(git=spack.util.executable.which("git"), remote=args.remote)
+
+    spack.config.set("repos", scope_repos, args.scope)
+    return 0
 
 
 def repo(parser, args):

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -480,12 +480,11 @@ def repo_update(args: Any) -> int:
     git_flags = ["commit", "tag", "branch"]
     active_flag = next((attr for attr in git_flags if getattr(args, attr)), None)
     if active_flag and len(args.names) != 1:
-        error_msg = (
+        raise SpackError(
             f"Unable to set --{active_flag} because more than one namespace was given."
             if len(args.names) > 1
             else f"Unable to apply --{active_flag} without a namespace"
         )
-        raise SpackError(error_msg)
 
     for name in args.names:
         if name not in descriptors:

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -483,28 +483,23 @@ def repo_update(args: Any) -> int:
     # Get the repos for the specific scope we're modifying
     scope_repos: Dict[str, Any] = spack.config.get("repos", default={}, scope=args.scope)
 
-    namespace_flags = ["commit", "tag", "branch"]
-    active_flag = next((attr for attr in namespace_flags if getattr(args, attr)), None)
-    if active_flag and len(args.namespaces) != 1:
+    git_flags = ["commit", "tag", "branch"]
+    active_flag = next((attr for attr in git_flags if getattr(args, attr)), None)
+    if active_flag and len(args.names) != 1:
         error_msg = (
             f"Unable to set --{active_flag} because more than one namespace was given."
-            if len(args.namespaces) > 1
+            if len(args.names) > 1
             else f"Unable to apply --{active_flag} without a namespace"
         )
         raise SpackError(error_msg)
 
-    if args.namespaces:
-        for namespace in args.namespaces:
-            if namespace not in descriptors:
-                raise SpackError(f"{namespace} is not a known repository namespace.")
+    for name in args.names:
+        if name not in descriptors:
+            raise SpackError(f"{name} is not a known repository name.")
 
         # filter descriptors when namespaces are provided as arguments
         descriptors = spack.repo.RepoDescriptors(
-            {
-                name: descriptor
-                for name, descriptor in descriptors.items()
-                if name in args.namespaces
-            }
+            {name: descriptor for name, descriptor in descriptors.items() if name in args.names}
         )
 
     for name, descriptor in descriptors.items():
@@ -518,13 +513,11 @@ def repo_update(args: Any) -> int:
             # prune previous values of git fields
             for entry in {"commit", "tag", "branch"} - {active_flag}:
                 setattr(descriptor, entry, None)
-                scope_repos[namespace].pop(entry, None)
+                scope_repos[name].pop(entry, None)
 
-            scope_repos[namespace][active_flag] = args.commit or args.tag or args.branch
+            scope_repos[name][active_flag] = args.commit or args.tag or args.branch
 
         descriptor.update(git=spack.util.executable.which("git"), remote=args.remote)
-        if descriptor.error:  # need to fix this / find a better way
-            raise SpackError(descriptor.error)
 
     if active_flag:
         spack.config.set("repos", scope_repos, args.scope)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -473,15 +473,9 @@ def _iter_repos_from_descriptors(
 
 
 def repo_update(args: Any) -> int:
-    config = spack.config.CONFIG
-    scope = args.scope
-
     descriptors = spack.repo.RepoDescriptors.from_config(
-        spack.repo.package_repository_lock(), config, scope=scope
+        spack.repo.package_repository_lock(), spack.config.CONFIG
     )
-
-    # Get the repos for the specific scope we're modifying
-    scope_repos: Dict[str, Any] = spack.config.get("repos", default={}, scope=args.scope)
 
     git_flags = ["commit", "tag", "branch"]
     active_flag = next((attr for attr in git_flags if getattr(args, attr)), None)
@@ -502,6 +496,9 @@ def repo_update(args: Any) -> int:
             {name: descriptor for name, descriptor in descriptors.items() if name in args.names}
         )
 
+    # Get the repos for the specific scope we're modifying
+    scope_repos: Dict[str, Any] = spack.config.get("repos", default={}, scope=args.scope)
+
     for name, descriptor in descriptors.items():
         if not isinstance(descriptor, spack.repo.RemoteRepoDescriptor):
             continue
@@ -510,12 +507,15 @@ def repo_update(args: Any) -> int:
             # update the git commit, tag, or branch of the descriptor
             setattr(descriptor, active_flag, getattr(args, active_flag))
 
+            updated_entry = scope_repos[name] if name in scope_repos else {}
+
             # prune previous values of git fields
             for entry in {"commit", "tag", "branch"} - {active_flag}:
                 setattr(descriptor, entry, None)
-                scope_repos[name].pop(entry, None)
+                updated_entry.pop(entry, None)
 
-            scope_repos[name][active_flag] = args.commit or args.tag or args.branch
+            updated_entry[active_flag] = args.commit or args.tag or args.branch
+            scope_repos[name] = updated_entry
 
         descriptor.update(git=spack.util.executable.which("git"), remote=args.remote)
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -136,6 +136,31 @@ def setup_parser(subparser: argparse.ArgumentParser):
         help="automatically migrate the repository to the latest Package API",
     )
 
+    # Update
+    update_parser = sp.add_parser("update", help=repo_update.__doc__)
+    update_parser.add_argument("namespace", nargs="?", help="repository namespace to update")
+    update_parser.add_argument(
+        "--remote",
+        "-r",
+        default="origin",
+        nargs="?",
+        help="name of remote to check for branches, tags, or commits",
+    )
+    update_parser.add_argument(
+        "--scope",
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
+        help="configuration scope to modify",
+    )
+    refspec = update_parser.add_mutually_exclusive_group(required=False)
+    refspec.add_argument(
+        "--branch", "-b", nargs="?", default=None, help="name of a branch to change to"
+    )
+    refspec.add_argument("--tag", "-t", nargs="?", default=None, help="name of a tag to change to")
+    refspec.add_argument(
+        "--commit", "-c", nargs="?", default=None, help="name of a commit to change to"
+    )
+
 
 def repo_create(args):
     """create a new package repository"""
@@ -447,6 +472,30 @@ def _iter_repos_from_descriptors(
             yield name, descriptor.repository, None  # None indicates remote descriptor
 
 
+def repo_update(args: Any) -> int:
+    config = spack.config.CONFIG
+    scope = args.scope
+
+    if args.namespace:
+        existing: Dict[str, Any] = config.get("repos", default={}, scope=scope)
+        if args.namespace not in existing:
+            raise SpackError(f"{args.namespace} is not a known repository namespace.")
+
+        entry = spack.util.path.canonicalize_path(args.namespace)
+        descriptors = {
+            args.namespace: spack.repo.parse_config_descriptor(
+                args.namespace or "<unnamed>", entry, lock=spack.repo.package_repository_lock()
+            )
+        }
+    else:
+        descriptors = spack.repo.RepoDescriptors.from_config(
+            spack.repo.package_repository_lock(), spack.config.CONFIG
+        )
+
+    for _, descriptor in descriptors.items():
+        descriptor.update(git=spack.util.executable.which("git"))
+
+
 def repo(parser, args):
     return {
         "create": repo_create,
@@ -457,4 +506,5 @@ def repo(parser, args):
         "remove": repo_remove,
         "rm": repo_remove,
         "migrate": repo_migrate,
+        "update": repo_update,
     }[args.repo_command](args)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -518,6 +518,8 @@ def repo_update(args: Any) -> int:
             scope_repos[namespace][active_flag] = args.commit or args.tag or args.branch
 
         descriptor.update(git=spack.util.executable.which("git"), remote=args.remote)
+        if descriptor.error:
+            raise SpackError(descriptor.error)
 
     spack.config.set("repos", scope_repos, args.scope)
     return 0

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -510,7 +510,7 @@ def repo_update(args: Any) -> int:
         )
 
     for name, descriptor in descriptors.items():
-        if descriptor is not spack.repo.RemoteRepoDescriptor:
+        if not isinstance(descriptor, spack.repo.RemoteRepoDescriptor):
             continue
 
         if active_flag:

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -501,11 +501,18 @@ def repo_update(args: Any) -> int:
                 raise SpackError(f"{namespace} is not a known repository namespace.")
 
         # filter descriptors when namespaces are provided as arguments
-        descriptors = {
-            name: descriptor for name, descriptor in descriptors.items() if name in args.namespaces
-        }
+        descriptors = spack.repo.RepoDescriptors(
+            {
+                name: descriptor
+                for name, descriptor in descriptors.items()
+                if name in args.namespaces
+            }
+        )
 
     for name, descriptor in descriptors.items():
+        if descriptor is not spack.repo.RemoteRepoDescriptor:
+            continue
+
         if active_flag:
             # update the git commit, tag, or branch of the descriptor
             setattr(descriptor, active_flag, getattr(args, active_flag))
@@ -518,7 +525,7 @@ def repo_update(args: Any) -> int:
             scope_repos[namespace][active_flag] = args.commit or args.tag or args.branch
 
         descriptor.update(git=spack.util.executable.which("git"), remote=args.remote)
-        if descriptor.error:
+        if descriptor.error:  # need to fix this / find a better way
             raise SpackError(descriptor.error)
 
     spack.config.set("repos", scope_repos, args.scope)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -138,9 +138,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
 
     # Update
     update_parser = sp.add_parser("update", help=repo_update.__doc__)
-    update_parser.add_argument(
-        "namespaces", nargs="*", default=[], help="repository namespaces to update"
-    )
+    update_parser.add_argument("names", nargs="*", default=[], help="repositories to update")
     update_parser.add_argument(
         "--remote",
         "-r",

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1655,32 +1655,6 @@ class RemoteRepoDescriptor(RepoDescriptor):
             return self._fetched()
         return False
 
-    def _init_git_repo(self, git: spack.util.executable.Executable, remote: str):
-        git("init", self.destination, output=str)
-        git("remote", "add", "origin", self.repository)
-        # versions of git prior to v2.24 may not have the manyFiles feature
-        # so we should ignore errors here on older versions of git
-        git("config", "feature.manyFiles", "true", ignore_errors=True)
-
-    def _pull_checkout_commit(self, git: spack.util.executable.Executable):
-        git("fetch", "--all")
-        git("checkout", self.commit)
-
-    def _pull_checkout_tag(self, git: spack.util.executable.Executable, remote: str, depth: int):
-        git("fetch", f"--depth={depth}", "--force", "--tags", remote)
-        git("checkout", self.tag)
-
-    def _pull_checkout_branch(
-        self, git: spack.util.executable.Executable, remote: str, depth: int
-    ):
-        git("fetch", f"--depth={depth}", remote, self.branch)
-        git("checkout", self.branch)
-        try:
-            git("rebase", f"{remote}/{self.branch}")
-        except spack.util.executable.ProcessError as e:
-            git("rebase", "--abort")
-            raise e
-
     def _clone_or_pull(
         self,
         git: spack.util.executable.Executable,
@@ -1700,7 +1674,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
 
                     # setup the repository if it does not exist
                     if not fetched:
-                        self._init_git_repo(git, remote)
+                        spack.util.git.init_git_repo(self.repository, self.destination, remote)
 
                         # determine the default branch from ls-remote
                         refs = git("ls-remote", "--symref", remote, "HEAD", output=str)
@@ -1716,12 +1690,12 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         remote = git("config", f"branch.{self.branch}.remote", output=str).strip()
 
                     if self.commit:
-                        self._pull_checkout_commit(git)
+                        spack.util.git.pull_checkout_commit(self.commit)
 
                     elif self.tag:
-                        self._pull_checkout_tag(git, remote, depth)
+                        spack.util.git.pull_checkout_tag(self.tag, remote, depth)
 
-                    else:
+                    elif self.branch:
                         # if the branch already exists we should use the
                         # previously configured remote
                         try:
@@ -1729,7 +1703,9 @@ class RemoteRepoDescriptor(RepoDescriptor):
                             remote = output.strip()
                         except spack.util.executable.ProcessError:
                             pass
-                        self._pull_checkout_branch(git, remote, depth)
+                        spack.util.git.pull_checkout_branch(
+                            self.branch, remote=remote, depth=depth
+                        )
 
             except spack.util.executable.ProcessError as e:
                 self.error = (

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1715,9 +1715,12 @@ class RemoteRepoDescriptor(RepoDescriptor):
 
     def update(self, git: MaybeExecutable = None, remote: str = "origin") -> None:
         if git is None:
-            self.error = "Git executable not found"
-            return
+            raise RepoError("Git executable not found")
+
         self._clone_or_pull(git, update=True, remote=remote)
+
+        if self.error:
+            raise RepoError(self.error)
 
     def initialize(self, fetch: bool = True, git: MaybeExecutable = None) -> None:
         """Clone the remote repository if it has not been fetched yet and read the index file
@@ -1953,9 +1956,7 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 
 
 #: Global package repository instance.
-PATH: RepoPath = llnl.util.lang.Singleton(
-    lambda: create_and_enable(spack.config.CONFIG)
-)  # type: ignore[assignment]
+PATH: RepoPath = llnl.util.lang.Singleton(lambda: create_and_enable(spack.config.CONFIG))  # type: ignore[assignment]
 
 
 # Add the finder to sys.meta_path

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1674,7 +1674,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
 
                     # setup the repository if it does not exist
                     if not fetched:
-                        spack.util.git.init_git_repo(self.repository, self.destination, remote)
+                        spack.util.git.init_git_repo(self.repository, remote=remote)
 
                         # determine the default branch from ls-remote
                         refs = git("ls-remote", "--symref", remote, "HEAD", output=str)
@@ -1953,9 +1953,7 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 
 
 #: Global package repository instance.
-PATH: RepoPath = llnl.util.lang.Singleton(
-    lambda: create_and_enable(spack.config.CONFIG)
-)  # type: ignore[assignment]
+PATH: RepoPath = llnl.util.lang.Singleton(lambda: create_and_enable(spack.config.CONFIG))  # type: ignore[assignment]
 
 
 # Add the finder to sys.meta_path

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1955,7 +1955,9 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 
 
 #: Global package repository instance.
-PATH: RepoPath = llnl.util.lang.Singleton(lambda: create_and_enable(spack.config.CONFIG))  # type: ignore[assignment]
+PATH: RepoPath = llnl.util.lang.Singleton(
+    lambda: create_and_enable(spack.config.CONFIG)
+)  # type: ignore[assignment]
 
 # Add the finder to sys.meta_path
 REPOS_FINDER = ReposFinder()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1092,8 +1092,7 @@ class Repo:
             # From Package API v2.0 the namespace follows from the directory structure.
             check(
                 f"{os.sep}spack_repo{os.sep}" in self.root,
-                f"Invalid repository path '{self.root}'. "
-                f"Path must contain 'spack_repo{os.sep}'",
+                f"Invalid repository path '{self.root}'. Path must contain 'spack_repo{os.sep}'",
             )
             derived_namespace = self.root.rpartition(f"spack_repo{os.sep}")[2].replace(os.sep, ".")
             if "namespace" in config:
@@ -1596,6 +1595,9 @@ class RepoDescriptor:
     def initialize(self, fetch: bool = True, git: MaybeExecutable = None) -> None:
         return None
 
+    def update(self, git: MaybeExecutable = None) -> None:
+        return None
+
     def construct(
         self, cache: spack.util.file_cache.FileCache, overrides: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Union[Repo, Exception]]:
@@ -1625,12 +1627,18 @@ class RemoteRepoDescriptor(RepoDescriptor):
         self,
         name: Optional[str],
         repository: str,
+        branch: str,
+        commit: str,
+        tag: str,
         destination: str,
         relative_paths: Optional[List[str]],
         lock: spack.util.lock.Lock,
     ) -> None:
         super().__init__(name)
         self.repository = repository
+        self.branch = branch
+        self.commit = commit
+        self.tag = tag
         self.destination = destination
         self.relative_paths = relative_paths
         self.error: Optional[str] = None
@@ -1646,6 +1654,73 @@ class RemoteRepoDescriptor(RepoDescriptor):
             return self._fetched()
         return False
 
+    def _init_git_repo(self, git: spack.util.executable.Executable, remote: str):
+        git("init", self.destination, output=str)
+        git("-C", self.destination, "remote", "add", "origin", self.repository)
+        git("-C", self.destination, "config", "feature.manyFiles", "true")
+
+    def _pull_checkout_commit(self, git: spack.util.executable.Executable, commit: str):
+        git("-C", self.destination, "fetch", "--all")
+        git("-C", self.destination, "checkout", commit)
+
+    def _pull_checkout_tag(self, git: spack.util.executable.Executable, remote: str, depth: int):
+        git("-C", self.destination, "fetch", f"--depth={depth}", "--force", "--tags", remote)
+        git("-C", self.destination, "checkout", self.tag)
+
+    def _pull_checkout_branch(
+        self, git: spack.util.executable.Executable, remote: str, depth: int
+    ):
+        git("-C", self.destination, "fetch", f"--depth={depth}", remote, self.branch)
+        git("-C", self.destination, "checkout", self.branch)
+        git("-C", self.destination, "rebase", f"{remote}/{self.branch}")
+
+    def _clone_or_pull(
+        self,
+        git: spack.util.executable.Executable,
+        update: bool = False,
+        remote: str = "origin",
+        depth: int = 20,
+    ) -> None:
+        with self.write_transaction:
+            try:
+                # do not fetch if the package repository was fetched by another
+                # process while we were waiting for the lock
+                fetched = self._fetched()
+                if not fetched:
+                    self._init_git_repo(git, remote)
+
+                    refs = git(
+                        "-C", self.destination, "ls-remote", "--symref", remote, "HEAD", output=str
+                    )
+                    ref_match = re.search(r"refs/heads/(\S+)", refs)
+                    self.branch = ref_match.group(1)
+
+                elif update and not (self.commit or self.tag or self.branch):
+                    # need to add logic here to see if we're on a branch, tag, or commit
+                    self.branch = git(
+                        "-C", self.destination, "rev-parse", "--abbrev-ref", "HEAD", output=str
+                    )
+                    remote = git("-C", self.destination, "config", f"branch.{self.branch}.remote")
+
+                if update or not fetched:
+                    if self.commit:
+                        self._pull_checkout_commit(git, remote)
+
+                    elif self.tag:
+                        self._pull_checkout_tag(git, remote, depth)
+
+                    else:
+                        self._pull_checkout_branch(git, remote, depth)
+
+            except spack.util.executable.ProcessError as e:
+                self.error = f"Failed to {'update' if update else 'clone'} repository {self.repository}: {e}"
+                return
+
+            self.read_index_file()
+
+    def update(self, git: MaybeExecutable = None) -> None:
+        self._clone_or_pull(git, update=True)
+
     def initialize(self, fetch: bool = True, git: MaybeExecutable = None) -> None:
         """Clone the remote repository if it has not been fetched yet and read the index file
         if necessary."""
@@ -1660,18 +1735,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
             self.error = "Git executable not found"
             return
 
-        with self.write_transaction:
-            try:
-                # do not fetch if the package repository was fetched by another process while we
-                # were waiting for the lock
-                if not self._fetched():
-                    # users can always unshallow manually to fetch more.
-                    git("clone", "--depth=100", self.repository, self.destination)
-            except spack.util.executable.ProcessError as e:
-                self.error = f"Failed to clone repository {self.repository}: {e}"
-                return
-
-            self.read_index_file()
+        self._clone_or_pull(git)
 
     def read_index_file(self) -> None:
         if self.relative_paths is not None:
@@ -1858,12 +1922,29 @@ def parse_config_descriptor(
     else:
         destination = spack.util.path.canonicalize_path(destination)
 
+    if "branch" in descriptor:
+        branch = descriptor["branch"]
+    else:
+        branch = None
+
+    if "commit" in descriptor:
+        commit = descriptor["commit"]
+    else:
+        commit = None
+
+    if "tag" in descriptor:
+        tag = descriptor["tag"]
+    else:
+        tag = None
+
     if "paths" in descriptor:
         rel_paths = descriptor["paths"]
     else:
         rel_paths = None
 
-    return RemoteRepoDescriptor(name, repository, destination, rel_paths, lock)
+    return RemoteRepoDescriptor(
+        name, repository, branch, commit, tag, destination, rel_paths, lock
+    )
 
 
 def create_or_construct(
@@ -1887,9 +1968,7 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 
 
 #: Global package repository instance.
-PATH: RepoPath = llnl.util.lang.Singleton(
-    lambda: create_and_enable(spack.config.CONFIG)
-)  # type: ignore[assignment]
+PATH: RepoPath = llnl.util.lang.Singleton(lambda: create_and_enable(spack.config.CONFIG))  # type: ignore[assignment]
 
 # Add the finder to sys.meta_path
 REPOS_FINDER = ReposFinder()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1707,10 +1707,8 @@ class RemoteRepoDescriptor(RepoDescriptor):
                             self.branch, remote=remote, depth=depth
                         )
 
-            except spack.util.executable.ProcessError as e:
-                self.error = (
-                    f"Failed to {'update' if update else 'clone'} repository {self.name}: {e}"
-                )
+            except spack.util.executable.ProcessError:
+                self.error = f"Failed to {'update' if update else 'clone'} repository {self.name}"
                 return
 
             self.read_index_file()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1625,11 +1625,12 @@ class LocalRepoDescriptor(RepoDescriptor):
 class RemoteRepoDescriptor(RepoDescriptor):
     def __init__(
         self,
+        *,
         name: Optional[str],
         repository: str,
-        branch: str,
-        commit: str,
-        tag: str,
+        branch: Optional[str],
+        commit: Optional[str],
+        tag: Optional[str],
         destination: str,
         relative_paths: Optional[List[str]],
         lock: spack.util.lock.Lock,
@@ -1657,7 +1658,9 @@ class RemoteRepoDescriptor(RepoDescriptor):
     def _init_git_repo(self, git: spack.util.executable.Executable, remote: str):
         git("init", self.destination, output=str)
         git("remote", "add", "origin", self.repository)
-        git("config", "feature.manyFiles", "true")
+        # versions of git prior to v2.24 may not have the manyFiles feature
+        # so we should ignore errors here on older versions of git
+        git("config", "feature.manyFiles", "true", ignore_errors=True)
 
     def _pull_checkout_commit(self, git: spack.util.executable.Executable):
         git("fetch", "--all")
@@ -1943,28 +1946,15 @@ def parse_config_descriptor(
     else:
         destination = spack.util.path.canonicalize_path(destination)
 
-    if "branch" in descriptor:
-        branch = descriptor["branch"]
-    else:
-        branch = None
-
-    if "commit" in descriptor:
-        commit = descriptor["commit"]
-    else:
-        commit = None
-
-    if "tag" in descriptor:
-        tag = descriptor["tag"]
-    else:
-        tag = None
-
-    if "paths" in descriptor:
-        rel_paths = descriptor["paths"]
-    else:
-        rel_paths = None
-
     return RemoteRepoDescriptor(
-        name, repository, branch, commit, tag, destination, rel_paths, lock
+        name=name,
+        repository=repository,
+        branch=descriptor.get("branch"),
+        commit=descriptor.get("commit"),
+        tag=descriptor.get("tag"),
+        destination=destination,
+        relative_paths=descriptor.get("paths"),
+        lock=lock,
     )
 
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1696,12 +1696,15 @@ class RemoteRepoDescriptor(RepoDescriptor):
 
                         refs = git("ls-remote", "--symref", remote, "HEAD", output=str)
                         ref_match = re.search(r"refs/heads/(\S+)", refs)
+                        if not ref_match:
+                            self.error = f"Unable to locate a default branch for {self.repository}"
+                            return
                         self.branch = ref_match.group(1)
 
                     elif update and not (self.commit or self.tag or self.branch):
                         # need to add logic here to see if we're on a branch, tag, or commit
-                        self.branch = git("rev-parse", "--abbrev-ref", "HEAD", output=str)
-                        remote = git("config", f"branch.{self.branch}.remote")
+                        self.branch = str(git("rev-parse", "--abbrev-ref", "HEAD", output=str))
+                        remote = str(git("config", f"branch.{self.branch}.remote"))
 
                     if update or not fetched:
                         if self.commit:
@@ -1722,6 +1725,9 @@ class RemoteRepoDescriptor(RepoDescriptor):
             self.read_index_file()
 
     def update(self, git: MaybeExecutable = None, remote: str = "origin") -> None:
+        if git is None:
+            self.error = "Git executable not found"
+            return
         self._clone_or_pull(git, update=True, remote=remote)
 
     def initialize(self, fetch: bool = True, git: MaybeExecutable = None) -> None:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1664,6 +1664,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
     ) -> None:
         with self.write_transaction:
             try:
+                fs.mkdirp(self.destination)
                 with fs.working_dir(self.destination):
                     # do not fetch if the package repository was fetched by another
                     # process while we were waiting for the lock
@@ -1955,9 +1956,7 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 
 
 #: Global package repository instance.
-PATH: RepoPath = llnl.util.lang.Singleton(
-    lambda: create_and_enable(spack.config.CONFIG)
-)  # type: ignore[assignment]
+PATH: RepoPath = llnl.util.lang.Singleton(lambda: create_and_enable(spack.config.CONFIG))  # type: ignore[assignment]
 
 # Add the finder to sys.meta_path
 REPOS_FINDER = ReposFinder()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1656,23 +1656,23 @@ class RemoteRepoDescriptor(RepoDescriptor):
 
     def _init_git_repo(self, git: spack.util.executable.Executable, remote: str):
         git("init", self.destination, output=str)
-        git("-C", self.destination, "remote", "add", "origin", self.repository)
-        git("-C", self.destination, "config", "feature.manyFiles", "true")
+        git("remote", "add", "origin", self.repository)
+        git("config", "feature.manyFiles", "true")
 
-    def _pull_checkout_commit(self, git: spack.util.executable.Executable, commit: str):
-        git("-C", self.destination, "fetch", "--all")
-        git("-C", self.destination, "checkout", commit)
+    def _pull_checkout_commit(self, git: spack.util.executable.Executable):
+        git("fetch", "--all")
+        git("checkout", self.commit)
 
     def _pull_checkout_tag(self, git: spack.util.executable.Executable, remote: str, depth: int):
-        git("-C", self.destination, "fetch", f"--depth={depth}", "--force", "--tags", remote)
-        git("-C", self.destination, "checkout", self.tag)
+        git("fetch", f"--depth={depth}", "--force", "--tags", remote)
+        git("checkout", self.tag)
 
     def _pull_checkout_branch(
         self, git: spack.util.executable.Executable, remote: str, depth: int
     ):
-        git("-C", self.destination, "fetch", f"--depth={depth}", remote, self.branch)
-        git("-C", self.destination, "checkout", self.branch)
-        git("-C", self.destination, "rebase", f"{remote}/{self.branch}")
+        git("fetch", f"--depth={depth}", remote, self.branch)
+        git("checkout", self.branch)
+        git("rebase", f"{remote}/{self.branch}")
 
     def _clone_or_pull(
         self,
@@ -1683,34 +1683,31 @@ class RemoteRepoDescriptor(RepoDescriptor):
     ) -> None:
         with self.write_transaction:
             try:
-                # do not fetch if the package repository was fetched by another
-                # process while we were waiting for the lock
-                fetched = self._fetched()
-                if not fetched:
-                    self._init_git_repo(git, remote)
+                with fs.working_dir(self.destination):
+                    # do not fetch if the package repository was fetched by another
+                    # process while we were waiting for the lock
+                    fetched = self._fetched()
+                    if not fetched:
+                        self._init_git_repo(git, remote)
 
-                    refs = git(
-                        "-C", self.destination, "ls-remote", "--symref", remote, "HEAD", output=str
-                    )
-                    ref_match = re.search(r"refs/heads/(\S+)", refs)
-                    self.branch = ref_match.group(1)
+                        refs = git("ls-remote", "--symref", remote, "HEAD", output=str)
+                        ref_match = re.search(r"refs/heads/(\S+)", refs)
+                        self.branch = ref_match.group(1)
 
-                elif update and not (self.commit or self.tag or self.branch):
-                    # need to add logic here to see if we're on a branch, tag, or commit
-                    self.branch = git(
-                        "-C", self.destination, "rev-parse", "--abbrev-ref", "HEAD", output=str
-                    )
-                    remote = git("-C", self.destination, "config", f"branch.{self.branch}.remote")
+                    elif update and not (self.commit or self.tag or self.branch):
+                        # need to add logic here to see if we're on a branch, tag, or commit
+                        self.branch = git("rev-parse", "--abbrev-ref", "HEAD", output=str)
+                        remote = git("config", f"branch.{self.branch}.remote")
 
-                if update or not fetched:
-                    if self.commit:
-                        self._pull_checkout_commit(git, remote)
+                    if update or not fetched:
+                        if self.commit:
+                            self._pull_checkout_commit(git)
 
-                    elif self.tag:
-                        self._pull_checkout_tag(git, remote, depth)
+                        elif self.tag:
+                            self._pull_checkout_tag(git, remote, depth)
 
-                    else:
-                        self._pull_checkout_branch(git, remote, depth)
+                        else:
+                            self._pull_checkout_branch(git, remote, depth)
 
             except spack.util.executable.ProcessError as e:
                 self.error = f"Failed to {'update' if update else 'clone'} repository {self.repository}: {e}"
@@ -1718,8 +1715,8 @@ class RemoteRepoDescriptor(RepoDescriptor):
 
             self.read_index_file()
 
-    def update(self, git: MaybeExecutable = None) -> None:
-        self._clone_or_pull(git, update=True)
+    def update(self, git: MaybeExecutable = None, remote: str = "origin") -> None:
+        self._clone_or_pull(git, update=True, remote=remote)
 
     def initialize(self, fetch: bool = True, git: MaybeExecutable = None) -> None:
         """Clone the remote repository if it has not been fetched yet and read the index file

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1595,7 +1595,7 @@ class RepoDescriptor:
     def initialize(self, fetch: bool = True, git: MaybeExecutable = None) -> None:
         return None
 
-    def update(self, git: MaybeExecutable = None) -> None:
+    def update(self, git: MaybeExecutable = None, remote: str = "origin") -> None:
         return None
 
     def construct(
@@ -1956,7 +1956,9 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 
 
 #: Global package repository instance.
-PATH: RepoPath = llnl.util.lang.Singleton(lambda: create_and_enable(spack.config.CONFIG))  # type: ignore[assignment]
+PATH: RepoPath = llnl.util.lang.Singleton(
+    lambda: create_and_enable(spack.config.CONFIG)
+)  # type: ignore[assignment]
 
 
 # Add the finder to sys.meta_path

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1664,8 +1664,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
     ) -> None:
         with self.write_transaction:
             try:
-                fs.mkdirp(self.destination)
-                with fs.working_dir(self.destination):
+                with fs.working_dir(self.destination, create=True):
                     # do not fetch if the package repository was fetched by another
                     # process while we were waiting for the lock
                     fetched = self._fetched()
@@ -1959,6 +1958,7 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 PATH: RepoPath = llnl.util.lang.Singleton(
     lambda: create_and_enable(spack.config.CONFIG)
 )  # type: ignore[assignment]
+
 
 # Add the finder to sys.meta_path
 REPOS_FINDER = ReposFinder()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1956,7 +1956,9 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 
 
 #: Global package repository instance.
-PATH: RepoPath = llnl.util.lang.Singleton(lambda: create_and_enable(spack.config.CONFIG))  # type: ignore[assignment]
+PATH: RepoPath = llnl.util.lang.Singleton(
+    lambda: create_and_enable(spack.config.CONFIG)
+)  # type: ignore[assignment]
 
 # Add the finder to sys.meta_path
 REPOS_FINDER = ReposFinder()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1953,7 +1953,9 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 
 
 #: Global package repository instance.
-PATH: RepoPath = llnl.util.lang.Singleton(lambda: create_and_enable(spack.config.CONFIG))  # type: ignore[assignment]
+PATH: RepoPath = llnl.util.lang.Singleton(
+    lambda: create_and_enable(spack.config.CONFIG)
+)  # type: ignore[assignment]
 
 
 # Add the finder to sys.meta_path

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1691,9 +1691,15 @@ class RemoteRepoDescriptor(RepoDescriptor):
                     # do not fetch if the package repository was fetched by another
                     # process while we were waiting for the lock
                     fetched = self._fetched()
+                    if fetched and not update:
+                        self.read_index_file()
+                        return
+
+                    # setup the repository if it does not exist
                     if not fetched:
                         self._init_git_repo(git, remote)
 
+                        # determine the default branch from ls-remote
                         refs = git("ls-remote", "--symref", remote, "HEAD", output=str)
                         ref_match = re.search(r"refs/heads/(\S+)", refs)
                         if not ref_match:
@@ -1701,20 +1707,26 @@ class RemoteRepoDescriptor(RepoDescriptor):
                             return
                         self.branch = ref_match.group(1)
 
-                    elif update and not (self.commit or self.tag or self.branch):
-                        # need to add logic here to see if we're on a branch, tag, or commit
-                        self.branch = str(git("rev-parse", "--abbrev-ref", "HEAD", output=str))
-                        remote = str(git("config", f"branch.{self.branch}.remote"))
+                    # determine the branch and remote if no config values exist
+                    elif not (self.commit or self.tag or self.branch):
+                        self.branch = git("rev-parse", "--abbrev-ref", "HEAD", output=str).strip()
+                        remote = git("config", f"branch.{self.branch}.remote", output=str).strip()
 
-                    if update or not fetched:
-                        if self.commit:
-                            self._pull_checkout_commit(git)
+                    if self.commit:
+                        self._pull_checkout_commit(git)
 
-                        elif self.tag:
-                            self._pull_checkout_tag(git, remote, depth)
+                    elif self.tag:
+                        self._pull_checkout_tag(git, remote, depth)
 
-                        else:
-                            self._pull_checkout_branch(git, remote, depth)
+                    else:
+                        # if the branch already exists we should use the
+                        # previously configured remote
+                        try:
+                            output = git("config", f"branch.{self.branch}.remote", output=str)
+                            remote = output.strip()
+                        except spack.util.executable.ProcessError:
+                            pass
+                        self._pull_checkout_branch(git, remote, depth)
 
             except spack.util.executable.ProcessError as e:
                 self.error = (

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1672,7 +1672,11 @@ class RemoteRepoDescriptor(RepoDescriptor):
     ):
         git("fetch", f"--depth={depth}", remote, self.branch)
         git("checkout", self.branch)
-        git("rebase", f"{remote}/{self.branch}")
+        try:
+            git("rebase", f"{remote}/{self.branch}")
+        except spack.util.executable.ProcessError as e:
+            git("rebase", "--abort")
+            raise e
 
     def _clone_or_pull(
         self,
@@ -1710,7 +1714,9 @@ class RemoteRepoDescriptor(RepoDescriptor):
                             self._pull_checkout_branch(git, remote, depth)
 
             except spack.util.executable.ProcessError as e:
-                self.error = f"Failed to {'update' if update else 'clone'} repository {self.repository}: {e}"
+                self.error = (
+                    f"Failed to {'update' if update else 'clone'} repository {self.name}: {e}"
+                )
                 return
 
             self.read_index_file()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1674,7 +1674,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
 
                     # setup the repository if it does not exist
                     if not fetched:
-                        spack.util.git.init_git_repo(self.repository, remote=remote)
+                        spack.util.git.init_git_repo(self.repository, remote=remote, git_exe=git)
 
                         # determine the default branch from ls-remote
                         refs = git("ls-remote", "--symref", remote, "HEAD", output=str)
@@ -1690,10 +1690,10 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         remote = git("config", f"branch.{self.branch}.remote", output=str).strip()
 
                     if self.commit:
-                        spack.util.git.pull_checkout_commit(self.commit)
+                        spack.util.git.pull_checkout_commit(self.commit, git_exe=git)
 
                     elif self.tag:
-                        spack.util.git.pull_checkout_tag(self.tag, remote, depth)
+                        spack.util.git.pull_checkout_tag(self.tag, remote, depth, git_exe=git)
 
                     elif self.branch:
                         # if the branch already exists we should use the
@@ -1704,7 +1704,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         except spack.util.executable.ProcessError:
                             pass
                         spack.util.git.pull_checkout_branch(
-                            self.branch, remote=remote, depth=depth
+                            self.branch, remote=remote, depth=depth, git_exe=git
                         )
 
             except spack.util.executable.ProcessError:
@@ -1732,7 +1732,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
         if not fetch:
             return
 
-        if git is None:
+        if not git:
             self.error = "Git executable not found"
             return
 
@@ -1847,7 +1847,7 @@ class RepoDescriptors(Mapping[str, RepoDescriptor]):
         self,
         cache: spack.util.file_cache.FileCache,
         fetch: bool = True,
-        find_git: Callable[[], MaybeExecutable] = lambda: spack.util.executable.which("git"),
+        find_git: Callable[[], MaybeExecutable] = lambda: spack.util.git.git(required=True),
         overrides: Optional[Dict[str, Any]] = None,
     ) -> Tuple[RepoPath, Dict[str, Exception]]:
         """Construct a RepoPath from the descriptors.

--- a/lib/spack/spack/schema/repos.py
+++ b/lib/spack/spack/schema/repos.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/repos.py
    :lines: 18-
 """
+
 from typing import Any, Dict
 
 #: Properties for inclusion in other schemas
@@ -36,6 +37,9 @@ properties: Dict[str, Any] = {
                             "type": "object",
                             "properties": {
                                 "git": {"type": "string"},
+                                "branch": {"type": "string"},
+                                "commit": {"type": "string"},
+                                "tag": {"type": "string"},
                                 "destination": {"type": "string"},
                                 "paths": {"type": "array", "items": {"type": "string"}},
                             },

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -263,6 +263,9 @@ class MockDescriptor(spack.repo.RepoDescriptor):
     def initialize(self, fetch=True, git=None) -> None:
         self.initialized = True
 
+    def update(self, git, fetch: bool = False, remote=None) -> None:
+        pass
+
     def construct(self, cache, overrides=None):
         assert self.initialized, "MockDescriptor must be initialized before construction"
         return self.to_construct
@@ -773,3 +776,40 @@ def test_repo_list_format_flags(
     config_names_output = repo("list", "--names", output=str)
     config_names_lines = config_names_output.strip().split("\n")
     assert config_names_lines == ["monorepo", "uninitialized", "misconfigured"]
+
+
+@pytest.mark.parametrize(
+    "repo_name,flags",
+    [
+        (None, []),
+        ("new_repo", []),
+        ("new_repo", ["--branch", "develop"]),
+        ("new_repo", ["--branch", "develop", "--remote", "upstream"]),
+        ("new_repo", ["--tag", "v1.0"]),
+        ("new_repo", ["--commit", "abc123"]),
+    ],
+)
+def test_repo_update(monkeypatch, mutable_config, tmp_path, repo_name, flags):
+    """Test repo update with flags."""
+
+    def mock_parse_config_descriptor(name, entry, lock):
+        return MockDescriptor({"/path": MockRepo("new_repo")})
+
+    monkeypatch.setattr(spack.repo, "parse_config_descriptor", mock_parse_config_descriptor)
+    monkeypatch.setattr(spack.repo, "RemoteRepoDescriptor", MockDescriptor)
+
+    spack.config.set("repos", {repo_name: {"git": "https://github.com/example/repo.git"}})
+
+    repo("update", repo_name, *flags)
+
+    # check that the branch,tag,commit was updated in the configuration
+    repos_config = spack.config.get("repos")
+
+    if "--branch" in flags:
+        assert repos_config[repo_name]["branch"] == "develop"
+
+    if "--tag" in flags:
+        assert repos_config[repo_name]["tag"] == "v1.0"
+
+    if "--commit" in flags:
+        assert repos_config[repo_name]["commit"] == "abc123"

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -781,7 +781,6 @@ def test_repo_list_format_flags(
 @pytest.mark.parametrize(
     "repo_name,flags",
     [
-        (None, []),
         ("new_repo", []),
         ("new_repo", ["--branch", "develop"]),
         ("new_repo", ["--branch", "develop", "--remote", "upstream"]),
@@ -789,7 +788,7 @@ def test_repo_list_format_flags(
         ("new_repo", ["--commit", "abc123"]),
     ],
 )
-def test_repo_update(monkeypatch, mutable_config, tmp_path, repo_name, flags):
+def test_repo_update_successful_flags(monkeypatch, mutable_config, tmp_path, repo_name, flags):
     """Test repo update with flags."""
 
     def mock_parse_config_descriptor(name, entry, lock):
@@ -798,7 +797,9 @@ def test_repo_update(monkeypatch, mutable_config, tmp_path, repo_name, flags):
     monkeypatch.setattr(spack.repo, "parse_config_descriptor", mock_parse_config_descriptor)
     monkeypatch.setattr(spack.repo, "RemoteRepoDescriptor", MockDescriptor)
 
-    spack.config.set("repos", {repo_name: {"git": "https://github.com/example/repo.git"}})
+    repos_config = spack.config.get("repos")
+    repos_config[repo_name] = {"git": "https://github.com/example/repo.git"}
+    spack.config.set("repos", repos_config)
 
     repo("update", repo_name, *flags)
 
@@ -813,3 +814,18 @@ def test_repo_update(monkeypatch, mutable_config, tmp_path, repo_name, flags):
 
     if "--commit" in flags:
         assert repos_config[repo_name]["commit"] == "abc123"
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--branch", "develop"],
+        ["--branch", "develop", "new_repo_1", "new_repo_2"],
+        ["--branch", "develop", "unknown_repo"],
+    ],
+)
+def test_repo_update_invalid_flags(monkeypatch, mutable_config, tmp_path, flags):
+    """Test repo update with invalid flags."""
+
+    with pytest.raises(spack.error.SpackError):
+        repo("update", *flags)

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -827,5 +827,5 @@ def test_repo_update_successful_flags(monkeypatch, mutable_config, tmp_path, rep
 def test_repo_update_invalid_flags(monkeypatch, mutable_config, tmp_path, flags):
     """Test repo update with invalid flags."""
 
-    with pytest.raises(spack.error.SpackError):
+    with pytest.raises(SpackError):
         repo("update", *flags)

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -263,7 +263,7 @@ class MockDescriptor(spack.repo.RepoDescriptor):
     def initialize(self, fetch=True, git=None) -> None:
         self.initialized = True
 
-    def update(self, git, fetch: bool = False, remote=None) -> None:
+    def update(self, git: Optional[Executable] = None, remote: Optional[str] = "origin") -> None:
         pass
 
     def construct(self, cache, overrides=None):

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -6,8 +6,6 @@ import pathlib
 
 import pytest
 
-import llnl.util.filesystem as fs
-
 import spack
 import spack.environment
 import spack.package_base
@@ -15,6 +13,7 @@ import spack.paths
 import spack.repo
 import spack.schema.repos
 import spack.spec
+import spack.util.executable
 import spack.util.file_cache
 import spack.util.lock
 import spack.util.naming
@@ -621,6 +620,40 @@ def test_parse_config_descriptor_git_2(tmp_path: pathlib.Path):
     assert descriptor.relative_paths == ["some/path"]
 
 
+def test_remote_descriptor_no_git(tmp_path: pathlib.Path):
+    """Test that descriptor fails without git."""
+    descriptor = spack.repo.parse_config_descriptor(
+        name="name",
+        descriptor={
+            "git": str(tmp_path / "repo.git"),
+            "destination": str(tmp_path / "some/destination"),
+        },
+        lock=spack.util.lock.Lock(str(tmp_path / "x"), enable=False),
+    )
+
+    descriptor.initialize(fetch=True, git=None)
+
+    assert isinstance(descriptor, spack.repo.RemoteRepoDescriptor)
+    assert descriptor.error == "Git executable not found"
+
+
+def test_remote_descriptor_update_no_git(tmp_path: pathlib.Path):
+    """Test that descriptor fails without git."""
+    descriptor = spack.repo.parse_config_descriptor(
+        name="name",
+        descriptor={
+            "git": str(tmp_path / "repo.git"),
+            "destination": str(tmp_path / "some/destination"),
+        },
+        lock=spack.util.lock.Lock(str(tmp_path / "x"), enable=False),
+    )
+
+    assert isinstance(descriptor, spack.repo.RemoteRepoDescriptor)
+
+    with pytest.raises(spack.repo.RepoError, match="Git executable not found"):
+        descriptor.update(git=None)
+
+
 def test_parse_config_descriptor_local(tmp_path: pathlib.Path):
     descriptor = spack.repo.parse_config_descriptor(
         name="name",
@@ -642,7 +675,7 @@ def test_parse_config_descriptor_no_git(tmp_path: pathlib.Path):
         )
 
 
-def test_repo_descriptors_construct(tmp_path: pathlib.Path, git):
+def test_repo_descriptors_construct(tmp_path: pathlib.Path):
     """Test the RepoDescriptors construct function. Ensure it does not raise when we cannot
     construct a Repo instance, e.g. due to missing repo.yaml file. Check that it parses the
     spack-repo-index.yaml file both when newly initialized and when already cloned."""
@@ -650,34 +683,16 @@ def test_repo_descriptors_construct(tmp_path: pathlib.Path, git):
     lock = spack.util.lock.Lock(str(tmp_path / "x"), enable=False)
     cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
 
-    git("init", os.path.join(tmp_path, "foo.git"))
-
-    with open(tmp_path / "foo.git" / "spack-repo-index.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            """\
-repo_index:
-  paths:
-  - spack_repo/foo
-"""
-        )
-
-    with fs.working_dir(os.path.join(tmp_path, "foo.git")):
-        git("config", "user.name", "Spack")
-        git("config", "user.email", "spack@spack.io")
-
-        git("add", "spack-repo-index.yaml")
-        git("commit", "--no-gpg-sign", "-am", "add index to repo")
-
     # Construct 3 identical descriptors
     descriptors_1, descriptors_2, descriptors_3 = [
         {
             "foo": spack.repo.RemoteRepoDescriptor(
                 name="foo",
                 repository=str(tmp_path / "foo.git"),
-                branch=None,
-                commit=None,
-                tag=None,
                 destination=str(tmp_path / "foo_destination"),
+                branch=None,
+                tag=None,
+                commit=None,
                 relative_paths=None,
                 lock=lock,
             )
@@ -689,7 +704,40 @@ repo_index:
     repos_2 = spack.repo.RepoDescriptors(descriptors_2)  # type: ignore
     repos_3 = spack.repo.RepoDescriptors(descriptors_3)  # type: ignore
 
-    repo_path_1, errors_1 = repos_1.construct(cache=cache)
+    class MockGit(spack.util.executable.Executable):
+        def __init__(self):
+            pass
+
+        def __call__(self, *args, **kwargs) -> str:  # type: ignore
+            action = args[0]
+
+            if action == "ls-remote":
+                return "refs/heads/develop"
+
+            elif action == "rev-parse":
+                return "develop"
+
+            elif action == "config":
+                return "origin"
+
+            elif action == "init":
+                # The git repo needs a .git subdir
+                os.makedirs(os.path.join(".git"))
+
+            elif action == "checkout":
+                # The spack-repo-index.yaml is optional; we test Spack reads from it.
+                with open(os.path.join("spack-repo-index.yaml"), "w", encoding="utf-8") as f:
+                    f.write(
+                        """\
+repo_index:
+  paths:
+  - spack_repo/foo
+"""
+                    )
+
+            return ""
+
+    repo_path_1, errors_1 = repos_1.construct(cache=cache, find_git=MockGit)
 
     # Verify it cannot construct a Repo instance, and that this does *not* throw, since that would
     # break Spack very early on. Instead, an error is returned. Also verify that
@@ -700,7 +748,7 @@ repo_index:
     assert descriptors_1["foo"].relative_paths == ["spack_repo/foo"]
 
     # Do the same test with another instance: it should *not* clone a second time.
-    repo_path_2, errors_2 = repos_2.construct(cache=cache)
+    repo_path_2, errors_2 = repos_2.construct(cache=cache, find_git=MockGit)
     assert len(repo_path_2.repos) == 0
     assert len(errors_2) == 1
     assert all("No repo.yaml" in str(err) for err in errors_2.values()), errors_2
@@ -708,7 +756,87 @@ repo_index:
 
     # Finally fill the repo with an actual repo and check that the repo can be constructed.
     spack.repo.create_repo(str(tmp_path / "foo_destination"), "foo")
-    repo_path_3, errors_3 = repos_3.construct(cache=cache)
+    repo_path_3, errors_3 = repos_3.construct(cache=cache, find_git=MockGit)
     assert not errors_3
     assert len(repo_path_3.repos) == 1
     assert repo_path_3.repos[0].namespace == "foo"
+
+
+def test_repo_descriptors_update(tmp_path: pathlib.Path):
+    """Test the RepoDescriptors construct function. Ensure it does not raise when we cannot
+    construct a Repo instance, e.g. due to missing repo.yaml file. Check that it parses the
+    spack-repo-index.yaml file both when newly initialized and when already cloned."""
+
+    lock = spack.util.lock.Lock(str(tmp_path / "x"), enable=False)
+    cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
+
+    # Construct 3 identical descriptors
+    descriptors_1, descriptors_2, descriptors_3 = [
+        {
+            "foo": spack.repo.RemoteRepoDescriptor(
+                name="foo",
+                repository=str(tmp_path / "foo.git"),
+                destination=str(tmp_path / "foo_destination"),
+                branch="develop" if i == 0 else None,
+                tag="v1.0" if i == 1 else None,
+                commit="abc123" if i == 2 else None,
+                relative_paths=None,
+                lock=lock,
+            )
+        }
+        for i in range(3)
+    ]
+
+    repos_1 = spack.repo.RepoDescriptors(descriptors_1)  # type: ignore
+    repos_2 = spack.repo.RepoDescriptors(descriptors_2)  # type: ignore
+    repos_3 = spack.repo.RepoDescriptors(descriptors_3)  # type: ignore
+
+    class MockGit(spack.util.executable.Executable):
+        def __init__(self):
+            pass
+
+        def __call__(self, *args, **kwargs) -> str:  # type: ignore
+            action = args[0]
+
+            if action == "ls-remote":
+                return "refs/heads/develop"
+
+            elif action == "rev-parse":
+                return "develop"
+
+            elif action == "config":
+                return "origin"
+
+            elif action == "init":
+                # The git repo needs a .git subdir
+                os.makedirs(os.path.join(".git"))
+
+            elif action == "checkout":
+                # The spack-repo-index.yaml is optional; we test Spack reads from it.
+                with open(os.path.join("spack-repo-index.yaml"), "w", encoding="utf-8") as f:
+                    f.write(
+                        """\
+repo_index:
+  paths:
+  - spack_repo/foo
+"""
+                    )
+
+            return ""
+
+    spack.repo.create_repo(str(tmp_path / "foo_destination"), "foo")
+
+    _, errors_1 = repos_1.construct(cache=cache, find_git=MockGit)
+    assert not errors_1
+    for descriptor in repos_1.values():
+        descriptor.update(git=MockGit())
+
+    _, errors_2 = repos_2.construct(cache=cache, find_git=MockGit)
+    assert not errors_2
+    for descriptor in repos_2.values():
+        descriptor.update(git=MockGit())
+
+    _, errors_3 = repos_3.construct(cache=cache, find_git=MockGit)
+    assert not errors_3
+    for descriptor in repos_3.values():
+        descriptor.update(git=MockGit())

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -665,8 +665,11 @@ repo_index:
         )
 
     with fs.working_dir(os.path.join(tmp_path, "foo.git")):
-        git("add", "-A")
-        git("commit", "--no-gpg-sign", "-m", "add index to repo")
+        git("config", "user.name", "Spack")
+        git("config", "user.email", "spack@spack.io")
+
+        git("add", "spack-repo-index.yaml")
+        git("commit", "--no-gpg-sign", "-am", "add index to repo")
 
     # Construct 3 identical descriptors
     descriptors_1, descriptors_2, descriptors_3 = [

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -83,9 +83,9 @@ def test_repo_last_mtime(mock_packages):
         modified_after = "\n    ".join(
             f"{path} ({mtime})" for mtime, path in mtime_with_package_py if mtime > repo_mtime
         )
-        assert (
-            max_mtime <= repo_mtime
-        ), f"the following files were modified while running tests:\n    {modified_after}"
+        assert max_mtime <= repo_mtime, (
+            f"the following files were modified while running tests:\n    {modified_after}"
+        )
     assert max_mtime == repo_mtime, f"last_mtime incorrect for {max_file}"
 
 
@@ -584,7 +584,7 @@ def test_repo_update(tmp_path: pathlib.Path):
     config = {"repos": [existing_root, nonexisting_root]}
     assert spack.schema.repos.update(config)
     assert config["repos"] == {
-        "foo": existing_root,
+        "foo": existing_root
         # non-existing root is removed for simplicity; would be a warning otherwise.
     }
 
@@ -656,6 +656,9 @@ def test_repo_descriptors_construct(tmp_path: pathlib.Path):
                 name="foo",
                 repository=str(tmp_path / "foo.git"),
                 destination=str(tmp_path / "foo_destination"),
+                branch="main",
+                tag="",
+                commit="",
                 relative_paths=None,
                 lock=lock,
             )

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -584,7 +584,7 @@ def test_repo_update(tmp_path: pathlib.Path):
     config = {"repos": [existing_root, nonexisting_root]}
     assert spack.schema.repos.update(config)
     assert config["repos"] == {
-        "foo": existing_root
+        "foo": existing_root,
         # non-existing root is removed for simplicity; would be a warning otherwise.
     }
 
@@ -656,9 +656,6 @@ def test_repo_descriptors_construct(tmp_path: pathlib.Path):
                 name="foo",
                 repository=str(tmp_path / "foo.git"),
                 destination=str(tmp_path / "foo_destination"),
-                branch="main",
-                tag="",
-                commit="",
                 relative_paths=None,
                 lock=lock,
             )

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -83,9 +83,9 @@ def test_repo_last_mtime(mock_packages):
         modified_after = "\n    ".join(
             f"{path} ({mtime})" for mtime, path in mtime_with_package_py if mtime > repo_mtime
         )
-        assert (
-            max_mtime <= repo_mtime
-        ), f"the following files were modified while running tests:\n    {modified_after}"
+        assert max_mtime <= repo_mtime, (
+            f"the following files were modified while running tests:\n    {modified_after}"
+        )
     assert max_mtime == repo_mtime, f"last_mtime incorrect for {max_file}"
 
 
@@ -584,7 +584,7 @@ def test_repo_update(tmp_path: pathlib.Path):
     config = {"repos": [existing_root, nonexisting_root]}
     assert spack.schema.repos.update(config)
     assert config["repos"] == {
-        "foo": existing_root,
+        "foo": existing_root
         # non-existing root is removed for simplicity; would be a warning otherwise.
     }
 
@@ -655,6 +655,9 @@ def test_repo_descriptors_construct(tmp_path: pathlib.Path):
             "foo": spack.repo.RemoteRepoDescriptor(
                 name="foo",
                 repository=str(tmp_path / "foo.git"),
+                branch=None,
+                commit=None,
+                tag=None,
                 destination=str(tmp_path / "foo_destination"),
                 relative_paths=None,
                 lock=lock,

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -6,6 +6,8 @@ import pathlib
 
 import pytest
 
+import llnl.util.filesystem as fs
+
 import spack
 import spack.environment
 import spack.package_base
@@ -13,8 +15,8 @@ import spack.paths
 import spack.repo
 import spack.schema.repos
 import spack.spec
-import spack.util.executable
 import spack.util.file_cache
+import spack.util.git
 import spack.util.lock
 import spack.util.naming
 from spack.util.naming import valid_module_name
@@ -649,6 +651,23 @@ def test_repo_descriptors_construct(tmp_path: pathlib.Path):
     lock = spack.util.lock.Lock(str(tmp_path / "x"), enable=False)
     cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
 
+    git = spack.util.git.git()
+
+    git("init", os.path.join(tmp_path, "foo.git"))
+
+    with open(tmp_path / "foo.git" / "spack-repo-index.yaml", "w", encoding="utf-8") as f:
+        f.write(
+            """\
+repo_index:
+  paths:
+  - spack_repo/foo
+"""
+        )
+
+    with fs.working_dir(os.path.join(tmp_path, "foo.git")):
+        git("add", "-A")
+        git("commit", "--no-gpg-sign", "-m", "add index to repo")
+
     # Construct 3 identical descriptors
     descriptors_1, descriptors_2, descriptors_3 = [
         {
@@ -670,52 +689,18 @@ def test_repo_descriptors_construct(tmp_path: pathlib.Path):
     repos_2 = spack.repo.RepoDescriptors(descriptors_2)  # type: ignore
     repos_3 = spack.repo.RepoDescriptors(descriptors_3)  # type: ignore
 
-    git_clone_calls = 0
-
-    class MockGit(spack.util.executable.Executable):
-        def __init__(self):
-            pass
-
-        def __call__(self, *args, **kwargs) -> str:  # type: ignore
-            nonlocal git_clone_calls
-            git_clone_calls += 1
-
-            action, flag, repo, dest = args
-
-            assert action == "clone"
-            assert flag == "--depth=100"
-            assert "foo.git" in repo
-            assert "foo_destination" in dest
-
-            # The git repo needs a .git subdir
-            os.makedirs(os.path.join(dest, ".git"))
-
-            # The spack-repo-index.yaml is optional; we test Spack reads from it.
-            with open(os.path.join(dest, "spack-repo-index.yaml"), "w", encoding="utf-8") as f:
-                f.write(
-                    """\
-repo_index:
-  paths:
-  - spack_repo/foo
-"""
-                )
-
-            return ""
-
-    repo_path_1, errors_1 = repos_1.construct(cache=cache, find_git=MockGit)
+    repo_path_1, errors_1 = repos_1.construct(cache=cache)
 
     # Verify it cannot construct a Repo instance, and that this does *not* throw, since that would
     # break Spack very early on. Instead, an error is returned. Also verify that
     # relative_paths is read from spack-repo-index.yaml.
-    assert git_clone_calls == 1
     assert len(repo_path_1.repos) == 0
     assert len(errors_1) == 1
     assert all("No repo.yaml" in str(err) for err in errors_1.values()), errors_1
     assert descriptors_1["foo"].relative_paths == ["spack_repo/foo"]
 
     # Do the same test with another instance: it should *not* clone a second time.
-    repo_path_2, errors_2 = repos_2.construct(cache=cache, find_git=MockGit)
-    assert git_clone_calls == 1
+    repo_path_2, errors_2 = repos_2.construct(cache=cache)
     assert len(repo_path_2.repos) == 0
     assert len(errors_2) == 1
     assert all("No repo.yaml" in str(err) for err in errors_2.values()), errors_2
@@ -723,8 +708,7 @@ repo_index:
 
     # Finally fill the repo with an actual repo and check that the repo can be constructed.
     spack.repo.create_repo(str(tmp_path / "foo_destination"), "foo")
-    repo_path_3, errors_3 = repos_3.construct(cache=cache, find_git=MockGit)
-    assert git_clone_calls == 1
+    repo_path_3, errors_3 = repos_3.construct(cache=cache)
     assert not errors_3
     assert len(repo_path_3.repos) == 1
     assert repo_path_3.repos[0].namespace == "foo"

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -83,9 +83,9 @@ def test_repo_last_mtime(mock_packages):
         modified_after = "\n    ".join(
             f"{path} ({mtime})" for mtime, path in mtime_with_package_py if mtime > repo_mtime
         )
-        assert (
-            max_mtime <= repo_mtime
-        ), f"the following files were modified while running tests:\n    {modified_after}"
+        assert max_mtime <= repo_mtime, (
+            f"the following files were modified while running tests:\n    {modified_after}"
+        )
     assert max_mtime == repo_mtime, f"last_mtime incorrect for {max_file}"
 
 
@@ -827,26 +827,33 @@ repo_index:
 
     spack.repo.create_repo(str(tmp_path / "foo_destination"), "foo")
 
+    # branch develop
     _, errors_1 = repos_1.construct(cache=cache, find_git=MockGit)
     assert not errors_1
     for descriptor in repos_1.values():
         descriptor.update(git=MockGit())
 
+    # tag v1.0
     _, errors_2 = repos_2.construct(cache=cache, find_git=MockGit)
     assert not errors_2
     for descriptor in repos_2.values():
         descriptor.update(git=MockGit())
 
+    # commit abc123
     _, errors_3 = repos_3.construct(cache=cache, find_git=MockGit)
     assert not errors_3
     for descriptor in repos_3.values():
         descriptor.update(git=MockGit())
 
+    # default branch
     _, errors_4 = repos_4.construct(cache=cache, find_git=MockGit)
     assert not errors_4
     for descriptor in repos_4.values():
         descriptor.update(git=MockGit())
-        descriptor.update(git=MockGit())
+
+    # Rerun construction after initialization to test early exit logic
+    _, errors_4 = repos_4.construct(cache=cache, find_git=MockGit)
+    assert not errors_4
 
 
 def test_repo_descriptors_update_invalid(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -83,9 +83,9 @@ def test_repo_last_mtime(mock_packages):
         modified_after = "\n    ".join(
             f"{path} ({mtime})" for mtime, path in mtime_with_package_py if mtime > repo_mtime
         )
-        assert max_mtime <= repo_mtime, (
-            f"the following files were modified while running tests:\n    {modified_after}"
-        )
+        assert (
+            max_mtime <= repo_mtime
+        ), f"the following files were modified while running tests:\n    {modified_after}"
     assert max_mtime == repo_mtime, f"last_mtime incorrect for {max_file}"
 
 

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -16,7 +16,6 @@ import spack.repo
 import spack.schema.repos
 import spack.spec
 import spack.util.file_cache
-import spack.util.git
 import spack.util.lock
 import spack.util.naming
 from spack.util.naming import valid_module_name
@@ -643,15 +642,13 @@ def test_parse_config_descriptor_no_git(tmp_path: pathlib.Path):
         )
 
 
-def test_repo_descriptors_construct(tmp_path: pathlib.Path):
+def test_repo_descriptors_construct(tmp_path: pathlib.Path, git):
     """Test the RepoDescriptors construct function. Ensure it does not raise when we cannot
     construct a Repo instance, e.g. due to missing repo.yaml file. Check that it parses the
     spack-repo-index.yaml file both when newly initialized and when already cloned."""
 
     lock = spack.util.lock.Lock(str(tmp_path / "x"), enable=False)
     cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
-
-    git = spack.util.git.git()
 
     git("init", os.path.join(tmp_path, "foo.git"))
 

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -83,9 +83,9 @@ def test_repo_last_mtime(mock_packages):
         modified_after = "\n    ".join(
             f"{path} ({mtime})" for mtime, path in mtime_with_package_py if mtime > repo_mtime
         )
-        assert (
-            max_mtime <= repo_mtime
-        ), f"the following files were modified while running tests:\n    {modified_after}"
+        assert max_mtime <= repo_mtime, (
+            f"the following files were modified while running tests:\n    {modified_after}"
+        )
     assert max_mtime == repo_mtime, f"last_mtime incorrect for {max_file}"
 
 
@@ -771,7 +771,7 @@ def test_repo_descriptors_update(tmp_path: pathlib.Path):
     cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
 
     # Construct 3 identical descriptors
-    descriptors_1, descriptors_2, descriptors_3 = [
+    descriptors_1, descriptors_2, descriptors_3, descriptors_4 = [
         {
             "foo": spack.repo.RemoteRepoDescriptor(
                 name="foo",
@@ -784,12 +784,13 @@ def test_repo_descriptors_update(tmp_path: pathlib.Path):
                 lock=lock,
             )
         }
-        for i in range(3)
+        for i in range(4)
     ]
 
     repos_1 = spack.repo.RepoDescriptors(descriptors_1)  # type: ignore
     repos_2 = spack.repo.RepoDescriptors(descriptors_2)  # type: ignore
     repos_3 = spack.repo.RepoDescriptors(descriptors_3)  # type: ignore
+    repos_4 = spack.repo.RepoDescriptors(descriptors_4)  # type: ignore
 
     class MockGit(spack.util.executable.Executable):
         def __init__(self):
@@ -840,3 +841,61 @@ repo_index:
     assert not errors_3
     for descriptor in repos_3.values():
         descriptor.update(git=MockGit())
+
+    _, errors_4 = repos_4.construct(cache=cache, find_git=MockGit)
+    assert not errors_4
+    for descriptor in repos_4.values():
+        descriptor.update(git=MockGit())
+        descriptor.update(git=MockGit())
+
+
+def test_repo_descriptors_update_invalid(tmp_path: pathlib.Path):
+    """Test the RepoDescriptors construct function. Ensure it does not raise when we cannot
+    construct a Repo instance, e.g. due to missing repo.yaml file. Check that it parses the
+    spack-repo-index.yaml file both when newly initialized and when already cloned."""
+
+    lock = spack.util.lock.Lock(str(tmp_path / "x"), enable=False)
+    cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
+
+    # Construct 3 identical descriptors
+    descriptors_1 = {
+        "foo": spack.repo.RemoteRepoDescriptor(
+            name="foo",
+            repository=str(tmp_path / "foo.git"),
+            destination=str(tmp_path / "foo_destination"),
+            branch=None,
+            tag=None,
+            commit=None,
+            relative_paths=None,
+            lock=lock,
+        )
+    }
+
+    repos_1 = spack.repo.RepoDescriptors(descriptors_1)  # type: ignore
+
+    class MockGitInvalidRemote(spack.util.executable.Executable):
+        def __init__(self):
+            pass
+
+        def __call__(self, *args, **kwargs) -> str:  # type: ignore
+            action = args[0]
+
+            if action == "ls-remote":
+                return "bad string"
+
+    class MockGitFailed(spack.util.executable.Executable):
+        def __init__(self):
+            pass
+
+        def __call__(self, *args, **kwargs) -> str:  # type: ignore
+            raise spack.util.executable.ProcessError("failed")
+
+    spack.repo.create_repo(str(tmp_path / "foo_destination"), "foo")
+
+    _, errors_1 = repos_1.construct(cache=cache, find_git=MockGitFailed)
+    assert len(errors_1) == 1
+    assert all("Failed to clone repository" in str(err) for err in errors_1.values()), errors_1
+
+    with pytest.raises(spack.repo.RepoError, match="Unable to locate a default branch"):
+        for descriptor in repos_1.values():
+            descriptor.update(git=MockGitInvalidRemote())

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -3,13 +3,73 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from llnl.util.filesystem import working_dir
 
-from spack.util.git import get_modified_files
+import spack.util.git
+import spack.util.executable as exe
+import pytest
+
+from typing import Optional
+
+
+def test_git_not_found(monkeypatch):
+    def _mock_find_git() -> Optional[str]:
+        return None
+
+    monkeypatch.setattr(spack.util.git, "_find_git", _mock_find_git)
+
+    git = spack.util.git.git(required=False)
+    assert git is None
+
+    with pytest.raises(exe.CommandNotFoundError):
+        spack.util.git.git(required=True)
 
 
 def test_modified_files(mock_git_package_changes):
     repo, filename, commits = mock_git_package_changes
 
     with working_dir(repo.packages_path):
-        files = get_modified_files(from_ref="HEAD~1", to_ref="HEAD")
+        files = spack.util.git.get_modified_files(from_ref="HEAD~1", to_ref="HEAD")
         assert len(files) == 1
         assert files[0] == filename
+
+
+def test_init_git_repo(git, tmp_path):
+    repo_url = "https://github.com/spack/spack.git"
+    destination = tmp_path / "test_git_init"
+
+    with working_dir(destination, create=True):
+        spack.util.git.init_git_repo(repo_url)
+
+        "No commits yet" in git("status", output=str)
+
+
+def test_pull_checkout_commit(git, tmp_path, mock_git_version_info):
+    repo, _, commits = mock_git_version_info
+    destination = tmp_path / "test_git_checkout_commit"
+
+    with working_dir(destination, create=True):
+        spack.util.git.init_git_repo(repo)
+        spack.util.git.pull_checkout_commit(commits[0])
+
+        commits[0] in git("rev-parse", "HEAD", output=str)
+
+
+def test_pull_checkout_tag(git, tmp_path, mock_git_version_info):
+    repo, _, _ = mock_git_version_info
+    destination = tmp_path / "test_git_checkout_tag"
+
+    with working_dir(destination, create=True):
+        spack.util.git.init_git_repo(repo)
+        spack.util.git.pull_checkout_tag("v1.1")
+
+        "v1.1" in git("describe", "--exact-match", "--tags", output=str)
+
+
+def test_pull_checkout_branch(git, tmp_path, mock_git_version_info):
+    repo, _, _ = mock_git_version_info
+    destination = tmp_path / "test_git_checkout_branch"
+
+    with working_dir(destination, create=True):
+        spack.util.git.init_git_repo(repo)
+        spack.util.git.pull_checkout_branch("1.x")
+
+        "1.x" in git("rev-parse", "--abbrev-ref", "HEAD", output=str)

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -74,3 +74,9 @@ def test_pull_checkout_branch(git, tmp_path, mock_git_version_info):
         spack.util.git.pull_checkout_branch("1.x")
 
         "1.x" in git("rev-parse", "--abbrev-ref", "HEAD", output=str)
+
+        with open("file.txt", "w", encoding="utf-8") as f:
+            f.write("hi harmen")
+
+        with pytest.raises(exe.ProcessError):
+            spack.util.git.pull_checkout_branch("main")

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -1,13 +1,14 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from llnl.util.filesystem import working_dir
+from typing import Optional
 
-import spack.util.git
-import spack.util.executable as exe
 import pytest
 
-from typing import Optional
+from llnl.util.filesystem import working_dir
+
+import spack.util.executable as exe
+import spack.util.git
 
 
 def test_git_not_found(monkeypatch):

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -47,8 +47,12 @@ def git(required: bool = False) -> Optional[exe.Executable]:
     return git
 
 
-def init_git_repo(repository: str, remote: str = "origin", git_exe=lambda: git(required=True)):
+def init_git_repo(
+    repository: str, remote: str = "origin", git_exe: Optional[exe.Executable] = None
+):
     """Initialize a new Git repository and configure it with a remote."""
+    git_exe = git_exe or git(required=True)
+
     git_exe("init", "--quiet", output=str)
     git_exe("remote", "add", remote, repository)
     # versions of git prior to v2.24 may not have the manyFiles feature
@@ -56,24 +60,30 @@ def init_git_repo(repository: str, remote: str = "origin", git_exe=lambda: git(r
     git_exe("config", "feature.manyFiles", "true", ignore_errors=True)
 
 
-def pull_checkout_commit(commit: str, git_exe=lambda: git(required=True)):
+def pull_checkout_commit(commit: str, git_exe: Optional[exe.Executable] = None):
     """Fetch all remotes and checkout the specified commit."""
+    git_exe = git_exe or git(required=True)
+
     git_exe("fetch", "--all")
     git_exe("checkout", commit)
 
 
 def pull_checkout_tag(
-    tag: str, remote: str = "origin", depth: int = 20, git_exe=lambda: git(required=True)
+    tag: str, remote: str = "origin", depth: int = 20, git_exe: Optional[exe.Executable] = None
 ):
     """Fetch tags with specified depth and checkout the given tag."""
+    git_exe = git_exe or git(required=True)
+
     git_exe("fetch", f"--depth={depth}", "--force", "--tags", remote)
     git_exe("checkout", tag)
 
 
 def pull_checkout_branch(
-    branch: str, remote: str = "origin", depth: int = 20, git_exe=lambda: git(required=True)
+    branch: str, remote: str = "origin", depth: int = 20, git_exe: Optional[exe.Executable] = None
 ):
     """Fetch and checkout branch, then rebase with remote tracking branch."""
+    git_exe = git_exe or git(required=True)
+
     git_exe("fetch", f"--depth={depth}", remote, branch)
     git_exe("checkout", "--quiet", branch)
 
@@ -85,7 +95,7 @@ def pull_checkout_branch(
 
 
 def get_modified_files(
-    from_ref: str = "HEAD~1", to_ref: str = "HEAD", git_exe=lambda: git(required=True)
+    from_ref: str = "HEAD~1", to_ref: str = "HEAD", git_exe: Optional[exe.Executable] = None
 ) -> List[str]:
     """Get a list of files modified between `from_ref` and `to_ref`
     Args:
@@ -93,6 +103,8 @@ def get_modified_files(
        to_ref (str): newer git ref, defaults to `HEAD`
     Returns: list of file paths
     """
+    git_exe = git_exe or git(required=True)
+
     stdout = git_exe("diff", "--name-only", from_ref, to_ref, output=str)
 
     return stdout.split()

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -95,12 +95,12 @@ def pull_checkout_branch(branch: str, remote: str = "origin", depth: int = 20):
     git_exe = git(required=True)
 
     git_exe("fetch", f"--depth={depth}", remote, branch)
-    git_exe("checkout", branch)
+    git_exe("checkout", "--quiet", branch)
 
     try:
-        git_exe("rebase", f"{remote}/{branch}")
+        git_exe("rebase", "--quiet", f"{remote}/{branch}")
     except exe.ProcessError as e:
-        git_exe("rebase", "--abort", ignore_errors=True)
+        git_exe("rebase", "--quiet", "--abort", ignore_errors=True)
         raise e
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -83,9 +83,9 @@ def pull_checkout_branch(branch: str, remote: str = "origin", depth: int = 20):
 
     try:
         git_exe("rebase", "--quiet", f"{remote}/{branch}")
-    except exe.ProcessError as e:
+    except exe.ProcessError:
         git_exe("rebase", "--abort", fail_on_error=False, error=str, output=str)
-        raise e
+        raise
 
 
 def get_modified_files(from_ref: str = "HEAD~1", to_ref: str = "HEAD") -> List[str]:

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -47,27 +47,11 @@ def git(required: bool = False) -> Optional[exe.Executable]:
     return git
 
 
-def init_git_repo(repository: str, destination: str, remote: str = "origin"):
-    """Initialize a new Git repository and configure it with a remote.
-
-    Creates a new Git repository at the specified destination directory,
-    adds a remote repository URL, and optimizes configuration for repositories
-    with many files.
-
-    Args:
-        repository: The URL of the remote repository to add.
-        destination: The local directory path where the Git repository will be initialized.
-        remote: The name for the remote repository. Defaults to "origin".
-
-    Raises:
-        RuntimeError: If git executable is not found or git init/remote add commands fail.
-
-    Note:
-        The manyFiles configuration may fail silently on Git versions prior to v2.24.
-    """
+def init_git_repo(repository: str, remote: str = "origin"):
+    """Initialize a new Git repository and configure it with a remote."""
     git_exe = git(required=True)
 
-    git_exe("init", "--quiet", destination, output=str)
+    git_exe("init", "--quiet", output=str)
     git_exe("remote", "add", remote, repository)
     # versions of git prior to v2.24 may not have the manyFiles feature
     # so we should ignore errors here on older versions of git

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -47,10 +47,8 @@ def git(required: bool = False) -> Optional[exe.Executable]:
     return git
 
 
-def init_git_repo(repository: str, remote: str = "origin"):
+def init_git_repo(repository: str, remote: str = "origin", git_exe=lambda: git(required=True)):
     """Initialize a new Git repository and configure it with a remote."""
-    git_exe = git(required=True)
-
     git_exe("init", "--quiet", output=str)
     git_exe("remote", "add", remote, repository)
     # versions of git prior to v2.24 may not have the manyFiles feature
@@ -58,26 +56,24 @@ def init_git_repo(repository: str, remote: str = "origin"):
     git_exe("config", "feature.manyFiles", "true", ignore_errors=True)
 
 
-def pull_checkout_commit(commit: str):
+def pull_checkout_commit(commit: str, git_exe=lambda: git(required=True)):
     """Fetch all remotes and checkout the specified commit."""
-    git_exe = git(required=True)
-
     git_exe("fetch", "--all")
     git_exe("checkout", commit)
 
 
-def pull_checkout_tag(tag: str, remote: str = "origin", depth: int = 20):
+def pull_checkout_tag(
+    tag: str, remote: str = "origin", depth: int = 20, git_exe=lambda: git(required=True)
+):
     """Fetch tags with specified depth and checkout the given tag."""
-    git_exe = git(required=True)
-
     git_exe("fetch", f"--depth={depth}", "--force", "--tags", remote)
     git_exe("checkout", tag)
 
 
-def pull_checkout_branch(branch: str, remote: str = "origin", depth: int = 20):
+def pull_checkout_branch(
+    branch: str, remote: str = "origin", depth: int = 20, git_exe=lambda: git(required=True)
+):
     """Fetch and checkout branch, then rebase with remote tracking branch."""
-    git_exe = git(required=True)
-
     git_exe("fetch", f"--depth={depth}", remote, branch)
     git_exe("checkout", "--quiet", branch)
 
@@ -88,15 +84,15 @@ def pull_checkout_branch(branch: str, remote: str = "origin", depth: int = 20):
         raise
 
 
-def get_modified_files(from_ref: str = "HEAD~1", to_ref: str = "HEAD") -> List[str]:
+def get_modified_files(
+    from_ref: str = "HEAD~1", to_ref: str = "HEAD", git_exe=lambda: git(required=True)
+) -> List[str]:
     """Get a list of files modified between `from_ref` and `to_ref`
     Args:
        from_ref (str): oldest git ref, defaults to `HEAD~1`
        to_ref (str): newer git ref, defaults to `HEAD`
     Returns: list of file paths
     """
-    git_exe = git(required=True)
-
     stdout = git_exe("diff", "--name-only", from_ref, to_ref, output=str)
 
     return stdout.split()

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -100,7 +100,7 @@ def pull_checkout_branch(branch: str, remote: str = "origin", depth: int = 20):
     try:
         git_exe("rebase", f"{remote}/{branch}")
     except exe.ProcessError as e:
-        git_exe("rebase", "--abort")
+        git_exe("rebase", "--abort", ignore_errors=True)
         raise e
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -67,7 +67,7 @@ def init_git_repo(repository: str, destination: str, remote: str = "origin"):
     """
     git_exe = git(required=True)
 
-    git_exe("init", destination, output=str)
+    git_exe("init", "--quiet", destination, output=str)
     git_exe("remote", "add", remote, repository)
     # versions of git prior to v2.24 may not have the manyFiles feature
     # so we should ignore errors here on older versions of git

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -100,7 +100,7 @@ def pull_checkout_branch(branch: str, remote: str = "origin", depth: int = 20):
     try:
         git_exe("rebase", "--quiet", f"{remote}/{branch}")
     except exe.ProcessError as e:
-        git_exe("rebase", "--quiet", "--abort", ignore_errors=True)
+        git_exe("rebase", "--abort", fail_on_error=False, error=str, output=str)
         raise e
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -47,6 +47,63 @@ def git(required: bool = False) -> Optional[exe.Executable]:
     return git
 
 
+def init_git_repo(repository: str, destination: str, remote: str = "origin"):
+    """Initialize a new Git repository and configure it with a remote.
+
+    Creates a new Git repository at the specified destination directory,
+    adds a remote repository URL, and optimizes configuration for repositories
+    with many files.
+
+    Args:
+        repository: The URL of the remote repository to add.
+        destination: The local directory path where the Git repository will be initialized.
+        remote: The name for the remote repository. Defaults to "origin".
+
+    Raises:
+        RuntimeError: If git executable is not found or git init/remote add commands fail.
+
+    Note:
+        The manyFiles configuration may fail silently on Git versions prior to v2.24.
+    """
+    git_exe = git(required=True)
+
+    git_exe("init", destination, output=str)
+    git_exe("remote", "add", remote, repository)
+    # versions of git prior to v2.24 may not have the manyFiles feature
+    # so we should ignore errors here on older versions of git
+    git_exe("config", "feature.manyFiles", "true", ignore_errors=True)
+
+
+def pull_checkout_commit(commit: str):
+    """Fetch all remotes and checkout the specified commit."""
+    git_exe = git(required=True)
+
+    git_exe("fetch", "--all")
+    git_exe("checkout", commit)
+
+
+def pull_checkout_tag(tag: str, remote: str = "origin", depth: int = 20):
+    """Fetch tags with specified depth and checkout the given tag."""
+    git_exe = git(required=True)
+
+    git_exe("fetch", f"--depth={depth}", "--force", "--tags", remote)
+    git_exe("checkout", tag)
+
+
+def pull_checkout_branch(branch: str, remote: str = "origin", depth: int = 20):
+    """Fetch and checkout branch, then rebase with remote tracking branch."""
+    git_exe = git(required=True)
+
+    git_exe("fetch", f"--depth={depth}", remote, branch)
+    git_exe("checkout", branch)
+
+    try:
+        git_exe("rebase", f"{remote}/{branch}")
+    except exe.ProcessError as e:
+        git_exe("rebase", "--abort")
+        raise e
+
+
 def get_modified_files(from_ref: str = "HEAD~1", to_ref: str = "HEAD") -> List[str]:
     """Get a list of files modified between `from_ref` and `to_ref`
     Args:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1784,7 +1784,7 @@ _spack_repo() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create list ls add set remove rm migrate"
+        SPACK_COMPREPLY="create list ls add set remove rm migrate update"
     fi
 }
 
@@ -1845,6 +1845,15 @@ _spack_repo_migrate() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help --dry-run --fix"
+    else
+        _repos
+    fi
+}
+
+_spack_repo_update() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --remote -r --scope --branch -b --tag -t --commit -c"
     else
         _repos
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1855,7 +1855,7 @@ _spack_repo_update() {
     then
         SPACK_COMPREPLY="-h --help --remote -r --scope --branch -b --tag -t --commit -c"
     else
-        _repos
+        SPACK_COMPREPLY=""
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2762,6 +2762,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a set -d 'modif
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a rm -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a migrate -d 'migrate a package repository to the latest Package API'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a update
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -d 'show this help message and exit'
 
@@ -2844,6 +2845,22 @@ complete -c spack -n '__fish_spack_using_command repo migrate' -l dry-run -f -a 
 complete -c spack -n '__fish_spack_using_command repo migrate' -l dry-run -d 'do not modify the repository, but dump a patch file'
 complete -c spack -n '__fish_spack_using_command repo migrate' -l fix -f -a fix
 complete -c spack -n '__fish_spack_using_command repo migrate' -l fix -d 'automatically migrate the repository to the latest Package API'
+
+# spack repo update
+set -g __fish_spack_optspecs_spack_repo_update h/help r/remote= scope= b/branch= t/tag= c/commit=
+
+complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -f -a remote
+complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -d 'name of remote to check for branches, tags, or commits'
+complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -f -a branch
+complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -d 'name of a branch to change to'
+complete -c spack -n '__fish_spack_using_command repo update' -l tag -s t -r -f -a tag
+complete -c spack -n '__fish_spack_using_command repo update' -l tag -s t -r -d 'name of a tag to change to'
+complete -c spack -n '__fish_spack_using_command repo update' -l commit -s c -r -f -a commit
+complete -c spack -n '__fish_spack_using_command repo update' -l commit -s c -r -d 'name of a commit to change to'
 
 # spack resource
 set -g __fish_spack_optspecs_spack_resource h/help


### PR DESCRIPTION
This PR introduces a new spack repo update command that allows users to update remote Git repositories and switch between branches, tags, or commits in their Spack repository configuration.

```bash
# Update all remote repositories
spack repo update

# Update specific repositories
spack repo update my-repo another-repo

# Switch to a specific branch/tag/commit
spack repo update my-repo --branch develop
spack repo update my-repo --tag v2.1.0
spack repo update my-repo --commit abc123

# Use a different remote
spack repo update --remote upstream

```

This PR also adds optional branch, tag, and commit keys to a git repository's configuration in `repos.yaml`.

`repos.yaml`:
```yaml
repos:
  builtin:
    git: https://github.com/spack/spack-packages.git
    branch: develop  # optional
    tag: 2025.06     # optional
    commit: abc123   # optional
```

If multiple keys are specified they are prioritized `commit` >  `tag` > `branch`. 