### PR TITLE
Add handling for cases where extension are duplicated

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -86,15 +86,36 @@ def all_commands():
     global _all_commands
     if _all_commands is None:
         _all_commands = []
-        command_paths = [spack.paths.command_path]  # Built-in commands
+        command_module = {}
+        ambiguous_command = {}
+
+        command_paths = [("_builtin", spack.paths.command_path)]  # Built-in commands
         command_paths += spack.extensions.get_command_paths()  # Extensions
-        for path in command_paths:
+        for module, path in command_paths:
             for file in os.listdir(path):
                 if file.endswith(".py") and not re.search(ignore_files, file):
                     cmd = re.sub(r".py$", "", file)
-                    _all_commands.append(cmd_name(cmd))
+                    name = cmd_name(cmd)
+                    if name in command_module:
+                        cmd_modules = ambiguous_command.get(name, [])
+                        cmd_modules.append((module, path))
+                        ambiguous_command[name] = cmd_modules
+                    else:
+                        command_module[name] = (module, path)
+                        _all_commands.append(name)
 
         _all_commands.sort()
+
+        if ambiguous_command:
+            tty.warn(
+                "Detected ambiguous commands: " + ", ".join([c for c in ambiguous_command.keys()])
+            )
+            for cmd in ambiguous_command:
+                tty.debug(f"  Command: {cmd}")
+                tty.debug(f"      First defined in: {command_module[cmd]}")
+                tty.debug("      Redefined in:")
+                for amb_cmd in ambiguous_command[cmd]:
+                    tty.debug(f"         {amb_cmd}")
 
     return _all_commands
 

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -148,6 +148,7 @@ def extension_paths_from_entry_points() -> List[str]:
     spack extensions
 
     """
+
     extension_paths: List[str] = []
     for entry_point in llnl.util.lang.get_entry_points(group="spack.extensions"):
         hook = entry_point.load()
@@ -166,8 +167,11 @@ def get_command_paths():
     extension_paths = get_extension_paths()
 
     for path in extension_paths:
+        # Skip duplicate paths, only load extensions once
+        if any([p.startswith(path) for _, p in command_paths]):
+            continue
         extension = _python_name(extension_name(path))
-        command_paths.append(os.path.join(path, extension, "cmd"))
+        command_paths.append((extension, os.path.join(path, extension, "cmd")))
 
     return command_paths
 

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -260,10 +260,18 @@ def test_get_command_paths(config):
         ext_paths.append(ext_path)
         path = os.path.join(ext_path, spack.cmd.python_name(ext), "cmd")
         path = os.path.abspath(path)
-        expected_cmd_paths.append(path)
+        expected_cmd_paths.append((ext, path))
 
     with spack.config.override("config:extensions", ext_paths):
-        assert spack.extensions.get_command_paths() == expected_cmd_paths
+        found_paths = spack.extensions.get_command_paths()
+
+        def check_path(p):
+            return any([p[1] == x[1] for x in found_paths])
+
+        # Verify all of the test extensions are found
+        # If running unit-tests with other extensions enabled there
+        # may be additional extensions found
+        assert all([check_path(p) for p in expected_cmd_paths])
 
 
 def test_variable_in_extension_path(config, working_env):
@@ -276,7 +284,15 @@ def test_variable_in_extension_path(config, working_env):
         os.path.join(os.environ[home_env], os.environ["_MY_VAR"], "spack-extension-1")
     ]
     with spack.config.override("config:extensions", ext_paths):
-        assert spack.extensions.get_extension_paths() == expected_ext_paths
+        found_paths = spack.extensions.get_extension_paths()
+
+        def check_path(p):
+            return any([p[1] == x[1] for x in found_paths])
+
+        # Verify all of the test extensions are found
+        # If running unit-tests with other extensions enabled there
+        # may be additional extensions found
+        assert all([check_path(p) for p in expected_ext_paths])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If multiple extensions are configured and they define duplicate commands spack should at least warn about that.

Only add commands paths found using entry points once.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
