### PR TITLE
Preserve compiler wrapper log in stage/install dirs, not CWD

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -77,7 +77,6 @@ import spack.deptypes as dt
 import spack.error
 import spack.multimethod
 import spack.package_base
-import spack.paths
 import spack.platforms
 import spack.schema.environment
 import spack.spec
@@ -469,7 +468,7 @@ def set_wrapper_variables(pkg, env):
         env.set(SPACK_DEBUG, "TRUE")
     env.set(SPACK_SHORT_SPEC, pkg.spec.short_spec)
     env.set(SPACK_DEBUG_LOG_ID, pkg.spec.format("{name}-{hash:7}"))
-    env.set(SPACK_DEBUG_LOG_DIR, spack.paths.spack_working_dir)
+    env.set(SPACK_DEBUG_LOG_DIR, pkg.stage.path)
 
     if spack.config.get("config:ccache"):
         # Enable ccache in the compiler wrapper

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -705,6 +705,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
             tty.warn(f"Errors occurred when archiving files.\n\tSee: {error_file}")
 
     dump_packages(pkg.spec, packages_dir)
+    pkg.relocate_staged_wrapper_logs()
 
 
 def package_id(spec: "spack.spec.Spec") -> str:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -17,6 +17,7 @@ import hashlib
 import io
 import os
 import re
+import shutil
 import sys
 import textwrap
 import time
@@ -1353,6 +1354,14 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # Otherwise, return the current install log path name.
         return os.path.join(self.metadata_dir, _spack_build_logfile + ".gz")
+
+    def relocate_staged_wrapper_logs(self):
+        wrapper_logs = list()
+        for fname in os.listdir(self.stage.path):
+            if fname.startswith("spack-cc-"):
+                wrapper_logs.append(os.path.join(self.stage.path, fname))
+        for log in wrapper_logs:
+            shutil.copy(log, self.metadata_dir)
 
     @property
     def configure_args_path(self):


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/50972

If you `spack -d install`, Spack will save logs of all compiler invocations (that use the compiler wrappers) in `spack-cc...in/out` (`.in` is what the wrapper sees, and `.out` is the compiler invocation that is dispatched by the wrapper after inserting flags).

This used to be saved in the user's CWD. This PR diverts it to the stage path, and copies the logs into the install metadata path when they are found (still controlled by `spack -d`).