### PR TITLE
Fix git sparse paths checkout.

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1737,6 +1737,7 @@ def for_package_version(pkg, version=None):
         kwargs = {ref_type: ref_value, "no_cache": ref_type != "commit"}
         kwargs["git"] = pkg.version_or_package_attr("git", version)
         kwargs["submodules"] = pkg.version_or_package_attr("submodules", version, False)
+        kwargs["git_sparse_paths"] = pkg.version_or_package_attr("git_sparse_paths", version, None)
 
         # if the ref_version is a known version from the package, use that version's
         # attributes

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -337,6 +337,33 @@ def test_package_can_have_sparse_checkout_properties(mock_packages, mock_fetch, 
     assert fetcher.git_sparse_paths == pkg_cls.git_sparse_paths
 
 
+def test_package_can_have_sparse_checkout_properties_with_commit_version(
+    mock_packages, mock_fetch, mock_stage
+):
+    spec = Spec("git-sparsepaths-pkg commit=abcdefg")
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    assert hasattr(pkg_cls, "git_sparse_paths")
+
+    fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), "1.0")
+    assert isinstance(fetcher, spack.fetch_strategy.GitFetchStrategy)
+    assert hasattr(fetcher, "git_sparse_paths")
+    assert fetcher.git_sparse_paths == pkg_cls.git_sparse_paths
+
+
+def test_package_can_have_sparse_checkout_properties_with_gitversion(
+    mock_packages, mock_fetch, mock_stage
+):
+    spec = Spec("git-sparsepaths-pkg")
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    assert hasattr(pkg_cls, "git_sparse_paths")
+
+    version = "git.foo=1.0"
+    fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), version)
+    assert isinstance(fetcher, spack.fetch_strategy.GitFetchStrategy)
+    assert hasattr(fetcher, "git_sparse_paths")
+    assert fetcher.git_sparse_paths == pkg_cls.git_sparse_paths
+
+
 def test_package_can_depend_on_commit_of_dependency(mock_packages, config):
     spec = spack.concretize.concretize_one(Spec("git-ref-commit-dep@1.0.0"))
     assert spec.satisfies(f"^git-ref-package commit={'a' * 40}")


### PR DESCRIPTION
For packages where either the commit variant is set or the version is a GitVersion.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
