### PR TITLE
Increase the `operations-per-run` limit in stale workflow to 1000

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -39,7 +39,7 @@ jobs:
 
           # General configuration
           ascending: true
-          operations-per-run: 200
+          operations-per-run: 1000
           remove-stale-when-updated: true
           enable-statistics: true
           days-before-stale: 180


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
