### PR TITLE
`get_pkg_class`: improve reporting of import error resulting from repo mismatch

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1401,7 +1401,7 @@ class Repo:
                 sys.path.insert(0, self.python_path)
             module = importlib.import_module(fullname)
         except Exception as e:
-            msg = f"Cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
+            msg = f"cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
             raise RepoError(msg) from e
         finally:
             if self.python_path:
@@ -2035,7 +2035,13 @@ class UnknownEntityError(RepoError):
 class UnknownPackageError(UnknownEntityError):
     """Raised when we encounter a package spack doesn't have."""
 
-    def __init__(self, name, repo: Optional[Union[Repo, RepoPath, str]] = None):
+    def __init__(
+        self,
+        name,
+        repo: Optional[Union[Repo, RepoPath, str]] = None,
+        *,
+        get_close_matches=difflib.get_close_matches,
+    ):
         msg = "Attempting to retrieve anonymous package."
         long_msg = None
         if name:
@@ -2063,7 +2069,7 @@ class UnknownPackageError(UnknownEntityError):
                 similar = []
                 if isinstance(repo, RepoPath):
                     try:
-                        similar = difflib.get_close_matches(pkg_name, repo.all_package_names())
+                        similar = get_close_matches(pkg_name, repo.all_package_names())
                     except Exception:
                         pass
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1393,14 +1393,15 @@ class Repo:
 
         class_name = nm.pkg_name_to_class_name(pkg_name)
 
+        if not self.exists(pkg_name):
+            raise UnknownPackageError(fullname, self)
+
         try:
             if self.python_path:
                 sys.path.insert(0, self.python_path)
             module = importlib.import_module(fullname)
-        except ImportError as e:
-            raise UnknownPackageError(fullname) from e
         except Exception as e:
-            msg = f"cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
+            msg = f"Cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
             raise RepoError(msg) from e
         finally:
             if self.python_path:
@@ -2034,15 +2035,16 @@ class UnknownEntityError(RepoError):
 class UnknownPackageError(UnknownEntityError):
     """Raised when we encounter a package spack doesn't have."""
 
-    def __init__(self, name, repo=None):
+    def __init__(self, name, repo: Optional[Union[Repo, RepoPath, str]] = None):
         msg = "Attempting to retrieve anonymous package."
         long_msg = None
         if name:
+            msg = f"Package '{name}' not found"
             if repo:
-                msg = "Package '{0}' not found in repository '{1.root}'"
-                msg = msg.format(name, repo)
-            else:
-                msg = "Package '{0}' not found.".format(name)
+                if isinstance(repo, Repo):
+                    msg += f" in repository '{repo.root}'"
+                elif isinstance(repo, str):
+                    msg += f" in repository '{repo}'"
 
             # Special handling for specs that may have been intended as
             # filenames: prompt the user to ask whether they intended to write
@@ -2054,14 +2056,16 @@ class UnknownPackageError(UnknownEntityError):
                 long_msg = "Use 'spack create' to create a new package."
 
                 if not repo:
-                    repo = PATH
+                    repo = PATH.ensure_unwrapped()
 
                 # We need to compare the base package name
                 pkg_name = name.rsplit(".", 1)[-1]
-                try:
-                    similar = difflib.get_close_matches(pkg_name, repo.all_package_names())
-                except Exception:
-                    similar = []
+                similar = []
+                if isinstance(repo, RepoPath):
+                    try:
+                        similar = difflib.get_close_matches(pkg_name, repo.all_package_names())
+                    except Exception:
+                        pass
 
                 if 1 <= len(similar) <= 5:
                     long_msg += "\n\nDid you mean one of the following packages?\n  "

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -1,10 +1,13 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import difflib
 import os
 import pathlib
 
 import pytest
+
+import llnl.util.filesystem as fs
 
 import spack
 import spack.environment
@@ -911,3 +914,80 @@ def test_repo_descriptors_update_invalid(tmp_path: pathlib.Path):
     with pytest.raises(spack.repo.RepoError, match="Unable to locate a default branch"):
         for descriptor in repos_1.values():
             descriptor.update(git=MockGitInvalidRemote())
+
+
+def test_repo_use_bad_import(
+    config, mock_packages_repo, repo_builder: RepoBuilder, tmpdir, monkeypatch
+):
+    """Demonstrate failure when attempt to get the class for package containing
+    a failing import (e.g., missing repository)."""
+    package_name = "importer"
+    package_py = repo_builder._recipe_filename(package_name)
+    fs.mkdirp(os.path.dirname(package_py))
+    with open(package_py, "w", encoding="utf-8") as f:
+        f.write(
+            f"""
+from spack_repo.missing.packages import base
+from spack.package import *
+
+
+class {package_name.capitalize()}(PackageBase):
+    homepage = "https://www.bad-importer.com"
+    url = "https://www.bad-importer.com/v1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+"""
+        )
+
+    with spack.repo.use_repositories(repo_builder.root):
+        with pytest.raises(spack.repo.RepoError, match="Cannot load"):
+            spack.repo.PATH.get_pkg_class(package_name)
+
+
+def test_repo_use_bad_syntax(
+    config, mock_packages_repo, repo_builder: RepoBuilder, tmpdir, monkeypatch
+):
+    """Demonstrate failure when attempt to get class for package with invalid syntax."""
+    package_name = "erroneous"
+    package_py = repo_builder._recipe_filename(package_name)
+    fs.mkdirp(os.path.dirname(package_py))
+    with open(package_py, "w", encoding="utf-8") as f:
+        f.write(
+            f"""
+from spack.package import *
+
+class {package_name.capitalize()}(PackageBase)
+    homepage = "https://www.bad-syntax.com"
+    url = "https://www.bad-syntax.com/v1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+"""
+        )
+
+    with spack.repo.use_repositories(repo_builder.root):
+        with pytest.raises(spack.repo.RepoError):
+            spack.repo.PATH.get_pkg_class(package_name)
+
+
+def test_unknownpkgerror_match_fails(monkeypatch):
+    """Ensure fails with basic message when get_close_matches fails."""
+
+    def _get_close_matches(*args, **kwargs):
+        raise MemoryError("Too many packages to compare")
+
+    monkeypatch.setattr(difflib, "get_close_matches", _get_close_matches)
+
+    with pytest.raises(spack.repo.UnknownPackageError) as exc:
+        raise spack.repo.UnknownPackageError("pkg_a")
+
+    # Confirm that the error indicates there were no matches (default).
+    assert "mean one of the following" not in str(exc)
+
+
+def test_unknownpkgerror_str_repo(tmpdir):
+    """Ensure reasonable error message when repo is a string."""
+    with pytest.raises(spack.repo.UnknownPackageError) as exc:
+        raise spack.repo.UnknownPackageError("pkg_a", "my_special_repo")
+
+    # Confirm that the error includes the repository part of the message.
+    assert "not found in repository" in str(exc)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -1,13 +1,10 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import difflib
 import os
 import pathlib
 
 import pytest
-
-import llnl.util.filesystem as fs
 
 import spack
 import spack.environment
@@ -16,7 +13,6 @@ import spack.paths
 import spack.repo
 import spack.schema.repos
 import spack.spec
-import spack.test.conftest
 import spack.util.executable
 import spack.util.file_cache
 import spack.util.lock
@@ -916,78 +912,53 @@ def test_repo_descriptors_update_invalid(tmp_path: pathlib.Path):
             descriptor.update(git=MockGitInvalidRemote())
 
 
-def test_repo_use_bad_import(
-    config, mock_packages_repo, repo_builder: RepoBuilder, tmpdir, monkeypatch
-):
+def test_repo_use_bad_import(config, repo_builder: RepoBuilder):
     """Demonstrate failure when attempt to get the class for package containing
     a failing import (e.g., missing repository)."""
-    package_name = "importer"
-    package_py = repo_builder._recipe_filename(package_name)
-    fs.mkdirp(os.path.dirname(package_py))
-    with open(package_py, "w", encoding="utf-8") as f:
-        f.write(
-            f"""
+    package_py = pathlib.Path(repo_builder._recipe_filename("importer"))
+    package_py.parent.mkdir(parents=True)
+    package_py.write_text(
+        """\
 from spack_repo.missing.packages import base
 from spack.package import *
 
 
-class {package_name.capitalize()}(PackageBase):
+class Importer(PackageBase):
     homepage = "https://www.bad-importer.com"
     url = "https://www.bad-importer.com/v1.0.tar.gz"
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
-"""
-        )
+""",
+        encoding="utf-8",
+    )
 
     with spack.repo.use_repositories(repo_builder.root):
-        with pytest.raises(spack.repo.RepoError, match="Cannot load"):
-            spack.repo.PATH.get_pkg_class(package_name)
+        with pytest.raises(spack.repo.RepoError, match="cannot load"):
+            spack.repo.PATH.get_pkg_class("importer")
 
 
-def test_repo_use_bad_syntax(
-    config, mock_packages_repo, repo_builder: RepoBuilder, tmpdir, monkeypatch
-):
+def test_repo_use_bad_syntax(config, repo_builder: RepoBuilder):
     """Demonstrate failure when attempt to get class for package with invalid syntax."""
-    package_name = "erroneous"
-    package_py = repo_builder._recipe_filename(package_name)
-    fs.mkdirp(os.path.dirname(package_py))
-    with open(package_py, "w", encoding="utf-8") as f:
-        f.write(
-            f"""
-from spack.package import *
-
-class {package_name.capitalize()}(PackageBase)
-    homepage = "https://www.bad-syntax.com"
-    url = "https://www.bad-syntax.com/v1.0.tar.gz"
-
-    version("1.0", md5="0123456789abcdef0123456789abcdef")
-"""
-        )
+    package_py = pathlib.Path(repo_builder._recipe_filename("erroneous"))
+    package_py.parent.mkdir(parents=True)
+    package_py.write_text("class 123: pass", encoding="utf-8")
 
     with spack.repo.use_repositories(repo_builder.root):
         with pytest.raises(spack.repo.RepoError):
-            spack.repo.PATH.get_pkg_class(package_name)
+            spack.repo.PATH.get_pkg_class("erroneous")
 
 
-def test_unknownpkgerror_match_fails(monkeypatch):
+def test_unknownpkgerror_match_fails():
     """Ensure fails with basic message when get_close_matches fails."""
 
     def _get_close_matches(*args, **kwargs):
         raise MemoryError("Too many packages to compare")
 
-    monkeypatch.setattr(difflib, "get_close_matches", _get_close_matches)
-
-    with pytest.raises(spack.repo.UnknownPackageError) as exc:
-        raise spack.repo.UnknownPackageError("pkg_a")
-
     # Confirm that the error indicates there were no matches (default).
-    assert "mean one of the following" not in str(exc)
+    exception = spack.repo.UnknownPackageError("pkg_a", get_close_matches=_get_close_matches)
+    assert "mean one of the following" not in str(exception)
 
 
-def test_unknownpkgerror_str_repo(tmpdir):
+def test_unknownpkgerror_str_repo():
     """Ensure reasonable error message when repo is a string."""
-    with pytest.raises(spack.repo.UnknownPackageError) as exc:
-        raise spack.repo.UnknownPackageError("pkg_a", "my_special_repo")
-
-    # Confirm that the error includes the repository part of the message.
-    assert "not found in repository" in str(exc)
+    assert "not found in repository" in str(spack.repo.UnknownPackageError("pkg_a", "my_repo"))


### PR DESCRIPTION
Debugging #50934 required additional information about the reason the error was raised, which turned out to be a problem with the package assuming access to the `builtin_mock` repository.

Given support for multiple package repositories, it is important that the error messages associated with import errors related to packages/repositories provide additional information to aid debugging.

~This PR modifies `UnknownPackageError` to allow and use, in one case, the inclusion of the exception error message.~

