### PR TITLE
path: fix handling non-file paths in  canonicalize_path

### DIFF
--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -275,7 +275,7 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
     if url.scheme:
         if url.scheme != "file":
             # Have a remote URL so simply return it with substitutions
-            return os.path.normpath(path)
+            return path
 
         # Drop the URL scheme from the local path
         path = url_path


### PR DESCRIPTION
After this change a non-file URL passed to canonicalize_path will be properly processed (only with its expanded variables).

Before this change a non-file URL such as `https://google.com` will have its path normalized using `os.path.normpath`  which results in a returned malformed URL of the type `https:/google.com` (note the single slash).