### PR TITLE
use compiler archspec_name for optimization flags

### DIFF
--- a/lib/spack/spack/archspec.py
+++ b/lib/spack/spack/archspec.py
@@ -33,6 +33,6 @@ def microarchitecture_flags_from_target(
         compiler.version.dotted_numeric_string
     )
     try:
-        return target.optimization_flags(compiler.name, version_number)
+        return target.optimization_flags(compiler.package.archspec_name(), version_number)
     except ValueError:
         return ""


### PR DESCRIPTION
Fixes the issue that `intel-oneapi-compilers` (and probably others) wouldn't get any optimization flags due to wrong name being used when querying for flags.

good: https://gitlab.spack.io/spack/spack-packages/-/jobs/17222354
bad: https://gitlab.spack.io/spack/spack-packages/-/jobs/17443492

`compiler.name` ("intel-oneapi-compiler") doesn't return any flags, unlike `compiler.package.archspec_name()` "oneapi".

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
