### PR TITLE
bootstrap: ensure spack.repo.PATH is initialized before bootstrap

### DIFF
--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -14,6 +14,7 @@ import spack.compilers.config
 import spack.config
 import spack.environment
 import spack.modules
+import spack.repo
 import spack.paths
 import spack.platforms
 import spack.spec
@@ -142,6 +143,7 @@ def _add_compilers_if_missing() -> None:
 
 @contextlib.contextmanager
 def _ensure_bootstrap_configuration() -> Generator:
+    spack.repo.PATH.repos  # ensure this is instantiated from current config.
     spack.store.ensure_singleton_created()
     bootstrap_store_path = store_path()
     user_configuration = _read_and_sanitize_configuration()

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -14,9 +14,9 @@ import spack.compilers.config
 import spack.config
 import spack.environment
 import spack.modules
-import spack.repo
 import spack.paths
 import spack.platforms
+import spack.repo
 import spack.spec
 import spack.store
 import spack.util.path

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """High-level functions to concretize list of specs"""
+import importlib
 import sys
 import time
 from typing import Iterable, List, Optional, Sequence, Tuple, Union
@@ -111,9 +112,12 @@ def concretize_separately(
         if not abstract.concrete
     ]
     ret = [(i, abstract) for i, abstract in enumerate(to_concretize) if abstract.concrete]
-    # Ensure we don't try to bootstrap clingo in parallel
-    with ensure_bootstrap_configuration():
-        ensure_clingo_importable_or_raise()
+    try:
+        # Ensure we don't try to bootstrap clingo in parallel
+        importlib.import_module("clingo")
+    except ImportError:
+        with ensure_bootstrap_configuration():
+            ensure_clingo_importable_or_raise()
 
     # Ensure all the indexes have been built or updated, since
     # otherwise the processes in the pool may timeout on waiting


### PR DESCRIPTION
Bootstrapping should (for now) just use the user's configured package repo; this avoids a redundant clone.

In the concretizer, also avoid that we swap to bootstrap config if ultimately we don't need to bootstrap clingo.