### PR TITLE
bugfix/testing: repo.MockRepositoryBuilder support use_repositories override=True

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -186,7 +186,6 @@ class ReposFinder:
 #
 # These names describe how repos should be laid out in the filesystem.
 #
-build_systems_dir_name = "build_systems"  # Top-level repo directory containing build systems.
 repo_config_name = "repo.yaml"  # Top-level filename for repo config.
 repo_index_name = "index.yaml"  # Top-level filename for repository index.
 packages_dir_name = "packages"  # Top-level repo directory containing pkgs.
@@ -2029,31 +2028,13 @@ class MockRepositoryBuilder:
                 ``spack.dependency.default_deptype`` and ``spack.spec.Spec()`` are used.
         """
         dependencies = dependencies or []
-        context = {
-            "cls_name": nm.pkg_name_to_class_name(name),
-            "dependencies": dependencies,
-            "namespace": self.namespace,
-        }
+        context = {"cls_name": nm.pkg_name_to_class_name(name), "dependencies": dependencies}
         template = spack.tengine.make_environment().get_template("mock-repository/package.pyt")
         text = template.render(context)
         package_py = self.recipe_filename(name)
         fs.mkdirp(os.path.dirname(package_py))
         with open(package_py, "w", encoding="utf-8") as f:
             f.write(text)
-
-        # The only relevant build system is GenericBuilder.
-        generic_py = self.generic_buildsystem_filename
-        if not os.path.exists(generic_py):
-            dest_root = os.path.dirname(generic_py)
-            source_root = os.path.join(spack.paths.mock_packages_path, build_systems_dir_name)
-
-            # GenericBuilder
-            source_path = os.path.join(source_root, "generic.py")
-            fs.mkdirp(os.path.dirname(generic_py))
-            fs.copy(source_path, generic_py)
-
-            # Requires _checks.py too
-            fs.copy(os.path.join(source_root, "_checks.py"), os.path.join(dest_root, "_checks.py"))
 
     def remove(self, name):
         package_py = self.recipe_filename(name)
@@ -2063,10 +2044,6 @@ class MockRepositoryBuilder:
         return os.path.join(
             self.root, "packages", nm.pkg_name_to_pkg_dir(name, package_api=(2, 0)), "package.py"
         )
-
-    @property
-    def generic_buildsystem_filename(self):
-        return os.path.join(self.root, build_systems_dir_name, "generic.py")
 
 
 class RepoError(spack.error.SpackError):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -186,6 +186,7 @@ class ReposFinder:
 #
 # These names describe how repos should be laid out in the filesystem.
 #
+build_systems_dir_name = "build_systems"  # Top-level repo directory containing build systems.
 repo_config_name = "repo.yaml"  # Top-level filename for repo config.
 repo_index_name = "index.yaml"  # Top-level filename for repository index.
 packages_dir_name = "packages"  # Top-level repo directory containing pkgs.
@@ -2028,13 +2029,31 @@ class MockRepositoryBuilder:
                 ``spack.dependency.default_deptype`` and ``spack.spec.Spec()`` are used.
         """
         dependencies = dependencies or []
-        context = {"cls_name": nm.pkg_name_to_class_name(name), "dependencies": dependencies}
+        context = {
+            "cls_name": nm.pkg_name_to_class_name(name),
+            "dependencies": dependencies,
+            "namespace": self.namespace,
+        }
         template = spack.tengine.make_environment().get_template("mock-repository/package.pyt")
         text = template.render(context)
         package_py = self.recipe_filename(name)
         fs.mkdirp(os.path.dirname(package_py))
         with open(package_py, "w", encoding="utf-8") as f:
             f.write(text)
+
+        # The only relevant build system is GenericBuilder.
+        generic_py = self.generic_buildsystem_filename
+        if not os.path.exists(generic_py):
+            dest_root = os.path.dirname(generic_py)
+            source_root = os.path.join(spack.paths.mock_packages_path, build_systems_dir_name)
+
+            # GenericBuilder
+            source_path = os.path.join(source_root, "generic.py")
+            fs.mkdirp(os.path.dirname(generic_py))
+            fs.copy(source_path, generic_py)
+
+            # Requires _checks.py too
+            fs.copy(os.path.join(source_root, "_checks.py"), os.path.join(dest_root, "_checks.py"))
 
     def remove(self, name):
         package_py = self.recipe_filename(name)
@@ -2044,6 +2063,10 @@ class MockRepositoryBuilder:
         return os.path.join(
             self.root, "packages", nm.pkg_name_to_pkg_dir(name, package_api=(2, 0)), "package.py"
         )
+
+    @property
+    def generic_buildsystem_filename(self):
+        return os.path.join(self.root, build_systems_dir_name, "generic.py")
 
 
 class RepoError(spack.error.SpackError):

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -906,3 +906,11 @@ def test_repo_descriptors_update_invalid(tmp_path: pathlib.Path):
     with pytest.raises(spack.repo.RepoError, match="Unable to locate a default branch"):
         for descriptor in repos_1.values():
             descriptor.update(git=MockGitInvalidRemote())
+
+
+def test_repo_use_import_success(config, mock_packages_repo, tmpdir, monkeypatch):
+    """Demonstrate success when attempt to get class for package in correct repo."""
+    builder = spack.repo.MockRepositoryBuilder(tmpdir)
+    builder.add_package("pkg-a")
+    with spack.repo.use_repositories(builder.root, override=True):
+        spack.repo.PATH.get_pkg_class("pkg-a")

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -908,6 +908,7 @@ def test_repo_descriptors_update_invalid(tmp_path: pathlib.Path):
             descriptor.update(git=MockGitInvalidRemote())
 
 
+@pytest.mark.regression("50934")
 def test_repo_use_import_success(config, mock_packages_repo, tmpdir, monkeypatch):
     """Demonstrate success when attempt to get class for package in correct repo."""
     builder = spack.repo.MockRepositoryBuilder(tmpdir)

--- a/share/spack/templates/mock-repository/package.pyt
+++ b/share/spack/templates/mock-repository/package.pyt
@@ -1,7 +1,6 @@
-from spack_repo.{{ namespace }}.build_systems.generic import Package
 from spack.package import *
 
-class {{ cls_name }}(Package):
+class {{ cls_name }}(PackageBase):
     homepage = "http://www.example.com"
     url = "http://www.example.com/root-1.0.tar.gz"
 

--- a/share/spack/templates/mock-repository/package.pyt
+++ b/share/spack/templates/mock-repository/package.pyt
@@ -1,4 +1,4 @@
-from spack_repo.builtin_mock.build_systems.generic import Package
+from spack_repo.{{ namespace }}.build_systems.generic import Package
 from spack.package import *
 
 class {{ cls_name }}(Package):


### PR DESCRIPTION
Fixes #50934

The failure reported in #50934 occurs when `spack.repo.PATH.get_pkg_class()` attempts to import the package and gets an `import error: No module named 'spack_repo.builtin_mock'` failure but that information is not provided in the exception. (This is addressed in #50935 and would benefit from `test_repo_use_import_failure` implemented there.)

~This PR lazily ensures that `MockRepositoryBuilder` uses the repository namespace for the build system and creates and populates its own `build_systems` directory (with the minimum files).~ 

The only change needed was to switch from `Package` to PackageBase` in the template. Left the unit test in place.