### PR TITLE
Enable concretization caching (redux)

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -91,6 +91,7 @@ concretizer:
   # cases where there are requirements that prevent part of the search space to be explored.
   static_analysis: false
 
+  # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
+  # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.
   concretization_cache:
     enable: true
-    url: $user_cache_path/concretization

--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -90,3 +90,7 @@ concretizer:
   # Static analysis may reduce the concretization time by generating smaller ASP problems, in
   # cases where there are requirements that prevent part of the search space to be explored.
   static_analysis: false
+
+  concretization_cache:
+    enable: true
+    url: $user_cache_path/concretization

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -294,7 +294,7 @@ When ``false`` or omitted, all concretization requests will be performed from sc
 Path to the location where Spack will root the concretization cache.
 Currently this only supports paths on the local filesystem.
 
-Default location is under the :ref:`Misc Cache` at: ``$misc_cache/concretization``
+Default location is under the :ref:`Misc Cache` at: ``$user_cache_path/concretization``
 
 ``concretization_cache:entry_limit``
 ------------------------------------

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -294,7 +294,7 @@ When ``false`` or omitted, all concretization requests will be performed from sc
 Path to the location where Spack will root the concretization cache.
 Currently this only supports paths on the local filesystem.
 
-Default location is under the :ref:`Misc Cache` at: ``$user_cache_path/concretization``
+Default location is under the :ref:`Misc Cache` at: ``$misc_cache/concretization``
 
 ``concretization_cache:entry_limit``
 ------------------------------------

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1761,7 +1761,7 @@ class Database:
             )
 
         results = list(local_results) + list(x for x in upstream_results if x not in local_results)
-        results.sort()  # type: ignore[call-arg]
+        results.sort()  # type: ignore[call-arg,call-overload]
         return results
 
     def query_one(

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -2717,7 +2717,7 @@ def temporary_file_position(stream):
 
 
 @contextmanager
-def current_file_position(stream: IO[str], loc: int, relative_to=io.SEEK_CUR):
+def current_file_position(stream: IO, loc: int, relative_to=io.SEEK_CUR):
     with temporary_file_position(stream):
         stream.seek(loc, relative_to)
         yield

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -116,9 +116,6 @@ default_user_bootstrap_path = os.path.join(user_cache_path, "bootstrap")
 #: transient caches for Spack data (virtual cache, patch sha256 lookup, etc.)
 default_misc_cache_path = os.path.join(user_cache_path, spack_instance_id, "cache")
 
-#: concretization cache for Spack concretizations
-default_conc_cache_path = os.path.join(default_misc_cache_path, "concretization")
-
 # Below paths pull configuration from the host environment.
 #
 # There are three environment variables you can use to isolate spack from

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -102,7 +102,6 @@ properties: Dict[str, Any] = {
                     "enable": {"type": "boolean"},
                     "url": {"type": "string"},
                     "entry_limit": {"type": "integer", "minimum": 0},
-                    "size_limit": {"type": "integer", "minimum": 0},
                 },
             },
         },

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -96,6 +96,15 @@ properties: Dict[str, Any] = {
             "timeout": {"type": "integer", "minimum": 0},
             "error_on_timeout": {"type": "boolean"},
             "os_compatible": {"type": "object", "additionalProperties": {"type": "array"}},
+            "concretization_cache": {
+                "type": "object",
+                "properties": {
+                    "enable": {"type": "boolean"},
+                    "url": {"type": "string"},
+                    "entry_limit": {"type": "integer", "minimum": 0},
+                    "size_limit": {"type": "integer", "minimum": 0},
+                },
+            },
         },
     }
 }

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -46,15 +46,6 @@ properties: Dict[str, Any] = {
                     **spack.schema.projections.properties,
                 },
             },
-            "concretization_cache": {
-                "type": "object",
-                "properties": {
-                    "enable": {"type": "boolean"},
-                    "url": {"type": "string"},
-                    "entry_limit": {"type": "integer", "minimum": 0},
-                    "size_limit": {"type": "integer", "minimum": 0},
-                },
-            },
             "install_hash_length": {"type": "integer", "minimum": 1},
             "build_stage": {
                 "oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -703,8 +703,11 @@ class ConcretizationCache:
         """Removes cache entries with handling for the case where the entry has been
         removed already or there are multiple cache entries in a directory"""
         try:
-            cache_dir.unlink(missing_ok=True)
+            cache_dir.unlink()
             return True
+        except FileNotFoundError:
+            # That's fine, removal is idempotent
+            pass
         except OSError as e:
             # Catch other timing/access related issues
             tty.debug(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3201,9 +3201,9 @@ class SpackSolverSetup:
                                 symbol = AspFunction(name)(arg.string)
                                 if _use_unsat_cores:
                                     self.assumptions.append((parse_term(str(symbol)), True))
-                                    self.gen.asp_problem.append(f"{{ {symbol} }}.\n")
+                                    self.gen.asp_problem.append(f"{{{symbol}}}.")
                                 else:
-                                    self.gen.asp_problem.append(f"{symbol}.\n")
+                                    self.gen.asp_problem.append(f"{symbol}.")
 
         path = os.path.join(parent_dir, "concretize.lp")
         parse_files([path], visit)
@@ -3482,14 +3482,17 @@ class ProblemInstanceBuilder:
         self.asp_problem: List[str] = []
 
     def fact(self, atom: AspFunction) -> None:
-        self.asp_problem.append(f"{atom}.\n")
+        self.asp_problem.append(f"{atom}.")
 
     def append(self, rule: str) -> None:
         self.asp_problem.append(rule)
 
     def title(self, header: str, char: str) -> None:
         sep = char * 76
-        self.asp_problem.append(f"\n%{sep}\n% {header}\n%{sep}\n")
+        self.newline()
+        self.asp_problem.append(f"%{sep}")
+        self.asp_problem.append(f"% {header}")
+        self.asp_problem.append(f"%{sep}")
 
     def h1(self, header: str) -> None:
         self.title(header, "=")
@@ -3498,10 +3501,10 @@ class ProblemInstanceBuilder:
         self.title(header, "-")
 
     def h3(self, header: str):
-        self.asp_problem.append(f"% {header}\n")
+        self.asp_problem.append(f"% {header}")
 
     def newline(self):
-        self.asp_problem.append("\n")
+        self.asp_problem.append("")
 
     def value(self, randomize: bool = False) -> str:
         """Return the ASP problem as a string that can be loaded directly by clingo.
@@ -3513,7 +3516,7 @@ class ProblemInstanceBuilder:
         value = self.asp_problem
         if randomize:
             value = random.sample(value, len(value))  # create a shuffled copy
-        return "".join(value)
+        return "\n".join(value)
 
 
 def possible_compilers(*, configuration) -> Tuple[Set["spack.spec.Spec"], Set["spack.spec.Spec"]]:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -651,7 +651,7 @@ class ConcretizationCache:
         self._lockfile = self.root / ".cc_lock"
 
     def cleanup(self):
-        """Prunes the concretization cache according to configured size and entry
+        """Prunes the concretization cache according to configured entry
         count limits. Cleanup is done in LRU ordering."""
         entry_limit = spack.config.get("concretizer:concretization_cache:entry_limit", 1000)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -681,7 +681,7 @@ class ConcretizationCache:
             # make it through every entry in the queue and dont exit, exit anyway
             while entry_count > (entry_limit // 2) and removal_queue:
                 # entries are descending, so least recently used is last entry
-                entry_to_rm = removal_queue.pop()
+                entry_to_rm = removal_queue.pop()[0]
                 # short timeout, if we can't get a lock, its being read, so it's been used
                 # more recently, i.e. not a good candidate for LRU, or the system is busy,
                 # or it's already being removed so we dont care. Could also be a write

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -836,13 +836,7 @@ class ConcretizationCache:
             if locked:
                 lock.release_write()
 
-    def store(
-        self,
-        problem: str,
-        result: Result,
-        statistics: List,
-        test: spack.concretize.TestsType = False,
-    ) -> None:
+    def store(self, problem: str, result: Result, statistics: List) -> None:
         """Creates entry in concretization cache for problem if none exists,
         storing the concretization Result object and statistics in the cache
         as serialized json joined as a single file.
@@ -1326,7 +1320,7 @@ class PyclingoDriver:
             problem_repr = "\n".join(problem)
             result = self._run_clingo(specs, setup, problem_repr, control_file_paths, timer)
             if conc_cache_enabled:
-                CONC_CACHE.store(cache_key, result, self.control.statistics, test=setup.tests)
+                CONC_CACHE.store(cache_key, result, self.control.statistics)
 
         if output.timers:
             timer.write_tty()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -580,7 +580,11 @@ class Result:
         if spec_list:
             spec_list = [_str_to_spec(x) for x in spec_list]
         result = Result(spec_list, asp)
-        result.criteria = obj.get("criteria")
+
+        criteria = obj.get("criteria")
+        result.criteria = (
+            None if criteria is None else [OptimizationCriteria(*t) for t in criteria]
+        )
         result.optimal = obj.get("optimal")
         result.warnings = obj.get("warnings")
         result.nmodels = obj.get("nmodels")
@@ -601,6 +605,28 @@ class Result:
             result._concrete_specs_by_input[_str_to_spec(input)] = _dict_to_spec(spec)
             result._concrete_specs.append(_dict_to_spec(spec))
         return result
+
+    def __eq__(self, other):
+        eq = (
+            self.asp == other.asp,
+            self.satisfiable == other.satisfiable,
+            self.optimal == other.optimal,
+            self.warnings == other.warnings,
+            self.nmodels == other.nmodels,
+            self.criteria == other.criteria,
+            self.answers == other.answers,
+            self.abstract_specs == other.abstract_specs,
+            self._concrete_specs_by_input == other._concrete_specs_by_input,
+            self._concrete_specs == other._concrete_specs,
+            self._unsolved_specs == other._unsolved_specs,
+            # Not considered for equality
+            # self.control
+            # self.possible_dependencies
+            # self.cores
+            # self.possible_dependencies
+        )
+        print(eq)
+        return all(eq)
 
 
 class ConcretizationCache:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -649,72 +649,65 @@ class ConcretizationCache:
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
         self.root.mkdir(parents=True, exist_ok=True)
         self._lockfile = self.root / ".cc_lock"
-        self._default_lock_timeout = 120
 
     def cleanup(self):
         """Prunes the concretization cache according to configured size and entry
         count limits. Cleanup is done in LRU ordering."""
         entry_limit = spack.config.get("concretizer:concretization_cache:entry_limit", 1000)
-        bytes_limit = spack.config.get("concretizer:concretization_cache:size_limit", 3e8)
 
-        entry_count, bytes_count = 0, 0
-        rm_reg: Dict[pathlib.Path, Tuple[float, int]] = {}
-        for entry in self.cache_entries():
-            # short timeout, if we can't access it, its either being cleaned
-            # or being used, either way, we don't need to bother here
-            with self.read_transaction(entry, timeout=10) as f:
-                if not f:
-                    # cache entry doesn't exist, was likely already removed
-                    # move on
-                    continue
-                # get info about entry for cleanup
-                entry_stat_info = entry.stat()
-                entry_size = entry_stat_info.st_size
-                # aggregate information about cache to determine if cleanup is required
-                entry_count += 1
-                bytes_count += entry_size
-                # get time of last use so we can implement an LRU removal
-                access_time = entry_stat_info.st_atime
-                mod_time = entry_stat_info.st_mtime
-                most_recent_op_time = access_time if access_time > mod_time else mod_time
-                rm_reg[entry] = (most_recent_op_time, entry_size)
-        # Sort entries in descending order
-        removal_queue = [
-            (entry, stats)
-            for entry, stats in sorted(rm_reg.items(), key=lambda x: x[1][0], reverse=True)
-        ]
-        while (entry_count > entry_limit or bytes_count > bytes_limit) and removal_queue:
-            # entries are descending, so least recently used is last entry
-            entry_info_to_rm = removal_queue.pop()
-            entry_to_rm = entry_info_to_rm[0]
-            entry_stats = entry_info_to_rm[1]
-            # short timeout, if we can't get a lock, its being read, so it's been used
-            # more recently, i.e. not a good candidate for LRU, or it's already being removed
-            # so we dont care. Could also be a write lock from another clean operation
-            # in which case that operation can remove it
-            with self.write_transaction(entry_to_rm, timeout=10) as exists:
-                # cache bucket was removed by another process, that's fine
-                # try pruning something else
-                if not exists:
-                    # entry was likely removed by another cleaning
-                    # process, no worries
-                    tty.debug(
-                        f"Attempting to purge concretization cache entry {entry_to_rm}"
-                        " but it was already removed"
-                    )
-                    continue
-                entry_size = entry_stats[1]
-                removed = self._safe_remove(entry_to_rm)
-                if removed:
-                    entry_count -= 1
-                    bytes_count -= entry_size
+        # determine if we even need to clean up
+        entries = list(self.cache_entries())
+        entry_count = sum(1 for _ in entries)
+        # we have too many entries
+        if entry_count > entry_limit:
+            removal_queue = []
+            # collect stat info for mod time about all entries
+            for entry in entries:
+                # take read transaction so we can guaruntee the file
+                # we're trying to stat exists
+                with self.read_transaction(entry, timeout=1e-6) as exists:
+                    # if file doesn't exist, we probably don't need to
+                    # worry about cleanup
+                    if exists:
+                        entry_stat_info = entry.stat()
+                        # mtime will always be time of last use as we update it after 
+                        # each read and obviously after each write
+                        mod_time = entry_stat_info.st_mtime
+                        removal_queue.append((entry, mod_time))
+            # sort items for removal 
+            removal_queue.sort(key=lambda x: x[1], reverse=True)
+
+            # try to remove half the current cache, but if we for some reason
+            # make it through every entry in the queue and dont exit, exit anyway
+            while entry_count > (entry_limit // 2) and removal_queue:
+                # entries are descending, so least recently used is last entry
+                entry_to_rm = removal_queue.pop()
+                # short timeout, if we can't get a lock, its being read, so it's been used
+                # more recently, i.e. not a good candidate for LRU, or it's already being removed
+                # so we dont care. Could also be a write lock from another clean operation
+                # in which case that operation can remove it
+                with self.write_transaction(entry_to_rm, timeout=1e-6) as exists:
+                    # cache bucket was removed by another process, that's fine
+                    # try pruning something else
+                    if not exists:
+                        # entry was likely removed by another cleaning
+                        # process, no worries
+                        tty.debug(
+                            f"Attempting to purge concretization cache entry {entry_to_rm}"
+                            " but it was already removed"
+                        )
+                        removed = True
+                    else:
+                        removed = self._safe_remove(entry_to_rm)
+                    if removed:
+                        entry_count -= 1
 
     def cache_entries(self):
         """Generator producing cache entries within a bucket"""
         for cache_entry in self.root.iterdir():
             # Lockfile starts with "."
             # old style concretization cache entries are in directories
-            if not cache_entry.name.startswith(".") and not cache_entry.is_dir():
+            if not cache_entry.name.startswith(".") and cache_entry.is_file():
                 yield cache_entry
 
     def _results_from_cache(self, cache_entry_file: str) -> Union[Result, None]:
@@ -765,7 +758,7 @@ class ConcretizationCache:
             pass
         return False
 
-    def _lock(self, path: pathlib.Path, timeout: Optional[int] = None) -> lk.Lock:
+    def _lock(self, path: pathlib.Path, timeout: Optional[float] = None) -> lk.Lock:
         """Returns a lock over the byte range correspnding to the hash of the asp problem.
 
         ``path`` is a path to a file in the cache, and its basename is the hash of the problem.
@@ -780,12 +773,12 @@ class ConcretizationCache:
                 path.name, spack.util.crypto.bit_length(sys.maxsize)
             ),
             length=1,
-            default_timeout=timeout if timeout else self._default_lock_timeout,
+            default_timeout=timeout if timeout else None,
             desc=f"Concretization cache lock for {path}",
         )
 
     @contextmanager
-    def read_transaction(self, path: pathlib.Path, timeout: Optional[int] = None):
+    def read_transaction(self, path: pathlib.Path, timeout: Optional[float] = None):
         """Read transactions for concretization cache entries.
 
         Takes a read lock on the cache entry indicated by ``path`` and returns
@@ -796,17 +789,25 @@ class ConcretizationCache:
 
         """
         lock = self._lock(path, timeout=timeout)
-        lock.acquire_read()
-
+        locked = False
         try:
+            # can timeout
+            # if it does, no lock is acquired so we
+            # must be careful about releasing
+            lock.acquire_read()
+            locked = True
             yield path.exists()
+        except lk.LockTimeoutError:
+            # if read lock times out, just exit early
+            tty.debug(f"Concretization cache read lock on {path} timed out")
         except Exception:
             raise
         finally:
-            lock.release_read()
+            if locked:
+                lock.release_read()
 
     @contextmanager
-    def write_transaction(self, path: pathlib.Path, timeout: Optional[int] = None):
+    def write_transaction(self, path: pathlib.Path, timeout: Optional[float] = None):
         """Write transactions for concretization cache entries
 
         Takes a write lock on the cache entry indicated by ``path`` and returns
@@ -819,14 +820,19 @@ class ConcretizationCache:
         # path must be absolute at this point
         assert path.is_absolute()
         lock = self._lock(path, timeout=timeout)
-        lock.acquire_write()
-
+        locked = False
         try:
+            lock.acquire_write()
+            locked = True
             yield path.exists()
+        except lk.LockTimeoutError:
+            # if read lock times out, just exit early
+            tty.debug(f"Concretization cache write lock on {path} timed out")
         except Exception:
             raise
         finally:
-            lock.release_write()
+            if locked:
+                lock.release_write()
 
     def store(
         self,
@@ -868,7 +874,7 @@ class ConcretizationCache:
         """
         cache_path = self._cache_path_from_problem(problem)
         result, statistics = None, None
-        with self.read_transaction(cache_path) as exists:
+        with self.read_transaction(cache_path, timeout=2) as exists:
             # if exists is false, then there's no chance of a hit
             if exists:
                 cache_entry_content = None
@@ -892,6 +898,8 @@ class ConcretizationCache:
                         else:
                             raise
                 if cache_entry_content:
+                    # update mod/access time for use w/ LRU cleanup
+                    os.utime(cache_path)
                     result = self._results_from_cache(cache_entry_content)
                     statistics = self._stats_from_cache(cache_entry_content)
         if result and statistics:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -38,6 +38,7 @@ from typing import (
 import spack.vendor.archspec.cpu
 
 import spack
+import spack.caches
 import spack.compilers.config
 import spack.compilers.flags
 import spack.concretize
@@ -51,7 +52,6 @@ import spack.llnl.util.tty as tty
 import spack.package_base
 import spack.package_prefs
 import spack.patch
-import spack.paths
 import spack.platforms
 import spack.repo
 import spack.solver.splicing
@@ -643,9 +643,9 @@ class ConcretizationCache:
     """
 
     def __init__(self, root: Union[str, None] = None):
-        root = root or spack.config.get(
-            "concretizer:concretization_cache:url", spack.paths.default_conc_cache_path
-        )
+        root = root or spack.config.get("concretizer:concretization_cache:url", None)
+        if root is None:
+            root = os.path.join(spack.caches.misc_cache_location(), "concretization")
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
         self.root.mkdir(parents=True, exist_ok=True)
         self._lockfile = self.root / ".cc_lock"
@@ -1315,7 +1315,7 @@ class PyclingoDriver:
             problem_repr = "\n".join(problem)
             result = self._run_clingo(specs, setup, problem_repr, control_file_paths, timer)
             if conc_cache_enabled:
-                CONC_CACHE.store(problem_repr, result, self.control.statistics, test=setup.tests)
+                CONC_CACHE.store(cache_key, result, self.control.statistics, test=setup.tests)
 
         if output.timers:
             timer.write_tty()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -96,6 +96,10 @@ GitOrStandardVersion = Union[spack.version.GitVersion, spack.version.StandardVer
 
 TransformFunction = Callable[[spack.spec.Spec, List[AspFunction]], List[AspFunction]]
 
+#: strip comments and whitespace from ASP code
+_STRIP_COMMENTS_RE = re.compile(r"\%[^\n]*\n")
+_STRIP_NEWLINES_RE = re.compile(r"\s*\n\s*")
+
 
 class OutputConfiguration(NamedTuple):
     """Data class that contains configuration on what a clingo solve should output."""
@@ -2906,7 +2910,7 @@ class SpackSolverSetup:
         """Define what version_satisfies(...) means in ASP logic."""
 
         for pkg_name, versions in sorted(self.possible_versions.items()):
-            for v in versions:
+            for v in sorted(versions):
                 if v in self.git_commit_versions[pkg_name]:
                     sha = self.git_commit_versions[pkg_name].get(v)
                     if sha:
@@ -3004,8 +3008,8 @@ class SpackSolverSetup:
         variant definitions.
 
         """
-        # Tell the concretizer about possible values from specs seen in spec_clauses().
-        # We might want to order these facts by pkg and name if we are debugging.
+        # for determinism, sort by variant ids, not variant def ids (which are object ids)
+        def_info = []
         for pkg_name, variant_def_id, value in sorted(self.variant_values_from_specs):
             try:
                 vid = self.variant_ids_by_def_id[variant_def_id]
@@ -3014,7 +3018,10 @@ class SpackSolverSetup:
                     f"[{__name__}] cannot retrieve id of the {value} variant from {pkg_name}"
                 )
                 continue
+            def_info.append((pkg_name, vid, value))
 
+        # Tell the concretizer about possible values from specs seen in spec_clauses().
+        for pkg_name, vid, value in sorted(def_info):
             self.gen.fact(fn.pkg_fact(pkg_name, fn.variant_possible_value(vid, value)))
 
     def register_concrete_spec(self, spec, possible):
@@ -3564,6 +3571,24 @@ class ProblemInstanceBuilder:
 
     def newline(self):
         self.asp_problem.append("")
+
+    def problem(self, strip: bool = False) -> List[str]:
+        """Return the ASP problem as a list of rules.
+
+        Arguments:
+            strip: strip comments and empty lines.
+        """
+        if not strip:
+            return self.asp_problem
+
+        def strip_statement(stmt: str) -> str:
+            lines = [line for line in stmt.split("\n") if not line.startswith("%")]
+            return "".join(line.strip() for line in lines if line)
+
+        stripped = [strip_statement(stmt) for stmt in self.asp_problem]
+        stripped = [s for s in stripped if s]
+
+        return stripped
 
     def value(self, randomize: bool = False) -> str:
         """Return the ASP problem as a string that can be loaded directly by clingo.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -789,6 +789,7 @@ class ConcretizationCache:
             path: absolute path to the concretization cache entry to be locked
 
         """
+        assert path.is_absolute()
         lock = self._lock(path, timeout=timeout)
         locked = False
         try:
@@ -851,7 +852,7 @@ class ConcretizationCache:
         """
         cache_path = self._cache_path_from_problem(problem)
 
-        with self.write_transaction(cache_path) as exists:
+        with self.write_transaction(cache_path, timeout=30) as exists:
             if exists:
                 # if cache path file exists, we already have a cache
                 # entry for this, likely created by another process

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -765,63 +765,64 @@ class ConcretizationCache:
             pass
         return False
 
-    def _lock(self, problem: pathlib.Path, timeout: Optional[int] = None) -> lk.Lock:
-        """Returns a lock over the byte range correspnding to the hash
-        of the asp problem
+    def _lock(self, path: pathlib.Path, timeout: Optional[int] = None) -> lk.Lock:
+        """Returns a lock over the byte range correspnding to the hash of the asp problem.
+
+        ``path`` is a path to a file in the cache, and its basename is the hash of the problem.
 
         Args:
 
-            problem: Absolute path to concretization cache entry to be locked
+            path: absolute path to concretization cache entry to be locked
         """
         return lk.Lock(
             str(self._lockfile),
             start=spack.util.hash.base32_prefix_bits(
-                problem.name, spack.util.crypto.bit_length(sys.maxsize)
+                path.name, spack.util.crypto.bit_length(sys.maxsize)
             ),
             length=1,
             default_timeout=timeout if timeout else self._default_lock_timeout,
-            desc=f"Concretization cache lock for {problem}",
+            desc=f"Concretization cache lock for {path}",
         )
 
     @contextmanager
-    def read_transaction(self, problem_path: pathlib.Path, timeout: Optional[int] = None):
-        """Read transactions for concretization cache entries
-        Takes a read lock on the cache entry indicated by
-        problem_path and returns control back to the caller
-        releases lock on exit
+    def read_transaction(self, path: pathlib.Path, timeout: Optional[int] = None):
+        """Read transactions for concretization cache entries.
+
+        Takes a read lock on the cache entry indicated by ``path`` and returns
+        control back to the caller releases lock on exit
 
         Args:
-            problem_path: absolute path to the concretization
-                            cache entry to be locked
+            path: absolute path to the concretization cache entry to be locked
+
         """
-        lock = self._lock(problem_path, timeout=timeout)
+        lock = self._lock(path, timeout=timeout)
         lock.acquire_read()
 
         try:
-            yield problem_path.exists()
+            yield path.exists()
         except Exception:
             raise
         finally:
             lock.release_read()
 
     @contextmanager
-    def write_transaction(self, problem_path: pathlib.Path, timeout: Optional[int] = None):
+    def write_transaction(self, path: pathlib.Path, timeout: Optional[int] = None):
         """Write transactions for concretization cache entries
-        Takes a write lock on the cache entry indicated by
-        problem_path and returns control back to the caller
-        releases lock on exit
+
+        Takes a write lock on the cache entry indicated by ``path`` and returns
+        control back to the caller releases lock on exit
 
         Args:
-            problem_path: absolute path to the concretization
-                            cache entry to be locked
+            path: absolute path to the concretization cache entry to be locked
+
         """
         # path must be absolute at this point
-        assert problem_path.is_absolute()
-        lock = self._lock(problem_path, timeout=timeout)
+        assert path.is_absolute()
+        lock = self._lock(path, timeout=timeout)
         lock.acquire_write()
 
         try:
-            yield problem_path.exists()
+            yield path.exists()
         except Exception:
             raise
         finally:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1064,12 +1064,14 @@ class PyclingoDriver:
 
         timer.start("setup")
         output_is_set = output.out is not None
-        asp_problem = setup.setup(
+        problem_builder = setup.setup(
             specs,
             reuse=reuse,
             allow_deprecated=allow_deprecated,
             _use_unsat_cores=not output_is_set,
         )
+
+        asp_problem = problem_builder.value(randomize="SPACK_SOLVER_RANDOMIZATION" in os.environ)
         if output_is_set:
             output.out.write(asp_problem)
         if output.setup_only:
@@ -3017,7 +3019,7 @@ class SpackSolverSetup:
         reuse: Optional[List[spack.spec.Spec]] = None,
         allow_deprecated: bool = False,
         _use_unsat_cores: bool = True,
-    ) -> str:
+    ) -> "ProblemInstanceBuilder":
         """Generate an ASP program with relevant constraints for specs.
 
         This calls methods on the solve driver to set up the problem with
@@ -3029,10 +3031,13 @@ class SpackSolverSetup:
             reuse: list of concrete specs that can be reused
             allow_deprecated: if True adds deprecated versions into the solve
             _use_unsat_cores: if True, use unsat cores for internal errors
+
+        Return:
+            A ProblemInstanceBuilder populated with facts and rules for an ASP solve.
         """
         reuse = reuse or []
         check_packages_exist(specs)
-        self.gen = ProblemInstanceBuilder(randomize="SPACK_SOLVER_RANDOMIZATION" in os.environ)
+        self.gen = ProblemInstanceBuilder()
 
         # Compute possible compilers first, so we can record which dependencies they might inject
         _ = spack.compilers.config.all_compilers(init_config=True)
@@ -3180,7 +3185,7 @@ class SpackSolverSetup:
         self.gen.h1("Internal errors")
         self.internal_errors(_use_unsat_cores=_use_unsat_cores)
 
-        return self.gen.value()
+        return self.gen
 
     def internal_errors(self, *, _use_unsat_cores: bool):
         parent_dir = os.path.dirname(__file__)
@@ -3471,12 +3476,9 @@ class ProblemInstanceBuilder:
 
     The problem instance can be added directly to the "control" structure of clingo.
 
-    Arguments:
-        randomize: whether to randomize the order of facts to the solver. Useful for benchmarking.
     """
 
-    def __init__(self, randomize: bool = False) -> None:
-        self.randomize = randomize
+    def __init__(self) -> None:
         self.asp_problem: List[str] = []
 
     def fact(self, atom: AspFunction) -> None:
@@ -3501,10 +3503,17 @@ class ProblemInstanceBuilder:
     def newline(self):
         self.asp_problem.append("\n")
 
-    def value(self) -> str:
-        if self.randomize:
-            random.shuffle(self.asp_problem)
-        return "".join(self.asp_problem)
+    def value(self, randomize: bool = False) -> str:
+        """Return the ASP problem as a string that can be loaded directly by clingo.
+
+        Arguments:
+            randomize: whether to randomize the order of facts to the solver.
+                Useful for understanding performance variation when benchmarking.
+        """
+        value = self.asp_problem
+        if randomize:
+            value = random.sample(value, len(value))  # create a shuffled copy
+        return "".join(value)
 
 
 def possible_compilers(*, configuration) -> Tuple[Set["spack.spec.Spec"], Set["spack.spec.Spec"]]:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -5,7 +5,7 @@ import collections
 import collections.abc
 import enum
 import errno
-import hashlib
+import gzip
 import io
 import itertools
 import json
@@ -14,26 +14,18 @@ import pathlib
 import pprint
 import random
 import re
+import shutil
 import sys
 import time
 import typing
 import warnings
 from contextlib import contextmanager
-from typing import (
-    IO,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Callable, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type, Union
 
 import spack.vendor.archspec.cpu
+
+import llnl.util.tty as tty
+from llnl.util.lang import elide_list
 
 import spack
 import spack.compilers.config
@@ -65,9 +57,9 @@ import spack.version as vn
 import spack.version.git_ref_lookup
 from spack import traverse
 from spack.compilers.libraries import CompilerPropertyDetector
-from spack.llnl.util.filesystem import current_file_position
 from spack.llnl.util.lang import elide_list
-from spack.util.file_cache import FileCache
+from spack.util.compression import GZipFileType
+from spack.util.file_cache import DirectoryFileCache
 
 from .core import (
     AspFunction,
@@ -608,136 +600,90 @@ class ConcretizationCache:
 
     def __init__(self, root: Union[str, None] = None):
         root = root or spack.config.get(
-            "config:concretization_cache:url", spack.paths.default_conc_cache_path
+            "concretizer:concretization_cache:url", spack.paths.default_conc_cache_path
         )
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
-        self._fc = FileCache(self.root)
-        self._cache_manifest = ".cache_manifest"
-        self._manifest_queue: List[Tuple[pathlib.Path, int]] = []
+        self._fc = DirectoryFileCache(self.root)
 
     def cleanup(self):
         """Prunes the concretization cache according to configured size and entry
         count limits. Cleanup is done in FIFO ordering."""
         # TODO: determine a better default
-        entry_limit = spack.config.get("config:concretization_cache:entry_limit", 1000)
-        bytes_limit = spack.config.get("config:concretization_cache:size_limit", 3e8)
+        entry_limit = spack.config.get("concretizer:concretization_cache:entry_limit", 1000)
+        bytes_limit = spack.config.get("concretizer:concretization_cache:size_limit", 3e8)
         # lock the entire buildcache as we're removing a lot of data from the
         # manifest and cache itself
-        with self._fc.read_transaction(self._cache_manifest) as f:
-            count, cache_bytes = self._extract_cache_metadata(f)
-            if not count or not cache_bytes:
-                return
-            entry_count = int(count)
-            manifest_bytes = int(cache_bytes)
-            # move beyond the metadata entry
-            f.readline()
-            if entry_count > entry_limit and entry_limit > 0:
-                with self._fc.write_transaction(self._cache_manifest) as (old, new):
-                    # prune the oldest 10% or until we have removed 10% of
-                    # total bytes starting from oldest entry
-                    # TODO: make this configurable?
-                    prune_count = entry_limit // 10
-                    lines_to_prune = f.readlines(prune_count)
-                    for i, line in enumerate(lines_to_prune):
-                        sha, cache_entry_bytes = self._parse_manifest_entry(line)
-                        if sha and cache_entry_bytes:
-                            cache_path = self._cache_path_from_hash(sha)
-                            if self._fc.remove(cache_path):
-                                entry_count -= 1
-                                manifest_bytes -= int(cache_entry_bytes)
-                        else:
-                            tty.warn(
-                                f"Invalid concretization cache entry: '{line}' on line: {i+1}"
-                            )
-                    self._write_manifest(f, entry_count, manifest_bytes)
+        entry_count, bytes_count = 0, 0
+        rm_reg: List[pathlib.Path] = []
+        for bucket in self.cache_buckets():
+            with self._fc.read_transaction(bucket) as f:
+                if not f:
+                    raise RuntimeError(
+                        "Attempting to clean non existent cache bucket" f" {bucket.name}"
+                    )
+                # advance new beyond metadata entry
+                for entry in self.cache_entries(bucket):
+                    entry_count += 1
+                    bytes_count += entry.stat().st_size
+                    rm_reg.append(entry)
+        rm_reg.sort(key=lambda x: x.stat().st_mtime, reverse=True)
+        while (entry_count > entry_limit or bytes_count > bytes_limit) and rm_reg:
+            entry_to_rm = rm_reg.pop()
+            entry_bucket = self._cache_bucket_from_path(entry_to_rm)
+            with self._fc.write_transaction(entry_bucket) as valid_bucket:
+                # cache bucket was removed by another process, that's fine
+                # try pruning something else
+                if not valid_bucket:
+                    continue
+                entry_size = entry_to_rm.stat().st_size
+                removed = self._safe_remove(entry_to_rm)
+                if removed:
+                    entry_count -= 1
+                    bytes_count -= entry_size
+        # remove any buckets with no more cache entries
+        for cache_bucket in self.cache_buckets():
+            # remove takes a write lock, but there's a race
+            # if another process adds something to the bucket
+            # between the check for emptiness and the remove
+            removed = False
+            with self._fc.write_transaction(cache_bucket) as bucket:
+                if bucket and not any(cache_bucket.iterdir()):
+                    self._fc.remove(cache_bucket)
+                    removed = True
+            if removed:
+                self._fc.purge_lock(cache_bucket)
 
-            elif manifest_bytes > bytes_limit and bytes_limit > 0:
-                with self._fc.write_transaction(self._cache_manifest) as (old, new):
-                    # take 10% of current size off
-                    prune_amount = bytes_limit // 10
-                    total_pruned = 0
-                    i = 0
-                    while total_pruned < prune_amount:
-                        sha, manifest_cache_bytes = self._parse_manifest_entry(f.readline())
-                        if sha and manifest_cache_bytes:
-                            entry_bytes = int(manifest_cache_bytes)
-                            cache_path = self.root / sha[:2] / sha
-                            if self._safe_remove(cache_path):
-                                entry_count -= 1
-                                entry_bytes -= entry_bytes
-                                total_pruned += entry_bytes
-                        else:
-                            tty.warn(
-                                "Invalid concretization cache entry "
-                                f"'{sha} {manifest_cache_bytes}' on line: {i}"
-                            )
-                        i += 1
-                    self._write_manifest(f, entry_count, manifest_bytes)
-            for cache_dir in self.root.iterdir():
-                if cache_dir.is_dir() and not any(cache_dir.iterdir()):
-                    self._safe_remove(cache_dir)
+    def cache_buckets(self):
+        """Generator producing cache buckets"""
+        for bucket in self.root.iterdir():
+            # skip bucket lockfiles
+            if bucket.is_dir():
+                yield bucket
 
-    def cache_entries(self):
-        """Generator producing cache entries"""
-        for cache_dir in self.root.iterdir():
-            # ensure component is cache entry directory
-            # not metadata file
-            if cache_dir.is_dir():
-                for cache_entry in cache_dir.iterdir():
-                    if not cache_entry.is_dir():
-                        yield cache_entry
-                    else:
-                        raise RuntimeError(
-                            "Improperly formed concretization cache. "
-                            f"Directory {cache_entry.name} is improperly located "
-                            "within the concretization cache."
-                        )
+    def cache_entries(self, bucket: pathlib.Path):
+        """Generator producing cache entries within a bucket"""
+        for cache_entry in bucket.iterdir():
+            if not cache_entry.is_dir():
+                yield cache_entry
+            else:
+                raise RuntimeError(
+                    "Improperly formed concretization cache. "
+                    f"Directory {cache_entry.name} is improperly located "
+                    "within the concretization cache."
+                )
 
-    def _parse_manifest_entry(self, line):
-        """Returns parsed manifest entry lines
-        with handling for invalid reads."""
-        if line:
-            cache_values = line.strip("\n").split(" ")
-            if len(cache_values) < 2:
-                tty.warn(f"Invalid cache entry at {line}")
-                return None, None
-        return None, None
-
-    def _write_manifest(self, manifest_file, entry_count, entry_bytes):
-        """Writes new concretization cache manifest file.
-
-        Arguments:
-            manifest_file: IO stream opened for readin
-                            and writing wrapping the manifest file
-                            with cursor at calltime set to location
-                            where manifest should be truncated
-            entry_count: new total entry count
-            entry_bytes: new total entry bytes count
-
-        """
-        persisted_entries = manifest_file.readlines()
-        manifest_file.truncate(0)
-        manifest_file.write(f"{entry_count} {entry_bytes}\n")
-        manifest_file.writelines(persisted_entries)
-
-    def _results_from_cache(self, cache_entry_buffer: IO[str]) -> Union[Result, None]:
+    def _results_from_cache(self, cache_entry_file: str) -> Union[Result, None]:
         """Returns a Results object from the concretizer cache
 
         Reads the cache hit and uses `Result`'s own deserializer
         to produce a new Result object
         """
 
-        with current_file_position(cache_entry_buffer, 0):
-            cache_str = cache_entry_buffer.read()
-            # TODO: Should this be an error if None?
-            # Same for _stats_from_cache
-            if cache_str:
-                cache_entry = json.loads(cache_str)
-                result_json = cache_entry["results"]
-                return Result.from_dict(result_json)
-        return None
+        cache_entry = json.loads(cache_entry_file)
+        result_json = cache_entry["results"]
+        return Result.from_dict(result_json)
 
-    def _stats_from_cache(self, cache_entry_buffer: IO[str]) -> Union[List, None]:
+    def _stats_from_cache(self, cache_entry_file: str) -> Union[List, None]:
         """Returns concretization statistic from the
         concretization associated with the cache.
 
@@ -745,23 +691,12 @@ class ConcretizationCache:
         statistics covering the cached concretization run
         and returns the Python data structures
         """
-        with current_file_position(cache_entry_buffer, 0):
-            cache_str = cache_entry_buffer.read()
-            if cache_str:
-                return json.loads(cache_str)["statistics"]
-        return None
-
-    def _extract_cache_metadata(self, cache_stream: IO[str]):
-        """Extracts and returns cache entry count and bytes count from head of manifest
-        file"""
-        # make sure we're always reading from the beginning of the stream
-        # concretization cache manifest data lives at the top of the file
-        with current_file_position(cache_stream, 0):
-            return self._parse_manifest_entry(cache_stream.readline())
+        return json.loads(cache_entry_file)["statistics"]
 
     def _prefix_digest(self, problem: str) -> Tuple[str, str]:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
-        prob_digest = hashlib.sha256(problem.encode()).hexdigest()
+        # compress the problem w/ gzip so we can validate checksum w/o decompressing
+        prob_digest = spack.util.hash.b32_hash(problem)
         prefix = prob_digest[:2]
         return prefix, prob_digest
 
@@ -771,51 +706,21 @@ class ConcretizationCache:
         prefix, digest = self._prefix_digest(problem)
         return pathlib.Path(prefix) / digest
 
+    def _cache_bucket_from_path(self, cache_entry: pathlib.Path) -> str:
+        """Returns the 2 byte cache entry bucket string from a cache entry"""
+        return cache_entry.parent.name
+
     def _cache_path_from_hash(self, hash: str) -> pathlib.Path:
         """Returns a Path object representing the cache entry
         corresponding to the given sha256 hash"""
         return pathlib.Path(hash[:2]) / hash
 
-    def _lock_prefix_from_cache_path(self, cache_path: str):
-        """Returns the bit location corresponding to a given cache entry path
-        for file locking"""
-        return spack.util.hash.base32_prefix_bits(
-            spack.util.hash.b32_hash(cache_path), spack.util.crypto.bit_length(sys.maxsize)
-        )
-
-    def flush_manifest(self):
-        """Updates the concretization cache manifest file after a cache write operation
-        Updates the current byte count and entry counts and writes to the head of the
-        manifest file"""
-        manifest_file = self.root / self._cache_manifest
-        manifest_file.touch(exist_ok=True)
-        with open(manifest_file, "r+", encoding="utf-8") as f:
-            # check if manifest is empty
-            count, cache_bytes = self._extract_cache_metadata(f)
-            if not count or not cache_bytes:
-                # cache is unintialized
-                count = 0
-                cache_bytes = 0
-            f.seek(0, io.SEEK_END)
-            for manifest_update in self._manifest_queue:
-                entry_path, entry_bytes = manifest_update
-                count += 1
-                cache_bytes += entry_bytes
-                f.write(f"{entry_path.name} {entry_bytes}")
-            f.seek(0, io.SEEK_SET)
-            new_stats = f"{int(count)+1} {int(cache_bytes)}\n"
-            f.write(new_stats)
-
-    def _register_cache_update(self, cache_path: pathlib.Path, bytes_written: int):
-        """Adds manifest entry to update queue for later updates to the manifest"""
-        self._manifest_queue.append((cache_path, bytes_written))
-
-    def _safe_remove(self, cache_dir: pathlib.Path):
+    def _safe_remove(self, cache_dir: pathlib.Path) -> bool:
         """Removes cache entries with handling for the case where the entry has been
         removed already or there are multiple cache entries in a directory"""
         try:
             if cache_dir.is_dir():
-                cache_dir.rmdir()
+                shutil.rmtree(cache_dir)
             else:
                 cache_dir.unlink()
             return True
@@ -836,20 +741,21 @@ class ConcretizationCache:
         Hash membership is computed based on the sha256 of the provided asp
         problem.
         """
-        cache_path = self._cache_path_from_problem(problem)
-        if self._fc.init_entry(cache_path):
-            # if an entry for this conc hash exists already, we're don't want
-            # to overwrite, just exit
-            tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
-            return
-        with self._fc.write_transaction(cache_path) as (old, new):
-            if old:
+        bucket, digest = self._prefix_digest(problem)
+        cache_path = self.root / bucket / digest
+        self._fc.init_entry(bucket)
+        with self._fc.write_transaction(bucket) as exists:
+            if not exists:
+                # The directory may have been pruned between init entry and the write
+                # transaction, recreate the directory
+                os.makedirs(bucket)
+            try:
+                with gzip.open(cache_path, "xb", compresslevel=6) as cache_entry:
+                    cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
+                    cache_entry.write(json.dumps(cache_dict).encode())
+            except FileExistsError:
                 # Entry for this conc hash exists already, do not overwrite
                 tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
-                return
-            cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
-            bytes_written = new.write(json.dumps(cache_dict))
-            self._register_cache_update(cache_path, bytes_written)
 
     def fetch(self, problem: str) -> Union[Tuple[Result, List], Tuple[None, None]]:
         """Returns the concretization cache result for a lookup based on the given problem.
@@ -858,12 +764,35 @@ class ConcretizationCache:
         Python objects cached on disk representing the concretization results and statistics
         or returns none if no cache entry was found.
         """
-        cache_path = self._cache_path_from_problem(problem)
+        bucket, entry = self._prefix_digest(problem)
+        cache_path = self.root / bucket / entry
         result, statistics = None, None
-        with self._fc.read_transaction(cache_path) as f:
-            if f:
-                result = self._results_from_cache(f)
-                statistics = self._stats_from_cache(f)
+        self._fc.init_entry(bucket)
+        with self._fc.read_transaction(bucket) as exists:
+            # if exists is false, then there's no chance of a hit
+            # in this bucket, as it does not exist
+            if exists:
+                cache_entry_content = None
+                try:
+                    with gzip.open(cache_path, "rb", compresslevel=6) as f:
+                        f.peek(1)  # Try to read at least one byte
+                        f.seek(0)
+                        cache_entry_content = f.read().decode("utf-8")
+                except FileNotFoundError:
+                    # cache miss
+                    pass
+                except OSError:
+                    # Cache may have been created pre compression
+                    # check if gzip, and if so, read from plaintext
+                    # otherwise re raise
+                    with open(cache_path, "rb") as f:
+                        if GZipFileType().matches_magic(f):
+                            cache_entry_content = f.read().decode()
+                        else:
+                            raise
+                if cache_entry_content:
+                    result = self._results_from_cache(cache_entry_content)
+                    statistics = self._stats_from_cache(cache_entry_content)
         if result and statistics:
             tty.debug(f"Concretization cache hit at {str(cache_path)}")
             return result, statistics
@@ -1115,7 +1044,7 @@ class PyclingoDriver:
                 problem_repr += "\n" + f.read()
 
         result = None
-        conc_cache_enabled = spack.config.get("config:concretization_cache:enable", False)
+        conc_cache_enabled = spack.config.get("concretizer:concretization_cache:enable", False)
         if conc_cache_enabled:
             result, concretization_stats = CONC_CACHE.fetch(problem_repr)
 
@@ -4314,11 +4243,11 @@ class Solver:
         setup = SpackSolverSetup(tests=tests)
         output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=setup_only)
 
-        CONC_CACHE.flush_manifest()
-        CONC_CACHE.cleanup()
-        return self.driver.solve(
+        result = self.driver.solve(
             setup, specs, reuse=reusable_specs, output=output, allow_deprecated=allow_deprecated
         )
+        CONC_CACHE.cleanup()
+        return result
 
     def solve(self, specs, **kwargs):
         """
@@ -4381,7 +4310,6 @@ class Solver:
             for spec in result.specs:
                 reusable_specs.extend(spec.traverse())
 
-        CONC_CACHE.flush_manifest()
         CONC_CACHE.cleanup()
 
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -658,50 +658,41 @@ class ConcretizationCache:
         # determine if we even need to clean up
         entries = list(self.cache_entries())
         entry_count = sum(1 for _ in entries)
-        # we have too many entries
-        if entry_count > entry_limit:
-            removal_queue = []
-            # collect stat info for mod time about all entries
-            for entry in entries:
-                # take read transaction so we can guaruntee the file
-                # we're trying to stat exists
-                with self.read_transaction(entry, timeout=1e-6) as exists:
-                    # if file doesn't exist, we probably don't need to
-                    # worry about cleanup
-                    if exists:
-                        entry_stat_info = entry.stat()
-                        # mtime will always be time of last use as we update it after
-                        # each read and obviously after each write
-                        mod_time = entry_stat_info.st_mtime
-                        removal_queue.append((entry, mod_time))
-            # sort items for removal
-            removal_queue.sort(key=lambda x: x[1], reverse=True)
 
-            # try to remove half the current cache, but if we for some reason
-            # make it through every entry in the queue and dont exit, exit anyway
-            while entry_count > (entry_limit // 2) and removal_queue:
-                # entries are descending, so least recently used is last entry
-                entry_to_rm = removal_queue.pop()[0]
-                # short timeout, if we can't get a lock, its being read, so it's been used
-                # more recently, i.e. not a good candidate for LRU, or the system is busy,
-                # or it's already being removed so we dont care. Could also be a write
-                # lock from another clean operation in which case that operation can
-                # remove it
-                with self.write_transaction(entry_to_rm, timeout=1e-6) as exists:
-                    # cache bucket was removed by another process, that's fine
-                    # try pruning something else
-                    if not exists:
-                        # entry was likely removed by another cleaning
-                        # process, no worries
-                        tty.debug(
-                            f"Attempting to purge concretization cache entry {entry_to_rm}"
-                            " but it was already removed"
-                        )
-                        removed = True
-                    else:
-                        removed = self._safe_remove(entry_to_rm)
-                    if removed:
-                        entry_count -= 1
+        # if we're under the limit, we're done.
+        if entry_count <= entry_limit:
+            return
+
+        removal_queue = []
+        # collect stat info for mod time about all entries
+        for entry in entries:
+            # take read transaction so we can guaruntee the file we're trying to stat exists
+            with self.read_transaction(entry, timeout=1e-6) as exists:
+                # if file doesn't exist, we probably don't need to worry about cleanup
+                if exists:
+                    entry_stat_info = entry.stat()
+                    # mtime will always be time of last use as we update it after
+                    # each read and obviously after each write
+                    mod_time = entry_stat_info.st_mtime
+                    removal_queue.append((mod_time, entry))
+
+        removal_queue.sort()  # sort items for removal, ascending, so oldest first
+
+        # Try to remove the oldest half of the cache.
+        for _, entry_to_rm in removal_queue[: entry_limit // 2]:
+            # short timeout, if we can't get a lock, it's being read, so it's been used
+            # more recently, i.e. not a good candidate for LRU, or the system is busy,
+            # or it's already being removed so we dont care. Could also be a write lock
+            # from another clean operation in which case that operation can remove it
+            with self.write_transaction(entry_to_rm, timeout=1e-6) as exists:
+                # cache bucket was removed by another process. that's fine; move on
+                if not exists:
+                    tty.debug(
+                        f"Attempting to purge concretization cache entry {entry_to_rm},"
+                        " but it was already removed"
+                    )
+                else:
+                    self._safe_remove(entry_to_rm)
 
     def cache_entries(self):
         """Generator producing cache entries within a bucket"""

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1065,7 +1065,7 @@ class PyclingoDriver:
         """
         self.cores = cores
         # This attribute will be reset at each call to solve
-        self.control = None
+        self.control: Any = None  # TODO: fix typing of dynamic clingo import
         self._conc_cache = conc_cache
 
     def _control_file_paths(self, control_files: List[str]) -> List[str]:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -598,7 +598,7 @@ class ConcretizationCache:
             "concretizer:concretization_cache:url", spack.paths.default_conc_cache_path
         )
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
-        self.root.mkdir(exist_ok=True)
+        self.root.mkdir(parents=True, exist_ok=True)
         self._lockfile = self.root / ".cc_lock"
         self._default_lock_timeout = 120
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -793,8 +793,6 @@ class ConcretizationCache:
         except lk.LockTimeoutError:
             # if read lock times out, just exit early
             tty.debug(f"Concretization cache read lock on {path} timed out")
-        except Exception:
-            raise
         finally:
             if locked:
                 lock.release_read()
@@ -821,8 +819,6 @@ class ConcretizationCache:
         except lk.LockTimeoutError:
             # if read lock times out, just exit early
             tty.debug(f"Concretization cache write lock on {path} timed out")
-        except Exception:
-            raise
         finally:
             if locked:
                 lock.release_write()
@@ -844,13 +840,9 @@ class ConcretizationCache:
                 # exit early
                 # just opening it updates atime to indicate recent use
                 return
-            try:
-                with gzip.open(cache_path, "xb", compresslevel=6) as cache_entry:
-                    cache_dict = {"results": result.to_dict(), "statistics": statistics}
-                    cache_entry.write(json.dumps(cache_dict).encode())
-            except FileExistsError:
-                # Entry for this conc hash exists already, do not overwrite
-                tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
+            with gzip.open(cache_path, "xb", compresslevel=6) as cache_entry:
+                cache_dict = {"results": result.to_dict(), "statistics": statistics}
+                cache_entry.write(json.dumps(cache_dict).encode())
 
     def fetch(self, problem: str) -> Union[Tuple[Result, Dict], Tuple[None, None]]:
         """Returns the concretization cache result for a lookup based on the given problem.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -18,19 +18,7 @@ import time
 import typing
 import warnings
 from contextlib import contextmanager
-from typing import (
-    Callable,
-    Dict,
-    Generator,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Callable, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type, Union
 
 import spack.vendor.archspec.cpu
 
@@ -610,6 +598,7 @@ class ConcretizationCache:
             "concretizer:concretization_cache:url", spack.paths.default_conc_cache_path
         )
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
+        self.root.mkdir(exist_ok=True)
         self._lockfile = self.root / ".cc_lock"
         self._default_lock_timeout = 120
 
@@ -671,7 +660,7 @@ class ConcretizationCache:
                     entry_count -= 1
                     bytes_count -= entry_size
 
-    def cache_entries(self) -> Generator[pathlib.Path]:
+    def cache_entries(self):
         """Generator producing cache entries within a bucket"""
         for cache_entry in self.root.iterdir():
             # Lockfile starts with "."

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -13,13 +13,24 @@ import pathlib
 import pprint
 import random
 import re
-import shutil
 import sys
 import time
 import typing
 import warnings
 from contextlib import contextmanager
-from typing import Callable, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type, Union
+from typing import (
+    Callable,
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 import spack.vendor.archspec.cpu
 
@@ -45,6 +56,7 @@ import spack.store
 import spack.util.crypto
 import spack.util.hash
 import spack.util.libc
+import spack.util.lock as lk
 import spack.util.module_cmd as md
 import spack.util.path
 import spack.util.timer
@@ -55,7 +67,6 @@ from spack import traverse
 from spack.compilers.libraries import CompilerPropertyDetector
 from spack.llnl.util.lang import elide_list
 from spack.util.compression import GZipFileType
-from spack.util.file_cache import DirectoryFileCache
 
 from .core import (
     AspFunction,
@@ -599,38 +610,36 @@ class ConcretizationCache:
             "concretizer:concretization_cache:url", spack.paths.default_conc_cache_path
         )
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
-        self._fc = DirectoryFileCache(self.root)
+        self._lockfile = self.root / ".cc_lock"
+        self._default_lock_timeout = 120
 
     def cleanup(self):
         """Prunes the concretization cache according to configured size and entry
-        count limits. Cleanup is done in FIFO ordering."""
-        # TODO: determine a better default
+        count limits. Cleanup is done in LRU ordering."""
         entry_limit = spack.config.get("concretizer:concretization_cache:entry_limit", 1000)
         bytes_limit = spack.config.get("concretizer:concretization_cache:size_limit", 3e8)
-        # lock the entire buildcache as we're removing a lot of data from the
-        # manifest and cache itself
+
         entry_count, bytes_count = 0, 0
         rm_reg: Dict[pathlib.Path, Tuple[float, int]] = {}
-        for bucket in self.cache_buckets():
-            with self._fc.read_transaction(bucket) as f:
+        for entry in self.cache_entries():
+            # short timeout, if we can't access it, its either being cleaned
+            # or being used, either way, we don't need to bother here
+            with self.read_transaction(entry, timeout=10) as f:
                 if not f:
-                    # bucket was likely removed by another cleaning
-                    # process, no worries
-                    tty.debug(
-                        f"Attempting to purge concretization cache bucket {bucket}"
-                        " but it was already removed"
-                    )
+                    # cache entry doesn't exist, was likely already removed
+                    # move on
                     continue
-                # advance new beyond metadata entry
-                for entry in self.cache_entries(bucket):
-                    entry_count += 1
-                    entry_stat_info = entry.stat()
-                    entry_size = entry_stat_info.st_size
-                    bytes_count += entry_size
-                    access_time = entry_stat_info.st_atime
-                    mod_time = entry_stat_info.st_mtime
-                    most_recent_op_time = access_time if access_time > mod_time else mod_time
-                    rm_reg[entry] = (most_recent_op_time, entry_size)
+                # get info about entry for cleanup
+                entry_stat_info = entry.stat()
+                entry_size = entry_stat_info.st_size
+                # aggregate information about cache to determine if cleanup is required
+                entry_count += 1
+                bytes_count += entry_size
+                # get time of last use so we can implement an LRU removal
+                access_time = entry_stat_info.st_atime
+                mod_time = entry_stat_info.st_mtime
+                most_recent_op_time = access_time if access_time > mod_time else mod_time
+                rm_reg[entry] = (most_recent_op_time, entry_size)
         # Sort entries in descending order
         removal_queue = [
             (entry, stats)
@@ -641,53 +650,34 @@ class ConcretizationCache:
             entry_info_to_rm = removal_queue.pop()
             entry_to_rm = entry_info_to_rm[0]
             entry_stats = entry_info_to_rm[1]
-            entry_bucket = self._cache_bucket_from_path(entry_to_rm)
-            with self._fc.write_transaction(entry_bucket) as valid_bucket:
+            # short timeout, if we can't get a lock, its being read, so it's been used
+            # more recently, i.e. not a good candidate for LRU, or it's already being removed
+            # so we dont care. Could also be a write lock from another clean operation
+            # in which case that operation can remove it
+            with self.write_transaction(entry_to_rm, timeout=10) as exists:
                 # cache bucket was removed by another process, that's fine
                 # try pruning something else
-                if not valid_bucket:
+                if not exists:
+                    # entry was likely removed by another cleaning
+                    # process, no worries
+                    tty.debug(
+                        f"Attempting to purge concretization cache entry {entry_to_rm}"
+                        " but it was already removed"
+                    )
                     continue
                 entry_size = entry_stats[1]
                 removed = self._safe_remove(entry_to_rm)
                 if removed:
                     entry_count -= 1
                     bytes_count -= entry_size
-        # remove any buckets with no more cache entries
-        for cache_bucket in self.cache_buckets():
-            # remove takes a write lock, but there's a race
-            # if another process adds something to the bucket
-            # between the check for emptiness and the remove
-            removed = False
-            with self._fc.write_transaction(cache_bucket) as bucket:
-                if bucket and not any(cache_bucket.iterdir()):
-                    self._fc.remove(cache_bucket)
-                    removed = True
-            if removed:
-                try:
-                    self._fc.purge_lock(cache_bucket)
-                except OSError:
-                    # lock was likely taken by another process
-                    # don't clean it, something is using it!
-                    continue
 
-    def cache_buckets(self):
-        """Generator producing cache buckets"""
-        for bucket in self.root.iterdir():
-            # skip bucket lockfiles
-            if bucket.is_dir():
-                yield bucket
-
-    def cache_entries(self, bucket: pathlib.Path):
+    def cache_entries(self) -> Generator[pathlib.Path]:
         """Generator producing cache entries within a bucket"""
-        for cache_entry in bucket.iterdir():
-            if not cache_entry.is_dir():
+        for cache_entry in self.root.iterdir():
+            # Lockfile starts with "."
+            # old style concretization cache entries are in directories
+            if not cache_entry.name.startswith(".") and not cache_entry.is_dir():
                 yield cache_entry
-            else:
-                raise RuntimeError(
-                    "Improperly formed concretization cache. "
-                    f"Directory {cache_entry.name} is improperly located "
-                    "within the concretization cache."
-                )
 
     def _results_from_cache(self, cache_entry_file: str) -> Union[Result, None]:
         """Returns a Results object from the concretizer cache
@@ -710,45 +700,93 @@ class ConcretizationCache:
         """
         return json.loads(cache_entry_file)["statistics"]
 
-    def _prefix_digest(self, problem: str) -> Tuple[str, str]:
+    def _prefix_digest(self, problem: str) -> str:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
-        prob_digest = spack.util.hash.b32_hash(problem)
-        prefix = prob_digest[:2]
-        return prefix, prob_digest
+        return spack.util.hash.b32_hash(problem)
 
     def _cache_path_from_problem(self, problem: str) -> pathlib.Path:
         """Returns a Path object representing the path to the cache
-        entry for the given problem"""
-        prefix, digest = self._prefix_digest(problem)
-        return pathlib.Path(prefix) / digest
-
-    def _cache_bucket_from_path(self, cache_entry: pathlib.Path) -> str:
-        """Returns the 2 byte cache entry bucket string from a cache entry"""
-        return cache_entry.parent.name
-
-    def _cache_path_from_hash(self, hash: str) -> pathlib.Path:
-        """Returns a Path object representing the cache entry
-        corresponding to the given sha256 hash"""
-        return pathlib.Path(hash[:2]) / hash
+        entry for the given problem where the problem is the sha256 of the given asp problem"""
+        prefix = self._prefix_digest(problem)
+        return self.root / prefix
 
     def _safe_remove(self, cache_dir: pathlib.Path) -> bool:
         """Removes cache entries with handling for the case where the entry has been
         removed already or there are multiple cache entries in a directory"""
         try:
-            if cache_dir.is_dir():
-                shutil.rmtree(cache_dir)
-            else:
-                cache_dir.unlink()
+            cache_dir.unlink(missing_ok=True)
             return True
-        except FileNotFoundError:
-            # This is acceptable, removal is idempotent
-            pass
-        except OSError:
+        except OSError as e:
             # Catch other timing/access related issues
+            tty.debug(
+                f"Exception occured while attempting to remove Concretization Cache entry, {e}"
+            )
             pass
         return False
 
-    def store(self, problem: str, result: Result, statistics: List, test: bool = False):
+    def _lock(self, problem: pathlib.Path, timeout: Optional[int] = None) -> lk.Lock:
+        """Returns a lock over the byte range correspnding to the hash
+        of the asp problem
+
+        Args:
+
+            problem: Absolute path to concretization cache entry to be locked
+        """
+        return lk.Lock(
+            str(self._lockfile),
+            start=spack.util.hash.base32_prefix_bits(
+                problem.name, spack.util.crypto.bit_length(sys.maxsize)
+            ),
+            length=1,
+            default_timeout=timeout if timeout else self._default_lock_timeout,
+            desc=f"Concretization cache lock for {problem}",
+        )
+
+    @contextmanager
+    def read_transaction(self, problem_path: pathlib.Path, timeout: Optional[int] = None):
+        """Read transactions for concretization cache entries
+        Takes a read lock on the cache entry indicated by
+        problem_path and returns control back to the caller
+        releases lock on exit
+
+        Args:
+            problem_path: absolute path to the concretization
+                            cache entry to be locked
+        """
+        lock = self._lock(problem_path, timeout=timeout)
+        lock.acquire_read()
+
+        try:
+            yield problem_path.exists()
+        except Exception:
+            raise
+        finally:
+            lock.release_read()
+
+    @contextmanager
+    def write_transaction(self, problem_path: pathlib.Path, timeout: Optional[int] = None):
+        """Write transactions for concretization cache entries
+        Takes a write lock on the cache entry indicated by
+        problem_path and returns control back to the caller
+        releases lock on exit
+
+        Args:
+            problem_path: absolute path to the concretization
+                            cache entry to be locked
+        """
+        # path must be absolute at this point
+        assert problem_path.is_absolute()
+        lock = self._lock(problem_path, timeout=timeout)
+        lock.acquire_write()
+
+        try:
+            yield problem_path.exists()
+        except Exception:
+            raise
+        finally:
+            lock.release_write()
+
+    def store(self, problem: str, result: Result, statistics: List, test: bool = False) -> None:
         """Creates entry in concretization cache for problem if none exists,
         storing the concretization Result object and statistics in the cache
         as serialized json joined as a single file.
@@ -756,14 +794,15 @@ class ConcretizationCache:
         Hash membership is computed based on the sha256 of the provided asp
         problem.
         """
-        bucket, digest = self._prefix_digest(problem)
-        cache_path = self.root / bucket / digest
-        self._fc.init_entry(bucket)
-        with self._fc.write_transaction(bucket) as exists:
-            if not exists:
-                # The directory may have been pruned between init entry and the write
-                # transaction, recreate the directory
-                os.makedirs(bucket)
+        cache_path = self._cache_path_from_problem(problem)
+
+        with self.write_transaction(cache_path) as exists:
+            if exists:
+                # if cache path file exists, we already have a cache
+                # entry for this, likely created by another process
+                # exit early
+                # just opening it updates atime to indicate recent use
+                return
             try:
                 with gzip.open(cache_path, "xb", compresslevel=6) as cache_entry:
                     cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
@@ -779,13 +818,10 @@ class ConcretizationCache:
         Python objects cached on disk representing the concretization results and statistics
         or returns none if no cache entry was found.
         """
-        bucket, entry = self._prefix_digest(problem)
-        cache_path = self.root / bucket / entry
+        cache_path = self._cache_path_from_problem(problem)
         result, statistics = None, None
-        self._fc.init_entry(bucket)
-        with self._fc.read_transaction(bucket) as exists:
+        with self.read_transaction(cache_path) as exists:
             # if exists is false, then there's no chance of a hit
-            # in this bucket, as it does not exist
             if exists:
                 cache_entry_content = None
                 try:
@@ -801,7 +837,7 @@ class ConcretizationCache:
                     # check if gzip, and if not, read from plaintext
                     # otherwise re raise
                     with open(cache_path, "rb") as f:
-                        # ensure the file was not a gzip file we just failed
+                        # ensure the file was not just a gzip file we failed
                         # to open
                         if not GZipFileType().matches_magic(f):
                             cache_entry_content = f.read().decode()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -23,6 +23,7 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    Iterable,
     Iterator,
     List,
     NamedTuple,
@@ -1074,6 +1075,150 @@ class PyclingoDriver:
         # This attribute will be reset at each call to solve
         self.control = None
 
+    def _control_file_paths(self, control_files: List[str]) -> List[str]:
+        """Get absolute paths based on relative paths of control files.
+
+        Right now the control files just live next to this file in the Spack tree.
+        """
+        parent_dir = os.path.dirname(__file__)
+        return [os.path.join(parent_dir, rel_path) for rel_path in control_files]
+
+    def _make_cache_key(self, asp_problem: List[str], control_file_paths: List[str]) -> str:
+        """Make a key for fetching a solve from the concretization cache.
+
+        A key comprises the entire input to clingo, i.e., the problem instance plus the
+        control files.  The problem instance is assumed to already be sorted and stripped of
+        comments and empty lines.
+
+        The control files are stripped but not sorted, so changes to the control files will cause
+        cache misses if they modify any code.
+
+        Arguments:
+            asp_problem: list of statements in the ASP program
+            control_file_paths: list of paths to control files we'll send to clingo
+        """
+        lines = list(asp_problem)
+        for path in control_file_paths:
+            with open(path, "r", encoding="utf-8") as f:
+                lines.extend(strip_asp_problem(f.readlines()))
+
+        return "\n".join(lines)
+
+    def _run_clingo(
+        self,
+        specs: List[spack.spec.Spec],
+        setup: "SpackSolverSetup",
+        problem_str: str,
+        control_file_paths: List[str],
+        timer: spack.util.timer.Timer,
+    ) -> Result:
+        """Actually run clingo and generate a result.
+
+        This is the core solve logic once the setup is done and once we know we can't
+        fetch a result from cache. See ``solve()`` for caching and setup logic.
+        """
+        # We could just take the cache_key and add it to clingo (since it is the
+        # full problem representation), but we load conrol files separately as it
+        # makes clingo give us better, file-aware error messages.
+        with timer.measure("load"):
+            # Add the problem instance
+            self.control.add("base", [], problem_str)
+            # Load additinoal files
+            for path in control_file_paths:
+                self.control.load(path)
+
+        # Grounding is the first step in the solve -- it turns our facts
+        # and first-order logic rules into propositional logic.
+        with timer.measure("ground"):
+            self.control.ground([("base", [])])
+
+        # With a grounded program, we can run the solve.
+        models = []  # stable models if things go well
+        cores: List = []  # unsatisfiable cores if they do not
+
+        def on_model(model):
+            models.append((model.cost, model.symbols(shown=True, terms=True)))
+
+        solve_kwargs = {
+            "assumptions": setup.assumptions,
+            "on_model": on_model,
+            "on_core": cores.append,
+        }
+
+        if clingo_cffi():
+            solve_kwargs["on_unsat"] = cores.append
+
+        timer.start("solve")
+        # A timeout of 0 means no timeout
+        time_limit = spack.config.CONFIG.get("concretizer:timeout", 0)
+        timeout_end = time.monotonic() + time_limit if time_limit > 0 else float("inf")
+        error_on_timeout = spack.config.CONFIG.get("concretizer:error_on_timeout", True)
+        with self.control.solve(**solve_kwargs, async_=True) as handle:
+            # Allow handling of interrupts every second.
+            #
+            # pyclingo's `SolveHandle` blocks the calling thread for the duration of each
+            # `.wait()` call. Python also requires that signal handlers must be handled in
+            # the main thread, so any `KeyboardInterrupt` is postponed until after the
+            # `.wait()` call exits the control of pyclingo.
+            finished = False
+            while not finished and time.monotonic() < timeout_end:
+                finished = handle.wait(1.0)
+
+            if not finished:
+                specs_str = ", ".join(spack.llnl.util.lang.elide_list([str(s) for s in specs], 4))
+                header = f"Spack is taking more than {time_limit} seconds to solve for {specs_str}"
+                if error_on_timeout:
+                    raise UnsatisfiableSpecError(f"{header}, stopping concretization")
+                warnings.warn(f"{header}, using the best configuration found so far")
+                handle.cancel()
+
+            solve_result = handle.get()
+        timer.stop("solve")
+
+        # once done, construct the solve result
+        result = Result(specs)
+        result.satisfiable = solve_result.satisfiable
+
+        if result.satisfiable:
+            timer.start("construct_specs")
+            # get the best model
+            builder = SpecBuilder(specs, hash_lookup=setup.reusable_and_possible)
+            min_cost, best_model = min(models)
+
+            # first check for errors
+            error_handler = ErrorHandler(best_model, specs)
+            error_handler.raise_if_errors()
+
+            # build specs from spec attributes in the model
+            spec_attrs = [(name, tuple(rest)) for name, *rest in extract_args(best_model, "attr")]
+            answers = builder.build_specs(spec_attrs)
+
+            # add best spec to the results
+            result.answers.append((list(min_cost), 0, answers))
+
+            # get optimization criteria
+            criteria_args = extract_args(best_model, "opt_criterion")
+            result.criteria = build_criteria_names(min_cost, criteria_args)
+
+            # record the number of models the solver considered
+            result.nmodels = len(models)
+
+            # record the possible dependencies in the solve
+            result.possible_dependencies = setup.pkgs
+            timer.stop("construct_specs")
+            timer.stop()
+
+        elif cores:
+            result.control = self.control
+            result.cores.extend(cores)
+
+        result.raise_if_unsat()
+
+        if result.satisfiable and result.unsolved_specs and setup.concretize_everything:
+            raise OutputDoesNotSatisfyInputError(result.unsolved_specs)
+
+        return result
+
     def solve(
         self,
         setup: "SpackSolverSetup",
@@ -1112,6 +1257,9 @@ class PyclingoDriver:
         if sys.platform == "win32":
             tty.debug("Ensuring basic dependencies {win-sdk, wgl} available")
             ensure_winsdk_external_or_raise()
+
+        # assemble a list of the control files needed for this problem. Some are conditionally
+        # included depending on what features we're using in the solve.
         control_files = ["concretize.lp", "heuristic.lp", "display.lp", "direct_dependency.lp"]
         if not setup.concretize_everything:
             control_files.append("when_possible.lp")
@@ -1129,146 +1277,55 @@ class PyclingoDriver:
             allow_deprecated=allow_deprecated,
             _use_unsat_cores=output.out is None,
         )
-
-        asp_problem = problem_builder.value(randomize="SPACK_SOLVER_RANDOMIZATION" in os.environ)
-        if output.out is not None:
-            output.out.write(asp_problem)
-        if output.setup_only:
-            return Result(specs), None, None
         timer.stop("setup")
 
-        timer.start("cache-check")
         timer.start("ordering")
-        # ensure deterministic output
-        problem_repr = "\n".join(sorted(asp_problem.split("\n")))
-        timer.stop("ordering")
-        parent_dir = os.path.dirname(__file__)
-        full_path = lambda x: os.path.join(parent_dir, x)
-        abs_control_files = [full_path(x) for x in control_files]
-        for ctrl_file in abs_control_files:
-            with open(ctrl_file, "r", encoding="utf-8") as f:
-                problem_repr += "\n" + f.read()
+        # print the output with comments, etc. if the user asked
+        problem = problem_builder.asp_problem
+        if output.out is not None:
+            output.out.write("\n".join(problem))
 
-        result = None
+        if output.setup_only:
+            return Result(specs), None, None
+
+        # strip the problem of comments and empty lines
+        problem = strip_asp_problem(problem)
+        randomize = "SPACK_SOLVER_RANDOMIZATION" in os.environ
+        if randomize:
+            # create a shuffled copy -- useful for understanding performance variation
+            problem = random.sample(problem, len(problem))
+        else:
+            problem.sort()  # sort for deterministic output
+
+        timer.stop("ordering")
+
+        timer.start("cache-check")
+        # load control files to add to the input representation
+        control_file_paths = self._control_file_paths(control_files)
+        cache_key = self._make_cache_key(problem, control_file_paths)
+
+        result, concretization_stats = None, None
         conc_cache_enabled = spack.config.get("concretizer:concretization_cache:enable", False)
         if conc_cache_enabled:
-            result, concretization_stats = CONC_CACHE.fetch(problem_repr)
-
+            result, concretization_stats = CONC_CACHE.fetch(cache_key)
         timer.stop("cache-check")
+
+        # run the solver and store the result, if it wasn't cached already
         if not result:
-            timer.start("load")
-            # Add the problem instance
-            self.control.add("base", [], asp_problem)
-            # Load the files
-            [self.control.load(lp) for lp in abs_control_files]
-            timer.stop("load")
-
-            # Grounding is the first step in the solve -- it turns our facts
-            # and first-order logic rules into propositional logic.
-            timer.start("ground")
-            self.control.ground([("base", [])])
-            timer.stop("ground")
-
-            # With a grounded program, we can run the solve.
-            models = []  # stable models if things go well
-            cores: List = []  # unsatisfiable cores if they do not
-
-            def on_model(model):
-                models.append((model.cost, model.symbols(shown=True, terms=True)))
-
-            solve_kwargs = {
-                "assumptions": setup.assumptions,
-                "on_model": on_model,
-                "on_core": cores.append,
-            }
-
-            if clingo_cffi():
-                solve_kwargs["on_unsat"] = cores.append
-
-            timer.start("solve")
-            # A timeout of 0 means no timeout
-            time_limit = spack.config.CONFIG.get("concretizer:timeout", 0)
-            timeout_end = time.monotonic() + time_limit if time_limit > 0 else float("inf")
-            error_on_timeout = spack.config.CONFIG.get("concretizer:error_on_timeout", True)
-            with self.control.solve(**solve_kwargs, async_=True) as handle:
-                # Allow handling of interrupts every second.
-                #
-                # pyclingo's `SolveHandle` blocks the calling thread for the duration of each
-                # `.wait()` call. Python also requires that signal handlers must be handled in
-                # the main thread, so any `KeyboardInterrupt` is postponed until after the
-                # `.wait()` call exits the control of pyclingo.
-                finished = False
-                while not finished and time.monotonic() < timeout_end:
-                    finished = handle.wait(1.0)
-
-                if not finished:
-                    specs_str = ", ".join(
-                        spack.llnl.util.lang.elide_list([str(s) for s in specs], 4)
-                    )
-                    header = (
-                        f"Spack is taking more than {time_limit} seconds to solve for {specs_str}"
-                    )
-                    if error_on_timeout:
-                        raise UnsatisfiableSpecError(f"{header}, stopping concretization")
-                    warnings.warn(f"{header}, using the best configuration found so far")
-                    handle.cancel()
-
-                solve_result = handle.get()
-            timer.stop("solve")
-
-            # once done, construct the solve result
-            result = Result(specs)
-            result.satisfiable = solve_result.satisfiable
-
-            if result.satisfiable:
-                timer.start("construct_specs")
-                # get the best model
-                builder = SpecBuilder(specs, hash_lookup=setup.reusable_and_possible)
-                min_cost, best_model = min(models)
-
-                # first check for errors
-                error_handler = ErrorHandler(best_model, specs)
-                error_handler.raise_if_errors()
-
-                # build specs from spec attributes in the model
-                spec_attrs = [
-                    (name, tuple(rest)) for name, *rest in extract_args(best_model, "attr")
-                ]
-                answers = builder.build_specs(spec_attrs)
-
-                # add best spec to the results
-                result.answers.append((list(min_cost), 0, answers))
-
-                # get optimization criteria
-                criteria_args = extract_args(best_model, "opt_criterion")
-                result.criteria = build_criteria_names(min_cost, criteria_args)
-
-                # record the number of models the solver considered
-                result.nmodels = len(models)
-
-                # record the possible dependencies in the solve
-                result.possible_dependencies = setup.pkgs
-                timer.stop("construct_specs")
-                timer.stop()
-            elif cores:
-                result.control = self.control
-                result.cores.extend(cores)
-
-            result.raise_if_unsat()
-
-            if result.satisfiable and result.unsolved_specs and setup.concretize_everything:
-                raise OutputDoesNotSatisfyInputError(result.unsolved_specs)
-
+            problem_repr = "\n".join(problem)
+            result = self._run_clingo(specs, setup, problem_repr, control_file_paths, timer)
             if conc_cache_enabled:
                 CONC_CACHE.store(problem_repr, result, self.control.statistics, test=setup.tests)
-            concretization_stats = self.control.statistics
+
         if output.timers:
             timer.write_tty()
             print()
 
+        concretization_stats = concretization_stats or self.control.statistics
         if output.stats:
             print("Statistics:")
             pprint.pprint(concretization_stats)
+
         return result, timer, concretization_stats
 
 
@@ -3531,6 +3588,19 @@ class _Body:
     propagate = fn.attr("propagate")
 
 
+def strip_asp_problem(asp_problem: Iterable[str]) -> List[str]:
+    """Remove comments and empty lines from an ASP program."""
+
+    def strip_statement(stmt: str) -> str:
+        lines = [line for line in stmt.split("\n") if not line.startswith("%")]
+        return "".join(line.strip() for line in lines if line)
+
+    value = [strip_statement(stmt) for stmt in asp_problem]
+    value = [s for s in value if s]
+
+    return value
+
+
 class ProblemInstanceBuilder:
     """Provides an interface to construct a problem instance.
 
@@ -3571,36 +3641,6 @@ class ProblemInstanceBuilder:
 
     def newline(self):
         self.asp_problem.append("")
-
-    def problem(self, strip: bool = False) -> List[str]:
-        """Return the ASP problem as a list of rules.
-
-        Arguments:
-            strip: strip comments and empty lines.
-        """
-        if not strip:
-            return self.asp_problem
-
-        def strip_statement(stmt: str) -> str:
-            lines = [line for line in stmt.split("\n") if not line.startswith("%")]
-            return "".join(line.strip() for line in lines if line)
-
-        stripped = [strip_statement(stmt) for stmt in self.asp_problem]
-        stripped = [s for s in stripped if s]
-
-        return stripped
-
-    def value(self, randomize: bool = False) -> str:
-        """Return the ASP problem as a string that can be loaded directly by clingo.
-
-        Arguments:
-            randomize: whether to randomize the order of facts to the solver.
-                Useful for understanding performance variation when benchmarking.
-        """
-        value = self.asp_problem
-        if randomize:
-            value = random.sample(value, len(value))  # create a shuffled copy
-        return "\n".join(value)
 
 
 def possible_compilers(*, configuration) -> Tuple[Set["spack.spec.Spec"], Set["spack.spec.Spec"]]:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -683,9 +683,10 @@ class ConcretizationCache:
                 # entries are descending, so least recently used is last entry
                 entry_to_rm = removal_queue.pop()
                 # short timeout, if we can't get a lock, its being read, so it's been used
-                # more recently, i.e. not a good candidate for LRU, or it's already being removed
-                # so we dont care. Could also be a write lock from another clean operation
-                # in which case that operation can remove it
+                # more recently, i.e. not a good candidate for LRU, or the system is busy,
+                # or it's already being removed so we dont care. Could also be a write 
+                # lock from another clean operation in which case that operation can 
+                # remove it
                 with self.write_transaction(entry_to_rm, timeout=1e-6) as exists:
                     # cache bucket was removed by another process, that's fine
                     # try pruning something else

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -523,7 +523,7 @@ class Result:
                 msg += "\n\t(No candidate specs from solver)"
         return msg
 
-    def to_dict(self, test: bool = False) -> dict:
+    def to_dict(self) -> dict:
         """Produces dict representation of Result object
 
         Does not include anything related to unsatisfiability as we
@@ -847,7 +847,7 @@ class ConcretizationCache:
                 return
             try:
                 with gzip.open(cache_path, "xb", compresslevel=6) as cache_entry:
-                    cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
+                    cache_dict = {"results": result.to_dict(), "statistics": statistics}
                     cache_entry.write(json.dumps(cache_dict).encode())
             except FileExistsError:
                 # Entry for this conc hash exists already, do not overwrite

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -896,11 +896,6 @@ class ConcretizationCache:
         return None, None
 
 
-CONC_CACHE: ConcretizationCache = spack.llnl.util.lang.Singleton(
-    lambda: ConcretizationCache()
-)  # type: ignore
-
-
 def _is_checksummed_git_version(v):
     return isinstance(v, vn.GitVersion) and v.is_commit
 
@@ -1060,16 +1055,18 @@ class ErrorHandler:
 
 
 class PyclingoDriver:
-    def __init__(self, cores=True):
+    def __init__(self, cores=True, conc_cache: Optional[ConcretizationCache] = None):
         """Driver for the Python clingo interface.
 
         Arguments:
             cores (bool): whether to generate unsatisfiable cores for better
                 error reporting.
+            conc_cache (ConcretizationCache)
         """
         self.cores = cores
         # This attribute will be reset at each call to solve
         self.control = None
+        self._conc_cache = conc_cache
 
     def _control_file_paths(self, control_files: List[str]) -> List[str]:
         """Get absolute paths based on relative paths of control files.
@@ -1302,16 +1299,16 @@ class PyclingoDriver:
 
         result, concretization_stats = None, None
         conc_cache_enabled = spack.config.get("concretizer:concretization_cache:enable", False)
-        if conc_cache_enabled:
-            result, concretization_stats = CONC_CACHE.fetch(cache_key)
+        if conc_cache_enabled and self._conc_cache:
+            result, concretization_stats = self._conc_cache.fetch(cache_key)
         timer.stop("cache-check")
 
         # run the solver and store the result, if it wasn't cached already
         if not result:
             problem_repr = "\n".join(problem)
             result = self._run_clingo(specs, setup, problem_repr, control_file_paths, timer)
-            if conc_cache_enabled:
-                CONC_CACHE.store(cache_key, result, self.control.statistics)
+            if conc_cache_enabled and self._conc_cache:
+                self._conc_cache.store(cache_key, result, self.control.statistics)
 
         if output.timers:
             timer.write_tty()
@@ -4347,7 +4344,8 @@ class Solver:
     """
 
     def __init__(self):
-        self.driver = PyclingoDriver()
+        self._conc_cache = ConcretizationCache()
+        self.driver = PyclingoDriver(conc_cache=self._conc_cache)
         self.selector = ReusableSpecsSelector(configuration=spack.config.CONFIG)
 
     @staticmethod
@@ -4423,7 +4421,7 @@ class Solver:
         result = self.driver.solve(
             setup, specs, reuse=reusable_specs, output=output, allow_deprecated=allow_deprecated
         )
-        CONC_CACHE.cleanup()
+        self._conc_cache.cleanup()
         return result
 
     def solve(self, specs: Sequence[spack.spec.Spec], **kwargs) -> Result:
@@ -4493,7 +4491,7 @@ class Solver:
             for spec in result.specs:
                 reusable_specs.extend(spec.traverse())
 
-        CONC_CACHE.cleanup()
+        self._conc_cache.cleanup()
 
 
 class UnsatisfiableSpecError(spack.error.UnsatisfiableSpecError):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -670,11 +670,11 @@ class ConcretizationCache:
                     # worry about cleanup
                     if exists:
                         entry_stat_info = entry.stat()
-                        # mtime will always be time of last use as we update it after 
+                        # mtime will always be time of last use as we update it after
                         # each read and obviously after each write
                         mod_time = entry_stat_info.st_mtime
                         removal_queue.append((entry, mod_time))
-            # sort items for removal 
+            # sort items for removal
             removal_queue.sort(key=lambda x: x[1], reverse=True)
 
             # try to remove half the current cache, but if we for some reason
@@ -684,8 +684,8 @@ class ConcretizationCache:
                 entry_to_rm = removal_queue.pop()
                 # short timeout, if we can't get a lock, its being read, so it's been used
                 # more recently, i.e. not a good candidate for LRU, or the system is busy,
-                # or it's already being removed so we dont care. Could also be a write 
-                # lock from another clean operation in which case that operation can 
+                # or it's already being removed so we dont care. Could also be a write
+                # lock from another clean operation in which case that operation can
                 # remove it
                 with self.write_transaction(entry_to_rm, timeout=1e-6) as exists:
                     # cache bucket was removed by another process, that's fine

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -18,13 +18,28 @@ import time
 import typing
 import warnings
 from contextlib import contextmanager
-from typing import Callable, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 import spack.vendor.archspec.cpu
 
 import spack
 import spack.compilers.config
 import spack.compilers.flags
+import spack.concretize
 import spack.config
 import spack.deptypes as dt
 import spack.detection
@@ -329,6 +344,9 @@ class Result:
 
         # Abstract user requests
         self.abstract_specs = specs
+
+        # possible dependencies
+        self.possible_dependencies = None
 
         # Concrete specs
         self._concrete_specs_by_input = None
@@ -679,7 +697,7 @@ class ConcretizationCache:
         result_json = cache_entry["results"]
         return Result.from_dict(result_json)
 
-    def _stats_from_cache(self, cache_entry_file: str) -> Union[List, None]:
+    def _stats_from_cache(self, cache_entry_file: str) -> Union[Dict, None]:
         """Returns concretization statistic from the
         concretization associated with the cache.
 
@@ -778,7 +796,13 @@ class ConcretizationCache:
         finally:
             lock.release_write()
 
-    def store(self, problem: str, result: Result, statistics: List, test: bool = False) -> None:
+    def store(
+        self,
+        problem: str,
+        result: Result,
+        statistics: List,
+        test: spack.concretize.TestsType = False,
+    ) -> None:
         """Creates entry in concretization cache for problem if none exists,
         storing the concretization Result object and statistics in the cache
         as serialized json joined as a single file.
@@ -803,7 +827,7 @@ class ConcretizationCache:
                 # Entry for this conc hash exists already, do not overwrite
                 tty.debug(f"Cache entry {cache_path} exists, will not be overwritten")
 
-    def fetch(self, problem: str) -> Union[Tuple[Result, List], Tuple[None, None]]:
+    def fetch(self, problem: str) -> Union[Tuple[Result, Dict], Tuple[None, None]]:
         """Returns the concretization cache result for a lookup based on the given problem.
 
         Checks the concretization cache for the given problem, and either returns the
@@ -1020,17 +1044,23 @@ class PyclingoDriver:
         # This attribute will be reset at each call to solve
         self.control = None
 
-    def solve(self, setup, specs, reuse=None, output=None, control=None, allow_deprecated=False):
+    def solve(
+        self,
+        setup: "SpackSolverSetup",
+        specs: List[spack.spec.Spec],
+        reuse: Optional[List[spack.spec.Spec]] = None,
+        output: Optional[OutputConfiguration] = None,
+        control: Optional[Any] = None,  # TODO: figure out how to annotate clingo.Control
+        allow_deprecated: bool = False,
+    ) -> Tuple[Result, Optional[spack.util.timer.Timer], Optional[Dict]]:
         """Set up the input and solve for dependencies of ``specs``.
 
         Arguments:
-            setup (SpackSolverSetup): An object to set up the ASP problem.
-            specs (list): List of ``Spec`` objects to solve for.
-            reuse (None or list): list of concrete specs that can be reused
-            output (None or OutputConfiguration): configuration object to set
-                the output of this solve.
-            control (clingo.Control): configuration for the solver. If None,
-                default values will be used
+            setup: An object to set up the ASP problem.
+            specs: List of ``Spec`` objects to solve for.
+            reuse: list of concrete specs that can be reused
+            output: configuration object to set the output of this solve.
+            control: configuration for the solver. If None, default values will be used
             allow_deprecated: if True, allow deprecated versions in the solve
 
         Return:
@@ -1063,16 +1093,15 @@ class PyclingoDriver:
             control_files.append("splices.lp")
 
         timer.start("setup")
-        output_is_set = output.out is not None
         problem_builder = setup.setup(
             specs,
             reuse=reuse,
             allow_deprecated=allow_deprecated,
-            _use_unsat_cores=not output_is_set,
+            _use_unsat_cores=output.out is None,
         )
 
         asp_problem = problem_builder.value(randomize="SPACK_SOLVER_RANDOMIZATION" in os.environ)
-        if output_is_set:
+        if output.out is not None:
             output.out.write(asp_problem)
         if output.setup_only:
             return Result(specs), None, None
@@ -1112,7 +1141,7 @@ class PyclingoDriver:
 
             # With a grounded program, we can run the solve.
             models = []  # stable models if things go well
-            cores = []  # unsatisfiable cores if they do not
+            cores: List = []  # unsatisfiable cores if they do not
 
             def on_model(model):
                 models.append((model.cost, model.symbols(shown=True, terms=True)))
@@ -1393,7 +1422,7 @@ class SpackSolverSetup:
 
     gen: "ProblemInstanceBuilder"
 
-    def __init__(self, tests: bool = False):
+    def __init__(self, tests: spack.concretize.TestsType = False):
         self.possible_graph = create_graph_analyzer()
 
         # these are all initialized in setup()
@@ -3014,7 +3043,7 @@ class SpackSolverSetup:
 
     def setup(
         self,
-        specs: List[spack.spec.Spec],
+        specs: Sequence[spack.spec.Spec],
         *,
         reuse: Optional[List[spack.spec.Spec]] = None,
         allow_deprecated: bool = False,
@@ -3059,13 +3088,17 @@ class SpackSolverSetup:
 
         candidate_compilers.update(compilers_from_reuse)
         self.possible_compilers = list(candidate_compilers)
-        self.possible_compilers.sort()  # type: ignore[call-arg]
+
+        # TODO: warning is because mypy doesn't know Spec supports rich comparison via decorator
+        self.possible_compilers.sort()  # type: ignore[call-arg,call-overload]
 
         self.gen.h1("Runtimes")
         injected_dependencies = self.define_runtime_constraints()
 
         node_counter = create_counter(
-            specs + injected_dependencies, tests=self.tests, possible_graph=self.possible_graph
+            list(specs) + injected_dependencies,
+            tests=self.tests,
+            possible_graph=self.possible_graph,
         )
         self.possible_virtuals = node_counter.possible_virtuals()
         self.pkgs = node_counter.possible_dependencies()
@@ -4232,7 +4265,7 @@ class Solver:
 
     @staticmethod
     def _check_input_and_extract_concrete_specs(
-        specs: List[spack.spec.Spec],
+        specs: Sequence[spack.spec.Spec],
     ) -> List[spack.spec.Spec]:
         reusable: List[spack.spec.Spec] = []
         analyzer = create_graph_analyzer()
@@ -4272,27 +4305,27 @@ class Solver:
 
     def solve_with_stats(
         self,
-        specs,
-        out=None,
-        timers=False,
-        stats=False,
-        tests=False,
-        setup_only=False,
-        allow_deprecated=False,
-    ):
+        specs: Sequence[spack.spec.Spec],
+        out: Optional[io.IOBase] = None,
+        timers: bool = False,
+        stats: bool = False,
+        tests: spack.concretize.TestsType = False,
+        setup_only: bool = False,
+        allow_deprecated: bool = False,
+    ) -> Tuple[Result, Optional[spack.util.timer.Timer], Optional[Dict]]:
         """
         Concretize a set of specs and track the timing and statistics for the solve
 
         Arguments:
-          specs (list): List of ``Spec`` objects to solve for.
+          specs: List of ``Spec`` objects to solve for.
           out: Optionally write the generate ASP program to a file-like object.
-          timers (bool): Print out coarse timers for different solve phases.
-          stats (bool): Print out detailed stats from clingo.
-          tests (bool or tuple): If True, concretize test dependencies for all packages.
+          timers: Print out coarse timers for different solve phases.
+          stats: Print out detailed stats from clingo.
+          tests: If True, concretize test dependencies for all packages.
             If a tuple of package names, concretize test dependencies for named
             packages (defaults to False: do not concretize test dependencies).
-          setup_only (bool): if True, stop after setup and don't solve (default False).
-          allow_deprecated (bool): allow deprecated version in the solve
+          setup_only: if True, stop after setup and don't solve (default False).
+          allow_deprecated: allow deprecated version in the solve
         """
         specs = [s.lookup_hash() for s in specs]
         reusable_specs = self._check_input_and_extract_concrete_specs(specs)
@@ -4306,7 +4339,7 @@ class Solver:
         CONC_CACHE.cleanup()
         return result
 
-    def solve(self, specs, **kwargs):
+    def solve(self, specs: Sequence[spack.spec.Spec], **kwargs) -> Result:
         """
         Convenience function for concretizing a set of specs and ignoring timing
         and statistics. Uses the same kwargs as solve_with_stats.
@@ -4316,8 +4349,14 @@ class Solver:
         return result
 
     def solve_in_rounds(
-        self, specs, out=None, timers=False, stats=False, tests=False, allow_deprecated=False
-    ):
+        self,
+        specs: Sequence[spack.spec.Spec],
+        out: Optional[io.IOBase] = None,
+        timers: bool = False,
+        stats: bool = False,
+        tests: spack.concretize.TestsType = False,
+        allow_deprecated: bool = False,
+    ) -> Generator[Result, None, None]:
         """Solve for a stable model of specs in multiple rounds.
 
         This relaxes the assumption of solve that everything must be consistent and

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -666,15 +666,15 @@ class ConcretizationCache:
         removal_queue = []
         # collect stat info for mod time about all entries
         for entry in entries:
-            # take read transaction so we can guaruntee the file we're trying to stat exists
-            with self.read_transaction(entry, timeout=1e-6) as exists:
-                # if file doesn't exist, we probably don't need to worry about cleanup
-                if exists:
-                    entry_stat_info = entry.stat()
-                    # mtime will always be time of last use as we update it after
-                    # each read and obviously after each write
-                    mod_time = entry_stat_info.st_mtime
-                    removal_queue.append((mod_time, entry))
+            try:
+                entry_stat_info = entry.stat()
+                # mtime will always be time of last use as we update it after
+                # each read and obviously after each write
+                mod_time = entry_stat_info.st_mtime
+                removal_queue.append((mod_time, entry))
+            except FileNotFoundError:
+                # don't need to cleanup the file, it's not there!
+                pass
 
         removal_queue.sort()  # sort items for removal, ascending, so oldest first
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -4,7 +4,6 @@
 import collections
 import collections.abc
 import enum
-import errno
 import gzip
 import io
 import itertools
@@ -23,9 +22,6 @@ from contextlib import contextmanager
 from typing import Callable, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type, Union
 
 import spack.vendor.archspec.cpu
-
-import llnl.util.tty as tty
-from llnl.util.lang import elide_list
 
 import spack
 import spack.compilers.config
@@ -614,28 +610,44 @@ class ConcretizationCache:
         # lock the entire buildcache as we're removing a lot of data from the
         # manifest and cache itself
         entry_count, bytes_count = 0, 0
-        rm_reg: List[pathlib.Path] = []
+        rm_reg: Dict[pathlib.Path, Tuple[float, int]] = {}
         for bucket in self.cache_buckets():
             with self._fc.read_transaction(bucket) as f:
                 if not f:
-                    raise RuntimeError(
-                        "Attempting to clean non existent cache bucket" f" {bucket.name}"
+                    # bucket was likely removed by another cleaning
+                    # process, no worries
+                    tty.debug(
+                        f"Attempting to purge concretization cache bucket {bucket}"
+                        " but it was already removed"
                     )
+                    continue
                 # advance new beyond metadata entry
                 for entry in self.cache_entries(bucket):
                     entry_count += 1
-                    bytes_count += entry.stat().st_size
-                    rm_reg.append(entry)
-        rm_reg.sort(key=lambda x: x.stat().st_mtime, reverse=True)
-        while (entry_count > entry_limit or bytes_count > bytes_limit) and rm_reg:
-            entry_to_rm = rm_reg.pop()
+                    entry_stat_info = entry.stat()
+                    entry_size = entry_stat_info.st_size
+                    bytes_count += entry_size
+                    access_time = entry_stat_info.st_atime
+                    mod_time = entry_stat_info.st_mtime
+                    most_recent_op_time = access_time if access_time > mod_time else mod_time
+                    rm_reg[entry] = (most_recent_op_time, entry_size)
+        # Sort entries in descending order
+        removal_queue = [
+            (entry, stats)
+            for entry, stats in sorted(rm_reg.items(), key=lambda x: x[1][0], reverse=True)
+        ]
+        while (entry_count > entry_limit or bytes_count > bytes_limit) and removal_queue:
+            # entries are descending, so least recently used is last entry
+            entry_info_to_rm = removal_queue.pop()
+            entry_to_rm = entry_info_to_rm[0]
+            entry_stats = entry_info_to_rm[1]
             entry_bucket = self._cache_bucket_from_path(entry_to_rm)
             with self._fc.write_transaction(entry_bucket) as valid_bucket:
                 # cache bucket was removed by another process, that's fine
                 # try pruning something else
                 if not valid_bucket:
                     continue
-                entry_size = entry_to_rm.stat().st_size
+                entry_size = entry_stats[1]
                 removed = self._safe_remove(entry_to_rm)
                 if removed:
                     entry_count -= 1
@@ -651,7 +663,12 @@ class ConcretizationCache:
                     self._fc.remove(cache_bucket)
                     removed = True
             if removed:
-                self._fc.purge_lock(cache_bucket)
+                try:
+                    self._fc.purge_lock(cache_bucket)
+                except OSError:
+                    # lock was likely taken by another process
+                    # don't clean it, something is using it!
+                    continue
 
     def cache_buckets(self):
         """Generator producing cache buckets"""
@@ -695,7 +712,6 @@ class ConcretizationCache:
 
     def _prefix_digest(self, problem: str) -> Tuple[str, str]:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
-        # compress the problem w/ gzip so we can validate checksum w/o decompressing
         prob_digest = spack.util.hash.b32_hash(problem)
         prefix = prob_digest[:2]
         return prefix, prob_digest
@@ -727,10 +743,9 @@ class ConcretizationCache:
         except FileNotFoundError:
             # This is acceptable, removal is idempotent
             pass
-        except OSError as e:
-            if e.errno == errno.ENOTEMPTY:
-                # there exists another cache entry in this directory, don't clean yet
-                pass
+        except OSError:
+            # Catch other timing/access related issues
+            pass
         return False
 
     def store(self, problem: str, result: Result, statistics: List, test: bool = False):
@@ -783,10 +798,12 @@ class ConcretizationCache:
                     pass
                 except OSError:
                     # Cache may have been created pre compression
-                    # check if gzip, and if so, read from plaintext
+                    # check if gzip, and if not, read from plaintext
                     # otherwise re raise
                     with open(cache_path, "rb") as f:
-                        if GZipFileType().matches_magic(f):
+                        # ensure the file was not a gzip file we just failed
+                        # to open
+                        if not GZipFileType().matches_magic(f):
                             cache_entry_content = f.read().decode()
                         else:
                             raise

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -8,6 +8,7 @@ from typing import Dict, List, NamedTuple, Set, Tuple, Union
 import spack.vendor.archspec.cpu
 
 import spack.binary_distribution
+import spack.concretize
 import spack.config
 import spack.deptypes as dt
 import spack.platforms
@@ -363,7 +364,10 @@ class Counter:
     """
 
     def __init__(
-        self, specs: List["spack.spec.Spec"], tests: bool, possible_graph: PossibleDependencyGraph
+        self,
+        specs: List[spack.spec.Spec],
+        tests: spack.concretize.TestsType,
+        possible_graph: PossibleDependencyGraph,
     ) -> None:
         self.possible_graph = possible_graph
         self.specs = specs
@@ -426,7 +430,10 @@ class NoDuplicatesCounter(Counter):
 
 class MinimalDuplicatesCounter(NoDuplicatesCounter):
     def __init__(
-        self, specs: List["spack.spec.Spec"], tests: bool, possible_graph: PossibleDependencyGraph
+        self,
+        specs: List[spack.spec.Spec],
+        tests: spack.concretize.TestsType,
+        possible_graph: PossibleDependencyGraph,
     ) -> None:
         super().__init__(specs, tests, possible_graph)
         self._link_run: Set[str] = set()
@@ -528,7 +535,9 @@ class FullDuplicatesCounter(MinimalDuplicatesCounter):
 
 
 def create_counter(
-    specs: List[spack.spec.Spec], tests: bool, possible_graph: PossibleDependencyGraph
+    specs: List[spack.spec.Spec],
+    tests: spack.concretize.TestsType,
+    possible_graph: PossibleDependencyGraph,
 ) -> Counter:
     strategy = spack.config.CONFIG.get("concretizer:duplicates:strategy", "none")
     if strategy == "full":

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -90,13 +90,13 @@ class RuntimePropertyRecorder:
             f"% {description}\n"
             f'1 {{ attr("depends_on", {node_variable}, node(0..X-1, "{runtime_pkg}"), "{type}") :'
             f' max_dupes("{runtime_pkg}", X)}} 1:-\n'
-            f"{body_str}.\n\n"
+            f"{body_str}."
         )
         if is_virtual:
             main_rule = (
                 f"% {description}\n"
                 f'attr("dependency_holds", {node_variable}, "{runtime_pkg}", "{type}") :-\n'
-                f"{body_str}.\n\n"
+                f"{body_str}."
             )
 
         self.rules.append(main_rule)
@@ -114,7 +114,7 @@ class RuntimePropertyRecorder:
                     f"  provider(ProviderNode, {runtime_node}),\n"
                 )
 
-            rule = f"{head_str} :-\n" f"{depends_on_constraint}" f"{body_str}.\n\n"
+            rule = f"{head_str} :-\n" f"{depends_on_constraint}" f"{body_str}."
             self.rules.append(rule)
 
         self.reset()
@@ -198,7 +198,7 @@ class RuntimePropertyRecorder:
                 )
                 args = f'"{constraint_spec.name}", "{constraint_spec.versions}"'
                 head_str = f"propagate({node_variable}, node_version_satisfies({args}))"
-                rule = f"{head_str} :-\n{body_str}.\n\n"
+                rule = f"{head_str} :-\n{body_str}."
                 self.rules.append(rule)
 
         self.reset()
@@ -225,7 +225,7 @@ class RuntimePropertyRecorder:
             if clause.args[0] == "node":
                 continue
             head_str = str(clause).replace(f'"{node_placeholder}"', f"{node_variable}")
-            rule = f"{head_str} :-\n{body_str}.\n\n"
+            rule = f"{head_str} :-\n{body_str}."
             self.rules.append(rule)
 
         self.reset()
@@ -246,7 +246,7 @@ class RuntimePropertyRecorder:
         self._setup.gen.newline()
         for rule in self.rules:
             self._setup.gen.append(rule)
-        self._setup.gen.newline()
+            self._setup.gen.newline()
 
         self._setup.gen.h2("Runtimes: requirements")
         for imposed_spec, when_spec in sorted(self.runtime_conditions):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3348,57 +3348,11 @@ def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusabl
         assert (spec1.dag_hash() == spec2.dag_hash()) == reusable
 
 
-def test_concretization_cache_roundtrip(
-    mock_packages, use_concretization_cache, monkeypatch, mutable_config
-):
-    """Tests whether we can write the results of a clingo solve to the cache
-    and load the same spec request from the cache to produce identical specs"""
-    # Force determinism:
-    # Solver setup is normally non-deterministic due to non-determinism in
-    # asp solver setup logic generation. The only other inputs to the cache keys are
-    # the .lp files, which are invariant over the course of this test.
-    # This method forces the same setup to be produced for the same specs
-    # which gives us a guarantee of cache hits, as it removes the only
-    # element of non deterministic solver setup for the same spec
-    # Basically just a quick and dirty memoization
-    solver_setup = spack.solver.asp.SpackSolverSetup.setup
-
-    def _setup(self, specs, *, reuse=None, allow_deprecated=False, _use_unsat_cores=True):
-        if not getattr(_setup, "cache_setup", None):
-            cache_setup = solver_setup(self, specs, reuse=reuse, allow_deprecated=allow_deprecated)
-            setattr(_setup, "cache_setup", cache_setup)
-        return getattr(_setup, "cache_setup")
-
-    # monkeypatch our forced determinism setup method into solver setup
-    monkeypatch.setattr(spack.solver.asp.SpackSolverSetup, "setup", _setup)
-
-    assert spack.config.get("config:concretization_cache:enable")
-
-    # run one standard concretization to populate the cache and the setup method
-    # memoization
-    h = spack.concretize.concretize_one("hdf5")
-
-    # due to our forced determinism above, we should not be observing
-    # cache misses, assert that we're not storing any new cache entries
-    def _ensure_no_store(self, problem: str, result, statistics, test=False):
-        # always throw, we never want to reach this code path
-        assert False, "Concretization cache hit expected"
-
-    # Assert that we're actually hitting the cache
-    cache_fetch = spack.solver.asp.ConcretizationCache.fetch
-
-    def _ensure_cache_hits(self, problem: str):
-        result, statistics = cache_fetch(self, problem)
-        assert result, "Expected successful concretization cache hit"
-        assert statistics, "Expected statistics to be non null on cache hit"
-        return result, statistics
-
-    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _ensure_no_store)
-    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "fetch", _ensure_cache_hits)
-    # ensure subsequent concretizations of the same spec produce the same spec
-    # object
-    for _ in range(5):
-        assert h == spack.concretize.concretize_one("hdf5")
+def extract_cache_metadata():
+    cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
+    cache = cache_root / ".cache_manifest"
+    with cache.open("r") as f:
+        return spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
 
 
 @pytest.mark.regression("42679")
@@ -4278,3 +4232,77 @@ def test_when_possible_above_all(mutable_config, mock_packages):
     for result in solver.solve_in_rounds(specs):
         criteria = sorted(result.criteria, reverse=True)
         assert criteria[0].name == "number of input specs not concretized"
+
+
+def test_concretization_cache_roundtrip(
+    mock_packages, use_concretization_cache, monkeypatch, mutable_config
+):
+    """Tests whether we can write the results of a clingo solve to the cache
+    and load the same spec request from the cache to produce identical specs"""
+
+    assert spack.config.get("concretizer:concretization_cache:enable")
+
+    # run one standard concretization to populate the cache and the setup method
+    # memoization
+    h = spack.concretize.concretize_one("hdf5")
+
+    # due to our forced determinism above, we should not be observing
+    # cache misses, assert that we're not storing any new cache entries
+    def _ensure_no_store(self, problem: str, result, statistics, test=False):
+        # always throw, we never want to reach this code path
+        assert False, "Concretization cache hit expected"
+
+    # Assert that we're actually hitting the cache
+    cache_fetch = spack.solver.asp.ConcretizationCache.fetch
+
+    def _ensure_cache_hits(self, problem: str):
+        result, statistics = cache_fetch(self, problem)
+        assert result, "Expected successful concretization cache hit"
+        assert statistics, "Expected statistics to be non null on cache hit"
+        return result, statistics
+
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _ensure_no_store)
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "fetch", _ensure_cache_hits)
+    # ensure subsequent concretizations of the same spec produce the same spec
+    # object
+    for _ in range(5):
+        assert h == spack.concretize.concretize_one("hdf5")
+
+
+def get_current_cache_data():
+    count, byte_size = 0, 0
+    for bucket in spack.solver.asp.CONC_CACHE.cache_buckets():
+        for entry in spack.solver.asp.CONC_CACHE.cache_entries(bucket):
+            count += 1
+            byte_size += entry.stat().st_size
+    return count, byte_size
+
+
+def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_config):
+    """Tests to ensure we are cleaning the cache when we should be respective to the
+    number of entries allowed in the cache"""
+
+    spack.config.set("concretizer:concretization_cache:entry_limit", 2)
+    spack.concretize.concretize_one("zlib")
+    spack.concretize.concretize_one("hdf5")
+    # cleanup should be run after the third execution
+    spack.concretize.concretize_one("py-black")
+
+    real_count, _ = get_current_cache_data()
+    # ensure we only have 2 entries
+    assert real_count == 2, "Concretization cache cleanup pruned incorrectly"
+
+
+def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_config):
+    """Tests to ensure we are cleaning the cache when we should be respective to the
+    size of the cache in bytes"""
+    spack.config.set("concretizer:concretization_cache:size_limit", 1000)
+    spack.concretize.concretize_one("zlib")
+    # cleanup should be run after hdf5 is concretized
+    spack.concretize.concretize_one("hdf5")
+    real_count, real_size = get_current_cache_data()
+    # ensure we have less than our byte size limit
+    assert real_size < 1000, "Concretization cache cleanup did not reduce enough bytes"
+    # ensure there's fewer cache entries
+    # 1000 is an absurdly low cache size, all entries should be pruned
+    assert real_count == 0, "Concretization cache did not properly prune on byte limit"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4283,13 +4283,15 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
 
     spack.config.set("concretizer:concretization_cache:entry_limit", 1000)
 
+    def names():
+        return set(x.name for x in spack.solver.asp.CONC_CACHE.cache_entries())
+
+    assert len(names()) == 0
+
     for i in range(1000):
         name = spack.util.hash.b32_hash(f"mock_cache_file_{i}")
         mock_cache_file = conc_cache_dir / name
         mock_cache_file.touch()
-
-    def names():
-        return set(x.name for x in spack.solver.asp.CONC_CACHE.cache_entries())
 
     before = names()
     assert len(before) == 1000

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4264,6 +4264,17 @@ def test_concretization_cache_roundtrip(
         assert h == spack.concretize.concretize_one("hdf5")
 
 
+def test_concretization_cache_roundtrip_result(use_concretization_cache):
+    """Ensure the concretization cache doesn't change Solver Result objects."""
+    specs = [Spec("hdf5")]
+    solver = spack.solver.asp.Solver()
+
+    result1 = solver.solve(specs)
+    result2 = solver.solve(specs)
+
+    assert result1 == result2
+
+
 def get_current_cache_data():
     count, byte_size = 0, 0
     for entry in spack.solver.asp.CONC_CACHE.cache_entries():

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4294,19 +4294,20 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     spack.concretize.concretize_one("py-black")
 
     real_count, _ = get_current_cache_data()
-    # ensure we only have 2 entries
-    assert real_count == 2, "Concretization cache cleanup pruned incorrectly"
+    # ensure we only have 1 entry
+    # should be cleaning entry count // 2
+    assert real_count == 1, "Concretization cache cleanup pruned incorrectly"
 
 
 def test_concretization_cache_uncompressed_entry(use_concretization_cache, monkeypatch):
-    def _store(self, problem, result, statistics, test=False):
+    def _store(self, problem, result, statistics):
         cache_path = self._cache_path_from_problem(problem)
         with self.write_transaction(cache_path) as exists:
             if exists:
                 return
             try:
                 with open(cache_path, "x", encoding="utf-8") as cache_entry:
-                    cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
+                    cache_dict = {"results": result.to_dict(), "statistics": statistics}
                     cache_entry.write(json.dumps(cache_dict))
             except FileExistsError:
                 pass

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import json
 import os
 import pathlib
 import platform
@@ -3348,13 +3349,6 @@ def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusabl
         assert (spec1.dag_hash() == spec2.dag_hash()) == reusable
 
 
-def extract_cache_metadata():
-    cache_root = pathlib.Path(spack.config.get("config:concretization_cache:url"))
-    cache = cache_root / ".cache_manifest"
-    with cache.open("r") as f:
-        return spack.solver.asp.CONC_CACHE._extract_cache_metadata(f)
-
-
 @pytest.mark.regression("42679")
 @pytest.mark.parametrize("compiler_str", ["gcc@=9.4.0", "gcc@=9.4.0-foo"])
 def test_selecting_compiler_with_suffix(mutable_config, mock_packages, compiler_str):
@@ -4246,8 +4240,9 @@ def test_concretization_cache_roundtrip(
     # memoization
     h = spack.concretize.concretize_one("hdf5")
 
-    # due to our forced determinism above, we should not be observing
-    # cache misses, assert that we're not storing any new cache entries
+    # ASP output should be stable, concretizing the same spec
+    # should have the same problem output
+    # assert that we're not storing any new cache entries
     def _ensure_no_store(self, problem: str, result, statistics, test=False):
         # always throw, we never want to reach this code path
         assert False, "Concretization cache hit expected"
@@ -4315,7 +4310,7 @@ def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable
     spack.config.set("concretizer:concretization_cache:entry_limit", 1)
     spack.concretize.concretize_one("zlib")
     spack.concretize.concretize_one("hdf5")
-    # cleanup should have been run and there should be no lockfiles
+    # cleanup should have been run and there should be one lockfile
     lock_count = 0
     for file in spack.solver.asp.CONC_CACHE.root.iterdir():
         if file.is_file() and file.suffix == ".lock":
@@ -4324,3 +4319,28 @@ def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable
         lock_count == 1
     ), f"Unexpected number of lockfiles {lock_count} \
 concretization cache cleanup operation failed."
+
+
+def test_concretization_cache_uncompressed_entry(use_concretization_cache, monkeypatch):
+    def store(self, problem, result, statistics, test=False):
+        bucket, digest = self._prefix_digest(problem)
+        cache_path = self.root / bucket / digest
+        self._fc.init_entry(bucket)
+        with self._fc.write_transaction(bucket) as exists:
+            if not exists:
+                # The directory may have been pruned between init entry and the write
+                # transaction, recreate the directory
+                os.makedirs(bucket)
+            try:
+                with open(cache_path, "x", encoding="utf-8") as cache_entry:
+                    cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
+                    cache_entry.write(json.dumps(cache_dict))
+            except FileExistsError:
+                # Entry for this conc hash exists already, do not overwrite
+                pass
+
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", store)
+    # Store the results in plaintext
+    spack.concretize.concretize_one("zlib")
+    # Ensure fetch can handle the plaintext cache entry
+    spack.concretize.concretize_one("zlib")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4266,10 +4266,9 @@ def test_concretization_cache_roundtrip(
 
 def get_current_cache_data():
     count, byte_size = 0, 0
-    for bucket in spack.solver.asp.CONC_CACHE.cache_buckets():
-        for entry in spack.solver.asp.CONC_CACHE.cache_entries(bucket):
-            count += 1
-            byte_size += entry.stat().st_size
+    for entry in spack.solver.asp.CONC_CACHE.cache_entries():
+        count += 1
+        byte_size += entry.stat().st_size
     return count, byte_size
 
 
@@ -4303,43 +4302,20 @@ def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_co
     assert real_count == 0, "Concretization cache did not properly prune on byte limit"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="No locks on Windows")
-def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable_config):
-    """Tests to ensure we're not leaving dangling lockfiles when we perform cleanup
-    operations"""
-    spack.config.set("concretizer:concretization_cache:entry_limit", 1)
-    spack.concretize.concretize_one("zlib")
-    spack.concretize.concretize_one("hdf5")
-    # cleanup should have been run and there should be one lockfile
-    lock_count = 0
-    for file in spack.solver.asp.CONC_CACHE.root.iterdir():
-        if file.is_file() and file.suffix == ".lock":
-            lock_count += 1
-    assert (
-        lock_count == 1
-    ), f"Unexpected number of lockfiles {lock_count} \
-concretization cache cleanup operation failed."
-
-
 def test_concretization_cache_uncompressed_entry(use_concretization_cache, monkeypatch):
-    def store(self, problem, result, statistics, test=False):
-        bucket, digest = self._prefix_digest(problem)
-        cache_path = self.root / bucket / digest
-        self._fc.init_entry(bucket)
-        with self._fc.write_transaction(bucket) as exists:
-            if not exists:
-                # The directory may have been pruned between init entry and the write
-                # transaction, recreate the directory
-                os.makedirs(bucket)
+    def _store(self, problem, result, statistics, test=False):
+        cache_path = self._cache_path_from_problem(problem)
+        with self.write_transaction(cache_path) as exists:
+            if exists:
+                return
             try:
                 with open(cache_path, "x", encoding="utf-8") as cache_entry:
                     cache_dict = {"results": result.to_dict(test=test), "statistics": statistics}
                     cache_entry.write(json.dumps(cache_dict))
             except FileExistsError:
-                # Entry for this conc hash exists already, do not overwrite
                 pass
 
-    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", store)
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _store)
     # Store the results in plaintext
     spack.concretize.concretize_one("zlib")
     # Ensure fetch can handle the plaintext cache entry

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4306,3 +4306,21 @@ def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_co
     # ensure there's fewer cache entries
     # 1000 is an absurdly low cache size, all entries should be pruned
     assert real_count == 0, "Concretization cache did not properly prune on byte limit"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="No locks on Windows")
+def test_concretization_cache_lockfile_cleanup(use_concretization_cache, mutable_config):
+    """Tests to ensure we're not leaving dangling lockfiles when we perform cleanup
+    operations"""
+    spack.config.set("concretizer:concretization_cache:entry_limit", 1)
+    spack.concretize.concretize_one("zlib")
+    spack.concretize.concretize_one("hdf5")
+    # cleanup should have been run and there should be no lockfiles
+    lock_count = 0
+    for file in spack.solver.asp.CONC_CACHE.root.iterdir():
+        if file.is_file() and file.suffix == ".lock":
+            lock_count += 1
+    assert (
+        lock_count == 1
+    ), f"Unexpected number of lockfiles {lock_count} \
+concretization cache cleanup operation failed."

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -37,6 +37,7 @@ import spack.spec
 import spack.store
 import spack.test.conftest
 import spack.util.file_cache
+import spack.util.hash
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack.installer import PackageInstaller
@@ -4275,28 +4276,31 @@ def test_concretization_cache_roundtrip_result(use_concretization_cache):
     assert result1 == result2
 
 
-def get_current_cache_data():
-    count, byte_size = 0, 0
-    for entry in spack.solver.asp.CONC_CACHE.cache_entries():
-        count += 1
-        byte_size += entry.stat().st_size
-    return count, byte_size
-
-
 def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we are cleaning the cache when we should be respective to the
     number of entries allowed in the cache"""
+    conc_cache_dir = use_concretization_cache
 
-    spack.config.set("concretizer:concretization_cache:entry_limit", 2)
-    spack.concretize.concretize_one("zlib")
-    spack.concretize.concretize_one("hdf5")
-    # cleanup should be run after the third execution
+    spack.config.set("concretizer:concretization_cache:entry_limit", 1000)
+
+    for i in range(1000):
+        name = spack.util.hash.b32_hash(f"mock_cache_file_{i}")
+        mock_cache_file = conc_cache_dir / name
+        mock_cache_file.touch()
+
+    def names():
+        return set(x.name for x in spack.solver.asp.CONC_CACHE.cache_entries())
+
+    before = names()
+    assert len(before) == 1000
+
+    # cleanup should be run after the 1,001st execution
     spack.concretize.concretize_one("py-black")
 
-    real_count, _ = get_current_cache_data()
-    # ensure we only have 1 entry
-    # should be cleaning entry count // 2
-    assert real_count == 1, "Concretization cache cleanup pruned incorrectly"
+    # ensure that half the elements were removed and that one more was created
+    after = names()
+    assert len(after) == 501
+    assert len(after - before) == 1  # one additional hash added by 1001st concretization
 
 
 def test_concretization_cache_uncompressed_entry(use_concretization_cache, monkeypatch):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4298,21 +4298,6 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     assert real_count == 2, "Concretization cache cleanup pruned incorrectly"
 
 
-def test_concretization_cache_bytes_cleanup(use_concretization_cache, mutable_config):
-    """Tests to ensure we are cleaning the cache when we should be respective to the
-    size of the cache in bytes"""
-    spack.config.set("concretizer:concretization_cache:size_limit", 1000)
-    spack.concretize.concretize_one("zlib")
-    # cleanup should be run after hdf5 is concretized
-    spack.concretize.concretize_one("hdf5")
-    real_count, real_size = get_current_cache_data()
-    # ensure we have less than our byte size limit
-    assert real_size < 1000, "Concretization cache cleanup did not reduce enough bytes"
-    # ensure there's fewer cache entries
-    # 1000 is an absurdly low cache size, all entries should be pruned
-    assert real_count == 0, "Concretization cache did not properly prune on byte limit"
-
-
 def test_concretization_cache_uncompressed_entry(use_concretization_cache, monkeypatch):
     def _store(self, problem, result, statistics, test=False):
         cache_path = self._cache_path_from_problem(problem)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4284,7 +4284,11 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     spack.config.set("concretizer:concretization_cache:entry_limit", 1000)
 
     def names():
-        return set(x.name for x in spack.solver.asp.CONC_CACHE.cache_entries())
+        return set(
+            x.name
+            for x in conc_cache_dir.iterdir()
+            if (not x.is_dir() and not x.name.startswith("."))
+        )
 
     assert len(names()) == 0
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import difflib
 import json
 import os
 import pathlib
@@ -4327,3 +4328,34 @@ def test_concretization_cache_uncompressed_entry(use_concretization_cache, monke
     spack.concretize.concretize_one("zlib")
     # Ensure fetch can handle the plaintext cache entry
     spack.concretize.concretize_one("zlib")
+
+
+@pytest.mark.parametrize(
+    "asp_file",
+    [
+        "concretize.lp",
+        "heuristic.lp",
+        "display.lp",
+        "direct_dependency.lp",
+        "when_possible.lp",
+        "libc_compatibility.lp",
+        "os_compatibility.lp",
+        "splices.lp",
+    ],
+)
+def test_concretization_cache_asp_canonicalization(asp_file):
+    path = os.path.join(os.path.dirname(spack.solver.asp.__file__), asp_file)
+
+    with open(path, "r", encoding="utf-8") as f:
+        original = [line.strip() for line in f.readlines()]
+        stripped = spack.solver.asp.strip_asp_problem(original)
+
+    diff = list(difflib.unified_diff(original, stripped))
+
+    assert all(
+        [
+            line == "-" or line.startswith("-%")
+            for line in diff
+            if line.startswith("-") and not line.startswith("---")
+        ]
+    )

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2018,7 +2018,7 @@ class TestConcretize:
         mutable_config.set("packages", packages_yaml["packages"])
 
         setup = spack.solver.asp.SpackSolverSetup()
-        asp_problem = setup.setup([Spec("mpileaks")], reuse=[], allow_deprecated=False)
+        asp_problem = setup.setup([Spec("mpileaks")], reuse=[], allow_deprecated=False).asp_problem
 
         assert all(x in asp_problem for x in expected)
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -439,7 +439,7 @@ def use_concretization_cache(mutable_config, tmp_path: Path):
     with spack.config.override(
         "concretizer:concretization_cache", {"enable": True, "url": str(conc_cache_dir)}
     ):
-        yield
+        yield conc_cache_dir
 
 
 #

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -429,28 +429,17 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_as_slow)
 
 
-@pytest.fixture(scope="session")
-def concretization_cache_root(tmp_path_factory):
-    """Sets a consistent root directory for the concretization cache singleton"""
-    conc_cache_dir = tmp_path_factory.mktemp("concretization")
-    return conc_cache_dir
-
-
 @pytest.fixture(scope="function")
-def use_concretization_cache(mutable_config, concretization_cache_root):
+def use_concretization_cache(mutable_config, tmp_path: Path):
     """Enables the use of the concretization cache"""
+    conc_cache_dir = tmp_path / "concretization"
+    conc_cache_dir.mkdir()
 
     # ensure we have an isolated concretization cache while using fixture
     with spack.config.override(
-        "concretizer:concretization_cache", {"enable": True, "url": str(concretization_cache_root)}
+        "concretizer:concretization_cache", {"enable": True, "url": str(conc_cache_dir)}
     ):
-        yield concretization_cache_root
-
-    for item in concretization_cache_root.iterdir():
-        if item.is_dir():
-            item.rmdir()
-        else:
-            item.unlink()
+        yield conc_cache_dir
 
 
 #

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -432,12 +432,12 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(scope="function")
 def use_concretization_cache(mutable_config, tmp_path: Path):
     """Enables the use of the concretization cache"""
-    spack.config.set("config:concretization_cache:enable", True)
+    spack.config.set("concretizer:concretization_cache:enable", True)
     # ensure we have an isolated concretization cache
     conc_cache_dir = tmp_path / "concretization"
     conc_cache_dir.mkdir()
     new_conc_cache_loc = str(conc_cache_dir)
-    spack.config.set("config:concretization_cache:path", new_conc_cache_loc)
+    spack.config.set("concretizer:concretization_cache:url", new_conc_cache_loc)
     yield
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -429,17 +429,28 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_as_slow)
 
 
+@pytest.fixture(scope="session")
+def concretization_cache_root(tmp_path_factory):
+    """Sets a consistent root directory for the concretization cache singleton"""
+    conc_cache_dir = tmp_path_factory.mktemp("concretization")
+    return conc_cache_dir
+
+
 @pytest.fixture(scope="function")
-def use_concretization_cache(mutable_config, tmp_path: Path):
+def use_concretization_cache(mutable_config, concretization_cache_root):
     """Enables the use of the concretization cache"""
-    conc_cache_dir = tmp_path / "concretization"
-    conc_cache_dir.mkdir()
 
     # ensure we have an isolated concretization cache while using fixture
     with spack.config.override(
-        "concretizer:concretization_cache", {"enable": True, "url": str(conc_cache_dir)}
+        "concretizer:concretization_cache", {"enable": True, "url": str(concretization_cache_root)}
     ):
-        yield conc_cache_dir
+        yield concretization_cache_root
+
+    for item in concretization_cache_root.iterdir():
+        if item.is_dir():
+            item.rmdir()
+        else:
+            item.unlink()
 
 
 #

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -432,13 +432,14 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(scope="function")
 def use_concretization_cache(mutable_config, tmp_path: Path):
     """Enables the use of the concretization cache"""
-    spack.config.set("concretizer:concretization_cache:enable", True)
-    # ensure we have an isolated concretization cache
     conc_cache_dir = tmp_path / "concretization"
     conc_cache_dir.mkdir()
-    new_conc_cache_loc = str(conc_cache_dir)
-    spack.config.set("concretizer:concretization_cache:url", new_conc_cache_loc)
-    yield
+
+    # ensure we have an isolated concretization cache while using fixture
+    with spack.config.override(
+        "concretizer:concretization_cache", {"enable": True, "url": str(conc_cache_dir)}
+    ):
+        yield
 
 
 #

--- a/lib/spack/spack/test/data/config/concretizer.yaml
+++ b/lib/spack/spack/test/data/config/concretizer.yaml
@@ -5,3 +5,5 @@ concretizer:
     host_compatible: false
   duplicates:
     strategy: minimal
+  concretization_cache:
+    enable: false

--- a/lib/spack/spack/test/data/config/config.yaml
+++ b/lib/spack/spack/test/data/config/config.yaml
@@ -14,5 +14,3 @@ config:
   checksum: true
   dirty: false
   locks: {1}
-  concretization_cache:
-    enable: false


### PR DESCRIPTION
Third time is the charm?

Redux of https://github.com/spack/spack/pull/49589 which was reverted by https://github.com/spack/spack/pull/50851 due to race conditions, which efforts have since been made to remove.

#48198 Introduces the concretization cache, and associated manifest. However it only added testing for the cache itself, not the manifest or cleanup procedures.

This PR:

- [x] Adds tests for cleanup
- [x] Refactors the cache to store base32 hashes like the rest of Spack's hashes
- [x] gzips the cache entries for a smaller memory footprint
- [x] Removes redundant stat calls 
- [x] Less aggressive/error prone cleanup phase
- [x] Rewrite pruning to use LRU instead of FIFO

`FileCache` class was refactored into an abstract base `Cache` class which provides the general cache read/write transaction interface, and a `FileCache` and `DirectoryCache` child classes, `FileCache` which should be functionally identical to the `FileCache` class pre refactor, deals with caches at the individual file level, and `DirectoryCache`, which is mean to provide a directory level or "bucket" caching level. 
