### PR TITLE
spack repo list: --namespaces and --names instead of branch on stdout.isatty()

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -5,7 +5,6 @@
 import argparse
 import os
 import shlex
-import sys
 import tempfile
 from typing import Any, Dict, List, Optional, Union
 
@@ -50,6 +49,13 @@ def setup_parser(subparser: argparse.ArgumentParser):
     list_parser = sp.add_parser("list", aliases=["ls"], help=repo_list.__doc__)
     list_parser.add_argument(
         "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
+    )
+    output_group = list_parser.add_mutually_exclusive_group()
+    output_group.add_argument(
+        "--config-names", action="store_true", help="show configuration names only"
+    )
+    output_group.add_argument(
+        "--namespaces", action="store_true", help="show repository namespaces only"
     )
 
     # Add
@@ -261,11 +267,28 @@ def repo_list(args):
         lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG, scope=args.scope
     )
 
-    if not sys.stdout.isatty():
+    # Handle --config-names: just print config names
+    if args.config_names:
         for name in descriptors:
             print(name)
         return
 
+    # Handle --namespaces: print all repo namespaces
+    if args.namespaces:
+        namespaces = []
+        for name, descriptor in descriptors.items():
+            descriptor.initialize(fetch=False)
+            repos_for_descriptor = descriptor.construct(cache=spack.caches.MISC_CACHE)
+
+            for path, maybe_repo in repos_for_descriptor.items():
+                if isinstance(maybe_repo, spack.repo.Repo):
+                    namespaces.append(maybe_repo.namespace)
+
+        for namespace in namespaces:
+            print(namespace)
+        return
+
+    # Default table format: verbose output always (no more tty check)
     # Collect all repository information for aligned output
     repo_info = []
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -51,9 +51,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
     )
     output_group = list_parser.add_mutually_exclusive_group()
-    output_group.add_argument(
-        "--config-names", action="store_true", help="show configuration names only"
-    )
+    output_group.add_argument("--names", action="store_true", help="show configuration names only")
     output_group.add_argument(
         "--namespaces", action="store_true", help="show repository namespaces only"
     )
@@ -267,13 +265,13 @@ def repo_list(args):
         lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG, scope=args.scope
     )
 
-    # Handle --config-names: just print config names
-    if args.config_names:
+    # --names: just print config names
+    if args.names:
         for name in descriptors:
             print(name)
         return
 
-    # Handle --namespaces: print all repo namespaces
+    # --namespaces: print all repo namespaces
     if args.namespaces:
         for name, path, maybe_repo in _iter_repos_from_descriptors(descriptors):
             if isinstance(maybe_repo, spack.repo.Repo):

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -6,7 +6,7 @@ import argparse
 import os
 import shlex
 import tempfile
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import llnl.util.tty as tty
 from llnl.util.tty import color
@@ -275,39 +275,23 @@ def repo_list(args):
 
     # Handle --namespaces: print all repo namespaces
     if args.namespaces:
-        namespaces = []
-        for name, descriptor in descriptors.items():
-            descriptor.initialize(fetch=False)
-            repos_for_descriptor = descriptor.construct(cache=spack.caches.MISC_CACHE)
-
-            for path, maybe_repo in repos_for_descriptor.items():
-                if isinstance(maybe_repo, spack.repo.Repo):
-                    namespaces.append(maybe_repo.namespace)
-
-        for namespace in namespaces:
-            print(namespace)
+        for name, path, maybe_repo in _iter_repos_from_descriptors(descriptors):
+            if isinstance(maybe_repo, spack.repo.Repo):
+                print(maybe_repo.namespace)
         return
 
-    # Default table format: verbose output always (no more tty check)
-    # Collect all repository information for aligned output
+    # Default table format: collect all repository information for aligned output
     repo_info = []
 
-    for name, descriptor in descriptors.items():
-        descriptor.initialize(fetch=False)
-        repos_for_descriptor = descriptor.construct(cache=spack.caches.MISC_CACHE)
-
-        # Register all repos and errors for this descriptor
-        for path, maybe_repo in repos_for_descriptor.items():
-            if isinstance(maybe_repo, spack.repo.Repo):
-                repo_info.append(
-                    ("@g{[+]}", maybe_repo.namespace, maybe_repo.package_api_str, maybe_repo.root)
-                )
-            else:  # exception
-                repo_info.append(("@r{[-]}", name, "", f"{path}: {maybe_repo}"))
-
-        # If there are no repos, it means it's not yet cloned; then we status + git repository
-        if not repos_for_descriptor and isinstance(descriptor, spack.repo.RemoteRepoDescriptor):
-            repo_info.append(("@K{ - }", name, "", descriptor.repository))
+    for name, path, maybe_repo in _iter_repos_from_descriptors(descriptors):
+        if isinstance(maybe_repo, spack.repo.Repo):
+            repo_info.append(
+                ("@g{[+]}", maybe_repo.namespace, maybe_repo.package_api_str, maybe_repo.root)
+            )
+        elif maybe_repo is None:  # Uninitialized Git-based repo case
+            repo_info.append(("@K{ - }", name, "", path))
+        else:  # Exception/error case
+            repo_info.append(("@r{[-]}", name, "", f"{path}: {maybe_repo}"))
 
     if repo_info:
         max_namespace_width = max(len(namespace) for _, namespace, _, _ in repo_info) + 3
@@ -441,6 +425,28 @@ def repo_set(args):
     spack.config.set("repos", scope_repos, args.scope)
 
     tty.msg(f"Updated repo '{namespace}'")
+
+
+def _iter_repos_from_descriptors(
+    descriptors: spack.repo.RepoDescriptors,
+) -> Generator[Tuple[str, str, Union[spack.repo.Repo, Exception, None]], None, None]:
+    """Iterate through repository descriptors and yield (name, path, maybe_repo) tuples.
+
+    Yields:
+        Tuple of (config_name, path, maybe_repo) where maybe_repo is a Repo instance if it could
+        be instantiated, an Exception if it could not be instantiated, or None if it was not
+        initialized yet.
+    """
+    for name, descriptor in descriptors.items():
+        descriptor.initialize(fetch=False)
+        repos_for_descriptor = descriptor.construct(cache=spack.caches.MISC_CACHE)
+
+        for path, maybe_repo in repos_for_descriptor.items():
+            yield name, path, maybe_repo
+
+        # If there are no repos, it means it's not yet cloned; yield descriptor info
+        if not repos_for_descriptor and isinstance(descriptor, spack.repo.RemoteRepoDescriptor):
+            yield name, descriptor.repository, None  # None indicates remote descriptor
 
 
 def repo(parser, args):

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -727,3 +727,39 @@ def test_add_repo_prepends_instead_of_appends(monkeypatch, tmp_path):
     assert repo_names == ["new_repo", "existing_repo"]
     assert repos_config["new_repo"] == new_path
     assert repos_config["existing_repo"] == existing_path
+
+
+def test_repo_list_format_flags(
+    mutable_config: spack.config.Configuration, tmp_path: pathlib.Path
+):
+    """Test the --config-names and --namespaces flags for repo list command"""
+    # Fake a git monorepo with two package repositories
+    (tmp_path / ".git").mkdir()
+    repo("create", str(tmp_path), "repo_one")
+    repo("create", str(tmp_path), "repo_two")
+
+    mutable_config.set(
+        "repos",
+        {
+            "monorepo": {
+                "git": "https://example.com/monorepo.git",
+                "destination": str(tmp_path),
+                "paths": ["spack_repo/repo_one", "spack_repo/repo_two"],
+            }
+        },
+        scope="site",
+    )
+
+    # Test default table format, which shows one line per package repository
+    table_output = repo("list", output=str)
+    assert "[+] repo_one" in table_output
+    assert "[+] repo_two" in table_output
+
+    # Test --namespaces flag
+    namespaces_output = repo("list", "--namespaces", output=str)
+    assert namespaces_output.strip().split("\n") == ["repo_one", "repo_two"]
+
+    # Test --config-names flag
+    config_names_output = repo("list", "--config-names", output=str)
+    config_names_lines = config_names_output.strip().split("\n")
+    assert config_names_lines == ["monorepo"]

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -734,18 +734,26 @@ def test_repo_list_format_flags(
 ):
     """Test the --config-names and --namespaces flags for repo list command"""
     # Fake a git monorepo with two package repositories
-    (tmp_path / ".git").mkdir()
-    repo("create", str(tmp_path), "repo_one")
-    repo("create", str(tmp_path), "repo_two")
+    (tmp_path / "monorepo" / ".git").mkdir(parents=True)
+    repo("create", str(tmp_path / "monorepo"), "repo_one")
+    repo("create", str(tmp_path / "monorepo"), "repo_two")
 
     mutable_config.set(
         "repos",
         {
+            # git repo that provides two package repositories
             "monorepo": {
                 "git": "https://example.com/monorepo.git",
-                "destination": str(tmp_path),
+                "destination": str(tmp_path / "monorepo"),
                 "paths": ["spack_repo/repo_one", "spack_repo/repo_two"],
-            }
+            },
+            # git repo that is not yet cloned
+            "uninitialized": {
+                "git": "https://example.com/uninitialized.git",
+                "destination": str(tmp_path / "uninitialized"),
+            },
+            # invalid local repository
+            "misconfigured": str(tmp_path / "misconfigured"),
         },
         scope="site",
     )
@@ -754,12 +762,14 @@ def test_repo_list_format_flags(
     table_output = repo("list", output=str)
     assert "[+] repo_one" in table_output
     assert "[+] repo_two" in table_output
+    assert " -  uninitialized" in table_output
+    assert "[-] misconfigured" in table_output
 
     # Test --namespaces flag
     namespaces_output = repo("list", "--namespaces", output=str)
     assert namespaces_output.strip().split("\n") == ["repo_one", "repo_two"]
 
-    # Test --config-names flag
-    config_names_output = repo("list", "--config-names", output=str)
+    # Test --names flag
+    config_names_output = repo("list", "--names", output=str)
     config_names_lines = config_names_output.strip().split("\n")
-    assert config_names_lines == ["monorepo"]
+    assert config_names_lines == ["monorepo", "uninitialized", "misconfigured"]

--- a/share/spack/bash/spack-completion.bash
+++ b/share/spack/bash/spack-completion.bash
@@ -219,7 +219,7 @@ _mirrors() {
 _repos() {
     if [[ -z "${SPACK_REPOS:-}" ]]
     then
-        SPACK_REPOS="$(spack repo list --config-names)"
+        SPACK_REPOS="$(spack repo list --names)"
     fi
     SPACK_COMPREPLY="$SPACK_REPOS"
 }

--- a/share/spack/bash/spack-completion.bash
+++ b/share/spack/bash/spack-completion.bash
@@ -219,7 +219,7 @@ _mirrors() {
 _repos() {
     if [[ -z "${SPACK_REPOS:-}" ]]
     then
-        SPACK_REPOS="$(spack repo list | awk '{print $1}')"
+        SPACK_REPOS="$(spack repo list --config-names)"
     fi
     SPACK_COMPREPLY="$SPACK_REPOS"
 }

--- a/share/spack/fish/spack-completion.fish
+++ b/share/spack/fish/spack-completion.fish
@@ -242,7 +242,7 @@ function __fish_spack_providers
 end
 
 function __fish_spack_repos
-    spack repo list --config-names
+    spack repo list --names
 end
 
 function __fish_spack_scopes

--- a/share/spack/fish/spack-completion.fish
+++ b/share/spack/fish/spack-completion.fish
@@ -242,7 +242,7 @@ function __fish_spack_providers
 end
 
 function __fish_spack_repos
-    spack repo list | awk {'printf ("%s\t%s", $1, $2)'}
+    spack repo list --config-names
 end
 
 function __fish_spack_scopes

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -219,7 +219,7 @@ _mirrors() {
 _repos() {
     if [[ -z "${SPACK_REPOS:-}" ]]
     then
-        SPACK_REPOS="$(spack repo list | awk '{print $1}')"
+        SPACK_REPOS="$(spack repo list --config-names)"
     fi
     SPACK_COMPREPLY="$SPACK_REPOS"
 }
@@ -1807,11 +1807,11 @@ _spack_repo_create() {
 }
 
 _spack_repo_list() {
-    SPACK_COMPREPLY="-h --help --scope"
+    SPACK_COMPREPLY="-h --help --scope --config-names --namespaces"
 }
 
 _spack_repo_ls() {
-    SPACK_COMPREPLY="-h --help --scope"
+    SPACK_COMPREPLY="-h --help --scope --config-names --namespaces"
 }
 
 _spack_repo_add() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -219,7 +219,7 @@ _mirrors() {
 _repos() {
     if [[ -z "${SPACK_REPOS:-}" ]]
     then
-        SPACK_REPOS="$(spack repo list --config-names)"
+        SPACK_REPOS="$(spack repo list --names)"
     fi
     SPACK_COMPREPLY="$SPACK_REPOS"
 }
@@ -1807,11 +1807,11 @@ _spack_repo_create() {
 }
 
 _spack_repo_list() {
-    SPACK_COMPREPLY="-h --help --scope --config-names --namespaces"
+    SPACK_COMPREPLY="-h --help --scope --names --namespaces"
 }
 
 _spack_repo_ls() {
-    SPACK_COMPREPLY="-h --help --scope --config-names --namespaces"
+    SPACK_COMPREPLY="-h --help --scope --names --namespaces"
 }
 
 _spack_repo_add() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -242,7 +242,7 @@ function __fish_spack_providers
 end
 
 function __fish_spack_repos
-    spack repo list --config-names
+    spack repo list --names
 end
 
 function __fish_spack_scopes
@@ -2783,24 +2783,24 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirectory -r -d 'subdirectory to store packages in the repository'
 
 # spack repo list
-set -g __fish_spack_optspecs_spack_repo_list h/help scope= config-names namespaces
+set -g __fish_spack_optspecs_spack_repo_list h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
-complete -c spack -n '__fish_spack_using_command repo list' -l config-names -f -a config_names
-complete -c spack -n '__fish_spack_using_command repo list' -l config-names -d 'show configuration names only'
+complete -c spack -n '__fish_spack_using_command repo list' -l names -f -a names
+complete -c spack -n '__fish_spack_using_command repo list' -l names -d 'show configuration names only'
 complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -f -a namespaces
 complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -d 'show repository namespaces only'
 
 # spack repo ls
-set -g __fish_spack_optspecs_spack_repo_ls h/help scope= config-names namespaces
+set -g __fish_spack_optspecs_spack_repo_ls h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -d 'configuration scope to read from'
-complete -c spack -n '__fish_spack_using_command repo ls' -l config-names -f -a config_names
-complete -c spack -n '__fish_spack_using_command repo ls' -l config-names -d 'show configuration names only'
+complete -c spack -n '__fish_spack_using_command repo ls' -l names -f -a names
+complete -c spack -n '__fish_spack_using_command repo ls' -l names -d 'show configuration names only'
 complete -c spack -n '__fish_spack_using_command repo ls' -l namespaces -f -a namespaces
 complete -c spack -n '__fish_spack_using_command repo ls' -l namespaces -d 'show repository namespaces only'
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -242,7 +242,7 @@ function __fish_spack_providers
 end
 
 function __fish_spack_repos
-    spack repo list | awk {'printf ("%s\t%s", $1, $2)'}
+    spack repo list --config-names
 end
 
 function __fish_spack_scopes
@@ -2783,18 +2783,26 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirectory -r -d 'subdirectory to store packages in the repository'
 
 # spack repo list
-set -g __fish_spack_optspecs_spack_repo_list h/help scope=
+set -g __fish_spack_optspecs_spack_repo_list h/help scope= config-names namespaces
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
+complete -c spack -n '__fish_spack_using_command repo list' -l config-names -f -a config_names
+complete -c spack -n '__fish_spack_using_command repo list' -l config-names -d 'show configuration names only'
+complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -f -a namespaces
+complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -d 'show repository namespaces only'
 
 # spack repo ls
-set -g __fish_spack_optspecs_spack_repo_ls h/help scope=
+set -g __fish_spack_optspecs_spack_repo_ls h/help scope= config-names namespaces
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -d 'configuration scope to read from'
+complete -c spack -n '__fish_spack_using_command repo ls' -l config-names -f -a config_names
+complete -c spack -n '__fish_spack_using_command repo ls' -l config-names -d 'show configuration names only'
+complete -c spack -n '__fish_spack_using_command repo ls' -l namespaces -f -a namespaces
+complete -c spack -n '__fish_spack_using_command repo ls' -l namespaces -d 'show repository namespaces only'
 
 # spack repo add
 set -g __fish_spack_optspecs_spack_repo_add h/help name= path= scope=


### PR DESCRIPTION
```
spack repo list
```
shows the usual table output `<status> <namespace> <api> <path>`

```
spack repo list --namespaces
```
shows just `<namespace>`

```
spack repo list --names
```
shows the config keys from `spack config get repos`, which in certain cases differs from namespaces, for example

```yaml
repos:
  monorepo:
    git: https://example.com/example.git
    paths:
    - spack_repo/example/one
    - spack_repo/example/two
```
has config name `monorepo` and namespaces `example.one` and `example.two`.

The output does not depend on whether stdout is a tty. The reason being that the verbose output is helpful in cases where we don't have a tty, like when generating tutorial outputs and in CI.

Bash and fish command completion now use `spack repo list --names` for commands like `spack repo rm`.