### PR TITLE
Optimize patch injection when building concrete specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -4460,11 +4460,11 @@ def _inject_patches_variant(root: spack.spec.Spec) -> None:
 
         edge_patches: List[spack.patch.Patch] = []
         for cond, deps_by_name in pkg_deps.items():
-            if not dspec.parent.satisfies(cond):
-                continue
-
             dependency = deps_by_name.get(dspec.spec.name)
             if not dependency:
+                continue
+
+            if not dspec.parent.satisfies(cond):
                 continue
 
             for pcond, patch_list in dependency.patches.items():

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -779,6 +779,7 @@ class DependencySpec:
         yield self.depflag
         yield self.virtuals
         yield self.direct
+        yield self.when
 
     def __str__(self) -> str:
         parent = self.parent.name if self.parent else None
@@ -4050,6 +4051,7 @@ class Spec:
                         edge.depflag,
                         edge.virtuals,
                         edge.direct,
+                        edge.when,
                     )
                 )
 
@@ -4060,7 +4062,7 @@ class Spec:
 
             # level 1 edges all start with zero
             for i, edge in enumerate(sorted_l1_edges, start=1):
-                yield (0, i, edge.depflag, edge.virtuals, edge.direct)
+                yield (0, i, edge.depflag, edge.virtuals, edge.direct, edge.when)
 
             # yield remaining edges in the order they were encountered during traversal
             if edge_list:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2169,7 +2169,7 @@ EMPTY_FLG = Spec().compiler_flags
                     ("a", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                     ("b", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
-                ((0, 1, 0, (), False),),
+                ((0, 1, 0, (), False, Spec()),),
             ),
         ],
         # root with multiple deps
@@ -2182,7 +2182,11 @@ EMPTY_FLG = Spec().compiler_flags
                     ("c", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                     ("d", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
-                ((0, 1, 0, (), False), (0, 2, 0, (), False), (0, 3, 0, (), False)),
+                (
+                    (0, 1, 0, (), False, Spec()),
+                    (0, 2, 0, (), False, Spec()),
+                    (0, 3, 0, (), False, Spec()),
+                ),
             ),
         ],
         # root with multiple build deps
@@ -2195,7 +2199,11 @@ EMPTY_FLG = Spec().compiler_flags
                     ("c", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                     ("d", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
-                ((0, 1, 0, (), True), (0, 2, 0, (), True), (0, 3, 0, (), True)),
+                (
+                    (0, 1, 0, (), True, Spec()),
+                    (0, 2, 0, (), True, Spec()),
+                    (0, 3, 0, (), True, Spec()),
+                ),
             ),
         ],
         # dependencies with dependencies
@@ -2212,12 +2220,12 @@ EMPTY_FLG = Spec().compiler_flags
                     ("g", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
                 (
-                    (0, 1, 0, (), False),
-                    (0, 2, 0, (), False),
-                    (1, 3, 0, (), True),
-                    (1, 4, 0, (), True),
-                    (2, 5, 0, (), True),
-                    (2, 6, 0, (), True),
+                    (0, 1, 0, (), False, Spec()),
+                    (0, 2, 0, (), False, Spec()),
+                    (1, 3, 0, (), True, Spec()),
+                    (1, 4, 0, (), True, Spec()),
+                    (2, 5, 0, (), True, Spec()),
+                    (2, 6, 0, (), True, Spec()),
                 ),
             ),
         ],
@@ -2324,3 +2332,11 @@ def test_specs_equality(lhs, rhs, expected):
     """Tests the semantic of == for abstract specs"""
     lhs, rhs = Spec(lhs), Spec(rhs)
     assert (lhs == rhs) is expected
+
+
+def test_edge_equality_accounts_for_when_condition():
+    """Tests that edges can be distinguished by their 'when' condition."""
+    parent, child = Spec("parent"), Spec("child")
+    edge1 = DependencySpec(parent, child, depflag=0, virtuals=(), when=Spec("%c"))
+    edge2 = DependencySpec(parent, child, depflag=0, virtuals=())
+    assert edge1 != edge2

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -35,9 +35,9 @@ class EdgeAndDepth(NamedTuple):
     depth: int
 
 
-# Sort edges by name first, then abstract hash, then full edge string to break ties
+# Sort edges by name first, then abstract hash, then full edge comparison to break ties
 def sort_edges(edges):
-    edges.sort(key=lambda edge: (edge.spec.name or "", edge.spec.abstract_hash or "", str(edge)))
+    edges.sort(key=lambda edge: (edge.spec.name or "", edge.spec.abstract_hash or "", edge))
     return edges
 
 


### PR DESCRIPTION
Modifications:
- [x] Switch two early exit condition, so the fastest to compute is first
- [x] Fix a bug with edge comparison that doesn't account for `when` condition

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
