### PR TITLE
Fix ci pruning in `spack-packages` PRs

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -451,17 +451,16 @@ def get_unaffected_pruners(
 
         affected_pkgs.update(repo_affected_pkgs)
 
+    if not affected_pkgs:
+        tty.info("Skipping unaffected pruning no package changes were detected")
+        return None
+
     affected_specs = get_spec_filter_list(
         env, affected_pkgs, dependent_traverse_depth=untouched_pruning_dependent_depth
     )
     tty.debug(f"dependent_traverse_depth={untouched_pruning_dependent_depth}, affected specs:")
     for s in affected_specs:
         tty.debug(f"  {PipelineDag.key(s)}")
-
-    # If specs changed, but no packages were affected, rebuild everything that has changed.
-    if not affected_specs:
-        tty.info("Skipping unaffected pruning no package changes were detected")
-        return None
 
     return create_unaffected_pruner(affected_specs)
 

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -452,7 +452,7 @@ def get_unaffected_pruners(
         affected_pkgs.update(repo_affected_pkgs)
 
     if not affected_pkgs:
-        tty.info("Skipping unaffected pruning no package changes were detected")
+        tty.info("Skipping unaffected pruning: no package changes were detected")
         return None
 
     affected_specs = get_spec_filter_list(


### PR DESCRIPTION
Currently, we have PRs which are rebuilding unrelated packages.

It seems we should move the "unaffected pruning" check before we compute the affected specs.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
