### PR TITLE
debug: report commit and source path for local builtin repo

### DIFF
--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -26,8 +26,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 
 def _format_repo_info(source, commit):
-    if ".git" in source:
-        return f"{source.replace('.git', '')}/commit/{commit}"
+    if source.endswith(".git"):
+        return f"{source[:-4]}/commit/{commit}"
 
     return f"{source} ({commit[:7]})"
 

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -31,13 +31,16 @@ def _get_builtin_repo_commit() -> Optional[str]:
     descriptors = spack.repo.RepoDescriptors.from_config(
         spack.repo.package_repository_lock(), spack.config.CONFIG
     )
-
     if "builtin" not in descriptors:
         return None
 
     builtin = descriptors["builtin"]
 
-    if not isinstance(builtin, spack.repo.RemoteRepoDescriptor) or not builtin.fetched():
+    if isinstance(builtin, spack.repo.RemoteRepoDescriptor) and builtin.fetched():
+        destination = builtin.destination
+    elif isinstance(builtin, spack.repo.LocalRepoDescriptor):
+        destination = builtin.path
+    else:
         return None  # no git info
 
     git = spack.util.git.git(required=False)
@@ -45,19 +48,16 @@ def _get_builtin_repo_commit() -> Optional[str]:
         return None
 
     rev = git(
-        "-C",
-        builtin.destination,
-        "rev-parse",
-        "HEAD",
-        output=str,
-        error=os.devnull,
-        fail_on_error=False,
+        "-C", destination, "rev-parse", "HEAD", output=str, error=os.devnull, fail_on_error=False
     )
     if git.returncode != 0:
         return None
 
     match = re.match(r"[a-f\d]{7,}$", rev)
-    return match.group(0) if match else None
+    extra = (
+        f" (source: {builtin.path})" if isinstance(builtin, spack.repo.LocalRepoDescriptor) else ""
+    )
+    return f"{match.group(0)}{extra}" if match else None
 
 
 def report(args):

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -25,6 +25,13 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     sp.add_parser("report", help="print information useful for bug reports")
 
 
+def _format_repo_info(source, commit):
+    if ".git" in source:
+        return f"{source.replace('.git', '')}/commit/{commit}"
+
+    return f"{source} ({commit[:7]})"
+
+
 def _get_builtin_repo_info() -> Optional[str]:
     """Get the builtin package repository git commit sha."""
     # Get builtin from config
@@ -57,7 +64,17 @@ def _get_builtin_repo_info() -> Optional[str]:
         return None
 
     match = re.match(r"[a-f\d]{7,}$", rev)
-    return f"{source} ({match.group(0)})" if match else None
+    return _format_repo_info(source, match.group(0)) if match else None
+
+
+def _get_spack_repo_info() -> str:
+    """Get the spack package repository git info."""
+    commit = spack.get_spack_commit()
+    if not commit:
+        return spack.spack_version
+
+    repo_info = _format_repo_info("https://github.com/spack/spack.git", commit)
+    return f"{spack.spack_version} ({repo_info})"
 
 
 def report(args):
@@ -65,7 +82,7 @@ def report(args):
     host_os = host_platform.default_operating_system()
     host_target = host_platform.default_target()
     architecture = spack.spec.ArchSpec((str(host_platform), str(host_os), str(host_target)))
-    print("* **Spack:**", spack.get_version())
+    print("* **Spack:**", _get_spack_repo_info())
     print("* **Builtin repo:**", _get_builtin_repo_info() or "not available")
     print("* **Python:**", platform.python_version())
     print("* **Platform:**", architecture)

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -25,7 +25,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     sp.add_parser("report", help="print information useful for bug reports")
 
 
-def _get_builtin_repo_commit() -> Optional[str]:
+def _get_builtin_repo_info() -> Optional[str]:
     """Get the builtin package repository git commit sha."""
     # Get builtin from config
     descriptors = spack.repo.RepoDescriptors.from_config(
@@ -36,10 +36,13 @@ def _get_builtin_repo_commit() -> Optional[str]:
 
     builtin = descriptors["builtin"]
 
+    source = None
     if isinstance(builtin, spack.repo.RemoteRepoDescriptor) and builtin.fetched():
         destination = builtin.destination
+        source = builtin.repository
     elif isinstance(builtin, spack.repo.LocalRepoDescriptor):
         destination = builtin.path
+        source = builtin.path
     else:
         return None  # no git info
 
@@ -54,10 +57,7 @@ def _get_builtin_repo_commit() -> Optional[str]:
         return None
 
     match = re.match(r"[a-f\d]{7,}$", rev)
-    extra = (
-        f" (source: {builtin.path})" if isinstance(builtin, spack.repo.LocalRepoDescriptor) else ""
-    )
-    return f"{match.group(0)}{extra}" if match else None
+    return f"{source} ({match.group(0)})" if match else None
 
 
 def report(args):
@@ -66,7 +66,7 @@ def report(args):
     host_target = host_platform.default_target()
     architecture = spack.spec.ArchSpec((str(host_platform), str(host_os), str(host_target)))
     print("* **Spack:**", spack.get_version())
-    print("* **Builtin repo:**", _get_builtin_repo_commit() or "not available")
+    print("* **Builtin repo:**", _get_builtin_repo_info() or "not available")
     print("* **Python:**", platform.python_version())
     print("* **Platform:**", architecture)
 

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -5,9 +5,12 @@
 import platform
 
 import spack
+import spack.cmd.debug
 import spack.platforms
+import spack.repo
 import spack.spec
 from spack.main import SpackCommand
+from spack.test.conftest import _return_none
 
 debug = SpackCommand("debug")
 
@@ -23,3 +26,53 @@ def test_report():
     assert spack.get_spack_commit() in out
     assert platform.python_version() in out
     assert str(architecture) in out
+
+
+def test_get_builtin_repo_info_local_repo(mock_git_version_info, monkeypatch):
+    """Confirm local git repo descriptor returns expected path."""
+    path = mock_git_version_info[0]
+
+    def _from_config(*args, **kwargs):
+        return {"builtin": spack.repo.LocalRepoDescriptor("builtin", path)}
+
+    monkeypatch.setattr(spack.repo.RepoDescriptors, "from_config", _from_config)
+    assert path in spack.cmd.debug._get_builtin_repo_info()
+
+
+def test_get_builtin_repo_info_unsupported_type(mock_git_version_info, monkeypatch):
+    """Confirm None is return if the 'builtin' repo descriptor's type is unsupported."""
+
+    def _from_config(*args, **kwargs):
+        path = mock_git_version_info[0]
+        return {"builtin": path}
+
+    monkeypatch.setattr(spack.repo.RepoDescriptors, "from_config", _from_config)
+    assert spack.cmd.debug._get_builtin_repo_info() is None
+
+
+def test_get_builtin_repo_info_no_builtin(monkeypatch):
+    """Confirm None is return if there is no 'builtin' repo descriptor."""
+
+    def _from_config(*args, **kwargs):
+        return {"local": "/assumes/no/descriptor/needed"}
+
+    monkeypatch.setattr(spack.repo.RepoDescriptors, "from_config", _from_config)
+    assert spack.cmd.debug._get_builtin_repo_info() is None
+
+
+def test_get_builtin_repo_info_bad_destination(mock_git_version_info, monkeypatch):
+    """Confirm git failure of a repository returns None."""
+
+    def _from_config(*args, **kwargs):
+        path = mock_git_version_info[0]
+        return {"builtin": spack.repo.LocalRepoDescriptor("builtin", f"{path}/missing")}
+
+    monkeypatch.setattr(spack.repo.RepoDescriptors, "from_config", _from_config)
+    assert spack.cmd.debug._get_builtin_repo_info() is None
+
+
+def test_get_spack_repo_info_no_commit(monkeypatch):
+    """Confirm the version is returned if there is no spack commit."""
+
+    monkeypatch.setattr(spack, "get_spack_commit", _return_none)
+    assert spack.cmd.debug._get_spack_repo_info() == spack.spack_version

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -19,6 +19,7 @@ def test_report():
     host_target = host_platform.default_target()
     architecture = spack.spec.ArchSpec((str(host_platform), str(host_os), str(host_target)))
 
-    assert spack.get_version() in out
+    assert spack.spack_version in out
+    assert spack.get_spack_commit() in out
     assert platform.python_version() in out
     assert str(architecture) in out


### PR DESCRIPTION
Fixes #50881 

If you have a local directory configured in your `$HOME/.spack/repos.yaml` (e.g., you're working on spack packages), the debug report will say. e.g.,:

```
$ spack debug report
* **Spack:** 1.0.0.dev0 (a40b98368c75dc1af94b48799f14e7bee57fca68)
* **Builtin repo:** not available
* **Python:** 3.13.3
* **Platform:** darwin-sequoia-m1
```

UPDATE: The changes in this PR report the path and commit (within parentheses) for local repositories and an auto linked reference for remote repositories.

For example, with the  remote repository configured and pasted into `spack/spack`:

* **Spack:** 1.0.0.dev0 (https://github.com/spack/spack/commit/6585888bb2e94f72509344cc9017180bdb146b47)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/cee4995d962a5dae18b998821b454e7e375457fe
* **Python:** 3.13.3
* **Platform:** darwin-sequoia-m1

While a locally formatted repository pasted here would look like:

* **Spack:** 1.0.0.dev0 (https://github.com/spack/spack/commit/6585888bb2e94f72509344cc9017180bdb146b47)
* **Builtin repo:** $spack-packages/repos/spack_repo/builtin (a92fc15)
* **Python:** 3.13.3
* **Platform:** darwin-sequoia-m1

When pasted into the `spack/spack-packages` repository, you would see the following if a remote  is configured:

* **Spack:** 1.0.0.dev0 [(spack/spack@6585888)](https://github.com/spack/spack/commit/6585888bb2e94f72509344cc9017180bdb146b47)
* **Builtin repo:** [cee4995](https://github.com/spack/spack-packages/commit/cee4995d962a5dae18b998821b454e7e375457fe)
* **Python:** 3.13.3
* **Platform:** darwin-sequoia-m1

Or a local repository could appear there as:

* **Spack:** 1.0.0.dev0 [(spack/spack@6585888)](https://github.com/spack/spack/commit/6585888bb2e94f72509344cc9017180bdb146b47)
* **Builtin repo:** $spack-packages/repos/spack_repo/builtin [(a92fc15)](https://github.com/spack/spack-packages/commit/a92fc159b54d37fd0c55262e88e35fdbb1ca333c)
* **Python:** 3.13.3
* **Platform:** darwin-sequoia-m1