### PR TITLE
disable `v` toggle feature temporarily

### DIFF
--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -24,13 +24,6 @@ from typing import Callable, Optional
 import llnl.util.tty as tty
 
 termios: Optional[ModuleType] = None
-try:
-    import termios as term_mod
-
-    termios = term_mod
-except ImportError:
-    pass
-
 
 esc, bell, lbracket, bslash, newline = r"\x1b", r"\x07", r"\[", r"\\", r"\n"
 # Ansi Control Sequence Introducers (CSI) are a well-defined format


### PR DESCRIPTION
> [!NOTE] 
> This PR disables the `v` feature to restore sanity, while a better fix is worked on, so we don't have to merge this if the fix is submitted earlier.


With `spack install -p 2` the second process will use the terminal defaults
that the first process modified, and ultimately reset to those if it finishes
later than the first process.

The first process disables echo, so upon exit you may end up with echo disabled.

User have to type `stty echo` to use their terminal again.




