### PR TITLE
add warning with mirror if buildcache index is empty

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -19,6 +19,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import textwrap
 import time
 import urllib.error
 import urllib.parse
@@ -268,13 +269,22 @@ class BinaryCacheIndex:
                         self._fetch_and_cache_index(url_and_version, cache_entry)
 
                     if os.path.getsize(cache_file_path) == 0:
-                        tty.warn(
-                            f"Buildcache index for the '{mirror_url}' v{layout_version} mirror \n"
-                            "    is empty. If the mirror layout is deprecated and you cannot migrate it to the new format, consider removing it via: \n"
-                            "      'spack mirror list' \n"
-                            "      'spack mirror remove <name>' \n"
-                            "    with the <name> for the mirror url shown in the list. \n"
+                        lines = textwrap.wrap(
+                            f"Buildcache index for the v{layout_version} mirror "
+                            f"at '{mirror_url}' is empty. "
+                            "If the mirror layout is deprecated and you cannot migrate "
+                            "it to the new format, consider removing it using:",
+                            width=72,
+                            subsequent_indent="  ",
                         )
+                        lines.extend(
+                            [
+                                "    'spack mirror list'",
+                                "    'spack mirror remove <name>'",
+                                "  with the <name> for the mirror url shown in the list.",
+                            ]
+                        )
+                        tty.warn("\n".join(lines))
                         return
 
                     db._read_from_file(cache_file_path)
@@ -687,15 +697,24 @@ def buildcache_relative_index_url(layout_version: int = CURRENT_BUILD_CACHE_LAYO
 
 @llnl.util.lang.memoized
 def warn_v2_layout(mirror_url: str, action: str) -> bool:
-    tty.warn(
-        f"{action} from a v2 binary mirror layout, located at \n"
-        f"    {mirror_url} is deprecated. Support for this will be \n"
-        "    removed in a future version of spack. \n\n"
-        "    If you manage the buildcache please consider running \n"
-        "      'spack buildcache migrate' \n"
-        "    or rebuilding the specs in this mirror. If you are not the mirror \n"
-        "    owner, consider running 'spack mirror remove <name>'. \n"
+    lines = textwrap.wrap(
+        f"{action} from a v2 binary mirror layout, located at "
+        f"{mirror_url} is deprecated. Support for this will be "
+        "removed in a future version of spack. "
+        "If you manage the buildcache please consider running:",
+        width=72,
+        subsequent_indent="  ",
     )
+    lines.extend(
+        [
+            "    'spack buildcache migrate'",
+            "  or rebuilding the specs in this mirror. Otherwise, consider running:",
+            "    'spack mirror list'",
+            "    'spack mirror remove <name>'",
+            "  with the <name> for the mirror url shown in the list.",
+        ]
+    )
+    tty.warn("\n".join(lines))
     return True
 
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1737,9 +1737,9 @@ def download_tarball(
         (if required), and its checksum validated. Otherwise, return the stage
         containing the downloaded tarball.
     """
-    configured_mirrors: Iterable[
-        spack.mirrors.mirror.Mirror
-    ] = spack.mirrors.mirror.MirrorCollection(binary=True).values()
+    configured_mirrors: Iterable[spack.mirrors.mirror.Mirror] = (
+        spack.mirrors.mirror.MirrorCollection(binary=True).values()
+    )
     if not configured_mirrors:
         tty.die("Please add a spack mirror to allow download of pre-compiled packages.")
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -270,8 +270,7 @@ class BinaryCacheIndex:
                     if os.path.getsize(cache_file_path) == 0:
                         tty.warn(
                             f"Buildcache index for the '{mirror_url}' v{layout_version} mirror \n"
-                            "    is empty. If the mirror layout is deprecated and you are only \n"
-                            "    using it, consider running: \n"
+                            "    is empty. If the mirror layout is deprecated and you cannot migrate it to the new format, consider removing it via: \n"
                             "      'spack mirror list' \n"
                             "      'spack mirror remove <name>' \n"
                             "    with the <name> for the mirror url shown in the list. \n"
@@ -694,8 +693,8 @@ def warn_v2_layout(mirror_url: str, action: str) -> bool:
         "    removed in a future version of spack. \n\n"
         "    If you manage the buildcache please consider running \n"
         "      'spack buildcache migrate' \n"
-        "    or rebuilding the specs in this mirror. If you are only using \n"
-        "    it, consider running 'spack mirror remove <name>'. \n"
+        "    or rebuilding the specs in this mirror. If you are not the mirror \n"
+        "    owner, consider running 'spack mirror remove <name>'. \n"
     )
     return True
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -266,6 +266,10 @@ class BinaryCacheIndex:
                         # recreate index if it is missing
                         cache_entry = self._local_index_cache[str(url_and_version)]
                         self._fetch_and_cache_index(url_and_version, cache_entry)
+                    if os.path.getsize(cache_file_path) == 0:
+                        tty.warn(f"The buildcache index is empty for mirror '{url_and_version}'")
+                        return
+
                     db._read_from_file(cache_file_path)
             except spack_db.InvalidDatabaseVersionError as e:
                 tty.warn(

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -266,8 +266,16 @@ class BinaryCacheIndex:
                         # recreate index if it is missing
                         cache_entry = self._local_index_cache[str(url_and_version)]
                         self._fetch_and_cache_index(url_and_version, cache_entry)
+
                     if os.path.getsize(cache_file_path) == 0:
-                        tty.warn(f"The buildcache index is empty for mirror '{url_and_version}'")
+                        tty.warn(
+                            f"Buildcache index for the '{mirror_url}' v{layout_version} mirror \n"
+                            "    is empty. If the mirror layout is deprecated and you are only \n"
+                            "    using it, consider running: \n"
+                            "      'spack mirror list' \n"
+                            "      'spack mirror remove <name>' \n"
+                            "    with the <name> for the mirror url shown in the list. \n"
+                        )
                         return
 
                     db._read_from_file(cache_file_path)
@@ -683,8 +691,11 @@ def warn_v2_layout(mirror_url: str, action: str) -> bool:
     tty.warn(
         f"{action} from a v2 binary mirror layout, located at \n"
         f"    {mirror_url} is deprecated. Support for this will be \n"
-        "    removed in a future version of spack. Please consider running `spack \n"
-        "    buildcache migrate' or rebuilding the specs in this mirror."
+        "    removed in a future version of spack. \n\n"
+        "    If you manage the buildcache please consider running \n"
+        "      'spack buildcache migrate' \n"
+        "    or rebuilding the specs in this mirror. If you are only using \n"
+        "    it, consider running 'spack mirror remove <name>'. \n"
     )
     return True
 
@@ -1726,9 +1737,9 @@ def download_tarball(
         (if required), and its checksum validated. Otherwise, return the stage
         containing the downloaded tarball.
     """
-    configured_mirrors: Iterable[spack.mirrors.mirror.Mirror] = (
-        spack.mirrors.mirror.MirrorCollection(binary=True).values()
-    )
+    configured_mirrors: Iterable[
+        spack.mirrors.mirror.Mirror
+    ] = spack.mirrors.mirror.MirrorCollection(binary=True).values()
     if not configured_mirrors:
         tty.die("Please add a spack mirror to allow download of pre-compiled packages.")
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -611,7 +611,8 @@ def test_install_v2_layout(
     assert "Extracting libdwarf" in output
     assert "libdwarf: Successfully installed" in output
     assert "Installing a spec from a v2 binary mirror layout" in output
-    assert "is deprecated" in output
+    assert "Fetching an index from a v2 binary mirror layout" in output
+    assert "deprecated" in output
 
 
 def test_basic_migrate_unsigned(capsys, v2_buildcache_layout, mutable_config):


### PR DESCRIPTION
Fixes #50887 
Issue was also reported in #50888 

The problem was encountered when helping debug #47755.

This will make it easier to identify some problems with corrupted databases. 

Adding this change reports the offending mirror and lets some processes (e.g., using commands with mock packages) work.

Output from a run attempting to use the develop build cache:

```
$ spack spec zlib
...
==> Warning: Buildcache index for the v3 mirror at
  'https://binaries.spack.io/develop' is empty. If the mirror layout is
  deprecated and you cannot migrate it to the new format, consider
  removing it using:
    'spack mirror list'
    'spack mirror remove <name>'
  with the <name> for the mirror url shown in the list.
==> Warning: Buildcache index for the v2 mirror at
  'https://binaries.spack.io/develop' is empty. If the mirror layout is
  deprecated and you cannot migrate it to the new format, consider
  removing it using:
    'spack mirror list'
    'spack mirror remove <name>'
  with the <name> for the mirror url shown in the list....
```

And an example -- after a couple of build cache-related commands -- of the other message:

```
$ spack  -d spec zlib
...
==> [2025-06-16-15:32:31.732384] Warning: Fetching an index from a v2 binary mirror layout, located at
  https://binaries.spack.io/develop is deprecated. Support for this will
  be removed in a future version of spack. If you manage the buildcache
  please consider running:
    'spack buildcache migrate'
  or rebuilding the specs in this mirror. Otherwise, consider running:
    'spack mirror list'
    'spack mirror remove <name>'
  with the <name> for the mirror url shown in the list.
...
```