### PR TITLE
spack clean: all means all

### DIFF
--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -23,10 +23,10 @@ level = "long"
 
 
 class AllClean(argparse.Action):
-    """Activates flags -s -d -f -m and -p simultaneously"""
+    """Activates flags -s -d -f -m -p and -b simultaneously"""
 
     def __call__(self, parser, namespace, values, option_string=None):
-        parser.parse_args(["-sdfmp"], namespace=namespace)
+        parser.parse_args(["-sdfmpb"], namespace=namespace)
 
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
@@ -61,11 +61,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="remove software and configuration needed to bootstrap Spack",
     )
     subparser.add_argument(
-        "-a",
-        "--all",
-        action=AllClean,
-        help="equivalent to ``-sdfmp`` (does not include ``--bootstrap``)",
-        nargs=0,
+        "-a", "--all", action=AllClean, help="equivalent to ``-sdfmpb``", nargs=0
     )
     arguments.add_common_arguments(subparser, ["specs"])
 

--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -36,14 +36,16 @@ def mock_calls_for_clean(monkeypatch):
     monkeypatch.setattr(spack.caches.MISC_CACHE, "destroy", Counter("caches"))
     monkeypatch.setattr(spack.store.STORE.failure_tracker, "clear_all", Counter("failures"))
     monkeypatch.setattr(spack.cmd.clean, "remove_python_cache", Counter("python_cache"))
+    monkeypatch.setattr(spack.cmd.clean, "remove_python_cache", Counter("python_cache"))
+    monkeypatch.setattr(fs, "remove_directory_contents", Counter("bootstrap"))
 
     yield counts
 
 
-all_effects = ["stages", "downloads", "caches", "failures", "python_cache"]
+all_effects = ["stages", "downloads", "caches", "failures", "python_cache", "bootstrap"]
 
 
-@pytest.mark.usefixtures("mock_packages", "config")
+@pytest.mark.usefixtures("mock_packages")
 @pytest.mark.parametrize(
     "command_line,effects",
     [
@@ -57,7 +59,9 @@ all_effects = ["stages", "downloads", "caches", "failures", "python_cache"]
         ("", []),
     ],
 )
-def test_function_calls(command_line, effects, mock_calls_for_clean):
+def test_function_calls(command_line, effects, mock_calls_for_clean, mutable_config):
+    mutable_config.set("bootstrap", {"root": "fake"})
+
     # Call the command with the supplied command line
     clean(command_line)
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -400,7 +400,7 @@ _spack() {
     then
         SPACK_COMPREPLY="--color -v --verbose -k --insecure -b --bootstrap -V --version -h --help -H --all-help -c --config -C --config-scope -e --env -D --env-dir -E --no-env --use-env-repo -d --debug -t --backtrace --pdb --timestamp -m --mock --print-shell-vars --stacktrace -l --enable-locks -L --disable-locks -p --profile --sorted-profile --lines"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse logs maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse logs maintainers make-installer mark mirror module parse patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -1641,6 +1641,15 @@ _spack_module_tcl_setdefault() {
         SPACK_COMPREPLY="-h --help"
     else
         _installed_packages
+    fi
+}
+
+_spack_parse() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        _all_packages
     fi
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -400,7 +400,7 @@ _spack() {
     then
         SPACK_COMPREPLY="--color -v --verbose -k --insecure -b --bootstrap -V --version -h --help -H --all-help -c --config -C --config-scope -e --env -D --env-dir -E --no-env --use-env-repo -d --debug -t --backtrace --pdb --timestamp -m --mock --print-shell-vars --stacktrace -l --enable-locks -L --disable-locks -p --profile --sorted-profile --lines"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse logs maintainers make-installer mark mirror module parse patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse logs maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -1641,15 +1641,6 @@ _spack_module_tcl_setdefault() {
         SPACK_COMPREPLY="-h --help"
     else
         _installed_packages
-    fi
-}
-
-_spack_parse() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help"
-    else
-        _all_packages
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -400,6 +400,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a make-installer -d
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a mark -d 'mark packages as explicitly or implicitly installed'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a mirror -d 'manage mirrors (source and binary)'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a module -d 'generate/manage module files'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a parse -d 'check that a spec string parses'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a patch -d 'patch expanded sources in preparation for install'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a pkg -d 'query packages associated with particular git revisions'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a providers -d 'list packages that provide a particular virtual package'
@@ -1056,7 +1057,7 @@ complete -c spack -n '__fish_spack_using_command clean' -s p -l python-cache -d 
 complete -c spack -n '__fish_spack_using_command clean' -s b -l bootstrap -f -a bootstrap
 complete -c spack -n '__fish_spack_using_command clean' -s b -l bootstrap -d 'remove software and configuration needed to bootstrap Spack'
 complete -c spack -n '__fish_spack_using_command clean' -s a -l all -f -a all
-complete -c spack -n '__fish_spack_using_command clean' -s a -l all -d 'equivalent to ``-sdfmp`` (does not include ``--bootstrap``)'
+complete -c spack -n '__fish_spack_using_command clean' -s a -l all -d 'equivalent to ``-sdfmpb``'
 
 # spack commands
 set -g __fish_spack_optspecs_spack_commands h/help update-completion a/aliases format= header= update=
@@ -2634,6 +2635,12 @@ set -g __fish_spack_optspecs_spack_module_tcl_setdefault h/help
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 module tcl setdefault' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command module tcl setdefault' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command module tcl setdefault' -s h -l help -d 'show this help message and exit'
+
+# spack parse
+set -g __fish_spack_optspecs_spack_parse h/help
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 parse' -f -k -a '(__fish_spack_specs)'
+complete -c spack -n '__fish_spack_using_command parse' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command parse' -s h -l help -d 'show this help message and exit'
 
 # spack patch
 set -g __fish_spack_optspecs_spack_patch h/help n/no-checksum f/force U/fresh reuse fresh-roots deprecated

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -400,7 +400,6 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a make-installer -d
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a mark -d 'mark packages as explicitly or implicitly installed'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a mirror -d 'manage mirrors (source and binary)'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a module -d 'generate/manage module files'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a parse -d 'check that a spec string parses'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a patch -d 'patch expanded sources in preparation for install'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a pkg -d 'query packages associated with particular git revisions'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a providers -d 'list packages that provide a particular virtual package'
@@ -2635,12 +2634,6 @@ set -g __fish_spack_optspecs_spack_module_tcl_setdefault h/help
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 module tcl setdefault' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command module tcl setdefault' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command module tcl setdefault' -s h -l help -d 'show this help message and exit'
-
-# spack parse
-set -g __fish_spack_optspecs_spack_parse h/help
-complete -c spack -n '__fish_spack_using_command_pos_remainder 0 parse' -f -k -a '(__fish_spack_specs)'
-complete -c spack -n '__fish_spack_using_command parse' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command parse' -s h -l help -d 'show this help message and exit'
 
 # spack patch
 set -g __fish_spack_optspecs_spack_patch h/help n/no-checksum f/force U/fresh reuse fresh-roots deprecated


### PR DESCRIPTION
Currently, `spack clean -a` doesn't do `spack clean -b`. This is turning into a huge footgun for users who expect "all" to mean "all".

This PR makes `spack clean -a` be equivalent to throwing all other feature flags for `spack clean`
