### PR TITLE
Fix compiler initialization with `unify:false`

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -122,9 +122,9 @@ def concretize_separately(
     # all the indexes if there's any need for that.
     _ = spack.repo.PATH.provider_index
 
-    # Ensure we have compilers in compilers.yaml to avoid that
+    # Ensure we have compilers in packages.yaml to avoid that
     # processes try to write the config file in parallel
-    _ = spack.compilers.config.all_compilers_from(spack.config.CONFIG)
+    _ = spack.compilers.config.all_compilers()
 
     # Early return if there is nothing to do
     if len(args) == 0:


### PR DESCRIPTION
We need to avoid that the compilers are searched for in concretization subprocesses, since the subprocesses will try to spawn other children, and they are daemonic.

This will cause an error similar to:
```
==> Error: daemonic processes are not allowed to have children
```
during concretization.

**To reproduce the bug on develop**
```console
# Ensure there are no compilers registered
$ spack env activate --temp
$ spack add hdf5 trilinos
# Modify spack.yaml to have concretizer:unify:false
$ spack concretize -f --fresh
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
