### PR TITLE
"spack mirror create -a" (mirror all) in parallel (continuation of #48411)

### DIFF
--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -146,9 +146,10 @@ Mirror environment
 To create a mirror of all packages required by a concrete environment, activate the environment and run ``spack mirror create -a``.
 This is especially useful to create a mirror of an environment that was concretized on another machine.
 
-Optionally specify ``-j <n_workers>`` to control the number of workers used to create a full mirror. If not specified, the optimal number of workers is
-determined dynamically. For a full mirror, the number of workers used is the minimum of 16 workers, available CPU cores, and number of packages to mirror. For
-individual packages, 1 worker is used.
+Optionally specify ``-j <n_workers>`` to control the number of workers used to create a full mirror.
+If not specified, the optimal number of workers is determined dynamically.
+For a full mirror, the number of workers used is the minimum of 16 workers, available CPU cores, and number of packages to mirror.
+For individual packages, 1 worker is used.
 
 .. code-block:: console
 

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -146,6 +146,8 @@ Mirror environment
 To create a mirror of all packages required by a concrete environment, activate the environment and call ``spack mirror create -a``.
 This is especially useful to create a mirror of an environment concretized on another machine.
 
+Optionally specify -j <thread count> to control the number of threads used to create a full mirror (default 16). 
+
 .. code-block:: console
 
    [remote] $ spack env create myenv

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -143,11 +143,11 @@ This is useful if there is a specific suite of software managed by your site.
 Mirror environment
 ^^^^^^^^^^^^^^^^^^
 
-To create a mirror of all packages required by a concrete environment, activate the environment and call ``spack mirror create -a``.
+To create a mirror of all packages required by a concrete environment, activate the environment and run ``spack mirror create -a``.
 This is especially useful to create a mirror of an environment that was concretized on another machine.
 
 Optionally specify ``-j <n_workers>`` to control the number of workers used to create a full mirror. If not specified, the optimal number of workers is
-determined dynamically. For a full mirror, the number of workers used is the minimum of 16 workers, system's available CPUs, and number of packages to mirror. For
+determined dynamically. For a full mirror, the number of workers used is the minimum of 16 workers, available CPU cores, and number of packages to mirror. For
 individual packages, 1 worker is used.
 
 .. code-block:: console

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -144,9 +144,11 @@ Mirror environment
 ^^^^^^^^^^^^^^^^^^
 
 To create a mirror of all packages required by a concrete environment, activate the environment and call ``spack mirror create -a``.
-This is especially useful to create a mirror of an environment concretized on another machine.
+This is especially useful to create a mirror of an environment that was concretized on another machine.
 
-Optionally specify -j <thread count> to control the number of threads used to create a full mirror (default 16).
+Optionally specify ``-j <n_workers>`` to control the number of workers used to create a full mirror. If not specified, the optimal number of workers is
+determined dynamically. For a full mirror, the number of workers used is the minimum of 16 workers, system's available CPUs, and number of packages to mirror. For
+individual packages, 1 worker is used.
 
 .. code-block:: console
 

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -146,7 +146,7 @@ Mirror environment
 To create a mirror of all packages required by a concrete environment, activate the environment and call ``spack mirror create -a``.
 This is especially useful to create a mirror of an environment concretized on another machine.
 
-Optionally specify -j <thread count> to control the number of threads used to create a full mirror (default 16). 
+Optionally specify -j <thread count> to control the number of threads used to create a full mirror (default 16).
 
 .. code-block:: console
 

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2321,6 +2321,9 @@ For example, the ``py-pyside2`` package contains some custom code for tweaking t
 
 .. literalinclude:: .spack/spack-packages/repos/spack_repo/builtin/packages/py_pyside2/package.py
    :pyobject: PyPyside2.patch
+.. 
+.. literalinclude:: .spack/spack-packages/repos/spack_repo/builtin/packages/py_pyside/package.py
+   :pyobject: PyPyside.patch
    :linenos:
 
 A ``patch`` function, if present, will be run after patch files are applied and before ``install()`` is run.

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2321,9 +2321,6 @@ For example, the ``py-pyside2`` package contains some custom code for tweaking t
 
 .. literalinclude:: .spack/spack-packages/repos/spack_repo/builtin/packages/py_pyside2/package.py
    :pyobject: PyPyside2.patch
-.. 
-.. literalinclude:: .spack/spack-packages/repos/spack_repo/builtin/packages/py_pyside/package.py
-   :pyobject: PyPyside.patch
    :linenos:
 
 A ``patch`` function, if present, will be run after patch files are applied and before ``install()`` is run.

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -12,12 +12,12 @@ import spack
 import spack.bootstrap
 import spack.bootstrap.config
 import spack.bootstrap.core
+import spack.cmd.mirror
 import spack.concretize
 import spack.config
 import spack.llnl.util.filesystem
 import spack.llnl.util.tty
 import spack.llnl.util.tty.color
-import spack.mirrors.utils
 import spack.stage
 import spack.util.path
 import spack.util.spack_yaml
@@ -400,7 +400,7 @@ def _mirror(args):
         spack.llnl.util.tty.set_msg_enabled(False)
         spec = spack.concretize.concretize_one(spec_str)
         for node in spec.traverse():
-            spack.mirrors.utils.create(mirror_dir, [node])
+            spack.cmd.mirror.create(mirror_dir, [node])
         spack.llnl.util.tty.set_msg_enabled(True)
 
     if args.binary_packages:

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -662,7 +662,7 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
     )
     tty.msg("Summary for mirror in {}".format(path))
     process_mirror_stats(present, mirrored, error)
-    
+
 
 def mirror_destroy(args):
     """given a url, recursively delete everything under it"""

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -634,9 +634,8 @@ def _specs_and_action(args):
 def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
     pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
     pkg_obj = pkg_cls(spack.spec.Spec(candidate))
-    mirror_stats.next_spec(pkg_obj.spec)
     spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
-
+    return pkg_obj
 
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions):
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
@@ -655,10 +654,14 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
         path, mirror_specs, skip_unstable_versions
     )
         # Submit tasks to the thread pool
-        _ = [
+        futures = [
             executor.submit(create_mirror_for_one_spec, candidate, mirror_cache, mirror_stats)
             for candidate in mirror_specs
         ]
+    for mirror_future in futures:
+        pkg_obj = mirror_future.result()
+        mirror_stats.next_spec(pkg_obj.spec)
+        
     process_mirror_stats(*mirror_stats.stats())
 
 def mirror_destroy(args):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -659,9 +659,9 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
             executor.submit(create_mirror_for_one_spec, candidate, mirror_cache, mirror_stats)
             for candidate in mirror_specs
         ]
-    for mirror_future in futures:
-        pkg_obj = mirror_future.result()
-        mirror_stats.next_spec(pkg_obj.spec)
+        for mirror_future in futures:
+            pkg_obj = mirror_future.result()
+            mirror_stats.next_spec(pkg_obj.spec)
 
     process_mirror_stats(*mirror_stats.stats())
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -658,6 +658,7 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, work
             mirror_stats.merge(ext_mirror_stats)
 
     process_mirror_stats(*mirror_stats.stats())
+    return mirror_stats
 
 
 def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions, workers):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -606,34 +606,27 @@ def mirror_create(args):
     # When no directory is provided, the source dir is used
     path = args.directory or spack.caches.fetch_cache_location()
 
-    mirror_specs, mirror_fn = _specs_and_action(args)
-    mirror_fn(
+    mirror_specs = _specs_and_action(args)
+    create_mirror_for_all_specs(
         mirror_specs,
         path=path,
         skip_unstable_versions=args.skip_unstable_versions,
-        workers=args.jobs,
+        workers=getattr(args, "jobs", 1),
     )
 
 
 def _specs_and_action(args):
     include_fn = IncludeFilter(args)
-    parallel = getattr(args, "jobs", 1) > 1
 
     if args.all and not ev.active_environment():
         mirror_specs = all_specs_with_all_versions()
-        parallel = True
     elif args.all and ev.active_environment():
         mirror_specs = concrete_specs_from_environment()
     else:
         mirror_specs = concrete_specs_from_user(args)
 
-    if parallel:
-        mirror_fn = create_mirror_for_all_specs
-    else:
-        mirror_fn = create_mirror_for_individual_specs
-
     mirror_specs, _ = lang.stable_partition(mirror_specs, predicate_fn=include_fn)
-    return mirror_specs, mirror_fn
+    return mirror_specs
 
 
 def create_mirror_for_one_spec(candidate, mirror_cache):
@@ -659,14 +652,6 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, work
 
     process_mirror_stats(*mirror_stats.stats())
     return mirror_stats
-
-
-def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions, workers):
-    present, mirrored, error = spack.mirrors.utils.create(
-        path, mirror_specs, skip_unstable_versions
-    )
-    tty.msg("Summary for mirror in {}".format(path))
-    process_mirror_stats(present, mirrored, error)
 
 
 def mirror_destroy(args):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -84,7 +84,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="for a private mirror, include non-redistributable packages",
     )
     arguments.add_common_arguments(create_parser, ["specs"])
-    arguments.add_common_arguments(create_parser, ["jobs"])
     arguments.add_concretizer_args(create_parser)
 
     # Destroy
@@ -606,15 +605,13 @@ def mirror_create(args):
 
     # When no directory is provided, the source dir is used
     path = args.directory or spack.caches.fetch_cache_location()
-    if not args.jobs:
-        args.jobs = spack.config.determine_number_of_jobs(parallel=True)
 
     mirror_specs, mirror_fn = _specs_and_action(args)
     mirror_fn(
         mirror_specs,
         path=path,
         skip_unstable_versions=args.skip_unstable_versions,
-        threads=args.jobs,
+        threads=args.parallel,
     )
 
 
@@ -640,12 +637,8 @@ def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
     spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
     return pkg_obj
 
-<<<<<<< HEAD
-def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions):
-=======
 
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, threads):
->>>>>>> 6ae2f6e1cc (Style fixes)
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
     )

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -643,6 +643,7 @@ def create_mirror_for_one_spec(candidate, mirror_cache):
     pkg_obj = pkg_cls(spack.spec.Spec(candidate))
     mirror_stats = spack.mirrors.utils.MirrorStatsForOneSpec(candidate)
     spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
+    mirror_stats.finalize()
     return mirror_stats
 
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -84,6 +84,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="for a private mirror, include non-redistributable packages",
     )
     arguments.add_common_arguments(create_parser, ["specs"])
+    arguments.add_common_arguments(create_parser, ["jobs"])
     arguments.add_concretizer_args(create_parser)
 
     # Destroy
@@ -611,7 +612,7 @@ def mirror_create(args):
         mirror_specs,
         path=path,
         skip_unstable_versions=args.skip_unstable_versions,
-        threads=args.parallel,
+        threads=args.jobs,
     )
 
 
@@ -697,5 +698,7 @@ def mirror(parser, args):
 
     if args.no_checksum:
         spack.config.set("config:checksum", False, scope="command_line")
+    if not args.jobs:
+        args.jobs = spack.config.determine_number_of_jobs(parallel=True)
 
     action[args.mirror_command](args)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -51,7 +51,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--jobs",
         type=int,
         default=1,
-        help="Use a given number of threads to make the mirror (used in combination with -a)",
+        help="Use a given number of workers to make the mirror (used in combination with -a)",
     )
     create_parser.add_argument("-f", "--file", help="file with specs of packages to put in mirror")
     create_parser.add_argument(
@@ -611,21 +611,24 @@ def mirror_create(args):
         mirror_specs,
         path=path,
         skip_unstable_versions=args.skip_unstable_versions,
-        threads=args.parallel,
+        workers=args.parallel,
     )
-
 
 def _specs_and_action(args):
     include_fn = IncludeFilter(args)
+    parallel = args.parallel > 1
 
     if args.all and not ev.active_environment():
         mirror_specs = all_specs_with_all_versions()
-        mirror_fn = create_mirror_for_all_specs
+        parallel = True
     elif args.all and ev.active_environment():
         mirror_specs = concrete_specs_from_environment()
-        mirror_fn = create_mirror_for_individual_specs
     else:
         mirror_specs = concrete_specs_from_user(args)
+
+    if parallel:
+       mirror_fn = create_mirror_for_all_specs
+    else:
         mirror_fn = create_mirror_for_individual_specs
 
     mirror_specs, _ = lang.stable_partition(mirror_specs, predicate_fn=include_fn)
@@ -639,12 +642,12 @@ def create_mirror_for_one_spec(candidate, mirror_cache):
     return mirror_stats
 
 
-def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, threads):
+def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, workers):
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
     )
-    with spack.util.parallel.make_concurrent_executor(jobs=threads) as executor:
-        # Submit tasks to the thread pool
+    with spack.util.parallel.make_concurrent_executor(jobs=workers) as executor:
+        # Submit tasks to the process pool
         futures = [
             executor.submit(create_mirror_for_one_spec, candidate, mirror_cache)
             for candidate in mirror_specs
@@ -656,7 +659,7 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, thre
     process_mirror_stats(*mirror_stats.stats())
 
 
-def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions, threads):
+def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions, workers):
     present, mirrored, error = spack.mirrors.utils.create(
         path, mirror_specs, skip_unstable_versions
     )

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -611,12 +611,12 @@ def mirror_create(args):
         mirror_specs,
         path=path,
         skip_unstable_versions=args.skip_unstable_versions,
-        workers=args.parallel,
+        workers=args.jobs,
     )
 
 def _specs_and_action(args):
     include_fn = IncludeFilter(args)
-    parallel = args.parallel > 1
+    parallel = args.jobs > 1
 
     if args.all and not ev.active_environment():
         mirror_specs = all_specs_with_all_versions()

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -18,8 +18,8 @@ import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.repo
 import spack.spec
-import spack.util.web as web_util
 import spack.util.parallel
+import spack.util.web as web_util
 from spack.cmd.common import arguments
 from spack.error import SpackError
 
@@ -637,7 +637,12 @@ def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
     spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
     return pkg_obj
 
+<<<<<<< HEAD
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions):
+=======
+
+def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, threads):
+>>>>>>> 6ae2f6e1cc (Style fixes)
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
     )
@@ -661,7 +666,7 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
     for mirror_future in futures:
         pkg_obj = mirror_future.result()
         mirror_stats.next_spec(pkg_obj.spec)
-        
+
     process_mirror_stats(*mirror_stats.stats())
 
 def mirror_destroy(args):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -50,8 +50,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--jobs",
         type=int,
         default=16,
-        help="Use a given number of threads to make the mirror"
-        " (used in combination with -a)"
+        help="Use a given number of threads to make the mirror (used in combination with -a)"
     )
     create_parser.add_argument("-f", "--file", help="file with specs of packages to put in mirror")
     create_parser.add_argument(
@@ -611,7 +610,7 @@ def mirror_create(args):
         mirror_specs,
         path=path,
         skip_unstable_versions=args.skip_unstable_versions,
-        threads=args.parallel
+        threads=args.parallel,
     )
 
 
@@ -670,12 +669,7 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, thre
     with ThreadPoolExecutor(max_workers=threads) as executor:
         # Submit tasks to the thread pool
         _ = [
-            executor.submit(
-                create_mirror_for_one_spec,
-                candidate,
-                mirror_cache,
-                mirror_stats
-            )
+            executor.submit(create_mirror_for_one_spec, candidate, mirror_cache, mirror_stats)
             for candidate in mirror_specs
         ]
     process_mirror_stats(*mirror_stats.stats())
@@ -683,9 +677,7 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, thre
 
 def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions, threads):
     present, mirrored, error = spack.mirrors.utils.create(
-        path,
-        mirror_specs,
-        skip_unstable_versions
+        path, mirror_specs, skip_unstable_versions
     )
     tty.msg("Summary for mirror in {}".format(path))
     process_mirror_stats(present, mirrored, error)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -607,12 +607,16 @@ def mirror_create(args):
     path = args.directory or spack.caches.fetch_cache_location()
 
     mirror_specs, mirror_fn = _specs_and_action(args)
-    mirror_fn(mirror_specs, path=path, skip_unstable_versions=args.skip_unstable_versions, threads=args.parallel)
+    mirror_fn(
+        mirror_specs,
+        path=path,
+        skip_unstable_versions=args.skip_unstable_versions,
+        threads=args.parallel
+    )
 
 
 def _specs_and_action(args):
     include_fn = IncludeFilter(args)
-
 
     if args.all and not ev.active_environment():
         mirror_specs = all_specs_with_all_versions()
@@ -628,10 +632,18 @@ def _specs_and_action(args):
     return mirror_specs, mirror_fn
 
 def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
+<<<<<<< HEAD
         pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
         pkg_obj = pkg_cls(spack.spec.Spec(candidate))
         mirror_stats.next_spec(pkg_obj.spec)
         spack.mirror.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
+=======
+    pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
+    pkg_obj = pkg_cls(spack.spec.Spec(candidate))
+    mirror_stats.next_spec(pkg_obj.spec)
+    spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
+
+>>>>>>> 519e76906f (Fix some styling issues)
 
 <<<<<<< HEAD
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions):
@@ -657,13 +669,24 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, thre
     )
     with ThreadPoolExecutor(max_workers=threads) as executor:
         # Submit tasks to the thread pool
-        futures = [executor.submit(create_mirror_for_one_spec, candidate, mirror_cache, mirror_stats) for candidate in mirror_specs]
+        futures = [
+            executor.submit(
+                create_mirror_for_one_spec,
+                candidate,
+                mirror_cache,
+                mirror_stats
+            ) 
+            for candidate in mirror_specs
+        ]
     process_mirror_stats(*mirror_stats.stats())
 
 
 def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions, threads):
-    present, mirrored, error = spack.mirror.create(path, mirror_specs, skip_unstable_versions)
->>>>>>> 1bab721151 (Add cmd-line option to select thread count for mirroring)
+    present, mirrored, error = spack.mirrors.utils.create(
+        path,
+        mirror_specs,
+        skip_unstable_versions
+    )
     tty.msg("Summary for mirror in {}".format(path))
     process_mirror_stats(present, mirrored, error)
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -606,7 +606,7 @@ def mirror_create(args):
     # When no directory is provided, the source dir is used
     path = args.directory or spack.caches.fetch_cache_location()
 
-    mirror_specs = _specs_and_action(args)
+    mirror_specs = _specs_to_mirror(args)
     workers = args.jobs
     if workers is None:
         if args.all:
@@ -624,7 +624,7 @@ def mirror_create(args):
     )
 
 
-def _specs_and_action(args):
+def _specs_to_mirror(args):
     include_fn = IncludeFilter(args)
 
     if args.all and not ev.active_environment():
@@ -641,7 +641,7 @@ def _specs_and_action(args):
 def create_mirror_for_one_spec(candidate, mirror_cache):
     pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
     pkg_obj = pkg_cls(spack.spec.Spec(candidate))
-    mirror_stats = spack.mirrors.utils.MirrorStatsForOneSpec()
+    mirror_stats = spack.mirrors.utils.MirrorStatsForOneSpec(candidate)
     spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
     return mirror_stats
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -19,6 +19,7 @@ import spack.mirrors.utils
 import spack.repo
 import spack.spec
 import spack.util.web as web_util
+import spack.util.parallel
 from spack.cmd.common import arguments
 from spack.error import SpackError
 
@@ -631,24 +632,18 @@ def _specs_and_action(args):
     return mirror_specs, mirror_fn
 
 def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
-<<<<<<< HEAD
-        pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
-        pkg_obj = pkg_cls(spack.spec.Spec(candidate))
-        mirror_stats.next_spec(pkg_obj.spec)
-        spack.mirror.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
-=======
     pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
     pkg_obj = pkg_cls(spack.spec.Spec(candidate))
     mirror_stats.next_spec(pkg_obj.spec)
     spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
 
->>>>>>> 519e76906f (Fix some styling issues)
 
 <<<<<<< HEAD
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions):
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
     )
+<<<<<<< HEAD
     for candidate in mirror_specs:
         pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
         pkg_obj = pkg_cls(spack.spec.Spec(candidate))
@@ -667,6 +662,10 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, thre
         path, skip_unstable_versions=skip_unstable_versions
     )
     with ThreadPoolExecutor(max_workers=threads) as executor:
+=======
+    #with ThreadPoolExecutor(max_workers=threads) as executor:
+    with spack.util.parallel.make_concurrent_executor(jobs=threads) as executor:
+>>>>>>> a0a4b58506 (Use Spack's implementation of a concurrent executor.)
         # Submit tasks to the thread pool
         _ = [
             executor.submit(create_mirror_for_one_spec, candidate, mirror_cache, mirror_stats)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -669,7 +669,7 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, thre
     )
     with ThreadPoolExecutor(max_workers=threads) as executor:
         # Submit tasks to the thread pool
-        futures = [
+        _ = [
             executor.submit(
                 create_mirror_for_one_spec,
                 candidate,

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -50,7 +50,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "-j",
         "--jobs",
         type=int,
-        default=1,
+        default=None,
         help="Use a given number of workers to make the mirror (used in combination with -a)",
     )
     create_parser.add_argument("--file", help="file with specs of packages to put in mirror")
@@ -606,12 +606,20 @@ def mirror_create(args):
     # When no directory is provided, the source dir is used
     path = args.directory or spack.caches.fetch_cache_location()
 
+    if args.jobs is None:
+        if args.all:
+            workers = 16
+        else:
+            workers = 1
+    else:
+        workers = args.jobs
+
     mirror_specs = _specs_and_action(args)
     create_mirror_for_all_specs(
         mirror_specs,
         path=path,
         skip_unstable_versions=args.skip_unstable_versions,
-        workers=getattr(args, "jobs", 1),
+        workers=workers,
     )
 
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -614,6 +614,7 @@ def mirror_create(args):
         workers=args.jobs,
     )
 
+
 def _specs_and_action(args):
     include_fn = IncludeFilter(args)
     parallel = args.jobs > 1
@@ -627,7 +628,7 @@ def _specs_and_action(args):
         mirror_specs = concrete_specs_from_user(args)
 
     if parallel:
-       mirror_fn = create_mirror_for_all_specs
+        mirror_fn = create_mirror_for_all_specs
     else:
         mirror_fn = create_mirror_for_individual_specs
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -617,13 +617,14 @@ def mirror_create(args):
 
 def _specs_and_action(args):
     include_fn = IncludeFilter(args)
-    parallel = args.jobs > 1
+    parallel = getattr(args, "jobs", 1) > 1
 
     if args.all and not ev.active_environment():
         mirror_specs = all_specs_with_all_versions()
         parallel = True
     elif args.all and ev.active_environment():
         mirror_specs = concrete_specs_from_environment()
+        print(f"AAL DEBUG: Got {len(mirror_specs)} specs from environment")
     else:
         mirror_specs = concrete_specs_from_user(args)
 
@@ -647,6 +648,7 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, work
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
     )
+    print(f"AAL create_mirror_for_all_specs: Got {len(mirror_specs)} specs from environment")
     with spack.util.parallel.make_concurrent_executor(jobs=workers) as executor:
         # Submit tasks to the process pool
         futures = [

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -662,8 +662,6 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
             for candidate in mirror_specs
         ]
         for mirror_future in as_completed(futures):
-            #TODO: AQ remove debug statement below. 
-            print("PROCESSING MIRROR FUTURE\n")
             ext_mirror_stats = mirror_future.result()
             mirror_stats.merge(ext_mirror_stats)
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -606,14 +606,16 @@ def mirror_create(args):
     # When no directory is provided, the source dir is used
     path = args.directory or spack.caches.fetch_cache_location()
 
+    mirror_specs = _specs_and_action(args)
     workers = args.jobs
     if workers is None:
         if args.all:
-            workers = 16
+            workers = min(
+                16, spack.config.determine_number_of_jobs(parallel=True), len(mirror_specs)
+            )
         else:
             workers = 1
 
-    mirror_specs = _specs_and_action(args)
     create_mirror_for_all_specs(
         mirror_specs,
         path=path,
@@ -639,15 +641,16 @@ def _specs_and_action(args):
 def create_mirror_for_one_spec(candidate, mirror_cache):
     pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
     pkg_obj = pkg_cls(spack.spec.Spec(candidate))
-    mirror_stats = spack.mirrors.utils.MirrorStats()
+    mirror_stats = spack.mirrors.utils.MirrorStatsForOneSpec()
     spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
     return mirror_stats
 
 
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, workers):
-    mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
+    mirror_cache = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
     )
+    mirror_stats = spack.mirrors.utils.MirrorStatsForAllSpecs()
     with spack.util.parallel.make_concurrent_executor(jobs=workers) as executor:
         # Submit tasks to the process pool
         futures = [

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -37,7 +37,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     create_parser.add_argument(
         "-d", "--directory", default=None, help="directory in which to create mirror"
     )
-
     create_parser.add_argument(
         "-a",
         "--all",
@@ -46,7 +45,15 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         " in the current environment if there is an active environment"
         " (this requires significant time and space)",
     )
-    create_parser.add_argument("--file", help="file with specs of packages to put in mirror")
+    create_parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=16,
+        help="Use a given number of threads to make the mirror"
+        " (used in combination with -a)"
+    )
+    create_parser.add_argument("-f", "--file", help="file with specs of packages to put in mirror")
     create_parser.add_argument(
         "--exclude-file",
         help="specs which Spack should not try to add to a mirror"
@@ -600,11 +607,12 @@ def mirror_create(args):
     path = args.directory or spack.caches.fetch_cache_location()
 
     mirror_specs, mirror_fn = _specs_and_action(args)
-    mirror_fn(mirror_specs, path=path, skip_unstable_versions=args.skip_unstable_versions)
+    mirror_fn(mirror_specs, path=path, skip_unstable_versions=args.skip_unstable_versions, threads=args.parallel)
 
 
 def _specs_and_action(args):
     include_fn = IncludeFilter(args)
+
 
     if args.all and not ev.active_environment():
         mirror_specs = all_specs_with_all_versions()
@@ -625,6 +633,7 @@ def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
         mirror_stats.next_spec(pkg_obj.spec)
         spack.mirror.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
 
+<<<<<<< HEAD
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions):
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
@@ -641,6 +650,20 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
     present, mirrored, error = spack.mirrors.utils.create(
         path, mirror_specs, skip_unstable_versions
     )
+=======
+def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, threads):
+    mirror_cache, mirror_stats = spack.mirror.mirror_cache_and_stats(
+        path, skip_unstable_versions=skip_unstable_versions
+    )
+    with ThreadPoolExecutor(max_workers=threads) as executor:
+        # Submit tasks to the thread pool
+        futures = [executor.submit(create_mirror_for_one_spec, candidate, mirror_cache, mirror_stats) for candidate in mirror_specs]
+    process_mirror_stats(*mirror_stats.stats())
+
+
+def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions, threads):
+    present, mirrored, error = spack.mirror.create(path, mirror_specs, skip_unstable_versions)
+>>>>>>> 1bab721151 (Add cmd-line option to select thread count for mirroring)
     tty.msg("Summary for mirror in {}".format(path))
     process_mirror_stats(present, mirrored, error)
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -606,13 +606,12 @@ def mirror_create(args):
     # When no directory is provided, the source dir is used
     path = args.directory or spack.caches.fetch_cache_location()
 
-    if args.jobs is None:
+    workers = args.jobs
+    if workers is None:
         if args.all:
             workers = 16
         else:
             workers = 1
-    else:
-        workers = args.jobs
 
     mirror_specs = _specs_and_action(args)
     create_mirror_for_all_specs(

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -624,7 +624,6 @@ def _specs_and_action(args):
         parallel = True
     elif args.all and ev.active_environment():
         mirror_specs = concrete_specs_from_environment()
-        print(f"AAL DEBUG: Got {len(mirror_specs)} specs from environment")
     else:
         mirror_specs = concrete_specs_from_user(args)
 
@@ -648,7 +647,6 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, work
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
     )
-    print(f"AAL create_mirror_for_all_specs: Got {len(mirror_specs)} specs from environment")
     with spack.util.parallel.make_concurrent_executor(jobs=workers) as executor:
         # Submit tasks to the process pool
         futures = [

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -4,6 +4,7 @@
 
 import argparse
 import sys
+from concurrent.futures import ThreadPoolExecutor
 
 import spack.caches
 import spack.cmd
@@ -618,6 +619,11 @@ def _specs_and_action(args):
     mirror_specs, _ = lang.stable_partition(mirror_specs, predicate_fn=include_fn)
     return mirror_specs, mirror_fn
 
+def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
+        pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
+        pkg_obj = pkg_cls(spack.spec.Spec(candidate))
+        mirror_stats.next_spec(pkg_obj.spec)
+        spack.mirror.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
 
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions):
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -631,11 +631,13 @@ def _specs_and_action(args):
     mirror_specs, _ = lang.stable_partition(mirror_specs, predicate_fn=include_fn)
     return mirror_specs, mirror_fn
 
+
+def create_mirror_for_one_spec(candidate, mirror_cache):
 def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
     pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
     pkg_obj = pkg_cls(spack.spec.Spec(candidate))
-    spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
-    return pkg_obj
+    mirror_stats = spack.mirrors.utils.cache_single_package(pkg_obj, mirror_cache)
+    return mirror_stats
 
 
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, threads):
@@ -656,12 +658,12 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
     )
         # Submit tasks to the thread pool
         futures = [
-            executor.submit(create_mirror_for_one_spec, candidate, mirror_cache, mirror_stats)
+            executor.submit(create_mirror_for_one_spec, candidate, mirror_cache)
             for candidate in mirror_specs
         ]
         for mirror_future in futures:
-            pkg_obj = mirror_future.result()
-            mirror_stats.next_spec(pkg_obj.spec)
+            ext_mirror_stats = mirror_future.result()
+            mirror_stats.merge(ext_mirror_stats)
 
     process_mirror_stats(*mirror_stats.stats())
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -648,7 +648,7 @@ def create_mirror_for_one_spec(candidate, mirror_cache):
 
 
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, workers):
-    mirror_cache = spack.mirrors.utils.mirror_cache_and_stats(
+    mirror_cache = spack.mirrors.utils.get_mirror_cache(
         path, skip_unstable_versions=skip_unstable_versions
     )
     mirror_stats = spack.mirrors.utils.MirrorStatsForAllSpecs()

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -675,7 +675,7 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, thre
                 candidate,
                 mirror_cache,
                 mirror_stats
-            ) 
+            )
             for candidate in mirror_specs
         ]
     process_mirror_stats(*mirror_stats.stats())

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -606,6 +606,8 @@ def mirror_create(args):
 
     # When no directory is provided, the source dir is used
     path = args.directory or spack.caches.fetch_cache_location()
+    if not args.jobs:
+        args.jobs = spack.config.determine_number_of_jobs(parallel=True)
 
     mirror_specs, mirror_fn = _specs_and_action(args)
     mirror_fn(
@@ -698,7 +700,5 @@ def mirror(parser, args):
 
     if args.no_checksum:
         spack.config.set("config:checksum", False, scope="command_line")
-    if not args.jobs:
-        args.jobs = spack.config.determine_number_of_jobs(parallel=True)
 
     action[args.mirror_command](args)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -638,12 +638,10 @@ def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
     spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
 
 
-<<<<<<< HEAD
 def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions):
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
     )
-<<<<<<< HEAD
     for candidate in mirror_specs:
         pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
         pkg_obj = pkg_cls(spack.spec.Spec(candidate))
@@ -656,31 +654,12 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
     present, mirrored, error = spack.mirrors.utils.create(
         path, mirror_specs, skip_unstable_versions
     )
-=======
-def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, threads):
-    mirror_cache, mirror_stats = spack.mirror.mirror_cache_and_stats(
-        path, skip_unstable_versions=skip_unstable_versions
-    )
-    with ThreadPoolExecutor(max_workers=threads) as executor:
-=======
-    #with ThreadPoolExecutor(max_workers=threads) as executor:
-    with spack.util.parallel.make_concurrent_executor(jobs=threads) as executor:
->>>>>>> a0a4b58506 (Use Spack's implementation of a concurrent executor.)
         # Submit tasks to the thread pool
         _ = [
             executor.submit(create_mirror_for_one_spec, candidate, mirror_cache, mirror_stats)
             for candidate in mirror_specs
         ]
     process_mirror_stats(*mirror_stats.stats())
-
-
-def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions, threads):
-    present, mirrored, error = spack.mirrors.utils.create(
-        path, mirror_specs, skip_unstable_versions
-    )
-    tty.msg("Summary for mirror in {}".format(path))
-    process_mirror_stats(present, mirrored, error)
-
 
 def mirror_destroy(args):
     """given a url, recursively delete everything under it"""

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -639,7 +639,8 @@ def _specs_and_action(args):
 def create_mirror_for_one_spec(candidate, mirror_cache):
     pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
     pkg_obj = pkg_cls(spack.spec.Spec(candidate))
-    mirror_stats = spack.mirrors.utils.cache_single_package(pkg_obj, mirror_cache)
+    mirror_stats = spack.mirrors.utils.MirrorStats()
+    spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
     return mirror_stats
 
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -49,7 +49,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "-j",
         "--jobs",
         type=int,
-        default=16,
+        default=1,
         help="Use a given number of threads to make the mirror (used in combination with -a)",
     )
     create_parser.add_argument("-f", "--file", help="file with specs of packages to put in mirror")

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -4,7 +4,7 @@
 
 import argparse
 import sys
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
 
 import spack.caches
 import spack.cmd
@@ -661,7 +661,9 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
             executor.submit(create_mirror_for_one_spec, candidate, mirror_cache)
             for candidate in mirror_specs
         ]
-        for mirror_future in futures:
+        for mirror_future in as_completed(futures):
+            #TODO: AQ remove debug statement below. 
+            print("PROCESSING MIRROR FUTURE\n")
             ext_mirror_stats = mirror_future.result()
             mirror_stats.merge(ext_mirror_stats)
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -50,7 +50,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--jobs",
         type=int,
         default=16,
-        help="Use a given number of threads to make the mirror (used in combination with -a)"
+        help="Use a given number of threads to make the mirror (used in combination with -a)",
     )
     create_parser.add_argument("-f", "--file", help="file with specs of packages to put in mirror")
     create_parser.add_argument(

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -666,6 +666,31 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, work
     return mirror_stats
 
 
+def create(path, specs, skip_unstable_versions=False):
+    """Create a directory to be used as a spack mirror, and fill it with
+    package archives.
+
+    Arguments:
+        path: Path to create a mirror directory hierarchy in.
+        specs: Any package versions matching these specs will be added \
+            to the mirror.
+        skip_unstable_versions: if true, this skips adding resources when
+            they do not have a stable archive checksum (as determined by
+            ``fetch_strategy.stable_target``)
+
+    Returns:
+        A tuple of lists, each containing specs
+
+        * present: Package specs that were already present.
+        * mirrored: Package specs that were successfully mirrored.
+        * error: Package specs that failed to mirror due to some error.
+    """
+    # automatically spec-ify anything in the specs array.
+    specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]
+    mirror_stats = create_mirror_for_all_specs(specs, path, skip_unstable_versions, workers=1)
+    return mirror_stats.stats()
+
+
 def mirror_destroy(args):
     """given a url, recursively delete everything under it"""
     mirror_url = None

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -53,7 +53,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=1,
         help="Use a given number of workers to make the mirror (used in combination with -a)",
     )
-    create_parser.add_argument("-f", "--file", help="file with specs of packages to put in mirror")
+    create_parser.add_argument("--file", help="file with specs of packages to put in mirror")
     create_parser.add_argument(
         "--exclude-file",
         help="specs which Spack should not try to add to a mirror"

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -633,7 +633,6 @@ def _specs_and_action(args):
 
 
 def create_mirror_for_one_spec(candidate, mirror_cache):
-def create_mirror_for_one_spec(candidate, mirror_cache, mirror_stats):
     pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
     pkg_obj = pkg_cls(spack.spec.Spec(candidate))
     mirror_stats = spack.mirrors.utils.cache_single_package(pkg_obj, mirror_cache)
@@ -644,18 +643,7 @@ def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, thre
     mirror_cache, mirror_stats = spack.mirrors.utils.mirror_cache_and_stats(
         path, skip_unstable_versions=skip_unstable_versions
     )
-    for candidate in mirror_specs:
-        pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
-        pkg_obj = pkg_cls(spack.spec.Spec(candidate))
-        mirror_stats.next_spec(pkg_obj.spec)
-        spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)
-    process_mirror_stats(*mirror_stats.stats())
-
-
-def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions):
-    present, mirrored, error = spack.mirrors.utils.create(
-        path, mirror_specs, skip_unstable_versions
-    )
+    with spack.util.parallel.make_concurrent_executor(jobs=threads) as executor:
         # Submit tasks to the thread pool
         futures = [
             executor.submit(create_mirror_for_one_spec, candidate, mirror_cache)
@@ -666,6 +654,15 @@ def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_version
             mirror_stats.merge(ext_mirror_stats)
 
     process_mirror_stats(*mirror_stats.stats())
+
+
+def create_mirror_for_individual_specs(mirror_specs, path, skip_unstable_versions, threads):
+    present, mirrored, error = spack.mirrors.utils.create(
+        path, mirror_specs, skip_unstable_versions
+    )
+    tty.msg("Summary for mirror in {}".format(path))
+    process_mirror_stats(present, mirrored, error)
+    
 
 def mirror_destroy(args):
     """given a url, recursively delete everything under it"""

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -233,7 +233,7 @@ class MirrorStats:
 
 
 def create_mirror_from_package_object(
-    pkg_obj, mirror_cache: "spack.caches.MirrorCache", stats: MirrorStats
+    pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: MirrorStats
 ) -> bool:
     """Add a single package object to a mirror.
 
@@ -243,7 +243,7 @@ def create_mirror_from_package_object(
     Args:
         pkg_obj (spack.package_base.PackageBase): package object with to be added.
         mirror_cache: mirror where to add the spec.
-        stats: statistics on the current mirror
+        mirror_stats: statistics on the current mirror
 
     Return:
         True if the spec was added successfully, False otherwise

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -173,9 +173,9 @@ def remove(name, scope):
 
 class MirrorStatsForOneSpec:
     def __init__(self, spec):
-        self.present = {}
-        self.new = {}
-        self.errors = set()
+        self.present = Counter()
+        self.new = Counter()
+        self.errors = Counter()
         self.spec = spec
         self.added_resources = set()
         self.existing_resources = set()
@@ -199,51 +199,40 @@ class MirrorStatsForOneSpec:
         self.added_resources.add(resource)
 
     def error(self):
-        if self.current_spec:
-            self.errors.add(self.current_spec)
+        if self.spec:
+            self.errors.add(self.spec)
 
     def stats(self):
         self.finalize()
         # Convert dictionaries to lists
-        present_list = []
-        for spec, count in self.present.items():
-            present_list.extend([spec] * count)
+        present_list = list(self.present.elements())
+        new_list = list(self.new.elements())
+        errors_list = list(self.errors.elements())
 
-        new_list = []
-        for spec, count in self.new.items():
-            new_list.extend([spec] * count)
+        return present_list, new_list, errors_list
 
 
 class MirrorStatsForAllSpecs:
     def __init__(self):
-        self.present = {}
-        self.new = {}
-        self.errors = set()
+        self.present = Counter()
+        self.new = Counter()
+        self.errors = Counter()
 
     def merge(self, ext_mirror_stat: MirrorStatsForOneSpec):
         # For the sake of parallelism we need a way to reduce/merge different
         # MirrorStats objects.
         ext_mirror_stat.finalize()
-        for spec, count in ext_mirror_stat.present.items():
-            self.present.setdefault(spec, 0)
-            self.present[spec] += count
-
-        for spec, count in ext_mirror_stat.new.items():
-            self.new.setdefault(spec, 0)
-            self.new[spec] += count
-
+        self.present.update(ext_mirror_stat.present)
+        self.new.update(ext_mirror_stat.new)
         self.errors.update(ext_mirror_stat.errors)
 
     def stats(self):
         # Convert dictionary to list
-        present_list = []
-        new_list = []
-        for spec, count in self.present.items():
-            present_list.extend([spec] * count)
-        for spec, count in self.new.items():
-            new_list.extend([spec] * count)
+        present_list = list(self.present.elements())
+        new_list = list(self.new.elements())
+        errors_list = list(self.errors.elements())
 
-        return present_list, new_list, list(self.errors)
+        return present_list, new_list, errors_list
 
 
 def create_mirror_from_package_object(

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -212,7 +212,24 @@ class MirrorStats:
     # TODO: AQ, Merge a given MirrorStats object to this one. Return just one MirrorStats
     def merge(self, ext_mirror_stat: MirrorStats) -> MirrorStats:
         # For the sake of parallelism we need a way to reduce/merge different
-        # MirrorStats objects. 
+        # MirrorStats objects.
+        self.present.update(ext_mirror_stat.present)
+        self.new.update(ext_mirror_stat.new)
+        self.errors.update(ext_mirror_stat.errors)
+
+        if self.current_spec != None and ext_mirror_stat.current_spec != None:
+            # If we already have a current_spec it needs to be tallied
+            # and then the new one set (via next_spec)
+            self.next_spec(ext_mirror_stat.current_spec)
+        elif self.current_spec != None and ext_mirror_stat.current_spec == None:
+            # If we have a current_spec, and there's no new one coming, leave things alone
+            continue
+        else
+            # In anycase where current_spec is None, use the incoming mirror_stat current. 
+            self.current_spec = ext_mirror_stat.current_spec
+
+        self.added_resources.update(ext_mirror_stat.added_resources)
+        self.existing_resources.update(ext_mirror_stat.existing_resources)
 
 
 def create_mirror_from_package_object(

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -215,18 +215,6 @@ class MirrorStats:
         self.present.update(ext_mirror_stat.present)
         self.new.update(ext_mirror_stat.new)
         self.errors.update(ext_mirror_stat.errors)
-
-        if self.current_spec is not None and ext_mirror_stat.current_spec is not None:
-            # If we already have a current_spec it needs to be tallied
-            # and then the new one set (via next_spec)
-            self.next_spec(ext_mirror_stat.current_spec)
-        elif self.current_spec is not None and ext_mirror_stat.current_spec is None:
-            # If we have a current_spec, and there's no new one coming, leave things alone
-            pass
-        else:
-            # In anycase where current_spec is None, use the incoming mirror_stat current.
-            self.current_spec = ext_mirror_stat.current_spec
-
         self.added_resources.update(ext_mirror_stat.added_resources)
         self.existing_resources.update(ext_mirror_stat.existing_resources)
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -209,7 +209,6 @@ class MirrorStats:
     def error(self):
         self.errors.add(self.current_spec)
 
-    # TODO: AQ, Merge a given MirrorStats object to this one. Return just one MirrorStats
     def merge(self, ext_mirror_stat: "MirrorStats") -> "MirrorStats":
         # For the sake of parallelism we need a way to reduce/merge different
         # MirrorStats objects.

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -216,15 +216,15 @@ class MirrorStats:
         self.new.update(ext_mirror_stat.new)
         self.errors.update(ext_mirror_stat.errors)
 
-        if self.current_spec != None and ext_mirror_stat.current_spec != None:
+        if self.current_spec is not None and ext_mirror_stat.current_spec is not None:
             # If we already have a current_spec it needs to be tallied
             # and then the new one set (via next_spec)
             self.next_spec(ext_mirror_stat.current_spec)
-        elif self.current_spec != None and ext_mirror_stat.current_spec == None:
+        elif self.current_spec is not None and ext_mirror_stat.current_spec is None:
             # If we have a current_spec, and there's no new one coming, leave things alone
             pass
         else:
-            # In anycase where current_spec is None, use the incoming mirror_stat current. 
+            # In anycase where current_spec is None, use the incoming mirror_stat current.
             self.current_spec = ext_mirror_stat.current_spec
 
         self.added_resources.update(ext_mirror_stat.added_resources)
@@ -303,7 +303,7 @@ def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> "
                 mirror_stats.error()
                 return mirror_stats
     return mirror_stats
-    
+
 
 def require_mirror_name(mirror_name):
     """Find a mirror by name and raise if it does not exist"""

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -272,7 +272,7 @@ def create_mirror_from_package_object(
 # I need a function that does the same thing as create_mirror_from_package_object(), but uses an
 # empty (fresh) spack mirror_stats object, and returns that, then we need a method in the mirror_stat object that will merge two mirror_stats
 def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> MirrorStats:
-    """Cache a single package object, and return the mirror_stats file.
+    """Cache a single package object, and return the MirrorStats object.
 
     The package object is only required to have an associated spec
     with a concrete version.
@@ -284,7 +284,7 @@ def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> M
     Return:
         mirror_stats: statistics on the current mirror
     """
-    # Create an empty MirrorStats file we will later combine with others
+    # Create an empty MirrorStats object we will later combine with others
     mirror_stats = MirrorStats()
     tty.msg("Adding package {} to mirror".format(pkg_obj.spec.format("{name}{@version}")))
     max_retries = 3

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -89,24 +89,6 @@ def get_matching_versions(specs, num_versions=1):
 
     return matching
 
-def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, workers):
-    mirror_cache = spack.mirrors.utils.get_mirror_cache(
-        path, skip_unstable_versions=skip_unstable_versions
-    )
-    mirror_stats = spack.mirrors.utils.MirrorStatsForAllSpecs()
-    with spack.util.parallel.make_concurrent_executor(jobs=workers) as executor:
-        # Submit tasks to the process pool
-        futures = [
-            executor.submit(create_mirror_for_one_spec, candidate, mirror_cache)
-            for candidate in mirror_specs
-        ]
-        for mirror_future in as_completed(futures):
-            ext_mirror_stats = mirror_future.result()
-            mirror_stats.merge(ext_mirror_stats)
-
-    process_mirror_stats(*mirror_stats.stats())
-    return mirror_stats
-
 
 def get_mirror_cache(path, skip_unstable_versions=False):
     """Returns a mirror cache, starting from the path where a mirror ought to be created.

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -233,7 +233,7 @@ class MirrorStats:
 
 
 def create_mirror_from_package_object(
-    pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: MirrorStats
+    pkg_obj, mirror_cache: "spack.caches.MirrorCache", stats: MirrorStats
 ) -> bool:
     """Add a single package object to a mirror.
 
@@ -243,7 +243,7 @@ def create_mirror_from_package_object(
     Args:
         pkg_obj (spack.package_base.PackageBase): package object with to be added.
         mirror_cache: mirror where to add the spec.
-        mirror_stats: statistics on the current mirror
+        stats: statistics on the current mirror
 
     Return:
         True if the spec was added successfully, False otherwise
@@ -280,7 +280,7 @@ def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> M
         mirror_cache: mirror where to add the spec.
 
     Return:
-        mirror_stats: statistics on the current mirror
+        statistics on the current mirror
     """
     # Create an empty MirrorStats object we will later combine with others
     mirror_stats = MirrorStats()

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -111,15 +111,8 @@ def create(path, specs, skip_unstable_versions=False):
     """
     # automatically spec-ify anything in the specs array.
     specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]
-
-    mirror_cache = get_mirror_cache(path, skip_unstable_versions)
-    mirror_all_stats = MirrorStatsForAllSpecs()
-    for spec in specs:
-        mirror_stats = MirrorStatsForOneSpec(spec)
-        create_mirror_from_package_object(spec.package, mirror_cache, mirror_stats)
-        mirror_all_stats.merge(mirror_stats)
-
-    return mirror_all_stats.stats()
+    mirror_stats = create_mirror_for_all_specs(specs, path, skip_unstable_versions, workers=1)
+    return mirror_stats.stats()
 
 
 def get_mirror_cache(path, skip_unstable_versions=False):

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -209,7 +209,7 @@ class MirrorStats:
     def error(self):
         self.errors.add(self.current_spec)
 
-    def merge(self, ext_mirror_stat: "MirrorStats") -> "MirrorStats":
+    def merge(self, ext_mirror_stat: "MirrorStats"):
         # For the sake of parallelism we need a way to reduce/merge different
         # MirrorStats objects.
         self.present.update(ext_mirror_stat.present)

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -233,7 +233,7 @@ class MirrorStats:
 
 
 def create_mirror_from_package_object(
-    pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: "MirrorStats"
+    pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: MirrorStats
 ) -> bool:
     """Add a single package object to a mirror.
 
@@ -269,7 +269,7 @@ def create_mirror_from_package_object(
     return True
 
 
-def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> "MirrorStats":
+def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> MirrorStats:
     """Cache a single package object, and return the MirrorStats object.
 
     The package object is only required to have an associated spec

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -212,7 +212,6 @@ class MirrorStatsForAllSpecs:
     def merge(self, ext_mirror_stat: MirrorStatsForOneSpec):
         # For the sake of parallelism we need a way to reduce/merge different
         # MirrorStats objects.
-        ext_mirror_stat.finalize()
         self.present.update(ext_mirror_stat.present)
         self.new.update(ext_mirror_stat.new)
         self.errors.update(ext_mirror_stat.errors)

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -200,16 +200,7 @@ class MirrorStatsForOneSpec:
 
     def error(self):
         if self.spec:
-            self.errors.add(self.spec)
-
-    def stats(self):
-        self.finalize()
-        # Convert dictionaries to lists
-        present_list = list(self.present.elements())
-        new_list = list(self.new.elements())
-        errors_list = list(self.errors.elements())
-
-        return present_list, new_list, errors_list
+            self.errors[self.spec] += 1
 
 
 class MirrorStatsForAllSpecs:

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -183,9 +183,9 @@ class MirrorStatsForOneSpec:
     def finalize(self):
         if self.spec:
             if self.added_resources:
-                self.new[self.spec] = 1
+                self.new[self.spec] = len(self.added_resources)
             if self.existing_resources:
-                self.present[self.spec] = 1
+                self.present[self.spec] = len(self.existing_resources)
             self.added_resources = set()
             self.existing_resources = set()
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -189,9 +189,9 @@ class MirrorStatsForAllSpecs:
 
     def stats(self):
         # Convert dictionary to list
-        present_list = list(self.present.elements())
-        new_list = list(self.new.elements())
-        errors_list = list(self.errors.elements())
+        present_list = list(self.present.keys())
+        new_list = list(self.new.keys())
+        errors_list = list(self.errors.keys())
 
         return present_list, new_list, errors_list
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -210,7 +210,7 @@ class MirrorStats:
         self.errors.add(self.current_spec)
 
     # TODO: AQ, Merge a given MirrorStats object to this one. Return just one MirrorStats
-    def merge(self, ext_mirror_stat: MirrorStats) -> MirrorStats:
+    def merge(self, ext_mirror_stat: "MirrorStats") -> "MirrorStats":
         # For the sake of parallelism we need a way to reduce/merge different
         # MirrorStats objects.
         self.present.update(ext_mirror_stat.present)
@@ -223,8 +223,8 @@ class MirrorStats:
             self.next_spec(ext_mirror_stat.current_spec)
         elif self.current_spec != None and ext_mirror_stat.current_spec == None:
             # If we have a current_spec, and there's no new one coming, leave things alone
-            continue
-        else
+            pass
+        else:
             # In anycase where current_spec is None, use the incoming mirror_stat current. 
             self.current_spec = ext_mirror_stat.current_spec
 
@@ -233,7 +233,7 @@ class MirrorStats:
 
 
 def create_mirror_from_package_object(
-    pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: MirrorStats
+    pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: "MirrorStats"
 ) -> bool:
     """Add a single package object to a mirror.
 
@@ -271,7 +271,7 @@ def create_mirror_from_package_object(
 # TODO: AQ
 # I need a function that does the same thing as create_mirror_from_package_object(), but uses an
 # empty (fresh) spack mirror_stats object, and returns that, then we need a method in the mirror_stat object that will merge two mirror_stats
-def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> MirrorStats:
+def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> "MirrorStats":
     """Cache a single package object, and return the MirrorStats object.
 
     The package object is only required to have an associated spec

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -268,9 +268,7 @@ def create_mirror_from_package_object(
                 return False
     return True
 
-# TODO: AQ
-# I need a function that does the same thing as create_mirror_from_package_object(), but uses an
-# empty (fresh) spack mirror_stats object, and returns that, then we need a method in the mirror_stat object that will merge two mirror_stats
+
 def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> "MirrorStats":
     """Cache a single package object, and return the MirrorStats object.
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -6,6 +6,7 @@ import traceback
 from collections import Counter
 
 import spack.caches
+import spack.cmd.mirror
 import spack.config
 import spack.error
 import spack.llnl.util.tty as tty
@@ -111,7 +112,9 @@ def create(path, specs, skip_unstable_versions=False):
     """
     # automatically spec-ify anything in the specs array.
     specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]
-    mirror_stats = create_mirror_for_all_specs(specs, path, skip_unstable_versions, workers=1)
+    mirror_stats = spack.cmd.mirror.create_mirror_for_all_specs(
+        specs, path, skip_unstable_versions, workers=1
+    )
     return mirror_stats.stats()
 
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -6,7 +6,6 @@ import traceback
 from collections import Counter
 
 import spack.caches
-import spack.cmd.mirror
 import spack.config
 import spack.error
 import spack.llnl.util.tty as tty
@@ -90,32 +89,23 @@ def get_matching_versions(specs, num_versions=1):
 
     return matching
 
-
-def create(path, specs, skip_unstable_versions=False):
-    """Create a directory to be used as a spack mirror, and fill it with
-    package archives.
-
-    Arguments:
-        path: Path to create a mirror directory hierarchy in.
-        specs: Any package versions matching these specs will be added \
-            to the mirror.
-        skip_unstable_versions: if true, this skips adding resources when
-            they do not have a stable archive checksum (as determined by
-            ``fetch_strategy.stable_target``)
-
-    Returns:
-        A tuple of lists, each containing specs
-
-        * present: Package specs that were already present.
-        * mirrored: Package specs that were successfully mirrored.
-        * error: Package specs that failed to mirror due to some error.
-    """
-    # automatically spec-ify anything in the specs array.
-    specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]
-    mirror_stats = spack.cmd.mirror.create_mirror_for_all_specs(
-        specs, path, skip_unstable_versions, workers=1
+def create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, workers):
+    mirror_cache = spack.mirrors.utils.get_mirror_cache(
+        path, skip_unstable_versions=skip_unstable_versions
     )
-    return mirror_stats.stats()
+    mirror_stats = spack.mirrors.utils.MirrorStatsForAllSpecs()
+    with spack.util.parallel.make_concurrent_executor(jobs=workers) as executor:
+        # Submit tasks to the process pool
+        futures = [
+            executor.submit(create_mirror_for_one_spec, candidate, mirror_cache)
+            for candidate in mirror_specs
+        ]
+        for mirror_future in as_completed(futures):
+            ext_mirror_stats = mirror_future.result()
+            mirror_stats.merge(ext_mirror_stats)
+
+    process_mirror_stats(*mirror_stats.stats())
+    return mirror_stats
 
 
 def get_mirror_cache(path, skip_unstable_versions=False):

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -183,9 +183,9 @@ class MirrorStatsForOneSpec:
     def finalize(self):
         if self.spec:
             if self.added_resources:
-                self.new[self.spec] = len(self.added_resources)
+                self.new[self.spec] = 1
             if self.existing_resources:
-                self.present[self.spec] = len(self.existing_resources)
+                self.present[self.spec] = 1
             self.added_resources = set()
             self.existing_resources = set()
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -229,6 +229,7 @@ class MirrorStats:
 
         self.added_resources.update(ext_mirror_stat.added_resources)
         self.existing_resources.update(ext_mirror_stat.existing_resources)
+        return self
 
 
 def create_mirror_from_package_object(

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -112,7 +112,7 @@ def create(path, specs, skip_unstable_versions=False):
     # automatically spec-ify anything in the specs array.
     specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]
 
-    mirror_cache = mirror_cache_and_stats(path, skip_unstable_versions)
+    mirror_cache = get_mirror_cache(path, skip_unstable_versions)
     mirror_all_stats = MirrorStatsForAllSpecs()
     for spec in specs:
         mirror_stats = MirrorStatsForOneSpec(spec)
@@ -122,15 +122,17 @@ def create(path, specs, skip_unstable_versions=False):
     return mirror_all_stats.stats()
 
 
-def mirror_cache_and_stats(path, skip_unstable_versions=False):
-    """Return both a mirror cache and a mirror stats, starting from the path
-    where a mirror ought to be created.
+def get_mirror_cache(path, skip_unstable_versions=False):
+    """Returns a mirror cache, starting from the path where a mirror ought to be created.
 
     Args:
         path (str): path to create a mirror directory hierarchy in.
         skip_unstable_versions: if true, this skips adding resources when
             they do not have a stable archive checksum (as determined by
-            ``fetch_strategy.stable_target``)
+            ``fetch_strategy.stable_target``).
+
+    Returns:
+        spack.caches.MirrorCache: mirror cache object for the given path.
     """
     # Get the absolute path of the root before we start jumping around.
     if not os.path.isdir(path):

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -229,7 +229,6 @@ class MirrorStats:
 
         self.added_resources.update(ext_mirror_stat.added_resources)
         self.existing_resources.update(ext_mirror_stat.existing_resources)
-        return self
 
 
 def create_mirror_from_package_object(
@@ -267,42 +266,6 @@ def create_mirror_from_package_object(
                 mirror_stats.error()
                 return False
     return True
-
-
-def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> MirrorStats:
-    """Cache a single package object, and return the MirrorStats object.
-
-    The package object is only required to have an associated spec
-    with a concrete version.
-
-    Args:
-        pkg_obj (spack.package_base.PackageBase): package object with to be added.
-        mirror_cache: mirror where to add the spec.
-
-    Return:
-        statistics on the current mirror
-    """
-    # Create an empty MirrorStats object we will later combine with others
-    mirror_stats = MirrorStats()
-    tty.msg("Adding package {} to mirror".format(pkg_obj.spec.format("{name}{@version}")))
-    max_retries = 3
-    for num_retries in range(max_retries):
-        try:
-            # Includes patches and resources
-            with pkg_obj.stage as pkg_stage:
-                pkg_stage.cache_mirror(mirror_cache, mirror_stats)
-            break
-        except Exception as e:
-            if num_retries + 1 == max_retries:
-                if spack.config.get("config:debug"):
-                    traceback.print_exc()
-                else:
-                    tty.warn(
-                        "Error while fetching %s" % pkg_obj.spec.format("{name}{@version}"), str(e)
-                    )
-                mirror_stats.error()
-                return mirror_stats
-    return mirror_stats
 
 
 def require_mirror_name(mirror_name):

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -111,9 +111,9 @@ def create(path, specs, skip_unstable_versions=False):
     # automatically spec-ify anything in the specs array.
     specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]
 
-    mirror_cache, mirror_stats = mirror_cache_and_stats(path, skip_unstable_versions)
+    mirror_cache = mirror_cache_and_stats(path, skip_unstable_versions)
+    mirror_stats = MirrorStatsForOneSpec()
     for spec in specs:
-        mirror_stats.next_spec(spec)
         create_mirror_from_package_object(spec.package, mirror_cache, mirror_stats)
 
     return mirror_stats.stats()
@@ -136,8 +136,7 @@ def mirror_cache_and_stats(path, skip_unstable_versions=False):
         except OSError as e:
             raise MirrorError("Cannot create directory '%s':" % path, str(e))
     mirror_cache = spack.caches.MirrorCache(path, skip_unstable_versions=skip_unstable_versions)
-    mirror_stats = MirrorStats()
-    return mirror_cache, mirror_stats
+    return mirror_cache
 
 
 def add(mirror: Mirror, scope=None):
@@ -169,21 +168,16 @@ def remove(name, scope):
     tty.msg("Removed mirror %s." % name)
 
 
-class MirrorStats:
+class MirrorStatsForOneSpec:
     def __init__(self):
         self.present = {}
         self.new = {}
         self.errors = set()
-
         self.current_spec = None
         self.added_resources = set()
         self.existing_resources = set()
 
-    def next_spec(self, spec):
-        self._tally_current_spec()
-        self.current_spec = spec
-
-    def _tally_current_spec(self):
+    def finalize(self):
         if self.current_spec:
             if self.added_resources:
                 self.new[self.current_spec] = len(self.added_resources)
@@ -192,10 +186,6 @@ class MirrorStats:
             self.added_resources = set()
             self.existing_resources = set()
         self.current_spec = None
-
-    def stats(self):
-        self._tally_current_spec()
-        return list(self.present), list(self.new), list(self.errors)
 
     def already_existed(self, resource):
         # If an error occurred after caching a subset of a spec's
@@ -207,20 +197,58 @@ class MirrorStats:
         self.added_resources.add(resource)
 
     def error(self):
-        self.errors.add(self.current_spec)
+        if self.current_spec:
+            self.errors.add(self.current_spec)
 
-    def merge(self, ext_mirror_stat: "MirrorStats"):
+    def stats(self):
+        self.finalize()
+        # Convert dictionaries to lists
+        present_list = []
+        for spec, count in self.present.items():
+            present_list.extend([spec] * count)
+
+        new_list = []
+        for spec, count in self.new.items():
+            new_list.extend([spec] * count)
+
+
+class MirrorStatsForAllSpecs:
+    def __init__(self):
+        self.present = {}
+        self.new = {}
+        self.errors = set()
+
+    def merge(self, ext_mirror_stat: MirrorStatsForOneSpec):
         # For the sake of parallelism we need a way to reduce/merge different
         # MirrorStats objects.
-        self.present.update(ext_mirror_stat.present)
-        self.new.update(ext_mirror_stat.new)
+        ext_mirror_stat.finalize()
+        for spec, count in ext_mirror_stat.present.items():
+            if spec in self.present:
+                self.present[spec] += count
+            else:
+                self.present[spec] = count
+
+        for spec, count in ext_mirror_stat.new.items():
+            if spec in self.new:
+                self.new[spec] += count
+            else:
+                self.new[spec] = count
         self.errors.update(ext_mirror_stat.errors)
-        self.added_resources.update(ext_mirror_stat.added_resources)
-        self.existing_resources.update(ext_mirror_stat.existing_resources)
+
+    def stats(self):
+        # Convert dictionary to list
+        present_list = []
+        new_list = []
+        for spec, count in self.present.items():
+            present_list.extend([spec] * count)
+        for spec, count in self.new.items():
+            new_list.extend([spec] * count)
+
+        return present_list, new_list, list(self.errors)
 
 
 def create_mirror_from_package_object(
-    pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: MirrorStats
+    pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: MirrorStatsForOneSpec
 ) -> bool:
     """Add a single package object to a mirror.
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -205,6 +205,7 @@ class MirrorStatsForOneSpec:
 
 class MirrorStatsForAllSpecs:
     def __init__(self):
+        # Counter is used to easily merge mirror stats for one spec into mirror stats for all specs
         self.present = Counter()
         self.new = Counter()
         self.errors = Counter()

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -209,6 +209,11 @@ class MirrorStats:
     def error(self):
         self.errors.add(self.current_spec)
 
+    # TODO: AQ, Merge a given MirrorStats object to this one. Return just one MirrorStats
+    def merge(self, ext_mirror_stat: MirrorStats) -> MirrorStats:
+        # For the sake of parallelism we need a way to reduce/merge different
+        # MirrorStats objects. 
+
 
 def create_mirror_from_package_object(
     pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: MirrorStats
@@ -246,6 +251,44 @@ def create_mirror_from_package_object(
                 return False
     return True
 
+# TODO: AQ
+# I need a function that does the same thing as create_mirror_from_package_object(), but uses an
+# empty (fresh) spack mirror_stats object, and returns that, then we need a method in the mirror_stat object that will merge two mirror_stats
+def cache_single_package(pkg_obj, mirror_cache: "spack.caches.MirrorCache") -> MirrorStats:
+    """Cache a single package object, and return the mirror_stats file.
+
+    The package object is only required to have an associated spec
+    with a concrete version.
+
+    Args:
+        pkg_obj (spack.package_base.PackageBase): package object with to be added.
+        mirror_cache: mirror where to add the spec.
+
+    Return:
+        mirror_stats: statistics on the current mirror
+    """
+    # Create an empty MirrorStats file we will later combine with others
+    mirror_stats = MirrorStats()
+    tty.msg("Adding package {} to mirror".format(pkg_obj.spec.format("{name}{@version}")))
+    max_retries = 3
+    for num_retries in range(max_retries):
+        try:
+            # Includes patches and resources
+            with pkg_obj.stage as pkg_stage:
+                pkg_stage.cache_mirror(mirror_cache, mirror_stats)
+            break
+        except Exception as e:
+            if num_retries + 1 == max_retries:
+                if spack.config.get("config:debug"):
+                    traceback.print_exc()
+                else:
+                    tty.warn(
+                        "Error while fetching %s" % pkg_obj.spec.format("{name}{@version}"), str(e)
+                    )
+                mirror_stats.error()
+                return mirror_stats
+    return mirror_stats
+    
 
 def require_mirror_name(mirror_name):
     """Find a mirror by name and raise if it does not exist"""

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import traceback
+from collections import Counter
 
 import spack.caches
 import spack.config
@@ -112,11 +113,13 @@ def create(path, specs, skip_unstable_versions=False):
     specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]
 
     mirror_cache = mirror_cache_and_stats(path, skip_unstable_versions)
-    mirror_stats = MirrorStatsForOneSpec()
+    mirror_all_stats = MirrorStatsForAllSpecs()
     for spec in specs:
+        mirror_stats = MirrorStatsForOneSpec(spec)
         create_mirror_from_package_object(spec.package, mirror_cache, mirror_stats)
+        mirror_all_stats.merge(mirror_stats)
 
-    return mirror_stats.stats()
+    return mirror_all_stats.stats()
 
 
 def mirror_cache_and_stats(path, skip_unstable_versions=False):
@@ -169,23 +172,22 @@ def remove(name, scope):
 
 
 class MirrorStatsForOneSpec:
-    def __init__(self):
+    def __init__(self, spec):
         self.present = {}
         self.new = {}
         self.errors = set()
-        self.current_spec = None
+        self.spec = spec
         self.added_resources = set()
         self.existing_resources = set()
 
     def finalize(self):
-        if self.current_spec:
+        if self.spec:
             if self.added_resources:
-                self.new[self.current_spec] = len(self.added_resources)
+                self.new[self.spec] = len(self.added_resources)
             if self.existing_resources:
-                self.present[self.current_spec] = len(self.existing_resources)
+                self.present[self.spec] = len(self.existing_resources)
             self.added_resources = set()
             self.existing_resources = set()
-        self.current_spec = None
 
     def already_existed(self, resource):
         # If an error occurred after caching a subset of a spec's
@@ -223,16 +225,13 @@ class MirrorStatsForAllSpecs:
         # MirrorStats objects.
         ext_mirror_stat.finalize()
         for spec, count in ext_mirror_stat.present.items():
-            if spec in self.present:
-                self.present[spec] += count
-            else:
-                self.present[spec] = count
+            self.present.setdefault(spec, 0)
+            self.present[spec] += count
 
         for spec, count in ext_mirror_stat.new.items():
-            if spec in self.new:
-                self.new[spec] += count
-            else:
-                self.new[spec] = count
+            self.new.setdefault(spec, 0)
+            self.new[spec] += count
+
         self.errors.update(ext_mirror_stat.errors)
 
     def stats(self):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -609,7 +609,9 @@ class Stage(LockableStagingDir):
         spack.caches.FETCH_CACHE.store(self.fetcher, self.mirror_layout.path)
 
     def cache_mirror(
-        self, mirror: "spack.caches.MirrorCache", stats: "spack.mirrors.utils.MirrorStats"
+        self,
+        mirror: "spack.caches.MirrorCache",
+        stats: "spack.mirrors.utils.MirrorStatsForOneSpec",
     ) -> None:
         """Perform a fetch if the resource is not already cached
 

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -9,11 +9,11 @@ import pytest
 
 import spack.bootstrap
 import spack.bootstrap.core
+import spack.cmd.mirror
 import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.main
-import spack.mirrors.utils
 import spack.spec
 from spack.llnl.path import convert_to_posix_path
 
@@ -184,8 +184,8 @@ def test_bootstrap_mirror_metadata(mutable_config, linux_os, monkeypatch, tmp_pa
     `spack bootstrap add`. Here we don't download data, since that would be an
     expensive operation for a unit test.
     """
-    old_create = spack.mirrors.utils.create
-    monkeypatch.setattr(spack.mirrors.utils, "create", lambda p, s: old_create(p, []))
+    old_create = spack.cmd.mirror.create
+    monkeypatch.setattr(spack.cmd.mirror, "create", lambda p, s: old_create(p, []))
     monkeypatch.setattr(spack.concretize, "concretize_one", lambda p: spack.spec.Spec(p))
 
     # Create the mirror in a temporary folder

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -20,7 +20,7 @@ import spack.util.git
 import spack.util.url as url_util
 import spack.version
 from spack.main import SpackCommand, SpackCommandError
-from spack.mirrors.utils import MirrorStats
+from spack.mirrors.utils import MirrorStatsForAllSpecs, MirrorStatsForOneSpec
 
 config = SpackCommand("config")
 mirror = SpackCommand("mirror")
@@ -109,22 +109,27 @@ def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_m
 
 def test_mirror_stats_merge():
     """Test MirrorStats merge functionality"""
-    test_spec1 = spack.spec.Spec("test-package@1.0")
-    test_spec2 = spack.spec.Spec("test-package@2.0")
+    spec1 = "package@1.0"
+    spec2 = "package@2.0"
 
-    stats1 = MirrorStats()
-    stats2 = MirrorStats()
+    s1 = MirrorStatsForOneSpec()
+    s1.current_spec = spec1
+    s1.added("/test/path/1")
+    s1.added("/test/path/2")
+    s1.finalize()
 
-    stats1.current_spec = test_spec1
-    stats1.existing_resources.add("pkg1")
-    stats1.merge(stats2)
-    assert "pkg1" in stats1.existing_resources
+    s2 = MirrorStatsForOneSpec()
+    s2.current_spec = spec2
+    s2.already_existed("/test/path/3")
+    s2.finalize()
 
-    stats1.current_spec = test_spec1
-    stats2.current_spec = test_spec2
-    stats2.existing_resources.add("pkg2")
-    stats1.merge(stats2)
-    assert "pkg2" in stats1.existing_resources
+    all_stats = MirrorStatsForAllSpecs()
+    all_stats.merge(s1)
+    all_stats.merge(s2)
+
+    present, mirrored, errors = all_stats.stats()
+    assert mirrored.count(spec1) == 2
+    assert present.count(spec2) == 1
 
 
 # Test for command line-specified spec in concretized environment

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -95,7 +95,9 @@ def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_m
     specs = list(e.specs_by_hash.values())
 
     with spack.config.override("config:checksum", False):
-        mirror_stats = spack.cmd.mirror.create_mirror_for_all_specs(specs, mirror_dir, False, workers=2)
+        mirror_stats = spack.cmd.mirror.create_mirror_for_all_specs(
+            specs, mirror_dir, False, workers=2
+        )
 
     assert len(mirror_stats.errors) == 0
     assert set(os.listdir(mirror_dir)) == set([s.name for s in e.user_specs])

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -120,6 +120,7 @@ def test_mirror_stats_merge():
     """Test MirrorStats merge functionality"""
     spec1 = "package@1.0"
     spec2 = "package@2.0"
+    spec3 = "package@3.0"
 
     s1 = MirrorStatsForOneSpec(spec1)
     s1.added("/test/path/1")
@@ -131,12 +132,38 @@ def test_mirror_stats_merge():
     s2.finalize()
 
     all_stats = MirrorStatsForAllSpecs()
+
+    # Check before merge, should be empty
+    present, mirrored, errors = all_stats.stats()
+    assert len(present) == 0
+    assert len(mirrored) == 0
+    assert len(errors) == 0
+
+    # Merge package 1 and 2
     all_stats.merge(s1)
     all_stats.merge(s2)
 
+    # Check after merge
     present, mirrored, errors = all_stats.stats()
-    assert mirrored.count(spec1) == 1
     assert present.count(spec2) == 1
+    assert mirrored.count(spec1) == 2
+    assert len(present) == 1
+    assert len(mirrored) == 2
+    assert len(errors) == 0
+
+    # Merge package 3
+    s3 = MirrorStatsForOneSpec(spec3)
+    s3.already_existed("/test/path/4")
+    s3.added("/test/path/5")
+    s3.finalize()
+    all_stats.merge(s3)
+
+    present, mirrored, errors = all_stats.stats()
+    assert present.count(spec3) == 1
+    assert mirrored.count(spec3) == 1
+    assert len(present) == 2
+    assert len(mirrored) == 3
+    assert len(errors) == 0
 
 
 # Test for command line-specified spec in concretized environment

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -83,6 +83,7 @@ def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_m
         expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
         assert mirror_res == expected
 
+
 # Test for command line-specified spec in concretized environment
 def test_mirror_spec_from_env(
     mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mock_fetch

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -203,7 +203,7 @@ def test_exclude_specs(mock_packages, config):
         specs=["mpich"], versions_per_spec="all", exclude_specs="mpich@3.0.1:3.0.2 mpich@1.0"
     )
 
-    mirror_specs, _ = spack.cmd.mirror._specs_and_action(args)
+    mirror_specs = spack.cmd.mirror._specs_and_action(args)
     expected_include = set(
         spack.concretize.concretize_one(x) for x in ["mpich@3.0.3", "mpich@3.0.4", "mpich@3.0"]
     )
@@ -220,7 +220,7 @@ def test_exclude_specs_public_mirror(mock_packages, config):
         private=False,
     )
 
-    mirror_specs, _ = spack.cmd.mirror._specs_and_action(args)
+    mirror_specs = spack.cmd.mirror._specs_and_action(args)
     assert not any(s.name == "no-redistribute" for s in mirror_specs)
     assert any(s.name == "no-redistribute-dependent" for s in mirror_specs)
 
@@ -237,7 +237,7 @@ mpich@1.0
 
     args = MockMirrorArgs(specs=["mpich"], versions_per_spec="all", exclude_file=str(exclude_path))
 
-    mirror_specs, _ = spack.cmd.mirror._specs_and_action(args)
+    mirror_specs = spack.cmd.mirror._specs_and_action(args)
     expected_include = set(
         spack.concretize.concretize_one(x) for x in ["mpich@3.0.3", "mpich@3.0.4", "mpich@3.0"]
     )
@@ -449,7 +449,7 @@ class TestMirrorCreate:
     @pytest.mark.regression("31736", "31985")
     def test_all_specs_with_all_versions_dont_concretize(self):
         args = MockMirrorArgs(all=True, exclude_file=None, exclude_specs=None)
-        mirror_specs, _ = spack.cmd.mirror._specs_and_action(args)
+        mirror_specs = spack.cmd.mirror._specs_and_action(args)
         assert all(not s.concrete for s in mirror_specs)
 
     @pytest.mark.parametrize(
@@ -507,7 +507,7 @@ class TestMirrorCreate:
         ],
     )
     def test_exclude_specs_from_user(self, cli_args, not_expected, config):
-        mirror_specs, _ = spack.cmd.mirror._specs_and_action(MockMirrorArgs(**cli_args))
+        mirror_specs = spack.cmd.mirror._specs_and_action(MockMirrorArgs(**cli_args))
         assert not any(s.satisfies(y) for s in mirror_specs for y in not_expected)
 
     @pytest.mark.parametrize("abstract_specs", [("bowtie", "callpath")])

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -65,10 +65,16 @@ def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_pac
         assert mirror_res == expected
 
 
-def test_mirror_cli_parallel_args(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):
+def test_mirror_cli_parallel_args(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path, monkeypatch):
     """Test the CLI parallel args"""
     mirror_dir = str(tmp_path / "mirror")
     env_name = "test-parallel"
+
+    def mock_create_mirror_for_all_specs(mirror_specs, path, skip_unstable_versions, workers):
+        assert path == mirror_dir
+        assert workers == 2
+
+    monkeypatch.setattr(spack.cmd.mirror, "create_mirror_for_all_specs", mock_create_mirror_for_all_specs)
 
     env("create", env_name)
     with ev.read(env_name):
@@ -77,7 +83,6 @@ def test_mirror_cli_parallel_args(tmp_path, mock_packages, mock_fetch, mutable_m
         concretize()
         with spack.config.override("config:checksum", False):
             mirror("create", "-d", mirror_dir, "--all", "-j", "2")
-    assert os.path.exists(mirror_dir)
 
 
 def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -65,8 +65,8 @@ def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_pac
         assert mirror_res == expected
 
 
-def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):
-    print("AAL in test_mirror_from_env_parallel")
+def test_mirror_cli_parallel_args(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):
+    """Test the CLI parallel args"""
     mirror_dir = str(tmp_path / "mirror")
     env_name = "test-parallel"
 
@@ -77,15 +77,36 @@ def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_m
         concretize()
         with spack.config.override("config:checksum", False):
             mirror("create", "-d", mirror_dir, "--all", "-j", "2")
+    assert os.path.exists(mirror_dir)
+
+
+def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):
+    """Directly test create_mirror_for_all_specs with parallel option"""
+    mirror_dir = str(tmp_path / "mirror")
+    env_name = "test-parallel"
+
+    env("create", env_name)
+    with ev.read(env_name):
+        add("trivial-install-test-package")
+        add("git-test")
+        concretize()
 
     e = ev.read(env_name)
+    specs = list(e.specs_by_hash.values())
+
+    with spack.config.override("config:checksum", False):
+        mirror_stats = spack.cmd.mirror.create_mirror_for_all_specs(specs, mirror_dir, False, workers=2)
+
+    assert len(mirror_stats.errors) == 0
     assert set(os.listdir(mirror_dir)) == set([s.name for s in e.user_specs])
     for spec in e.specs_by_hash.values():
         mirror_res = os.listdir(os.path.join(mirror_dir, spec.name))
         expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
         assert mirror_res == expected
 
-    # Test merge() function in depth
+
+def test_mirror_stats_merge():
+    """Test MirrorStats merge functionality"""
     test_spec1 = spack.spec.Spec("test-package@1.0")
     test_spec2 = spack.spec.Spec("test-package@2.0")
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -63,6 +63,7 @@ def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_pac
         expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
         assert mirror_res == expected
 
+
 def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):
     mirror_dir = str(tmp_path / "mirror")
     env_name = "test-parallel"

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -645,4 +645,3 @@ def test_git_provenance_relative_to_mirror(
 
     spec_head = spack.concretize.concretize_one(f"git-test-commit@main commit={head_commit}")
     assert spec_head.variants["commit"].value == head_commit
-

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -249,7 +249,7 @@ mpich@1.0
 
     args = MockMirrorArgs(specs=["mpich"], versions_per_spec="all", exclude_file=str(exclude_path))
 
-    mirror_specs = spack.cmd.mirror(args)
+    mirror_specs = spack.cmd.mirror._specs_to_mirror(args)
     expected_include = set(
         spack.concretize.concretize_one(x) for x in ["mpich@3.0.3", "mpich@3.0.4", "mpich@3.0"]
     )

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -65,7 +65,9 @@ def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_pac
         assert mirror_res == expected
 
 
-def test_mirror_cli_parallel_args(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path, monkeypatch):
+def test_mirror_cli_parallel_args(
+    tmp_path, mock_packages, mock_fetch, mutable_mock_env_path, monkeypatch
+):
     """Test the CLI parallel args"""
     mirror_dir = str(tmp_path / "mirror")
     env_name = "test-parallel"
@@ -74,7 +76,9 @@ def test_mirror_cli_parallel_args(tmp_path, mock_packages, mock_fetch, mutable_m
         assert path == mirror_dir
         assert workers == 2
 
-    monkeypatch.setattr(spack.cmd.mirror, "create_mirror_for_all_specs", mock_create_mirror_for_all_specs)
+    monkeypatch.setattr(
+        spack.cmd.mirror, "create_mirror_for_all_specs", mock_create_mirror_for_all_specs
+    )
 
     env("create", env_name)
     with ev.read(env_name):

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -645,3 +645,4 @@ def test_git_provenance_relative_to_mirror(
 
     spec_head = spack.concretize.concretize_one(f"git-test-commit@main commit={head_commit}")
     assert spec_head.variants["commit"].value == head_commit
+

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -206,7 +206,7 @@ def test_mirror_skip_unstable(
     specs = [
         spack.concretize.concretize_one(x) for x in ["git-test", "trivial-pkg-with-valid-hash"]
     ]
-    spack.mirrors.utils.create(mirror_dir, specs, skip_unstable_versions=True)
+    spack.cmd.mirror.create(mirror_dir, specs, skip_unstable_versions=True)
 
     assert set(os.listdir(mirror_dir)) - set(["_source-cache"]) == set(
         ["trivial-pkg-with-valid-hash"]

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -103,6 +103,7 @@ def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_m
     stats1.merge(stats2)
     assert "pkg2" in stats1.existing_resources
 
+
 # Test for command line-specified spec in concretized environment
 def test_mirror_spec_from_env(
     mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mock_fetch

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -121,14 +121,12 @@ def test_mirror_stats_merge():
     spec1 = "package@1.0"
     spec2 = "package@2.0"
 
-    s1 = MirrorStatsForOneSpec()
-    s1.current_spec = spec1
+    s1 = MirrorStatsForOneSpec(spec1)
     s1.added("/test/path/1")
     s1.added("/test/path/2")
     s1.finalize()
 
-    s2 = MirrorStatsForOneSpec()
-    s2.current_spec = spec2
+    s2 = MirrorStatsForOneSpec(spec2)
     s2.already_existed("/test/path/3")
     s2.finalize()
 
@@ -217,7 +215,7 @@ def test_exclude_specs(mock_packages, config):
         specs=["mpich"], versions_per_spec="all", exclude_specs="mpich@3.0.1:3.0.2 mpich@1.0"
     )
 
-    mirror_specs = spack.cmd.mirror._specs_and_action(args)
+    mirror_specs = spack.cmd.mirror._specs_to_mirror(args)
     expected_include = set(
         spack.concretize.concretize_one(x) for x in ["mpich@3.0.3", "mpich@3.0.4", "mpich@3.0"]
     )
@@ -234,7 +232,7 @@ def test_exclude_specs_public_mirror(mock_packages, config):
         private=False,
     )
 
-    mirror_specs = spack.cmd.mirror._specs_and_action(args)
+    mirror_specs = spack.cmd.mirror._specs_to_mirror(args)
     assert not any(s.name == "no-redistribute" for s in mirror_specs)
     assert any(s.name == "no-redistribute-dependent" for s in mirror_specs)
 
@@ -251,7 +249,7 @@ mpich@1.0
 
     args = MockMirrorArgs(specs=["mpich"], versions_per_spec="all", exclude_file=str(exclude_path))
 
-    mirror_specs = spack.cmd.mirror._specs_and_action(args)
+    mirror_specs = spack.cmd.mirror(args)
     expected_include = set(
         spack.concretize.concretize_one(x) for x in ["mpich@3.0.3", "mpich@3.0.4", "mpich@3.0"]
     )
@@ -463,7 +461,7 @@ class TestMirrorCreate:
     @pytest.mark.regression("31736", "31985")
     def test_all_specs_with_all_versions_dont_concretize(self):
         args = MockMirrorArgs(all=True, exclude_file=None, exclude_specs=None)
-        mirror_specs = spack.cmd.mirror._specs_and_action(args)
+        mirror_specs = spack.cmd.mirror._specs_to_mirror(args)
         assert all(not s.concrete for s in mirror_specs)
 
     @pytest.mark.parametrize(
@@ -521,7 +519,7 @@ class TestMirrorCreate:
         ],
     )
     def test_exclude_specs_from_user(self, cli_args, not_expected, config):
-        mirror_specs = spack.cmd.mirror._specs_and_action(MockMirrorArgs(**cli_args))
+        mirror_specs = spack.cmd.mirror._specs_to_mirror(MockMirrorArgs(**cli_args))
         assert not any(s.satisfies(y) for s in mirror_specs for y in not_expected)
 
     @pytest.mark.parametrize("abstract_specs", [("bowtie", "callpath")])

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -135,7 +135,7 @@ def test_mirror_stats_merge():
     all_stats.merge(s2)
 
     present, mirrored, errors = all_stats.stats()
-    assert mirrored.count(spec1) == 2
+    assert mirrored.count(spec1) == 1
     assert present.count(spec2) == 1
 
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -146,9 +146,9 @@ def test_mirror_stats_merge():
     # Check after merge
     present, mirrored, errors = all_stats.stats()
     assert present.count(spec2) == 1
-    assert mirrored.count(spec1) == 2
+    assert mirrored.count(spec1) == 1
     assert len(present) == 1
-    assert len(mirrored) == 2
+    assert len(mirrored) == 1
     assert len(errors) == 0
 
     # Merge package 3
@@ -162,7 +162,7 @@ def test_mirror_stats_merge():
     assert present.count(spec3) == 1
     assert mirrored.count(spec3) == 1
     assert len(present) == 2
-    assert len(mirrored) == 3
+    assert len(mirrored) == 2
     assert len(errors) == 0
 
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -20,6 +20,7 @@ import spack.util.git
 import spack.util.url as url_util
 import spack.version
 from spack.main import SpackCommand, SpackCommandError
+from spack.mirrors.utils import MirrorStats
 
 config = SpackCommand("config")
 mirror = SpackCommand("mirror")
@@ -65,6 +66,7 @@ def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_pac
 
 
 def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):
+    print("AAL in test_mirror_from_env_parallel")
     mirror_dir = str(tmp_path / "mirror")
     env_name = "test-parallel"
 
@@ -83,6 +85,23 @@ def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_m
         expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
         assert mirror_res == expected
 
+    # Test merge() function in depth
+    test_spec1 = spack.spec.Spec("test-package@1.0")
+    test_spec2 = spack.spec.Spec("test-package@2.0")
+
+    stats1 = MirrorStats()
+    stats2 = MirrorStats()
+
+    stats1.current_spec = test_spec1
+    stats1.existing_resources.add("pkg1")
+    stats1.merge(stats2)
+    assert "pkg1" in stats1.existing_resources
+
+    stats1.current_spec = test_spec1
+    stats2.current_spec = test_spec2
+    stats2.existing_resources.add("pkg2")
+    stats1.merge(stats2)
+    assert "pkg2" in stats1.existing_resources
 
 # Test for command line-specified spec in concretized environment
 def test_mirror_spec_from_env(

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -63,6 +63,24 @@ def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_pac
         expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
         assert mirror_res == expected
 
+def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):
+    mirror_dir = str(tmp_path / "mirror")
+    env_name = "test-parallel"
+
+    env("create", env_name)
+    with ev.read(env_name):
+        add("trivial-install-test-package")
+        add("git-test")
+        concretize()
+        with spack.config.override("config:checksum", False):
+            mirror("create", "-d", mirror_dir, "--all", "-j", "2")
+
+    e = ev.read(env_name)
+    assert set(os.listdir(mirror_dir)) == set([s.name for s in e.user_specs])
+    for spec in e.specs_by_hash.values():
+        mirror_res = os.listdir(os.path.join(mirror_dir, spec.name))
+        expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
+        assert mirror_res == expected
 
 # Test for command line-specified spec in concretized environment
 def test_mirror_spec_from_env(

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -9,6 +9,7 @@ import pathlib
 import pytest
 
 import spack.caches
+import spack.cmd.mirror
 import spack.concretize
 import spack.config
 import spack.fetch_strategy
@@ -61,7 +62,7 @@ def check_mirror():
         with spack.config.override("mirrors", mirrors):
             with spack.config.override("config:checksum", False):
                 specs = [spack.concretize.concretize_one(x) for x in repos]
-                spack.mirrors.utils.create(mirror_root, specs)
+                spack.cmd.mirror.create(mirror_root, specs)
 
             # Stage directory exists
             assert os.path.isdir(mirror_root)
@@ -254,7 +255,7 @@ def test_mirror_with_url_patches(mock_packages, monkeypatch):
         )
 
         with spack.config.override("config:checksum", False):
-            spack.mirrors.utils.create(mirror_root, list(spec.traverse()))
+            spack.cmd.mirror.create(mirror_root, list(spec.traverse()))
 
         assert {
             "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -17,11 +17,11 @@ import pytest
 
 import spack.binary_distribution
 import spack.cmd.buildcache as buildcache
+import spack.cmd.mirror
 import spack.concretize
 import spack.config
 import spack.error
 import spack.fetch_strategy
-import spack.mirrors.utils
 import spack.package_base
 import spack.stage
 import spack.util.gpg
@@ -54,7 +54,7 @@ def test_buildcache(mock_archive, tmp_path: pathlib.Path, monkeypatch, mutable_c
 
     # Create the build cache and put it directly into the mirror
     mirror_path = str(tmp_path / "test-mirror")
-    spack.mirrors.utils.create(mirror_path, specs=[])
+    spack.cmd.mirror.create(mirror_path, specs=[])
 
     # register mirror with spack config
     mirrors = {"spack-mirror-test": url_util.path_to_file_url(mirror_path)}

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1464,7 +1464,7 @@ _spack_mirror() {
 _spack_mirror_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --directory -a --all --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -d --directory -a --all -j --parallel -f --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1464,7 +1464,7 @@ _spack_mirror() {
 _spack_mirror_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --directory -a --all -j --parallel -f --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -d --directory -a --all -f --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -j --jobs -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1464,7 +1464,7 @@ _spack_mirror() {
 _spack_mirror_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --directory -a --all -j --parallel -f --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -d --directory -a --all -j --jobs -f --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1464,7 +1464,7 @@ _spack_mirror() {
 _spack_mirror_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --directory -a --all -j --jobs -f --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -d --directory -a --all -j --jobs --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1464,7 +1464,7 @@ _spack_mirror() {
 _spack_mirror_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --directory -a --all -f --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -j --jobs -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -d --directory -a --all -j --parallel -f --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2309,7 +2309,7 @@ complete -c spack -n '__fish_spack_using_command mirror' -s n -l no-checksum -f 
 complete -c spack -n '__fish_spack_using_command mirror' -s n -l no-checksum -d 'do not use checksums to verify downloaded files (unsafe)'
 
 # spack mirror create
-set -g __fish_spack_optspecs_spack_mirror_create h/help d/directory= a/all f/file= exclude-file= exclude-specs= skip-unstable-versions D/dependencies n/versions-per-spec= private j/jobs= U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_mirror_create h/help d/directory= a/all j/parallel= f/file= exclude-file= exclude-specs= skip-unstable-versions D/dependencies n/versions-per-spec= private U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 mirror create' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command mirror create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror create' -s h -l help -d 'show this help message and exit'
@@ -2317,6 +2317,8 @@ complete -c spack -n '__fish_spack_using_command mirror create' -s d -l director
 complete -c spack -n '__fish_spack_using_command mirror create' -s d -l directory -r -d 'directory in which to create mirror'
 complete -c spack -n '__fish_spack_using_command mirror create' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command mirror create' -s a -l all -d 'mirror all versions of all packages in Spack, or all packages in the current environment if there is an active environment (this requires significant time and space)'
+complete -c spack -n '__fish_spack_using_command mirror create' -s j -l parallel -r -f -a parallel
+complete -c spack -n '__fish_spack_using_command mirror create' -s j -l parallel -r -d 'Use a given number of threads to make the mirror (used in combination with -a)'
 complete -c spack -n '__fish_spack_using_command mirror create' -s f -l file -r -f -a file
 complete -c spack -n '__fish_spack_using_command mirror create' -s f -l file -r -d 'file with specs of packages to put in mirror'
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-file -r -f -a exclude_file
@@ -2331,8 +2333,6 @@ complete -c spack -n '__fish_spack_using_command mirror create' -s n -l versions
 complete -c spack -n '__fish_spack_using_command mirror create' -s n -l versions-per-spec -r -d 'the number of versions to fetch for each spec, choose '"'"'all'"'"' to retrieve all versions of each package'
 complete -c spack -n '__fish_spack_using_command mirror create' -l private -f -a private
 complete -c spack -n '__fish_spack_using_command mirror create' -l private -d 'for a private mirror, include non-redistributable packages'
-complete -c spack -n '__fish_spack_using_command mirror create' -s j -l jobs -r -f -a jobs
-complete -c spack -n '__fish_spack_using_command mirror create' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 complete -c spack -n '__fish_spack_using_command mirror create' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command mirror create' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command mirror create' -l reuse -f -a concretizer_reuse

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -601,7 +601,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_enable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap enable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap disable
@@ -609,7 +609,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_disable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap disable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap reset
@@ -624,14 +624,14 @@ set -g __fish_spack_optspecs_spack_bootstrap_root h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap root' -f -a '(__fish_complete_directories)'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap list
 set -g __fish_spack_optspecs_spack_bootstrap_list h/help scope=
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap add
@@ -640,7 +640,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap add' -f -a '(__
 complete -c spack -n '__fish_spack_using_command_pos 1 bootstrap add' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -f -a trust
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -d 'enable the source immediately upon addition'
@@ -817,7 +817,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirro
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -d 'override any configured mirrors with this mirror URL'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -f -a output_file
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -d 'file where rebuild info should be written'
-complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -d 'configuration scope containing mirrors to check'
 
 # spack buildcache download
@@ -1091,7 +1091,7 @@ complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolcha
 complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1105,7 +1105,7 @@ complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchai
 complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1117,7 +1117,7 @@ complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -
 complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler rm
@@ -1127,14 +1127,14 @@ complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler list
 set -g __fish_spack_optspecs_spack_compiler_list h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'list also compilers from registered buildcaches'
@@ -1143,7 +1143,7 @@ complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'li
 set -g __fish_spack_optspecs_spack_compiler_ls h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -d 'list also compilers from registered buildcaches'
@@ -1153,14 +1153,14 @@ set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -d 'list also compilers from registered buildcaches'
@@ -1223,7 +1223,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a update -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a revert -d 'revert configuration files to their state before update'
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
@@ -1775,7 +1775,7 @@ complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -d 'one or more alternative search paths for finding externals'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
 complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
@@ -2358,7 +2358,7 @@ set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsig
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -f -a 'binary source'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -d 'specify the mirror type: for both binary and source use ``--type binary --type source`` (default)'
@@ -2392,7 +2392,7 @@ set -g __fish_spack_optspecs_spack_mirror_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror rm
@@ -2400,7 +2400,7 @@ set -g __fish_spack_optspecs_spack_mirror_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror set-url
@@ -2412,7 +2412,7 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -f -a p
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -d 'set only the URL used for uploading'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -f -a fetch
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -d 'set only the URL used for downloading'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2454,7 +2454,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2479,14 +2479,14 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-var
 set -g __fish_spack_optspecs_spack_mirror_list h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -d 'configuration scope to read from'
 
 # spack mirror ls
 set -g __fish_spack_optspecs_spack_mirror_ls h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -d 'configuration scope to read from'
 
 # spack module
@@ -2799,7 +2799,7 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 set -g __fish_spack_optspecs_spack_repo_list h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo list' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo list' -l names -d 'show configuration names only'
@@ -2810,7 +2810,7 @@ complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -d 'sh
 set -g __fish_spack_optspecs_spack_repo_ls h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -d 'show configuration names only'
@@ -2826,7 +2826,7 @@ complete -c spack -n '__fish_spack_using_command repo add' -l name -r -f -a name
 complete -c spack -n '__fish_spack_using_command repo add' -l name -r -d 'config name for the package repository, defaults to the namespace of the repository'
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
 
 # spack repo set
@@ -2838,7 +2838,7 @@ complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -f 
 complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -d 'destination to clone git repository into'
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
@@ -2846,7 +2846,7 @@ set -g __fish_spack_optspecs_spack_repo_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
 
 # spack repo rm
@@ -2854,7 +2854,7 @@ set -g __fish_spack_optspecs_spack_repo_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
 
 # spack repo migrate
@@ -2874,7 +2874,7 @@ complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -f -a remote
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -d 'name of remote to check for branches, tags, or commits'
-complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
+complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -f -a branch
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -d 'name of a branch to change to'

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2309,7 +2309,7 @@ complete -c spack -n '__fish_spack_using_command mirror' -s n -l no-checksum -f 
 complete -c spack -n '__fish_spack_using_command mirror' -s n -l no-checksum -d 'do not use checksums to verify downloaded files (unsafe)'
 
 # spack mirror create
-set -g __fish_spack_optspecs_spack_mirror_create h/help d/directory= a/all file= exclude-file= exclude-specs= skip-unstable-versions D/dependencies n/versions-per-spec= private f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_mirror_create h/help d/directory= a/all j/parallel= f/file= exclude-file= exclude-specs= skip-unstable-versions D/dependencies n/versions-per-spec= private U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 mirror create' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command mirror create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror create' -s h -l help -d 'show this help message and exit'
@@ -2317,8 +2317,10 @@ complete -c spack -n '__fish_spack_using_command mirror create' -s d -l director
 complete -c spack -n '__fish_spack_using_command mirror create' -s d -l directory -r -d 'directory in which to create mirror'
 complete -c spack -n '__fish_spack_using_command mirror create' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command mirror create' -s a -l all -d 'mirror all versions of all packages in Spack, or all packages in the current environment if there is an active environment (this requires significant time and space)'
-complete -c spack -n '__fish_spack_using_command mirror create' -l file -r -f -a file
-complete -c spack -n '__fish_spack_using_command mirror create' -l file -r -d 'file with specs of packages to put in mirror'
+complete -c spack -n '__fish_spack_using_command mirror create' -s j -l parallel -r -f -a parallel
+complete -c spack -n '__fish_spack_using_command mirror create' -s j -l parallel -r -d 'Use a given number of threads to make the mirror (used in combination with -a)'
+complete -c spack -n '__fish_spack_using_command mirror create' -s f -l file -r -f -a file
+complete -c spack -n '__fish_spack_using_command mirror create' -s f -l file -r -d 'file with specs of packages to put in mirror'
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-file -r -f -a exclude_file
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-file -r -d 'specs which Spack should not try to add to a mirror (listed in a file, one per line)'
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-specs -r -f -a exclude_specs

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -601,7 +601,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_enable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap enable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap disable
@@ -609,7 +609,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_disable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap disable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap reset
@@ -624,14 +624,14 @@ set -g __fish_spack_optspecs_spack_bootstrap_root h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap root' -f -a '(__fish_complete_directories)'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap list
 set -g __fish_spack_optspecs_spack_bootstrap_list h/help scope=
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap add
@@ -640,7 +640,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap add' -f -a '(__
 complete -c spack -n '__fish_spack_using_command_pos 1 bootstrap add' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -f -a trust
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -d 'enable the source immediately upon addition'
@@ -817,7 +817,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirro
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -d 'override any configured mirrors with this mirror URL'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -f -a output_file
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -d 'file where rebuild info should be written'
-complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -d 'configuration scope containing mirrors to check'
 
 # spack buildcache download
@@ -1091,7 +1091,7 @@ complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolcha
 complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1105,7 +1105,7 @@ complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchai
 complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1117,7 +1117,7 @@ complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -
 complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler rm
@@ -1127,14 +1127,14 @@ complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler list
 set -g __fish_spack_optspecs_spack_compiler_list h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'list also compilers from registered buildcaches'
@@ -1143,7 +1143,7 @@ complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'li
 set -g __fish_spack_optspecs_spack_compiler_ls h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -d 'list also compilers from registered buildcaches'
@@ -1153,14 +1153,14 @@ set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -d 'list also compilers from registered buildcaches'
@@ -1223,7 +1223,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a update -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a revert -d 'revert configuration files to their state before update'
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
@@ -1775,7 +1775,7 @@ complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -d 'one or more alternative search paths for finding externals'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
 complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
@@ -2309,7 +2309,7 @@ complete -c spack -n '__fish_spack_using_command mirror' -s n -l no-checksum -f 
 complete -c spack -n '__fish_spack_using_command mirror' -s n -l no-checksum -d 'do not use checksums to verify downloaded files (unsafe)'
 
 # spack mirror create
-set -g __fish_spack_optspecs_spack_mirror_create h/help d/directory= a/all j/parallel= f/file= exclude-file= exclude-specs= skip-unstable-versions D/dependencies n/versions-per-spec= private U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_mirror_create h/help d/directory= a/all j/jobs= file= exclude-file= exclude-specs= skip-unstable-versions D/dependencies n/versions-per-spec= private f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 mirror create' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command mirror create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror create' -s h -l help -d 'show this help message and exit'
@@ -2317,10 +2317,10 @@ complete -c spack -n '__fish_spack_using_command mirror create' -s d -l director
 complete -c spack -n '__fish_spack_using_command mirror create' -s d -l directory -r -d 'directory in which to create mirror'
 complete -c spack -n '__fish_spack_using_command mirror create' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command mirror create' -s a -l all -d 'mirror all versions of all packages in Spack, or all packages in the current environment if there is an active environment (this requires significant time and space)'
-complete -c spack -n '__fish_spack_using_command mirror create' -s j -l parallel -r -f -a parallel
-complete -c spack -n '__fish_spack_using_command mirror create' -s j -l parallel -r -d 'Use a given number of threads to make the mirror (used in combination with -a)'
-complete -c spack -n '__fish_spack_using_command mirror create' -s f -l file -r -f -a file
-complete -c spack -n '__fish_spack_using_command mirror create' -s f -l file -r -d 'file with specs of packages to put in mirror'
+complete -c spack -n '__fish_spack_using_command mirror create' -s j -l jobs -r -f -a jobs
+complete -c spack -n '__fish_spack_using_command mirror create' -s j -l jobs -r -d 'Use a given number of workers to make the mirror (used in combination with -a)'
+complete -c spack -n '__fish_spack_using_command mirror create' -l file -r -f -a file
+complete -c spack -n '__fish_spack_using_command mirror create' -l file -r -d 'file with specs of packages to put in mirror'
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-file -r -f -a exclude_file
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-file -r -d 'specs which Spack should not try to add to a mirror (listed in a file, one per line)'
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-specs -r -f -a exclude_specs
@@ -2333,6 +2333,8 @@ complete -c spack -n '__fish_spack_using_command mirror create' -s n -l versions
 complete -c spack -n '__fish_spack_using_command mirror create' -s n -l versions-per-spec -r -d 'the number of versions to fetch for each spec, choose '"'"'all'"'"' to retrieve all versions of each package'
 complete -c spack -n '__fish_spack_using_command mirror create' -l private -f -a private
 complete -c spack -n '__fish_spack_using_command mirror create' -l private -d 'for a private mirror, include non-redistributable packages'
+complete -c spack -n '__fish_spack_using_command mirror create' -s f -l force -f -a concretizer_force
+complete -c spack -n '__fish_spack_using_command mirror create' -s f -l force -d 'allow changes to concretized specs in spack.lock (in an env)'
 complete -c spack -n '__fish_spack_using_command mirror create' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command mirror create' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command mirror create' -l reuse -f -a concretizer_reuse
@@ -2356,7 +2358,7 @@ set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsig
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -f -a 'binary source'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -d 'specify the mirror type: for both binary and source use ``--type binary --type source`` (default)'
@@ -2390,7 +2392,7 @@ set -g __fish_spack_optspecs_spack_mirror_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror rm
@@ -2398,7 +2400,7 @@ set -g __fish_spack_optspecs_spack_mirror_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror set-url
@@ -2410,7 +2412,7 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -f -a p
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -d 'set only the URL used for uploading'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -f -a fetch
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -d 'set only the URL used for downloading'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2452,7 +2454,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2477,14 +2479,14 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-var
 set -g __fish_spack_optspecs_spack_mirror_list h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -d 'configuration scope to read from'
 
 # spack mirror ls
 set -g __fish_spack_optspecs_spack_mirror_ls h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -d 'configuration scope to read from'
 
 # spack module
@@ -2797,7 +2799,7 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 set -g __fish_spack_optspecs_spack_repo_list h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo list' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo list' -l names -d 'show configuration names only'
@@ -2808,7 +2810,7 @@ complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -d 'sh
 set -g __fish_spack_optspecs_spack_repo_ls h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -d 'show configuration names only'
@@ -2824,7 +2826,7 @@ complete -c spack -n '__fish_spack_using_command repo add' -l name -r -f -a name
 complete -c spack -n '__fish_spack_using_command repo add' -l name -r -d 'config name for the package repository, defaults to the namespace of the repository'
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
 
 # spack repo set
@@ -2836,7 +2838,7 @@ complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -f 
 complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -d 'destination to clone git repository into'
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
@@ -2844,7 +2846,7 @@ set -g __fish_spack_optspecs_spack_repo_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
 
 # spack repo rm
@@ -2852,7 +2854,7 @@ set -g __fish_spack_optspecs_spack_repo_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
 
 # spack repo migrate
@@ -2872,7 +2874,7 @@ complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -f -a remote
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -d 'name of remote to check for branches, tags, or commits'
-complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults system site user env:test-env command_line'
 complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -f -a branch
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -d 'name of a branch to change to'

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2309,7 +2309,7 @@ complete -c spack -n '__fish_spack_using_command mirror' -s n -l no-checksum -f 
 complete -c spack -n '__fish_spack_using_command mirror' -s n -l no-checksum -d 'do not use checksums to verify downloaded files (unsafe)'
 
 # spack mirror create
-set -g __fish_spack_optspecs_spack_mirror_create h/help d/directory= a/all j/parallel= f/file= exclude-file= exclude-specs= skip-unstable-versions D/dependencies n/versions-per-spec= private U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_mirror_create h/help d/directory= a/all f/file= exclude-file= exclude-specs= skip-unstable-versions D/dependencies n/versions-per-spec= private j/jobs= U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 mirror create' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command mirror create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror create' -s h -l help -d 'show this help message and exit'
@@ -2317,8 +2317,6 @@ complete -c spack -n '__fish_spack_using_command mirror create' -s d -l director
 complete -c spack -n '__fish_spack_using_command mirror create' -s d -l directory -r -d 'directory in which to create mirror'
 complete -c spack -n '__fish_spack_using_command mirror create' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command mirror create' -s a -l all -d 'mirror all versions of all packages in Spack, or all packages in the current environment if there is an active environment (this requires significant time and space)'
-complete -c spack -n '__fish_spack_using_command mirror create' -s j -l parallel -r -f -a parallel
-complete -c spack -n '__fish_spack_using_command mirror create' -s j -l parallel -r -d 'Use a given number of threads to make the mirror (used in combination with -a)'
 complete -c spack -n '__fish_spack_using_command mirror create' -s f -l file -r -f -a file
 complete -c spack -n '__fish_spack_using_command mirror create' -s f -l file -r -d 'file with specs of packages to put in mirror'
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-file -r -f -a exclude_file
@@ -2333,8 +2331,8 @@ complete -c spack -n '__fish_spack_using_command mirror create' -s n -l versions
 complete -c spack -n '__fish_spack_using_command mirror create' -s n -l versions-per-spec -r -d 'the number of versions to fetch for each spec, choose '"'"'all'"'"' to retrieve all versions of each package'
 complete -c spack -n '__fish_spack_using_command mirror create' -l private -f -a private
 complete -c spack -n '__fish_spack_using_command mirror create' -l private -d 'for a private mirror, include non-redistributable packages'
-complete -c spack -n '__fish_spack_using_command mirror create' -s f -l force -f -a concretizer_force
-complete -c spack -n '__fish_spack_using_command mirror create' -s f -l force -d 'allow changes to concretized specs in spack.lock (in an env)'
+complete -c spack -n '__fish_spack_using_command mirror create' -s j -l jobs -r -f -a jobs
+complete -c spack -n '__fish_spack_using_command mirror create' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 complete -c spack -n '__fish_spack_using_command mirror create' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command mirror create' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command mirror create' -l reuse -f -a concretizer_reuse


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR continues the work started by @aquan9 in PR #48411 to improve the `spack mirror create -a` performance through parallelization. Uses the `-j/--jobs` flag to specify the number of workers used when creating a full mirror.

I rebased the changes into the current develop branch and resolved merge conflicts.
