### PR TITLE
test_binary_provenance_relative_to_mirror: do not require gpg signing

### DIFF
--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -642,7 +642,7 @@ def test_binary_provenance_relative_to_mirror(
 
     # push the commit past mirror
     git("-C", repo_path, "checkout", "main", output=str)
-    git("-C", repo_path, "commit", "--allow-empty", "-m", "bump sha")
+    git("-C", repo_path, "commit", "--no-gpg-sign", "--allow-empty", "-m", "bump sha")
     head_commit = git("-C", repo_path, "rev-parse", "main", output=str).strip()
 
     spec_mirror = spack.concretize.concretize_one("git-test-commit@main")


### PR DESCRIPTION
It is very annoying to get prompted to enter my GPG passphrase when I'm running unit tests. This PR adds an option to the `git` command to stop it from asking.