### PR TITLE
`spack repo`: add missing docstring to new `update` subcommand

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -473,6 +473,7 @@ def _iter_repos_from_descriptors(
 
 
 def repo_update(args: Any) -> int:
+    """update one or more package repositories"""
     descriptors = spack.repo.RepoDescriptors.from_config(
         spack.repo.package_repository_lock(), spack.config.CONFIG
     )

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2782,7 +2782,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a set -d 'modif
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a rm -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a migrate -d 'migrate a package repository to the latest Package API'
-complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a update
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a update -d 'update one or more package repositories'
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -d 'show this help message and exit'
 


### PR DESCRIPTION
In trying to help someone with a reported issue, I noticed the following output:

```
$ spack repo -h
usage: spack repo [-h] SUBCOMMAND ...

manage package source repositories

positional arguments:
  SUBCOMMAND
    create       create a new package repository
    list (ls)    show registered repositories and their namespaces
    add          add package repositories to Spack's configuration
    set          modify an existing repository configuration
    remove (rm)  remove a repository from Spack's configuration
    migrate      migrate a package repository to the latest Package API
    update

options:
  -h, --help     show this help message and exit
 ```

and that the code is properly referencing the docstring (in `help=repo_update.__doc__`) but that there was no docstring for the method.

With this PR, the output is now:

```
$ spack repo -h
...
positional arguments:
  SUBCOMMAND
...
    update     update one or more package repositories

optional arguments:
  -h, --help   show this help message and exit
```