### PR TITLE
Rename `legacy_*` attributes of `PackageBase` and `Builder`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,14 @@
 - Added:
   - `PackageBase.default_buildsystem`
   - `Builder.package_methods`
+  - `Builder.package_attributes`
+  - `Builder.package_long_methods`
 
   Deprecated the implicit attributes:
   - `PackageBase.legacy_buildsystem`
   - `Builder.legacy_methods`
+  - `Builder.legacy_attributes`
+  - `Builder.legacy_long_methods`
 
   Bumped the package API to v2.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Spack v1.0.0 Release notes
 
 ## Package API
+- Added `PackageBase.default_buildsystem`. 
+  Deprecated the implicit attributes `PackageBase.legacy_buildsystem`.
+  Bumped the package API to v2.2
+
 - Added `CompilerError` and `SpackError` to the list of names exported in `spack.package`.
   Bumped the package API to v2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,14 @@
 # Spack v1.0.0 Release notes
 
 ## Package API
-- Added `PackageBase.default_buildsystem`. 
-  Deprecated the implicit attributes `PackageBase.legacy_buildsystem`.
+- Added:
+  - `PackageBase.default_buildsystem`
+  - `Builder.package_methods`
+
+  Deprecated the implicit attributes:
+  - `PackageBase.legacy_buildsystem`
+  - `Builder.legacy_methods`
+
   Bumped the package API to v2.2
 
 - Added `CompilerError` and `SpackError` to the list of names exported in `spack.package`.

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -18,7 +18,7 @@ spack_version = __version__
 #: version is incremented when the package API is extended in a backwards-compatible way. The major
 #: version is incremented upon breaking changes. This version is changed independently from the
 #: Spack version.
-package_api_version = (2, 1)
+package_api_version = (2, 2)
 
 #: The minimum Package API version that this version of Spack is compatible with. This should
 #: always be a tuple of the form ``(major, 0)``, since compatibility with vX.Y implies

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -152,7 +152,7 @@ def _create(pkg: spack.package_base.PackageBase) -> "Builder":
     for method_name in (
         base_cls.phases  # type: ignore
         + package_methods(base_cls)  # type: ignore
-        + getattr(base_cls, "legacy_long_methods", tuple())
+        + package_long_methods(base_cls)  # type: ignore
         + ("setup_build_environment", "setup_dependent_build_environment")
     ):
         setattr(_ForwardToBaseBuilder, method_name, forward_method_to_getattr(method_name))
@@ -304,7 +304,7 @@ class _PackageAdapterMeta(BuilderMeta):
             attr_dict[method_name] = _PackageAdapterMeta.legacy_method_adapter(method_name)
 
         # These exist e.g. for Python, see discussion in https://github.com/spack/spack/pull/32068
-        for method_name in getattr(default_builder_cls, "legacy_long_methods", []):
+        for method_name in package_long_methods(default_builder_cls):
             attr_dict[method_name] = _PackageAdapterMeta.legacy_long_method_adapter(method_name)
 
         for attribute_name in package_attributes(default_builder_cls):
@@ -504,10 +504,17 @@ class Builder(BaseBuilder, collections.abc.Sequence):
     #: Build system name. Must also be defined in derived classes.
     build_system: Optional[str] = None
 
-    #: Methods that the adapter can find in Package classes, if a builder is not defined
+    #: Methods, with no arguments, that the adapter can find in Package classes,
+    #: if a builder is not defined.
     package_methods: Tuple[str, ...]
     #: (DEPRECATED) Deprecated attribute with the same semantics as "package_methods"
     legacy_methods: Tuple[str, ...] = ()
+
+    #: Methods with the same signature as phases, that the adapter can find in Package classes,
+    #: if a builder is not defined.
+    package_long_methods: Tuple[str, ...]
+    #: (DEPRECATED) Deprecated attribute with the same semantics as "package_long_methods"
+    legacy_long_methods: Tuple[str, ...]
 
     #: Attributes that the adapter can find in Package classes, if a builder is not defined
     package_attributes: Tuple[str, ...]
@@ -540,8 +547,8 @@ class Builder(BaseBuilder, collections.abc.Sequence):
 
 
 def package_methods(builder: Type[Builder]) -> Tuple[str, ...]:
-    """Returns the list of methods that are defined in the package class and are associated
-    with the builder.
+    """Returns the list of methods, taking no arguments, that are defined in the package
+    class and are associated with the builder.
     """
     if hasattr(builder, "package_methods"):
         # Package API v2.2
@@ -559,3 +566,14 @@ def package_attributes(builder: Type[Builder]) -> Tuple[str, ...]:
         return builder.package_attributes
 
     return builder.legacy_attributes
+
+
+def package_long_methods(builder: Type[Builder]) -> Tuple[str, ...]:
+    """Returns the list of methods, with the same signature as phases, that are defined in
+    the package class and are associated with the builder.
+    """
+    if hasattr(builder, "package_long_methods"):
+        # Package API v2.2
+        return builder.package_long_methods
+
+    return getattr(builder, "legacy_long_methods", tuple())

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -163,7 +163,7 @@ def _create(pkg: spack.package_base.PackageBase) -> "Builder":
 
         return __forward
 
-    for attribute_name in base_cls.legacy_attributes:  # type: ignore
+    for attribute_name in package_attributes(base_cls):  # type: ignore
         setattr(
             _ForwardToBaseBuilder,
             attribute_name,
@@ -307,7 +307,7 @@ class _PackageAdapterMeta(BuilderMeta):
         for method_name in getattr(default_builder_cls, "legacy_long_methods", []):
             attr_dict[method_name] = _PackageAdapterMeta.legacy_long_method_adapter(method_name)
 
-        for attribute_name in default_builder_cls.legacy_attributes:
+        for attribute_name in package_attributes(default_builder_cls):
             attr_dict[attribute_name] = _PackageAdapterMeta.legacy_attribute_adapter(
                 attribute_name
             )
@@ -509,6 +509,9 @@ class Builder(BaseBuilder, collections.abc.Sequence):
     #: (DEPRECATED) Deprecated attribute with the same semantics as "package_methods"
     legacy_methods: Tuple[str, ...] = ()
 
+    #: Attributes that the adapter can find in Package classes, if a builder is not defined
+    package_attributes: Tuple[str, ...]
+    #: (DEPRECATED) Deprecated attribute with the same semantics as "package_attributes"
     legacy_attributes: Tuple[str, ...] = ()
 
     # type hints for some of the legacy methods
@@ -545,3 +548,14 @@ def package_methods(builder: Type[Builder]) -> Tuple[str, ...]:
         return builder.package_methods
 
     return builder.legacy_methods
+
+
+def package_attributes(builder: Type[Builder]) -> Tuple[str, ...]:
+    """Returns the list of attributes that are defined in the package class and are associated
+    with the builder.
+    """
+    if hasattr(builder, "package_attributes"):
+        # Package API v2.2
+        return builder.package_attributes
+
+    return builder.legacy_attributes

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -14,6 +14,7 @@ import spack.phase_callbacks
 import spack.repo
 import spack.spec
 import spack.util.environment
+from spack.error import SpackError
 
 #: Builder classes, as registered by the "builder" decorator
 BUILDER_CLS: Dict[str, Type["Builder"]] = {}
@@ -205,9 +206,15 @@ def buildsystem_name(pkg: spack.package_base.PackageBase) -> str:
     return the name of its build system."""
     try:
         return pkg.spec.variants["build_system"].value
-    except KeyError:
+    except KeyError as e:
         # We are reading an old spec without the build_system variant
-        return pkg.legacy_buildsystem  # type: ignore
+        if hasattr(pkg, "default_buildsystem"):
+            # Package API v2.2
+            return pkg.default_buildsystem
+        elif hasattr(pkg, "legacy_buildsystem"):
+            return pkg.legacy_buildsystem
+
+        raise SpackError(f"Package {pkg.name} does not define a build system.") from e
 
 
 class BuilderMeta(

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -151,7 +151,7 @@ def _create(pkg: spack.package_base.PackageBase) -> "Builder":
     # (when _ForwardToBaseBuilder is initialized)
     for method_name in (
         base_cls.phases  # type: ignore
-        + base_cls.legacy_methods  # type: ignore
+        + package_methods(base_cls)  # type: ignore
         + getattr(base_cls, "legacy_long_methods", tuple())
         + ("setup_build_environment", "setup_dependent_build_environment")
     ):
@@ -300,7 +300,7 @@ class _PackageAdapterMeta(BuilderMeta):
         for phase_name in default_builder_cls.phases:
             attr_dict[phase_name] = _PackageAdapterMeta.phase_method_adapter(phase_name)
 
-        for method_name in default_builder_cls.legacy_methods:
+        for method_name in package_methods(default_builder_cls):
             attr_dict[method_name] = _PackageAdapterMeta.legacy_method_adapter(method_name)
 
         # These exist e.g. for Python, see discussion in https://github.com/spack/spack/pull/32068
@@ -504,7 +504,11 @@ class Builder(BaseBuilder, collections.abc.Sequence):
     #: Build system name. Must also be defined in derived classes.
     build_system: Optional[str] = None
 
+    #: Methods that the adapter can find in Package classes, if a builder is not defined
+    package_methods: Tuple[str, ...]
+    #: (DEPRECATED) Deprecated attribute with the same semantics as "package_methods"
     legacy_methods: Tuple[str, ...] = ()
+
     legacy_attributes: Tuple[str, ...] = ()
 
     # type hints for some of the legacy methods
@@ -530,3 +534,14 @@ class Builder(BaseBuilder, collections.abc.Sequence):
 
     def __len__(self):
         return len(self.phases)
+
+
+def package_methods(builder: Type[Builder]) -> Tuple[str, ...]:
+    """Returns the list of methods that are defined in the package class and are associated
+    with the builder.
+    """
+    if hasattr(builder, "package_methods"):
+        # Package API v2.2
+        return builder.package_methods
+
+    return builder.legacy_methods

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -618,6 +618,12 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: Store whether a given Spec source/binary should not be redistributed.
     disable_redistribute: Dict[spack.spec.Spec, DisableRedistribute]
 
+    #: Must be defined as a fallback for old specs that don't have the `build_system` variant
+    legacy_buildsystem: str
+
+    #: Must be defined in derived classes. Used when reporting the build system to users
+    build_system_class: str
+
     #: By default, packages are not virtual
     #: Virtual packages override this attribute
     virtual = False

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -619,6 +619,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     disable_redistribute: Dict[spack.spec.Spec, DisableRedistribute]
 
     #: Must be defined as a fallback for old specs that don't have the `build_system` variant
+    default_buildsystem: str
+
+    #: (DEPRECATED) Deprecated name for `default_buildsystem`
     legacy_buildsystem: str
 
     #: Must be defined in derived classes. Used when reporting the build system to users

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -192,11 +192,14 @@ def test_reading_api_v20_attributes():
     class TestBuilder(spack.builder.Builder):
         legacy_methods = ("configure", "install")
         legacy_attributes = ("foo", "bar")
+        legacy_long_methods = ("baz", "fee")
 
     methods = spack.builder.package_methods(TestBuilder)
     assert methods == ("configure", "install")
     attributes = spack.builder.package_attributes(TestBuilder)
     assert attributes == ("foo", "bar")
+    long_methods = spack.builder.package_long_methods(TestBuilder)
+    assert long_methods == ("baz", "fee")
 
 
 def test_reading_api_v22_attributes():
@@ -205,8 +208,11 @@ def test_reading_api_v22_attributes():
     class TestBuilder(spack.builder.Builder):
         package_methods = ("configure", "install")
         package_attributes = ("foo", "bar")
+        package_long_methods = ("baz", "fee")
 
     methods = spack.builder.package_methods(TestBuilder)
     assert methods == ("configure", "install")
     attributes = spack.builder.package_attributes(TestBuilder)
     assert attributes == ("foo", "bar")
+    long_methods = spack.builder.package_long_methods(TestBuilder)
+    assert long_methods == ("baz", "fee")

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -191,9 +191,12 @@ def test_reading_api_v20_attributes():
 
     class TestBuilder(spack.builder.Builder):
         legacy_methods = ("configure", "install")
+        legacy_attributes = ("foo", "bar")
 
     methods = spack.builder.package_methods(TestBuilder)
     assert methods == ("configure", "install")
+    attributes = spack.builder.package_attributes(TestBuilder)
+    assert attributes == ("foo", "bar")
 
 
 def test_reading_api_v22_attributes():
@@ -201,6 +204,9 @@ def test_reading_api_v22_attributes():
 
     class TestBuilder(spack.builder.Builder):
         package_methods = ("configure", "install")
+        package_attributes = ("foo", "bar")
 
     methods = spack.builder.package_methods(TestBuilder)
     assert methods == ("configure", "install")
+    attributes = spack.builder.package_attributes(TestBuilder)
+    assert attributes == ("foo", "bar")

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -184,3 +184,23 @@ def test_mixins_with_builders(working_env):
 
     # Check that callback from the GenericBuilder are in the list too
     assert any(fn.__name__ == "sanity_check_prefix" for _, fn in builder.run_after_callbacks)
+
+
+def test_reading_api_v20_attributes():
+    """Tests that we can read attributes from API v2.0 builders."""
+
+    class TestBuilder(spack.builder.Builder):
+        legacy_methods = ("configure", "install")
+
+    methods = spack.builder.package_methods(TestBuilder)
+    assert methods == ("configure", "install")
+
+
+def test_reading_api_v22_attributes():
+    """Tests that we can read attributes from API v2.2 builders."""
+
+    class TestBuilder(spack.builder.Builder):
+        package_methods = ("configure", "install")
+
+    methods = spack.builder.package_methods(TestBuilder)
+    assert methods == ("configure", "install")

--- a/share/spack/templates/mock-repository/build_system.pyt
+++ b/share/spack/templates/mock-repository/build_system.pyt
@@ -16,7 +16,7 @@ class Package(PackageBase):
 class GenericBuilder(Builder):
     phases = ("install",)
     package_methods: Tuple[str, ...] = ()
-    legacy_attributes: Tuple[str, ...] = ()
+    package_attributes: Tuple[str, ...] = ()
 
     def install(self, pkg: Package, spec: Spec, prefix: Prefix) -> None:
         raise NotImplementedError

--- a/share/spack/templates/mock-repository/build_system.pyt
+++ b/share/spack/templates/mock-repository/build_system.pyt
@@ -8,7 +8,7 @@ from spack.package import Builder, PackageBase, Prefix, Spec, build_system, regi
 
 class Package(PackageBase):
     build_system_class = "Package"
-    legacy_buildsystem = "{{ build_system_name }}"
+    default_buildsystem = "{{ build_system_name }}"
     build_system("{{ build_system_name }}")
 
 

--- a/share/spack/templates/mock-repository/build_system.pyt
+++ b/share/spack/templates/mock-repository/build_system.pyt
@@ -15,7 +15,7 @@ class Package(PackageBase):
 @register_builder("{{ build_system_name }}")
 class GenericBuilder(Builder):
     phases = ("install",)
-    legacy_methods: Tuple[str, ...] = ()
+    package_methods: Tuple[str, ...] = ()
     legacy_attributes: Tuple[str, ...] = ()
 
     def install(self, pkg: Package, spec: Spec, prefix: Prefix) -> None:

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
@@ -118,7 +118,7 @@ class AutotoolsBuilder(BuilderWithDefaults):
     package_methods = ("configure_args", "check", "installcheck")
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes = (
+    package_attributes = (
         "archive_files",
         "patch_libtool",
         "build_targets",

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
@@ -41,7 +41,7 @@ class AutotoolsPackage(spack.package_base.PackageBase):
     build_system_class = "AutotoolsPackage"
 
     #: Legacy buildsystem attribute used to deserialize and install old specs
-    legacy_buildsystem = "autotools"
+    default_buildsystem = "autotools"
 
     build_system("autotools")
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
@@ -115,7 +115,7 @@ class AutotoolsBuilder(BuilderWithDefaults):
     phases = ("autoreconf", "configure", "build", "install")
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = ("configure_args", "check", "installcheck")
+    package_methods = ("configure_args", "check", "installcheck")
 
     #: Names associated with package attributes in the old build-system format
     legacy_attributes = (

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/bundle.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/bundle.py
@@ -14,7 +14,7 @@ class BundlePackage(spack.package_base.PackageBase):
     build_system_class = "BundlePackage"
 
     #: Legacy buildsystem attribute used to deserialize and install old specs
-    legacy_buildsystem = "bundle"
+    default_buildsystem = "bundle"
 
     #: Bundle packages do not have associated source or binary code.
     has_code = False

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
@@ -312,7 +312,7 @@ class CMakeBuilder(BuilderWithDefaults):
     phases: Tuple[str, ...] = ("cmake", "build", "install")
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods: Tuple[str, ...] = ("cmake_args", "check")
+    package_methods: Tuple[str, ...] = ("cmake_args", "check")
 
     #: Names associated with package attributes in the old build-system format
     legacy_attributes: Tuple[str, ...] = (

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
@@ -197,7 +197,7 @@ class CMakePackage(spack.package_base.PackageBase):
     build_system_class = "CMakePackage"
 
     #: Legacy buildsystem attribute used to deserialize and install old specs
-    legacy_buildsystem = "cmake"
+    default_buildsystem = "cmake"
 
     #: When this package depends on Python and ``find_python_hints`` is set to True, pass the
     #: defines {Python3,Python,PYTHON}_EXECUTABLE explicitly, so that CMake locates the right

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
@@ -315,7 +315,7 @@ class CMakeBuilder(BuilderWithDefaults):
     package_methods: Tuple[str, ...] = ("cmake_args", "check")
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes: Tuple[str, ...] = (
+    package_attributes: Tuple[str, ...] = (
         "build_targets",
         "install_targets",
         "build_time_test_callbacks",

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/generic.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/generic.py
@@ -37,7 +37,7 @@ class GenericBuilder(BuilderWithDefaults):
     phases = ("install",)
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods: Tuple[str, ...] = ()
+    package_methods: Tuple[str, ...] = ()
 
     #: Names associated with package attributes in the old build-system format
     legacy_attributes: Tuple[str, ...] = ("archive_files", "install_time_test_callbacks")

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/generic.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/generic.py
@@ -22,7 +22,7 @@ class Package(spack.package_base.PackageBase):
     #: build-system class we are using
     build_system_class = "Package"
     #: Legacy buildsystem attribute used to deserialize and install old specs
-    legacy_buildsystem = "generic"
+    default_buildsystem = "generic"
 
     spack.directives.build_system("generic")
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/generic.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/generic.py
@@ -40,7 +40,7 @@ class GenericBuilder(BuilderWithDefaults):
     package_methods: Tuple[str, ...] = ()
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes: Tuple[str, ...] = ("archive_files", "install_time_test_callbacks")
+    package_attributes: Tuple[str, ...] = ("archive_files", "install_time_test_callbacks")
 
     #: Callback names for post-install phase tests
     install_time_test_callbacks = []

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
@@ -73,7 +73,7 @@ class MakefileBuilder(BuilderWithDefaults):
     package_methods = ("check", "installcheck")
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes = (
+    package_attributes = (
         "build_targets",
         "install_targets",
         "build_time_test_callbacks",

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
@@ -28,7 +28,7 @@ class MakefilePackage(spack.package_base.PackageBase):
     #: system base class
     build_system_class = "MakefilePackage"
     #: Legacy buildsystem attribute used to deserialize and install old specs
-    legacy_buildsystem = "makefile"
+    default_buildsystem = "makefile"
 
     build_system("makefile")
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
@@ -70,7 +70,7 @@ class MakefileBuilder(BuilderWithDefaults):
     phases = ("edit", "build", "install")
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = ("check", "installcheck")
+    package_methods = ("check", "installcheck")
 
     #: Names associated with package attributes in the old build-system format
     legacy_attributes = (

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
@@ -27,7 +27,7 @@ class PerlPackage(spack.package_base.PackageBase):
     #: system base class
     build_system_class = "PerlPackage"
     #: Legacy buildsystem attribute used to deserialize and install old specs
-    legacy_buildsystem = "perl"
+    default_buildsystem = "perl"
 
     build_system("perl")
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
@@ -111,7 +111,7 @@ class PerlBuilder(BuilderWithDefaults):
     phases = ("configure", "build", "install")
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = ("configure_args", "check", "test_use")
+    package_methods = ("configure_args", "check", "test_use")
 
     #: Names associated with package attributes in the old build-system format
     legacy_attributes = ()

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
@@ -114,7 +114,7 @@ class PerlBuilder(BuilderWithDefaults):
     package_methods = ("configure_args", "check", "test_use")
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes = ()
+    package_attributes = ()
 
     #: Callback names for build-time test
     build_time_test_callbacks = ["check"]

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
@@ -341,7 +341,7 @@ class PythonPipBuilder(BuilderWithDefaults):
     phases = ("install",)
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = ("test_imports",)
+    package_methods = ("test_imports",)
 
     #: Same as legacy_methods, but the signature is different
     legacy_long_methods = ("install_options", "global_options", "config_settings")

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
@@ -264,7 +264,7 @@ class PythonPackage(PythonExtension):
     # build-system class we are using
     build_system_class = "PythonPackage"
     #: Legacy buildsystem attribute used to deserialize and install old specs
-    legacy_buildsystem = "python_pip"
+    default_buildsystem = "python_pip"
 
     #: Callback names for install-time test
     install_time_test_callbacks = ["test_imports"]

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
@@ -344,7 +344,7 @@ class PythonPipBuilder(BuilderWithDefaults):
     package_methods = ("test_imports",)
 
     #: Same as legacy_methods, but the signature is different
-    legacy_long_methods = ("install_options", "global_options", "config_settings")
+    package_long_methods = ("install_options", "global_options", "config_settings")
 
     #: Names associated with package attributes in the old build-system format
     package_attributes = ("archive_files", "build_directory", "install_time_test_callbacks")

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
@@ -347,7 +347,7 @@ class PythonPipBuilder(BuilderWithDefaults):
     legacy_long_methods = ("install_options", "global_options", "config_settings")
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes = ("archive_files", "build_directory", "install_time_test_callbacks")
+    package_attributes = ("archive_files", "build_directory", "install_time_test_callbacks")
 
     #: Callback names for install-time test
     install_time_test_callbacks = ["test_imports"]


### PR DESCRIPTION
This PR does two things:
- [x] It declares a few attributes expected in classes derived from `PackageBase` or `Builder`.[^1]
- [x] It renames these attributes giving them meaningful names

To proceed with the rename, and provide backward compatibility, Spack now has to declare both the new and the old name, and document the old one as deprecated. Removal will not occur until we bump the minimum package API version.

Renames are the following:
- legacy_buildsystem -> default_buildsystem
- legacy_methods -> package_methods
- legacy_attributes -> package_attributes
- legacy_long_methods -> package_long_methods

[^1]:  Currently, these attributes are referenced in core, but only defined in the `buitlin` repository - which is not good to define a clear API for v1.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
