### PR TITLE
config: revert default `misc_cache` to `~/.spack/cache`

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -87,7 +87,7 @@ config:
 
   # Cache directory for miscellaneous files, like the package index.
   # This can be purged with `spack clean --misc-cache`
-  misc_cache: $user_cache_path/$spack_instance_id/cache
+  misc_cache: $user_cache_path/cache
 
 
   # Abort downloads after this many seconds if not data is received.

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -135,10 +135,14 @@ Temporary directory to store long-lived cache files, such as indices of
 packages available in repositories.  Defaults to ``~/.spack/cache``.  Can
 be purged with :ref:`spack clean --misc-cache <cmd-spack-clean>`.
 
-Temporary directory to store long-lived cache files, such as indices
-of packages available in repositories.  Defaults to
-``~/.spack/$spack_instance_id/cache``.  Can be purged with
-:ref:`spack clean --misc-cache <cmd-spack-clean>`.
+In some cases, e.g., if you work with many Spack instances or many different
+versions of Spack, it makes sense to have a cache per instance or per version.
+You can do that by changing the value to either:
+
+* ``~/.spack/$spack_instance_id/cache`` for per-instance caches, or
+* ``~/.spack/$spack_short_version/cache`` for per-spack-version caches.
+
+Can be purged with :ref:`spack clean --misc-cache <cmd-spack-clean>`.
 
 --------------------
 ``verify_ssl``

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -644,7 +644,7 @@ account all scopes. For example, to see the fully merged
      - ~/.spack/stage
      - $spack/var/spack/stage
      source_cache: $spack/var/spack/cache
-     misc_cache: $user_cache_path/$spack_instance_id/cache
+     misc_cache: ~/.spack/cache
      locks: true
 
 Likewise, this will show the fully merged ``packages.yaml``:
@@ -691,7 +691,7 @@ down the source of the configuration:
    /home/myuser/spack/etc/spack/defaults/config.yaml:51    - ~/.spack/stage
    /home/myuser/spack/etc/spack/defaults/config.yaml:52    - $spack/var/spack/stage
    /home/myuser/spack/etc/spack/defaults/config.yaml:57    source_cache: $spack/var/spack/cache
-   /home/myuser/spack/etc/spack/defaults/config.yaml:62    misc_cache: $user_cache_path/$spack_instance_id/cache
+   /home/myuser/spack/etc/spack/defaults/config.yaml:62    misc_cache: ~/.spack/cache
    /home/myuser/spack/etc/spack/defaults/config.yaml:86    locks: True
 
 You can see above that the ``build_jobs`` and ``debug`` settings are

--- a/lib/spack/spack/test/data/config/config.yaml
+++ b/lib/spack/spack/test/data/config/config.yaml
@@ -8,7 +8,7 @@ config:
   build_stage:
   - $tempdir/$user/spack-stage
   source_cache: $user_cache_path/source
-  misc_cache: $user_cache_path/$spack_instance_id/cache
+  misc_cache: $user_cache_path/cache
   verify_ssl: true
   ssl_certs: $SSL_CERT_FILE
   checksum: true


### PR DESCRIPTION
This (#50595) was more of a breaking change than we anticipated, so we're reverting the default back to `~/.spack/cache`.

This does, however, keep the `$spack_instance_id` variable, so you can still configure your own spack instances to use a per-instance default (or users can configure that in `~/.spack/config.yaml`).

There are some things we should do in the near future to fix issues with `spack clean -m`:

1. Fix cache invalidation so that we're not just looking at dates. We should be looking at stat records and hashes like `git` does. This will eliminate issues with broken caches altogether, but it won't fix the performance issue (needing to regenerate caches when changing between sufficiently different versions of Spack).

2. Figure out a better way to store caches for repository information. This will reduce the frequency with which you need to refresh caches. Per instance caches aren't really the right thing here -- it is more likely that per-spack-packages-checkout caches would work better, but it's subtle what the best setting should be.
