### PR TITLE
Add actions/stale to ci

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,10 +14,10 @@ jobs:
           # Issues configuration
           stale-issue-message: |
             This issue has been automatically marked as stale because it has not had 
-            recent activity in the last 6 months. It will be closed if no further activity occurs.
-            Thank you for your contributions.
+            any activity in the last 6 months. It will be closed if there is no further activity.
+            Thank you for your contributions!
           close-issue-message: |
-            This issue was closed because it has been stalled for 30 days with no activity.
+            This issue was closed because it had no activity for 30 days after being marked stale.
           stale-issue-label: 'stale'
           any-of-issue-labels: 'build-error'
           exempt-issue-labels: 'pinned,bug'
@@ -25,10 +25,10 @@ jobs:
           # Pull requests configuration
           stale-pr-message: |
             This pull request has been automatically marked as stale because it has not had 
-            recent activity in the last 6 months. It will be closed if no further activity occurs.
-            Thank you for your contributions.
+            any activity in the last 6 months. It will be closed if there is no further activity.
+            Thank you for your contributions!
           close-pr-message: |
-            This pull request was closed because it has been stalled for 30 days with no activity.
+            This pull request was closed because it had no activity for 30 days after being marked stale.
           stale-pr-label: 'stale'
           any-of-pr-labels: 'new-package'
           exempt-pr-labels: 'pinned'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,42 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    # Run every day at 1:14 UTC
+    - cron: '14 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
+        with:
+          # Issues configuration
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had 
+            recent activity in the last 6 months. It will be closed if no further activity occurs.
+            Thank you for your contributions.
+          close-issue-message: |
+            This issue was closed because it has been stalled for 30 days with no activity.
+          stale-issue-label: 'stale'
+          any-of-issue-labels: 'build-error'
+          exempt-issue-labels: 'pinned,bug'
+
+          # Pull requests configuration
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had 
+            recent activity in the last 6 months. It will be closed if no further activity occurs.
+            Thank you for your contributions.
+          close-pr-message: |
+            This pull request was closed because it has been stalled for 30 days with no activity.
+          stale-pr-label: 'stale'
+          any-of-pr-labels: 'new-package'
+          exempt-pr-labels: 'pinned'
+
+          # General configuration
+          ascending: true
+          operations-per-run: 30
+          remove-stale-when-updated: true
+          enable-statistics: true
+          days-before-stale: 180
+          days-before-close: 30

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -35,7 +35,7 @@ jobs:
 
           # General configuration
           ascending: true
-          operations-per-run: 30
+          operations-per-run: 200
           remove-stale-when-updated: true
           enable-statistics: true
           days-before-stale: 180


### PR DESCRIPTION
For now, just mark as stale / remove:
- Issues labeled as "build-error"
- PRs labeled as "new-package"

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
