### PR TITLE
`spack repo update`: fix broken partial package repository fetching

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -516,7 +516,26 @@ def repo_update(args: Any) -> int:
             updated_entry[active_flag] = args.commit or args.tag or args.branch
             scope_repos[name] = updated_entry
 
-        descriptor.update(git=spack.util.executable.which("git"), remote=args.remote)
+        git = spack.util.git.git(required=True)
+
+        previous_commit = descriptor.get_commit(git=git)
+        descriptor.update(git=git, remote=args.remote)
+        new_commit = descriptor.get_commit(git=git)
+
+        if previous_commit == new_commit:
+            tty.msg(f"{name}: Already up to date.")
+        else:
+            if any(
+                type(r) is spack.repo.BadRepoVersionError
+                for r in descriptor.construct(cache=spack.caches.MISC_CACHE).values()
+            ):
+                tty.error(
+                    f"{name}: repo is too new for this version of Spack. "
+                    "Please upgrade Spack or revert with:\n",
+                    f"      spack repo update -c {previous_commit[:7]}\n",
+                )
+            else:
+                tty.msg(f"{name}: Updated sucessfully.")
 
     if active_flag:
         spack.config.set("repos", scope_repos, args.scope)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -14,6 +14,7 @@ import spack.config
 import spack.llnl.util.tty as tty
 import spack.repo
 import spack.util.executable
+import spack.util.git
 import spack.util.path
 import spack.util.spack_yaml
 from spack.cmd.common import arguments
@@ -151,10 +152,10 @@ def setup_parser(subparser: argparse.ArgumentParser):
         default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )
-    refspec = update_parser.add_mutually_exclusive_group(required=False)
-    refspec.add_argument(
+    update_parser.add_argument(
         "--branch", "-b", nargs="?", default=None, help="name of a branch to change to"
     )
+    refspec = update_parser.add_mutually_exclusive_group(required=False)
     refspec.add_argument("--tag", "-t", nargs="?", default=None, help="name of a tag to change to")
     refspec.add_argument(
         "--commit", "-c", nargs="?", default=None, help="name of a commit to change to"
@@ -509,7 +510,7 @@ def repo_update(args: Any) -> int:
             updated_entry = scope_repos[name] if name in scope_repos else {}
 
             # prune previous values of git fields
-            for entry in {"commit", "tag", "branch"} - {active_flag}:
+            for entry in {"commit", "tag"} - {active_flag}:
                 setattr(descriptor, entry, None)
                 updated_entry.pop(entry, None)
 
@@ -525,15 +526,21 @@ def repo_update(args: Any) -> int:
         if previous_commit == new_commit:
             tty.msg(f"{name}: Already up to date.")
         else:
-            if any(
-                type(r) is spack.repo.BadRepoVersionError
+            fails = [
+                r
                 for r in descriptor.construct(cache=spack.caches.MISC_CACHE).values()
-            ):
+                if type(r) is spack.repo.BadRepoVersionError
+            ]
+            if fails:
+                min_ver = ".".join(str(n) for n in spack.min_package_api_version)
+                max_ver = ".".join(str(n) for n in spack.package_api_version)
                 tty.error(
-                    f"{name}: repo is too new for this version of Spack. "
-                    "Please upgrade Spack or revert with:\n",
-                    f"      spack repo update -c {previous_commit[:7]}\n",
+                    f"{name}: repo is too new for this version of Spack. ",
+                    f"  Spack supports API v{min_ver} to v{max_ver}, but repo is {fails[0].api}",
+                    "  Please upgrade Spack or revert with:\n",
+                    f"       spack repo update --commit {previous_commit}\n",
                 )
+
             else:
                 tty.msg(f"{name}: Updated sucessfully.")
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1659,16 +1659,13 @@ class RemoteRepoDescriptor(RepoDescriptor):
             return self._fetched()
         return False
 
-    def get_commit(self, git: spack.util.executable.Executable) -> Optional[str]:
-        result = None
+    def get_commit(self, git: spack.util.executable.Executable):
         with self.read_transaction:
             if not self._fetched():
-                return result
+                return None
 
             with fs.working_dir(self.destination):
-                result = git("rev-parse", "HEAD", output=str).strip()
-
-        return result
+                return git("rev-parse", "HEAD", output=str).strip()
 
     def _clone_or_pull(
         self,
@@ -1986,6 +1983,7 @@ def create_and_enable(config: spack.config.Configuration) -> RepoPath:
 PATH: RepoPath = spack.llnl.util.lang.Singleton(
     lambda: create_and_enable(spack.config.CONFIG)
 )  # type: ignore[assignment]
+
 
 
 # Add the finder to sys.meta_path

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1675,10 +1675,13 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         self.read_index_file()
                         return
 
-                    # download a partial copy of the package repository the first
-                    # time it is loaded to speed up CI/CD executions of Spack.
-                    # when updating an existing copy of the repository perform a full fetch
-                    if not depth:
+                    # If depth is not provided, default to:
+                    # 1. The first time the repo is loaded, download a partial clone. This speeds
+                    #    up CI/CD and other cases where the user never updates the repository.
+                    # 2. When *updating* an already cloned copy of the repository, perform a
+                    #    full fetch (unshallowing the repo if necessary) to optimize for full history.
+                    if depth is None and not fetched:
+                        depth = 2
                         depth = 2 if not fetched else None
 
                     # setup the repository if it does not exist

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1696,7 +1696,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         spack.util.git.pull_checkout_commit(self.commit, git_exe=git)
 
                     elif self.tag:
-                        spack.util.git.pull_checkout_tag(self.tag, remote, depth, git_exe=git)
+                        spack.util.git.pull_checkout_tag(self.tag, remote, git_exe=git)
 
                     elif self.branch:
                         # if the branch already exists we should use the
@@ -1707,7 +1707,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         except spack.util.executable.ProcessError:
                             pass
                         spack.util.git.pull_checkout_branch(
-                            self.branch, remote=remote, depth=depth, git_exe=git
+                            self.branch, remote=remote, git_exe=git
                         )
 
             except spack.util.executable.ProcessError:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1663,7 +1663,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
         git: spack.util.executable.Executable,
         update: bool = False,
         remote: str = "origin",
-        depth: int = 20,
+        depth: Optional[int] = None,
     ) -> None:
         with self.write_transaction:
             try:
@@ -1674,6 +1674,11 @@ class RemoteRepoDescriptor(RepoDescriptor):
                     if fetched and not update:
                         self.read_index_file()
                         return
+
+                    # download a partial copy of the package repository the first
+                    # time it is loaded to speed up CI/CD executions of Spack.
+                    # when updating an existing copy of the repository perform a full fetch
+                    depth = 2 if not fetched else None
 
                     # setup the repository if it does not exist
                     if not fetched:
@@ -1696,7 +1701,9 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         spack.util.git.pull_checkout_commit(self.commit, git_exe=git)
 
                     elif self.tag:
-                        spack.util.git.pull_checkout_tag(self.tag, remote, git_exe=git)
+                        spack.util.git.pull_checkout_tag(
+                            self.tag, remote, depth=depth, git_exe=git
+                        )
 
                     elif self.branch:
                         # if the branch already exists we should use the
@@ -1707,7 +1714,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         except spack.util.executable.ProcessError:
                             pass
                         spack.util.git.pull_checkout_branch(
-                            self.branch, remote=remote, git_exe=git
+                            self.branch, remote=remote, depth=depth, git_exe=git
                         )
 
             except spack.util.executable.ProcessError:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -974,8 +974,9 @@ def _parse_package_api_version(
     max_str = ".".join(str(i) for i in max_api)
     curr_str = ".".join(str(i) for i in package_api)
     raise BadRepoVersionError(
+        api,
         f"Package API v{curr_str} is not supported by this version of Spack ("
-        f"must be between v{min_str} and v{max_str})"
+        f"must be between v{min_str} and v{max_str})",
     )
 
 
@@ -1659,12 +1660,15 @@ class RemoteRepoDescriptor(RepoDescriptor):
         return False
 
     def get_commit(self, git: spack.util.executable.Executable) -> Optional[str]:
+        result = None
         with self.read_transaction:
             if not self._fetched():
-                return None
+                return result
 
             with fs.working_dir(self.destination):
-                return git("rev-parse", "HEAD", output=str).strip()
+                result = git("rev-parse", "HEAD", output=str).strip()
+
+        return result
 
     def _clone_or_pull(
         self,
@@ -1684,13 +1688,14 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         return
 
                     # If depth is not provided, default to:
-                    # 1. The first time the repo is loaded, download a partial clone. This speeds
-                    #    up CI/CD and other cases where the user never updates the repository.
-                    # 2. When *updating* an already cloned copy of the repository, perform a
-                    #    full fetch (unshallowing the repo if necessary) to optimize for full history.
+                    # 1. The first time the repo is loaded, download a partial clone.
+                    #     This speeds  up CI/CD and other cases where the user never
+                    #     updates the repository.
+                    # 2. When *updating* an already cloned copy of the repository,
+                    #    perform a full fetch (unshallowing the repo if necessary) to
+                    #    optimize for full history.
                     if depth is None and not fetched:
                         depth = 2
-                        depth = 2 if not fetched else None
 
                     # setup the repository if it does not exist
                     if not fetched:
@@ -2049,6 +2054,10 @@ class BadRepoError(RepoError):
 
 class BadRepoVersionError(BadRepoError):
     """Raised when repo API version is too high or too low for Spack."""
+
+    def __init__(self, api, *args, **kwargs):
+        self.api = api
+        super().__init__(*args, **kwargs)
 
 
 class UnknownEntityError(RepoError):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -973,7 +973,7 @@ def _parse_package_api_version(
     min_str = ".".join(str(i) for i in min_api)
     max_str = ".".join(str(i) for i in max_api)
     curr_str = ".".join(str(i) for i in package_api)
-    raise BadRepoError(
+    raise BadRepoVersionError(
         f"Package API v{curr_str} is not supported by this version of Spack ("
         f"must be between v{min_str} and v{max_str})"
     )
@@ -1658,6 +1658,14 @@ class RemoteRepoDescriptor(RepoDescriptor):
             return self._fetched()
         return False
 
+    def get_commit(self, git: spack.util.executable.Executable) -> Optional[str]:
+        with self.read_transaction:
+            if not self._fetched():
+                return None
+
+            with fs.working_dir(self.destination):
+                return git("rev-parse", "HEAD", output=str).strip()
+
     def _clone_or_pull(
         self,
         git: spack.util.executable.Executable,
@@ -2037,6 +2045,10 @@ class InvalidNamespaceError(RepoError):
 
 class BadRepoError(RepoError):
     """Raised when repo layout is invalid."""
+
+
+class BadRepoVersionError(BadRepoError):
+    """Raised when repo API version is too high or too low for Spack."""
 
 
 class UnknownEntityError(RepoError):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1678,7 +1678,8 @@ class RemoteRepoDescriptor(RepoDescriptor):
                     # download a partial copy of the package repository the first
                     # time it is loaded to speed up CI/CD executions of Spack.
                     # when updating an existing copy of the repository perform a full fetch
-                    depth = 2 if not fetched else None
+                    if not depth:
+                        depth = 2 if not fetched else None
 
                     # setup the repository if it does not exist
                     if not fetched:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1985,7 +1985,6 @@ PATH: RepoPath = spack.llnl.util.lang.Singleton(
 )  # type: ignore[assignment]
 
 
-
 # Add the finder to sys.meta_path
 REPOS_FINDER = ReposFinder()
 sys.meta_path.append(REPOS_FINDER)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1659,7 +1659,8 @@ class RemoteRepoDescriptor(RepoDescriptor):
             return self._fetched()
         return False
 
-    def get_commit(self, git: spack.util.executable.Executable):
+    def get_commit(self, git: MaybeExecutable = None):
+        git = git or spack.util.git.git(required=True)
         with self.read_transaction:
             if not self._fetched():
                 return None

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -263,7 +263,10 @@ class MockDescriptor(spack.repo.RepoDescriptor):
     def initialize(self, fetch=True, git=None) -> None:
         self.initialized = True
 
-    def update(self, git: Optional[Executable] = None, remote: Optional[str] = "origin") -> None:
+    def get_commit(self, git: Optional[Executable]):
+        pass
+
+    def update(self, git: Optional[Executable], remote: Optional[str] = "origin") -> None:
         pass
 
     def construct(self, cache, overrides=None):

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -263,10 +263,10 @@ class MockDescriptor(spack.repo.RepoDescriptor):
     def initialize(self, fetch=True, git=None) -> None:
         self.initialized = True
 
-    def get_commit(self, git: Optional[Executable]):
+    def get_commit(self, git: Optional[Executable] = None):
         pass
 
-    def update(self, git: Optional[Executable], remote: Optional[str] = "origin") -> None:
+    def update(self, git: Optional[Executable] = None, remote: Optional[str] = "origin") -> None:
         pass
 
     def construct(self, cache, overrides=None):

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -97,6 +97,8 @@ def pull_checkout_branch(
 
     fetch_args = ["--quiet", "--progress"]
     if depth:
+        if depth <= 0:
+            raise ValueError("depth must be a positive integer")
         fetch_args.append(f"--depth={depth}")
 
     git_exe("fetch", *fetch_args, remote, branch)

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -63,7 +63,7 @@ def pull_checkout_commit(commit: str, git_exe: Optional[exe.Executable] = None):
     """Fetch all remotes and checkout the specified commit."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", "--all")
+    git_exe("fetch", "--quiet", "--progress", "--filter=blob:none", "--all")
     git_exe("checkout", commit)
 
 
@@ -71,7 +71,7 @@ def pull_checkout_tag(tag: str, remote: str = "origin", git_exe: Optional[exe.Ex
     """Fetch tags with specified depth and checkout the given tag."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", "--tags", remote)
+    git_exe("fetch", "--quiet", "--progress", "--filter=blob:none", "--tags", remote)
     git_exe("checkout", tag)
 
 
@@ -81,11 +81,11 @@ def pull_checkout_branch(
     """Fetch and checkout branch, then rebase with remote tracking branch."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", remote, branch)
+    git_exe("fetch", "--quiet", "--progress", "--filter=blob:none", remote, branch)
     git_exe("checkout", "--quiet", branch)
 
     try:
-        git_exe("rebase", "--quiet", f"{remote}/{branch}")
+        git_exe("rebase", f"{remote}/{branch}")
     except exe.ProcessError:
         git_exe("rebase", "--abort", fail_on_error=False, error=str, output=str)
         raise

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -85,7 +85,12 @@ def pull_checkout_branch(
     git_exe("checkout", "--quiet", branch)
 
     try:
-        git_exe("rebase", f"{remote}/{branch}")
+        # git rebase output breaks pytest xdist when sharing stdout
+        # capturing output and echoing it via a print statement as a work around
+        # stderr is not captured so it will still be available to users on a
+        # failed repository update
+        out = git_exe("rebase", f"{remote}/{branch}", output=str)
+        print(out, end="")
     except exe.ProcessError:
         git_exe("rebase", "--abort", fail_on_error=False, error=str, output=str)
         raise

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -77,7 +77,9 @@ def pull_checkout_tag(
     git_exe = git_exe or git(required=True)
 
     fetch_args = ["--quiet", "--progress", "--tags"]
-    if depth:
+    if depth is not None:
+        if depth <= 0:
+            raise ValueError("depth must be a positive integer")
         fetch_args.append(f"--depth={depth}")
 
     git_exe("fetch", *fetch_args, remote)

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -63,25 +63,41 @@ def pull_checkout_commit(commit: str, git_exe: Optional[exe.Executable] = None):
     """Fetch all remotes and checkout the specified commit."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", "--quiet", "--progress", "--filter=blob:none", "--all")
+    git_exe("fetch", "--quiet", "--progress", "--all")
     git_exe("checkout", commit)
 
 
-def pull_checkout_tag(tag: str, remote: str = "origin", git_exe: Optional[exe.Executable] = None):
+def pull_checkout_tag(
+    tag: str,
+    remote: str = "origin",
+    depth: Optional[int] = None,
+    git_exe: Optional[exe.Executable] = None,
+):
     """Fetch tags with specified depth and checkout the given tag."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", "--quiet", "--progress", "--filter=blob:none", "--tags", remote)
+    fetch_args = ["--quiet", "--progress", "--tags"]
+    if depth:
+        fetch_args.append(f"--depth={depth}")
+
+    git_exe("fetch", *fetch_args, remote)
     git_exe("checkout", tag)
 
 
 def pull_checkout_branch(
-    branch: str, remote: str = "origin", git_exe: Optional[exe.Executable] = None
+    branch: str,
+    remote: str = "origin",
+    depth: Optional[int] = None,
+    git_exe: Optional[exe.Executable] = None,
 ):
     """Fetch and checkout branch, then rebase with remote tracking branch."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", "--quiet", "--progress", "--filter=blob:none", remote, branch)
+    fetch_args = ["--quiet", "--progress"]
+    if depth:
+        fetch_args.append(f"--depth={depth}")
+
+    git_exe("fetch", *fetch_args, remote, branch)
     git_exe("checkout", "--quiet", branch)
 
     try:

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -85,12 +85,7 @@ def pull_checkout_branch(
     git_exe("checkout", "--quiet", branch)
 
     try:
-        # git rebase output breaks pytest xdist when sharing stdout
-        # capturing output and echoing it via a print statement as a work around
-        # stderr is not captured so it will still be available to users on a
-        # failed repository update
-        out = git_exe("rebase", f"{remote}/{branch}", output=str)
-        print(out, end="")
+        git_exe("rebase", "--quiet", f"{remote}/{branch}")
     except exe.ProcessError:
         git_exe("rebase", "--abort", fail_on_error=False, error=str, output=str)
         raise

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -67,23 +67,21 @@ def pull_checkout_commit(commit: str, git_exe: Optional[exe.Executable] = None):
     git_exe("checkout", commit)
 
 
-def pull_checkout_tag(
-    tag: str, remote: str = "origin", depth: int = 20, git_exe: Optional[exe.Executable] = None
-):
+def pull_checkout_tag(tag: str, remote: str = "origin", git_exe: Optional[exe.Executable] = None):
     """Fetch tags with specified depth and checkout the given tag."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", f"--depth={depth}", "--force", "--tags", remote)
+    git_exe("fetch", "--tags", remote)
     git_exe("checkout", tag)
 
 
 def pull_checkout_branch(
-    branch: str, remote: str = "origin", depth: int = 20, git_exe: Optional[exe.Executable] = None
+    branch: str, remote: str = "origin", git_exe: Optional[exe.Executable] = None
 ):
     """Fetch and checkout branch, then rebase with remote tracking branch."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", f"--depth={depth}", remote, branch)
+    git_exe("fetch", remote, branch)
     git_exe("checkout", "--quiet", branch)
 
     try:


### PR DESCRIPTION
When we first added `spack repo update` I tried to be clever and perform partial clones to save users bandwidth.

After merging the initial `spack repo update` functionality in #50868, I started to notice periodic errors when updating my repository with the command and discovered that partial updates don't work how I thought they would. Right now we run `git fetch --depth=20` and if there have been > 20 commits to the packages repository since you last pulled the develop branch you'll get an from git error about disconnected histories.

This happens because git only downloads the latest 20 commits and doesn't not how to fast forward your existing repository if there are gaps in the history.

(**TLDR; `spack repo update` is broken right now and we shouldn't release v1.0 as it currently is. Sorry!!**)

To fix this we should instead perform a full fetch of the repository when updating an existing repository to get the full history. Both [CocoaPods](https://github.com/CocoaPods/CocoaPods/issues/4989#issuecomment-193772935) and brew tried doing partial downloads of their package repositories and ultimately moved away from it due to requests from GitHub to reduce compute time on the backend resources. We're not nearly as big as either of those projects, but I think we should learn from them and follow suit in performing full clones for now until we hear otherwise from GitHub.