### PR TITLE
Add a generic `CompilerError` exception to package API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Spack v1.0 Release notes
+# Spack v1.0.0 Release notes
 
 ## Package API
 - Added `CompilerError` and `SpackError` to the list of names exported in `spack.package`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,5 @@
+# Spack v1.0 Release notes
+
+## Package API
+- Added `CompilerError` and `SpackError` to the list of names exported in `spack.package`.
+  Bumped the package API to v2.1

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -18,7 +18,7 @@ spack_version = __version__
 #: version is incremented when the package API is extended in a backwards-compatible way. The major
 #: version is incremented upon breaking changes. This version is changed independently from the
 #: Spack version.
-package_api_version = (2, 0)
+package_api_version = (2, 1)
 
 #: The minimum Package API version that this version of Spack is compatible with. This should
 #: always be a tuple of the form ``(major, 0)``, since compatibility with vX.Y implies

--- a/lib/spack/spack/compilers/error.py
+++ b/lib/spack/spack/compilers/error.py
@@ -10,9 +10,3 @@ class CompilerAccessError(SpackError):
             f"Compiler '{compiler.spec}' has executables that are missing"
             f" or are not executable: {paths}"
         )
-
-
-class UnsupportedCompilerFlag(SpackError):
-    """Raised when a compiler does not support a flag type (e.g. a flag to enforce a
-    language standard).
-    """

--- a/lib/spack/spack/compilers/error.py
+++ b/lib/spack/spack/compilers/error.py
@@ -1,6 +1,8 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import warnings
+
 from ..error import SpackError
 
 
@@ -9,4 +11,17 @@ class CompilerAccessError(SpackError):
         super().__init__(
             f"Compiler '{compiler.spec}' has executables that are missing"
             f" or are not executable: {paths}"
+        )
+
+
+class UnsupportedCompilerFlag(SpackError):
+    """Raised when a compiler does not support a flag type (e.g. a flag to enforce a
+    language standard).
+    """
+
+    def __init__(self, message, long_message=None):
+        warnings.warn(
+            "UnsupportedCompilerFlag is deprecated, use CompilerError instead",
+            DeprecationWarning,
+            stacklevel=2,
         )

--- a/lib/spack/spack/compilers/error.py
+++ b/lib/spack/spack/compilers/error.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import warnings
 
-from ..error import SpackError
+from ..error import SpackAPIWarning, SpackError
 
 
 class CompilerAccessError(SpackError):
@@ -22,6 +22,6 @@ class UnsupportedCompilerFlag(SpackError):
     def __init__(self, message, long_message=None):
         warnings.warn(
             "UnsupportedCompilerFlag is deprecated, use CompilerError instead",
-            DeprecationWarning,
+            SpackAPIWarning,
             stacklevel=2,
         )

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -215,3 +215,7 @@ class NoChecksumException(SpackError):
             f"Expected {expected} but got {computed}. "
             f"File size = {size} bytes. Contents = {contents!r}",
         )
+
+
+class CompilerError(SpackError):
+    """Raised if something goes wrong when probing, or querying, a compiler."""

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -69,7 +69,7 @@ from spack.directives import (
     variant,
     version,
 )
-from spack.error import CompilerError, InstallError, NoHeadersError, NoLibrariesError
+from spack.error import CompilerError, InstallError, NoHeadersError, NoLibrariesError, SpackError
 from spack.install_test import (
     SkipTest,
     cache_extra_test_sources,
@@ -187,6 +187,7 @@ __all__ = [
     "InstallError",
     "NoHeadersError",
     "NoLibrariesError",
+    "SpackError",
     "SkipTest",
     "cache_extra_test_sources",
     "check_outputs",

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -69,7 +69,7 @@ from spack.directives import (
     variant,
     version,
 )
-from spack.error import InstallError, NoHeadersError, NoLibrariesError
+from spack.error import CompilerError, InstallError, NoHeadersError, NoLibrariesError
 from spack.install_test import (
     SkipTest,
     cache_extra_test_sources,
@@ -183,6 +183,7 @@ __all__ = [
     "resource",
     "variant",
     "version",
+    "CompilerError",
     "InstallError",
     "NoHeadersError",
     "NoLibrariesError",

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/compiler.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/compiler.py
@@ -12,9 +12,9 @@ import llnl.util.tty as tty
 from llnl.util.lang import classproperty, memoized
 
 import spack
-import spack.compilers.error
 import spack.package_base
 import spack.util.executable
+from spack.package import CompilerError
 
 # Local "type" for type hints
 Path = Union[str, pathlib.Path]
@@ -169,13 +169,11 @@ class CompilerPackage(spack.package_base.PackageBase):
     def standard_flag(self, *, language: str, standard: str) -> str:
         """Returns the flag used to enforce a given standard for a language"""
         if language not in self.supported_languages:
-            raise spack.compilers.error.UnsupportedCompilerFlag(
-                f"{self.spec} does not provide the '{language}' language"
-            )
+            raise CompilerError(f"{self.spec} does not provide the '{language}' language")
         try:
             return self._standard_flag(language=language, standard=standard)
         except (KeyError, RuntimeError) as e:
-            raise spack.compilers.error.UnsupportedCompilerFlag(
+            raise CompilerError(
                 f"{self.spec} does not provide the '{language}' standard {standard}"
             ) from e
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/repo.yaml
+++ b/var/spack/test_repos/spack_repo/builtin_mock/repo.yaml
@@ -1,3 +1,3 @@
 repo:
   namespace: builtin_mock
-  api: v2.0
+  api: v2.1


### PR DESCRIPTION
Modifications:
- [x] Deprecate `spack.compiler.error.UnsupportedCompilerFlag` in favor of a more generic `CompilerError` that is exported to the package API
- [x] Export `SpackError` to the package API
- [x] Add NEWS.md to keep track of changes between releases, add the package API bump

See https://github.com/spack/spack/issues/50388#issuecomment-2997379077
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
