### PR TITLE
Blame: support builtin repository packages (and files)

### DIFF
--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -4,8 +4,10 @@
 
 import argparse
 import os
+import pathlib
 import re
 import sys
+from typing import Optional, Union
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
@@ -113,7 +115,18 @@ def dump_json(rows, last_mod, total_lines, emails):
     sjson.dump(result, sys.stdout)
 
 
-def repo_prefix(path):
+def repo_prefix(path: str) -> Optional[Union[str, pathlib.Path]]:
+    """Find the root directory of a spack repository containing the file.
+
+    Args:
+      path: path to an arbitrary file presumably in one of the spack repos
+
+    Returns: path to the repository prefix or None
+    """
+
+    def find_root(p):
+        return p if os.path.exists(p / ".git") else find_root(p.parent)
+
     if path.startswith(spack.paths.prefix):
         return spack.paths.prefix
 
@@ -121,10 +134,10 @@ def repo_prefix(path):
         lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG
     )
     for _, desc in descriptors.items():
-        index = desc.path.find("repos/spack_repo")
+        index = desc.path.find("spack_repo")
         if index > -1:
-            prefix = desc.path[: index - 1]
-            if path.startswith(prefix):
+            prefix = find_root(pathlib.Path(desc.path[: index - 1]))
+            if prefix and path.startswith(str(prefix)):
                 return prefix
 
     return None
@@ -136,7 +149,8 @@ def blame(parser, args):
         tty.die("This spack is not a git clone. Can't use 'spack blame'")
     git = spack.util.git.git(required=True)
 
-    # Get name of file to blame
+    # Get the name of the file to blame and its repository prefix
+    # so we can honor any .git-blame-ignore-revs that may be present.
     blame_file = None
     prefix = None
     if os.path.isfile(args.package_or_file):
@@ -150,15 +164,15 @@ def blame(parser, args):
         try:
             pkg_cls = spack.repo.PATH.get_pkg_class(args.package_or_file)
             blame_file = pkg_cls.module.__file__.rstrip("c")  # .pyc -> .py
-            prefix = repo_prefix(blame_file)
+            prefix = repo_prefix(spack.repo.PATH.repo_for_pkg(args.package_or_file).root)
         except spack.repo.UnknownNamespaceError:
             pass
 
     if prefix is None:
-        tty.die(f"The file ({path}) is not within a spack repo. Can't use 'spack blame'.")
+        tty.die(f"'{args.package_or_file}' is not within a spack repo. Can't use 'spack blame'.")
 
-    # get git blame for the package EVEN when it is located in a different spack
-    # repository (e.g., spack/spack-packages)
+    # Get git blame for the path EVEN when it is located in a different
+    # spack repository (e.g., spack/spack-packages).
     with working_dir(prefix):
         options = ["blame"]
         # ignore the great black reformatting of 2022

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -155,6 +155,7 @@ def package_repo_root(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
         lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG
     )
     path = pathlib.Path(path)
+    prefix: Optional[pathlib.Path] = None
     for _, desc in descriptors.items():
         # Handle the remote case, whose destination is by definition the git root
         if hasattr(desc, "destination"):

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -134,11 +134,12 @@ def repo_prefix(path: str) -> Optional[Union[str, pathlib.Path]]:
         lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG
     )
     for _, desc in descriptors.items():
-        index = desc.path.find("spack_repo")
-        if index > -1:
-            prefix = find_root(pathlib.Path(desc.path[: index - 1]))
-            if prefix and path.startswith(str(prefix)):
-                return prefix
+        if hasattr(desc, "path"):
+            index = desc.path.find("spack_repo")
+            if index > -1:
+                prefix = find_root(pathlib.Path(desc.path[: index - 1]))
+                if prefix and path.startswith(str(prefix)):
+                    return prefix
 
     return None
 

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -197,8 +197,8 @@ def blame(parser, args):
         blame_file = os.path.realpath(args.package_or_file)
         prefix = package_repo_root(blame_file)
 
-    # Get path to what we assume is a package though (including
-    # to a cached version of a remote package repository.)
+    # Get path to what we assume is a package (including to a cached version
+    # of a remote package repository.)
     if not blame_file:
         try:
             blame_file = spack.repo.PATH.filename_for_package_name(args.package_or_file)

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import re
 import sys
+import textwrap
 from typing import Optional, Union
 
 import llnl.util.tty as tty
@@ -15,15 +16,17 @@ from llnl.util.lang import pretty_date
 from llnl.util.tty.colify import colify_table
 
 import spack.config
-import spack.paths
 import spack.repo
 import spack.util.git
 import spack.util.spack_json as sjson
 from spack.cmd import spack_is_git_repo
+from spack.util.executable import ProcessError
 
 description = "show contributors to packages"
 section = "developer"
 level = "long"
+
+git = spack.util.git.git(required=True)
 
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
@@ -115,30 +118,67 @@ def dump_json(rows, last_mod, total_lines, emails):
     sjson.dump(result, sys.stdout)
 
 
-def repo_prefix(path: str) -> Optional[Union[str, pathlib.Path]]:
-    """Find the root directory of a spack repository containing the file.
+def git_prefix(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
+    """Return the top level directory if path is under a git repository.
 
     Args:
-      path: path to an arbitrary file presumably in one of the spack repos
+      path: path of the item presumably under a git repository
 
-    Returns: path to the repository prefix or None
+    Returns: path to the root of the git repository
     """
+    if not os.path.exists(path):
+        return None
 
-    def find_root(p):
-        return p if os.path.exists(p / ".git") else find_root(p.parent)
+    work_dir = path if os.path.isdir(path) else os.path.dirname(path)
+    with working_dir(work_dir):
+        try:
+            result = git("rev-parse", "--show-toplevel", output=str, error=str)
+            return pathlib.Path(result.split("\n")[0])
+        except ProcessError:
+            tty.die(f"'{path}' is not in a git repository.")
 
-    if path.startswith(spack.paths.prefix):
-        return spack.paths.prefix
+    return None
 
+
+def package_repo_root(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
+    """Find the appropriate package repository's git root directory.
+
+    Provides a warning for a remote package repository since there is a risk that
+    the blame results are inaccurate.
+
+    Args:
+      path: path to an arbitrary file presumably in one of the spack package repos
+
+    Returns: path to the package repository's git root directory or None
+    """
     descriptors = spack.repo.RepoDescriptors.from_config(
         lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG
     )
+    path = pathlib.Path(path)
     for _, desc in descriptors.items():
+        # Handle the remote case, whose destination is by definition the git root
+        if hasattr(desc, "destination"):
+            repo_dest = pathlib.Path(desc.destination)
+            if (repo_dest / ".git").exists():
+                prefix = repo_dest
+                if prefix and path.is_relative_to(prefix):
+                    lines = textwrap.wrap(
+                        "Using the cached version of the remote repository "
+                        "may result in an inaccurate attribution of blame. "
+                        "Configure your 'builtin' package repository to a "
+                        "local clone of the remote repository if you want "
+                        "accurate results for packages.",
+                        subsequent_indent="  ",
+                    )
+                    tty.warn("\n".join(lines))
+                    return prefix
+
+        # Handle the local repository case, making sure it's a spack repository.
         if hasattr(desc, "path"):
-            index = desc.path.find("spack_repo")
-            if index > -1:
-                prefix = find_root(pathlib.Path(desc.path[: index - 1]))
-                if prefix and path.startswith(str(prefix)):
+            repo_path = pathlib.Path(desc.path)
+            if "spack_repo" in repo_path.parts:
+                prefix = git_prefix(repo_path)
+                if prefix and path.is_relative_to(prefix):
                     return prefix
 
     return None
@@ -147,48 +187,63 @@ def repo_prefix(path: str) -> Optional[Union[str, pathlib.Path]]:
 def blame(parser, args):
     # make sure this is a git repo
     if not spack_is_git_repo():
-        tty.die("This spack is not a git clone. Can't use 'spack blame'")
-    git = spack.util.git.git(required=True)
+        tty.die("This spack is not a git clone. You cannot use 'spack blame'.")
 
-    # Get the name of the file to blame and its repository prefix
+    # Get the name of the path to blame and its repository prefix
     # so we can honor any .git-blame-ignore-revs that may be present.
     blame_file = None
     prefix = None
-    if os.path.isfile(args.package_or_file):
-        path = os.path.realpath(args.package_or_file)
-        prefix = repo_prefix(path)
-        if prefix is not None:
-            blame_file = path
+    if os.path.exists(args.package_or_file):
+        blame_file = os.path.realpath(args.package_or_file)
+        prefix = package_repo_root(blame_file)
 
-    # get path to what we assume is a package
+    # Get path to what we assume is a package though (including
+    # to a cached version of a remote package repository.)
     if not blame_file:
         try:
-            pkg_cls = spack.repo.PATH.get_pkg_class(args.package_or_file)
-            blame_file = pkg_cls.module.__file__.rstrip("c")  # .pyc -> .py
-            prefix = repo_prefix(blame_file)
+            blame_file = spack.repo.PATH.filename_for_package_name(args.package_or_file)
+            if os.path.isfile(blame_file):
+                prefix = package_repo_root(blame_file)
         except spack.repo.UnknownNamespaceError:
+            # The file or path being checked is not a package
             pass
 
     if prefix is None:
-        tty.die(f"'{args.package_or_file}' is not within a spack repo. Can't use 'spack blame'.")
+        tty.debug(f"'{args.package_or_file}' is not within a spack package repository")
 
-    # Get git blame for the path EVEN when it is located in a different
-    # spack repository (e.g., spack/spack-packages).
-    with working_dir(prefix):
+    if not blame_file:
+        tty.die(f"'{args.package_or_file}' does not exist.")
+
+    path_prefix = git_prefix(blame_file)
+    if path_prefix != prefix:
+        # You are attempting to get 'blame' for a path outside of a configured
+        # package repository (e.g., within a spack/spack clone). We'll use the
+        # path's prefix instead to ensure working under the proper git
+        # repository.
+        prefix = path_prefix
+
+    # Get blame information for the path EVEN when it is located in a different
+    # spack repository (e.g., spack/spack-packages) or a different git
+    # repository.
+    with working_dir(path_prefix):
         options = ["blame"]
-        # ignore the great black reformatting of 2022
-        ignore_file = os.path.join(prefix, ".git-blame-ignore-revs")
-        if os.path.exists(ignore_file):
-            options.extend(["--ignore-revs-file", ignore_file])
 
-        if args.view == "git":
-            options.append(blame_file)
-            git(*options)
-            return
-        else:
-            options.extend(["--line-porcelain", blame_file])
-            output = git(*options, output=str)
-            lines = output.split("\n")
+        # ignore the great black reformatting of 2022
+        ignore_file = prefix / ".git-blame-ignore-revs"
+        if ignore_file.exists():
+            options.extend(["--ignore-revs-file", str(ignore_file)])
+
+        try:
+            if args.view == "git":
+                options.append(str(blame_file))
+                git(*options)
+                return
+            else:
+                options.extend(["--line-porcelain", str(blame_file)])
+                output = git(*options, output=str, error=str)
+                lines = output.split("\n")
+        except ProcessError as err:
+            tty.die(f"Blame information is not tracked for '{blame_file}':\n{err.long_message}")
 
     # Histogram authors
     counts = {}

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -136,8 +136,6 @@ def git_prefix(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
         except ProcessError:
             tty.die(f"'{path}' is not in a git repository.")
 
-    return None
-
 
 def package_repo_root(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
     """Find the appropriate package repository's git root directory.
@@ -204,11 +202,11 @@ def blame(parser, args):
         if blame_file and os.path.isfile(blame_file):
             prefix = package_repo_root(blame_file)
 
-    if prefix is None:
-        tty.debug(f"'{args.package_or_file}' is not within a spack package repository")
-
     if not blame_file or not os.path.exists(blame_file):
         tty.die(f"'{args.package_or_file}' does not exist.")
+
+    if prefix is None:
+        tty.msg(f"'{args.package_or_file}' is not within a spack package repository")
 
     path_prefix = git_prefix(blame_file)
     if path_prefix != prefix:
@@ -250,6 +248,7 @@ def blame(parser, args):
                 output = git(*options, output=str, error=str)
                 lines = output.split("\n")
         except ProcessError as err:
+            # e.g., blame information is not tracked if the path is a directory
             tty.die(f"Blame information is not tracked for '{blame_file}':\n{err.long_message}")
 
     # Histogram authors

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -200,13 +200,9 @@ def blame(parser, args):
     # Get path to what we assume is a package (including to a cached version
     # of a remote package repository.)
     if not blame_file:
-        try:
-            blame_file = spack.repo.PATH.filename_for_package_name(args.package_or_file)
-            if os.path.isfile(blame_file):
-                prefix = package_repo_root(blame_file)
-        except spack.repo.UnknownNamespaceError:
-            # The file or path being checked is not a package
-            pass
+        blame_file = spack.repo.PATH.filename_for_package_name(args.package_or_file)
+        if os.path.isfile(blame_file):
+            prefix = package_repo_root(blame_file)
 
     if prefix is None:
         tty.debug(f"'{args.package_or_file}' is not within a spack package repository")

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -177,6 +177,42 @@ def package_repo_root(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
     return None
 
 
+def git_supports_unshallow() -> bool:
+    output = git("fetch", "--help", output=str, error=str)
+    return "--unshallow" in output
+
+
+def ensure_full_history(prefix: str, path: str) -> None:
+    """Ensure the git repository at the prefix has its full history.
+
+    Args:
+        prefix: the root directory of the git repository
+        path: the package or file name under consideration (for messages)
+    """
+    assert os.path.isdir(prefix)
+
+    with working_dir(prefix):
+        shallow_dir = os.path.join(prefix, ".git", "shallow")
+        if os.path.isdir(shallow_dir):
+            if git_supports_unshallow():
+                try:
+                    # Capture the error output (e.g., irrelevant for full repo)
+                    # to ensure the output is clean.
+                    git("fetch", "--unshallow", error=str)
+                except ProcessError as e:
+                    tty.die(
+                        f"Cannot report blame for {path}.\n"
+                        "Unable to retrieve the full git history for "
+                        f'{prefix} due to "{str(e)}" error.'
+                    )
+            else:
+                tty.die(
+                    f"Cannot report blame for {path}.\n"
+                    f"Unable to retrieve the full git history for {prefix}. "
+                    "Use a newer 'git' that supports 'git fetch --unshallow'."
+                )
+
+
 def blame(parser, args):
     # make sure this is a git repo
     if not spack_is_git_repo():
@@ -216,20 +252,14 @@ def blame(parser, args):
         # repository.
         prefix = path_prefix
 
+    # Make sure we can get the full/known blame even when the repository
+    # is remote.
+    ensure_full_history(prefix, args.package_or_file)
+
     # Get blame information for the path EVEN when it is located in a different
     # spack repository (e.g., spack/spack-packages) or a different git
     # repository.
-    with working_dir(path_prefix):
-        # Make sure we can get the full/known blame even when the packages
-        # repository is remote.
-        try:
-            # Capture the error output (e.g., irrelevant for full repo) to
-            # ensure the output is clean.
-            git("fetch", "--unshallow", error=str)
-        except ProcessError:
-            # Ignore full repo complaint
-            pass
-
+    with working_dir(prefix):
         # Now we can get the blame results.
         options = ["blame"]
 

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -12,6 +12,7 @@ from llnl.util.filesystem import working_dir
 from llnl.util.lang import pretty_date
 from llnl.util.tty.colify import colify_table
 
+import spack.config
 import spack.paths
 import spack.repo
 import spack.util.git
@@ -112,6 +113,23 @@ def dump_json(rows, last_mod, total_lines, emails):
     sjson.dump(result, sys.stdout)
 
 
+def repo_prefix(path):
+    if path.startswith(spack.paths.prefix):
+        return spack.paths.prefix
+
+    descriptors = spack.repo.RepoDescriptors.from_config(
+        lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG
+    )
+    for _, desc in descriptors.items():
+        index = desc.path.find("repos/spack_repo")
+        if index > -1:
+            prefix = desc.path[: index - 1]
+            if path.startswith(prefix):
+                return prefix
+
+    return None
+
+
 def blame(parser, args):
     # make sure this is a git repo
     if not spack_is_git_repo():
@@ -120,37 +138,41 @@ def blame(parser, args):
 
     # Get name of file to blame
     blame_file = None
+    prefix = None
     if os.path.isfile(args.package_or_file):
         path = os.path.realpath(args.package_or_file)
-        if path.startswith(spack.paths.prefix):
+        prefix = repo_prefix(path)
+        if prefix is not None:
             blame_file = path
 
+    # get path to what we assume is a package
     if not blame_file:
-        pkg_cls = spack.repo.PATH.get_pkg_class(args.package_or_file)
-        blame_file = pkg_cls.module.__file__.rstrip("c")  # .pyc -> .py
+        try:
+            pkg_cls = spack.repo.PATH.get_pkg_class(args.package_or_file)
+            blame_file = pkg_cls.module.__file__.rstrip("c")  # .pyc -> .py
+            prefix = repo_prefix(blame_file)
+        except spack.repo.UnknownNamespaceError:
+            pass
 
-    # get git blame for the package EVEN IF it is located in a different
+    if prefix is None:
+        tty.die(f"The file ({path}) is not within a spack repo. Can't use 'spack blame'.")
+
+    # get git blame for the package EVEN when it is located in a different spack
     # repository (e.g., spack/spack-packages)
-    in_spack_repo = blame_file.startswith(spack.paths.prefix)
-    work_dir = spack.paths.prefix if in_spack_repo else os.path.dirname(blame_file)
-    with working_dir(work_dir):
+    with working_dir(prefix):
+        options = ["blame"]
         # ignore the great black reformatting of 2022
-        ignore_file = os.path.join(spack.paths.prefix, ".git-blame-ignore-revs")
+        ignore_file = os.path.join(prefix, ".git-blame-ignore-revs")
+        if os.path.exists(ignore_file):
+            options.extend(["--ignore-revs-file", ignore_file])
 
         if args.view == "git":
-            git("blame", "--ignore-revs-file", ignore_file, blame_file)
+            options.append(blame_file)
+            git(*options)
             return
         else:
-            if not in_spack_repo:
-                tty.debug(f"Processing blame for {blame_file}")
-            output = git(
-                "blame",
-                "--line-porcelain",
-                "--ignore-revs-file",
-                ignore_file,
-                blame_file,
-                output=str,
-            )
+            options.extend(["--line-porcelain", blame_file])
+            output = git(*options, output=str)
             lines = output.split("\n")
 
     # Histogram authors

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import re
 import sys
-import textwrap
 from typing import Optional, Union
 
 import llnl.util.tty as tty
@@ -163,17 +162,8 @@ def package_repo_root(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
             if (repo_dest / ".git").exists():
                 prefix = repo_dest
 
-                # TODO: replace check with `is_relative_to` once rhel8 can handle
+                # TODO: replace check with `is_relative_to` once supported
                 if prefix and str(path).startswith(str(prefix)):
-                    lines = textwrap.wrap(
-                        "Using the cached version of the remote repository "
-                        "may result in an inaccurate attribution of blame. "
-                        "Configure your 'builtin' package repository to a "
-                        "local clone of the remote repository if you want "
-                        "accurate results for packages.",
-                        subsequent_indent="  ",
-                    )
-                    tty.warn("\n".join(lines))
                     return prefix
 
         # Handle the local repository case, making sure it's a spack repository.
@@ -232,6 +222,17 @@ def blame(parser, args):
     # spack repository (e.g., spack/spack-packages) or a different git
     # repository.
     with working_dir(path_prefix):
+        # Make sure we can get the full/known blame even when the packages
+        # repository is remote.
+        try:
+            # Capture the error output (e.g., irrelevant for full repo) to
+            # ensure the output is clean.
+            git("fetch", "--unshallow", error=str)
+        except ProcessError:
+            # Ignore full repo complaint
+            pass
+
+        # Now we can get the blame results.
         options = ["blame"]
 
         # ignore the great black reformatting of 2022

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -201,14 +201,19 @@ def blame(parser, args):
     # Get path to what we assume is a package (including to a cached version
     # of a remote package repository.)
     if not blame_file:
-        blame_file = spack.repo.PATH.filename_for_package_name(args.package_or_file)
-        if os.path.isfile(blame_file):
+        try:
+            blame_file = spack.repo.PATH.filename_for_package_name(args.package_or_file)
+        except spack.repo.UnknownNamespaceError:
+            # the argument is not a package (or does not exist)
+            pass
+
+        if blame_file and os.path.isfile(blame_file):
             prefix = package_repo_root(blame_file)
 
     if prefix is None:
         tty.debug(f"'{args.package_or_file}' is not within a spack package repository")
 
-    if not blame_file:
+    if not blame_file or not os.path.exists(blame_file):
         tty.die(f"'{args.package_or_file}' does not exist.")
 
     path_prefix = git_prefix(blame_file)

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -165,7 +165,7 @@ def blame(parser, args):
         try:
             pkg_cls = spack.repo.PATH.get_pkg_class(args.package_or_file)
             blame_file = pkg_cls.module.__file__.rstrip("c")  # .pyc -> .py
-            prefix = repo_prefix(spack.repo.PATH.repo_for_pkg(args.package_or_file).root)
+            prefix = repo_prefix(blame_file)
         except spack.repo.UnknownNamespaceError:
             pass
 

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -162,7 +162,9 @@ def package_repo_root(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
             repo_dest = pathlib.Path(desc.destination)
             if (repo_dest / ".git").exists():
                 prefix = repo_dest
-                if prefix and path.is_relative_to(prefix):
+
+                # TODO: replace check with `is_relative_to` once rhel8 can handle
+                if prefix and str(path).startswith(str(prefix)):
                     lines = textwrap.wrap(
                         "Using the cached version of the remote repository "
                         "may result in an inaccurate attribution of blame. "
@@ -179,7 +181,9 @@ def package_repo_root(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
             repo_path = pathlib.Path(desc.path)
             if "spack_repo" in repo_path.parts:
                 prefix = git_prefix(repo_path)
-                if prefix and path.is_relative_to(prefix):
+
+                # TODO: replace check with `is_relative_to` once supported
+                if prefix and str(path).startswith(str(prefix)):
                     return prefix
 
     return None

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -129,8 +129,11 @@ def blame(parser, args):
         pkg_cls = spack.repo.PATH.get_pkg_class(args.package_or_file)
         blame_file = pkg_cls.module.__file__.rstrip("c")  # .pyc -> .py
 
-    # get git blame for the package
-    with working_dir(spack.paths.prefix):
+    # get git blame for the package EVEN IF it is located in a different
+    # repository (e.g., spack/spack-packages)
+    in_spack_repo = blame_file.startswith(spack.paths.prefix)
+    work_dir = spack.paths.prefix if in_spack_repo else os.path.dirname(blame_file)
+    with working_dir(work_dir):
         # ignore the great black reformatting of 2022
         ignore_file = os.path.join(spack.paths.prefix, ".git-blame-ignore-revs")
 
@@ -138,6 +141,8 @@ def blame(parser, args):
             git("blame", "--ignore-revs-file", ignore_file, blame_file)
             return
         else:
+            if not in_spack_repo:
+                tty.debug(f"Processing blame for {blame_file}")
             output = git(
                 "blame",
                 "--line-porcelain",

--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -8,13 +8,15 @@ from pathlib import Path
 
 import pytest
 
-from llnl.util.filesystem import working_dir
+from llnl.util.filesystem import mkdirp, working_dir
 
+import spack.cmd.blame
 import spack.paths
 import spack.util.spack_json as sjson
-from spack.cmd.blame import git_prefix, package_repo_root
+from spack.cmd.blame import ensure_full_history, git_prefix, package_repo_root
 from spack.main import SpackCommand, SpackCommandError
 from spack.repo import RepoDescriptors
+from spack.util.executable import ProcessError
 
 pytestmark = pytest.mark.usefixtures("git")
 
@@ -174,3 +176,65 @@ def test_git_prefix_bad(tmp_path):
     with pytest.raises(SystemExit):
         out = git_prefix(tmp_path)
         assert "not in a git repository" in out
+
+
+def test_ensure_full_history_shallow_works(mock_git_version_info, monkeypatch):
+    """Ensure a git that "supports" '--unshallow' "completes" without incident."""
+
+    def _git(*args, **kwargs):
+        if "--help" in args:
+            return "--unshallow"
+        else:
+            return ""
+
+    repo_path, filename, _ = mock_git_version_info
+    shallow_dir = os.path.join(repo_path, ".git", "shallow")
+    mkdirp(shallow_dir)
+
+    # Need to patch the blame command's
+    monkeypatch.setattr(spack.cmd.blame, "git", _git)
+    ensure_full_history(repo_path, filename)
+
+
+def test_ensure_full_history_shallow_fails(mock_git_version_info, monkeypatch, capsys):
+    """Ensure a git that supports '--unshallow' but fails generates useful error."""
+    error_msg = "Mock git cannot fetch."
+
+    def _git(*args, **kwargs):
+        if "--help" in args:
+            return "--unshallow"
+        else:
+            raise ProcessError(error_msg)
+
+    repo_path, filename, _ = mock_git_version_info
+    shallow_dir = os.path.join(repo_path, ".git", "shallow")
+    mkdirp(shallow_dir)
+
+    # Need to patch the blame command's since 'git' already used by
+    # mock_git_versioninfo
+    monkeypatch.setattr(spack.cmd.blame, "git", _git)
+    with pytest.raises(SystemExit):
+        ensure_full_history(repo_path, filename)
+
+    out = capsys.readouterr()
+    assert error_msg in out[1]
+
+
+def test_ensure_full_history_shallow_old_git(mock_git_version_info, monkeypatch, capsys):
+    """Ensure a git that doesn't support '--unshallow' fails."""
+
+    def _git(*args, **kwargs):
+        return ""
+
+    repo_path, filename, _ = mock_git_version_info
+    shallow_dir = os.path.join(repo_path, ".git", "shallow")
+    mkdirp(shallow_dir)
+
+    # Need to patch the blame command's since 'git' already used by
+    # mock_git_versioninfo
+    monkeypatch.setattr(spack.cmd.blame, "git", _git)
+    with pytest.raises(SystemExit):
+        ensure_full_history(repo_path, filename)
+
+    out = capsys.readouterr()
+    assert "Use a newer" in out[1]

--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -12,7 +12,7 @@ from llnl.util.filesystem import working_dir
 
 import spack.paths
 import spack.util.spack_json as sjson
-from spack.cmd.blame import package_repo_root
+from spack.cmd.blame import git_prefix, package_repo_root
 from spack.main import SpackCommand, SpackCommandError
 from spack.repo import RepoDescriptors
 
@@ -49,18 +49,34 @@ def test_blame_file():
 def test_blame_file_missing():
     """Ensure attempt to get blame for missing file fails."""
     with pytest.raises(SpackCommandError):
-        with working_dir(spack.paths.prefix):
-            out = blame(os.path.join("no", "such", "file.txt"))
-            assert "not within a spack repo" in out
+        out = blame(os.path.join("missing", "file.txt"))
+        assert "does not exist" in out
 
 
-def test_blame_file_outside_spack_repo():
-    """Trigger the UnknownNamespaceError path by and failure when attempting
-    to get blame outside spack."""
+def test_blame_directory():
+    """Ensure attempt to get blame for path that is a directory fails."""
     with pytest.raises(SpackCommandError):
-        with working_dir(os.path.join(spack.paths.prefix, "..")):
-            out = blame("help.txt")
-            assert "not within a spack repo" in out
+        out = blame(".")
+        assert "not tracked" in out
+
+
+def test_blame_file_outside_spack_repo(tmp_path):
+    """Ensure attempts to get blame outside a package repository are flagged."""
+    test_file = tmp_path / "test"
+    test_file.write_text("This is a test")
+    with pytest.raises(SpackCommandError):
+        out = blame(str(test_file))
+        assert "not within a spack repo" in out
+
+
+def test_blame_spack_not_git_clone(monkeypatch):
+    """Ensure attempt to get blame when spack not a git clone fails."""
+    non_git_dir = os.path.join(spack.paths.prefix, "..")
+    monkeypatch.setattr(spack.paths, "prefix", non_git_dir)
+
+    with pytest.raises(SpackCommandError):
+        out = blame(".")
+        assert "not in a git clone" in out
 
 
 def test_blame_json(mock_packages):
@@ -149,3 +165,12 @@ def test_repo_root_remote_descriptor(mock_git_version_info, monkeypatch):
     # The base repository directory is the git root of the package repo
     prefix = package_repo_root(git_repo_path)
     assert prefix == git_repo_path
+
+
+def test_git_prefix_bad(tmp_path):
+    """Exercise git_prefix paths with arguments that will not return success."""
+    assert git_prefix("no/such/file.txt") is None
+
+    with pytest.raises(SystemExit):
+        out = git_prefix(tmp_path)
+        assert "not in a git repository" in out

--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import collections
 import os
 
 import pytest
@@ -10,7 +11,9 @@ from llnl.util.filesystem import working_dir
 
 import spack.paths
 import spack.util.spack_json as sjson
-from spack.main import SpackCommand
+from spack.cmd.blame import repo_prefix
+from spack.main import SpackCommand, SpackCommandError
+from spack.repo import RepoDescriptors
 
 pytestmark = pytest.mark.usefixtures("git")
 
@@ -33,13 +36,30 @@ def test_blame_by_percent(mock_packages):
     assert "EMAIL" in out
 
 
-def test_blame_file(mock_packages):
+def test_blame_file():
     """Sanity check the blame command to make sure it works."""
     with working_dir(spack.paths.prefix):
         out = blame(os.path.join("bin", "spack"))
     assert "LAST_COMMIT" in out
     assert "AUTHOR" in out
     assert "EMAIL" in out
+
+
+def test_blame_file_missing():
+    """Ensure attempt to get blame for missing file fails."""
+    with pytest.raises(SpackCommandError):
+        with working_dir(spack.paths.prefix):
+            out = blame(os.path.join("no", "such", "file.txt"))
+            assert "not within a spack repo" in out
+
+
+def test_blame_file_outside_spack_repo():
+    """Trigger the UnknownNamespaceError path by and failure when attempting
+    to get blame outside spack."""
+    with pytest.raises(SpackCommandError):
+        with working_dir(os.path.join(spack.paths.prefix, "..")):
+            out = blame("help.txt")
+            assert "not within a spack repo" in out
 
 
 def test_blame_json(mock_packages):
@@ -72,3 +92,28 @@ def test_blame_by_git(mock_packages, capfd):
         out = blame("--git", "mpich")
     assert "class Mpich" in out
     assert '    homepage = "http://www.mpich.org"' in out
+
+
+def test_repo_prefix_using_repo_descriptor(tmp_path, monkeypatch):
+    """Sanity check blame's repo_prefix using a repo descriptor."""
+    # set up a mock repository
+    paths = [tmp_path / p for p in ["spack_repo", ".git", os.path.join("spack_repo", "builtin")]]
+    for p in paths:
+        p.mkdir()
+
+    # create a mock descriptor for the mock repository
+    MockDescriptor = collections.namedtuple("MockDescriptor", ["path"])
+    repo_descriptor = MockDescriptor(str(paths[0]))
+
+    def _from_config(*args, **kwargs):
+        return {"mock": repo_descriptor}
+
+    monkeypatch.setattr(RepoDescriptors, "from_config", _from_config)
+
+    # first a case that falls through to not find a match
+    prefix = repo_prefix(os.path.realpath(os.path.join(str(tmp_path), "..")))
+    assert prefix is None
+
+    # now the case where the non-spack prefix path is returned
+    prefix = repo_prefix(str(paths[-1]))
+    assert prefix == tmp_path

--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -4,6 +4,7 @@
 
 import collections
 import os
+from pathlib import Path
 
 import pytest
 
@@ -11,7 +12,7 @@ from llnl.util.filesystem import working_dir
 
 import spack.paths
 import spack.util.spack_json as sjson
-from spack.cmd.blame import repo_prefix
+from spack.cmd.blame import package_repo_root
 from spack.main import SpackCommand, SpackCommandError
 from spack.repo import RepoDescriptors
 
@@ -94,26 +95,57 @@ def test_blame_by_git(mock_packages, capfd):
     assert '    homepage = "http://www.mpich.org"' in out
 
 
-def test_repo_prefix_using_repo_descriptor(tmp_path, monkeypatch):
-    """Sanity check blame's repo_prefix using a repo descriptor."""
-    # set up a mock repository
-    paths = [tmp_path / p for p in ["spack_repo", ".git", os.path.join("spack_repo", "builtin")]]
-    for p in paths:
-        p.mkdir()
+def test_repo_root_local_descriptor(mock_git_version_info, monkeypatch):
+    """Sanity check blame's package repository root using a local repo descriptor."""
 
-    # create a mock descriptor for the mock repository
-    MockDescriptor = collections.namedtuple("MockDescriptor", ["path"])
-    repo_descriptor = MockDescriptor(str(paths[0]))
+    # create a mock descriptor for the mock local repository
+    MockLocalDescriptor = collections.namedtuple("MockLocalDescriptor", ["path"])
+    repo_path, filename, _ = mock_git_version_info
+    git_repo_path = Path(repo_path)
+    spack_repo_path = git_repo_path / "spack_repo"
+    spack_repo_path.mkdir()
+
+    repo_descriptor = MockLocalDescriptor(spack_repo_path)
 
     def _from_config(*args, **kwargs):
         return {"mock": repo_descriptor}
 
     monkeypatch.setattr(RepoDescriptors, "from_config", _from_config)
 
-    # first a case that falls through to not find a match
-    prefix = repo_prefix(os.path.realpath(os.path.join(str(tmp_path), "..")))
+    # The parent of the git repository is outside the package repo root
+    path = (git_repo_path / "..").resolve()
+    prefix = package_repo_root((path / "..").resolve())
     assert prefix is None
 
-    # now the case where the non-spack prefix path is returned
-    prefix = repo_prefix(str(paths[-1]))
-    assert prefix == tmp_path
+    # The base repository directory is the git root of the package repo
+    prefix = package_repo_root(git_repo_path)
+    assert prefix == git_repo_path
+
+    # The file under the base repository directory also has the package git root
+    prefix = package_repo_root(git_repo_path / filename)
+    assert prefix == git_repo_path
+
+
+def test_repo_root_remote_descriptor(mock_git_version_info, monkeypatch):
+    """Sanity check blame's package repository root using a remote repo descriptor."""
+
+    # create a mock descriptor for the mock local repository
+    MockRemoteDescriptor = collections.namedtuple("MockRemoteDescriptor", ["destination"])
+    repo_path, filename, _ = mock_git_version_info
+    git_repo_path = Path(repo_path)
+
+    repo_descriptor = MockRemoteDescriptor(git_repo_path)
+
+    def _from_config(*args, **kwargs):
+        return {"mock": repo_descriptor}
+
+    monkeypatch.setattr(RepoDescriptors, "from_config", _from_config)
+
+    # The parent of the git repository is outside the package repo root
+    path = (git_repo_path / "..").resolve()
+    prefix = package_repo_root((path / "..").resolve())
+    assert prefix is None
+
+    # The base repository directory is the git root of the package repo
+    prefix = package_repo_root(git_repo_path)
+    assert prefix == git_repo_path


### PR DESCRIPTION
Fixes #50876 

Without these changes, `spack blame <package>` fails. For example, with `builtin` configured with the `git` url:

```
$ spack  blame lua
fatal: '/Users/dahlgren1/.spack/package_repos/fncqgg4/repos/spack_repo/builtin/packages/lua/package.py' is outside repository at '/Users/dahlgren1/github/prs/spack'
==> Error: Command exited with status 128:
'/usr/bin/git' 'blame' '--line-porcelain' '--ignore-revs-file' '$spack/.git-blame-ignore-revs' $HOME/.spack/package_repos/fncqgg4/repos/spack_repo/builtin/packages/lua/package.py'
```

and `builtin` configured for a user's local repository (e.g., a clone of `spack/spack-packages`):

```
$ spack blame lua
fatal: '$spack-packages/repos/spack_repo/builtin/packages/lua/package.py' is outside repository at '$spack'
==> Error: Command exited with status 128:
'/usr/bin/git' 'blame' '--line-porcelain' '--ignore-revs-file' '$spack/.git-blame-ignore-revs' '$spack-packages/repos/spack_repo/builtin/packages/lua/package.py'
```

With these changes, you get the expected output:

```
$ spack blame lua
LAST_COMMIT   LINES  %      AUTHOR              EMAIL
3 weeks ago   5      2.0    Harmen Stoppels     <me@harmenstoppels.nl>
a month ago   12     4.7    Adam J. Stewart     <ajstewart426@gmail.com>
5 months ago  51     20.1   Todd Gamblin        <gamblin2@llnl.gov>
7 months ago  21     8.3    Giuncan             <38205328+Giuncan@users.noreply.github.com>
7 months ago  133    52.4   Tom Scogland        <scogland1@llnl.gov>
8 months ago  2      0.8    Auriane R.          <48684432+aurianer@users.noreply.github.com>
a year ago    2      0.8    John W. Parent      <45471568+johnwparent@users.noreply.github.com>
a year ago    11     4.3    Chris White         <white238@llnl.gov>
a year ago    1      0.4    Martin Aumüller     <aumuell@reserv.at>
2 years ago   3      1.2    Massimiliano Culpo  <massimiliano.culpo@gmail.com>
3 years ago   1      0.4    Tamara Dahlgren     <35777542+tldahlgren@users.noreply.github.com>
3 years ago   1      0.4    Vanessasaurus       <814322+vsoch@users.noreply.github.com>
5 years ago   9      3.5    Robert Pavel        <rspavel@lanl.gov>
6 years ago   2      0.8    Stephen Herbein     <SteVwonder@users.noreply.github.com>
                                                
3 weeks ago   254    100.0    
```

And if the equivalent ignore commits are added to `spack/spack-packages` (https://github.com/spack/spack-packages/pull/199), the `spack blame` output is a little different:

```
$ spack -d blame lua
...
/.git-blame-ignore-revs' '--line-porcelain' '/Users/dahlgren1/github/spack-packages/repos/spack_repo/builtin/packages/lua/package.py'
LAST_COMMIT   LINES  %      AUTHOR              EMAIL
3 weeks ago   5      2.0    Harmen Stoppels     <me@harmenstoppels.nl>
a month ago   9      3.5    Adam J. Stewart     <ajstewart426@gmail.com>
5 months ago  20     7.9    Todd Gamblin        <gamblin2@llnl.gov>
7 months ago  21     8.3    Giuncan             <38205328+Giuncan@users.noreply.github.com>
7 months ago  147    57.9   Tom Scogland        <scogland1@llnl.gov>
8 months ago  2      0.8    Auriane R.          <48684432+aurianer@users.noreply.github.com>
a year ago    2      0.8    John W. Parent      <45471568+johnwparent@users.noreply.github.com>
a year ago    11     4.3    Chris White         <white238@llnl.gov>
a year ago    1      0.4    Martin Aumüller     <aumuell@reserv.at>
2 years ago   4      1.6    Massimiliano Culpo  <massimiliano.culpo@gmail.com>
3 years ago   3      1.2    Peter Brady         <ptb@lanl.gov>
3 years ago   1      0.4    Tamara Dahlgren     <35777542+tldahlgren@users.noreply.github.com>
3 years ago   2      0.8    Vanessasaurus       <814322+vsoch@users.noreply.github.com>
4 years ago   24     9.4    Robert Pavel        <rspavel@lanl.gov>
6 years ago   2      0.8    Stephen Herbein     <SteVwonder@users.noreply.github.com>
                                                
3 weeks ago   254    100.0
```

The changes also allow `spack blame` to report on non-package files in spack repositories:

```
$ spack -d blame pyproject.toml
...
==> [2025-06-10-15:16:00.717914] '/usr/bin/git' 'blame' '--ignore-revs-file' '$pack-packages/.git-blame-ignore-revs' '--line-porcelain' '$spack-packages/pyproject.toml'
LAST_COMMIT  LINES  %      AUTHOR          EMAIL
2 weeks ago  242    100.0  Ryan Krattiger  <ryan.krattiger@kitware.com>
                                           
2 weeks ago  242    100.0
```