### PR TITLE
Untouched pruning default is false

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -94,7 +94,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--prune-unaffected",
         action="store_true",
         dest="prune_unaffected",
-        default=True,
+        default=False,
         help="skip up-to-date specs\n\n"
         "do not generate jobs for specs that are up-to-date on the mirror",
     )
@@ -102,7 +102,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--no-prune-unaffected",
         action="store_false",
         dest="prune_unaffected",
-        default=True,
+        default=False,
         help="process up-to-date specs\n\n"
         "generate jobs for specs even when they are up-to-date on the mirror",
     )


### PR DESCRIPTION
If the environment variable is not set, the default behavior is to no prune unaffected.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
