### PR TITLE
misc cache: restore old defaults

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -87,7 +87,8 @@ config:
 
   # Cache directory for miscellaneous files, like the package index.
   # This can be purged with `spack clean --misc-cache`
-  misc_cache: $user_cache_path/$spack_instance_id/cache
+  # Consider $user_cache_path/$spack_instance_id/cache when using multiple Spack instances
+  misc_cache: $user_cache_path/cache
 
 
   # Abort downloads after this many seconds if not data is received.

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -115,7 +115,7 @@ package_repos_path = os.path.join(user_cache_path, "package_repos")
 default_user_bootstrap_path = os.path.join(user_cache_path, "bootstrap")
 
 #: transient caches for Spack data (virtual cache, patch sha256 lookup, etc.)
-default_misc_cache_path = os.path.join(user_cache_path, spack_instance_id, "cache")
+default_misc_cache_path = os.path.join(user_cache_path, "cache")
 
 #: concretization cache for Spack concretizations
 default_conc_cache_path = os.path.join(default_misc_cache_path, "concretization")


### PR DESCRIPTION
The new default cache path `~/.spack/<instance>/cache` is bad for CI use cases. 

Gitlab CI may clone *the same Spack instance* for a subsequent job in a different dir (based on runner id, concurrency, etc).

A typical (?) CI workflow is:
1. Concretize in a first CI job, and upload cache as an artifact
2. Build jobs run in parallel and benefit from ~45s reduction in setup time.