### PR TITLE
spack.package: add to docs, drop re-exports

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -80,10 +80,8 @@ sphinx_apidoc(
     apidoc_args
     + [
         "_spack_root/lib/spack/spack",
-        "_spack_root/lib/spack/spack/package.py",  # sphinx struggles with os.chdir re-export.
         "_spack_root/lib/spack/spack/vendor",
-        "_spack_root/lib/spack/spack/test/*.py",
-        "_spack_root/lib/spack/spack/test/cmd/*.py",
+        "_spack_root/lib/spack/spack/test",
     ]
 )
 sphinx_apidoc(

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -648,7 +648,7 @@ def variant(
         sticky: The variant should not be changed by the concretizer to find a valid concrete spec
 
     Raises:
-        DirectiveError: If arguments passed to the directive are invalid
+        spack.directives_meta.DirectiveError: If arguments passed to the directive are invalid
     """
 
     # This validation can be removed at runtime and enforced with an audit in Spack v1.0.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -158,9 +158,13 @@ from spack.util.windows_registry import HKEY, WindowsRegistryView
 from spack.variant import any_combination_of, auto_or_any_combination_of, disjoint_sets
 from spack.version import Version, ver
 
-# Emulate some shell commands for convenience
+#: alias for ``os.environ``
 env = environ
+
+#: alias for ``os.chdir``
 cd = chdir
+
+#: alias for ``os.getcwd``
 pwd = getcwd
 
 # Not an import alias because black and isort disagree about style
@@ -228,7 +232,6 @@ __all__ = [
     "can_splice",
     "cd",
     "change_sed_delimiter",
-    "chdir",
     "check_outputs",
     "conditional",
     "conflicts",
@@ -240,7 +243,6 @@ __all__ = [
     "disjoint_sets",
     "env_flags",
     "env",
-    "environ",
     "extends",
     "filter_compiler_wrappers",
     "filter_file",
@@ -256,7 +258,6 @@ __all__ = [
     "force_remove",
     "force_symlink",
     "get_escaped_text_output",
-    "getcwd",
     "inject_flags",
     "install_test_root",
     "install_tree",

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2983,7 +2983,7 @@ class Spec:
             root (Spec): root spec to be analyzed
 
         Raises:
-            SpecDeprecatedError: if any deprecated spec is found
+            spack.spec.SpecDeprecatedError: if any deprecated spec is found
         """
         deprecated = []
         with spack.store.STORE.db.read_transaction():


### PR DESCRIPTION
`spack.package` has the following aliases which are exported:

```python
env = os.environ
cd = os.chdir
pwd = os.getcwd
```

but it *also* re-exports `environ`, `chdir` and `getcwd`, which are
unused in builtin.

That's likely an oversight, and I don't consider it breaking to
remove those given the lack of use in builtin.

Due to Python's [own docstring of `os.chdir`][1] which
docutils chokes on, we could not generate docs for `spack.package`.
Now we can.

[1]: https://github.com/python/cpython/pull/136709