### PR TITLE
Revert "Checks for databases and mirror indexes (#50859)"

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -194,16 +194,10 @@ class BinaryCacheIndex:
         self._mirrors_for_spec: Dict[str, List[MirrorForSpec]] = {}
 
     def _init_local_index_cache(self):
-        # seems logical but fails bootstrapping
-        # cache_key = self._index_contents_key
-        # exists = self._index_file_cache.init_entry(cache_key)
-        # cache_path = self._index_file_cache.cache_path(cache_key)
-        # if not exists and self._index_file_cache_initialized:
-        # raise FileNotFoundError(f"Missing {cache_path}")
-
         if not self._index_file_cache_initialized:
             cache_key = self._index_contents_key
             self._index_file_cache.init_entry(cache_key)
+
             cache_path = self._index_file_cache.cache_path(cache_key)
 
             self._local_index_cache = {}
@@ -218,7 +212,6 @@ class BinaryCacheIndex:
         clear associated data structures."""
         if self._index_file_cache:
             self._index_file_cache.destroy()
-            self._index_file_cache_initialized = False
             self._index_file_cache = file_cache.FileCache(self._index_cache_root)
         self._local_index_cache = {}
         self._specs_already_associated = set()
@@ -260,34 +253,10 @@ class BinaryCacheIndex:
             db = BuildCacheDatabase(tmpdir)
 
             try:
-                cache_file_exists = self._index_file_cache.init_entry(cache_key)
-                with self._index_file_cache.write_transaction(cache_key):
-                    cache_file_path = self._index_file_cache.cache_path(cache_key)
-                    if not cache_file_exists:
-                        # recreate index if it is missing
-                        cache_entry = self._local_index_cache[str(url_and_version)]
-                        self._fetch_and_cache_index(url_and_version, cache_entry)
-
-                    if os.path.getsize(cache_file_path) == 0:
-                        lines = textwrap.wrap(
-                            f"Buildcache index for the v{layout_version} mirror "
-                            f"at '{mirror_url}' is empty. "
-                            "If the mirror layout is deprecated and you cannot migrate "
-                            "it to the new format, consider removing it using:",
-                            width=72,
-                            subsequent_indent="  ",
-                        )
-                        lines.extend(
-                            [
-                                "    'spack mirror list'",
-                                "    'spack mirror remove <name>'",
-                                "  with the <name> for the mirror url shown in the list.",
-                            ]
-                        )
-                        tty.warn("\n".join(lines))
-                        return
-
-                    db._read_from_file(cache_file_path)
+                self._index_file_cache.init_entry(cache_key)
+                cache_path = self._index_file_cache.cache_path(cache_key)
+                with self._index_file_cache.read_transaction(cache_key):
+                    db._read_from_file(pathlib.Path(cache_path))
             except spack_db.InvalidDatabaseVersionError as e:
                 tty.warn(
                     "you need a newer Spack version to read the buildcache index "
@@ -584,7 +553,7 @@ class BinaryCacheIndex:
 
         # clean up the old cache_key if necessary
         old_cache_key = cache_entry.get("index_path", None)
-        if old_cache_key and old_cache_key != cache_key:
+        if old_cache_key:
             self._index_file_cache.remove(old_cache_key)
 
         # We fetched an index and updated the local index cache, we should

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -800,9 +800,6 @@ class Database:
 
         Does not do any locking.
         """
-        if not filename.is_file():
-            raise FileNotFoundError(f"database does not exist {filename}")
-
         try:
             # In the future we may use a stream of JSON objects, hence `raw_decode` for compat.
             fdata, _ = JSONDecoder().raw_decode(filename.read_text(encoding="utf-8"))

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -462,6 +462,30 @@ def test_generate_index_missing(monkeypatch, tmpdir, mutable_config):
         assert "libelf" not in cache_list
 
 
+@pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
+def test_use_bin_index(monkeypatch, tmpdir, mutable_config):
+    """Check use of binary cache index: perform an operation that
+    instantiates it, and a second operation that reconstructs it.
+    """
+    monkeypatch.setattr(bindist, "BINARY_INDEX", bindist.BinaryCacheIndex())
+
+    # Create a mirror, configure us to point at it, install a spec, and
+    # put it in the mirror
+    mirror_dir = tmpdir.join("mirror_dir")
+    mirror_url = url_util.path_to_file_url(mirror_dir.strpath)
+    spack.config.set("mirrors", {"test": mirror_url})
+    s = spack.concretize.concretize_one("libdwarf")
+    install_cmd("--fake", "--no-cache", s.name)
+    buildcache_cmd("push", "-u", mirror_dir.strpath, s.name)
+    buildcache_cmd("update-index", mirror_dir.strpath)
+
+    # Now the test
+    buildcache_cmd("list", "-al")
+    bindist.BINARY_INDEX = bindist.BinaryCacheIndex()
+    cache_list = buildcache_cmd("list", "-al")
+    assert "libdwarf" in cache_list
+
+
 def test_generate_key_index_failure(monkeypatch, tmp_path):
     def list_url(url, recursive=False):
         if "fails-listing" in url:

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -137,7 +137,6 @@ def default_config(tmp_path, config_directory, mock_packages_repo, install_mocke
             spack.config.set(
                 "config:build_stage", [str(mutable_dir / "build_stage")], scope="user"
             )
-        spack.config.set("config:misc_cache:", str(mutable_dir / "misc_cache"), scope="user")
         timeout = spack.config.get("config:connect_timeout")
         if not timeout:
             spack.config.set("config:connect_timeout", 10, scope="user")
@@ -326,11 +325,6 @@ def test_relative_rpaths_install_nondefault(temporary_mirror_dir):
     into the non-default directory layout scheme.
     """
     cspec = spack.concretize.concretize_one("corge")
-    # Install 'corge' without using a cache
-    install_cmd("--no-cache", cspec.name)
-    buildcache_cmd("push", "-u", temporary_mirror_dir, cspec.name)
-    buildcache_cmd("update-index", temporary_mirror_dir)
-    uninstall_cmd("-y", "--dependents", cspec.name)
 
     # Test install in non-default install path scheme and relative path
     buildcache_cmd("install", "-ufo", cspec.name)


### PR DESCRIPTION
This reverts commit 3b8011d77266878ae00839c29377a12605f12ece.

I don't understand the problems that #50859 was attempting to solve, but that PR broke the BinaryCacheIndex class, causing #50940. 

I'm happy to discuss the problems the PR is aimed at, and I'm sure we can come up with a way to fix those problem that preserves the ability to cache remote indices locally.
