### PR TITLE
Fix mock repo to not rely on builtin_mock

### DIFF
--- a/share/spack/templates/mock-repository/package.pyt
+++ b/share/spack/templates/mock-repository/package.pyt
@@ -1,9 +1,16 @@
-from spack_repo.builtin_mock.build_systems.generic import Package
 from spack.package import *
 
-class {{ cls_name }}(Package):
+class {{ cls_name }}(PackageBase):
     homepage = "http://www.example.com"
     url = "http://www.example.com/root-1.0.tar.gz"
+
+    #: This attribute is used in UI queries that require to know which
+    #: build-system class we are using
+    build_system_class = "Package"
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = "generic"
+
+    build_system("generic")
 
     version("3.0", sha256='abcde')
     version("2.0", sha256='abcde')
@@ -20,3 +27,18 @@ class {{ cls_name }}(Package):
     depends_on("{{ dep_spec }}")
 {% endif %}
 {% endfor %}
+
+
+@register_builder("generic")
+class GenericBuilder(Builder):
+    """A generic builder for a mocked package.
+    """
+
+    #: A generic package has only the "install" phase
+    phases = ("install",)
+
+    def install(
+        self, pkg: {{ cls_name }}, spec: Spec, prefix: Prefix
+    ) -> None:
+        """Noop install"""
+        pass


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Mock repos should not rely on `builtin_mock`.