### PR TITLE
allow managed environments to be organized into folders

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -142,6 +142,18 @@ guaranteed to initially have the same concrete specs as the original.
    directory then the source is referred to as an
    :ref:`independent environment <independent_environments>`.
 
+The name of an environment can be a nested path to help organize environments
+via subdirectories.
+
+.. code-block:: console
+
+   $ spack env create projectA/configA/myenv
+
+This will create a managed environment under
+``$environments_root/projectA/configA/myenv``. Changing ``environment_root``
+can therefore also be used to make a whole group of nested environments
+available.
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 Activating an Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -88,9 +88,10 @@ def environment_name(path: Union[str, pathlib.Path]) -> str:
     This is the path for directory environments, and just the name
     for managed environments.
     """
+    env_root = pathlib.Path(env_root_path()).resolve()
     path_str = str(path)
-    if path_str.startswith(env_root_path()):
-        return os.path.basename(path_str)
+    if path_str.startswith(str(env_root)):
+        return str(pathlib.Path(path_str).relative_to(env_root))
     else:
         return path_str
 
@@ -124,8 +125,10 @@ spack:
     )
 
 
+sep_re = re.escape(os.sep)
+
 #: regex for validating environment names
-valid_environment_name_re = r"^\w[\w-]*$"
+valid_environment_name_re = rf"^\w[{sep_re}\w-]*$"
 
 #: version of the lockfile format. Must increase monotonically.
 lockfile_format_version = 6
@@ -548,11 +551,18 @@ def all_environment_names():
     if not os.path.exists(env_root_path()):
         return []
 
-    candidates = sorted(os.listdir(env_root_path()))
+    env_root = pathlib.Path(env_root_path()).resolve()
+
+    def yaml_paths():
+        for root, dirs, files in os.walk(env_root, topdown=True, followlinks=True):
+            dirs[:] = [d for d in dirs if not env_root.samefile(os.path.join(root, d))]
+            if manifest_name in files:
+                yield os.path.join(root, manifest_name)
+
     names = []
-    for candidate in candidates:
-        yaml_path = os.path.join(_root(candidate), manifest_name)
-        if valid_env_name(candidate) and os.path.exists(yaml_path):
+    for yaml_path in yaml_paths():
+        candidate = str(pathlib.Path(yaml_path).relative_to(env_root).parent)
+        if valid_env_name(candidate):
             names.append(candidate)
     return names
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -555,7 +555,11 @@ def all_environment_names():
 
     def yaml_paths():
         for root, dirs, files in os.walk(env_root, topdown=True, followlinks=True):
-            dirs[:] = [d for d in dirs if not env_root.samefile(os.path.join(root, d))]
+            dirs[:] = [
+                d
+                for d in dirs
+                if not d.startswith(".") and not env_root.samefile(os.path.join(root, d))
+            ]
             if manifest_name in files:
                 yield os.path.join(root, manifest_name)
 

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -37,6 +37,14 @@ class TestDirectoryInitialization:
         with pytest.raises(ev.SpackEnvironmentError, match="environment already exists"):
             ev.environment_dir_from_name("test", exists_ok=False)
 
+    def test_environment_dir_from_nested_name(self, mutable_mock_env_path):
+        """Test the function mapping a nested managed environment name to its folder."""
+        env = ev.create("group/test")
+        environment_dir = ev.environment_dir_from_name("group/test")
+        assert env.path == environment_dir
+        with pytest.raises(ev.SpackEnvironmentError, match="environment already exists"):
+            ev.environment_dir_from_name("group/test", exists_ok=False)
+
 
 def test_hash_change_no_rehash_concrete(tmp_path: pathlib.Path, config):
     # create an environment
@@ -923,6 +931,16 @@ def test_environment_from_name_or_dir(mutable_mock_env_path):
     dir_env = ev.environment_from_name_or_dir(test_env.path)
     assert dir_env.name == test_env.name
     assert dir_env.path == test_env.path
+
+    nested_test_env = ev.create("group/test")
+
+    nested_name_env = ev.environment_from_name_or_dir(nested_test_env.name)
+    assert nested_name_env.name == nested_test_env.name
+    assert nested_name_env.path == nested_test_env.path
+
+    nested_dir_env = ev.environment_from_name_or_dir(nested_test_env.path)
+    assert nested_dir_env.name == nested_test_env.name
+    assert nested_dir_env.path == nested_test_env.path
 
     with pytest.raises(ev.SpackEnvironmentError, match="no such environment"):
         _ = ev.environment_from_name_or_dir("fake-env")


### PR DESCRIPTION
Spack currently forces environments to have simple names. This forces a flat folder structure for all managed environments. This PR relaxes this restriction and allows a folder structure to help organize environments. This would allow pointing Spack to a known environment root for a project which may be organized this way.

Below is a typical env setup that could make use of this. 
```console
% spack env list
==> 52 environments
    darwin/docs                                                 darwin/legion/ucx/cuda/openmpi-ampere-clang-debug
    darwin/format                                               darwin/legion/ucx/cuda/openmpi-volta-clang-debug
    darwin/hpx/mpich-clang-debug                                darwin/legion/ucx/openmp/openmpi-gcc-debug
    darwin/hpx/mpich-clang-release                              darwin/legion/ucx/openmp/openmpi-gcc-release
    darwin/hpx/mpich-gcc-debug                                  darwin/legion/ucx/serial/mpich-clang-debug
    darwin/hpx/mpich-gcc-release                                darwin/legion/ucx/serial/mpich-gcc-debug
    darwin/hpx/openmpi-gcc-debug                                darwin/legion/ucx/serial/mpich-gcc-defaults
    darwin/hpx/openmpi-gcc-release                              darwin/legion/ucx/serial/mpich-gcc-release
    darwin/legion/gasnet/cuda/openmpi-ibv-ampere-clang-debug    darwin/legion/ucx/serial/openmpi-gcc-debug
    darwin/legion/gasnet/cuda/openmpi-ibv-ampere-clang-release  darwin/legion/ucx/serial/openmpi-gcc-release
    darwin/legion/gasnet/cuda/openmpi-ibv-volta-clang-debug     darwin/mpi/cuda/mpich-ampere-clang-debug
    darwin/legion/gasnet/cuda/openmpi-ibv-volta-clang-release   darwin/mpi/cuda/mpich-volta-clang-debug
    darwin/legion/gasnet/cuda/openmpi-mpi-ampere-clang-debug    darwin/mpi/cuda/openmpi-ampere-clang-debug
    darwin/legion/gasnet/cuda/openmpi-mpi-ampere-clang-release  darwin/mpi/cuda/openmpi-volta-clang-debug
    darwin/legion/gasnet/cuda/openmpi-mpi-volta-clang-debug     darwin/mpi/openmp/mpich-clang-debug
    darwin/legion/gasnet/cuda/openmpi-mpi-volta-clang-release   darwin/mpi/rocm/openmpi-mi250-gcc-debug
    darwin/legion/gasnet/openmp/openmpi-ibv-gcc-debug           darwin/mpi/serial/mpich-clang-debug
    darwin/legion/gasnet/openmp/openmpi-ibv-gcc-release         darwin/mpi/serial/mpich-gcc-debug
    darwin/legion/gasnet/rocm/openmpi-mpi-mi250-gcc-debug       darwin/mpi/serial/mpich-gcc-release
    darwin/legion/gasnet/serial/mpich-ibv-clang-debug           darwin/mpi/serial/openmpi-clang-debug
    darwin/legion/gasnet/serial/mpich-ibv-gcc-debug             darwin/mpi/serial/openmpi-gcc-debug
    darwin/legion/gasnet/serial/mpich-ibv-gcc-defaults          darwin/mpi/serial/openmpi-gcc-release
    darwin/legion/gasnet/serial/mpich-ibv-gcc-release           
    darwin/legion/gasnet/serial/openmpi-ibv-gcc-debug
    darwin/legion/gasnet/serial/openmpi-ibv-gcc-release 
    darwin/legion/ucx/cuda/mpich-volta-clang-debug
% spack env activate darwin/hpx/mpich-clang-debug
```

Background: I've been writing wrappers/tools to circumvent this limitation by making use of directory environments. This PR tries to bring the missing feature to Spack itself. ~Marking this as draft for now until I see what else I break with this.~