### PR TITLE
Fix `package_attributes:build_directory` and Spack package subclass issues

### DIFF
--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -46,6 +46,8 @@ def serialize(pkg) -> io.BytesIO:
 def deserialize(serialized_pkg: io.BytesIO) -> Any:
     pkg = pickle.load(serialized_pkg)
     pkg.spec._package = pkg
+    # ensure overwritten package class attributes get applied
+    spack.repo.PATH.get_pkg_class(pkg.spec.name)
     return pkg
 
 


### PR DESCRIPTION
Closes #49326 and #50951.
It restores overwritten package class attributes in installer processes, which prevented `build_directory` to take effect.
