### PR TITLE
find: report in groups by compilers (not compiler)

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -370,9 +370,9 @@ def display_specs_as_json(specs, deps=False):
 
 
 def iter_groups(specs, indent, all_headers):
-    """Break a list of specs into groups indexed by arch/compiler."""
-    # Make a dict with specs keyed by architecture and compiler.
-    index = index_by(specs, ("architecture", "compiler"))
+    """Break a list of specs into groups indexed by arch/compilers."""
+    # Make a dict with specs keyed by architecture and compilers.
+    index = index_by(specs, ("architecture", "compilers"))
     ispace = indent * " "
 
     def _key(item):
@@ -381,25 +381,27 @@ def iter_groups(specs, indent, all_headers):
         return str(item)
 
     # Traverse the index and print out each package
-    for i, (architecture, compiler) in enumerate(sorted(index, key=_key)):
+    for i, (architecture, compilers) in enumerate(sorted(index, key=_key)):
         if i > 0:
             print()
 
+        # Drop the leading space from compilers to clean up output and aid checks.
+        compilers_info = compilers[1:] if compilers.startswith(" ") else compilers
         header = "%s{%s} / %s{%s}" % (
             spack.spec.ARCHITECTURE_COLOR,
             architecture if architecture else "no arch",
             spack.spec.COMPILER_COLOR,
-            f"{compiler.display_str}" if compiler else "no compiler",
+            compilers_info if compilers_info else "no compilers",
         )
 
         # Sometimes we want to display specs that are not yet concretized.
-        # If they don't have a compiler / architecture attached to them,
+        # If they don't have a compilers / architecture attached to them,
         # then skip the header
-        if all_headers or (architecture is not None or compiler is not None):
+        if all_headers or (architecture is not None or compilers_info):
             sys.stdout.write(ispace)
             tty.hline(colorize(header), char="-")
 
-        specs = index[(architecture, compiler)]
+        specs = index[(architecture, compilers)]
         specs.sort()
         yield specs
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -386,16 +386,16 @@ def iter_groups(specs, indent, all_headers):
             print()
 
         # Drop the leading space from compilers to clean up output and aid checks.
-        compilers_info = compilers[1:] if compilers.startswith(" ") else compilers
+        compilers_info = compilers.strip() or "no compilers"
         header = "%s{%s} / %s{%s}" % (
             spack.spec.ARCHITECTURE_COLOR,
             architecture if architecture else "no arch",
             spack.spec.COMPILER_COLOR,
-            compilers_info if compilers_info else "no compilers",
+            compilers_info,
         )
 
         # Sometimes we want to display specs that are not yet concretized.
-        # If they don't have a compilers / architecture attached to them,
+        # If they don't have compilers / architecture attached to them,
         # then skip the header
         if all_headers or (architecture is not None or compilers_info):
             sys.stdout.write(ispace)

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -53,7 +53,7 @@ def test_immediate_installed_dependents(mock_packages, database):
     with color_when(False):
         out = dependents("--installed", "libelf")
 
-    lines = [li for li in out.strip().split("\n") if not li.startswith("--")]
+    lines = [li for li in out.strip().split("\n") if li and not li.startswith("--")]
     hashes = set([re.split(r"\s+", li)[0] for li in lines])
 
     expected = set(

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -53,8 +53,8 @@ def test_immediate_installed_dependents(mock_packages, database):
     with color_when(False):
         out = dependents("--installed", "libelf")
 
-    lines = [li for li in out.strip().split("\n") if li and not li.startswith("--")]
-    hashes = set([re.split(r"\s+", li)[0] for li in lines])
+    lines = [li for li in out.strip().split("\n") if not li.startswith("--")]
+    hashes = set([re.split(r"\s+", li)[0] for li in lines if li])
 
     expected = set(
         [spack.store.STORE.db.query_one(s).dag_hash(7) for s in ["dyninst", "libdwarf"]]


### PR DESCRIPTION
This PR was inspired by a discussion in the `Spack General` meeting on June 18, 2025.

In the spirit of recent compiler changes, it might be helpful to start grouping installed packages by `compilers` instead of `compiler`. This PR changes the output, which seems fine for a "fresh" clone/installs BUT not so nice for a clone whose database was converted from `v7` to `v8` and references packages that are no longer installed.

### [RE]FRESH[ED] INSTALLS

```
$ spack find -If
-- darwin-sequoia-m1 / apple-clang@17.0.0 -----------------------
[+]  libelf@0.8.13  [+]  zlib@1.3.1

-- darwin-sequoia-m1 / no compiler ------------------------------
[e]  apple-clang@17.0.0  [e]  git@2.39.5    [e]  openssh@9.9p2
[e]  bison@2.3           [e]  gmake@3.81    [e]  perl@5.34.1
[e]  curl@8.7.1          [e]  m4@1.4.6      [e]  pkgconf@2.4.3
[e]  flex@2.6.4          [e]  meson@1.8.2   [e]  python@3.13.5
[e]  gettext@0.25        [e]  ninja@1.12.1
==> 16 installed package
```

to:

```
$ spack find -If
-- darwin-sequoia-m1 / %c,cxx=apple-clang@17.0.0 ----------------
[+]  zlib@1.3.1

-- darwin-sequoia-m1 / %c=apple-clang@17.0.0 --------------------
[+]  libelf@0.8.13

-- darwin-sequoia-m1 / no compilers -----------------------------
[e]  apple-clang@17.0.0  [e]  git@2.39.5    [e]  openssh@9.9p2
[e]  bison@2.3           [e]  gmake@3.81    [e]  perl@5.34.1
[e]  curl@8.7.1          [e]  m4@1.4.6      [e]  pkgconf@2.4.3
[e]  flex@2.6.4          [e]  meson@1.8.2   [e]  python@3.13.5
[e]  gettext@0.25        [e]  ninja@1.12.1
==> 16 installed packages
```

### "MIXED" INSTALLS

In this case, `find` doesn't necessarily have the information it needs to properly group the installed software by `compilers` plus is likely relying on a database that references packages that are no longer installed (after say a conversion from `v7` to `v8` schema).

From:

```
$ spack find -If
-- linux-rhel8-broadwell / gcc@12.1.1 ---------------------------
[+]  bzip2@1.0.8     [+]  gmake@4.4.1    [+]  pigz@2.8       [+]  zstd@1.5.7
[+]  bzip2@1.0.8     [+]  gmake@4.4.1    [+]  tar@1.35
[+]  diffutils@3.10  [+]  libiconv@1.18  [+]  xz@5.6.3
[+]  diffutils@3.10  [+]  libiconv@1.18  [+]  zlib-ng@2.2.4

-- linux-rhel8-broadwell / no compiler --------------------------
[+]  compiler-wrapper@1.0  [e]  gcc@11.3.0          [+]  gcc-runtime@12.1.1
[e]  gcc@10.3.1            [e]  gcc@12.1.1
[e]  gcc@11.2.1            [+]  gcc-runtime@12.1.1

-- linux-rhel8-x86_64_v3 / gcc@12.1.1 ---------------------------
[e]  glibc@2.28  [e]  openssl@1.1.1k  [e]  python@3.9.13  [e]  zlib@1.2.11

-- linux-rhel8-x86_64_v3 / gcc@10.3.1 ---------------------------
[e]  glibc@2.28  [e]  python@3.10.12

-- linux-rhel8-x86_64_v3 / gcc@11.2.1 ---------------------------
[e]  openssl@1.1.1k  [e]  zlib@1.2.11

-- linux-rhel8-x86_64_v3 / gcc@11.3.0 ---------------------------
[e]  glibc@2.28
==> 29 installed packages
```

to

```
$spack find -If 
-- linux-rhel8-broadwell / %c,cxx=gcc@12.1.1 --------------------
[+]  zlib-ng@2.2.4  [+]  zstd@1.5.7

-- linux-rhel8-broadwell / %c=gcc@12.1.1 ------------------------
[+]  bzip2@1.0.8     [+]  diffutils@3.10  [+]  libiconv@1.18  [+]  tar@1.35
[+]  bzip2@1.0.8     [+]  gmake@4.4.1     [+]  libiconv@1.18  [+]  xz@5.6.3
[+]  diffutils@3.10  [+]  gmake@4.4.1     [+]  pigz@2.8

-- linux-rhel8-broadwell / no compilers -------------------------
[+]  compiler-wrapper@1.0  [e]  gcc@11.3.0          [+]  gcc-runtime@12.1.1
[e]  gcc@10.3.1            [e]  gcc@12.1.1
[e]  gcc@11.2.1            [+]  gcc-runtime@12.1.1

-- linux-rhel8-x86_64_v3 / no compilers -------------------------
[e]  glibc@2.28  [e]  openssl@1.1.1k  [e]  python@3.10.12
[e]  glibc@2.28  [e]  openssl@1.1.1k  [e]  zlib@1.2.11
[e]  glibc@2.28  [e]  python@3.9.13   [e]  zlib@1.2.11
==> 29 installed packages
```