### PR TITLE
noop change to check if test failure is unique to another branch

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1219,7 +1219,7 @@ class ForwardQueryToPackage:
             _ = instance.wrapped_obj[instance.wrapped_obj.name]  # NOQA: ignore=F841
             query = instance.last_query
 
-        callbacks_chain = []
+        callbacks_chain = list()
         # First in the chain : specialized attribute for virtual packages
         if query.isvirtual:
             specialized_name = "{0}_{1}".format(query.name, self.attribute_name)


### PR DESCRIPTION
I don't think the error in https://github.com/spack/spack/pull/50970 is the fault of that branch. I'm opening this noop PR to see if the same failure (with `test_pkg_grep`) occurs here.