### PR TITLE
enable iterable values for disjunctive when clauses

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -32,6 +32,7 @@ The available directives are:
 """
 import collections
 import collections.abc
+import functools
 import os
 import re
 import warnings
@@ -130,6 +131,23 @@ def _make_when_spec(value: WhenType) -> Optional[spack.spec.Spec]:
 
     # This is conditional on the spec
     return spack.spec.Spec(value)
+
+
+def accept_multiple_when_clauses(func):
+    """Convert a list or tuple of ``when`` args into consecutive calls.
+
+    This simulates the action of invoking a directive within a ``for`` loop.
+    """
+
+    @functools.wraps(func)
+    def _multiple_when_impl(*args, **kwargs):
+        when_specs = kwargs.pop("when", None)
+        if not isinstance(when_specs, (list, tuple)):
+            when_specs = [when_specs]
+        for when in when_specs:
+            func(*args, when=when, **kwargs)
+
+    return _multiple_when_impl
 
 
 SubmoduleCallback = Callable[[spack.package_base.PackageBase], Union[str, List[str], bool]]
@@ -315,6 +333,7 @@ def _depends_on(
         execute_patch(dependency)
 
 
+@accept_multiple_when_clauses
 @directive("conflicts")
 def conflicts(conflict_spec: SpecType, when: WhenType = None, msg: Optional[str] = None):
     """Allows a package to define a conflict.
@@ -350,7 +369,8 @@ def conflicts(conflict_spec: SpecType, when: WhenType = None, msg: Optional[str]
     return _execute_conflicts
 
 
-@directive(("dependencies"))
+@accept_multiple_when_clauses
+@directive("dependencies")
 def depends_on(
     spec: SpecType,
     when: WhenType = None,
@@ -380,6 +400,7 @@ def depends_on(
     return _execute_depends_on
 
 
+@accept_multiple_when_clauses
 @directive("disable_redistribute")
 def redistribute(
     source: Optional[bool] = None, binary: Optional[bool] = None, when: WhenType = None
@@ -436,6 +457,7 @@ def _execute_redistribute(
         )
 
 
+@accept_multiple_when_clauses
 @directive(("extendees", "dependencies"))
 def extends(spec, when=None, type=("build", "run"), patches=None):
     """Same as depends_on, but also adds this package to the extendee list.
@@ -464,6 +486,7 @@ def extends(spec, when=None, type=("build", "run"), patches=None):
     return _execute_extends
 
 
+@accept_multiple_when_clauses
 @directive(dicts=("provided", "provided_together"))
 def provides(*specs: SpecType, when: WhenType = None):
     """Allows packages to provide a virtual dependency.
@@ -500,6 +523,7 @@ def provides(*specs: SpecType, when: WhenType = None):
     return _execute_provides
 
 
+@accept_multiple_when_clauses
 @directive("splice_specs")
 def can_splice(
     target: SpecType, *, when: SpecType, match_variants: Union[None, str, List[str]] = None
@@ -537,6 +561,7 @@ def can_splice(
     return _execute_can_splice
 
 
+@accept_multiple_when_clauses
 @directive("patches")
 def patch(
     url_or_filename: str,
@@ -619,6 +644,7 @@ def conditional(*values: Union[str, bool], when: Optional[WhenType] = None):
     )
 
 
+@accept_multiple_when_clauses
 @directive("variants")
 def variant(
     name: str,
@@ -627,7 +653,7 @@ def variant(
     values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]] = None,
     multi: Optional[bool] = None,
     validator: Optional[Callable[[str, str, Tuple[Any, ...]], None]] = None,
-    when: Optional[Union[str, bool]] = None,
+    when: WhenType = None,
     sticky: bool = False,
 ):
     """Define a variant for the package.
@@ -764,6 +790,7 @@ def variant(
     return _execute_variant
 
 
+@accept_multiple_when_clauses
 @directive("resources")
 def resource(
     *,
@@ -871,11 +898,12 @@ def _execute_license(
     pkg.licenses[when_spec] = license_identifier
 
 
+@accept_multiple_when_clauses
 @directive("licenses")
 def license(
     license_identifier: str,
     checked_by: Optional[Union[str, List[str]]] = None,
-    when: Optional[Union[str, bool]] = None,
+    when: WhenType = None,
 ):
     """Add a new license directive, to specify the SPDX identifier the software is
     distributed under.
@@ -891,6 +919,7 @@ def license(
     return lambda pkg: _execute_license(pkg, license_identifier, when)
 
 
+@accept_multiple_when_clauses
 @directive("requirements")
 def requires(*requirement_specs: str, policy="one_of", when=None, msg=None):
     """Allows a package to request a configuration to be present in all valid solutions.


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

# Problem
Applying a directive for multiple separate scenarios requires duplicating the directive for each case. For example, from spack/spack-packages#91:

```python
    with when("@:1.18"):
        patch("gdbm.patch", when="%gcc@10:")
        patch("gdbm.patch", when="%clang@11:")
        patch("gdbm.patch", when="%cce@11:")
        patch("gdbm.patch", when="%aocc@2:")
        patch("gdbm.patch", when="%oneapi")
        patch("gdbm.patch", when="%arm@21:")
```

While we can use `with when(...):` to reduce some of the boilerplate, packagers still run the risk of making a typo each time they have to repeat the same directive. We can replace this with a `for` loop:

```python
    with when("@:1.18"):
        for compiler in ["%gcc@10:", "%clang@11:", "%cce@11:", "%aocc@2:", "%oneapi", "%arm@21:"]:
            patch("gdbm.patch", when=compiler)
```

But this composes poorly with our more declarative `with when(...):` approach (should the `for` loop be inside or outside the `with`?), and it's possible to accidentally iterate over the characters of a string, leading to confusing error messages.

In general, we would like to provide declarative representations of common logic patterns in package recipes, so that we can better capture intent in the inputs to our concretizer and help our users to avoid subtle logic errors.

# Solution
- Expand directives with an iterable `when=["a", "b", "c"]` clause into version of the same directive for each element of the tuple `when="a"`, `when="b"`, `when="c"`.
    - We only support `str` or `Spec` iterable elements, not booleans.
    - This matches the semantics of a `for` loop iterating over the values.

# Result
We can now write something like:

```python
    with when("@:1.18"):
        patch("gdbm.patch", when=[
            "%gcc@10:",
            "%clang@11:",
            "%cce@11:",
            "%aocc@2:",
            "%oneapi",
            "%arm@21:",
        ])
```

## Future Work
We still need to use the separate `with when(...):`, because we are quite literally just generating a separate directive for each element of the iterable `when` clause. In order to remove that, we'd need to have a general disjunction method in the spec syntax itself, which seems worthwhile to investigate but would likely necessitate a lengthy design proposal.

# TODO
- [ ] unit testing
- [ ] documentation in the packaging guide