### PR TITLE
tests: fix leaky `spack_repo.builtin_mock` in `sys.modules`

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
-from typing import List, Optional, Set, Tuple
+from typing import List, Optional, Set, Tuple, Union
 
 import llnl.string as string
 import llnl.util.filesystem as fs
@@ -134,7 +134,7 @@ def _env_create(
     *,
     init_file: Optional[str] = None,
     dir: bool = False,
-    with_view: Optional[str] = None,
+    with_view: Optional[Union[bool, str]] = None,
     keep_relative: bool = False,
     include_concrete: Optional[List[str]] = None,
 ):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1405,7 +1405,7 @@ class Repo:
             raise RepoError(msg) from e
         finally:
             if self.python_path:
-                sys.path.pop(0)
+                sys.path.remove(self.python_path)
 
         cls = getattr(module, class_name)
         if not isinstance(cls, type):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1395,12 +1395,17 @@ class Repo:
         class_name = nm.pkg_name_to_class_name(pkg_name)
 
         try:
+            if self.python_path:
+                sys.path.insert(0, self.python_path)
             module = importlib.import_module(fullname)
         except ImportError as e:
             raise UnknownPackageError(fullname) from e
         except Exception as e:
             msg = f"cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
             raise RepoError(msg) from e
+        finally:
+            if self.python_path:
+                sys.path.pop(0)
 
         cls = getattr(module, class_name)
         if not isinstance(cls, type):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1996,6 +1996,7 @@ def use_repositories(
         yield new_repo
     finally:
         spack.config.CONFIG.remove_scope(scope_name=scope_name)
+        new_repo.disable()
         enable_repo(old_repo)
 
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -13,11 +13,9 @@ import importlib.util
 import inspect
 import itertools
 import os
-import random
 import re
 import shutil
 import stat
-import string
 import sys
 import traceback
 import types
@@ -53,7 +51,6 @@ import spack.paths
 import spack.provider_index
 import spack.spec
 import spack.tag
-import spack.tengine
 import spack.util.executable
 import spack.util.file_cache
 import spack.util.git
@@ -2007,43 +2004,6 @@ def enable_repo(repo_path: RepoPath) -> None:
     global PATH
     PATH = repo_path
     PATH.enable()
-
-
-class MockRepositoryBuilder:
-    """Build a mock repository in a directory"""
-
-    def __init__(self, root_directory, namespace=None):
-        namespace = namespace or "".join(random.choice(string.ascii_lowercase) for _ in range(10))
-        repo_root = os.path.join(root_directory, namespace)
-        os.mkdir(repo_root)
-        self.root, self.namespace = create_repo(repo_root, namespace)
-
-    def add_package(self, name, dependencies=None):
-        """Create a mock package in the repository, using a Jinja2 template.
-
-        Args:
-            name (str): name of the new package
-            dependencies (list): list of ("dep_spec", "dep_type", "condition") tuples.
-                Both "dep_type" and "condition" can default to ``None`` in which case
-                ``spack.dependency.default_deptype`` and ``spack.spec.Spec()`` are used.
-        """
-        dependencies = dependencies or []
-        context = {"cls_name": nm.pkg_name_to_class_name(name), "dependencies": dependencies}
-        template = spack.tengine.make_environment().get_template("mock-repository/package.pyt")
-        text = template.render(context)
-        package_py = self.recipe_filename(name)
-        fs.mkdirp(os.path.dirname(package_py))
-        with open(package_py, "w", encoding="utf-8") as f:
-            f.write(text)
-
-    def remove(self, name):
-        package_py = self.recipe_filename(name)
-        shutil.rmtree(os.path.dirname(package_py))
-
-    def recipe_filename(self, name: str):
-        return os.path.join(
-            self.root, "packages", nm.pkg_name_to_pkg_dir(name, package_api=(2, 0)), "package.py"
-        )
 
 
 class RepoError(spack.error.SpackError):

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -16,6 +16,7 @@ import spack.environment as ev
 import spack.error
 import spack.paths as spack_paths
 import spack.repo as repo
+import spack.test.conftest
 import spack.util.git
 from spack.test.conftest import MockHTTPResponse
 from spack.version import Version
@@ -83,7 +84,7 @@ def test_pipeline_dag(config, tmpdir):
           f                         f
 
     """
-    builder = repo.MockRepositoryBuilder(tmpdir)
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
     builder.add_package("pkg-h", dependencies=[("pkg-f", None, None)])
     builder.add_package("pkg-g")
     builder.add_package("pkg-f")

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -16,9 +16,8 @@ import spack.environment as ev
 import spack.error
 import spack.paths as spack_paths
 import spack.repo as repo
-import spack.test.conftest
 import spack.util.git
-from spack.test.conftest import MockHTTPResponse
+from spack.test.conftest import MockHTTPResponse, MockRepositoryBuilder
 from spack.version import Version
 
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
@@ -69,7 +68,7 @@ def test_get_added_versions_new_commit(mock_git_package_changes):
         assert added_versions[0] == Version("2.1.6")
 
 
-def test_pipeline_dag(config, tmpdir):
+def test_pipeline_dag(config, tmp_repo: MockRepositoryBuilder):
     r"""Test creation, pruning, and traversal of PipelineDAG using the
     following package dependency graph:
 
@@ -84,17 +83,16 @@ def test_pipeline_dag(config, tmpdir):
           f                         f
 
     """
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
-    builder.add_package("pkg-h", dependencies=[("pkg-f", None, None)])
-    builder.add_package("pkg-g")
-    builder.add_package("pkg-f")
-    builder.add_package("pkg-e", dependencies=[("pkg-h", None, None)])
-    builder.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
-    builder.add_package("pkg-c")
-    builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
-    builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
+    tmp_repo.add_package("pkg-h", dependencies=[("pkg-f", None, None)])
+    tmp_repo.add_package("pkg-g")
+    tmp_repo.add_package("pkg-f")
+    tmp_repo.add_package("pkg-e", dependencies=[("pkg-h", None, None)])
+    tmp_repo.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
+    tmp_repo.add_package("pkg-c")
+    tmp_repo.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
+    tmp_repo.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
 
-    with repo.use_repositories(builder.root):
+    with repo.use_repositories(tmp_repo.root):
         spec_a = spack.concretize.concretize_one("pkg-a")
 
         key_a = ci.common.PipelineDag.key(spec_a)

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -17,7 +17,7 @@ import spack.error
 import spack.paths as spack_paths
 import spack.repo as repo
 import spack.util.git
-from spack.test.conftest import MockHTTPResponse, MockRepositoryBuilder
+from spack.test.conftest import MockHTTPResponse, RepoBuilder
 from spack.version import Version
 
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
@@ -68,7 +68,7 @@ def test_get_added_versions_new_commit(mock_git_package_changes):
         assert added_versions[0] == Version("2.1.6")
 
 
-def test_pipeline_dag(config, tmp_repo: MockRepositoryBuilder):
+def test_pipeline_dag(config, repo_builder: RepoBuilder):
     r"""Test creation, pruning, and traversal of PipelineDAG using the
     following package dependency graph:
 
@@ -83,16 +83,16 @@ def test_pipeline_dag(config, tmp_repo: MockRepositoryBuilder):
           f                         f
 
     """
-    tmp_repo.add_package("pkg-h", dependencies=[("pkg-f", None, None)])
-    tmp_repo.add_package("pkg-g")
-    tmp_repo.add_package("pkg-f")
-    tmp_repo.add_package("pkg-e", dependencies=[("pkg-h", None, None)])
-    tmp_repo.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
-    tmp_repo.add_package("pkg-c")
-    tmp_repo.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
-    tmp_repo.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
+    repo_builder.add_package("pkg-h", dependencies=[("pkg-f", None, None)])
+    repo_builder.add_package("pkg-g")
+    repo_builder.add_package("pkg-f")
+    repo_builder.add_package("pkg-e", dependencies=[("pkg-h", None, None)])
+    repo_builder.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
+    repo_builder.add_package("pkg-c")
+    repo_builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
+    repo_builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
 
-    with repo.use_repositories(tmp_repo.root):
+    with repo.use_repositories(repo_builder.root):
         spec_a = spack.concretize.concretize_one("pkg-a")
 
         key_a = ci.common.PipelineDag.key(spec_a)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -33,7 +33,7 @@ from spack.ci.generator_registry import generator
 from spack.cmd.ci import FAILED_CREATE_BUILDCACHE_CODE
 from spack.error import SpackError
 from spack.schema.database_index import schema as db_idx_schema
-from spack.test.conftest import MockHTTPResponse
+from spack.test.conftest import MockHTTPResponse, MockRepositoryBuilder
 
 config_cmd = spack.main.SpackCommand("config")
 ci_cmd = spack.main.SpackCommand("ci")
@@ -1118,7 +1118,7 @@ def test_ci_generate_prune_untouched(ci_generate_test, tmp_path, tmpdir, monkeyp
     def fake_change_revisions(env_path):
         return "HEAD^", "HEAD"
 
-    builder = spack.repo.MockRepositoryBuilder(tmpdir)
+    builder = MockRepositoryBuilder(tmpdir)
     builder.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
     builder.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
     builder.add_package("pkg-c")

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -33,7 +33,7 @@ from spack.ci.generator_registry import generator
 from spack.cmd.ci import FAILED_CREATE_BUILDCACHE_CODE
 from spack.error import SpackError
 from spack.schema.database_index import schema as db_idx_schema
-from spack.test.conftest import MockHTTPResponse, MockRepositoryBuilder
+from spack.test.conftest import MockHTTPResponse, RepoBuilder
 
 config_cmd = spack.main.SpackCommand("config")
 ci_cmd = spack.main.SpackCommand("ci")
@@ -1102,7 +1102,7 @@ def test_ci_get_stack_changed(mock_git_repo, monkeypatch):
 
 
 def test_ci_generate_prune_untouched(
-    ci_generate_test, monkeypatch, tmp_path, tmp_repo: MockRepositoryBuilder
+    ci_generate_test, monkeypatch, tmp_path, repo_builder: RepoBuilder
 ):
     """Test pipeline generation with pruning works to eliminate
     specs that were not affected by a change"""
@@ -1120,16 +1120,16 @@ def test_ci_generate_prune_untouched(
     def fake_change_revisions(env_path):
         return "HEAD^", "HEAD"
 
-    tmp_repo.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
-    tmp_repo.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
-    tmp_repo.add_package("pkg-c")
-    tmp_repo.add_package("pkg-d")
+    repo_builder.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
+    repo_builder.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
+    repo_builder.add_package("pkg-c")
+    repo_builder.add_package("pkg-d")
 
     monkeypatch.setattr(ci, "compute_affected_packages", fake_compute_affected)
     monkeypatch.setattr(ci, "stack_changed", fake_stack_changed)
     monkeypatch.setattr(ci, "get_change_revisions", fake_change_revisions)
 
-    with spack.repo.use_repositories(tmp_repo.root, override=False):
+    with spack.repo.use_repositories(repo_builder.root, override=False):
         spack_yaml, outputfile, _ = ci_generate_test(
             f"""\
 spack:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1101,7 +1101,9 @@ def test_ci_get_stack_changed(mock_git_repo, monkeypatch):
     assert ci.stack_changed(fake_env_path) is True
 
 
-def test_ci_generate_prune_untouched(ci_generate_test, tmp_path, tmpdir, monkeypatch):
+def test_ci_generate_prune_untouched(
+    ci_generate_test, monkeypatch, tmp_path, tmp_repo: MockRepositoryBuilder
+):
     """Test pipeline generation with pruning works to eliminate
     specs that were not affected by a change"""
     monkeypatch.setenv("SPACK_PRUNE_UNTOUCHED", "TRUE")  # enables pruning of untouched specs
@@ -1118,17 +1120,16 @@ def test_ci_generate_prune_untouched(ci_generate_test, tmp_path, tmpdir, monkeyp
     def fake_change_revisions(env_path):
         return "HEAD^", "HEAD"
 
-    builder = MockRepositoryBuilder(tmpdir)
-    builder.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
-    builder.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
-    builder.add_package("pkg-c")
-    builder.add_package("pkg-d")
+    tmp_repo.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
+    tmp_repo.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
+    tmp_repo.add_package("pkg-c")
+    tmp_repo.add_package("pkg-d")
 
     monkeypatch.setattr(ci, "compute_affected_packages", fake_compute_affected)
     monkeypatch.setattr(ci, "stack_changed", fake_stack_changed)
     monkeypatch.setattr(ci, "get_change_revisions", fake_change_revisions)
 
-    with spack.repo.use_repositories(builder.root, override=False):
+    with spack.repo.use_repositories(tmp_repo.root, override=False):
         spack_yaml, outputfile, _ = ci_generate_test(
             f"""\
 spack:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -45,6 +45,7 @@ from spack.installer import PackageInstaller
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.stage import stage_prefix
+from spack.test.conftest import MockRepositoryBuilder
 from spack.util.executable import Executable
 from spack.util.path import substitute_path_variables
 from spack.version import Version
@@ -1825,17 +1826,16 @@ def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
     assert not test.user_specs
 
 
-def test_indirect_build_dep(tmp_path):
+def test_indirect_build_dep(tmp_repo: MockRepositoryBuilder):
     """Simple case of X->Y->Z where Y is a build/link dep and Z is a
     build-only dep. Make sure this concrete DAG is preserved when writing the
     environment out and reading it back.
     """
-    builder = spack.test.conftest.MockRepositoryBuilder(tmp_path)
-    builder.add_package("z")
-    builder.add_package("y", dependencies=[("z", "build", None)])
-    builder.add_package("x", dependencies=[("y", None, None)])
+    tmp_repo.add_package("z")
+    tmp_repo.add_package("y", dependencies=[("z", "build", None)])
+    tmp_repo.add_package("x", dependencies=[("y", None, None)])
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         x_spec = Spec("x")
         x_concretized = spack.concretize.concretize_one(x_spec)
 
@@ -1852,7 +1852,7 @@ def test_indirect_build_dep(tmp_path):
         assert x_env_spec == x_concretized
 
 
-def test_store_different_build_deps(tmp_path):
+def test_store_different_build_deps(tmp_repo: MockRepositoryBuilder):
     r"""Ensure that an environment can store two instances of a build-only
     dependency::
 
@@ -1863,12 +1863,11 @@ def test_store_different_build_deps(tmp_path):
               z1
 
     """
-    builder = spack.test.conftest.MockRepositoryBuilder(tmp_path)
-    builder.add_package("z")
-    builder.add_package("y", dependencies=[("z", "build", None)])
-    builder.add_package("x", dependencies=[("y", None, None), ("z", "build", None)])
+    tmp_repo.add_package("z")
+    tmp_repo.add_package("y", dependencies=[("z", "build", None)])
+    tmp_repo.add_package("x", dependencies=[("y", None, None), ("z", "build", None)])
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         y_spec = Spec("y ^z@3")
         y_concretized = spack.concretize.concretize_one(y_spec)
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -36,6 +36,7 @@ import spack.solver.asp
 import spack.spec
 import spack.stage
 import spack.store
+import spack.test.conftest
 import spack.util.environment
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml
@@ -1829,7 +1830,7 @@ def test_indirect_build_dep(tmp_path):
     build-only dep. Make sure this concrete DAG is preserved when writing the
     environment out and reading it back.
     """
-    builder = spack.repo.MockRepositoryBuilder(tmp_path)
+    builder = spack.test.conftest.MockRepositoryBuilder(tmp_path)
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", "build", None)])
     builder.add_package("x", dependencies=[("y", None, None)])
@@ -1862,7 +1863,7 @@ def test_store_different_build_deps(tmp_path):
               z1
 
     """
-    builder = spack.repo.MockRepositoryBuilder(tmp_path)
+    builder = spack.test.conftest.MockRepositoryBuilder(tmp_path)
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", "build", None)])
     builder.add_package("x", dependencies=[("y", None, None), ("z", "build", None)])

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -45,7 +45,7 @@ from spack.installer import PackageInstaller
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.stage import stage_prefix
-from spack.test.conftest import MockRepositoryBuilder
+from spack.test.conftest import RepoBuilder
 from spack.util.executable import Executable
 from spack.util.path import substitute_path_variables
 from spack.version import Version
@@ -1826,16 +1826,16 @@ def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
     assert not test.user_specs
 
 
-def test_indirect_build_dep(tmp_repo: MockRepositoryBuilder):
+def test_indirect_build_dep(repo_builder: RepoBuilder):
     """Simple case of X->Y->Z where Y is a build/link dep and Z is a
     build-only dep. Make sure this concrete DAG is preserved when writing the
     environment out and reading it back.
     """
-    tmp_repo.add_package("z")
-    tmp_repo.add_package("y", dependencies=[("z", "build", None)])
-    tmp_repo.add_package("x", dependencies=[("y", None, None)])
+    repo_builder.add_package("z")
+    repo_builder.add_package("y", dependencies=[("z", "build", None)])
+    repo_builder.add_package("x", dependencies=[("y", None, None)])
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         x_spec = Spec("x")
         x_concretized = spack.concretize.concretize_one(x_spec)
 
@@ -1852,7 +1852,7 @@ def test_indirect_build_dep(tmp_repo: MockRepositoryBuilder):
         assert x_env_spec == x_concretized
 
 
-def test_store_different_build_deps(tmp_repo: MockRepositoryBuilder):
+def test_store_different_build_deps(repo_builder: RepoBuilder):
     r"""Ensure that an environment can store two instances of a build-only
     dependency::
 
@@ -1863,11 +1863,11 @@ def test_store_different_build_deps(tmp_repo: MockRepositoryBuilder):
               z1
 
     """
-    tmp_repo.add_package("z")
-    tmp_repo.add_package("y", dependencies=[("z", "build", None)])
-    tmp_repo.add_package("x", dependencies=[("y", None, None), ("z", "build", None)])
+    repo_builder.add_package("z")
+    repo_builder.add_package("y", dependencies=[("z", "build", None)])
+    repo_builder.add_package("x", dependencies=[("y", None, None), ("z", "build", None)])
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         y_spec = Spec("y ^z@3")
         y_concretized = spack.concretize.concretize_one(y_spec)
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -36,7 +36,7 @@ import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack.installer import PackageInstaller
 from spack.spec import Spec
-from spack.test.conftest import MockRepositoryBuilder
+from spack.test.conftest import RepoBuilder
 from spack.version import Version, VersionList, ver
 
 
@@ -1721,31 +1721,31 @@ class TestConcretize:
 
     @pytest.mark.regression("45538")
     def test_reuse_from_other_namespace_no_raise(
-        self, temporary_store, monkeypatch, tmp_repo: MockRepositoryBuilder
+        self, temporary_store, monkeypatch, repo_builder: RepoBuilder
     ):
-        tmp_repo.add_package("zlib")
+        repo_builder.add_package("zlib")
 
         builtin = spack.concretize.concretize_one("zlib")
         PackageInstaller([builtin.package], fake=True, explicit=True).install()
 
-        with spack.repo.use_repositories(tmp_repo.root, override=False):
+        with spack.repo.use_repositories(repo_builder.root, override=False):
             with spack.config.override("concretizer:reuse", True):
-                zlib = spack.concretize.concretize_one(f"{tmp_repo.namespace}.zlib")
+                zlib = spack.concretize.concretize_one(f"{repo_builder.namespace}.zlib")
 
-        assert zlib.namespace == tmp_repo.namespace
+        assert zlib.namespace == repo_builder.namespace
 
     @pytest.mark.regression("28259")
     def test_reuse_with_unknown_package_dont_raise(
-        self, temporary_store, monkeypatch, tmp_repo: MockRepositoryBuilder
+        self, temporary_store, monkeypatch, repo_builder: RepoBuilder
     ):
-        tmp_repo.add_package("pkg-c")
-        with spack.repo.use_repositories(tmp_repo.root, override=False):
+        repo_builder.add_package("pkg-c")
+        with spack.repo.use_repositories(repo_builder.root, override=False):
             s = spack.concretize.concretize_one("pkg-c")
-            assert s.namespace == tmp_repo.namespace
+            assert s.namespace == repo_builder.namespace
             PackageInstaller([s.package], fake=True, explicit=True).install()
-        del sys.modules[f"spack_repo.{tmp_repo.namespace}.packages.pkg_c"]
-        tmp_repo.remove("pkg-c")
-        with spack.repo.use_repositories(tmp_repo.root, override=False) as repos:
+        del sys.modules[f"spack_repo.{repo_builder.namespace}.packages.pkg_c"]
+        repo_builder.remove("pkg-c")
+        with spack.repo.use_repositories(repo_builder.root, override=False) as repos:
             repos.repos[0]._pkg_checker.invalidate()
             with spack.config.override("concretizer:reuse", True):
                 s = spack.concretize.concretize_one("pkg-c")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -30,6 +30,7 @@ import spack.solver.asp
 import spack.solver.version_order
 import spack.spec
 import spack.store
+import spack.test.conftest
 import spack.util.file_cache
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
@@ -1719,7 +1720,7 @@ class TestConcretize:
 
     @pytest.mark.regression("45538")
     def test_reuse_from_other_namespace_no_raise(self, tmpdir, temporary_store, monkeypatch):
-        myrepo = spack.repo.MockRepositoryBuilder(tmpdir, namespace="mock_repo")
+        myrepo = spack.test.conftest.MockRepositoryBuilder(tmpdir)
         myrepo.add_package("zlib")
 
         builtin = spack.concretize.concretize_one("zlib")
@@ -1727,19 +1728,19 @@ class TestConcretize:
 
         with spack.repo.use_repositories(myrepo.root, override=False):
             with spack.config.override("concretizer:reuse", True):
-                myrepo = spack.concretize.concretize_one("mock_repo.zlib")
+                zlib = spack.concretize.concretize_one(f"{myrepo.namespace}.zlib")
 
-        assert myrepo.namespace == "mock_repo"
+        assert zlib.namespace == myrepo.namespace
 
     @pytest.mark.regression("28259")
     def test_reuse_with_unknown_package_dont_raise(self, tmpdir, temporary_store, monkeypatch):
-        builder = spack.repo.MockRepositoryBuilder(str(tmpdir), namespace="myrepo")
+        builder = spack.test.conftest.MockRepositoryBuilder(str(tmpdir))
         builder.add_package("pkg-c")
         with spack.repo.use_repositories(builder.root, override=False):
             s = spack.concretize.concretize_one("pkg-c")
-            assert s.namespace == "myrepo"
+            assert s.namespace == builder.namespace
             PackageInstaller([s.package], fake=True, explicit=True).install()
-        del sys.modules["spack_repo.myrepo.packages.pkg_c"]
+        del sys.modules[f"spack_repo.{builder.namespace}.packages.pkg_c"]
         builder.remove("pkg-c")
         with spack.repo.use_repositories(builder.root, override=False) as repos:
             # TODO (INJECT CONFIGURATION): unclear why the cache needs to be invalidated explicitly

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -36,6 +36,7 @@ import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack.installer import PackageInstaller
 from spack.spec import Spec
+from spack.test.conftest import MockRepositoryBuilder
 from spack.version import Version, VersionList, ver
 
 
@@ -1719,31 +1720,32 @@ class TestConcretize:
         assert s.namespace == "builtin_mock"
 
     @pytest.mark.regression("45538")
-    def test_reuse_from_other_namespace_no_raise(self, tmpdir, temporary_store, monkeypatch):
-        myrepo = spack.test.conftest.MockRepositoryBuilder(tmpdir)
-        myrepo.add_package("zlib")
+    def test_reuse_from_other_namespace_no_raise(
+        self, temporary_store, monkeypatch, tmp_repo: MockRepositoryBuilder
+    ):
+        tmp_repo.add_package("zlib")
 
         builtin = spack.concretize.concretize_one("zlib")
         PackageInstaller([builtin.package], fake=True, explicit=True).install()
 
-        with spack.repo.use_repositories(myrepo.root, override=False):
+        with spack.repo.use_repositories(tmp_repo.root, override=False):
             with spack.config.override("concretizer:reuse", True):
-                zlib = spack.concretize.concretize_one(f"{myrepo.namespace}.zlib")
+                zlib = spack.concretize.concretize_one(f"{tmp_repo.namespace}.zlib")
 
-        assert zlib.namespace == myrepo.namespace
+        assert zlib.namespace == tmp_repo.namespace
 
     @pytest.mark.regression("28259")
-    def test_reuse_with_unknown_package_dont_raise(self, tmpdir, temporary_store, monkeypatch):
-        builder = spack.test.conftest.MockRepositoryBuilder(str(tmpdir))
-        builder.add_package("pkg-c")
-        with spack.repo.use_repositories(builder.root, override=False):
+    def test_reuse_with_unknown_package_dont_raise(
+        self, temporary_store, monkeypatch, tmp_repo: MockRepositoryBuilder
+    ):
+        tmp_repo.add_package("pkg-c")
+        with spack.repo.use_repositories(tmp_repo.root, override=False):
             s = spack.concretize.concretize_one("pkg-c")
-            assert s.namespace == builder.namespace
+            assert s.namespace == tmp_repo.namespace
             PackageInstaller([s.package], fake=True, explicit=True).install()
-        del sys.modules[f"spack_repo.{builder.namespace}.packages.pkg_c"]
-        builder.remove("pkg-c")
-        with spack.repo.use_repositories(builder.root, override=False) as repos:
-            # TODO (INJECT CONFIGURATION): unclear why the cache needs to be invalidated explicitly
+        del sys.modules[f"spack_repo.{tmp_repo.namespace}.packages.pkg_c"]
+        tmp_repo.remove("pkg-c")
+        with spack.repo.use_repositories(tmp_repo.root, override=False) as repos:
             repos.repos[0]._pkg_checker.invalidate()
             with spack.config.override("concretizer:reuse", True):
                 s = spack.concretize.concretize_one("pkg-c")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -19,6 +19,7 @@ import stat
 import sys
 import tempfile
 import xml.etree.ElementTree
+from typing import List, Optional, Tuple
 
 import _vendoring.archspec.cpu
 import _vendoring.archspec.cpu.microarchitecture
@@ -59,10 +60,12 @@ import spack.spec
 import spack.stage
 import spack.store
 import spack.subprocess_context
+import spack.tengine
 import spack.util.executable
 import spack.util.file_cache
 import spack.util.git
 import spack.util.gpg
+import spack.util.naming
 import spack.util.parallel
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
@@ -82,7 +85,7 @@ mirror_cmd = SpackCommand("mirror")
 def clear_sys_modules():
     """Clear package repos from sys.modules before each test."""
     for key in list(sys.modules.keys()):
-        if key.startswith("spack_repo.") or key == "spack.repo":
+        if key.startswith("spack_repo.") or key == "spack_repo":
             del sys.modules[key]
     yield
 
@@ -673,10 +676,73 @@ def mutable_mock_repo(mock_packages_repo, request):
         yield mock_packages_repo
 
 
+class MockRepositoryBuilder:
+    """Build a mock repository in a directory"""
+
+    _counter = 0
+
+    def __init__(self, root_directory: str) -> None:
+        MockRepositoryBuilder._counter += 1
+        namespace = f"test_namespace_{MockRepositoryBuilder._counter}"
+        repo_root = os.path.join(root_directory, namespace)
+        os.mkdir(repo_root)
+        self.root, self.namespace = spack.repo.create_repo(repo_root, namespace)
+        self.build_system_name = f"test_build_system_{self.namespace}"
+        self._add_build_system()
+
+    def add_package(
+        self,
+        name: str,
+        dependencies: Optional[List[Tuple[str, Optional[str], Optional[str]]]] = None,
+    ) -> None:
+        """Create a mock package in the repository, using a Jinja2 template.
+
+        Args:
+            name: name of the new package
+            dependencies: list of ("dep_spec", "dep_type", "condition") tuples.
+                Both "dep_type" and "condition" can default to ``None`` in which case
+                ``spack.dependency.default_deptype`` and ``spack.spec.Spec()`` are used.
+        """
+        dependencies = dependencies or []
+        context = {
+            "cls_name": spack.util.naming.pkg_name_to_class_name(name),
+            "dependencies": dependencies,
+        }
+        template = spack.tengine.make_environment().get_template("mock-repository/package.pyt")
+        package_py = self._recipe_filename(name)
+        os.makedirs(os.path.dirname(package_py), exist_ok=True)
+        with open(package_py, "w", encoding="utf-8") as f:
+            f.write(template.render(context))
+
+    def remove(self, name: str) -> None:
+        package_py = self._recipe_filename(name)
+        shutil.rmtree(os.path.dirname(package_py))
+
+    def _add_build_system(self) -> None:
+        """Add spack_repo.<namespace>.build_systems.test_build_system with
+        build_system=test_build_system_<namespace>."""
+        template = spack.tengine.make_environment().get_template(
+            "mock-repository/build_system.pyt"
+        )
+        text = template.render({"build_system_name": self.build_system_name})
+        build_system_py = os.path.join(self.root, "build_systems", "test_build_system.py")
+        os.makedirs(os.path.dirname(build_system_py), exist_ok=True)
+        with open(build_system_py, "w", encoding="utf-8") as f:
+            f.write(text)
+
+    def _recipe_filename(self, name: str) -> str:
+        return os.path.join(
+            self.root,
+            "packages",
+            spack.util.naming.pkg_name_to_pkg_dir(name, package_api=(2, 0)),
+            "package.py",
+        )
+
+
 @pytest.fixture()
 def mock_custom_repository(tmpdir, mutable_mock_repo):
     """Create a custom repository with a single package "c" and return its path."""
-    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("myrepo"))
+    builder = MockRepositoryBuilder(tmpdir.mkdir("myrepo"))
     builder.add_package("pkg-c")
     return builder.root
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -79,6 +79,15 @@ mirror_cmd = SpackCommand("mirror")
 
 
 @pytest.fixture(autouse=True)
+def clear_sys_modules():
+    """Clear package repos from sys.modules before each test."""
+    for key in list(sys.modules.keys()):
+        if key.startswith("spack_repo.") or key == "spack.repo":
+            del sys.modules[key]
+    yield
+
+
+@pytest.fixture(autouse=True)
 def check_config_fixture(request):
     if "config" in request.fixturenames and "mutable_config" in request.fixturenames:
         raise RuntimeError("'config' and 'mutable_config' are both requested")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -676,16 +676,16 @@ def mutable_mock_repo(mock_packages_repo, request):
         yield mock_packages_repo
 
 
-class MockRepositoryBuilder:
+class RepoBuilder:
     """Build a mock repository in a directory"""
 
     _counter = 0
 
     def __init__(self, root_directory: str) -> None:
-        MockRepositoryBuilder._counter += 1
-        namespace = f"test_namespace_{MockRepositoryBuilder._counter}"
+        RepoBuilder._counter += 1
+        namespace = f"test_namespace_{RepoBuilder._counter}"
         repo_root = os.path.join(root_directory, namespace)
-        os.mkdir(repo_root)
+        os.makedirs(repo_root, exist_ok=True)
         self.root, self.namespace = spack.repo.create_repo(repo_root, namespace)
         self.build_system_name = f"test_build_system_{self.namespace}"
         self._add_build_system()
@@ -740,16 +740,14 @@ class MockRepositoryBuilder:
 
 
 @pytest.fixture
-def tmp_repo(tmp_path: pathlib.Path):
-    repo_path = tmp_path / "tmp_repo"
-    repo_path.mkdir(parents=True, exist_ok=True)
-    return MockRepositoryBuilder(str(repo_path))
+def repo_builder(tmp_path: pathlib.Path):
+    return RepoBuilder(str(tmp_path))
 
 
 @pytest.fixture()
 def mock_custom_repository(tmpdir, mutable_mock_repo):
     """Create a custom repository with a single package "c" and return its path."""
-    builder = MockRepositoryBuilder(tmpdir.mkdir("myrepo"))
+    builder = RepoBuilder(tmpdir.mkdir("myrepo"))
     builder.add_package("pkg-c")
     return builder.root
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -739,6 +739,13 @@ class MockRepositoryBuilder:
         )
 
 
+@pytest.fixture
+def tmp_repo(tmp_path: pathlib.Path):
+    repo_path = tmp_path / "tmp_repo"
+    repo_path.mkdir(parents=True, exist_ok=True)
+    return MockRepositoryBuilder(str(repo_path))
+
+
 @pytest.fixture()
 def mock_custom_repository(tmpdir, mutable_mock_repo):
     """Create a custom repository with a single package "c" and return its path."""

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -16,6 +16,7 @@ import sys
 import pytest
 
 import spack.subprocess_context
+import spack.test.conftest
 from spack.directory_layout import DirectoryLayoutError
 
 try:
@@ -154,7 +155,7 @@ def test_spec_installed_upstream(
 def test_installed_upstream(upstream_and_downstream_db, tmpdir):
     upstream_db, downstream_db = upstream_and_downstream_db
 
-    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("x")
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", None, None)])
@@ -198,7 +199,7 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
 
     upstream_db.layout.ensure_installed = fail_for_z
 
-    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", "build", None)])
 
@@ -237,7 +238,7 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
 def test_removed_upstream_dep(upstream_and_downstream_db, tmpdir, capsys, config):
     upstream_db, downstream_db = upstream_and_downstream_db
 
-    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", None, None)])
 
@@ -272,7 +273,7 @@ def test_add_to_upstream_after_downstream(upstream_and_downstream_db, tmpdir):
     """
     upstream_db, downstream_db = upstream_and_downstream_db
 
-    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("x")
 
     with spack.repo.use_repositories(builder.root):
@@ -317,7 +318,7 @@ def test_recursive_upstream_dbs(tmpdir, gen_mock_layout):
     roots = [str(tmpdir.mkdir(x)) for x in ["a", "b", "c"]]
     layouts = [gen_mock_layout(x) for x in ["/ra/", "/rb/", "/rc/"]]
 
-    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", None, None)])
     builder.add_package("x", dependencies=[("y", None, None)])
@@ -790,7 +791,7 @@ def test_115_reindex_with_packages_not_in_repo(mutable_database, tmpdir):
     # Dont add any package definitions to this repository, the idea is that
     # packages should not have to be defined in the repository once they
     # are installed
-    with spack.repo.use_repositories(spack.repo.MockRepositoryBuilder(tmpdir).root):
+    with spack.repo.use_repositories(spack.test.conftest.MockRepositoryBuilder(tmpdir).root):
         spack.store.STORE.reindex()
         _check_db_sanity(mutable_database)
 
@@ -1166,7 +1167,7 @@ def test_query_installed_when_package_unknown(database, tmpdir):
     """Test that we can query the installation status of a spec
     when we don't know its package.py
     """
-    with spack.repo.use_repositories(spack.repo.MockRepositoryBuilder(tmpdir).root):
+    with spack.repo.use_repositories(spack.test.conftest.MockRepositoryBuilder(tmpdir).root):
         specs = database.query("mpileaks")
         for s in specs:
             # Assert that we can query the installation methods even though we

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -43,7 +43,7 @@ import spack.version as vn
 from spack.enums import InstallRecordStatus
 from spack.installer import PackageInstaller
 from spack.schema.database_index import schema
-from spack.test.conftest import MockRepositoryBuilder
+from spack.test.conftest import RepoBuilder
 from spack.util.executable import Executable
 
 pytestmark = pytest.mark.db
@@ -152,15 +152,15 @@ def test_spec_installed_upstream(
 
 
 @pytest.mark.usefixtures("config")
-def test_installed_upstream(upstream_and_downstream_db, tmp_repo: MockRepositoryBuilder):
+def test_installed_upstream(upstream_and_downstream_db, repo_builder: RepoBuilder):
     upstream_db, downstream_db = upstream_and_downstream_db
 
-    tmp_repo.add_package("x")
-    tmp_repo.add_package("z")
-    tmp_repo.add_package("y", dependencies=[("z", None, None)])
-    tmp_repo.add_package("w", dependencies=[("x", None, None), ("y", None, None)])
+    repo_builder.add_package("x")
+    repo_builder.add_package("z")
+    repo_builder.add_package("y", dependencies=[("z", None, None)])
+    repo_builder.add_package("w", dependencies=[("x", None, None), ("y", None, None)])
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         spec = spack.concretize.concretize_one("w")
         with writable(upstream_db):
             for dep in spec.traverse(root=False):
@@ -188,7 +188,7 @@ def test_installed_upstream(upstream_and_downstream_db, tmp_repo: MockRepository
 
 
 def test_missing_upstream_build_dep(
-    upstream_and_downstream_db, tmpdir, monkeypatch, config, tmp_repo: MockRepositoryBuilder
+    upstream_and_downstream_db, tmpdir, monkeypatch, config, repo_builder: RepoBuilder
 ):
     upstream_db, downstream_db = upstream_and_downstream_db
 
@@ -200,12 +200,12 @@ def test_missing_upstream_build_dep(
 
     upstream_db.layout.ensure_installed = fail_for_z
 
-    tmp_repo.add_package("z")
-    tmp_repo.add_package("y", dependencies=[("z", "build", None)])
+    repo_builder.add_package("z")
+    repo_builder.add_package("y", dependencies=[("z", "build", None)])
 
     monkeypatch.setattr(spack.store.STORE, "db", downstream_db)
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         y = spack.concretize.concretize_one("y")
         z_y = y["z"]
         z_y.set_prefix(z_y_prefix)
@@ -236,14 +236,14 @@ def test_missing_upstream_build_dep(
 
 
 def test_removed_upstream_dep(
-    upstream_and_downstream_db, capsys, config, tmp_repo: MockRepositoryBuilder
+    upstream_and_downstream_db, capsys, config, repo_builder: RepoBuilder
 ):
     upstream_db, downstream_db = upstream_and_downstream_db
 
-    tmp_repo.add_package("z")
-    tmp_repo.add_package("y", dependencies=[("z", None, None)])
+    repo_builder.add_package("z")
+    repo_builder.add_package("y", dependencies=[("z", None, None)])
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         y = spack.concretize.concretize_one("y")
         z = y["z"]
 
@@ -267,18 +267,16 @@ def test_removed_upstream_dep(
 
 
 @pytest.mark.usefixtures("config")
-def test_add_to_upstream_after_downstream(
-    upstream_and_downstream_db, tmp_repo: MockRepositoryBuilder
-):
+def test_add_to_upstream_after_downstream(upstream_and_downstream_db, repo_builder: RepoBuilder):
     """An upstream DB can add a package after it is installed in the downstream
     DB. When a package is recorded as installed in both, the results should
     refer to the downstream DB.
     """
     upstream_db, downstream_db = upstream_and_downstream_db
 
-    tmp_repo.add_package("x")
+    repo_builder.add_package("x")
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         spec = spack.concretize.concretize_one("x")
 
         downstream_db.add(spec)
@@ -316,15 +314,15 @@ def test_cannot_write_upstream(tmp_path, mock_packages, config):
 
 
 @pytest.mark.usefixtures("config", "temporary_store")
-def test_recursive_upstream_dbs(tmpdir, gen_mock_layout, tmp_repo: MockRepositoryBuilder):
+def test_recursive_upstream_dbs(tmpdir, gen_mock_layout, repo_builder: RepoBuilder):
     roots = [str(tmpdir.mkdir(x)) for x in ["a", "b", "c"]]
     layouts = [gen_mock_layout(x) for x in ["/ra/", "/rb/", "/rc/"]]
 
-    tmp_repo.add_package("z")
-    tmp_repo.add_package("y", dependencies=[("z", None, None)])
-    tmp_repo.add_package("x", dependencies=[("y", None, None)])
+    repo_builder.add_package("z")
+    repo_builder.add_package("y", dependencies=[("z", None, None)])
+    repo_builder.add_package("x", dependencies=[("y", None, None)])
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         spec = spack.concretize.concretize_one("x")
         db_c = spack.database.Database(roots[2], layout=layouts[2])
         db_c.add(spec["z"])
@@ -788,11 +786,11 @@ def test_110_no_write_with_exception_on_install(database):
         assert database.query("cmake", installed=InstallRecordStatus.ANY) == []
 
 
-def test_115_reindex_with_packages_not_in_repo(mutable_database, tmp_repo: MockRepositoryBuilder):
+def test_115_reindex_with_packages_not_in_repo(mutable_database, repo_builder: RepoBuilder):
     # Dont add any package definitions to this repository, the idea is that
     # packages should not have to be defined in the repository once they
     # are installed
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         spack.store.STORE.reindex()
         _check_db_sanity(mutable_database)
 
@@ -1164,11 +1162,11 @@ def test_consistency_of_dependents_upon_remove(mutable_database):
 
 
 @pytest.mark.regression("30187")
-def test_query_installed_when_package_unknown(database, tmp_repo: MockRepositoryBuilder):
+def test_query_installed_when_package_unknown(database, repo_builder: RepoBuilder):
     """Test that we can query the installation status of a spec
     when we don't know its package.py
     """
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         specs = database.query("mpileaks")
         for s in specs:
             # Assert that we can query the installation methods even though we

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -16,7 +16,6 @@ import sys
 import pytest
 
 import spack.subprocess_context
-import spack.test.conftest
 from spack.directory_layout import DirectoryLayoutError
 
 try:
@@ -44,6 +43,7 @@ import spack.version as vn
 from spack.enums import InstallRecordStatus
 from spack.installer import PackageInstaller
 from spack.schema.database_index import schema
+from spack.test.conftest import MockRepositoryBuilder
 from spack.util.executable import Executable
 
 pytestmark = pytest.mark.db
@@ -152,16 +152,15 @@ def test_spec_installed_upstream(
 
 
 @pytest.mark.usefixtures("config")
-def test_installed_upstream(upstream_and_downstream_db, tmpdir):
+def test_installed_upstream(upstream_and_downstream_db, tmp_repo: MockRepositoryBuilder):
     upstream_db, downstream_db = upstream_and_downstream_db
 
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
-    builder.add_package("x")
-    builder.add_package("z")
-    builder.add_package("y", dependencies=[("z", None, None)])
-    builder.add_package("w", dependencies=[("x", None, None), ("y", None, None)])
+    tmp_repo.add_package("x")
+    tmp_repo.add_package("z")
+    tmp_repo.add_package("y", dependencies=[("z", None, None)])
+    tmp_repo.add_package("w", dependencies=[("x", None, None), ("y", None, None)])
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         spec = spack.concretize.concretize_one("w")
         with writable(upstream_db):
             for dep in spec.traverse(root=False):
@@ -188,7 +187,9 @@ def test_installed_upstream(upstream_and_downstream_db, tmpdir):
         downstream_db._check_ref_counts()
 
 
-def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypatch, config):
+def test_missing_upstream_build_dep(
+    upstream_and_downstream_db, tmpdir, monkeypatch, config, tmp_repo: MockRepositoryBuilder
+):
     upstream_db, downstream_db = upstream_and_downstream_db
 
     z_y_prefix = str(tmpdir.join("z-y"))
@@ -199,13 +200,12 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
 
     upstream_db.layout.ensure_installed = fail_for_z
 
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
-    builder.add_package("z")
-    builder.add_package("y", dependencies=[("z", "build", None)])
+    tmp_repo.add_package("z")
+    tmp_repo.add_package("y", dependencies=[("z", "build", None)])
 
     monkeypatch.setattr(spack.store.STORE, "db", downstream_db)
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         y = spack.concretize.concretize_one("y")
         z_y = y["z"]
         z_y.set_prefix(z_y_prefix)
@@ -235,14 +235,15 @@ def test_missing_upstream_build_dep(upstream_and_downstream_db, tmpdir, monkeypa
         assert not z_new.installed_upstream
 
 
-def test_removed_upstream_dep(upstream_and_downstream_db, tmpdir, capsys, config):
+def test_removed_upstream_dep(
+    upstream_and_downstream_db, capsys, config, tmp_repo: MockRepositoryBuilder
+):
     upstream_db, downstream_db = upstream_and_downstream_db
 
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
-    builder.add_package("z")
-    builder.add_package("y", dependencies=[("z", None, None)])
+    tmp_repo.add_package("z")
+    tmp_repo.add_package("y", dependencies=[("z", None, None)])
 
-    with spack.repo.use_repositories(builder):
+    with spack.repo.use_repositories(tmp_repo.root):
         y = spack.concretize.concretize_one("y")
         z = y["z"]
 
@@ -266,17 +267,18 @@ def test_removed_upstream_dep(upstream_and_downstream_db, tmpdir, capsys, config
 
 
 @pytest.mark.usefixtures("config")
-def test_add_to_upstream_after_downstream(upstream_and_downstream_db, tmpdir):
+def test_add_to_upstream_after_downstream(
+    upstream_and_downstream_db, tmp_repo: MockRepositoryBuilder
+):
     """An upstream DB can add a package after it is installed in the downstream
     DB. When a package is recorded as installed in both, the results should
     refer to the downstream DB.
     """
     upstream_db, downstream_db = upstream_and_downstream_db
 
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
-    builder.add_package("x")
+    tmp_repo.add_package("x")
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         spec = spack.concretize.concretize_one("x")
 
         downstream_db.add(spec)
@@ -314,16 +316,15 @@ def test_cannot_write_upstream(tmp_path, mock_packages, config):
 
 
 @pytest.mark.usefixtures("config", "temporary_store")
-def test_recursive_upstream_dbs(tmpdir, gen_mock_layout):
+def test_recursive_upstream_dbs(tmpdir, gen_mock_layout, tmp_repo: MockRepositoryBuilder):
     roots = [str(tmpdir.mkdir(x)) for x in ["a", "b", "c"]]
     layouts = [gen_mock_layout(x) for x in ["/ra/", "/rb/", "/rc/"]]
 
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
-    builder.add_package("z")
-    builder.add_package("y", dependencies=[("z", None, None)])
-    builder.add_package("x", dependencies=[("y", None, None)])
+    tmp_repo.add_package("z")
+    tmp_repo.add_package("y", dependencies=[("z", None, None)])
+    tmp_repo.add_package("x", dependencies=[("y", None, None)])
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         spec = spack.concretize.concretize_one("x")
         db_c = spack.database.Database(roots[2], layout=layouts[2])
         db_c.add(spec["z"])
@@ -787,11 +788,11 @@ def test_110_no_write_with_exception_on_install(database):
         assert database.query("cmake", installed=InstallRecordStatus.ANY) == []
 
 
-def test_115_reindex_with_packages_not_in_repo(mutable_database, tmpdir):
+def test_115_reindex_with_packages_not_in_repo(mutable_database, tmp_repo: MockRepositoryBuilder):
     # Dont add any package definitions to this repository, the idea is that
     # packages should not have to be defined in the repository once they
     # are installed
-    with spack.repo.use_repositories(spack.test.conftest.MockRepositoryBuilder(tmpdir).root):
+    with spack.repo.use_repositories(tmp_repo.root):
         spack.store.STORE.reindex()
         _check_db_sanity(mutable_database)
 
@@ -1163,11 +1164,11 @@ def test_consistency_of_dependents_upon_remove(mutable_database):
 
 
 @pytest.mark.regression("30187")
-def test_query_installed_when_package_unknown(database, tmpdir):
+def test_query_installed_when_package_unknown(database, tmp_repo: MockRepositoryBuilder):
     """Test that we can query the installation status of a spec
     when we don't know its package.py
     """
-    with spack.repo.use_repositories(spack.test.conftest.MockRepositoryBuilder(tmpdir).root):
+    with spack.repo.use_repositories(tmp_repo.root):
         specs = database.query("mpileaks")
         for s in specs:
             # Assert that we can query the installation methods even though we

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -27,6 +27,7 @@ import spack.package_prefs as prefs
 import spack.repo
 import spack.spec
 import spack.store
+import spack.test.conftest
 import spack.util.lock as lk
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
@@ -246,7 +247,7 @@ def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
     monkeypatch.setattr(spack.spec.Spec, "installed", _mock_installed)
 
     # Create mock repository with packages (a), (b), (c), (d), and (e)
-    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
 
     builder.add_package("pkg-a", dependencies=[("pkg-b", "build", None), ("pkg-c", "build", None)])
     builder.add_package("pkg-b", dependencies=[("pkg-d", "build", None)])

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -31,6 +31,7 @@ import spack.test.conftest
 import spack.util.lock as lk
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
+from spack.test.conftest import MockRepositoryBuilder
 
 
 def _mock_repo(root, namespace):
@@ -222,7 +223,9 @@ def test_installer_str(install_mockery):
     assert "failed (0)" in istr
 
 
-def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
+def test_installer_prune_built_build_deps(
+    install_mockery, monkeypatch, tmp_repo: MockRepositoryBuilder
+):
     r"""
     Ensure that build dependencies of installed deps are pruned
     from installer package queues.
@@ -247,19 +250,19 @@ def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
     monkeypatch.setattr(spack.spec.Spec, "installed", _mock_installed)
 
     # Create mock repository with packages (a), (b), (c), (d), and (e)
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
-
-    builder.add_package("pkg-a", dependencies=[("pkg-b", "build", None), ("pkg-c", "build", None)])
-    builder.add_package("pkg-b", dependencies=[("pkg-d", "build", None)])
-    builder.add_package(
+    tmp_repo.add_package(
+        "pkg-a", dependencies=[("pkg-b", "build", None), ("pkg-c", "build", None)]
+    )
+    tmp_repo.add_package("pkg-b", dependencies=[("pkg-d", "build", None)])
+    tmp_repo.add_package(
         "pkg-c",
         dependencies=[("pkg-d", "build", None), ("pkg-e", "all", None), ("pkg-f", "build", None)],
     )
-    builder.add_package("pkg-d")
-    builder.add_package("pkg-e")
-    builder.add_package("pkg-f")
+    tmp_repo.add_package("pkg-d")
+    tmp_repo.add_package("pkg-e")
+    tmp_repo.add_package("pkg-f")
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         installer = create_installer(["pkg-a"])
 
         installer._init_queue()

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -31,7 +31,7 @@ import spack.test.conftest
 import spack.util.lock as lk
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
-from spack.test.conftest import MockRepositoryBuilder
+from spack.test.conftest import RepoBuilder
 
 
 def _mock_repo(root, namespace):
@@ -223,9 +223,7 @@ def test_installer_str(install_mockery):
     assert "failed (0)" in istr
 
 
-def test_installer_prune_built_build_deps(
-    install_mockery, monkeypatch, tmp_repo: MockRepositoryBuilder
-):
+def test_installer_prune_built_build_deps(install_mockery, monkeypatch, repo_builder: RepoBuilder):
     r"""
     Ensure that build dependencies of installed deps are pruned
     from installer package queues.
@@ -249,19 +247,19 @@ def test_installer_prune_built_build_deps(
     monkeypatch.setattr(spack.spec.Spec, "installed", property(_mock_installed))
 
     # Create mock repository with packages (a), (b), (c), (d), and (e)
-    tmp_repo.add_package(
+    repo_builder.add_package(
         "pkg-a", dependencies=[("pkg-b", "build", None), ("pkg-c", "build", None)]
     )
-    tmp_repo.add_package("pkg-b", dependencies=[("pkg-d", "build", None)])
-    tmp_repo.add_package(
+    repo_builder.add_package("pkg-b", dependencies=[("pkg-d", "build", None)])
+    repo_builder.add_package(
         "pkg-c",
         dependencies=[("pkg-d", "build", None), ("pkg-e", "all", None), ("pkg-f", "build", None)],
     )
-    tmp_repo.add_package("pkg-d")
-    tmp_repo.add_package("pkg-e")
-    tmp_repo.add_package("pkg-f")
+    repo_builder.add_package("pkg-d")
+    repo_builder.add_package("pkg-e")
+    repo_builder.add_package("pkg-f")
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         installer = create_installer(["pkg-a"])
 
         installer._init_queue()

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -242,12 +242,11 @@ def test_installer_prune_built_build_deps(
     only include four packages. [(a), (b), (c), (d), (e)]
     """
 
-    @property
     def _mock_installed(self):
         return self.name == "pkg-c"
 
-    # Mock the installed property to say that (b) is installed
-    monkeypatch.setattr(spack.spec.Spec, "installed", _mock_installed)
+    # Mock the installed property to say that (c) is installed
+    monkeypatch.setattr(spack.spec.Spec, "installed", property(_mock_installed))
 
     # Create mock repository with packages (a), (b), (c), (d), and (e)
     tmp_repo.add_package(

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -18,7 +18,7 @@ import spack.util.executable
 import spack.util.file_cache
 import spack.util.lock
 import spack.util.naming
-from spack.test.conftest import MockRepositoryBuilder
+from spack.test.conftest import RepoBuilder
 from spack.util.naming import valid_module_name
 
 
@@ -142,14 +142,14 @@ def test_get_all_mock_packages(mock_packages):
         mock_packages.get_pkg_class(name)
 
 
-def test_repo_path_handles_package_removal(mock_packages, tmp_repo: MockRepositoryBuilder):
-    tmp_repo.add_package("pkg-c")
-    with spack.repo.use_repositories(tmp_repo.root, override=False) as repos:
+def test_repo_path_handles_package_removal(mock_packages, repo_builder: RepoBuilder):
+    repo_builder.add_package("pkg-c")
+    with spack.repo.use_repositories(repo_builder.root, override=False) as repos:
         r = repos.repo_for_pkg("pkg-c")
-        assert r.namespace == tmp_repo.namespace
+        assert r.namespace == repo_builder.namespace
 
-    tmp_repo.remove("pkg-c")
-    with spack.repo.use_repositories(tmp_repo.root, override=False) as repos:
+    repo_builder.remove("pkg-c")
+    with spack.repo.use_repositories(repo_builder.root, override=False) as repos:
         r = repos.repo_for_pkg("pkg-c")
         assert r.namespace == "builtin_mock"
 
@@ -171,7 +171,7 @@ def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages, ensure_deb
 
 @pytest.mark.parametrize("repos", [["mock"], ["extra"], ["mock", "extra"], ["extra", "mock"]])
 def test_repository_construction_doesnt_use_globals(
-    nullify_globals, tmp_path, repos, tmp_repo: MockRepositoryBuilder
+    nullify_globals, tmp_path, repos, repo_builder: RepoBuilder
 ):
     def _repo_descriptors(repos):
         descriptors = {}
@@ -183,8 +183,8 @@ def test_repository_construction_doesnt_use_globals(
             if entry == "extra":
                 repo_dir = tmp_path / "extra_mock"
                 repo_dir.mkdir()
-                descriptors[tmp_repo.namespace] = spack.repo.LocalRepoDescriptor(
-                    tmp_repo.namespace, tmp_repo.root
+                descriptors[repo_builder.namespace] = spack.repo.LocalRepoDescriptor(
+                    repo_builder.namespace, repo_builder.root
                 )
         return spack.repo.RepoDescriptors(descriptors)
 

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -18,6 +18,7 @@ import spack.util.executable
 import spack.util.file_cache
 import spack.util.lock
 import spack.util.naming
+from spack.test.conftest import MockRepositoryBuilder
 from spack.util.naming import valid_module_name
 
 
@@ -141,15 +142,14 @@ def test_get_all_mock_packages(mock_packages):
         mock_packages.get_pkg_class(name)
 
 
-def test_repo_path_handles_package_removal(tmpdir, mock_packages):
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
-    builder.add_package("pkg-c")
-    with spack.repo.use_repositories(builder.root, override=False) as repos:
+def test_repo_path_handles_package_removal(mock_packages, tmp_repo: MockRepositoryBuilder):
+    tmp_repo.add_package("pkg-c")
+    with spack.repo.use_repositories(tmp_repo.root, override=False) as repos:
         r = repos.repo_for_pkg("pkg-c")
-        assert r.namespace == builder.namespace
+        assert r.namespace == tmp_repo.namespace
 
-    builder.remove("pkg-c")
-    with spack.repo.use_repositories(builder.root, override=False) as repos:
+    tmp_repo.remove("pkg-c")
+    with spack.repo.use_repositories(tmp_repo.root, override=False) as repos:
         r = repos.repo_for_pkg("pkg-c")
         assert r.namespace == "builtin_mock"
 
@@ -170,7 +170,9 @@ def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages, ensure_deb
 
 
 @pytest.mark.parametrize("repos", [["mock"], ["extra"], ["mock", "extra"], ["extra", "mock"]])
-def test_repository_construction_doesnt_use_globals(nullify_globals, tmp_path, repos):
+def test_repository_construction_doesnt_use_globals(
+    nullify_globals, tmp_path, repos, tmp_repo: MockRepositoryBuilder
+):
     def _repo_descriptors(repos):
         descriptors = {}
         for entry in repos:
@@ -181,9 +183,8 @@ def test_repository_construction_doesnt_use_globals(nullify_globals, tmp_path, r
             if entry == "extra":
                 repo_dir = tmp_path / "extra_mock"
                 repo_dir.mkdir()
-                repo = spack.test.conftest.MockRepositoryBuilder(repo_dir)
-                descriptors[repo.namespace] = spack.repo.LocalRepoDescriptor(
-                    repo.namespace, repo.root
+                descriptors[tmp_repo.namespace] = spack.repo.LocalRepoDescriptor(
+                    tmp_repo.namespace, tmp_repo.root
                 )
         return spack.repo.RepoDescriptors(descriptors)
 

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -13,6 +13,7 @@ import spack.paths
 import spack.repo
 import spack.schema.repos
 import spack.spec
+import spack.test.conftest
 import spack.util.executable
 import spack.util.file_cache
 import spack.util.lock
@@ -141,11 +142,11 @@ def test_get_all_mock_packages(mock_packages):
 
 
 def test_repo_path_handles_package_removal(tmpdir, mock_packages):
-    builder = spack.repo.MockRepositoryBuilder(tmpdir, namespace="removal")
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
     builder.add_package("pkg-c")
     with spack.repo.use_repositories(builder.root, override=False) as repos:
         r = repos.repo_for_pkg("pkg-c")
-        assert r.namespace == "removal"
+        assert r.namespace == builder.namespace
 
     builder.remove("pkg-c")
     with spack.repo.use_repositories(builder.root, override=False) as repos:
@@ -178,11 +179,12 @@ def test_repository_construction_doesnt_use_globals(nullify_globals, tmp_path, r
                     "builtin_mock", spack.paths.mock_packages_path
                 )
             if entry == "extra":
-                name = "extra_mock"
-                repo_dir = tmp_path / name
+                repo_dir = tmp_path / "extra_mock"
                 repo_dir.mkdir()
-                repo = spack.repo.MockRepositoryBuilder(repo_dir, name)
-                descriptors[name] = spack.repo.LocalRepoDescriptor(name, repo.root)
+                repo = spack.test.conftest.MockRepositoryBuilder(repo_dir)
+                descriptors[repo.namespace] = spack.repo.LocalRepoDescriptor(
+                    repo.namespace, repo.root
+                )
         return spack.repo.RepoDescriptors(descriptors)
 
     descriptors = _repo_descriptors(repos)
@@ -430,18 +432,18 @@ def test_repo_v2_invalid_module_name(tmp_path: pathlib.Path, capsys):
     (repo_dir / "packages" / "zlib-ng").mkdir()
     (repo_dir / "packages" / "zlib-ng" / "package.py").write_text(
         """
-from spack_repo.builtin_mock.build_systems.generic import Package
+from spack.package import PackageBase
 
-class ZlibNg(Package):
+class ZlibNg(PackageBase):
     pass
 """
     )
     (repo_dir / "packages" / "UPPERCASE").mkdir()
     (repo_dir / "packages" / "UPPERCASE" / "package.py").write_text(
         """
-from spack_repo.builtin_mock.build_systems.generic import Package
+from spack.package import PackageBase
 
-class Uppercase(Package):
+class Uppercase(PackageBase):
     pass
 """
     )
@@ -463,9 +465,9 @@ def test_repo_v2_module_and_class_to_package_name(tmp_path: pathlib.Path, capsys
     (repo_dir / "packages" / "_1example_2_test").mkdir()
     (repo_dir / "packages" / "_1example_2_test" / "package.py").write_text(
         """
-from spack_repo.builtin_mock.build_systems.generic import Package
+from spack.package import PackageBase
 
-class _1example2Test(Package):
+class _1example2Test(PackageBase):
     pass
 """
     )

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -16,7 +16,7 @@ import spack.util.hash as hashutil
 import spack.version
 from spack.dependency import Dependency
 from spack.spec import Spec
-from spack.test.conftest import MockRepositoryBuilder
+from spack.test.conftest import RepoBuilder
 
 
 def check_links(spec_to_check):
@@ -59,7 +59,7 @@ def set_dependency(saved_deps, monkeypatch):
 
 
 @pytest.mark.usefixtures("config")
-def test_test_deptype(tmp_repo: MockRepositoryBuilder):
+def test_test_deptype(repo_builder: RepoBuilder):
     """Ensure that test-only dependencies are only included for specified
     packages in the following spec DAG::
 
@@ -71,12 +71,12 @@ def test_test_deptype(tmp_repo: MockRepositoryBuilder):
 
     w->y deptypes are (link, build), w->x and y->z deptypes are (test)
     """
-    tmp_repo.add_package("x")
-    tmp_repo.add_package("z")
-    tmp_repo.add_package("y", dependencies=[("z", "test", None)])
-    tmp_repo.add_package("w", dependencies=[("x", "test", None), ("y", None, None)])
+    repo_builder.add_package("x")
+    repo_builder.add_package("z")
+    repo_builder.add_package("y", dependencies=[("z", "test", None)])
+    repo_builder.add_package("w", dependencies=[("x", "test", None), ("y", None, None)])
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         spec = spack.concretize.concretize_one("w", tests=("w",))
         assert "x" in spec
         assert "z" not in spec
@@ -124,15 +124,15 @@ def test_installed_deps(monkeypatch, install_mockery):
 
 
 @pytest.mark.usefixtures("config")
-def test_specify_preinstalled_dep(monkeypatch, tmp_repo: MockRepositoryBuilder):
+def test_specify_preinstalled_dep(monkeypatch, repo_builder: RepoBuilder):
     """Specify the use of a preinstalled package during concretization with a
     transitive dependency that is only supplied by the preinstalled package.
     """
-    tmp_repo.add_package("pkg-c")
-    tmp_repo.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
-    tmp_repo.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
+    repo_builder.add_package("pkg-c")
+    repo_builder.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
+    repo_builder.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         b_spec = spack.concretize.concretize_one("pkg-b")
         monkeypatch.setattr(Spec, "installed", property(lambda x: x.name != "pkg-a"))
 
@@ -149,7 +149,7 @@ def test_specify_preinstalled_dep(monkeypatch, tmp_repo: MockRepositoryBuilder):
     [("x ^y@2", "y@2", True), ("x@1", "y", False), ("x", "y@3", True)],
 )
 def test_conditional_dep_with_user_constraints(
-    spec_str, expr_str, expected, tmp_repo: MockRepositoryBuilder
+    spec_str, expr_str, expected, repo_builder: RepoBuilder
 ):
     """This sets up packages X->Y such that X depends on Y conditionally. It
     then constructs a Spec with X but with no constraints on X, so that the
@@ -157,10 +157,10 @@ def test_conditional_dep_with_user_constraints(
     met to add the dependency; this checks whether a user-specified constraint
     on Y is applied properly.
     """
-    tmp_repo.add_package("y")
-    tmp_repo.add_package("x", dependencies=[("y", None, "x@2:")])
+    repo_builder.add_package("y")
+    repo_builder.add_package("x", dependencies=[("y", None, "x@2:")])
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         spec = spack.concretize.concretize_one(spec_str)
         result = expr_str in spec
         assert result is expected, "{0} in {1}".format(expr_str, spec)

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -16,6 +16,7 @@ import spack.util.hash as hashutil
 import spack.version
 from spack.dependency import Dependency
 from spack.spec import Spec
+from spack.test.conftest import MockRepositoryBuilder
 
 
 def check_links(spec_to_check):
@@ -58,7 +59,7 @@ def set_dependency(saved_deps, monkeypatch):
 
 
 @pytest.mark.usefixtures("config")
-def test_test_deptype(tmpdir):
+def test_test_deptype(tmp_repo: MockRepositoryBuilder):
     """Ensure that test-only dependencies are only included for specified
     packages in the following spec DAG::
 
@@ -70,13 +71,12 @@ def test_test_deptype(tmpdir):
 
     w->y deptypes are (link, build), w->x and y->z deptypes are (test)
     """
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
-    builder.add_package("x")
-    builder.add_package("z")
-    builder.add_package("y", dependencies=[("z", "test", None)])
-    builder.add_package("w", dependencies=[("x", "test", None), ("y", None, None)])
+    tmp_repo.add_package("x")
+    tmp_repo.add_package("z")
+    tmp_repo.add_package("y", dependencies=[("z", "test", None)])
+    tmp_repo.add_package("w", dependencies=[("x", "test", None), ("y", None, None)])
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         spec = spack.concretize.concretize_one("w", tests=("w",))
         assert "x" in spec
         assert "z" not in spec
@@ -124,16 +124,15 @@ def test_installed_deps(monkeypatch, install_mockery):
 
 
 @pytest.mark.usefixtures("config")
-def test_specify_preinstalled_dep(tmpdir, monkeypatch):
+def test_specify_preinstalled_dep(monkeypatch, tmp_repo: MockRepositoryBuilder):
     """Specify the use of a preinstalled package during concretization with a
     transitive dependency that is only supplied by the preinstalled package.
     """
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
-    builder.add_package("pkg-c")
-    builder.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
-    builder.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
+    tmp_repo.add_package("pkg-c")
+    tmp_repo.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
+    tmp_repo.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         b_spec = spack.concretize.concretize_one("pkg-b")
         monkeypatch.setattr(Spec, "installed", property(lambda x: x.name != "pkg-a"))
 
@@ -149,18 +148,19 @@ def test_specify_preinstalled_dep(tmpdir, monkeypatch):
     "spec_str,expr_str,expected",
     [("x ^y@2", "y@2", True), ("x@1", "y", False), ("x", "y@3", True)],
 )
-def test_conditional_dep_with_user_constraints(tmpdir, spec_str, expr_str, expected):
+def test_conditional_dep_with_user_constraints(
+    spec_str, expr_str, expected, tmp_repo: MockRepositoryBuilder
+):
     """This sets up packages X->Y such that X depends on Y conditionally. It
     then constructs a Spec with X but with no constraints on X, so that the
     initial normalization pass cannot determine whether the constraints are
     met to add the dependency; this checks whether a user-specified constraint
     on Y is applied properly.
     """
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
-    builder.add_package("y")
-    builder.add_package("x", dependencies=[("y", None, "x@2:")])
+    tmp_repo.add_package("y")
+    tmp_repo.add_package("x", dependencies=[("y", None, "x@2:")])
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         spec = spack.concretize.concretize_one(spec_str)
         result = expr_str in spec
         assert result is expected, "{0} in {1}".format(expr_str, spec)

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -11,6 +11,7 @@ import spack.deptypes as dt
 import spack.error
 import spack.installer
 import spack.repo
+import spack.test.conftest
 import spack.util.hash as hashutil
 import spack.version
 from spack.dependency import Dependency
@@ -69,7 +70,7 @@ def test_test_deptype(tmpdir):
 
     w->y deptypes are (link, build), w->x and y->z deptypes are (test)
     """
-    builder = spack.repo.MockRepositoryBuilder(tmpdir)
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
     builder.add_package("x")
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", "test", None)])
@@ -127,7 +128,7 @@ def test_specify_preinstalled_dep(tmpdir, monkeypatch):
     """Specify the use of a preinstalled package during concretization with a
     transitive dependency that is only supplied by the preinstalled package.
     """
-    builder = spack.repo.MockRepositoryBuilder(tmpdir)
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
     builder.add_package("pkg-c")
     builder.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
     builder.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
@@ -155,7 +156,7 @@ def test_conditional_dep_with_user_constraints(tmpdir, spec_str, expr_str, expec
     met to add the dependency; this checks whether a user-specified constraint
     on Y is applied properly.
     """
-    builder = spack.repo.MockRepositoryBuilder(tmpdir)
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir)
     builder.add_package("y")
     builder.add_package("x", dependencies=[("y", None, "x@2:")])
 

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -24,6 +24,7 @@ import spack.hash_types as ht
 import spack.paths
 import spack.repo
 import spack.spec
+import spack.test.conftest
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 from spack.spec import Spec, save_dependency_specfiles
@@ -232,7 +233,7 @@ def check_specs_equal(original_spec, spec_yaml_path):
 def test_save_dependency_spec_jsons_subset(tmpdir, config):
     output_path = str(tmpdir.mkdir("spec_jsons"))
 
-    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
+    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
     builder.add_package("pkg-g")
     builder.add_package("pkg-f")
     builder.add_package("pkg-e")

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -28,6 +28,7 @@ import spack.test.conftest
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 from spack.spec import Spec, save_dependency_specfiles
+from spack.test.conftest import MockRepositoryBuilder
 from spack.util.spack_yaml import SpackYAMLError, syaml_dict
 
 
@@ -230,19 +231,18 @@ def check_specs_equal(original_spec, spec_yaml_path):
         return original_spec.eq_dag(spec_from_yaml)
 
 
-def test_save_dependency_spec_jsons_subset(tmpdir, config):
+def test_save_dependency_spec_jsons_subset(tmpdir, config, tmp_repo: MockRepositoryBuilder):
     output_path = str(tmpdir.mkdir("spec_jsons"))
 
-    builder = spack.test.conftest.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
-    builder.add_package("pkg-g")
-    builder.add_package("pkg-f")
-    builder.add_package("pkg-e")
-    builder.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
-    builder.add_package("pkg-c")
-    builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
-    builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
+    tmp_repo.add_package("pkg-g")
+    tmp_repo.add_package("pkg-f")
+    tmp_repo.add_package("pkg-e")
+    tmp_repo.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
+    tmp_repo.add_package("pkg-c")
+    tmp_repo.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
+    tmp_repo.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
 
-    with spack.repo.use_repositories(builder.root):
+    with spack.repo.use_repositories(tmp_repo.root):
         spec_a = spack.concretize.concretize_one("pkg-a")
         b_spec = spec_a["pkg-b"]
         c_spec = spec_a["pkg-c"]

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -28,7 +28,7 @@ import spack.test.conftest
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 from spack.spec import Spec, save_dependency_specfiles
-from spack.test.conftest import MockRepositoryBuilder
+from spack.test.conftest import RepoBuilder
 from spack.util.spack_yaml import SpackYAMLError, syaml_dict
 
 
@@ -231,18 +231,18 @@ def check_specs_equal(original_spec, spec_yaml_path):
         return original_spec.eq_dag(spec_from_yaml)
 
 
-def test_save_dependency_spec_jsons_subset(tmpdir, config, tmp_repo: MockRepositoryBuilder):
+def test_save_dependency_spec_jsons_subset(tmpdir, config, repo_builder: RepoBuilder):
     output_path = str(tmpdir.mkdir("spec_jsons"))
 
-    tmp_repo.add_package("pkg-g")
-    tmp_repo.add_package("pkg-f")
-    tmp_repo.add_package("pkg-e")
-    tmp_repo.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
-    tmp_repo.add_package("pkg-c")
-    tmp_repo.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
-    tmp_repo.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
+    repo_builder.add_package("pkg-g")
+    repo_builder.add_package("pkg-f")
+    repo_builder.add_package("pkg-e")
+    repo_builder.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
+    repo_builder.add_package("pkg-c")
+    repo_builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
+    repo_builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
 
-    with spack.repo.use_repositories(tmp_repo.root):
+    with spack.repo.use_repositories(repo_builder.root):
         spec_a = spack.concretize.concretize_one("pkg-a")
         b_spec = spec_a["pkg-b"]
         c_spec = spec_a["pkg-c"]

--- a/share/spack/templates/mock-repository/build_system.pyt
+++ b/share/spack/templates/mock-repository/build_system.pyt
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from typing import Tuple
+
+from spack.package import Builder, PackageBase, Prefix, Spec, build_system, register_builder
+
+
+class Package(PackageBase):
+    build_system_class = "Package"
+    legacy_buildsystem = "{{ build_system_name }}"
+    build_system("{{ build_system_name }}")
+
+
+@register_builder("{{ build_system_name }}")
+class GenericBuilder(Builder):
+    phases = ("install",)
+    legacy_methods: Tuple[str, ...] = ()
+    legacy_attributes: Tuple[str, ...] = ()
+
+    def install(self, pkg: Package, spec: Spec, prefix: Prefix) -> None:
+        raise NotImplementedError

--- a/share/spack/templates/mock-repository/package.pyt
+++ b/share/spack/templates/mock-repository/package.pyt
@@ -1,4 +1,4 @@
-from spack_repo.builtin_mock.build_systems.generic import Package
+from ...build_systems.test_build_system import Package
 from spack.package import *
 
 class {{ cls_name }}(Package):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/cmake/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/cmake/package.py
@@ -46,18 +46,15 @@ class Cmake(Package):
         return match.group(1) if match else None
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        spack_cc  # Ensure spack module-scope variable is avaiable
+        spack_cc  # Ensure spack module-scope variable is available
         env.set("for_install", "for_install")
 
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
-        spack_cc  # Ensure spack module-scope variable is avaiable
         env.set("from_cmake", "from_cmake")
 
     def setup_dependent_package(self, module, dspec):
-        spack_cc  # Ensure spack module-scope variable is avaiable
-
         module.cmake = Executable(self.spec.prefix.bin.cmake)
         module.ctest = Executable(self.spec.prefix.bin.ctest)
         self.spec.from_cmake = "from_cmake"

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/cmake_client/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/cmake_client/package.py
@@ -58,7 +58,7 @@ class CmakeClient(CMakePackage):
         self.did_something = True
 
     def setup_build_environment(self, spack_env):
-        spack_cc  # Ensure spack module-scope variable is avaiabl
+        spack_cc  # Ensure spack module-scope variable is available
         check(
             from_cmake == "from_cmake",
             "setup_build_environment couldn't read global set by cmake.",
@@ -66,13 +66,12 @@ class CmakeClient(CMakePackage):
 
         check(
             self.spec["cmake"].link_arg == "test link arg",
-            "link arg on dependency spec not readable from " "setup_build_environment.",
+            "link arg on dependency spec not readable from setup_build_environment.",
         )
 
     def setup_dependent_build_environment(
         self, env: EnvironmentModifications, dependent_spec: Spec
     ) -> None:
-        spack_cc  # Ensure spack module-scope variable is avaiable
         check(
             from_cmake == "from_cmake",
             "setup_dependent_build_environment couldn't read global set by cmake.",
@@ -80,11 +79,10 @@ class CmakeClient(CMakePackage):
 
         check(
             self.spec["cmake"].link_arg == "test link arg",
-            "link arg on dependency spec not readable from " "setup_dependent_build_environment.",
+            "link arg on dependency spec not readable from setup_dependent_build_environment.",
         )
 
     def setup_dependent_package(self, module, dspec):
-        spack_cc  # Ensure spack module-scope variable is avaiable
         check(
             from_cmake == "from_cmake",
             "setup_dependent_package couldn't read global set by cmake.",
@@ -92,7 +90,7 @@ class CmakeClient(CMakePackage):
 
         check(
             self.spec["cmake"].link_arg == "test link arg",
-            "link arg on dependency spec not readable from " "setup_dependent_package.",
+            "link arg on dependency spec not readable from setup_dependent_package.",
         )
 
     def cmake(self, spec, prefix):


### PR DESCRIPTION
Add an auto-use fixture which deletes `spack_repo.*` from `sys.modules`. This ensures that tests don't rely on mock packages being imported in another test.

* Fix a few issues that showed up as a result of that: `MockRepositoryBuilder` now generates a builder (with a unique name).
* Add a fixture `repo_builder`, instantiating `RepoBuilder` (previously `MockRepositoryBuilder`)
* Fix an issue with the mock `cmake` package, which assumed `spack_cc` was available also in functions only called at runtime. It is only available at build time, since `compiler_wrapper` sets it.
* Fix the duration of which `style.py` uses a copy of `builtin_mock` -- enable/disable repo per test instead of per module.
* Fix an issue where `sys.path` was not cleared properly when using `use_repositories`.
* Fix an issue where `repo.is_virtual` would call `get_pkg_class` which failed if the repo was not activated -- it relies on `sys.path`. Solution is now to temporarily prepend to `sys.path` for the duration of `get_pkg_class`.