### PR TITLE
Constrain bootstrap dependency for CI

### DIFF
--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -128,7 +128,7 @@ def isort_root_spec() -> str:
 
 def mypy_root_spec() -> str:
     """Return the root spec used to bootstrap mypy"""
-    return _root_spec("py-mypy@0.900:")
+    return _root_spec("py-mypy@0.900: ^py-mypy-extensions@:1.0")
 
 
 def black_root_spec() -> str:


### PR DESCRIPTION
`bootstrap-dev-rhel8` fails because `py-mypy-extensions 1.1` (added a few hours ago) doesn't install on RHEL. This PR just constrains it for now in the bootstrapping env.