### PR TITLE
add spack.archspec interface

### DIFF
--- a/lib/spack/spack/archspec.py
+++ b/lib/spack/spack/archspec.py
@@ -1,0 +1,38 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Adapter for the archspec library."""
+
+import _vendoring.archspec.cpu
+
+import spack.spec
+
+
+def microarchitecture_flags(spec: spack.spec.Spec, language: str) -> str:
+    """Return the microarchitecture flags for a given spec and compiler associated with the given
+    language."""
+    target = spec.target
+
+    if not spec.has_virtual_dependency(language):
+        raise ValueError(f"The spec {spec.name} does not depend on {language}")
+    elif target is None:
+        raise ValueError(f"The spec {spec.name} does not have a target defined")
+
+    compiler = spec.dependencies(virtuals=language)[0]
+
+    return microarchitecture_flags_from_target(target, compiler)
+
+
+def microarchitecture_flags_from_target(
+    target: _vendoring.archspec.cpu.Microarchitecture, compiler: spack.spec.Spec
+) -> str:
+    """Return the microarchitecture flags for a given compiler and target."""
+    # Try to check if the current compiler comes with a version number or has an unexpected suffix.
+    # If so, treat it as a compiler with a custom spec.
+    version_number, _ = _vendoring.archspec.cpu.version_components(
+        compiler.version.dotted_numeric_string
+    )
+    try:
+        return target.optimization_flags(compiler.name, version_number)
+    except ValueError:
+        return ""


### PR DESCRIPTION
Add `spack.archspec` adapter for `archspec`.

Spec object's target attributes are an `archspec.cpu.MicroArchitecture`
instance, which unfortunately exposes the method `optimization_flags`.
It's not only a misnomer, but also is awkward to use from Spack since the
compiler version needs translation.

The latter is done incorrectly in many packages in builtin after compilers as deps.

This PR adds the following adapter functions:

```python
def microarchitecture_flags(spec: Spec, language: str) -> str: ...
def microarchitecture_flags_from_target(target: MicroArchitecture, compiler: spack.spec.Spec) -> str: ...
```

for a better API.

