### PR TITLE
Allow dict/list/etc. under extra_attributes for externals

### DIFF
--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -178,7 +178,7 @@ properties: Dict[str, Any] = {
                             "modules": {"type": "array", "items": {"type": "string"}},
                             "extra_attributes": {
                                 "type": "object",
-                                "additionalProperties": {"type": "string"},
+                                "additionalProperties": True,
                                 "properties": {
                                     "compilers": {
                                         "type": "object",

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -4,6 +4,7 @@
 
 import pathlib
 import shutil
+import sys
 
 import pytest
 
@@ -342,6 +343,9 @@ def test_group_arguments(
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="`pkg grep` generates cmdline length > 40000 chars"
+)
 @pytest.mark.skipif(not spack.cmd.pkg.get_grep(), reason="grep is not installed")
 def test_pkg_grep(mock_packages, capfd):
     # only splice-* mock packages have the string "splice" in them

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -372,3 +372,25 @@ def test_pkg_name_can_only_be_derived_when_package_module():
 
     with pytest.raises(ValueError, match="Package ExamplePackage is not a known Spack package"):
         ExamplePackage.name
+
+
+import spack.config
+
+
+def test_pkg_cfg_extra_attrs(mock_packages, mutable_config, tmpdir):
+    spack.config.set("packages:arbitrary-extra-attrs", {
+        "buildable": False,
+        "externals": [
+            { "spec": "arbitrary-extra-attrs@1.0",
+             "prefix": str(tmpdir),
+             "extra_attributes": {
+                 "exampledict": {
+                     "a": 1,
+                     "b": "2"
+                 }
+             }
+            }
+        ]
+    })
+    spec = spack.concretize.concretize_one(Spec("arbitrary-extra-attrs"))
+    spec.package.check()

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -10,6 +10,7 @@ import sys
 import pytest
 
 import spack.concretize
+import spack.config
 import spack.directives
 import spack.error
 import spack.fetch_strategy
@@ -374,23 +375,19 @@ def test_pkg_name_can_only_be_derived_when_package_module():
         ExamplePackage.name
 
 
-import spack.config
-
-
 def test_pkg_cfg_extra_attrs(mock_packages, mutable_config, tmpdir):
-    spack.config.set("packages:arbitrary-extra-attrs", {
-        "buildable": False,
-        "externals": [
-            { "spec": "arbitrary-extra-attrs@1.0",
-             "prefix": str(tmpdir),
-             "extra_attributes": {
-                 "exampledict": {
-                     "a": 1,
-                     "b": "2"
-                 }
-             }
-            }
-        ]
-    })
+    spack.config.set(
+        "packages:arbitrary-extra-attrs",
+        {
+            "buildable": False,
+            "externals": [
+                {
+                    "spec": "arbitrary-extra-attrs@1.0",
+                    "prefix": str(tmpdir),
+                    "extra_attributes": {"exampledict": {"a": 1, "b": "2"}},
+                }
+            ],
+        },
+    )
     spec = spack.concretize.concretize_one(Spec("arbitrary-extra-attrs"))
     spec.package.check()

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arbitrary_extra_attrs/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arbitrary_extra_attrs/package.py
@@ -1,0 +1,36 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems import autotools
+
+from spack.package import *
+
+
+class ArbitraryExtraAttrs(autotools.AutotoolsPackage):
+    """Simple package with one optional dependency"""
+
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0", sha256=64 * "a")
+
+    depends_on("c", type="build")
+
+    parallel = False
+
+    def check(self):
+        exampledict = self.spec.extra_attributes["exampledict"]
+        assert exampledict == {"a": 1, "b": "2"}
+
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
+    def autoreconf(self, pkg, spec, prefix):
+        pass
+
+    def configure(self, pkg, spec, prefix):
+        pass
+
+    def build(self, pkg, spec, prefix):
+        exampledict = spec.extra_attributes["exampledict"]
+        assert exampledict == {"a": 1, "b": "2"}
+
+    def install(self, pkg, spec, prefix):
+        mkdirp(prefix.bin)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arbitrary_extra_attrs/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arbitrary_extra_attrs/package.py
@@ -1,12 +1,12 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from spack_repo.builtin_mock.build_systems import autotools
+from spack_repo.builtin_mock.build_systems.generic import Package
 
 from spack.package import *
 
 
-class ArbitraryExtraAttrs(autotools.AutotoolsPackage):
+class ArbitraryExtraAttrs(Package):
     """Simple package with one optional dependency"""
 
     url = "http://www.example.com/a-1.0.tar.gz"
@@ -20,17 +20,3 @@ class ArbitraryExtraAttrs(autotools.AutotoolsPackage):
     def check(self):
         exampledict = self.spec.extra_attributes["exampledict"]
         assert exampledict == {"a": 1, "b": "2"}
-
-class AutotoolsBuilder(autotools.AutotoolsBuilder):
-    def autoreconf(self, pkg, spec, prefix):
-        pass
-
-    def configure(self, pkg, spec, prefix):
-        pass
-
-    def build(self, pkg, spec, prefix):
-        exampledict = spec.extra_attributes["exampledict"]
-        assert exampledict == {"a": 1, "b": "2"}
-
-    def install(self, pkg, spec, prefix):
-        mkdirp(prefix.bin)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arbitrary_extra_attrs/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arbitrary_extra_attrs/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class ArbitraryExtraAttrs(Package):
-    """Simple package with one optional dependency"""
+    """Package that depends on extra_attributes from external config."""
 
     url = "http://www.example.com/a-1.0.tar.gz"
 


### PR DESCRIPTION
Undo a change made in https://github.com/spack/spack/pull/48621 that restricts the values of `extra_attributes` : custom packages may wish to make use of this extended structure (example added in the form of a test).