### PR TITLE
llnl.util.symlink: do not give a suggested alternative, cause it is private api

### DIFF
--- a/lib/spack/spack/llnl/util/symlink.py
+++ b/lib/spack/spack/llnl/util/symlink.py
@@ -8,8 +8,7 @@ import spack.error
 import spack.llnl.util.filesystem
 
 warnings.warn(
-    "The `spack.llnl.util.symlink` module will be removed in Spack v1.1, "
-    "use `spack.llnl.util.filesystem` instead",
+    "The `spack.llnl.util.symlink` module will be removed in Spack v1.1",
     category=spack.error.SpackAPIWarning,
     stacklevel=2,
 )


### PR DESCRIPTION
The alternative presented in the warning is still private API, so it should not be promoted in people's custom repos, which is likely the only place this warning will show up.