### PR TITLE
solver: fix issues with identical externals (modulo compiler)

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -289,10 +289,6 @@ error(100, "Package '{0}' needs the deprecated version '{1}', and this is not al
      not concrete(node(ID, Package)),
      pkg_fact(Package, deprecated_version(Version)).
 
-possible_version_weight(node(ID, Package), Weight)
- :- attr("version", node(ID, Package), Version),
-    pkg_fact(Package, version_declared(Version, Weight)).
-
 % we can't use the weight for an external version if we don't use the
 % corresponding external spec.
 :- attr("version", node(ID, Package), Version),
@@ -1013,6 +1009,14 @@ attr("external_spec_selected", node(ID, Package), LocalIndex) :-
     attr("external_conditions_hold", node(ID, Package), LocalIndex),
     attr("node", node(ID, Package)),
     not attr("hash", node(ID, Package), _).
+
+% Allow clingo not to impose an external condition. This is needed to allow solving
+% for externals that are indistinguishable besides compiler "metadata" e.g.
+% mpich@4.2 %gcc vs. mpich@4.2 %clang
+{ do_not_impose(EffectID, node(X, Package)) } :-
+  trigger_condition_holds(TriggerID, node(X, Package)),
+  trigger_and_effect(Package, TriggerID, EffectID),
+  imposed_constraint(EffectID, "external_conditions_hold", Package, _).
 
 % Account for compiler annotation on externals
 :- not attr("root", ExternalNode),

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1344,3 +1344,32 @@ def test_preferring_compilers_can_be_overridden(mutable_config, mock_packages):
 
     assert concrete.satisfies("%c=gcc")
     assert concrete["pkg-b"].satisfies("%c=llvm")
+
+
+@pytest.mark.regression("50955")
+def test_multiple_externals_and_requirement(concretize_scope, mock_packages):
+    """Tests that we can concretize a required virtual, when we have multiple externals specs for
+    it, differing only by the compiler.
+    """
+    packages_yaml = """
+packages:
+  c:
+    require: gcc
+  mpi:
+    require: mpich
+  mpich:
+    buildable: false
+    externals:
+    - spec: "mpich@4.3.0 %gcc"
+      prefix: /opt/somewhere
+    - spec: "mpich@4.3.0 %clang"
+      prefix: /opt/somewhere/else
+"""
+    update_packages_config(packages_yaml)
+
+    s = spack.spec.Spec("mpileaks")
+    concrete = spack.concretize.concretize_one(s)
+
+    assert concrete.satisfies("%gcc")
+    assert concrete["mpi"].satisfies("mpich@4.3.0")
+    assert concrete["mpi"].prefix == "/opt/somewhere"

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1347,11 +1347,11 @@ def test_preferring_compilers_can_be_overridden(mutable_config, mock_packages):
 
 
 @pytest.mark.regression("50955")
-def test_multiple_externals_and_requirement(concretize_scope, mock_packages):
+def test_multiple_externals_and_requirement(concretize_scope, mock_packages, tmp_path):
     """Tests that we can concretize a required virtual, when we have multiple externals specs for
     it, differing only by the compiler.
     """
-    packages_yaml = """
+    packages_yaml = f"""
 packages:
   c:
     require: gcc
@@ -1361,9 +1361,9 @@ packages:
     buildable: false
     externals:
     - spec: "mpich@4.3.0 %gcc"
-      prefix: /opt/somewhere
+      prefix: {tmp_path / "gcc"}
     - spec: "mpich@4.3.0 %clang"
-      prefix: /opt/somewhere/else
+      prefix: {tmp_path / "clang"}
 """
     update_packages_config(packages_yaml)
 
@@ -1372,4 +1372,4 @@ packages:
 
     assert concrete.satisfies("%gcc")
     assert concrete["mpi"].satisfies("mpich@4.3.0")
-    assert concrete["mpi"].prefix == "/opt/somewhere"
+    assert concrete["mpi"].prefix == str(tmp_path / "gcc")


### PR DESCRIPTION
fixes #50955

Externals are coded with a pair of "trigger conditions" and "imposed conditions".

In this case the trigger conditions were the same for both mpich:
```
condition_requirement(22,"node","mpich").
condition_requirement(22,"node_version_satisfies","mpich","=4.3.0").
```
but the imposed conditions were conflicting.

To fix the issue, relax the set of rules and allow clingo to not impose an external condition.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
