### PR TITLE
docs: add spack.package section and improve various docstrings

### DIFF
--- a/lib/spack/docs/_static/.gitignore
+++ b/lib/spack/docs/_static/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/lib/spack/docs/_static/css/custom.css
+++ b/lib/spack/docs/_static/css/custom.css
@@ -1,0 +1,9 @@
+div.versionadded {
+    border-left: 3px solid #0c731f;
+    color: #0c731f;
+    padding-left: 1rem;
+}
+
+.py.property {
+  display: block !important;
+}

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -119,8 +119,9 @@ or refer to the full manual below.
    :maxdepth: 2
    :caption: API Docs
 
-   Spack API Docs <spack>
+   Spack Package API <package_api>
    Spack Builtin Repo <spack_repo>
+   Spack API Docs <spack>
 
 ==================
 Indices and tables

--- a/lib/spack/docs/package_api.rst
+++ b/lib/spack/docs/package_api.rst
@@ -36,3 +36,4 @@ Spack Package API Reference
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-value:

--- a/lib/spack/docs/package_api.rst
+++ b/lib/spack/docs/package_api.rst
@@ -1,0 +1,38 @@
+.. Copyright Spack Project Developers. See COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+Spack Package API v2.2
+======================
+
+This document describes the Spack Package API (:mod:`spack.package`), the stable interface for Spack package authors.
+It is assumed you have already read the :doc:`Spack Packaging Guide <packaging_guide_creation>`.
+
+The Spack Package API is the *only* module from the Spack codebase considered public API.
+It re-exports essential functions and classes from various Spack modules, allowing package authors to import them directly from :mod:`spack.package` without needing to know Spack's internal structure.
+
+Spack Package API Versioning
+----------------------------
+
+The current Package API version is |package_api_version|, defined in :attr:`spack.package_api_version`.
+Notice that the Package API is versioned independently from Spack itself:
+
+* The **minor version** is incremented when new functions or classes are exported from :mod:`spack.package`.
+* The **major version** is incremented when functions or classes are removed or have breaking changes to their signatures (a rare occurrence).
+
+This independent versioning allows package authors to utilize new Spack features without waiting for a new Spack release.
+
+Compatibility between Spack and :doc:`package repositories <repositories>` is managed as follows:
+
+* Package repositories declare their minimum required Package API version in their ``repo.yaml`` file using the ``api: vX.Y`` format.
+* Spack checks if the declared API version falls within its supported range, specifically between :attr:`spack.min_package_api_version` and :attr:`spack.package_api_version`.
+
+Spack version |spack_version| supports package repositories with a Package API version between |min_package_api_version| and |package_api_version|, inclusive.
+
+Spack Package API Reference
+---------------------------
+
+.. automodule:: spack.package
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/lib/spack/spack/archspec.py
+++ b/lib/spack/spack/archspec.py
@@ -18,8 +18,12 @@ def microarchitecture_flags(spec: spack.spec.Spec, language: str) -> str:
 
     Example::
 
-        >>> microarchitecture_flags(Spec("foo target=zen2 %c=gcc@=14.1.0"), language="c")
-        '-march=znver2 -mtune=znver2'
+        >>> spec.format("{target}")
+        'm1'
+        >>> spec["c"].format("{name}{@version}")
+        'apple-clang@17.0.0'
+        >>> microarchitecture_flags(spec, language="c")
+        '-mcpu=apple-m1'
     """
     target = spec.target
 

--- a/lib/spack/spack/archspec.py
+++ b/lib/spack/spack/archspec.py
@@ -9,8 +9,18 @@ import spack.spec
 
 
 def microarchitecture_flags(spec: spack.spec.Spec, language: str) -> str:
-    """Return the microarchitecture flags for a given spec and compiler associated with the given
-    language."""
+    """Get compiler flags for the spec's microarchitecture.
+
+    Args:
+        spec: The spec defining the target microarchitecture and compiler.
+        language: The language (``"c"``, ``"cxx"``, ``"fortran"``) used to select the appropriate
+            compiler from the spec.
+
+    Example::
+
+        >>> microarchitecture_flags(Spec("foo target=zen2 %c=gcc@=14.1.0"), language="c")
+        '-march=znver2 -mtune=znver2'
+    """
     target = spec.target
 
     if not spec.has_virtual_dependency(language):
@@ -26,7 +36,14 @@ def microarchitecture_flags(spec: spack.spec.Spec, language: str) -> str:
 def microarchitecture_flags_from_target(
     target: spack.vendor.archspec.cpu.Microarchitecture, compiler: spack.spec.Spec
 ) -> str:
-    """Return the microarchitecture flags for a given compiler and target."""
+    """Get compiler flags for the spec's microarchitecture. Similar to
+    :func:`microarchitecture_flags`, but takes a ``target`` and ``compiler`` directly instead of a
+    spec.
+
+    Args:
+        target: The target microarchitecture.
+        compiler: The spec defining the compiler.
+    """
     # Try to check if the current compiler comes with a version number or has an unexpected suffix.
     # If so, treat it as a compiler with a custom spec.
     version_number, _ = spack.vendor.archspec.cpu.version_components(

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -256,7 +256,7 @@ class MakeExecutable(Executable):
             jobs_env: environment variable that will be set to the current level of parallelism
             jobs_env_supports_jobserver: whether the jobs env supports a job server
 
-        For all the other **kwargs, refer to the base class.
+        For all the other ``**kwargs``, refer to :func:`spack.util.executable.Executable.__call__`.
         """
         jobs = get_effective_jobs(
             self.jobs, parallel=parallel, supports_jobserver=self.supports_jobserver
@@ -730,8 +730,9 @@ def get_rpath_deps(pkg: spack.package_base.PackageBase) -> List[spack.spec.Spec]
 
 
 def get_cmake_prefix_path(pkg: spack.package_base.PackageBase) -> List[str]:
-    """Obtain the CMAKE_PREFIX_PATH entries for a package, based on the cmake_prefix_path package
-    attribute of direct build/test and transitive link dependencies."""
+    """Obtain the ``CMAKE_PREFIX_PATH`` entries for a package, based on the
+    :attr:`~spack.package_base.PackageBase.cmake_prefix_paths` package attribute of direct
+    build/test and transitive link dependencies."""
     edges = traverse.traverse_topo_edges_generator(
         traverse.with_artificial_edges([pkg.spec]),
         visitor=traverse.MixedDepthVisitor(
@@ -1645,11 +1646,12 @@ def write_log_summary(out, log_type, log, last=None):
 
 
 class ModuleChangePropagator:
-    """Wrapper class to accept changes to a package.py Python module, and propagate them in the
-    MRO of the package.
-
-    It is mainly used as a substitute of the ``package.py`` module, when calling the
-    "setup_dependent_package" function during build environment setup.
+    """The function :meth:`spack.package_base.PackageBase.setup_dependent_package` receives
+    an instance of this class for the ``module`` argument. It's used to set global variables in the
+    module of a package, and propagate those globals to the modules of all classes in the
+    inheritance hierarchy of the package. It's reminiscent of
+    :class:`spack.util.environment.EnvironmentModifications`, but sets Python variables instead
+    of environment variables. This class should typically not be instantiated in packages directly.
     """
 
     _PROTECTED_NAMES = ("package", "current_module", "modules_in_mro", "_set_attributes")

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -697,7 +697,7 @@ class Package(spack.package_base.PackageBase):
 
        The :class:`Package` class is a *build system base class*, similar to
        ``CMakePackage``, and ``AutotoolsPackage``. It is called ``Package`` and not
-       ``GenericPackage`` because of legacy reasons.
+       ``GenericPackage`` for legacy reasons.
 
     """
 

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -29,11 +29,18 @@ _BUILDERS: Dict[int, "Builder"] = {}
 
 
 def register_builder(build_system_name: str):
-    """Class decorator used to register the default builder
-    for a given build-system.
+    """Class decorator used to register the default builder for a given build system. The name
+    corresponds to the ``build_system`` variant value of the package.
+
+    Example::
+
+       @register_builder("cmake")
+       class CMakeBuilder(BuilderWithDefaults):
+           pass
+
 
     Args:
-        build_system_name: name of the build-system
+        build_system_name: name of the build system
     """
 
     def _decorator(cls):
@@ -406,8 +413,9 @@ class InstallationPhase:
 
 class BaseBuilder(metaclass=BuilderMeta):
     """An interface for builders, without any phases defined. This class is exposed in the package
-    API, so that packagers can create a single class to define ``setup_build_environment`` and
-    ``@run_before`` and ``@run_after`` callbacks that can be shared among different builders.
+    API, so that packagers can create a single class to define :meth:`setup_build_environment` and
+    :func:`spack.phase_callbacks.run_before` and :func:`spack.phase_callbacks.run_after`
+    callbacks that can be shared among different builders.
 
     Example:
 
@@ -511,18 +519,18 @@ class Builder(BaseBuilder, collections.abc.Sequence):
     #: Methods, with no arguments, that the adapter can find in Package classes,
     #: if a builder is not defined.
     package_methods: Tuple[str, ...]
-    #: (DEPRECATED) Deprecated attribute with the same semantics as "package_methods"
+    # Use :attr:`package_methods` instead of this attribute, which is deprecated
     legacy_methods: Tuple[str, ...] = ()
 
     #: Methods with the same signature as phases, that the adapter can find in Package classes,
     #: if a builder is not defined.
     package_long_methods: Tuple[str, ...]
-    #: (DEPRECATED) Deprecated attribute with the same semantics as "package_long_methods"
+    # Use :attr:`package_long_methods` instead of this attribute, which is deprecated
     legacy_long_methods: Tuple[str, ...]
 
     #: Attributes that the adapter can find in Package classes, if a builder is not defined
     package_attributes: Tuple[str, ...]
-    #: (DEPRECATED) Deprecated attribute with the same semantics as "package_attributes"
+    # Use :attr:`package_attributes` instead of this attribute, which is deprecated
     legacy_attributes: Tuple[str, ...] = ()
 
     # type hints for some of the legacy methods
@@ -656,13 +664,47 @@ def execute_install_time_tests(builder: Builder):
 
 
 class Package(spack.package_base.PackageBase):
-    """General purpose class with a single ``install`` phase that needs to be
-    coded by packagers.
+    """Build system base class for packages that do not use a specific build system. It adds the
+    ``build_system=generic`` variant to the package.
+
+    This is the only build system base class defined in Spack core. All other build systems
+    are defined in the builtin package repository :mod:`spack_repo.builtin.build_systems`.
+
+    The associated builder is :class:`GenericBuilder`, which is only necessary when the package
+    has multiple build systems.
+
+    Example::
+
+       from spack.package import *
+
+       class MyPackage(Package):
+           \"\"\"A package that does not use a specific build system.\"\"\"
+
+           homepage = "https://example.com/mypackage"
+           url = "https://example.com/mypackage-1.0.tar.gz"
+
+           version("1.0", sha256="...")
+
+           def install(self, spec: Spec, prefix: Prefix) -> None:
+               # Custom installation logic here
+               pass
+
+    .. note::
+
+       The difference between :class:`Package` and :class:`~spack.package_base.PackageBase` is that
+       :class:`~spack.package_base.PackageBase` is the universal base class for all package
+       classes, no matter their build system.
+
+       The :class:`Package` class is a *build system base class*, similar to
+       ``CMakePackage``, and ``AutotoolsPackage``. It is called ``Package`` and not
+       ``GenericPackage`` because of legacy reasons.
+
     """
 
     #: This attribute is used in UI queries that require to know which
     #: build-system class we are using
     build_system_class = "Package"
+
     #: Legacy buildsystem attribute used to deserialize and install old specs
     default_buildsystem = "generic"
 
@@ -671,8 +713,27 @@ class Package(spack.package_base.PackageBase):
 
 @register_builder("generic")
 class GenericBuilder(BuilderWithDefaults):
-    """A builder for a generic build system, that require packagers
-    to implement an "install" phase.
+    """The associated builder for the :class:`Package` base class. This class is typically only
+    used in ``package.py`` files when a package has multiple build systems. Packagers need to
+    implement the :meth:`install` phase to define how the package is installed.
+
+    This is the only builder that is defined in the Spack core, all other builders are defined
+    in the builtin package repository :mod:`spack_repo.builtin.build_systems`.
+
+    Example::
+
+       from spack.package import *
+
+       class MyPackage(Package):
+           \"\"\"A package that does not use a specific build system.\"\"\"
+           homepage = "https://example.com/mypackage"
+           url = "https://example.com/mypackage-1.0.tar.gz"
+
+           version("1.0", sha256="...")
+
+       class GenericBuilder(GenericBuilder):
+           def install(self, pkg: Package, spec: Spec, prefix: Prefix) -> None:
+               pass
     """
 
     #: A generic package has only the "install" phase
@@ -694,4 +755,5 @@ class GenericBuilder(BuilderWithDefaults):
     spack.phase_callbacks.run_after("install")(execute_install_time_tests)
 
     def install(self, pkg: Package, spec: spack.spec.Spec, prefix: Prefix) -> None:
+        """Install phase for the generic builder, to be implemented by packagers."""
         raise NotImplementedError

--- a/lib/spack/spack/compilers/libraries.py
+++ b/lib/spack/spack/compilers/libraries.py
@@ -137,6 +137,7 @@ def _parse_link_paths(string):
 
 
 class CompilerPropertyDetector:
+    """Detects compiler properties of a given compiler spec. Useful for compiler wrappers."""
 
     def __init__(self, compiler_spec: spack.spec.Spec):
         assert compiler_spec.concrete, "only concrete compiler specs are allowed"
@@ -219,9 +220,11 @@ class CompilerPropertyDetector:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
     def compiler_verbose_output(self) -> Optional[str]:
+        """Get the compiler verbose output from the cache or by compiling a dummy C source."""
         return self.cache.get(self.spec).c_compiler_output
 
     def default_dynamic_linker(self) -> Optional[str]:
+        """Determine the default dynamic linker path from the compiler verbose output."""
         output = self.compiler_verbose_output()
 
         if not output:
@@ -244,6 +247,8 @@ class CompilerPropertyDetector:
         return spack.util.libc.libc_from_dynamic_linker(dynamic_linker)
 
     def implicit_rpaths(self) -> List[str]:
+        """Obtain the implicit rpaths to be added from the default ``-L`` link directories,
+        excluding system directories."""
         output = self.compiler_verbose_output()
         if output is None:
             return []

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -218,4 +218,4 @@ class NoChecksumException(SpackError):
 
 
 class CompilerError(SpackError):
-    """Raised if something goes wrong when probing, or querying, a compiler."""
+    """Raised if something goes wrong when probing or querying a compiler."""

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -39,7 +39,7 @@ interpreter_regex = re.compile(b"#![ \t]*?([^ \t\0\n]+)")
 
 
 def sbang_install_path():
-    """Location sbang should be installed within Spack's ``install_tree``."""
+    """Location sbang is installed within the install tree."""
     sbang_root = str(spack.store.STORE.unpadded_root)
     install_path = os.path.join(sbang_root, "bin", "sbang")
     path_length = len(install_path)

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -1009,6 +1009,20 @@ def force_remove(*paths):
 @contextmanager
 @system_path_filter
 def working_dir(dirname: str, *, create: bool = False):
+    """Context manager to change the current working directory to ``dirname``.
+
+    Args:
+        dirname: the directory to change to
+        create: if :obj:`True`, create the directory if it does not exist
+
+    Example usage:
+
+        .. code-block:: python
+
+            with working_dir("/path/to/dir"):
+                # do something in /path/to/dir
+                pass
+    """
     if create:
         mkdirp(dirname)
 

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -1165,6 +1165,7 @@ def force_symlink(src, dest):
 
 @system_path_filter
 def join_path(prefix, *args):
+    """Alias for :func:`os.path.join`"""
     path = str(prefix)
     for elt in args:
         path = os.path.join(path, str(elt))

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -219,7 +219,13 @@ else:
     getuid = os.getuid
 
 
+@system_path_filter
 def _win_rename(src, dst):
+    # On Windows, os.rename will fail if the destination file already exists
+    # os.replace is the same as os.rename on POSIX and is MoveFileExW w/
+    # the MOVEFILE_REPLACE_EXISTING flag on Windows
+    # Windows invocation is abstracted behind additional logic handling
+    # remaining cases of divergent behavior across platforms
     # os.replace will still fail if on Windows (but not POSIX) if the dst
     # is a symlink to a directory (all other cases have parity Windows <-> Posix)
     if os.path.islink(dst) and os.path.isdir(os.path.realpath(dst)):
@@ -244,20 +250,9 @@ def msdos_escape_parens(path):
 
 
 @system_path_filter
-def rename(src, dst):
-    # On Windows, os.rename will fail if the destination file already exists
-    # os.replace is the same as os.rename on POSIX and is MoveFileExW w/
-    # the MOVEFILE_REPLACE_EXISTING flag on Windows
-    # Windows invocation is abstracted behind additional logic handling
-    # remaining cases of divergent behavior across platforms
-    if sys.platform == "win32":
-        _win_rename(src, dst)
-    else:
-        os.replace(src, dst)
-
-
-@system_path_filter
-def path_contains_subdirectory(path, root):
+def path_contains_subdirectory(path: str, root: str) -> bool:
+    """Check if the path is a subdirectory of the root directory. Note: this is a symbolic check,
+    and does not resolve symlinks."""
     norm_root = os.path.abspath(root).rstrip(os.path.sep) + os.path.sep
     norm_path = os.path.abspath(path).rstrip(os.path.sep) + os.path.sep
     return norm_path.startswith(norm_root)
@@ -305,14 +300,14 @@ def filter_file(
     stop_at: Optional[str] = None,
     encoding: Optional[str] = "utf-8",
 ) -> None:
-    r"""Like sed, but uses python regular expressions.
+    r"""Like ``sed``, but uses Python regular expressions.
 
     Filters every line of each file through regex and replaces the file with a filtered version.
     Preserves mode of filtered files.
 
-    As with re.sub, ``repl`` can be either a string or a callable. If it is a callable, it is
-    passed the match object and should return a suitable replacement string.  If it is a string, it
-    can contain ``\1``, ``\2``, etc. to represent back-substitution as sed would allow.
+    As with :func:`re.sub`, ``repl`` can be either a string or a callable. If it is a callable, it
+    is passed the match object and should return a suitable replacement string. If it is a string,
+    it can contain ``\1``, ``\2``, etc. to represent back-substitution as sed would allow.
 
     Args:
         regex: The regular expression to search for
@@ -397,7 +392,21 @@ def filter_file(
 
 
 class FileFilter:
-    """Convenience class for calling ``filter_file`` a lot."""
+    """
+    Convenience class for repeatedly applying :func:`filter_file` to one or more files.
+
+    This class allows you to specify a set of filenames and then call :meth:`filter`
+    multiple times to perform search-and-replace operations using Python regular expressions,
+    similar to ``sed``.
+
+    Example usage:
+
+        .. code-block:: python
+
+            foo_c = FileFilter("foo.c")
+            foo_c.filter(r"#define FOO", "#define BAR")
+            foo_c.filter(r"old_func", "new_func")
+    """
 
     def __init__(self, *filenames):
         self.filenames = filenames
@@ -657,36 +666,33 @@ def unset_executable_mode(path):
 
 
 @system_path_filter
-def copy(src, dest, _permissions=False):
-    """Copy the file(s) *src* to the file or directory *dest*.
+def copy(src: str, dest: str, _permissions: bool = False) -> None:
+    """Copy the file(s) ``src`` to the file or directory ``dest``.
 
-    If *dest* specifies a directory, the file will be copied into *dest*
-    using the base filename from *src*.
+    If ``dest`` specifies a directory, the file will be copied into ``dest``
+    using the base filename from ``src``.
 
-    *src* may contain glob characters.
+    ``src`` may contain glob characters.
 
     Parameters:
-        src (str): the file(s) to copy
-        dest (str): the destination file or directory
+        src: the file(s) to copy
+        dest: the destination file or directory
         _permissions (bool): for internal use only
 
     Raises:
-        OSError: if *src* does not match any files or directories
-        ValueError: if *src* matches multiple files but *dest* is
-            not a directory
+        OSError: if ``src`` does not match any files or directories
+        ValueError: if ``src`` matches multiple files but ``dest`` is not a directory
     """
     if _permissions:
-        tty.debug("Installing {0} to {1}".format(src, dest))
+        tty.debug(f"Installing {src} to {dest}")
     else:
-        tty.debug("Copying {0} to {1}".format(src, dest))
+        tty.debug(f"Copying {src} to {dest}")
 
     files = glob.glob(src)
     if not files:
-        raise OSError("No such file or directory: '{0}'".format(src))
+        raise OSError(f"No such file or directory: '{src}'")
     if len(files) > 1 and not os.path.isdir(dest):
-        raise ValueError(
-            "'{0}' matches multiple files but '{1}' is not a directory".format(src, dest)
-        )
+        raise ValueError(f"'{src}' matches multiple files but '{dest}' is not a directory")
 
     for src in files:
         # Expand dest to its eventual full path if it is a directory.
@@ -702,20 +708,19 @@ def copy(src, dest, _permissions=False):
 
 
 @system_path_filter
-def install(src, dest):
-    """Install the file(s) *src* to the file or directory *dest*.
+def install(src: str, dest: str):
+    """Install the file(s) ``src`` to the file or directory ``dest``.
 
     Same as :py:func:`copy` with the addition of setting proper
     permissions on the installed file.
 
     Parameters:
-        src (str): the file(s) to install
-        dest (str): the destination file or directory
+        src: the file(s) to install
+        dest: the destination file or directory
 
     Raises:
-        OSError: if *src* does not match any files or directories
-        ValueError: if *src* matches multiple files but *dest* is
-            not a directory
+        OSError: if ``src`` does not match any files or directories
+        ValueError: if ``src`` matches multiple files but ``dest`` is not a directory
     """
     copy(src, dest, _permissions=True)
 
@@ -728,31 +733,31 @@ def copy_tree(
     ignore: Optional[Callable[[str], bool]] = None,
     _permissions: bool = False,
 ):
-    """Recursively copy an entire directory tree rooted at *src*.
+    """Recursively copy an entire directory tree rooted at ``src``.
 
-    If the destination directory *dest* does not already exist, it will
+    If the destination directory ``dest`` does not already exist, it will
     be created as well as missing parent directories.
 
-    *src* may contain glob characters.
+    ``src`` may contain glob characters.
 
     If *symlinks* is true, symbolic links in the source tree are represented
     as symbolic links in the new tree and the metadata of the original links
     will be copied as far as the platform allows; if false, the contents and
     metadata of the linked files are copied to the new tree.
 
-    If *ignore* is set, then each path relative to *src* will be passed to
+    If *ignore* is set, then each path relative to ``src`` will be passed to
     this function; the function returns whether that path should be skipped.
 
     Parameters:
-        src (str): the directory to copy
-        dest (str): the destination directory
-        symlinks (bool): whether or not to preserve symlinks
-        ignore (typing.Callable): function indicating which files to ignore
-        _permissions (bool): for internal use only
+        src: the directory to copy
+        dest: the destination directory
+        symlinks: whether or not to preserve symlinks
+        ignore: function indicating which files to ignore
+        _permissions: for internal use only
 
     Raises:
-        OSError: if *src* does not match any files or directories
-        ValueError: if *src* is a parent directory of *dest*
+        OSError: if ``src`` does not match any files or directories
+        ValueError: if ``src`` is a parent directory of ``dest``
     """
     if _permissions:
         tty.debug("Installing {0} to {1}".format(src, dest))
@@ -833,28 +838,31 @@ def copy_tree(
 
 
 @system_path_filter
-def install_tree(src, dest, symlinks=True, ignore=None):
-    """Recursively install an entire directory tree rooted at *src*.
+def install_tree(
+    src: str, dest: str, symlinks: bool = True, ignore: Optional[Callable[[str], bool]] = None
+):
+    """Recursively install an entire directory tree rooted at ``src``.
 
     Same as :py:func:`copy_tree` with the addition of setting proper
     permissions on the installed files and directories.
 
     Parameters:
-        src (str): the directory to install
-        dest (str): the destination directory
-        symlinks (bool): whether or not to preserve symlinks
-        ignore (typing.Callable): function indicating which files to ignore
+        src: the directory to install
+        dest: the destination directory
+        symlinks: whether or not to preserve symlinks
+        ignore: function indicating which files to ignore
 
     Raises:
-        OSError: if *src* does not match any files or directories
-        ValueError: if *src* is a parent directory of *dest*
+        OSError: if ``src`` does not match any files or directories
+        ValueError: if ``src`` is a parent directory of ``dest``
     """
     copy_tree(src, dest, symlinks=symlinks, ignore=ignore, _permissions=True)
 
 
 @system_path_filter
 def is_exe(path):
-    """True if path is an executable file."""
+    """Returns :obj:`True` iff the specified path exists, is a regular file, and has executable
+    permissions for the current process."""
     return os.path.isfile(path) and os.access(path, os.X_OK)
 
 
@@ -1133,6 +1141,7 @@ def touchp(path):
 
 @system_path_filter
 def force_symlink(src, dest):
+    """Create a symlink at ``dest`` pointing to ``src``. Similar to ``ln -sf``."""
     try:
         symlink(src, dest)
     except OSError:
@@ -1224,7 +1233,7 @@ def temp_cwd():
 
 @system_path_filter
 def can_access(file_name):
-    """True if we have read/write access to the file."""
+    """True if the current process has read and write access to the file."""
     return os.access(file_name, os.R_OK | os.W_OK)
 
 
@@ -1462,6 +1471,7 @@ def visit_directory_tree(
 
 @system_path_filter
 def set_executable(path):
+    """Set the executable bit on a file or directory."""
     mode = os.stat(path).st_mode
     if mode & stat.S_IRUSR:
         mode |= stat.S_IXUSR
@@ -3359,10 +3369,12 @@ if sys.platform == "win32":
     symlink = _windows_symlink
     readlink = _windows_readlink
     islink = _windows_islink
+    rename = _win_rename
 else:
     symlink = os.symlink
     readlink = os.readlink
     islink = os.path.islink
+    rename = os.rename
 
 
 class SymlinkError(RuntimeError):

--- a/lib/spack/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/spack/llnl/util/tty/__init__.py
@@ -158,6 +158,7 @@ def get_timestamp(force=False):
 
 
 def msg(message: Any, *args: Any, newline: bool = True) -> None:
+    """Print a message to the console."""
     if not msg_enabled():
         return
 
@@ -178,6 +179,7 @@ def msg(message: Any, *args: Any, newline: bool = True) -> None:
 
 
 def info(message, *args, **kwargs):
+    """Print an informational message."""
     if isinstance(message, Exception):
         message = "%s: %s" % (message.__class__.__name__, str(message))
 
@@ -211,12 +213,14 @@ def info(message, *args, **kwargs):
 
 
 def verbose(message, *args, **kwargs):
+    """Print a verbose message if the verbose flag is set."""
     if _verbose:
         kwargs.setdefault("format", "c")
         info(message, *args, **kwargs)
 
 
 def debug(message, *args, **kwargs):
+    """Print a debug message if the debug level is set."""
     level = kwargs.get("level", 1)
     if is_debug(level):
         kwargs.setdefault("format", "g")
@@ -225,6 +229,7 @@ def debug(message, *args, **kwargs):
 
 
 def error(message, *args, **kwargs):
+    """Print an error message."""
     if not error_enabled():
         return
 
@@ -234,6 +239,7 @@ def error(message, *args, **kwargs):
 
 
 def warn(message, *args, **kwargs):
+    """Print a warning message."""
     if not warn_enabled():
         return
 

--- a/lib/spack/spack/mixins.py
+++ b/lib/spack/spack/mixins.py
@@ -11,40 +11,42 @@ import spack.llnl.util.filesystem
 import spack.phase_callbacks
 
 
-def filter_compiler_wrappers(*files, **kwargs):
-    """Substitutes any path referring to a Spack compiler wrapper with the
-    path of the underlying compiler that has been used.
+def filter_compiler_wrappers(*files: str, **kwargs):
+    """Registers a phase callback (e.g. post-install) to look for references to Spack's compiler
+    wrappers in the given files and replace them with the underlying compilers.
 
-    If this isn't done, the files will have CC, CXX, F77, and FC set to
-    Spack's generic cc, c++, f77, and f90. We want them to be bound to
-    whatever compiler they were built with.
+    Example usage::
+
+        class MyPackage(Package):
+
+            filter_compiler_wrappers("mpicc", "mpicxx", relative_root="bin")
+
+    This is useful for packages that register the path to the compiler they are built with to be
+    used later at runtime. Spack's compiler wrappers cannot be used at runtime, as they require
+    Spack's build environment to be set up. Using this function, the compiler wrappers are replaced
+    with the actual compilers, so that the package works correctly at runtime.
 
     Args:
-        *files: files to be filtered relative to the search root (which is,
-            by default, the installation prefix)
+        *files: files to be filtered relative to the search root (install prefix by default).
 
         **kwargs: allowed keyword arguments
 
             after
-                specifies after which phase the files should be
-                filtered (defaults to 'install')
+                specifies after which phase the files should be filtered (defaults to "install")
 
             relative_root
-                path relative to prefix where to start searching for
-                the files to be filtered. If not set the install prefix
-                wil be used as the search root. **It is highly recommended
-                to set this, as searching from the installation prefix may
-                affect performance severely in some cases**.
+                path relative to install prefix where to start searching for the files to be
+                filtered. If not set the install prefix will be used as the search root.
+                It is *highly recommended* to set this, as searching recursively from the
+                installation prefix can be very slow.
 
             ignore_absent, backup
-                these two keyword arguments, if present, will be forwarded
-                to ``filter_file`` (see its documentation for more information
-                on their behavior)
+                these two keyword arguments, if present, will be forwarded to
+                :func:`~spack.llnl.util.filesystem.filter_file`
 
             recursive
                 this keyword argument, if present, will be forwarded to
-                ``find`` (see its documentation for more information on the
-                behavior)
+                :func:`~spack.llnl.util.filesystem.find`
     """
     after = kwargs.get("after", "install")
     relative_root = kwargs.get("relative_root", None)

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -233,7 +233,7 @@ class when:
                 # Do more common install stuff
 
     Note that the default version of decorated methods must *always* come first. Otherwise it will
-    override all of the decorated versions. This is a limitation of Python itself.
+    override all of the decorated versions. This is a limitation of the Python language.
     """
 
     def __init__(self, condition: Union[str, bool]):

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -240,7 +240,6 @@ class when:
         """Can be used both as a decorator, for multimethods, or as a context
         manager to group ``when=`` arguments together.
 
-        Examples are given in the docstrings below.
 
         Args:
             condition (str): condition to be met

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -25,6 +25,7 @@ so package authors should use their judgement.
 """
 import functools
 from contextlib import contextmanager
+from typing import Union
 
 import spack.directives_meta
 import spack.error
@@ -151,7 +152,91 @@ class SpecMultiMethod:
 
 
 class when:
-    def __init__(self, condition):
+    """This is a multi-purpose class, which can be used
+
+    1. As a context manager to **group directives together** that share the same `when=` argument.
+    2. As a **decorator** for defining multi-methods (multiple methods with the same name are
+       defined, but the version that is called depends on the condition of the package's spec)
+
+    As a **context manager** it groups directives together. It allows you to write::
+
+       with when("+nvptx"):
+           conflicts("@:6", msg="NVPTX only supported from gcc 7")
+           conflicts("languages=ada")
+           conflicts("languages=brig")
+
+    instead of the more repetitive::
+
+       conflicts("@:6", when="+nvptx", msg="NVPTX only supported from gcc 7")
+       conflicts("languages=ada", when="+nvptx")
+       conflicts("languages=brig", when="+nvptx")
+
+    This context manager is composable both with nested ``when`` contexts and with other ``when=``
+    arguments in directives. For example::
+
+       with when("+foo"):
+           with when("+bar"):
+               depends_on("dependency", when="+baz")
+
+    is equilavent to::
+
+       depends_on("dependency", when="+foo +bar +baz")
+
+    As a **decorator**, it allows packages to declare multiple versions of methods like
+    `install()` that depend on the package's spec. For example::
+
+       class SomePackage(Package):
+           ...
+
+           def install(self, spec: Spec, prefix: Prefix):
+               # Do default install
+
+           @when("target=x86_64:")
+           def install(self, spec: Spec, prefix: Prefix):
+               # This will be executed instead of the default install if
+               # the package's target is in the x86_64 family.
+
+           @when("target=aarch64:")
+           def install(self, spec: Spec, prefix: Prefix):
+               # This will be executed if the package's target is in
+               # the aarch64 family
+
+    This allows each package to have a default version of install() AND
+    specialized versions for particular platforms.  The version that is
+    called depends on the architecture of the instantiated package.
+
+    Note that this works for methods other than install, as well.  So,
+    if you only have part of the install that is platform specific, you
+    could do this:
+
+    .. code-block:: python
+
+        class SomePackage(Package):
+            ...
+            # virtual dependence on MPI.
+            # could resolve to mpich, mpich2, OpenMPI
+            depends_on("mpi")
+
+            def setup(self):
+                # do nothing in the default case
+                pass
+
+            @when("^openmpi")
+            def setup(self):
+                # do something special when this is built with OpenMPI for
+                # its MPI implementations.
+
+
+            def install(self, prefix):
+                # Do common install stuff
+                self.setup()
+                # Do more common install stuff
+
+    Note that the default version of decorated methods must *always* come first. Otherwise it will
+    override all of the decorated versions. This is a limitation of Python itself.
+    """
+
+    def __init__(self, condition: Union[str, bool]):
         """Can be used both as a decorator, for multimethods, or as a context
         manager to group ``when=`` arguments together.
 
@@ -166,65 +251,6 @@ class when:
             self.spec = spack.spec.Spec(condition)
 
     def __call__(self, method):
-        """This annotation lets packages declare multiple versions of
-        methods like install() that depend on the package's spec.
-
-        For example:
-
-           .. code-block:: python
-
-              class SomePackage(Package):
-                  ...
-
-                  def install(self, prefix):
-                      # Do default install
-
-                  @when('target=x86_64:')
-                  def install(self, prefix):
-                      # This will be executed instead of the default install if
-                      # the package's target is in the x86_64 family.
-
-                  @when('target=ppc64:')
-                  def install(self, prefix):
-                      # This will be executed if the package's target is in
-                      # the ppc64 family
-
-           This allows each package to have a default version of install() AND
-           specialized versions for particular platforms.  The version that is
-           called depends on the architecture of the instantiated package.
-
-           Note that this works for methods other than install, as well.  So,
-           if you only have part of the install that is platform specific, you
-           could do this:
-
-           .. code-block:: python
-
-              class SomePackage(Package):
-                  ...
-                  # virtual dependence on MPI.
-                  # could resolve to mpich, mpich2, OpenMPI
-                  depends_on('mpi')
-
-                  def setup(self):
-                      # do nothing in the default case
-                      pass
-
-                  @when('^openmpi')
-                  def setup(self):
-                      # do something special when this is built with OpenMPI for
-                      # its MPI implementations.
-
-
-                  def install(self, prefix):
-                      # Do common install stuff
-                      self.setup()
-                      # Do more common install stuff
-
-           Note that the default version of decorated methods must
-           *always* come first.  Otherwise it will override all of the
-           platform-specific versions.  There's not much we can do to get
-           around this because of the way decorators work.
-        """
         assert (
             MultiMethodMeta._locals is not None
         ), "cannot use multimethod, missing MultiMethodMeta metaclass?"
@@ -240,26 +266,6 @@ class when:
         return original_method
 
     def __enter__(self):
-        """Inject the constraint spec into the `when=` argument of directives
-        in the context.
-
-        This context manager allows you to write:
-
-            with when('+nvptx'):
-                conflicts('@:6', msg='NVPTX only supported from gcc 7')
-                conflicts('languages=ada')
-                conflicts('languages=brig')
-
-        instead of writing:
-
-             conflicts('@:6', when='+nvptx', msg='NVPTX only supported from gcc 7')
-             conflicts('languages=ada', when='+nvptx')
-             conflicts('languages=brig', when='+nvptx')
-
-        Context managers can be nested (but this is not recommended for readability)
-        and add their constraint to whatever may be already present in the directive
-        `when=` argument.
-        """
         spack.directives_meta.DirectiveMeta.push_to_context(str(self.spec))
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -268,6 +274,27 @@ class when:
 
 @contextmanager
 def default_args(**kwargs):
+    """Context manager to override the default arguments of directives.
+
+    Example::
+
+        with default_args(type=("build", "run")):
+            depends_on("py-foo")
+            depends_on("py-bar")
+            depends_on("py-baz")
+
+    Notice that unlike then :func:`when` context manager, this one is *not* composable, as it
+    merely overrides the default argument values for the duration of the context. For example::
+
+        with default_args(when="+foo"):
+            depends_on("pkg-a")
+            depends_on("pkg-b", when="+bar")
+
+    is equivalent to::
+
+        depends_on("pkg-a", when="+foo")
+        depends_on("pkg-b", when="+bar")
+    """
     spack.directives_meta.DirectiveMeta.push_default_args(kwargs)
     yield
     spack.directives_meta.DirectiveMeta.pop_default_args()

--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -5,26 +5,16 @@ import platform as py_platform
 import re
 from subprocess import check_output
 
-from spack.version import Version
+from spack.version import StandardVersion
 
 from ._operating_system import OperatingSystem
 
 
-def kernel_version():
-    """Return the kernel version as a Version object.
-    Note that the kernel version is distinct from OS and/or
-    distribution versions. For instance:
-    >>> distro.id()
-    'centos'
-    >>> distro.version()
-    '7'
-    >>> platform.release()
-    '5.10.84+'
-    """
+def kernel_version() -> StandardVersion:
+    """Return the host's kernel version as a :class:`~spack.version.StandardVersion` object."""
     # Strip '+' characters just in case we're running a
     # version built from git/etc
-    clean_version = re.sub(r"\+", r"", py_platform.release())
-    return Version(clean_version)
+    return StandardVersion.from_string(re.sub(r"\+", r"", py_platform.release()))
 
 
 class LinuxDistro(OperatingSystem):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2,20 +2,17 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-"""spack.package defines the public API for Spack packages, by re-exporting useful symbols from
-other modules. Packages should import this module, instead of importing from spack.* directly
-to ensure forward compatibility with future versions of Spack."""
-
 import warnings
 from os import chdir, environ, getcwd, makedirs, mkdir, remove, removedirs
 from shutil import move, rmtree
 
 # import most common types used in packages
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from spack.vendor.macholib.MachO import LC_ID_DYLIB, MachO
 
 import spack.builder
+import spack.llnl.util.tty as _tty
 from spack.archspec import microarchitecture_flags, microarchitecture_flags_from_target
 from spack.build_environment import (
     MakeExecutable,
@@ -158,22 +155,57 @@ from spack.util.windows_registry import HKEY, WindowsRegistryView
 from spack.variant import any_combination_of, auto_or_any_combination_of, disjoint_sets
 from spack.version import Version, ver
 
-#: alias for ``os.environ``
+#: Alias for :data:`os.environ`
 env = environ
 
-#: alias for ``os.chdir``
+#: Alias for :func:`os.chdir`
 cd = chdir
 
-#: alias for ``os.getcwd``
+#: Alias for :func:`os.getcwd`
 pwd = getcwd
+
+#: Alias for :func:`os.rename`
+rename = rename
+
+#: Alias for :func:`os.makedirs`
+makedirs = makedirs
+
+#: Alias for :func:`os.mkdir`
+mkdir = mkdir
+
+#: Alias for :func:`os.remove`
+remove = remove
+
+#: Alias for :func:`os.removedirs`
+removedirs = removedirs
+
+#: Alias for :func:`shutil.move`
+move = move
+
+#: Alias for :func:`shutil.rmtree`
+rmtree = rmtree
+
+#: Alias for :func:`os.readlink` (with certain Windows-specific changes)
+readlink = readlink
+
+#: Alias for :func:`os.rename` (with certain Windows-specific changes)
+rename = rename
+
+#: Alias for :func:`os.symlink` (with certain Windows-specific changes)
+symlink = symlink
 
 # Not an import alias because black and isort disagree about style
 create_builder = spack.builder.create
 
+#: MachO class from the ``macholib`` package (vendored in Spack).
+MachO = MachO
+
+#: Constant for MachO ``LC_ID_DYLIB`` load command, from the ``macholib`` package (vendored in
+#: Spack).
+LC_ID_DYLIB = LC_ID_DYLIB
+
 
 class tty:
-    import spack.llnl.util.tty as _tty
-
     debug = _tty.debug
     error = _tty.error
     info = _tty.info
@@ -182,7 +214,10 @@ class tty:
 
 
 def is_system_path(path: str) -> bool:
-    """Returns True if the argument is a system path, False otherwise."""
+    """Returns :obj:`True` iff the argument is a system path.
+
+    .. deprecated:: v2.0
+    """
     warnings.warn(
         "spack.package.is_system_path is deprecated", category=SpackAPIWarning, stacklevel=2
     )
@@ -190,13 +225,185 @@ def is_system_path(path: str) -> bool:
 
 
 def filter_system_paths(paths: Iterable[str]) -> List[str]:
-    """Returns a copy of the input where system paths are filtered out."""
+    """Returns a copy of the input where system paths are filtered out.
+
+    .. deprecated:: v2.0
+    """
     warnings.warn(
         "spack.package.filter_system_paths is deprecated", category=SpackAPIWarning, stacklevel=2
     )
     return _filter_system_paths(paths)
 
 
+api: Dict[str, Tuple[str, ...]] = {
+    "v2.0": (
+        "BaseBuilder",
+        "Builder",
+        "Dict",
+        "EnvironmentModifications",
+        "Executable",
+        "FileFilter",
+        "FileList",
+        "HeaderList",
+        "InstallError",
+        "LibraryList",
+        "List",
+        "MakeExecutable",
+        "NoHeadersError",
+        "NoLibrariesError",
+        "Optional",
+        "PackageBase",
+        "Prefix",
+        "ProcessError",
+        "SkipTest",
+        "Spec",
+        "Version",
+        "all_deptypes",
+        "ancestor",
+        "any_combination_of",
+        "auto_or_any_combination_of",
+        "bash_completion_path",
+        "build_system_flags",
+        "build_system",
+        "cache_extra_test_sources",
+        "can_access",
+        "can_splice",
+        "cd",
+        "change_sed_delimiter",
+        "check_outputs",
+        "conditional",
+        "conflicts",
+        "copy_tree",
+        "copy",
+        "default_args",
+        "depends_on",
+        "determine_number_of_jobs",
+        "disjoint_sets",
+        "env_flags",
+        "env",
+        "extends",
+        "filter_compiler_wrappers",
+        "filter_file",
+        "find_all_headers",
+        "find_first",
+        "find_headers",
+        "find_libraries",
+        "find_required_file",
+        "find_system_libraries",
+        "find",
+        "fish_completion_path",
+        "fix_darwin_install_name",
+        "force_remove",
+        "force_symlink",
+        "get_escaped_text_output",
+        "inject_flags",
+        "install_test_root",
+        "install_tree",
+        "install",
+        "is_exe",
+        "join_path",
+        "keep_modification_time",
+        "library_extensions",
+        "license",
+        "maintainers",
+        "makedirs",
+        "mkdir",
+        "mkdirp",
+        "move",
+        "on_package_attributes",
+        "patch",
+        "provides",
+        "pwd",
+        "redistribute",
+        "register_builder",
+        "remove_directory_contents",
+        "remove_linked_tree",
+        "remove",
+        "removedirs",
+        "rename",
+        "requires",
+        "resource",
+        "rmtree",
+        "run_after",
+        "run_before",
+        "set_executable",
+        "set_install_permissions",
+        "symlink",
+        "test_part",
+        "touch",
+        "tty",
+        "variant",
+        "ver",
+        "version",
+        "when",
+        "which_string",
+        "which",
+        "working_dir",
+        "zsh_completion_path",
+    ),
+    "v2.1": ("CompilerError", "SpackError"),
+    "v2.2": (
+        "BuilderWithDefaults",
+        "ClassProperty",
+        "CompilerPropertyDetector",
+        "GenericBuilder",
+        "HKEY",
+        "LC_ID_DYLIB",
+        "LinkTree",
+        "MachO",
+        "ModuleChangePropagator",
+        "Package",
+        "WindowsRegistryView",
+        "apply_macos_rpath_fixups",
+        "classproperty",
+        "compare_output_file",
+        "compare_output",
+        "compile_c_and_execute",
+        "compiler_spec",
+        "create_builder",
+        "dedupe",
+        "delete_needed_from_elf",
+        "delete_rpath",
+        "environment_modifications_for_specs",
+        "execute_install_time_tests",
+        "filter_shebang",
+        "filter_system_paths",
+        "find_all_libraries",
+        "find_compilers",
+        "get_cmake_prefix_path",
+        "get_effective_jobs",
+        "get_elf_compat",
+        "get_path_args_from_module_line",
+        "get_user",
+        "has_shebang",
+        "host_platform",
+        "is_system_path",
+        "join_url",
+        "kernel_version",
+        "libc_from_dynamic_linker",
+        "macos_version",
+        "make_package_test_rpath",
+        "memoized",
+        "microarchitecture_flags_from_target",
+        "microarchitecture_flags",
+        "module_command",
+        "parse_dynamic_linker",
+        "parse_elf",
+        "path_contains_subdirectory",
+        "readlink",
+        "safe_remove",
+        "sbang_install_path",
+        "sbang_shebang_line",
+        "set_env",
+        "shared_library_suffix",
+        "spack_script",
+        "static_library_suffix",
+        "substitute_version_in_url",
+        "windows_sfn",
+    ),
+}
+
+# Splatting does not work for static analysis tools.
 __all__ = [
     # v2.0
     "BaseBuilder",
@@ -364,6 +571,9 @@ __all__ = [
     "substitute_version_in_url",
     "windows_sfn",
 ]
+
+# Make sure `__all__` and `api` are consistent.
+assert __all__ == [symbol for symbols in api.values() for symbol in symbols]
 
 # These are just here for editor support; they may be set when the build env is set up.
 configure: Executable

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -513,7 +513,7 @@ class DisableRedistribute:
 
 
 class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
-    """This is the superclass for all spack packages.
+    """This is the universal base class for all spack packages.
 
     ***The Package class***
 
@@ -620,7 +620,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: Must be defined as a fallback for old specs that don't have the `build_system` variant
     default_buildsystem: str
 
-    #: (DEPRECATED) Deprecated name for `default_buildsystem`
+    # Use :attr:`default_buildsystem` instead of this attribute, which is deprecated
     legacy_buildsystem: str
 
     #: Must be defined in derived classes. Used when reporting the build system to users
@@ -1846,7 +1846,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         return b32_hash
 
     @property
-    def cmake_prefix_paths(self):
+    def cmake_prefix_paths(self) -> List[str]:
+        """Return a list of paths to be used in CMake's ``CMAKE_PREFIX_PATH``."""
         return [self.prefix]
 
     def _has_make_target(self, target):

--- a/lib/spack/spack/package_test.py
+++ b/lib/spack/spack/package_test.py
@@ -3,15 +3,17 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+from typing import List
 
 from spack.util.executable import Executable, which
 
 
-def compile_c_and_execute(source_file, include_flags, link_flags):
-    """Compile C @p source_file with @p include_flags and @p link_flags,
-    run and return the output.
-    """
-    cc = which("cc")
+def compile_c_and_execute(
+    source_file: str, include_flags: List[str], link_flags: List[str]
+) -> str:
+    """Compile a C source file with the given include and link flags, execute the resulting binary,
+    and return its output as a string. Used in package tests."""
+    cc = which("cc", required=True)
     flags = include_flags
     flags.extend([source_file])
     cc("-c", *flags)
@@ -22,8 +24,8 @@ def compile_c_and_execute(source_file, include_flags, link_flags):
     return check(output=str)
 
 
-def compare_output(current_output, blessed_output):
-    """Compare blessed and current output of executables."""
+def compare_output(current_output: str, blessed_output: str) -> None:
+    """Compare blessed and current output of executables. Used in package tests."""
     if not (current_output == blessed_output):
         print("Produced output does not match expected output.")
         print("Expected output:")
@@ -37,8 +39,8 @@ def compare_output(current_output, blessed_output):
         raise RuntimeError("Ouput check failed.", "See spack_output.log for details")
 
 
-def compare_output_file(current_output, blessed_output_file):
-    """Same as above, but when the blessed output is given as a file."""
+def compare_output_file(current_output: str, blessed_output_file: str) -> None:
+    """Same as above, but when the blessed output is given as a file. Used in package tests."""
     with open(blessed_output_file, "r", encoding="utf-8") as f:
         blessed_output = f.read()
 

--- a/lib/spack/spack/phase_callbacks.py
+++ b/lib/spack/spack/phase_callbacks.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import collections
+from typing import Optional
 
 import spack.llnl.util.lang as lang
 
@@ -18,9 +19,9 @@ CallbackTemporaryStage = collections.namedtuple(
 )
 
 #: Shared global state to aggregate "@run_before" callbacks
-_RUN_BEFORE = CallbackTemporaryStage(attribute_name="run_before_callbacks", callbacks=[])
+_RUN_BEFORE = CallbackTemporaryStage(attribute_name="_run_before_callbacks", callbacks=[])
 #: Shared global state to aggregate "@run_after" callbacks
-_RUN_AFTER = CallbackTemporaryStage(attribute_name="run_after_callbacks", callbacks=[])
+_RUN_AFTER = CallbackTemporaryStage(attribute_name="_run_after_callbacks", callbacks=[])
 
 
 class PhaseCallbacksMeta(type):
@@ -65,12 +66,19 @@ class PhaseCallbacksMeta(type):
         return super(PhaseCallbacksMeta, mcs).__new__(mcs, name, bases, attr_dict)
 
     @staticmethod
-    def run_after(phase, when=None):
+    def run_after(phase: str, when: Optional[str] = None):
         """Decorator to register a function for running after a given phase.
 
+        Example::
+
+            @run_after("install", when="@2:")
+            def install_missing_files(self):
+                # Do something after the install phase for versions 2.x and above
+                pass
+
         Args:
-            phase (str): phase after which the function must run.
-            when (str): condition under which the function is run (if None, it is always run).
+            phase: phase after which the function must run.
+            when: condition under which the function is run (if :obj:`None`, it is always run).
         """
 
         def _decorator(fn):
@@ -82,12 +90,19 @@ class PhaseCallbacksMeta(type):
         return _decorator
 
     @staticmethod
-    def run_before(phase, when=None):
+    def run_before(phase: str, when: Optional[str] = None):
         """Decorator to register a function for running before a given phase.
 
+        Example::
+
+            @run_before("build", when="@2:")
+            def patch_generated_source_file(pkg):
+                # Do something before the build phase for versions 2.x and above
+                pass
+
         Args:
-           phase (str): phase before which the function must run.
-           when (str): condition under which the function is run (if None, it is always run).
+           phase: phase before which the function must run.
+           when: condition under which the function is run (if :obj:`None`, it is always run).
         """
 
         def _decorator(fn):

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -178,11 +178,11 @@ def test_mixins_with_builders(working_env):
     builder = spack.builder.create(s.package)
 
     # Check that callbacks added by the mixin are in the list
-    assert any(fn.__name__ == "before_install" for _, fn in builder.run_before_callbacks)
-    assert any(fn.__name__ == "after_install" for _, fn in builder.run_after_callbacks)
+    assert any(fn.__name__ == "before_install" for _, fn in builder._run_before_callbacks)
+    assert any(fn.__name__ == "after_install" for _, fn in builder._run_after_callbacks)
 
     # Check that callback from the GenericBuilder are in the list too
-    assert any(fn.__name__ == "sanity_check_prefix" for _, fn in builder.run_after_callbacks)
+    assert any(fn.__name__ == "sanity_check_prefix" for _, fn in builder._run_after_callbacks)
 
 
 def test_reading_api_v20_attributes():

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -505,7 +505,7 @@ def wildcard_version(path):
     return result
 
 
-def substitute_version(path, new_version):
+def substitute_version(path: str, new_version) -> str:
     """Given a URL or archive name, find the version in the path and
     substitute the new version for it.  Replace all occurrences of
     the version *if* they don't overlap with the package name.

--- a/lib/spack/spack/util/elf.py
+++ b/lib/spack/spack/util/elf.py
@@ -460,8 +460,8 @@ def parse_elf(
     dynamic_section: bool = False,
     only_header: bool = False,
 ) -> ElfFile:
-    """Given a file handle f for an ELF file opened in binary mode, return an ElfFile
-    object that is stores data about rpaths"""
+    """Given a file handle ``f`` for an ELF file opened in binary mode, return an
+    :class:`~spack.util.elf.ElfFile` object with the parsed contents."""
     try:
         return _do_parse_elf(f, interpreter, dynamic_section, only_header)
     except (DeprecationWarning, struct.error):
@@ -520,8 +520,8 @@ def _delete_dynamic_array_entry(
 
 def delete_rpath(path: str) -> None:
     """Modifies a binary to remove the rpath. It zeros out the rpath string and also drops the
-    DT_R(UN)PATH entry from the dynamic section, so it doesn't show up in 'readelf -d file', nor
-    in 'strings file'."""
+    ``DT_RPATH`` / ``DT_RUNPATH`` entry from the dynamic section, so it doesn't show up in
+    ``readelf -d file``, nor in ``strings file``."""
     with open(path, "rb+") as f:
         elf = parse_elf(f, interpreter=False, dynamic_section=True)
 
@@ -690,9 +690,9 @@ def pt_interp(path: str) -> Optional[str]:
     return elf.pt_interp_str.decode("utf-8")
 
 
-def get_elf_compat(path):
-    """Get a triplet (EI_CLASS, EI_DATA, e_machine) from an ELF file, which can be used to see if
-    two ELF files are compatible."""
+def get_elf_compat(path: str) -> Tuple[bool, bool, int]:
+    """Get a triplet (is_64_bit, is_little_endian, e_machine) from an ELF file, which can be used
+    to see if two ELF files are compatible."""
     # On ELF platforms supporting, we try to be a bit smarter when it comes to shared
     # libraries, by dropping those that are not host compatible.
     with open(path, "rb") as f:

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -14,18 +14,18 @@ from spack.llnl.util.filesystem import edit_in_place_through_temporary_file
 from spack.util.executable import Executable
 
 
-def fix_darwin_install_name(path):
+def fix_darwin_install_name(path: str) -> None:
     """Fix install name of dynamic libraries on Darwin to have full path.
 
     There are two parts of this task:
 
-    1. Use ``install_name('-id', ...)`` to change install name of a single lib
-    2. Use ``install_name('-change', ...)`` to change the cross linking between
-       libs. The function assumes that all libraries are in one folder and
-       currently won't follow subfolders.
+    1. Use ``install_name("-id", ...)`` to change install name of a single lib
+    2. Use ``install_name("-change", ...)`` to change the cross linking between libs.
+       The function assumes that all libraries are in one folder and currently won't follow
+       subfolders.
 
     Parameters:
-        path (str): directory in which .dylib files are located
+        path: directory in which .dylib files are located
     """
     libs = glob.glob(os.path.join(path, "*.dylib"))
     install_name_tool = Executable("install_name_tool")

--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -60,6 +60,7 @@ def default_search_paths_from_dynamic_linker(dynamic_linker: str) -> List[str]:
 
 
 def libc_from_dynamic_linker(dynamic_linker: str) -> Optional["spack.spec.Spec"]:
+    """Get the libc spec from the dynamic linker path."""
     maybe_spec = _libc_from_dynamic_linker(dynamic_linker)
     if maybe_spec:
         return maybe_spec.copy()
@@ -155,7 +156,7 @@ def libc_from_current_python_process() -> Optional["spack.spec.Spec"]:
 
 
 def parse_dynamic_linker(output: str):
-    """Parse -dynamic-linker /path/to/ld.so from compiler output"""
+    """Parse ``-dynamic-linker /path/to/ld.so`` from compiler output"""
     for line in reversed(output.splitlines()):
         if "-dynamic-linker" not in line:
             continue

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -22,11 +22,22 @@ awk_cmd = r"""awk 'BEGIN{for(name in ENVIRON)""" r"""printf("%s=%s%c", name, ENV
 
 
 def module(
-    *args,
+    *args: str,
     module_template: Optional[str] = None,
     module_src_cmd: Optional[str] = None,
     environb: Optional[MutableMapping[bytes, bytes]] = None,
 ):
+    """Run the ``module`` shell function in ``/bin/bash`` subprocess, and either collect its
+    changes to environment variables and apply them in the current process (for ``module load``,
+    ``module swap``, etc.), or return its output as a string (for ``module show``, etc.).
+
+    This requires ``/bin/bash`` to be available on the system and ``awk`` to be in ``PATH``.
+
+    Args:
+        args: Command line arguments for the module command.
+        environb: (Binary) environment variables dictionary. If not provided, the current
+            process's environment is modified.
+    """
     module_cmd = module_template or ("module " + " ".join(args))
     environb = environb or os.environb
     if b"MODULESHOME" in environb:

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -27,7 +27,7 @@ def module(
     module_src_cmd: Optional[str] = None,
     environb: Optional[MutableMapping[bytes, bytes]] = None,
 ):
-    """Run the ``module`` shell function in ``/bin/bash`` subprocess, and either collect its
+    """Run the ``module`` shell function in a ``/bin/bash`` subprocess, and either collect its
     changes to environment variables and apply them in the current process (for ``module load``,
     ``module swap``, etc.), or return its output as a string (for ``module show``, etc.).
 

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -68,7 +68,7 @@ def format(parsed_url):
 
 
 def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> str:
-    """Convenience wrapper around ``urllib.parse.urljoin``, with a few differences:
+    """Convenience wrapper around :func:`urllib.parse.urljoin`, with a few differences:
 
     1. By default ``resolve_href=False``, which makes the function like :func:`os.path.join`.
        For example ``https://example.com/a/b + c/d = https://example.com/a/b/c/d``. If

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -69,12 +69,14 @@ def format(parsed_url):
 
 def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> str:
     """Convenience wrapper around ``urllib.parse.urljoin``, with a few differences:
-    1. By default resolve_href=False, which makes the function like os.path.join: for example
-    https://example.com/a/b + c/d = https://example.com/a/b/c/d. If resolve_href=True, the
-    behavior is how a browser would resolve the URL: https://example.com/a/c/d.
-    2. s3://, gs://, oci:// URLs are joined like http:// URLs.
-    3. It accepts multiple components for convenience. Note that components[1:] are treated as
-    literal path components and appended to components[0] separated by slashes."""
+
+    1. By default ``resolve_href=False``, which makes the function like :func:`os.path.join`.
+       For example ``https://example.com/a/b + c/d = https://example.com/a/b/c/d``. If
+       ``resolve_href=True``, the behavior is how a browser would resolve the URL:
+       ``https://example.com/a/c/d``.
+    2. ``s3://``, ``gs://``, ``oci://`` URLs are joined like ``http://`` URLs.
+    3. It accepts multiple components for convenience. Note that ``components[1:]`` are treated as
+       literal path components and appended to ``components[0]`` separated by slashes."""
     # Ensure a trailing slash in the path component of the base URL to get os.path.join-like
     # behavior instead of web browser behavior.
     if not resolve_href:

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -605,27 +605,37 @@ def any_combination_of(*values):
     values, and also allows the user to specify 'none' (as a string) to choose
     none of them.
 
-    It is up to the package implementation to handle the value 'none'
-    specially, if at all.
+    It is up to the package implementation to handle the value `"none"` specially, if at all.
 
     Args:
         *values: allowed variant values
 
+    Example::
+
+        variant("cuda_arch", values=any_combination_of("10", "11"))
+
     Returns:
-        a properly initialized instance of DisjointSetsOfValues
+        a properly initialized instance of :class:`~spack.variant.DisjointSetsOfValues`
     """
     return _a_single_value_or_a_combination("none", *values)
 
 
 def auto_or_any_combination_of(*values):
     """Multi-valued variant that allows any combination of a set of values
-    (but not the empty set) or 'auto'.
+    (but not the empty set) or `"auto"`.
 
     Args:
         *values: allowed variant values
 
+    Example::
+
+       variant(
+           "file_systems",
+           values=auto_or_any_combination_of("lustre", "gpfs", "nfs", "ufs"),
+       )
+
     Returns:
-        a properly initialized instance of DisjointSetsOfValues
+        a properly initialized instance of :class:`~spack.variant.DisjointSetsOfValues`
     """
     return _a_single_value_or_a_combination("auto", *values)
 
@@ -644,7 +654,7 @@ def disjoint_sets(*sets):
         *sets:
 
     Returns:
-        a properly initialized instance of DisjointSetsOfValues
+        a properly initialized instance of :class:`~spack.variant.DisjointSetsOfValues`
     """
     return DisjointSetsOfValues(*sets).allow_empty_set().with_default("none")
 

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -1313,8 +1313,8 @@ def from_string(string: str) -> VersionType:
 
 
 def ver(obj: Union[VersionType, str, list, tuple, int, float]) -> VersionType:
-    """Parses a Version, VersionRange, or VersionList from a string
-    or list of strings.
+    """Returns a :class:`~spack.version.ClosedOpenRange`, :class:`~spack.version.StandardVersion`,
+    :class:`~spack.version.GitVersion`, or :class:`~spack.version.VersionList` from the argument.
     """
     if isinstance(obj, VersionType):
         return obj

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
@@ -164,7 +164,8 @@ def generator(*names: str, default: Optional[str] = None) -> None:
 
 
 def get_cmake_prefix_path(pkg: spack.package_base.PackageBase) -> List[str]:
-    """Obtain the CMAKE_PREFIX_PATH entries for a package, based on the cmake_prefix_path package
+    """Obtain the CMAKE_PREFIX_PATH entries for a package, based on the
+    :attr:`~spack.package_base.PackageBase.cmake_prefix_paths` package
     attribute of direct build/test and transitive link dependencies."""
     edges = traverse.traverse_topo_edges_generator(
         traverse.with_artificial_edges([pkg.spec]),


### PR DESCRIPTION
Closes #49536 sufficiently.

It's a bit of a chaotic list of functions, classes and constants, but at least documents what we expose in `spack.package`.