### PR TITLE
Set the default for builds to be p1j16

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -151,7 +151,7 @@ config:
   url_fetch_method: urllib
 
   # The maximum number of jobs to use for the build system (e.g. `make`), when
-  # the -j flag is not given on the command line. Defaults to 4 when not set.
+  # the -j flag is not given on the command line. Defaults to 16 when not set.
   # Note that the maximum number of jobs is limited by the number of cores
   # available, taking thread affinity into account when supported.
   # For instance:
@@ -162,7 +162,7 @@ config:
 
   # The maximum number of concurrent package builds a single Spack instance will run,
   # when the `-p` / `--concurrent-packages`  flag is not given on the command line.
-  # Defaults to 4 when not set.
+  # Defaults to 1 when not set.
   # Generally, big builds like LLVM are going to perform better with a higher -j, and
   # builds with lots of dependencies may build better with higher -p. It is currently
   # up to the user to balance between -j (build_jobs) and -p (concurrent_packages)
@@ -171,7 +171,7 @@ config:
   # This, like `build_jobs`, is also limited by available cores.
   # Note: This option has no effect on windows, as parallel builds are disabled on
   # windows due to a lack of filesystem locks.
-  concurrent_packages: 4
+  concurrent_packages: 1
 
 
   # If set to true, Spack will use ccache to cache C compiles.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1603,7 +1603,7 @@ def determine_number_of_jobs(
     except ValueError:
         pass
 
-    return min(max_cpus, cfg.get("config:build_jobs", 4))
+    return min(max_cpus, cfg.get("config:build_jobs", 16))
 
 
 class ConfigSectionError(spack.error.ConfigError):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1500,7 +1500,7 @@ class PackageInstaller:
             explicit = {pkg.spec.dag_hash() for pkg in packages} if explicit else set()
 
         if concurrent_packages is None:
-            concurrent_packages = spack.config.get("config:concurrent_packages", default=4)
+            concurrent_packages = spack.config.get("config:concurrent_packages", default=1)
         self.concurrent_packages = concurrent_packages
 
         install_args = {


### PR DESCRIPTION
Set the default for builds to be `--concurrent-packages 1` and `--jobs 16` (i.e., `-p1 -j16`).

Packages will install one at a time with 16 build jobs unless otherwise set with `--concurrent-packages/--jobs` on the command line or in config with
* `config:concurrent_packages` or
* `config:build_jobs`

The main reasons for doing this are:
1. Without `gmake` job server support, `-p4 -j4` is slower than `-p1 -j16` for large package builds like `llvm` and `trilinos`; and
2. Currently, Spack does not ensure that parallel build output is synced line-by-line or task-by-task. Without this, output can appear messy by default.

When we've added (1) and (2), we'll make concurrent builds the default again.