### PR TITLE
Allow passing repo namespace to `spack create -r`

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -1049,7 +1049,12 @@ def get_repository(args, name):
     # Figure out where the new package should live
     repo_path = args.repo
     if repo_path is not None:
-        repo = spack.repo.from_path(repo_path)
+        repo = None
+        try:
+            repo = spack.repo.PATH.get_repo(repo_path)
+        except spack.repo.UnknownNamespaceError:
+            repo = spack.repo.from_path(repo_path)
+
         if spec.namespace and spec.namespace != repo.namespace:
             tty.die(
                 "Can't create package with namespace {0} in repo with "

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -54,6 +54,7 @@ package_template = '''\
 # ----------------------------------------------------------------------------
 
 {package_class_import}
+
 from spack.package import *
 
 

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -244,3 +244,22 @@ def test_language_and_build_system_detection(tmp_path, source_files, languages):
 
     assert guesser.build_system == "autotools"
     assert guesser.languages == languages
+
+
+def test_create_in_repo(mock_test_multi_repo):
+    """Test creating a repo using the repo path or the repo name
+    when there are multiple repositories
+    """
+    repo_path = mock_test_multi_repo
+
+    mock_repo = repo_path.get_repo("mock_test_repo")
+
+    name = "create-new-package-in-repo"
+    create("--skip-editor", "-r", mock_repo.namespace, "-n", name)
+    filename = mock_repo.filename_for_package_name(name)
+    assert os.path.exists(filename)
+
+    name = "create-new-package-in-path"
+    create("--skip-editor", "-r", mock_repo.root, "-n", name)
+    filename = mock_repo.filename_for_package_name(name)
+    assert os.path.exists(filename)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1745,6 +1745,18 @@ repo:
 
 
 @pytest.fixture(scope="function")
+def mock_test_multi_repo(mock_test_repo, mock_packages):
+    """Create an empty repository."""
+
+    mock_repo, _ = mock_test_repo
+    builtin_mock_repo = mock_packages
+
+    # Enable both of the mock repos at the same time
+    with spack.repo.use_repositories(*mock_repo.repos, *builtin_mock_repo.repos) as repo:
+        yield repo
+
+
+@pytest.fixture(scope="function")
 def mock_clone_repo(tmpdir_factory):
     """Create a cloned repository."""
     repo_namespace = "mock_clone_repo"


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

It is not super ergonomic when working with multiple repositories to have to specify the entire path to a repo in order to create a package. This attempts to find the repo by namespace name first, and then falls back to `spack.repo.from_path`.