### PR TITLE
Fix issue when preferring virtual compilers

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1109,10 +1109,9 @@ required_provider(Provider, Virtual)
      pkg_fact(Virtual, condition_effect(ConditionID, EffectID)),
      imposed_constraint(EffectID, "node", Provider).
 
-error(1, "Trying to use {0} as a provider for {1}, but {2} is required", Package, Virtual, Provider) :-
-   provider(node(Y, Package), node(X, Virtual)),
+error(1, "Cannot use {1} for the {0} virtual, but that is required", Virtual, Provider) :-
    required_provider(Provider, Virtual),
-   Package != Provider.
+   not provider(node(_, Provider), node(_, Virtual)).
 
 % TODO: the following choice rule allows the solver to add compiler
 % flags if their only source is from a requirement. This is overly-specific

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1339,7 +1339,7 @@ def test_preferring_compilers_can_be_overridden(mutable_config, mock_packages):
     """Tests that we can override preferences for languages, without triggering an error."""
     mutable_config.set("packages:c", {"prefer": ["llvm"]})
 
-    s = spack.spec.Spec("pkg-a %gcc ^pkg-b% llvm")
+    s = spack.spec.Spec("pkg-a %gcc ^pkg-b %llvm")
     concrete = spack.concretize.concretize_one(s)
 
     assert concrete.satisfies("%c=gcc")

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1332,3 +1332,15 @@ def test_requirements_conditional_deps(
 
     assert requirements.satisfies(required_spec)
     assert (requirements == no_requirements) == req_is_noop  # show the reqs change concretization
+
+
+@pytest.mark.regression("50898")
+def test_preferring_compilers_can_be_overridden(mutable_config, mock_packages):
+    """Tests that we can override preferences for languages, without triggering an error."""
+    mutable_config.set("packages:c", {"prefer": ["llvm"]})
+
+    s = spack.spec.Spec("pkg-a %gcc ^pkg-b% llvm")
+    concrete = spack.concretize.concretize_one(s)
+
+    assert concrete.satisfies("%c=gcc")
+    assert concrete["pkg-b"].satisfies("%c=llvm")


### PR DESCRIPTION
fixes #50898

The error rule was wrongly assuming that there could be only one provider for a virtual, when it is required.

This is not true anymore since #45189, where we introduced the use of build-only virtual deps.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
