### PR TITLE
Parametrize tests to also run against S3 buildcache

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -258,3 +258,51 @@ jobs:
         name: coverage-windows
         path: coverage
         include-hidden-files: true
+  minio-buildcache:
+    runs-on: ubuntu-22.04
+    services:
+      minio:
+        image: minio/minio:edge-cicd
+        env:
+          MINIO_ROOT_USER: minioAccessKey
+          MINIO_ROOT_PASSWORD: minioSecretKey
+        options: >-
+          --health-cmd "mc ready local"
+          --health-timeout 1s
+          --health-start-period 30s
+          --health-start-interval 2s
+        ports:
+          - 9000:9000
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+      with:
+        python-version: '3.7'
+    # On ubuntu 24.04, kcov was removed. It may come back in some future Ubuntu
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@40e9946c182a64b3db1bf51be0dcb915f7802aa9
+    - name: Install kcov with brew
+      run: "brew install kcov"
+    - name: Install Python packages
+      run: |
+          pip install --upgrade pip setuptools pytest pytest-xdist pytest-cov
+          pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
+          pip install --upgrade awscli boto3
+    - name: Run unit tests
+      env:
+          SPACK_PYTHON: python
+          SPACK_TEST_PARALLEL: 2
+          COVERAGE: true
+          COVERAGE_FILE: coverage/.coverage-minio-integration
+          UNIT_TEST_COVERAGE: true
+      run: |
+          source share/spack/setup-env.sh
+          spack unit-test -x --verbose --cov --cov-config=pyproject.toml --minio-integration-tests
+    - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+      with:
+        name: coverage-minio-integration
+        path: coverage
+        include-hidden-files: true

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -760,9 +760,10 @@ def _url_generate_package_index(url: str, tmpdir: str):
     """
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
         try:
-            file_list, read_fn = get_entries_from_cache(
+            filename_to_mtime_mapping, read_fn = get_entries_from_cache(
                 url, tmpspecsdir, component_type=BuildcacheComponent.SPEC
             )
+            file_list = list(filename_to_mtime_mapping.keys())
         except ListMirrorSpecsError as e:
             raise GenerateIndexError(f"Unable to generate package index: {e}") from e
 

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -1,13 +1,13 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import os
 import pathlib
 import re
 import tempfile
 from concurrent.futures import Future, as_completed
 from fnmatch import fnmatch
+from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set, Tuple, cast
 
 import spack.binary_distribution
@@ -31,7 +31,7 @@ from .url_buildcache import (
 
 def _fetch_manifests(
     mirror: Mirror, tmpspecsdir: str
-) -> Tuple[List[str], Callable[[str], URLBuildcacheEntry], List[str]]:
+) -> Tuple[Dict[str, float], Callable[[str], URLBuildcacheEntry], List[str]]:
     """
     Fetch all manifests from the buildcache for a given mirror.
 
@@ -43,7 +43,9 @@ def _fetch_manifests(
     :return: A tuple with three elements - a list of manifest files in the mirror, a
              callable to read each manifest, and a list of blobs in the mirror.
     """
-    manifests, read_fn = get_entries_from_cache(url=mirror.fetch_url, tmpspecsdir=tmpspecsdir)
+    manifest_file_to_mtime_mapping, read_fn = get_entries_from_cache(
+        url=mirror.fetch_url, tmpspecsdir=tmpspecsdir
+    )
     url_to_list = url_util.join(
         mirror.fetch_url, spack.binary_distribution.buildcache_relative_blobs_path()
     )
@@ -57,11 +59,11 @@ def _fetch_manifests(
         )
         for blob_name in blobs
     ]
-    return manifests, read_fn, blobs
+    return manifest_file_to_mtime_mapping, read_fn, blobs
 
 
 def _delete_manifests_from_cache_aws(
-    url: str, tmpspecsdir: str, urls_to_delete: Set[str]
+    url: str, tmpspecsdir: str, urls_to_delete: Set[str], pruning_started_at: float
 ) -> Optional[int]:
     aws = which("aws")
 
@@ -79,7 +81,7 @@ def _delete_manifests_from_cache_aws(
     urls_to_delete = {url_util.path_to_file_url(url) for url in urls_to_delete}
 
     tty.debug(f"Deleting {len(urls_to_delete)} entries from cache at {url}")
-    deleted = _delete_entries_from_cache_manual(tmpspecsdir, urls_to_delete)
+    deleted = _delete_entries_from_cache_manual(tmpspecsdir, urls_to_delete, pruning_started_at)
     tty.debug(f"Deleted {deleted} entries from cache at {url}")
 
     sync_command_args = [
@@ -110,13 +112,15 @@ def _delete_manifests_from_cache_aws(
     return None
 
 
-def _delete_entries_from_cache_manual(url: str, urls_to_delete: Set[str]) -> int:
+def _delete_entries_from_cache_manual(
+    url: str, urls_to_delete: Set[str], pruning_started_at: float
+) -> int:
     pruned_objects = 0
     futures: List[Future] = []
 
     with spack.util.parallel.make_concurrent_executor() as executor:
         for url in urls_to_delete:
-            futures.append(executor.submit(_delete_object, url))
+            futures.append(executor.submit(_delete_object, url, pruning_started_at))
 
         for manifest_or_blob_future in as_completed(futures):
             pruned_objects += manifest_or_blob_future.result()
@@ -124,8 +128,13 @@ def _delete_entries_from_cache_manual(url: str, urls_to_delete: Set[str]) -> int
     return pruned_objects
 
 
-def _delete_object(url: str) -> int:
+def _delete_object(url: str, pruning_started_at: float) -> int:
     try:
+        stat_result = web_util.stat_url(url)
+        assert stat_result is not None
+        if stat_result[1] > pruning_started_at:
+            tty.info(f"Skipping deletion of {url} because it was modified after pruning started")
+            return 0
         web_util.remove_url(url=url)
         tty.info(f"Removed object {url}")
         return 1
@@ -139,6 +148,7 @@ def _prune_orphans(
     manifests: List[str],
     read_fn: Callable[[str], URLBuildcacheEntry],
     blobs: List[str],
+    pruning_started_at: float,
     tmpspecsdir: str,
     dry_run: bool,
 ) -> int:
@@ -226,7 +236,10 @@ def _prune_orphans(
     pruned_manifests: Optional[int] = None
     if mirror.fetch_url.startswith("s3://"):
         pruned_manifests = _delete_manifests_from_cache_aws(
-            url=mirror.fetch_url, tmpspecsdir=tmpspecsdir, urls_to_delete=orphaned_manifests
+            url=mirror.fetch_url,
+            tmpspecsdir=tmpspecsdir,
+            urls_to_delete=orphaned_manifests,
+            pruning_started_at=pruning_started_at,
         )
 
     if pruned_manifests is None:
@@ -241,7 +254,9 @@ def _prune_orphans(
         pruned_object_count = pruned_manifests
 
     pruned_object_count += _delete_entries_from_cache_manual(
-        url=mirror.fetch_url, urls_to_delete=orphans_to_delete
+        url=mirror.fetch_url,
+        urls_to_delete=orphans_to_delete,
+        pruning_started_at=pruning_started_at,
     )
 
     for manifest in orphaned_manifests:
@@ -252,7 +267,9 @@ def _prune_orphans(
     return pruned_object_count
 
 
-def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> None:
+def prune_direct(
+    mirror: Mirror, keeplist_file: pathlib.Path, pruning_started_at: float, dry_run: bool
+) -> None:
     """
     Execute direct pruning for a given mirror using a keeplist file.
 
@@ -264,6 +281,7 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
     Args:
         mirror: Mirror to prune
         keeplist_file: Path to file containing newline-delimited hashes to keep
+        pruning_started_at: Timestamp of when the pruning started
         dry_run: Whether to perform a dry run without actually deleting
     """
     tty.info("=== Direct Pruning Phase ===")
@@ -283,7 +301,7 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
     total_pruned: Optional[int] = None
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
         try:
-            manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
+            manifest_to_mtime_mapping, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
         except Exception as e:
             raise BuildcachePruningException("Error getting entries from buildcache") from e
 
@@ -291,7 +309,7 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
         manifests_to_prune: List[str] = []
         specs_to_prune: List[str] = []
 
-        for manifest in manifest_list:
+        for manifest in manifest_to_mtime_mapping.keys():
             if not fnmatch(
                 manifest,
                 URLBuildcacheEntry.get_buildcache_component_include_pattern(
@@ -341,13 +359,16 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
                     url=mirror.fetch_url,
                     tmpspecsdir=tmpspecsdir,
                     urls_to_delete=manifests_to_delete,
+                    pruning_started_at=pruning_started_at,
                 )
 
             if total_pruned is None:
                 # Fall back to manual deletion if using a non-S3 mirror and/or
                 # AWS CLI is not available
                 total_pruned = _delete_entries_from_cache_manual(
-                    url=mirror.fetch_url, urls_to_delete=manifests_to_delete
+                    url=mirror.fetch_url,
+                    urls_to_delete=manifests_to_delete,
+                    pruning_started_at=pruning_started_at,
                 )
 
     if dry_run:
@@ -361,7 +382,7 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
             tty.info("Run `spack buildcache update-index` to update the index for this mirror.")
 
 
-def prune_orphan(mirror: Mirror, dry_run: bool) -> None:
+def prune_orphan(mirror: Mirror, pruning_started_at: float, dry_run: bool) -> None:
     """
     Execute the pruning process for a given mirror.
 
@@ -373,16 +394,18 @@ def prune_orphan(mirror: Mirror, dry_run: bool) -> None:
     total_pruned = 0
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
         try:
-            manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
+            manifest_to_mtime_mapping, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
+            manifests = list(manifest_to_mtime_mapping.keys())
         except Exception as e:
             raise BuildcachePruningException("Error getting entries from buildcache") from e
         while True:
             # Continue pruning until no more orphaned objects are found
             pruned = _prune_orphans(
                 mirror=mirror,
-                manifests=manifest_list,
+                manifests=manifests,
                 read_fn=read_fn,
                 blobs=blob_list,
+                pruning_started_at=pruning_started_at,
                 tmpspecsdir=tmpspecsdir,
                 dry_run=dry_run,
             )
@@ -406,6 +429,34 @@ def prune_orphan(mirror: Mirror, dry_run: bool) -> None:
                 tty.info(
                     "Run `spack buildcache update-index` to update the index for this mirror."
                 )
+
+
+def get_buildcache_normalized_time(mirror: Mirror) -> float:
+    """
+    Get the current time as reported by the buildcache.
+
+    This is necessary because different buildcache implementations may use different
+    time formats/time zones. This function creates a temporary file, calls `stat_url`
+    on it, and then deletes it. This guarentees that the time used for the beginning
+    of the pruning is consistent across all buildcache implementations.
+    """
+    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as f:
+        tmpdir = Path(f)
+        touch_file = tmpdir / ".spack-prune-marker"
+        touch_file.touch()
+        remote_path = url_util.join(mirror.push_url, touch_file.name)
+
+        web_util.push_to_url(
+            local_file_path=str(touch_file), remote_path=remote_path, keep_original=True
+        )
+
+        stat_info = web_util.stat_url(remote_path)
+        assert stat_info is not None
+        start_time = stat_info[1]
+
+        web_util.remove_url(remote_path)
+
+        return start_time
 
 
 class BuildcachePruningException(spack.error.SpackError):

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -359,7 +359,7 @@ def prune_direct(
             # Attempt to regex match the manifest name in order to extract the name, version,
             # and hash for the spec.
             manifest_name = manifest.split("/")[-1]  # strip off parent directories
-            regex_match = re.match(r"([^ ]+)-([^_ ]+)-([^-_\. ]+)", manifest_name)
+            regex_match = re.match(r"([^ ]+)-([^- ]+)[-_]([^-_\. ]+)", manifest_name)
 
             if regex_match is None:
                 # This should never happen, unless the buildcache is somehow corrupted

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -266,15 +266,17 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
     tty.info("=== Direct Pruning Phase ===")
     tty.debug(f"Direct pruning mirror: {mirror.fetch_url}" + (" (dry run)" if dry_run else ""))
 
+    keep_hashes: Optional[Set[str]] = None
     try:
         keep_hashes = set(
             line.strip() for line in keeplist_file.read_text().splitlines() if line.strip()
         )
     except Exception as e:
-        tty.die(f"Error reading keeplist file {keeplist_file}: {e}")
+        tty.error(f"Error reading keeplist file {keeplist_file}: {e}")
 
     if not keep_hashes:
-        tty.die(f"No hashes found in keeplist file: {keeplist_file}")
+        tty.error(f"No hashes found in keeplist file: {keeplist_file}")
+        return
 
     tty.info(f"Loaded {len(keep_hashes)} hashes to keep from {keeplist_file}")
     total_pruned: Optional[int] = None

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import re
 import tempfile
+import uuid
 from concurrent.futures import Future, as_completed
 from fnmatch import fnmatch
 from pathlib import Path
@@ -442,7 +443,7 @@ def get_buildcache_normalized_time(mirror: Mirror) -> float:
     """
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as f:
         tmpdir = Path(f)
-        touch_file = tmpdir / ".spack-prune-marker"
+        touch_file = tmpdir / f".spack-prune-marker-{uuid.uuid4()}"
         touch_file.touch()
         remote_path = url_util.join(mirror.push_url, touch_file.name)
 

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -259,9 +259,9 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
     to do that, `prune_orphan` must be invoked to clean up the now-orphaned blobs.
 
     Args:
-        mirror (spack.mirrors.mirror.Mirror): Mirror to prune
-        keeplist_file (pathlib.Path): Path to file containing newline-delimited hashes to keep
-        dry_run (bool): Whether to perform a dry run without actually deleting
+        mirror: Mirror to prune
+        keeplist_file: Path to file containing newline-delimited hashes to keep
+        dry_run: Whether to perform a dry run without actually deleting
     """
     tty.info("=== Direct Pruning Phase ===")
     tty.debug(f"Direct pruning mirror: {mirror.fetch_url}" + (" (dry run)" if dry_run else ""))

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -253,8 +253,8 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
     """
     Execute direct pruning for a given mirror using a keeplist file.
 
-    This function reads a file containing package hashes to keep, then deletes
-    all other package manifests from the buildcache.
+    This function reads a file containing spec hashes to keep, then deletes
+    all other spec manifests from the buildcache.
     Note that this function does *not* prune the blobs associated with the manifests;
     to do that, `prune_orphan` must be invoked to clean up the now-orphaned blobs.
 
@@ -308,10 +308,10 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
                     cache_entry.destroy()
 
         if not manifests_to_prune:
-            tty.info("No packages to prune - all packages are in the keeplist")
+            tty.info("No specs to prune - all specs are in the keeplist")
             return
 
-        tty.info(f"Found {len(manifests_to_prune)} package(s) to prune")
+        tty.info(f"Found {len(manifests_to_prune)} spec(s) to prune")
 
         if dry_run:
             for spec_name in specs_to_prune:

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -163,7 +163,7 @@ def _delete_object(url: str) -> int:
         return 0
 
 
-def _object_has_prunable_mtime(url: str, pruning_started_at: float) -> tuple[str, bool]:
+def _object_has_prunable_mtime(url: str, pruning_started_at: float) -> Tuple[str, bool]:
     """Check if an object's modification time makes it eligible for pruning.
 
     Objects modified after pruning started should not be pruned to avoid

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -326,7 +326,7 @@ def prune_direct(
 
     keep_hashes: Set[str] = set()
     for line in keeplist_file.read_text().splitlines():
-        keep_hash = line.strip().lstrip('/')
+        keep_hash = line.strip().lstrip("/")
         if len(keep_hash) != 32:
             raise MalformedKeepListException(f"Found malformed hash in keeplist: {line}")
         keep_hashes.add(keep_hash)

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -9,6 +9,7 @@ from concurrent.futures import Future, as_completed
 from typing import Callable, Dict, List, Optional, Set, Tuple, cast
 
 import spack.binary_distribution
+import spack.error
 import spack.llnl.util.tty as tty
 import spack.stage
 import spack.util.parallel
@@ -272,11 +273,10 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
             line.strip() for line in keeplist_file.read_text().splitlines() if line.strip()
         )
     except Exception as e:
-        tty.error(f"Error reading keeplist file {keeplist_file}: {e}")
+        raise BuildcachePruningException(f"Error reading keeplist file {keeplist_file}") from e
 
     if not keep_hashes:
-        tty.error(f"No hashes found in keeplist file: {keeplist_file}")
-        return
+        raise BuildcachePruningException(f"No hashes found in keeplist file: {keeplist_file}")
 
     tty.info(f"Loaded {len(keep_hashes)} hashes to keep from {keeplist_file}")
     total_pruned: Optional[int] = None
@@ -284,8 +284,7 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
         try:
             manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
         except Exception as e:
-            tty.error(f"Error getting entries from buildcache: {e}")
-            return
+            raise BuildcachePruningException("Error getting entries from buildcache") from e
 
         # Determine which manifests correspond to specs we want to prune
         manifests_to_prune: List[str] = []
@@ -364,8 +363,7 @@ def prune_orphan(mirror: Mirror, dry_run: bool) -> None:
         try:
             manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
         except Exception as e:
-            tty.error(f"Error getting entries from buildcache: {e}")
-            return
+            raise BuildcachePruningException("Error getting entries from buildcache") from e
         while True:
             # Continue pruning until no more orphaned objects are found
             pruned = _prune_orphans(
@@ -396,3 +394,11 @@ def prune_orphan(mirror: Mirror, dry_run: bool) -> None:
                 tty.info(
                     "Run `spack buildcache update-index` to update the index for this mirror."
                 )
+
+
+class BuildcachePruningException(spack.error.SpackError):
+    """
+    Raised when pruning fails irrevocably
+    """
+
+    pass

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -267,13 +267,12 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
     tty.info("=== Direct Pruning Phase ===")
     tty.debug(f"Direct pruning mirror: {mirror.fetch_url}" + (" (dry run)" if dry_run else ""))
 
-    keep_hashes: Optional[Set[str]] = None
-    try:
-        keep_hashes = set(
-            line.strip() for line in keeplist_file.read_text().splitlines() if line.strip()
-        )
-    except Exception as e:
-        raise BuildcachePruningException(f"Error reading keeplist file {keeplist_file}") from e
+    keep_hashes: Set[str] = set()
+    for line in keeplist_file.read_text().splitlines():
+        keep_hash = line.strip()
+        if len(keep_hash) != 32:
+            raise MalformedKeepListException(f"Found malformed hash in keeplist: {keep_hash}")
+        keep_hashes.add(keep_hash)
 
     if not keep_hashes:
         raise BuildcachePruningException(f"No hashes found in keeplist file: {keeplist_file}")
@@ -399,6 +398,15 @@ def prune_orphan(mirror: Mirror, dry_run: bool) -> None:
 class BuildcachePruningException(spack.error.SpackError):
     """
     Raised when pruning fails irrevocably
+    """
+
+    pass
+
+
+class MalformedKeepListException(BuildcachePruningException):
+    """
+    Raised when the keeplist passed to the direct pruner
+    is invalid or malformed in some way
     """
 
     pass

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -255,13 +255,13 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
 
     This function reads a file containing package hashes to keep, then deletes
     all other package manifests from the buildcache.
-
     Note that this function does *not* prune the blobs associated with the manifests;
     to do that, `prune_orphan` must be invoked to clean up the now-orphaned blobs.
 
-    :param mirror: The mirror to prune
-    :param keeplist_file: Path to file containing newline-delimited hashes to keep
-    :param dry_run: Whether to perform a dry run without actually deleting
+    Args:
+        mirror (spack.mirrors.mirror.Mirror): Mirror to prune
+        keeplist_file (pathlib.Path): Path to file containing newline-delimited hashes to keep
+        dry_run (bool): Whether to perform a dry run without actually deleting
     """
     tty.info("=== Direct Pruning Phase ===")
     tty.debug(f"Direct pruning mirror: {mirror.fetch_url}" + (" (dry run)" if dry_run else ""))

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -134,7 +134,7 @@ def _delete_object(url: str, pruning_started_at: float) -> int:
         stat_result = web_util.stat_url(url)
         assert stat_result is not None
         if stat_result[1] > pruning_started_at:
-            tty.info(f"Skipping deletion of {url} because it was modified after pruning started")
+            tty.verbose(f"Skipping deletion of {url} because it was modified after pruning started")
             return 0
         web_util.remove_url(url=url)
         tty.info(f"Removed object {url}")
@@ -285,14 +285,14 @@ def prune_direct(
         pruning_started_at: Timestamp of when the pruning started
         dry_run: Whether to perform a dry run without actually deleting
     """
-    tty.info("=== Direct Pruning Phase ===")
+    tty.info("Running Direct Pruning")
     tty.debug(f"Direct pruning mirror: {mirror.fetch_url}" + (" (dry run)" if dry_run else ""))
 
     keep_hashes: Set[str] = set()
     for line in keeplist_file.read_text().splitlines():
         keep_hash = line.strip()
         if len(keep_hash) != 32:
-            raise MalformedKeepListException(f"Found malformed hash in keeplist: {keep_hash}")
+            raise MalformedKeepListException(f"Found malformed hash in keeplist: {line}")
         keep_hashes.add(keep_hash)
 
     if not keep_hashes:

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -14,6 +14,7 @@ import spack.stage
 import spack.util.parallel
 import spack.util.url as url_util
 import spack.util.web as web_util
+from spack.spec import Spec
 from spack.util.executable import which
 
 from .mirrors.mirror import Mirror
@@ -248,12 +249,108 @@ def _prune_orphans(
     return pruned_object_count
 
 
-def prune(mirror: Mirror, dry_run: bool) -> None:
+def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> None:
+    """
+    Execute direct pruning for a given mirror using a keeplist file.
+
+    This function reads a file containing package hashes to keep, then deletes
+    all other package manifests from the buildcache.
+
+    Note that this function does *not* prune the blobs associated with the manifests;
+    to do that, `prune_orphan` must be invoked to clean up the now-orphaned blobs.
+
+    :param mirror: The mirror to prune
+    :param keeplist_file: Path to file containing newline-delimited hashes to keep
+    :param dry_run: Whether to perform a dry run without actually deleting
+    """
+    tty.info("=== Direct Pruning Phase ===")
+    tty.debug(f"Direct pruning mirror: {mirror.fetch_url}" + (" (dry run)" if dry_run else ""))
+
+    try:
+        keep_hashes = set(
+            line.strip() for line in keeplist_file.read_text().splitlines() if line.strip()
+        )
+    except Exception as e:
+        tty.die(f"Error reading keeplist file {keeplist_file}: {e}")
+
+    if not keep_hashes:
+        tty.die(f"No hashes found in keeplist file: {keeplist_file}")
+
+    tty.info(f"Loaded {len(keep_hashes)} hashes to keep from {keeplist_file}")
+    total_pruned: Optional[int] = None
+    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
+        manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
+
+        # Determine which manifests correspond to specs we want to prune
+        manifests_to_prune: List[str] = []
+        specs_to_prune: List[str] = []
+
+        for manifest in manifest_list:
+            cache_entry: Optional[URLBuildcacheEntry] = None
+            try:
+                cache_entry = cast(URLBuildcacheEntry, read_fn(manifest))
+                spec_dict = cache_entry.fetch_metadata()
+
+                spec = Spec.from_dict(spec_dict)
+                spec_hash = spec.dag_hash()
+                spec_name = spec.name
+
+                if spec_hash not in keep_hashes:
+                    manifests_to_prune.append(manifest)
+                    specs_to_prune.append(f"{spec_name}/{spec_hash[:7]}")
+            except Exception as e:
+                tty.debug(f"Unable to process manifest {manifest} due to: {e}")
+                continue
+            finally:
+                if cache_entry:
+                    cache_entry.destroy()
+
+        if not manifests_to_prune:
+            tty.info("No packages to prune - all packages are in the keeplist")
+            return
+
+        tty.info(f"Found {len(manifests_to_prune)} package(s) to prune")
+
+        if dry_run:
+            for spec_name in specs_to_prune:
+                tty.info(f"  Would prune: {spec_name}")
+            total_pruned = len(manifests_to_prune)
+        else:
+            manifests_to_delete = set(manifests_to_prune)
+
+            # Try AWS CLI deletion first for S3 mirrors
+            if mirror.fetch_url.startswith("s3://"):
+                total_pruned = _delete_manifests_from_cache_aws(
+                    url=mirror.fetch_url,
+                    tmpspecsdir=tmpspecsdir,
+                    urls_to_delete=manifests_to_delete,
+                )
+
+            if total_pruned is None:
+                # Fall back to manual deletion if using a non-S3 mirror and/or
+                # AWS CLI is not available
+                total_pruned = _delete_entries_from_cache_manual(
+                    url=mirror.fetch_url, urls_to_delete=manifests_to_delete
+                )
+
+    if dry_run:
+        tty.info(f"Would have pruned {total_pruned} objects from mirror: {mirror.fetch_url}")
+    else:
+        tty.info(f"Pruned {total_pruned} objects from mirror: {mirror.fetch_url}")
+        if total_pruned > 0:
+            tty.info(
+                "As a consequence of pruning, the buildcache index is now likely out of date."
+            )
+            tty.info("Run `spack buildcache update-index` to update the index for this mirror.")
+
+
+def prune_orphan(mirror: Mirror, dry_run: bool) -> None:
     """
     Execute the pruning process for a given mirror.
 
     Currently, this function only performs the pruning of orphaned manifests and blobs.
     """
+    tty.info("=== Orphan Pruning Phase ===")
     tty.debug(f"Pruning mirror: {mirror.fetch_url}" + (" (dry run)" if dry_run else ""))
 
     total_pruned = 0

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -9,7 +9,7 @@ import uuid
 from concurrent.futures import Future, as_completed
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set, Tuple, cast
+from typing import Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple, cast
 
 import spack.binary_distribution
 import spack.error
@@ -64,7 +64,7 @@ def _fetch_manifests(
 
 
 def _delete_manifests_from_cache_aws(
-    url: str, tmpspecsdir: str, urls_to_delete: Set[str], pruning_started_at: float
+    url: str, tmpspecsdir: str, urls_to_delete: Set[str]
 ) -> Optional[int]:
     aws = which("aws")
 
@@ -82,7 +82,7 @@ def _delete_manifests_from_cache_aws(
     urls_to_delete = {url_util.path_to_file_url(url) for url in urls_to_delete}
 
     tty.debug(f"Deleting {len(urls_to_delete)} entries from cache at {url}")
-    deleted = _delete_entries_from_cache_manual(tmpspecsdir, urls_to_delete, pruning_started_at)
+    deleted = _delete_entries_from_cache_manual(tmpspecsdir, urls_to_delete)
     tty.debug(f"Deleted {deleted} entries from cache at {url}")
 
     sync_command_args = [
@@ -113,15 +113,13 @@ def _delete_manifests_from_cache_aws(
     return None
 
 
-def _delete_entries_from_cache_manual(
-    url: str, urls_to_delete: Set[str], pruning_started_at: float
-) -> int:
+def _delete_entries_from_cache_manual(url: str, urls_to_delete: Set[str]) -> int:
     pruned_objects = 0
     futures: List[Future] = []
 
     with spack.util.parallel.make_concurrent_executor() as executor:
         for url in urls_to_delete:
-            futures.append(executor.submit(_delete_object, url, pruning_started_at))
+            futures.append(executor.submit(_delete_object, url))
 
         for manifest_or_blob_future in as_completed(futures):
             pruned_objects += manifest_or_blob_future.result()
@@ -130,20 +128,13 @@ def _delete_entries_from_cache_manual(
 
 
 def _delete_entries_from_cache(
-    mirror: Mirror,
-    tmpspecsdir: str,
-    manifests_to_delete: Set[str],
-    blobs_to_delete: Set[str],
-    pruning_started_at: float,
+    mirror: Mirror, tmpspecsdir: str, manifests_to_delete: Set[str], blobs_to_delete: Set[str]
 ) -> int:
     pruned_manifests: Optional[int] = None
 
     if mirror.fetch_url.startswith("s3://"):
         pruned_manifests = _delete_manifests_from_cache_aws(
-            url=mirror.fetch_url,
-            tmpspecsdir=tmpspecsdir,
-            urls_to_delete=manifests_to_delete,
-            pruning_started_at=pruning_started_at,
+            url=mirror.fetch_url, tmpspecsdir=tmpspecsdir, urls_to_delete=manifests_to_delete
         )
 
     if pruned_manifests is None:
@@ -158,27 +149,49 @@ def _delete_entries_from_cache(
         pruned_objects = pruned_manifests
 
     return pruned_objects + _delete_entries_from_cache_manual(
-        url=mirror.fetch_url,
-        urls_to_delete=objects_to_delete,
-        pruning_started_at=pruning_started_at,
+        url=mirror.fetch_url, urls_to_delete=objects_to_delete
     )
 
 
-def _delete_object(url: str, pruning_started_at: float) -> int:
+def _delete_object(url: str) -> int:
     try:
-        stat_result = web_util.stat_url(url)
-        assert stat_result is not None
-        if stat_result[1] > pruning_started_at:
-            tty.verbose(
-                f"Skipping deletion of {url} because it was modified after pruning started"
-            )
-            return 0
         web_util.remove_url(url=url)
         tty.info(f"Removed object {url}")
         return 1
     except Exception as e:
         tty.warn(f"Unable to remove object {url} due to: {e}")
         return 0
+
+
+def _object_has_prunable_mtime(url: str, pruning_started_at: float) -> tuple[str, bool]:
+    """Check if an object's modification time makes it eligible for pruning.
+
+    Objects modified after pruning started should not be pruned to avoid
+    race conditions with concurrent uploads.
+    """
+    stat_result = web_util.stat_url(url)
+    assert stat_result is not None
+    if stat_result[1] > pruning_started_at:
+        tty.verbose(f"Skipping deletion of {url} because it was modified after pruning started")
+        return url, False
+    return url, True
+
+
+def _filter_new_specs(urls: Iterable[str], pruning_started_at: float) -> Iterator[str]:
+    """Filter out URLs that were modified after pruning started.
+
+    Runs parallel modification time checks on all URLs and yields only
+    those that are old enough to be safely pruned.
+    """
+    with spack.util.parallel.make_concurrent_executor() as executor:
+        futures = []
+        for url in urls:
+            futures.append(executor.submit(_object_has_prunable_mtime, url, pruning_started_at))
+
+        for manifest_or_blob_future in as_completed(futures):
+            url, has_prunable_mtime = manifest_or_blob_future.result()
+            if has_prunable_mtime:
+                yield url
 
 
 def _prune_orphans(
@@ -254,6 +267,10 @@ def _prune_orphans(
     if not orphaned_blobs and not orphaned_manifests:
         return 0
 
+    # Filter out any new specs that have been uploaded since the pruning started
+    orphaned_blobs = set(_filter_new_specs(orphaned_blobs, pruning_started_at))
+    orphaned_manifests = set(_filter_new_specs(orphaned_manifests, pruning_started_at))
+
     if orphaned_blobs:
         tty.info(f"Found {len(orphaned_blobs)} blob(s) with no manifest")
     if orphaned_manifests:
@@ -277,7 +294,6 @@ def _prune_orphans(
         tmpspecsdir=tmpspecsdir,
         manifests_to_delete=orphaned_manifests,
         blobs_to_delete=orphaned_blobs,
-        pruning_started_at=pruning_started_at,
     )
 
     for manifest in orphaned_manifests:
@@ -372,14 +388,13 @@ def prune_direct(
                 tty.info(f"  Would prune: {spec_name}")
             total_pruned = len(manifests_to_prune)
         else:
-            manifests_to_delete = set(manifests_to_prune)
+            manifests_to_delete = set(_filter_new_specs(manifests_to_prune, pruning_started_at))
 
             total_pruned = _delete_entries_from_cache(
                 mirror=mirror,
                 tmpspecsdir=tmpspecsdir,
                 manifests_to_delete=manifests_to_delete,
                 blobs_to_delete=set(),
-                pruning_started_at=pruning_started_at,
             )
 
     if dry_run:

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -78,9 +78,6 @@ def _delete_manifests_from_cache_aws(
 
     file_count_before_deletion = len(list(pathlib.Path(tmpspecsdir).rglob(include_pattern)))
 
-    # Add file:// prefix to URLs so that they are deleted properly by web_util.remove_url
-    urls_to_delete = {url_util.path_to_file_url(url) for url in urls_to_delete}
-
     tty.debug(f"Deleting {len(urls_to_delete)} entries from cache at {url}")
     deleted = _delete_entries_from_cache_manual(tmpspecsdir, urls_to_delete)
     tty.debug(f"Deleted {deleted} entries from cache at {url}")

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -4,8 +4,10 @@
 
 import os
 import pathlib
+import re
 import tempfile
 from concurrent.futures import Future, as_completed
+from fnmatch import fnmatch
 from typing import Callable, Dict, List, Optional, Set, Tuple, cast
 
 import spack.binary_distribution
@@ -15,12 +17,12 @@ import spack.stage
 import spack.util.parallel
 import spack.util.url as url_util
 import spack.util.web as web_util
-from spack.spec import Spec
 from spack.util.executable import which
 
 from .mirrors.mirror import Mirror
 from .url_buildcache import (
     CURRENT_BUILD_CACHE_LAYOUT_VERSION,
+    BuildcacheComponent,
     URLBuildcacheEntry,
     get_entries_from_cache,
     get_url_buildcache_class,
@@ -290,24 +292,35 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
         specs_to_prune: List[str] = []
 
         for manifest in manifest_list:
-            cache_entry: Optional[URLBuildcacheEntry] = None
-            try:
-                cache_entry = cast(URLBuildcacheEntry, read_fn(manifest))
-                spec_dict = cache_entry.fetch_metadata()
-
-                spec = Spec.from_dict(spec_dict)
-                spec_hash = spec.dag_hash()
-                spec_name = spec.name
-
-                if spec_hash not in keep_hashes:
-                    manifests_to_prune.append(manifest)
-                    specs_to_prune.append(f"{spec_name}/{spec_hash[:7]}")
-            except Exception as e:
-                tty.debug(f"Unable to process manifest {manifest} due to: {e}")
+            if not fnmatch(
+                manifest,
+                URLBuildcacheEntry.get_buildcache_component_include_pattern(
+                    BuildcacheComponent.SPEC
+                ),
+            ):
+                tty.info(f"Found a non-spec manifest at {manifest}, skipping...")
                 continue
-            finally:
-                if cache_entry:
-                    cache_entry.destroy()
+
+            # Attempt to regex match the manifest name in order to extract the name, version,
+            # and hash for the spec.
+            regex_match = re.match(r"([^ ]+)-([^_ ]+)-([^-_\. ]+)", manifest)
+
+            if regex_match is None:
+                # This should never happen, unless the buildcache is somehow corrupted
+                # and/or there is a bug.
+                raise BuildcachePruningException(
+                    "Unable to extract spec name, version, and hash from "
+                    f'the manifest named "{manifest}"'
+                )
+
+            spec_name, spec_version, spec_hash = regex_match.groups()
+
+            # Chop off any prefix/parent file path to get just the name
+            spec_name = pathlib.Path(spec_name).name
+
+            if spec_hash not in keep_hashes:
+                manifests_to_prune.append(manifest)
+                specs_to_prune.append(f"{spec_name}/{spec_hash[:7]}")
 
         if not manifests_to_prune:
             tty.info("No specs to prune - all specs are in the keeplist")

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -326,7 +326,7 @@ def prune_direct(
 
     keep_hashes: Set[str] = set()
     for line in keeplist_file.read_text().splitlines():
-        keep_hash = line.strip()
+        keep_hash = line.strip().lstrip('/')
         if len(keep_hash) != 32:
             raise MalformedKeepListException(f"Found malformed hash in keeplist: {line}")
         keep_hashes.add(keep_hash)

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -281,7 +281,11 @@ def prune_direct(mirror: Mirror, keeplist_file: pathlib.Path, dry_run: bool) -> 
     tty.info(f"Loaded {len(keep_hashes)} hashes to keep from {keeplist_file}")
     total_pruned: Optional[int] = None
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
-        manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
+        try:
+            manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
+        except Exception as e:
+            tty.error(f"Error getting entries from buildcache: {e}")
+            return
 
         # Determine which manifests correspond to specs we want to prune
         manifests_to_prune: List[str] = []
@@ -357,7 +361,11 @@ def prune_orphan(mirror: Mirror, dry_run: bool) -> None:
 
     total_pruned = 0
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
-        manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
+        try:
+            manifest_list, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
+        except Exception as e:
+            tty.error(f"Error getting entries from buildcache: {e}")
+            return
         while True:
             # Continue pruning until no more orphaned objects are found
             pruned = _prune_orphans(

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -129,12 +129,49 @@ def _delete_entries_from_cache_manual(
     return pruned_objects
 
 
+def _delete_entries_from_cache(
+    mirror: Mirror,
+    tmpspecsdir: str,
+    manifests_to_delete: Set[str],
+    blobs_to_delete: Set[str],
+    pruning_started_at: float,
+) -> int:
+    pruned_manifests: Optional[int] = None
+
+    if mirror.fetch_url.startswith("s3://"):
+        pruned_manifests = _delete_manifests_from_cache_aws(
+            url=mirror.fetch_url,
+            tmpspecsdir=tmpspecsdir,
+            urls_to_delete=manifests_to_delete,
+            pruning_started_at=pruning_started_at,
+        )
+
+    if pruned_manifests is None:
+        # If the AWS CLI deletion failed, we fall back to deleting both manifests
+        # and blobs with the fallback method.
+        objects_to_delete = blobs_to_delete.union(manifests_to_delete)
+        pruned_objects = 0
+    else:
+        # If the AWS CLI deletion succeeded, we only need to worry about
+        # deleting the blobs, since the manifests have already been deleted.
+        objects_to_delete = blobs_to_delete
+        pruned_objects = pruned_manifests
+
+    return pruned_objects + _delete_entries_from_cache_manual(
+        url=mirror.fetch_url,
+        urls_to_delete=objects_to_delete,
+        pruning_started_at=pruning_started_at,
+    )
+
+
 def _delete_object(url: str, pruning_started_at: float) -> int:
     try:
         stat_result = web_util.stat_url(url)
         assert stat_result is not None
         if stat_result[1] > pruning_started_at:
-            tty.verbose(f"Skipping deletion of {url} because it was modified after pruning started")
+            tty.verbose(
+                f"Skipping deletion of {url} because it was modified after pruning started"
+            )
             return 0
         web_util.remove_url(url=url)
         tty.info(f"Removed object {url}")
@@ -222,6 +259,8 @@ def _prune_orphans(
     if orphaned_manifests:
         tty.info(f"Found {len(orphaned_manifests)} manifest(s) that are missing blobs")
 
+    # If dry run, just print the manifests and blobs that would be deleted
+    # and exit early.
     if dry_run:
         pruned_object_count = len(orphaned_blobs) + len(orphaned_manifests)
         for manifest in orphaned_manifests:
@@ -232,31 +271,12 @@ def _prune_orphans(
             tty.info(f"  Would prune blob: {blob}")
         return pruned_object_count
 
-    # Try to delete the orphaned manifests using the AWS CLI,
-    # if possible.
-    pruned_manifests: Optional[int] = None
-    if mirror.fetch_url.startswith("s3://"):
-        pruned_manifests = _delete_manifests_from_cache_aws(
-            url=mirror.fetch_url,
-            tmpspecsdir=tmpspecsdir,
-            urls_to_delete=orphaned_manifests,
-            pruning_started_at=pruning_started_at,
-        )
-
-    if pruned_manifests is None:
-        # If the AWS CLI deletion failed, we fall back to deleting both manifests
-        # and blobs with the fallback method.
-        orphans_to_delete = orphaned_blobs.union(orphaned_manifests)
-        pruned_object_count = 0
-    else:
-        # If the AWS CLI deletion succeeded, we only need to worry about
-        # deleting the blobs, since the manifests have already been deleted.
-        orphans_to_delete = orphaned_blobs
-        pruned_object_count = pruned_manifests
-
-    pruned_object_count += _delete_entries_from_cache_manual(
-        url=mirror.fetch_url,
-        urls_to_delete=orphans_to_delete,
+    # Otherwise, perform the deletions.
+    pruned_object_count = _delete_entries_from_cache(
+        mirror=mirror,
+        tmpspecsdir=tmpspecsdir,
+        manifests_to_delete=orphaned_manifests,
+        blobs_to_delete=orphaned_blobs,
         pruning_started_at=pruning_started_at,
     )
 
@@ -354,23 +374,13 @@ def prune_direct(
         else:
             manifests_to_delete = set(manifests_to_prune)
 
-            # Try AWS CLI deletion first for S3 mirrors
-            if mirror.fetch_url.startswith("s3://"):
-                total_pruned = _delete_manifests_from_cache_aws(
-                    url=mirror.fetch_url,
-                    tmpspecsdir=tmpspecsdir,
-                    urls_to_delete=manifests_to_delete,
-                    pruning_started_at=pruning_started_at,
-                )
-
-            if total_pruned is None:
-                # Fall back to manual deletion if using a non-S3 mirror and/or
-                # AWS CLI is not available
-                total_pruned = _delete_entries_from_cache_manual(
-                    url=mirror.fetch_url,
-                    urls_to_delete=manifests_to_delete,
-                    pruning_started_at=pruning_started_at,
-                )
+            total_pruned = _delete_entries_from_cache(
+                mirror=mirror,
+                tmpspecsdir=tmpspecsdir,
+                manifests_to_delete=manifests_to_delete,
+                blobs_to_delete=set(),
+                pruning_started_at=pruning_started_at,
+            )
 
     if dry_run:
         tty.info(f"Would have pruned {total_pruned} objects from mirror: {mirror.fetch_url}")

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -358,14 +358,15 @@ def prune_direct(
 
             # Attempt to regex match the manifest name in order to extract the name, version,
             # and hash for the spec.
-            regex_match = re.match(r"([^ ]+)-([^_ ]+)-([^-_\. ]+)", manifest)
+            manifest_name = manifest.split("/")[-1]  # strip off parent directories
+            regex_match = re.match(r"([^ ]+)-([^_ ]+)-([^-_\. ]+)", manifest_name)
 
             if regex_match is None:
                 # This should never happen, unless the buildcache is somehow corrupted
                 # and/or there is a bug.
                 raise BuildcachePruningException(
                     "Unable to extract spec name, version, and hash from "
-                    f'the manifest named "{manifest}"'
+                    f'the manifest named "{manifest_name}"'
                 )
 
             spec_name, spec_version, spec_hash = regex_match.groups()

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -858,7 +858,15 @@ def prune_fn(args):
     dry_run: bool = args.dry_run
     assert isinstance(mirror, spack.mirrors.mirror.Mirror)
 
-    started_at = get_buildcache_normalized_time(mirror)
+    # Determine the time to use as the "started at" time for pruning.
+    # If a cache index exists, use that time. Otherwise, use the current time (normalized
+    # to the buildcache's time zone).
+    cache_index_url = URLBuildcacheEntry.get_index_url(mirror_url=mirror.fetch_url)
+    stat_result = web_util.stat_url(cache_index_url)
+    if stat_result is not None:
+        started_at = stat_result[1]
+    else:
+        started_at = get_buildcache_normalized_time(mirror)
 
     if args.keeplist:
         prune_direct(mirror, pathlib.Path(args.keeplist), started_at, dry_run)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -4,6 +4,7 @@
 import argparse
 import glob
 import json
+import pathlib
 import sys
 import tempfile
 from typing import List, Optional, Tuple
@@ -32,7 +33,7 @@ from spack.llnl.util.lang import elide_list, stable_partition
 from spack.spec import Spec, save_dependency_specfiles
 
 from ..buildcache_migrate import migrate
-from ..buildcache_prune import prune
+from ..buildcache_prune import prune_direct, prune_orphan
 from ..enums import InstallRecordStatus
 from ..url_buildcache import (
     BuildcacheComponent,
@@ -215,6 +216,12 @@ def setup_parser(subparser: argparse.ArgumentParser):
     prune = subparsers.add_parser("prune", help=prune_fn.__doc__)
     prune.add_argument(
         "mirror", type=arguments.mirror_name_or_url, help="mirror name, path, or URL"
+    )
+    prune.add_argument(
+        "-k",
+        "--keeplist",
+        default=None,
+        help="file containing newline-delimited list of package hashes to keep (optional)",
     )
     prune.add_argument(
         "--dry-run",
@@ -842,12 +849,19 @@ def migrate_fn(args):
 
 
 def prune_fn(args):
-    """prune stale buildcache entries from the mirror"""
+    """prune buildcache entries from the mirror
+
+    If a keeplist file is provided, performs direct pruning (deletes packages not in keeplist)
+    followed by orphan pruning. If no keeplist is provided, only performs orphan pruning.
+    """
     mirror: spack.mirrors.mirror.Mirror = args.mirror
     dry_run: bool = args.dry_run
     assert isinstance(mirror, spack.mirrors.mirror.Mirror)
 
-    prune(mirror, dry_run)
+    if args.keeplist:
+        prune_direct(mirror, pathlib.Path(args.keeplist), dry_run)
+
+    prune_orphan(mirror, dry_run)
 
 
 def buildcache(parser, args):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -33,7 +33,7 @@ from spack.llnl.util.lang import elide_list, stable_partition
 from spack.spec import Spec, save_dependency_specfiles
 
 from ..buildcache_migrate import migrate
-from ..buildcache_prune import prune_direct, prune_orphan
+from ..buildcache_prune import get_buildcache_normalized_time, prune_direct, prune_orphan
 from ..enums import InstallRecordStatus
 from ..url_buildcache import (
     BuildcacheComponent,
@@ -858,10 +858,12 @@ def prune_fn(args):
     dry_run: bool = args.dry_run
     assert isinstance(mirror, spack.mirrors.mirror.Mirror)
 
-    if args.keeplist:
-        prune_direct(mirror, pathlib.Path(args.keeplist), dry_run)
+    started_at = get_buildcache_normalized_time(mirror)
 
-    prune_orphan(mirror, dry_run)
+    if args.keeplist:
+        prune_direct(mirror, pathlib.Path(args.keeplist), started_at, dry_run)
+
+    prune_orphan(mirror, started_at, dry_run)
 
 
 def buildcache(parser, args):

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -891,7 +891,7 @@ def test_buildcache_prune_direct_with_keeplist(
 def test_buildcache_prune_direct_removes_unlisted(
     tmp_path: pathlib.Path, mutable_database, mock_gnupghome, dry_run
 ):
-    """Test that direct pruning removes packages not in the keeplist"""
+    """Test that direct pruning removes specs not in the keeplist"""
     mirror_directory = str(tmp_path)
     mirror("add", "--unsigned", "my-mirror", mirror_directory)
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -10,6 +10,7 @@ import shutil
 import urllib.parse
 from datetime import datetime, timedelta
 from typing import Dict, List
+from uuid import uuid4
 
 import pytest
 
@@ -64,6 +65,48 @@ def mock_get_specs_multiarch(database, monkeypatch):
             break
 
     monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: specs)
+
+
+@pytest.fixture
+def buildcache_url_fs(tmp_path):
+    return "file://" + str(tmp_path)
+
+
+@pytest.fixture
+def buildcache_url_minio(request):
+    import boto3
+
+    # Set up MinIO environment variables.
+    # These can be overridden by the user, but defaults are provided that align
+    # with what CI uses.
+    os.environ["AWS_ACCESS_KEY_ID"] = os.environ.get("AWS_ACCESS_KEY_ID", "minioAccessKey")
+    os.environ["AWS_SECRET_ACCESS_KEY"] = os.environ.get("AWS_SECRET_ACCESS_KEY", "minioSecretKey")
+    os.environ["AWS_ENDPOINT_URL"] = os.environ.get("AWS_ENDPOINT_URL", "http://localhost:9000")
+
+    s3 = boto3.client("s3")
+
+    bucket_name = f"spack-{uuid4()}"
+
+    s3.create_bucket(Bucket=bucket_name)
+
+    yield f"s3://{bucket_name}"
+
+    bucket = boto3.resource("s3").Bucket(bucket_name)
+    bucket.objects.all().delete()
+    bucket.delete()
+
+
+@pytest.fixture(params=["buildcache_url_fs", "buildcache_url_minio"])
+def buildcache_url(request: pytest.FixtureRequest):
+    run_minio = request.config.getoption("--minio-integration-tests")
+
+    # Filter parameters based on flag
+    if run_minio and request.param != "buildcache_url_minio":
+        pytest.skip("Skipping non-MinIO variant because --minio-integration-tests is set")
+    elif not run_minio and request.param == "buildcache_url_minio":
+        pytest.skip("Skipping MinIO variant because --minio-integration-tests is NOT set")
+
+    return request.getfixturevalue(request.param)
 
 
 @pytest.mark.db
@@ -178,13 +221,12 @@ def test_update_key_index(
     assert "keys.manifest.json" in key_dir_list
 
 
-def test_buildcache_autopush(tmp_path: pathlib.Path, install_mockery, mock_fetch):
+def test_buildcache_autopush(buildcache_url, install_mockery, mock_fetch):
     """Test buildcache with autopush"""
-    mirror_dir = tmp_path / "mirror"
-    mirror_autopush_dir = tmp_path / "mirror_autopush"
+    autopush_buildcache_url = buildcache_url + "/mirror_autopush"
 
-    mirror("add", "--unsigned", "mirror", mirror_dir.as_uri())
-    mirror("add", "--autopush", "--unsigned", "mirror-autopush", mirror_autopush_dir.as_uri())
+    mirror("add", "--unsigned", "mirror", buildcache_url)
+    mirror("add", "--autopush", "--unsigned", "mirror-autopush", autopush_buildcache_url)
 
     s = spack.concretize.concretize_one("libdwarf")
 
@@ -196,9 +238,8 @@ def test_buildcache_autopush(tmp_path: pathlib.Path, install_mockery, mock_fetch
     specs_dirs = os.path.join(
         *URLBuildcacheEntry.get_relative_path_components(BuildcacheComponent.SPEC), s.name
     )
-
-    assert not (mirror_dir / specs_dirs / manifest_file).exists()
-    assert (mirror_autopush_dir / specs_dirs / manifest_file).exists()
+    assert not web_util.url_exists(url_util.join(buildcache_url, specs_dirs, manifest_file))
+    assert web_util.url_exists(url_util.join(autopush_buildcache_url, specs_dirs, manifest_file))
 
 
 def test_buildcache_sync(
@@ -766,8 +807,8 @@ def test_migrate_requires_index(capsys, v2_buildcache_layout, mutable_config):
 
 
 @pytest.mark.parametrize("dry_run", [False, True])
-def test_buildcache_prune_no_orphans(tmp_path, mutable_database, mock_gnupghome, dry_run):
-    mirror("add", "--unsigned", "my-mirror", str(tmp_path))
+def test_buildcache_prune_no_orphans(buildcache_url, mutable_database, mock_gnupghome, dry_run):
+    mirror("add", "--unsigned", "my-mirror", buildcache_url)
     spec = mutable_database.query_local("libelf", installed=True)[0]
     buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
@@ -780,27 +821,23 @@ def test_buildcache_prune_no_orphans(tmp_path, mutable_database, mock_gnupghome,
 
 
 @pytest.mark.parametrize("dry_run", [False, True])
-def test_buildcache_prune_orphaned_blobs(tmp_path, mutable_database, mock_gnupghome, dry_run):
+def test_buildcache_prune_orphaned_blobs(
+    buildcache_url, mutable_database, mock_gnupghome, dry_run
+):
     # Create a mirror and push a package to it
-    mirror_directory = str(tmp_path)
-
-    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+    mirror("add", "--unsigned", "my-mirror", buildcache_url)
     spec = mutable_database.query_local("libelf", installed=True)[0]
     buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
-    cache_entry = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
-    )
+    cache_entry = URLBuildcacheEntry(mirror_url=buildcache_url, spec=spec, allow_unsigned=True)
 
     blob_urls = [
-        URLBuildcacheEntry.get_blob_url(mirror_url=f"file://{mirror_directory}", record=blob)
+        URLBuildcacheEntry.get_blob_url(mirror_url=buildcache_url, record=blob)
         for blob in cache_entry.read_manifest().data
     ]
 
     # Remove the manifest from the cache, orphaning the blobs
-    manifest_url = URLBuildcacheEntry.get_manifest_url(
-        spec, mirror_url=f"file://{mirror_directory}"
-    )
+    manifest_url = URLBuildcacheEntry.get_manifest_url(spec, mirror_url=buildcache_url)
     web_util.remove_url(manifest_url)
 
     # Ensure the blobs are still there before pruning
@@ -820,27 +857,25 @@ def test_buildcache_prune_orphaned_blobs(tmp_path, mutable_database, mock_gnupgh
 
 
 @pytest.mark.parametrize("dry_run", [False, True])
-def test_buildcache_prune_orphaned_manifest(tmp_path, mutable_database, mock_gnupghome, dry_run):
+def test_buildcache_prune_orphaned_manifest(
+    buildcache_url, mutable_database, mock_gnupghome, dry_run
+):
     # Create a mirror and push a package to it
-    mirror_directory = str(tmp_path)
-
-    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+    mirror("add", "--unsigned", "my-mirror", buildcache_url)
     spec = mutable_database.query_local("libelf", installed=True)[0]
     buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
     # Create a cache entry and read the manifest, which should succeed
     # as we haven't pruned anything yet
-    cache_entry = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
-    )
+    cache_entry = URLBuildcacheEntry(mirror_url=buildcache_url, spec=spec, allow_unsigned=True)
     manifest = cache_entry.read_manifest()
 
-    manifest_url = f"file://{cache_entry.get_manifest_url(spec=spec, mirror_url=mirror_directory)}"
+    manifest_url = cache_entry.get_manifest_url(spec=spec, mirror_url=buildcache_url)
 
     # Remove the blobs from the cache, orphaning the manifest
     for blob_file in manifest.data:
-        blob_url = cache_entry.get_blob_url(mirror_url=mirror_directory, record=blob_file)
-        web_util.remove_url(url=f"file://{blob_url}")
+        blob_url = cache_entry.get_blob_url(mirror_url=buildcache_url, record=blob_file)
+        web_util.remove_url(url=blob_url)
 
     cmd_args = ["prune", "my-mirror"]
     if dry_run:

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -13,6 +13,7 @@ import pytest
 
 import spack.binary_distribution
 import spack.buildcache_migrate as migrate
+import spack.buildcache_prune
 import spack.cmd.buildcache
 import spack.concretize
 import spack.environment as ev

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -7,6 +7,7 @@ import json
 import os
 import pathlib
 import shutil
+import urllib.parse
 from datetime import datetime, timedelta
 from typing import Dict, List
 
@@ -982,7 +983,8 @@ def test_buildcache_prune_new_specs_race_condition(
         """
         if url == manifest_url:
             return 1, datetime.now().timestamp() + timedelta(minutes=10).total_seconds()
-        stat_result = pathlib.Path(url.removeprefix("file://")).stat()
+        parsed_url = urllib.parse.urlparse(url)
+        stat_result = pathlib.Path(parsed_url.path).stat()
         return stat_result.st_size, stat_result.st_mtime
 
     monkeypatch.setattr(web_util, "stat_url", mock_stat_url)

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -73,7 +73,11 @@ def buildcache_url_fs(tmp_path):
 
 
 @pytest.fixture
-def buildcache_url_minio(request):
+def buildcache_url_minio(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
+    if not request.config.getoption("--minio-integration-tests", default=False):
+        pytest.skip("MinIO tests disabled, use --minio-integration-tests to enable")
+
+    # Assume boto3 is installed, since the user has requested MinIO integration tests
     import boto3
 
     # Set up MinIO environment variables.

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -850,3 +850,87 @@ def test_buildcache_prune_orphaned_manifest(tmp_path, mutable_database, mock_gnu
     assert "Found 1 manifest(s) that are missing blobs" in output
 
     cache_entry.destroy()
+
+
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_buildcache_prune_direct_with_keeplist(
+    tmp_path: pathlib.Path, mutable_database, mock_gnupghome, dry_run
+):
+    """Test direct pruning functionality with a keeplist file"""
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # Install and push multiple packages
+    specs = mutable_database.query_local("libelf", installed=True)
+    spec1 = specs[0]
+
+    cache_entry = URLBuildcacheEntry(
+        mirror_url=f"file://{mirror_directory}", spec=spec1, allow_unsigned=True
+    )
+    manifest_url = cache_entry.get_manifest_url(spec1, f"file://{mirror_directory}")
+
+    # Push the first spec (package only, no dependencies)
+    buildcache("push", "--only", "package", "--update-index", "my-mirror", f"/{spec1.dag_hash()}")
+
+    # Create a keeplist file that includes only spec1
+    keeplist_file = tmp_path / "keeplist.txt"
+    keeplist_file.write_text(f"{spec1.dag_hash()}\n")
+
+    # Run direct pruning
+    cmd_args = ["prune", "my-mirror", "--keeplist", str(keeplist_file)]
+    if dry_run:
+        cmd_args.append("--dry-run")
+    output = buildcache(*cmd_args)
+
+    # Since all packages are in the keeplist, nothing should be pruned
+    assert web_util.url_exists(manifest_url)
+    assert "No specs to prune - all specs are in the keeplist" in output
+
+
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_buildcache_prune_direct_removes_unlisted(
+    tmp_path: pathlib.Path, mutable_database, mock_gnupghome, dry_run
+):
+    """Test that direct pruning removes packages not in the keeplist"""
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # Install and push a package (package only, no dependencies)
+    specs = mutable_database.query_local("libelf", installed=True)
+    spec1 = specs[0]
+    buildcache("push", "--only", "package", "--update-index", "my-mirror", f"/{spec1.dag_hash()}")
+
+    # Create a keeplist file that excludes the pushed package
+    keeplist_file = tmp_path / "keeplist.txt"
+    keeplist_file.write_text("0" * 32)
+
+    cache_entry = URLBuildcacheEntry(
+        mirror_url=f"file://{mirror_directory}", spec=spec1, allow_unsigned=True
+    )
+    manifest_url = cache_entry.get_manifest_url(spec1, f"file://{mirror_directory}")
+
+    assert web_util.url_exists(manifest_url)
+
+    # Run direct pruning
+    cmd_args = ["prune", "my-mirror", "--keeplist", str(keeplist_file)]
+    if dry_run:
+        cmd_args.append("--dry-run")
+    buildcache(*cmd_args)
+
+    assert web_util.url_exists(manifest_url) == dry_run
+
+
+def test_buildcache_prune_direct_empty_keeplist_fails(
+    tmp_path: pathlib.Path, mutable_database, mock_gnupghome
+):
+    """Test that direct pruning fails with an empty keeplist file"""
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # Create empty keeplist file
+    keeplist_file = tmp_path / "empty_keeplist.txt"
+    keeplist_file.write_text("")
+
+    # Should fail with empty keeplist
+    with pytest.raises(spack.main.SpackCommandError):
+        buildcache("prune", "my-mirror", "--keeplist", str(keeplist_file))

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -7,6 +7,7 @@ import json
 import os
 import pathlib
 import shutil
+from datetime import datetime, timedelta
 from typing import Dict, List
 
 import pytest
@@ -957,78 +958,43 @@ def test_buildcache_prune_with_invalid_keep_hash(
 
 
 def test_buildcache_prune_new_specs_race_condition(
-    tmp_path: pathlib.Path, mutable_database, mock_gnupghome, monkeypatch
+    tmp_path: pathlib.Path, mutable_database, mock_gnupghome, monkeypatch: pytest.MonkeyPatch
 ):
-    """Test that specs uploaded after pruning begins are not considered for pruning"""
-
+    """Test that specs uploaded after pruning begins are protected"""
     mirror_directory = str(tmp_path)
     mirror("add", "--unsigned", "my-mirror", mirror_directory)
 
-    # Install and push multiple packages
-    spec1 = mutable_database.query_local("libelf", installed=True)[0]
-    spec2 = mutable_database.query_local("mpich", installed=True)[0]
+    spec = mutable_database.query_local("libelf", installed=True)[0]
 
-    # Push libelf first (this will be "old" and should be pruned)
-    buildcache("push", "--only", "package", "--update-index", "my-mirror", f"/{spec1.dag_hash()}")
+    buildcache("push", "--only", "package", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
-    # Get current time to simulate pruning start time
-    pruning_start_time = time.time()
-
-    # Wait a moment, then push mpich (this will be "new" and should be protected)
-    time.sleep(0.1)
-    buildcache("push", "--only", "package", "--update-index", "my-mirror", f"/{spec2.dag_hash()}")
-
-    # Create a keeplist with a dummy hash so both specs are not in the keeplist.
-    keeplist_file = tmp_path / "keeplist.txt"
-    keeplist_file.write_text("00000000000000000000000000000000\n")
-
-    # Mock stat_url to return different modification times for different specs
-    original_stat_url = web_util.stat_url
+    cache_entry = URLBuildcacheEntry(
+        mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
+    )
+    manifest_url = cache_entry.get_manifest_url(spec, f"file://{mirror_directory}")
 
     def mock_stat_url(url: str):
-        """Mock stat_url to simulate different modification times"""
-        # Call original stat first to get real size
-        original_result = original_stat_url(url)
-        if original_result is None:
-            return None
-        size = original_result[0]
+        """
+        Mock the stat_url function for testing.
 
-        # For mpich, return a time after pruning started (should be protected)
-        if spec2.dag_hash() in url:
-            return (size, pruning_start_time + 10)  # Modified after pruning started
-        # For libelf, return a time before pruning started (should be pruned)
-        elif spec1.dag_hash() in url:
-            return (size, pruning_start_time - 10)  # Modified before pruning started
-        else:
-            return original_result
+        For the specific spec created in this test, fake its mtime so that it appears to
+        have been created after the pruning started.
+        """
+        if url == manifest_url:
+            return 1, datetime.now().timestamp() + timedelta(minutes=10).total_seconds()
+        stat_result = pathlib.Path(url.removeprefix("file://")).stat()
+        return stat_result.st_size, stat_result.st_mtime
 
     monkeypatch.setattr(web_util, "stat_url", mock_stat_url)
 
-    # Get URLs for both specs before pruning
-    cache_entry1 = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec1, allow_unsigned=True
-    )
-    cache_entry2 = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec2, allow_unsigned=True
-    )
-    manifest_url1 = cache_entry1.get_manifest_url(spec1, f"file://{mirror_directory}")
-    manifest_url2 = cache_entry2.get_manifest_url(spec2, f"file://{mirror_directory}")
+    keeplist_file = tmp_path / "keeplist.txt"
+    keeplist_file.write_text("0" * 32)
 
-    # Verify both specs exist before pruning
-    assert web_util.url_exists(manifest_url1)
-    assert web_util.url_exists(manifest_url2)
-
-    # Run direct pruning with dummy keeplist (both specs would normally be pruned)
+    # Run end-to-end buildcache prune - this should not delete `libelf`, despite it
+    # not being in the keeplist, because its mtime is after the pruning started
+    assert web_util.url_exists(manifest_url)
     output = buildcache("prune", "my-mirror", "--keeplist", str(keeplist_file))
+    assert web_util.url_exists(manifest_url)
 
-    # Verify the race condition protection worked:
-    # 1. The pruner should find 2 specs to prune
-    assert "Found 2 spec(s) to prune" in output
-
-    # 2. But due to race condition protection, no objects should be pruned in direct phase
-    assert "Pruned 0 objects from mirror" in output
-
-    # 3. Both manifests should still exist because the race condition logic
-    #    protected them from deletion (they appear to be modified after pruning started)
-    assert web_util.url_exists(manifest_url1)
-    assert web_util.url_exists(manifest_url2)
+    # Verify the race condition warning message appears for protected objects
+    assert "Skipping deletion" in output and "modified after pruning started" in output

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -77,8 +77,13 @@ def buildcache_url_minio(request: pytest.FixtureRequest, monkeypatch: pytest.Mon
     if not request.config.getoption("--minio-integration-tests", default=False):
         pytest.skip("MinIO tests disabled, use --minio-integration-tests to enable")
 
-    def _entries_from_cache_fallback_patch(*args, **kwargs):
-        raise NotImplementedError()
+    def _entries_from_cache_fallback_patch(url: str, *args, **kwargs):
+        if url.startswith("s3://"):
+            raise NotImplementedError()
+        else:
+            from spack.url_buildcache import _entries_from_cache_fallback
+
+            return _entries_from_cache_fallback(url, *args, **kwargs)
 
     # We want to ensure the MinIO tests use the `_entries_from_cache_aws_cli`
     # function, and do not fall back to the `_entries_from_cache_fallback`
@@ -911,20 +916,18 @@ def test_buildcache_prune_orphaned_manifest(
 
 @pytest.mark.parametrize("dry_run", [False, True])
 def test_buildcache_prune_direct_with_keeplist(
-    tmp_path: pathlib.Path, mutable_database, mock_gnupghome, dry_run
+    buildcache_url, tmp_path: pathlib.Path, mutable_database, mock_gnupghome, dry_run
 ):
     """Test direct pruning functionality with a keeplist file"""
-    mirror_directory = str(tmp_path)
+    mirror_directory = buildcache_url
     mirror("add", "--unsigned", "my-mirror", mirror_directory)
 
     # Install and push multiple packages
     specs = mutable_database.query_local("libelf", installed=True)
     spec1 = specs[0]
 
-    cache_entry = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec1, allow_unsigned=True
-    )
-    manifest_url = cache_entry.get_manifest_url(spec1, f"file://{mirror_directory}")
+    cache_entry = URLBuildcacheEntry(mirror_url=mirror_directory, spec=spec1, allow_unsigned=True)
+    manifest_url = cache_entry.get_manifest_url(spec1, mirror_directory)
 
     # Push the first spec (package only, no dependencies)
     buildcache("push", "--only", "package", "--update-index", "my-mirror", f"/{spec1.dag_hash()}")

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -954,3 +954,81 @@ def test_buildcache_prune_with_invalid_keep_hash(
 
     with pytest.raises(spack.buildcache_prune.BuildcachePruningException):
         buildcache(*cmd_args)
+
+
+def test_buildcache_prune_new_specs_race_condition(
+    tmp_path: pathlib.Path, mutable_database, mock_gnupghome, monkeypatch
+):
+    """Test that specs uploaded after pruning begins are not considered for pruning"""
+
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # Install and push multiple packages
+    spec1 = mutable_database.query_local("libelf", installed=True)[0]
+    spec2 = mutable_database.query_local("mpich", installed=True)[0]
+
+    # Push libelf first (this will be "old" and should be pruned)
+    buildcache("push", "--only", "package", "--update-index", "my-mirror", f"/{spec1.dag_hash()}")
+
+    # Get current time to simulate pruning start time
+    pruning_start_time = time.time()
+
+    # Wait a moment, then push mpich (this will be "new" and should be protected)
+    time.sleep(0.1)
+    buildcache("push", "--only", "package", "--update-index", "my-mirror", f"/{spec2.dag_hash()}")
+
+    # Create a keeplist with a dummy hash so both specs are not in the keeplist.
+    keeplist_file = tmp_path / "keeplist.txt"
+    keeplist_file.write_text("00000000000000000000000000000000\n")
+
+    # Mock stat_url to return different modification times for different specs
+    original_stat_url = web_util.stat_url
+
+    def mock_stat_url(url: str):
+        """Mock stat_url to simulate different modification times"""
+        # Call original stat first to get real size
+        original_result = original_stat_url(url)
+        if original_result is None:
+            return None
+        size = original_result[0]
+
+        # For mpich, return a time after pruning started (should be protected)
+        if spec2.dag_hash() in url:
+            return (size, pruning_start_time + 10)  # Modified after pruning started
+        # For libelf, return a time before pruning started (should be pruned)
+        elif spec1.dag_hash() in url:
+            return (size, pruning_start_time - 10)  # Modified before pruning started
+        else:
+            return original_result
+
+    monkeypatch.setattr(web_util, "stat_url", mock_stat_url)
+
+    # Get URLs for both specs before pruning
+    cache_entry1 = URLBuildcacheEntry(
+        mirror_url=f"file://{mirror_directory}", spec=spec1, allow_unsigned=True
+    )
+    cache_entry2 = URLBuildcacheEntry(
+        mirror_url=f"file://{mirror_directory}", spec=spec2, allow_unsigned=True
+    )
+    manifest_url1 = cache_entry1.get_manifest_url(spec1, f"file://{mirror_directory}")
+    manifest_url2 = cache_entry2.get_manifest_url(spec2, f"file://{mirror_directory}")
+
+    # Verify both specs exist before pruning
+    assert web_util.url_exists(manifest_url1)
+    assert web_util.url_exists(manifest_url2)
+
+    # Run direct pruning with dummy keeplist (both specs would normally be pruned)
+    output = buildcache("prune", "my-mirror", "--keeplist", str(keeplist_file))
+
+    # Verify the race condition protection worked:
+    # 1. The pruner should find 2 specs to prune
+    assert "Found 2 spec(s) to prune" in output
+
+    # 2. But due to race condition protection, no objects should be pruned in direct phase
+    assert "Pruned 0 objects from mirror" in output
+
+    # 3. Both manifests should still exist because the race condition logic
+    #    protected them from deletion (they appear to be modified after pruning started)
+    assert web_util.url_exists(manifest_url1)
+    assert web_util.url_exists(manifest_url2)

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -997,4 +997,3 @@ def test_buildcache_prune_new_specs_race_condition(
     assert web_util.url_exists(manifest_url)
     buildcache("prune", "my-mirror", "--keeplist", str(keeplist_file))
     assert web_util.url_exists(manifest_url)
-

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -77,6 +77,21 @@ def buildcache_url_minio(request: pytest.FixtureRequest, monkeypatch: pytest.Mon
     if not request.config.getoption("--minio-integration-tests", default=False):
         pytest.skip("MinIO tests disabled, use --minio-integration-tests to enable")
 
+    def _entries_from_cache_fallback_patch(*args, **kwargs):
+        raise NotImplementedError()
+
+    # We want to ensure the MinIO tests use the `_entries_from_cache_aws_cli`
+    # function, and do not fall back to the `_entries_from_cache_fallback`
+    # (which happens when awscli is not installed).
+    # So, we patch the fallback function to raise an error if it is called.
+    import spack.url_buildcache
+
+    monkeypatch.setattr(
+        target=spack.url_buildcache,
+        name="_entries_from_cache_fallback",
+        value=_entries_from_cache_fallback_patch,
+    )
+
     # Assume boto3 is installed, since the user has requested MinIO integration tests
     import boto3
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -995,8 +995,6 @@ def test_buildcache_prune_new_specs_race_condition(
     # Run end-to-end buildcache prune - this should not delete `libelf`, despite it
     # not being in the keeplist, because its mtime is after the pruning started
     assert web_util.url_exists(manifest_url)
-    output = buildcache("prune", "my-mirror", "--keeplist", str(keeplist_file))
+    buildcache("prune", "my-mirror", "--keeplist", str(keeplist_file))
     assert web_util.url_exists(manifest_url)
 
-    # Verify the race condition warning message appears for protected objects
-    assert "Skipping deletion" in output and "modified after pruning started" in output

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -933,5 +933,24 @@ def test_buildcache_prune_direct_empty_keeplist_fails(
     keeplist_file.write_text("")
 
     # Should fail with empty keeplist
-    with pytest.raises(spack.main.SpackCommandError):
+    with pytest.raises(spack.buildcache_prune.BuildcachePruningException):
         buildcache("prune", "my-mirror", "--keeplist", str(keeplist_file))
+
+
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_buildcache_prune_with_invalid_keep_hash(
+    tmp_path: pathlib.Path, mutable_database, mock_gnupghome, dry_run: bool
+):
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # Create a keeplist file that includes an invalid hash
+    keeplist_file = tmp_path / "keeplist.txt"
+    keeplist_file.write_text("this_is_an_invalid_hash")
+
+    cmd_args = ["prune", "my-mirror", "--keeplist", str(keeplist_file)]
+    if dry_run:
+        cmd_args.append("--dry-run")
+
+    with pytest.raises(spack.buildcache_prune.BuildcachePruningException):
+        buildcache(*cmd_args)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -416,6 +416,13 @@ def pytest_addoption(parser):
         help='runs only "fast" unit tests, instead of the whole suite',
     )
 
+    group.addoption(
+        "--minio-integration-tests",
+        action="store_true",
+        default=False,
+        help="Run tests that require a MinIO server to be running",
+    )
+
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--fast"):

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1107,7 +1107,7 @@ def _entries_from_cache_aws_cli(
 
     def file_read_method(manifest_path: str) -> URLBuildcacheEntry:
         cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
-        cache_entry.read_manifest(manifest_url=f"file://{manifest_path}")
+        cache_entry.read_manifest(manifest_url=manifest_path)
         return cache_entry
 
     include_pattern = cache_class.get_buildcache_component_include_pattern(component_type)
@@ -1150,7 +1150,7 @@ def _entries_from_cache_aws_cli(
                 local_path = url_util.join(tmpspecsdir, filename)
 
                 if Path(local_path).exists():
-                    filename_to_mtime[local_path] = datetime.strptime(
+                    filename_to_mtime[url_util.path_to_file_url(local_path)] = datetime.strptime(
                         match.group(1), "%Y-%m-%d %H:%M:%S"
                     ).timestamp()
     except Exception as e:

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -11,6 +11,7 @@ import json
 import os
 import re
 import shutil
+import urllib.parse
 from contextlib import closing, contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -1139,9 +1140,14 @@ def _entries_from_cache_aws_cli(
         for line in aws(*ls_command_args, output=str, error=os.devnull).splitlines():
             match = s3_ls_regex.match(line)
             if match:
-                s3_path = "/".join(url.removeprefix("s3://").split("/")[1:])
-                filename = match.group(2).removeprefix(s3_path).lstrip("/")
-                local_path = "/".join([tmpspecsdir, filename])
+                # Parse the url and use the S3 path of the file to derive the
+                # local path of the file (i.e. where `aws s3 sync` put it).
+                parsed_url = urllib.parse.urlparse(url)
+                s3_path = parsed_url.path.lstrip("/")
+                filename = match.group(2)
+                if s3_path and filename.startswith(s3_path):
+                    filename = filename[len(s3_path) :].lstrip("/")
+                local_path = url_util.join(tmpspecsdir, filename)
 
                 if Path(local_path).exists():
                     filename_to_mtime[local_path] = datetime.strptime(

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -12,6 +12,8 @@ import os
 import re
 import shutil
 from contextlib import closing, contextmanager
+from datetime import datetime
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
@@ -1120,16 +1122,36 @@ def _entries_from_cache_aws_cli(
         tmpspecsdir,
     ]
 
+    # Use aws s3 ls to get mtimes of manifests
+    ls_command_args = ["s3", "ls", "--recursive", url]
+    s3_ls_regex = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\s+\d+\s+(.+)$")
+
+    filename_to_mtime: Dict[str, float] = {}
+
     tty.debug(f"Using aws s3 sync to download manifests from {url} to {tmpspecsdir}")
 
     try:
         aws(*sync_command_args, output=os.devnull, error=os.devnull)
         file_list = fsys.find(tmpspecsdir, [include_pattern])
         read_fn = file_read_method
-    except Exception:
-        tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
 
-    return file_list, read_fn
+        # Use `aws s3 ls` to get mtimes of manifests
+        for line in aws(*ls_command_args, output=str, error=os.devnull).splitlines():
+            match = s3_ls_regex.match(line)
+            if match:
+                s3_path = "/".join(url.removeprefix("s3://").split("/")[1:])
+                filename = match.group(2).removeprefix(s3_path).lstrip("/")
+                local_path = "/".join([tmpspecsdir, filename])
+
+                if Path(local_path).exists():
+                    filename_to_mtime[local_path] = datetime.strptime(
+                        match.group(1), "%Y-%m-%d %H:%M:%S"
+                    ).timestamp()
+    except Exception as e:
+        tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
+        raise e
+
+    return filename_to_mtime, read_fn
 
 
 def _entries_from_cache_fallback(
@@ -1149,7 +1171,7 @@ def _entries_from_cache_fallback(
         returning a `URLBuildcacheEntry` for that manifest.
     """
     read_fn = None
-    file_list = None
+    filename_to_mtime = None
 
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
 
@@ -1159,20 +1181,23 @@ def _entries_from_cache_fallback(
         return cache_entry
 
     try:
-        file_list = [
-            url_util.join(url, entry)
-            for entry in web_util.list_url(url, recursive=True)
+        filename_to_mtime = {}
+
+        for entry in web_util.list_url(url, recursive=True):
             if fnmatch.fnmatch(
                 entry, cache_class.get_buildcache_component_include_pattern(component_type)
-            )
-        ]
+            ):
+                entry_url = url_util.join(url, entry)
+                stat_result = web_util.stat_url(entry_url)
+                if stat_result is not None:
+                    filename_to_mtime[entry_url] = stat_result[1]  # mtime is second element
         read_fn = url_read_method
     except Exception as err:
         # If we got some kind of S3 (access denied or other connection error), the first non
         # boto-specific class in the exception is Exception.  Just print a warning and return
         tty.warn(f"Encountered problem listing packages at {url}: {err}")
 
-    return file_list, read_fn
+    return filename_to_mtime, read_fn
 
 
 def get_entries_from_cache(
@@ -1198,9 +1223,9 @@ def get_entries_from_cache(
     callbacks.append(_entries_from_cache_fallback)
 
     for specs_from_cache_fn in callbacks:
-        file_list, read_fn = specs_from_cache_fn(url, tmpspecsdir, component_type)
-        if file_list:
-            return file_list, read_fn
+        file_to_mtime_mapping, read_fn = specs_from_cache_fn(url, tmpspecsdir, component_type)
+        if file_to_mtime_mapping:
+            return file_to_mtime_mapping, read_fn
 
     raise ListMirrorSpecsError("Failed to get list of entries from {0}".format(url))
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -623,7 +623,7 @@ _spack_buildcache_download() {
 _spack_buildcache_prune() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --dry-run"
+        SPACK_COMPREPLY="-h --help -k --keeplist --dry-run"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -694,7 +694,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a list -d
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a keys -d 'get public keys available on mirrors'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a check -d 'check specs against remote binary mirror(s) to see if any need to be rebuilt'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a download -d 'download buildcache entry from a remote mirror to local folder'
-complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a prune -d 'prune stale buildcache entries from the mirror'
+complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a prune -d 'prune buildcache entries from the mirror'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a save-specfile -d 'get full spec for dependencies and write them to files in the specified output directory'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a sync -d 'sync binaries (and associated metadata) from one mirror to another'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a update-index -d 'update a buildcache index'
@@ -830,10 +830,12 @@ complete -c spack -n '__fish_spack_using_command buildcache download' -s p -l pa
 complete -c spack -n '__fish_spack_using_command buildcache download' -s p -l path -r -d 'path to directory where tarball should be downloaded'
 
 # spack buildcache prune
-set -g __fish_spack_optspecs_spack_buildcache_prune h/help dry-run
+set -g __fish_spack_optspecs_spack_buildcache_prune h/help k/keeplist= dry-run
 
 complete -c spack -n '__fish_spack_using_command buildcache prune' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache prune' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command buildcache prune' -s k -l keeplist -r -f -a keeplist
+complete -c spack -n '__fish_spack_using_command buildcache prune' -s k -l keeplist -r -d 'file containing newline-delimited list of package hashes to keep (optional)'
 complete -c spack -n '__fish_spack_using_command buildcache prune' -l dry-run -f -a dry_run
 complete -c spack -n '__fish_spack_using_command buildcache prune' -l dry-run -d 'do not actually delete anything from the buildcache, but log what would be deleted'
 


### PR DESCRIPTION
<h3>Background</h3>
Currently, unit tests for spack buildcaches execute against a local filesystem-based buildcache. This means that the code in spack that is only ever invoked for S3 buildcaches (particularly, code that uses the `aws` CLI/`boto3` to make buildcache operations faster) is not covered at all by the unit tests. When I was implementing buildcache pruning, CI failed to catch a major bug due to this issue. ([for reference](https://github.com/spack/spack/pull/50778#discussion_r2146029406))

<h3>This PR</h3>
This PR refactors the buildcaches created in the unit tests into a pytest fixture, which itself is parameterized as both a filesystem buildcache and an S3 buildcache (via MinIO). So far I've only converted a handful of tests to use this; I figured this PR would be a good place to settle on how exactly this fixture should be implemented, and then once agreed on and merged I can convert the rest in a follow up.

<h3>Effects on other tests/CI</h3>
One other thing worth mentioning is these additional tests obviously require a MinIO server to work properly. Consequently, `spack unit-test` shouldn't run them by default unless the user wants to spin up a MinIO server themselves. To allow for this, I added a new pytest CLI argument, `--minio-integration-tests`, to toggle them on and off. I also added a new CI workflow that spins up a MinIO container and runs the tests against it using the new CLI argument. 