### PR TITLE
CI: Allow configuration of retry in ci.yaml

### DIFF
--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -262,7 +262,9 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             )
 
             job_object["stage"] = stage_name
-            job_object["retry"] = {"max": 2, "when": JOB_RETRY_CONDITIONS}
+            job_object["retry"] = spack.schema.merge_yaml(
+                {"max": 2, "when": JOB_RETRY_CONDITIONS}, job_object.get("retry", {})
+            )
             job_object["interruptible"] = True
 
             length_needs = len(job_object["needs"])


### PR DESCRIPTION
Allow user to override/extend retry configuration

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->