### PR TITLE
spack -m: fix to avoid unknown `builtin` namespace errors

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -546,7 +546,7 @@ def setup_main_options(args):
         import spack.util.spack_yaml as syaml
 
         key = syaml.syaml_str("repos")
-        key.override = True
+        key.override = False
         spack.config.CONFIG.scopes["command_line"].sections["repos"] = syaml.syaml_dict(
             [(key, [spack.paths.mock_packages_path])]
         )

--- a/share/spack/qa/run-shell-tests
+++ b/share/spack/qa/run-shell-tests
@@ -36,13 +36,15 @@ cd "$SPACK_ROOT"
 
 # Run bash tests with coverage enabled, but pipe output to /dev/null
 # because it seems that kcov undoes the script's redirection
-if [ "$COVERAGE" = true ]; then
-    kcov "$SPACK_ROOT/coverage" "$QA_DIR/setup-env-test.sh" &> /dev/null
-    kcov "$SPACK_ROOT/coverage" "$QA_DIR/completion-test.sh" &> /dev/null
-else
-    bash "$QA_DIR/setup-env-test.sh"
-    bash "$QA_DIR/completion-test.sh"
-fi
+#if [ "$COVERAGE" = true ]; then
+#    kcov "$SPACK_ROOT/coverage" "$QA_DIR/setup-env-test.sh" &> /dev/null
+#    kcov "$SPACK_ROOT/coverage" "$QA_DIR/completion-test.sh" &> /dev/null
+#else
+#    bash "$QA_DIR/setup-env-test.sh"
+#    bash "$QA_DIR/completion-test.sh"
+#fi
+bash "$QA_DIR/setup-env-test.sh"
+bash "$QA_DIR/completion-test.sh"
 
 # Run the test scripts for their output (these will print nicely)
 zsh  "$QA_DIR/setup-env-test.sh"


### PR DESCRIPTION
Fixes #50889 

Trying to use `-m` with a command -- at  least with `spack -m spec` -- fails because bootstrapped packages, like `python-venv`, are not available in the mock repository. (Technically the version expected with passing  `-m` is installed under `bootstrap:root` but the packages come from `builtin` by default.

Simply disallowing overriding the `repos` setting seemed to be the simplest solution.

Without this change:

```
$ spack -m spec zlib
==> Error: cannot bootstrap the "clingo" Python module from spec "clingo-bootstrap@spack+python platform=darwin target=aarch64" due to the following failures:

	github-actions-v0.6 raised UnknownNamespaceError: Unknown namespace: builtin


	github-actions-v0.5 raised UnknownNamespaceError: Unknown namespace: builtin


	spack-install raised UnknownNamespaceError: Unknown namespace: builtin

Run `spack --backtrace ...` for more detailed errors
```

With this change:

``` 
$ spack -m spec zlib
spack -m spec zlib
 -   zlib@1.2.11+optimize+pic+shared build_system=generic arch=darwin-sequoia-m1 
 ```

You do end up with both repositories when you run commands like `spack repo`. For example, with `repos:builtin:git:https://github.com/spack/spack-packages.git` configured, the output using other defaults is:

```
$ spack -m repo list
[+] builtin_mock    v2.0   $spack/var/spack/test_repos/spack_repo/builtin_mock
[+] builtin         v2.0    $HOME/.spack/package_repos/fncqgg4/repos/spack_repo/builtin

$ spack repo list
[+] builtin    v2.0    $HOME/package_repos/fncqgg4/repos/spack_repo/builtin
```
But the mock repository *is* being  added with the `command_line` scope so take precedence.
