### PR TITLE
Git provenance: exception for bad url

### DIFF
--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -23,7 +23,6 @@ import spack.package_base
 import spack.spec
 import spack.store
 import spack.subprocess_context
-import spack.util.git
 from spack.error import InstallError
 from spack.package_base import PackageBase
 from spack.solver.input_analysis import NoStaticAnalysis, StaticAnalysis

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -376,7 +376,6 @@ def test_binary_provenance_find_commit_ls_remote(
 def test_binary_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, capsys):
     """Fail all attempts to resolve git commits"""
     monkeypatch.setattr(spack.package_base.PackageBase, "do_fetch", lambda *args, **kwargs: None)
-    monkeypatch.setattr(spack.util.git, "get_commit_sha", lambda x, y: None, raising=False)
     spec = spack.concretize.concretize_one("git-ref-package@develop")
     captured = capsys.readouterr()
     assert "commit" not in spec.variants

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -140,9 +140,19 @@ def get_commit_sha(path: str, ref: str) -> Optional[str]:
 
     for try_ref in ref_list:
         # this command enabled in git@1.7 so no version checking supplied (1.7 released in 2009)
-        query = git(required=True)("ls-remote", path, try_ref, output=str, error=str)
+        try:
+            query = git(required=True)(
+                "ls-remote",
+                path,
+                try_ref,
+                output=str,
+                error=str,
+                extra_env={"GIT_TERMINAL_PROMPT": "0"},
+            )
 
-        if query:
-            return query.strip().split()[0]
+            if query:
+                return query.strip().split()[0]
+        except spack.util.executable.ProcessError:
+            continue
 
     return None


### PR DESCRIPTION
If a user provides a bad url concretization can fail due to a process exception for `git ls-remote`.
Add a try except guard for this case.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
