### PR TITLE
Spec.installed_upstream fix

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -739,9 +739,6 @@ class Database:
             return False, data[hash_key]
         if not data:
             with self.read_transaction():
-                # TODO: if there is a local record but it is not installed
-                # locally, should we then check all upstreams and favor
-                # those?
                 if hash_key in self._data:
                     return False, self._data[hash_key]
         for db in self.upstream_dbs:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -727,19 +727,22 @@ class Database:
 
         Return:
             (tuple): (bool, optional InstallRecord): bool tells us whether
-                the spec is installed upstream. Its InstallRecord is also
-                returned if it's installed at all; otherwise None.
+                the record is from an upstream. Its InstallRecord is also
+                returned if available (the record must be checked to know
+                whether the hash is installed).
         """
         if data and hash_key in data:
             return False, data[hash_key]
         if not data:
             with self.read_transaction():
+                # TODO: if there is a local record but it is not installed
+                # locally, should we then check all upstreams and favor
+                # those?
                 if hash_key in self._data:
                     return False, self._data[hash_key]
         for db in self.upstream_dbs:
             if hash_key in db._data:
-                record = db._data[hash_key]
-                return record.installed, record
+                return True, db._data[hash_key]
         return False, None
 
     def query_local_by_spec_hash(self, hash_key):
@@ -1176,7 +1179,7 @@ class Database:
         key = spec.dag_hash()
         spec_pkg_hash = spec._package_hash  # type: ignore[attr-defined]
         upstream, record = self.query_by_spec_hash(key)
-        if upstream:
+        if upstream and record and record.installed:
             return
 
         installation_time = installation_time or _now()
@@ -1265,7 +1268,7 @@ class Database:
     def _get_matching_spec_key(self, spec: "spack.spec.Spec", **kwargs) -> str:
         """Get the exact spec OR get a single spec that matches."""
         key = spec.dag_hash()
-        upstream, record = self.query_by_spec_hash(key)
+        _, record = self.query_by_spec_hash(key)
         if not record:
             match = self.query_one(spec, **kwargs)
             if match:
@@ -1276,7 +1279,7 @@ class Database:
     @_autospec
     def get_record(self, spec: "spack.spec.Spec", **kwargs) -> Optional[InstallRecord]:
         key = self._get_matching_spec_key(spec, **kwargs)
-        upstream, record = self.query_by_spec_hash(key)
+        _, record = self.query_by_spec_hash(key)
         return record
 
     def _decrement_ref_count(self, spec: "spack.spec.Spec") -> None:
@@ -1784,7 +1787,7 @@ class Database:
 
     def missing(self, spec):
         key = spec.dag_hash()
-        upstream, record = self.query_by_spec_hash(key)
+        _, record = self.query_by_spec_hash(key)
         return record and not record.installed
 
     def is_occupied_install_prefix(self, path):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -738,7 +738,8 @@ class Database:
                     return False, self._data[hash_key]
         for db in self.upstream_dbs:
             if hash_key in db._data:
-                return True, db._data[hash_key]
+                record = db._data[hash_key]
+                return record.installed, record
         return False, None
 
     def query_local_by_spec_hash(self, hash_key):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -730,6 +730,10 @@ class Database:
                 the record is from an upstream. Its InstallRecord is also
                 returned if available (the record must be checked to know
                 whether the hash is installed).
+
+        If the record is available locally, this function will always have
+        a preference for returning that, even if it is not installed locally
+        and is installed upstream.
         """
         if data and hash_key in data:
             return False, data[hash_key]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2019,8 +2019,8 @@ class Spec:
         if not self.concrete:
             return False
 
-        upstream, _ = spack.store.STORE.db.query_by_spec_hash(self.dag_hash())
-        return upstream
+        upstream, record = spack.store.STORE.db.query_by_spec_hash(self.dag_hash())
+        return upstream and record and record.installed
 
     @overload
     def traverse(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2838,7 +2838,7 @@ class Spec:
                 return name, depflag
 
             def spec_and_dependency_types(
-                s: Union[Spec, Tuple[Spec, str]],
+                s: Union[Spec, Tuple[Spec, str]]
             ) -> Tuple[Spec, dt.DepFlag]:
                 """Given a non-string key in the literal, extracts the spec
                 and its dependency types.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2838,7 +2838,7 @@ class Spec:
                 return name, depflag
 
             def spec_and_dependency_types(
-                s: Union[Spec, Tuple[Spec, str]]
+                s: Union[Spec, Tuple[Spec, str]],
             ) -> Tuple[Spec, dt.DepFlag]:
                 """Given a non-string key in the literal, extracts the spec
                 and its dependency types.

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -185,6 +185,40 @@ def test_installed_upstream(upstream_and_downstream_db, tmpdir):
         upstream_db._check_ref_counts()
         downstream_db._check_ref_counts()
 
+from spack.directory_layout import DirectoryLayoutError
+#from conftest import MockLayout
+
+def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypatch, config):
+    upstream_db, downstream_db = upstream_and_downstream_db
+
+    def fail_for_z(spec):
+        if spec.name == "z":
+            raise DirectoryLayoutError("Fake layout error for z")
+    #monkeypatch.setattr(MockLayout, "ensure_installed", fail_for_z)
+
+    upstream_db.layout.ensure_installed = fail_for_z
+
+    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
+    builder.add_package("z")
+    builder.add_package("y", dependencies=[("z", "build", None)])
+    builder.add_package("x", dependencies=[("y", None, None)])
+
+    with spack.repo.use_repositories(builder.root):
+        x = spack.concretize.concretize_one("x")
+        y = x["y"]
+        z = y["z"]
+
+        with writable(upstream_db):
+            upstream_db.add(y)
+        upstream_db._read()
+
+        upstream, record = downstream_db.query_by_spec_hash(z.dag_hash())
+        assert upstream
+        assert not record.installed
+
+        assert not z.installed
+        assert not z.installed_upstream
+
 
 def test_removed_upstream_dep(upstream_and_downstream_db, tmpdir, capsys, config):
     upstream_db, downstream_db = upstream_and_downstream_db

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -216,6 +216,9 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
         assert upstream
         assert not record.installed
 
+        assert y.installed
+        assert y.installed_upstream
+
         assert not z.installed
         assert not z.installed_upstream
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -190,8 +190,10 @@ def test_installed_upstream(upstream_and_downstream_db, tmpdir):
 def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypatch, config):
     upstream_db, downstream_db = upstream_and_downstream_db
 
+    z_y_prefix = str(tmpdir.join("z-y"))
+
     def fail_for_z(spec):
-        if spec.name == "z":
+        if spec.prefix == z_y_prefix:
             raise DirectoryLayoutError("Fake layout error for z")
 
     upstream_db.layout.ensure_installed = fail_for_z
@@ -204,21 +206,37 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
 
     with spack.repo.use_repositories(builder.root):
         y = spack.concretize.concretize_one("y")
-        z = y["z"]
+        z_y = None
+        for dep in y.traverse():
+            if dep.name == "z":
+                z_y = dep
+                break
+        assert z_y
+        z_y.set_prefix(z_y_prefix)
 
         with writable(upstream_db):
             upstream_db.add(y)
         upstream_db._read()
 
-        upstream, record = downstream_db.query_by_spec_hash(z.dag_hash())
+        upstream, record = downstream_db.query_by_spec_hash(z_y.dag_hash())
         assert upstream
         assert not record.installed
 
         assert y.installed
         assert y.installed_upstream
 
-        assert not z.installed
-        assert not z.installed_upstream
+        assert not z_y.installed
+        assert not z_y.installed_upstream
+
+        # Now add z to downstream with non-triggering prefix
+        # and make sure z *is* installed 
+
+        z_new = z_y.copy()
+        z_new.set_prefix(str(tmpdir.join("z-new")))
+        downstream_db.add(z_new)
+
+        assert z_new.installed
+        assert not z_new.installed_upstream
 
 
 def test_removed_upstream_dep(upstream_and_downstream_db, tmpdir, capsys, config):

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -16,6 +16,7 @@ import sys
 import pytest
 
 import spack.subprocess_context
+from spack.directory_layout import DirectoryLayoutError
 
 try:
     import uuid
@@ -185,7 +186,6 @@ def test_installed_upstream(upstream_and_downstream_db, tmpdir):
         upstream_db._check_ref_counts()
         downstream_db._check_ref_counts()
 
-from spack.directory_layout import DirectoryLayoutError
 
 def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypatch, config):
     upstream_db, downstream_db = upstream_and_downstream_db

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -186,7 +186,6 @@ def test_installed_upstream(upstream_and_downstream_db, tmpdir):
         downstream_db._check_ref_counts()
 
 from spack.directory_layout import DirectoryLayoutError
-#from conftest import MockLayout
 
 def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypatch, config):
     upstream_db, downstream_db = upstream_and_downstream_db
@@ -194,7 +193,6 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
     def fail_for_z(spec):
         if spec.name == "z":
             raise DirectoryLayoutError("Fake layout error for z")
-    #monkeypatch.setattr(MockLayout, "ensure_installed", fail_for_z)
 
     upstream_db.layout.ensure_installed = fail_for_z
 
@@ -202,6 +200,8 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", "build", None)])
     builder.add_package("x", dependencies=[("y", None, None)])
+
+    monkeypatch.setattr(spack.store.STORE, "db", downstream_db)
 
     with spack.repo.use_repositories(builder.root):
         x = spack.concretize.concretize_one("x")

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -199,13 +199,11 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", "build", None)])
-    builder.add_package("x", dependencies=[("y", None, None)])
 
     monkeypatch.setattr(spack.store.STORE, "db", downstream_db)
 
     with spack.repo.use_repositories(builder.root):
-        x = spack.concretize.concretize_one("x")
-        y = x["y"]
+        y = spack.concretize.concretize_one("y")
         z = y["z"]
 
         with writable(upstream_db):

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -206,12 +206,7 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
 
     with spack.repo.use_repositories(builder.root):
         y = spack.concretize.concretize_one("y")
-        z_y = None
-        for dep in y.traverse():
-            if dep.name == "z":
-                z_y = dep
-                break
-        assert z_y
+        z_y = y["z"]
         z_y.set_prefix(z_y_prefix)
 
         with writable(upstream_db):
@@ -229,7 +224,7 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
         assert not z_y.installed_upstream
 
         # Now add z to downstream with non-triggering prefix
-        # and make sure z *is* installed 
+        # and make sure z *is* installed
 
         z_new = z_y.copy()
         z_new.set_prefix(str(tmpdir.join("z-new")))


### PR DESCRIPTION
`Database.query_by_spec_hash` returns `upstream, record`, and claims in its docstring that `upstream = True` if the spec is installed upstream. However, the record only needs to be *present* upstream for this to be true. `Spec.installed_upstream` was going by the docstring (which meant it could be wrong in circumstances where the upstream had a record, but the spec wasn't actually installed there).

I think it's useful for `query_by_spec_hash` to preserve its behavior, so I

* Updated the docstring
* Made `Spec.installed_upstream` check the record

I also added a test. More than just the behavior here, I didn't see an explicit test for the case where a spec is added to the DB with no prefix - something that can now happen fairly frequently with the compiler wrappers when installing from a binary cache (which is also how a user found this problem).