### PR TITLE
Docs/Packaging: version constraints, conflicts and requires: more examples and links

### DIFF
--- a/lib/spack/docs/build_systems/bundlepackage.rst
+++ b/lib/spack/docs/build_systems/bundlepackage.rst
@@ -14,9 +14,9 @@ The associated software is specified as dependencies.
 
 If it makes sense, variants, conflicts, and requirements can be added to
 the package. :ref:`Variants <variants>` ensure that common build options
-are consistent across the packages supporting them.  :ref:`Conflicts
-and requirements <packaging_conflicts>` prevent attempts to build with known
-bugs or limitations.
+are consistent across the packages supporting them.
+:ref:`Conflicts <packaging_conflicts>` prevent attempts to build with known bugs and limitations.
+:ref:`Requirements <packaging_requires>` prevent attempts to build without critical options.
 
 For example, if ``MyBundlePackage`` is known to only build on ``linux``,
 it could use the ``require`` directive as follows:

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1208,7 +1208,7 @@ Example situations would be a "snapshot"-like Version Control System (VCS) tag, 
 Specifying version constraints
 ------------------------------
 
-Many Spack directives allow limiting versions to support features such as :ref:`version_compatibility`.
+Many Spack directives allow limiting versions to support features such as :ref:`backward and forward compatibility <version_compatibility>`.
 These constraints on :ref:`package specs <sec-specs>` are defined using the ``@<specifier>`` syntax.
 (See :ref:`version-specifier` for more information.)
 
@@ -1225,7 +1225,7 @@ illustrates, in order, three of four forms of version range constraints: implici
 
 In this example, the implicit range is used to indicate that the package :ref:`depends on <dependencies>` *any* ``python`` *with* ``3`` *as the major version number* (e.g., ``3.13.5``).
 The other two range constraints are shown in the :ref:`conflict <packaging_conflicts>` with the dependency package ``foo``.
-The lower bound *at version* ``1.2.3`` *or newer* is **triggered** for builds of the package at *any version up to and including* ``4.5``.
+The conflict with ``foo`` *at version* ``1.2.3`` *or newer* is **triggered** for builds of the package at *any version up to and including* ``4.5``.
 For an example of the fourth form, suppose the dependency in this example had been ``python@3.6:3``.
 In this case, the package would depend on *any version of* ``python`` *from* ``3.6`` *on so long as the major version number is* ``3``.
 

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -654,6 +654,9 @@ For that, Spack goes a step further and defines a mixin class that takes care of
 .. literalinclude:: .spack/spack-packages/repos/spack_repo/builtin/packages/autoconf/package.py
    :lines: 9-18
 
+
+.. _preferred_versions:
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Preferring versions over others
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -669,6 +672,7 @@ In this case, you can mark an older version as preferred using the ``preferred=T
        version("1.2.3", sha256="...", preferred=True)
 
 See the section on :ref:`version ordering <version-comparison>` for more details and exceptions on how the latest version is computed.
+
 
 .. _deprecate:
 
@@ -720,14 +724,15 @@ This gives users a chance to complain about the deprecation in case the old vers
 If you require a deprecated version of a package, simply submit a PR to remove ``deprecated=True`` from the package.
 However, you may be asked to help maintain this version of the package if the current maintainers are unwilling to support this older version.
 
+
 .. _version-comparison:
 
 ^^^^^^^^^^^^^^^^
 Version ordering
 ^^^^^^^^^^^^^^^^
 
-Without version constraints, preferences and deprecations, Spack will always pick *the latest* version as defined in the package.
-What latest means is determined by the version comparison rules defined in Spack, and not the order in which versions are listed in the package file.
+Without :ref:`version constraints <version_constraints>`), :ref:`preferences <preferred_versions>` and :ref:`deprecations <deprecate>`, Spack will always pick *the latest* version as defined in the package.
+What latest means is determined by the version comparison rules defined in Spack, *not* the order in which versions are listed in the package file.
 
 Spack imposes a generic total ordering on the set of versions, independently from the package they are associated with.
 
@@ -777,28 +782,41 @@ The logic behind this sort order is two-fold:
 #. The most-recent development version of a package will usually be newer than any released numeric versions.
    This allows the ``@develop`` version to satisfy dependencies like ``depends_on(abc, when="@x.y.z:")``
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Specifying versions in other directives
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Many Spack directives accept versions speciers, for example
+.. _version_constraints:
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Specifying version constraints
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Many Spack directives accept version constraints to restrict the spec to a given version using the ``@=<version>`` syntax, or a range using the ``@<specifier>`` syntax.
+Refer to :ref:`version-specifier` for the complete syntax.
+Version range constraints are useful for :ref:`version_compatibility`.
+
+For example,
 
 .. code-block:: python
 
-   depends_on("python@3")
-   conflicts("foo@1.2.3:", when="@:4.5")
+   depends_on("foo")
+   depends_on("python@=3.10.1")
 
-When specifying versions in Spack using the ``@<specifier>`` syntax, you can use either ranges or specific versions.
-It is generally recommended to use ranges instead of specific versions when packaging to avoid overly constraining dependencies, patches, and conflicts.
+   conflicts("^foo@1.2.3:", when="@:4.5")
 
-For example, ``depends_on("python@3")`` denotes a range of versions, allowing Spack to pick any ``3.x.y`` version for Python, while ``depends_on("python@=3.10.1")`` restricts it to a specific version.
+illustrates a specific version *and* two version range constraints.
 
-Specific ``@=`` versions should only be used in exceptional cases, such as when the package has a versioning scheme that omits the zero in the first patch release: ``3.1``, ``3.1.1``, ``3.1.2``.
-In this example, the specifier ``@=3.1`` is the correct way to select only the ``3.1`` version, whereas ``@3.1`` would match all those versions.
+Specifically, the package depends on ``python`` *at* version ``3.10.1``.
+It also has a conflict with one of its dependencies, package ``foo``, when that
+package is at version ``1.2.3`` *or newer*, triggered for builds of the package at any version *up to and including* version ``4.5``.
 
-Ranges are preferred even if they would only match a single version defined in the package.
-This is because users can define custom versions in ``packages.yaml`` that typically include a custom suffix.
-For example, if the package defines the version ``1.2.3``, the specifier ``@1.2.3`` will also match a user-defined version ``1.2.3-custom``.
+Ranges are **preferred** even if they would only match a single version currently defined in the package.
+Doing so is useful since using ranges can avoid overly constraining dependencies, patches, and conflicts.
+Furthermore, users can define custom versions in :ref:`packages-config` that typically include a custom suffix.
+For example, if the package defines the version ``1.2.3``, we know from :ref:`version-comparison`, the specifier ``@1.2.3`` will also match a user-defined version ``1.2.3-custom``.
+
+.. warning::
+
+   Specific ``@=`` versions should only be used in exceptional cases, such as when the package has a versioning scheme that omits the zero in the first patch release, such as: ``3.1``, ``3.1.1``, ``3.1.2``.
+   In this example, the specifier ``@=3.1`` is the correct way to select only the ``3.1`` version, whereas ``@3.1`` would match all those versions.
 
 
 .. _vcs-fetch:
@@ -1569,6 +1587,8 @@ command line to find installed packages or to install packages with
 particular constraints, and package authors can use specs to describe
 relationships between packages.
 
+.. _version_compatibility:
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Specifying backward and forward compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2064,7 +2084,7 @@ means the package cannot be built on a Mac running Ventura, Monterey, or Big Sur
 .. note::
 
    These examples illustrate a few of the types of constraints that can be specified.
-   Conflict and ``when`` specs can constrain the compiler, version, variants, architecture, dependencies, versions and variants of dependencies, etcetera.
+   Conflict and ``when`` specs can constrain the compiler, :ref:`version <version_constraints>`, :ref:`variants <basic-variants>`, :ref:`architecture <architecture_specifiers>`, :ref:`dependencies <dependencies>`, etcetera.
 
 
 .. _packaging_requires:
@@ -2114,7 +2134,7 @@ Or the package must be built with a GCC or Clang that supports C++ 20, which you
 .. note::
 
    These examples show only a few of the constraints that can be specified.
-   Required and ``when`` specs can constrain the compiler, version, variants, architecture, dependencies, versions and variants of dependencies, etcetera.
+   Required and ``when`` specs can constrain the compiler, :ref:`version <version_constraints>`, :ref:`variants <basic-variants>`, :ref:`architecture <architecture_specifiers>`, :ref:`dependencies <dependencies>`, etcetera.
 
 
 .. _patching:

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2065,7 +2065,7 @@ Adding the following to a package:
          msg="known bug when using Intel oneAPI compilers through v2024",
     )
 
-expresses that the current package *cannot be built* with Intel oneAPI compilers *up through any version ``2024``* when trying to install the package with a *version up to ``1.2``*.
+expresses that the current package *cannot be built* with Intel oneAPI compilers *up through any version* ``2024`` *when trying to install the package with a version up to* ``1.2``.
 
 If the ``when`` argument is omitted, then the conflict is *always triggered* for specs satisfying the conflict spec.
 For example,

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2019,31 +2019,63 @@ This means that language dependencies translate to one or more compiler packages
 
 .. _packaging_conflicts:
 
---------------------------
-Conflicts and requirements
---------------------------
+---------
+Conflicts
+---------
 
-Sometimes packages have known bugs, or limitations, that would prevent them from building e.g. against other dependencies or with certain compilers.
-Spack makes it possible to express such constraints with the ``conflicts`` directive.
+Sometimes packages have known bugs, or limitations, that would prevent them from concretizing or building usable software.
+Spack makes it possible to express such constraints with the ``conflicts`` directive, which optionally takes ``when`` and ``msg`` arguments.
+
+The ``when`` argument is used to specify the spec conditions under which the conflict applies.
+The conditions can include constraints on the compiler, version, variants, architecture, dependencies, etc. that are known to cause problems building usable software.
+
+The ``msg`` argument allows you to provide a custom error message that Spack prints when the spec to be installed matches the constraints provided in ``when``.
 
 Adding the following to a package:
 
 .. code-block:: python
 
     conflicts(
-        "%intel-oneapi-compilers",
+        "%intel-oneapi-compilers@:2024",
          when="@:1.2",
-         msg="known bug with Intel oneAPI compilers"
+         msg="known bug when using Intel oneAPI compilers through v2024"
     )
 
-we express the fact that the current package *cannot be built* with the Intel oneAPI compilers up to version ``1.2``.
+expresses that the current package *cannot be built* with the Intel oneAPI compilers before version ``2025`` when trying to install versions of the package up to version ``1.2``.
 
-The ``when`` argument can be omitted, in which case the conflict will always be active.
+A conflict with the ``when`` argument omitted means the conflict is always active for specs matching the first argument.
+For example,
 
-An optional custom error message can be added via the ``msg=`` parameter, and may be printed by Spack in case the conflict cannot be avoided and leads to a concretization error.
+.. code-block:: python
 
-Sometimes, packages allow only very specific choices and they can't use the rest.
-In those cases the ``requires`` directive can be used:
+   conflicts("+cuda+rocm", msg="Cannot build with both cuda and rocm enabled")
+
+means the package cannot be installed when both variants are enabled.
+
+You can also indicate a conflict based on where the build is being performed.
+For example,
+
+.. code-block:: python
+
+   for os in ["ventura", "monterey", "bigsur"]:
+       conflicts(f"platform=darwin os={os}", msg=f"{os} is not supported")
+
+means the package cannot be built on a Mac running Ventura, Monterey, or Big Sur.
+
+.. _packaging_requires:
+
+------------
+Requirements
+------------
+
+Sometimes packages can be built only with specific option choices.
+In those cases the ``requires`` directive can be used.
+It supports the same ``when`` and ``msg`` arguments as ``conflicts`` (:ref:`packaging_conflicts`).
+It also allows for more complex requirements involving more than a single spec through the ability to specify multiple specs before keyword arguments.
+A ``policy`` keyword argument is used to determine how the multiple specs apply, supporting values that are either ``any_of`` or ``one_of`` (default) with the same semantics described in :ref:`package-requirements`.
+
+Suppose a package can only be built with Apple Clang on Darwin.
+This requirement would be specified as:
 
 .. code-block:: python
 
@@ -2053,22 +2085,26 @@ In those cases the ``requires`` directive can be used:
         msg="builds only with Apple Clang compiler on Darwin"
     )
 
-In the example above, our package can only be built with Apple Clang on Darwin.
-The ``requires`` directive is effectively the opposite of the ``conflicts`` directive, and takes the same optional ``when`` and ``msg`` arguments.
+Similarly, suppose a package only builds for the ``x86_64`` target:
 
-If a package needs to express more complex requirements, involving more than a single spec, that can also be done using the ``requires`` directive.
-To express that a package can be built either with GCC or with Clang we can write:
+.. code-block:: python
+
+    requires("target=x86_64:", msg="package is only available on x86_64")
+
+Or the package must be built with a GCC or Clang that supports C++ 20, which you could ensure by adding the following ``requires`` directive:
 
 .. code-block:: python
 
     requires(
-        "%gcc", "%clang",
+        "%gcc@10:", "%clang@16:",
         policy="one_of"
-        msg="builds only with GCC or Clang"
+        msg="builds only with GCC or Clang that support C++ 20"
     )
 
-When using multiple specs in a ``requires`` directive, it is advised to set the ``policy=`` argument explicitly.
-That argument can take either the value ``any_of`` or the value ``one_of``, and the semantic is the same as for :ref:`package-requirements`.
+.. hint::
+
+   We recommend that the ``policy`` argument be explicitly specified when multiple specs are used with the directive.
+
 
 .. _patching:
 

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2024,12 +2024,11 @@ Conflicts
 ---------
 
 Sometimes packages have known bugs, or limitations, that would prevent them from concretizing or building usable software.
-Spack makes it possible to express such constraints with the ``conflicts`` directive, which optionally takes ``when`` and ``msg`` arguments.
+Spack makes it possible to express such constraints with the ``conflicts`` directive, which takes a spec that is known to cause a conflict and optional ``when`` and ``msg`` arguments.
 
-The ``when`` argument is used to specify the spec conditions under which the conflict applies.
-The conditions can include constraints on the compiler, version, variants, architecture, dependencies, etc. that are known to cause problems building usable software.
+The ``when`` argument is a spec that triggers the conflict.
 
-The ``msg`` argument allows you to provide a custom error message that Spack prints when the spec to be installed matches the constraints provided in ``when``.
+The ``msg`` argument allows you to provide a custom error message that Spack prints when the spec to be installed matches the spec and ``when`` arguments.
 
 Adding the following to a package:
 
@@ -2041,18 +2040,18 @@ Adding the following to a package:
          msg="known bug when using Intel oneAPI compilers through v2024"
     )
 
-expresses that the current package *cannot be built* with the Intel oneAPI compilers before version ``2025`` when trying to install versions of the package up to version ``1.2``.
+expresses that the current package *cannot be built* with Intel oneAPI compilers up through any version ``2024`` when trying to install the package with a version up to ``1.2``.
 
-A conflict with the ``when`` argument omitted means the conflict is always active for specs matching the first argument.
+If the ``when`` argument is omitted, then the conflict is *always active* for specs matching the first, or conflict, spec.
 For example,
 
 .. code-block:: python
 
    conflicts("+cuda+rocm", msg="Cannot build with both cuda and rocm enabled")
 
-means the package cannot be installed when both variants are enabled.
+means the package cannot be installed with both variants enabled.
 
-You can also indicate a conflict based on where the build is being performed.
+Similarly, you can indicate a conflict based on where the build is being performed.
 For example,
 
 .. code-block:: python
@@ -2062,19 +2061,30 @@ For example,
 
 means the package cannot be built on a Mac running Ventura, Monterey, or Big Sur.
 
+.. note::
+
+   These examples illustrate a few of the types of constraints that can be specified.
+   Conflict and ``when`` specs can constrain the compiler, version, variants, architecture, dependencies, versions and variants of dependencies, etcetera.
+
+
 .. _packaging_requires:
 
-------------
-Requirements
-------------
+--------
+Requires
+--------
 
-Sometimes packages can be built only with specific option choices.
+Sometimes packages can be built only with specific options.
 In those cases the ``requires`` directive can be used.
-It supports the same ``when`` and ``msg`` arguments as ``conflicts`` (:ref:`packaging_conflicts`).
-It also allows for more complex requirements involving more than a single spec through the ability to specify multiple specs before keyword arguments.
-A ``policy`` keyword argument is used to determine how the multiple specs apply, supporting values that are either ``any_of`` or ``one_of`` (default) with the same semantics described in :ref:`package-requirements`.
+It allows for complex conditions involving more than a single spec through the ability to specify multiple required specs before keyword arguments.
+It supports the same optional ``when`` and ``msg`` arguments as ``conflicts`` (see :ref:`packaging_conflicts`).
+It also allows for a ``policy`` argument, which is used to determine how the multiple required specs apply.
+The values for ``policy`` may be either ``any_of`` or ``one_of`` (default) and have the same semantics described in :ref:`package-requirements`.
 
-Suppose a package can only be built with Apple Clang on Darwin.
+.. hint::
+
+   We recommend that the ``policy`` argument be explicitly specified when multiple specs are used with the directive.
+
+For example, suppose a package can only be built with Apple Clang on Darwin.
 This requirement would be specified as:
 
 .. code-block:: python
@@ -2082,7 +2092,7 @@ This requirement would be specified as:
     requires(
         "%apple-clang",
         when="platform=darwin",
-        msg="builds only with Apple Clang compiler on Darwin"
+        msg="builds only with Apple Clang compiler on Darwin",
     )
 
 Similarly, suppose a package only builds for the ``x86_64`` target:
@@ -2097,13 +2107,14 @@ Or the package must be built with a GCC or Clang that supports C++ 20, which you
 
     requires(
         "%gcc@10:", "%clang@16:",
-        policy="one_of"
-        msg="builds only with GCC or Clang that support C++ 20"
+        policy="one_of",
+        msg="builds only with GCC or Clang that support C++ 20",
     )
 
-.. hint::
+.. note::
 
-   We recommend that the ``policy`` argument be explicitly specified when multiple specs are used with the directive.
+   These examples show only a few of the constraints that can be specified.
+   Required and ``when`` specs can constrain the compiler, version, variants, architecture, dependencies, versions and variants of dependencies, etcetera.
 
 
 .. _patching:

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -731,7 +731,7 @@ However, you may be asked to help maintain this version of the package if the cu
 Version ordering
 ^^^^^^^^^^^^^^^^
 
-Without :ref:`version constraints <version_constraints>`), :ref:`preferences <preferred_versions>` and :ref:`deprecations <deprecate>`, Spack will always pick *the latest* version as defined in the package.
+Without :ref:`version constraints <version_constraints>`, :ref:`preferences <preferred_versions>` and :ref:`deprecations <deprecate>`, Spack will always pick *the latest* version as defined in the package.
 What latest means is determined by the version comparison rules defined in Spack, *not* the order in which versions are listed in the package file.
 
 Spack imposes a generic total ordering on the set of versions, independently from the package they are associated with.
@@ -789,33 +789,32 @@ The logic behind this sort order is two-fold:
 Specifying version constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Many Spack directives accept version constraints to restrict the spec to a given version using the ``@=<version>`` syntax, or a range using the ``@<specifier>`` syntax.
-Refer to :ref:`version-specifier` for the complete syntax.
-Version range constraints are useful for :ref:`version_compatibility`.
+Many Spack directives allow limiting versions to support features such as :ref:`version_compatibility`.
+These constraints on package specs are defined using the ``@<specifier>`` syntax (see :ref:`version-specifier` for more information).
 
 For example,
 
 .. code-block:: python
 
    depends_on("foo")
-   depends_on("python@=3.10.1")
+   depends_on("python@3")
 
    conflicts("^foo@1.2.3:", when="@:4.5")
 
-illustrates a specific version *and* two version range constraints.
-Specifically, the package depends on ``python`` *at* version ``3.10.1``.
-It also has a conflict with one of its dependencies, package ``foo``, when that package is *at version ``1.2.3`` or newer*, triggered for builds of the package at *any version up to and including version ``4.5``*.
+illustrates three forms of a version range constraint.
+First, the package depends on *any* ``python`` with ``3`` as the major version number (e.g., ``3.13.5``).
+Then there is a conflict with the package ``foo`` dependency *at version ``1.2.3`` or newer*, which is triggered for builds of the package at *any version up to and including version ``4.5``*.
 
-Ranges are **preferred** even if they would only match a single version currently defined in the package.
+While you can constrain the spec to a single version -- using the ``@=<version>`` form of ``specifier`` -- ranges are **preferred** even if they would only match a single version currently defined in the package.
 Using ranges helps avoid overly constraining dependencies, patches, and conflicts.
-
-Furthermore, users can define custom versions in :ref:`packages-config` that typically include a custom suffix.
-For example, if the package defines the version ``1.2.3``, we know from :ref:`version-comparison`, the specifier ``@1.2.3`` will also match a user-defined version ``1.2.3-custom``.
+They also come in handy when, for example, users define versions in :ref:`packages-config` that include custom suffixes.
+For example, if the package defines the version ``1.2.3``, we know from :ref:`version-comparison`, that a user-defined version ``1.2.3-custom`` will satisfy the version constraint ``@1.2.3``.
 
 .. warning::
 
    Specific ``@=`` versions should only be used in exceptional cases, such as when the package has a versioning scheme that omits the zero in the first patch release, such as: ``3.1``, ``3.1.1``, ``3.1.2``.
    In this example, the specifier ``@=3.1`` is the correct way to select only the ``3.1`` version, whereas ``@3.1`` would match all of those versions.
+
 
 
 .. _vcs-fetch:

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -803,20 +803,19 @@ For example,
    conflicts("^foo@1.2.3:", when="@:4.5")
 
 illustrates a specific version *and* two version range constraints.
-
 Specifically, the package depends on ``python`` *at* version ``3.10.1``.
-It also has a conflict with one of its dependencies, package ``foo``, when that
-package is at version ``1.2.3`` *or newer*, triggered for builds of the package at any version *up to and including* version ``4.5``.
+It also has a conflict with one of its dependencies, package ``foo``, when that package is *at version ``1.2.3`` or newer*, triggered for builds of the package at *any version up to and including version ``4.5``*.
 
 Ranges are **preferred** even if they would only match a single version currently defined in the package.
-Doing so is useful since using ranges can avoid overly constraining dependencies, patches, and conflicts.
+Using ranges helps avoid overly constraining dependencies, patches, and conflicts.
+
 Furthermore, users can define custom versions in :ref:`packages-config` that typically include a custom suffix.
 For example, if the package defines the version ``1.2.3``, we know from :ref:`version-comparison`, the specifier ``@1.2.3`` will also match a user-defined version ``1.2.3-custom``.
 
 .. warning::
 
    Specific ``@=`` versions should only be used in exceptional cases, such as when the package has a versioning scheme that omits the zero in the first patch release, such as: ``3.1``, ``3.1.1``, ``3.1.2``.
-   In this example, the specifier ``@=3.1`` is the correct way to select only the ``3.1`` version, whereas ``@3.1`` would match all those versions.
+   In this example, the specifier ``@=3.1`` is the correct way to select only the ``3.1`` version, whereas ``@3.1`` would match all of those versions.
 
 
 .. _vcs-fetch:
@@ -1559,6 +1558,8 @@ needs to build and install the ``libelf`` package before it builds
 guaranteed that ``libelf`` has been built and installed successfully,
 so you can rely on it for your libdwarf build.
 
+.. _dependency_specs:
+
 ^^^^^^^^^^^^^^^^
 Dependency specs
 ^^^^^^^^^^^^^^^^
@@ -2057,10 +2058,10 @@ Adding the following to a package:
     conflicts(
         "%intel-oneapi-compilers@:2024",
          when="@:1.2",
-         msg="known bug when using Intel oneAPI compilers through v2024"
+         msg="known bug when using Intel oneAPI compilers through v2024",
     )
 
-expresses that the current package *cannot be built* with Intel oneAPI compilers up through any version ``2024`` when trying to install the package with a version up to ``1.2``.
+expresses that the current package *cannot be built* with Intel oneAPI compilers *up through any version ``2024``* when trying to install the package with a *version up to ``1.2``*.
 
 If the ``when`` argument is omitted, then the conflict is *always triggered* for specs satisfying the conflict spec.
 For example,
@@ -2084,7 +2085,8 @@ means the package cannot be built on a Mac running Ventura, Monterey, or Big Sur
 .. note::
 
    These examples illustrate a few of the types of constraints that can be specified.
-   Conflict and ``when`` specs can constrain the compiler, :ref:`version <version_constraints>`, :ref:`variants <basic-variants>`, :ref:`architecture <architecture_specifiers>`, :ref:`dependencies <dependencies>`, etcetera.
+   Conflict and ``when`` specs can constrain the compiler, :ref:`version <version_constraints>`, :ref:`variants <basic-variants>`, :ref:`architecture <architecture_specifiers>`, :ref:`dependencies <dependency_specs>`, and more.
+   See :ref:`sec-specs` for more information.
 
 
 .. _packaging_requires:
@@ -2134,7 +2136,8 @@ Or the package must be built with a GCC or Clang that supports C++ 20, which you
 .. note::
 
    These examples show only a few of the constraints that can be specified.
-   Required and ``when`` specs can constrain the compiler, :ref:`version <version_constraints>`, :ref:`variants <basic-variants>`, :ref:`architecture <architecture_specifiers>`, :ref:`dependencies <dependencies>`, etcetera.
+   Required and ``when`` specs can constrain the compiler, :ref:`version <version_constraints>`, :ref:`variants <basic-variants>`, :ref:`architecture <architecture_specifiers>`, :ref:`dependencies <dependency_specs>`, and more.
+   See :ref:`sec-specs` for more information.
 
 
 .. _patching:

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -783,40 +783,6 @@ The logic behind this sort order is two-fold:
    This allows the ``@develop`` version to satisfy dependencies like ``depends_on(abc, when="@x.y.z:")``
 
 
-.. _version_constraints:
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Specifying version constraints
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Many Spack directives allow limiting versions to support features such as :ref:`version_compatibility`.
-These constraints on package specs are defined using the ``@<specifier>`` syntax (see :ref:`version-specifier` for more information).
-
-For example,
-
-.. code-block:: python
-
-   depends_on("foo")
-   depends_on("python@3")
-
-   conflicts("^foo@1.2.3:", when="@:4.5")
-
-illustrates three forms of a version range constraint.
-First, the package depends on *any* ``python`` with ``3`` as the major version number (e.g., ``3.13.5``).
-Then there is a conflict with the package ``foo`` dependency *at version ``1.2.3`` or newer*, which is triggered for builds of the package at *any version up to and including version ``4.5``*.
-
-While you can constrain the spec to a single version -- using the ``@=<version>`` form of ``specifier`` -- ranges are **preferred** even if they would only match a single version currently defined in the package.
-Using ranges helps avoid overly constraining dependencies, patches, and conflicts.
-They also come in handy when, for example, users define versions in :ref:`packages-config` that include custom suffixes.
-For example, if the package defines the version ``1.2.3``, we know from :ref:`version-comparison`, that a user-defined version ``1.2.3-custom`` will satisfy the version constraint ``@1.2.3``.
-
-.. warning::
-
-   Specific ``@=`` versions should only be used in exceptional cases, such as when the package has a versioning scheme that omits the zero in the first patch release, such as: ``3.1``, ``3.1.1``, ``3.1.2``.
-   In this example, the specifier ``@=3.1`` is the correct way to select only the ``3.1`` version, whereas ``@3.1`` would match all of those versions.
-
-
-
 .. _vcs-fetch:
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1234,6 +1200,45 @@ Download caching
 Spack maintains a cache (described :ref:`here <caching>`) which saves files retrieved during package installations to avoid re-downloading in the case that a package is installed with a different specification (but the same version) or reinstalled on account of a change in the hashing scheme.
 In rare cases, it may be necessary to avoid caching for a particular version by adding ``no_cache=True`` as an option to the ``version()`` directive.
 Example situations would be a "snapshot"-like Version Control System (VCS) tag, a VCS branch such as ``v6-16-00-patches``, or a URL specifying a regularly updated snapshot tarball.
+
+
+.. _version_constraints:
+
+------------------------------
+Specifying version constraints
+------------------------------
+
+Many Spack directives allow limiting versions to support features such as :ref:`version_compatibility`.
+These constraints on :ref:`package specs <sec-specs>` are defined using the ``@<specifier>`` syntax.
+(See :ref:`version-specifier` for more information.)
+
+For example, the following:
+
+.. code-block:: python
+
+   depends_on("foo")
+   depends_on("python@3")
+
+   conflicts("^foo@1.2.3:", when="@:4.5")
+
+illustrates, in order, three of four forms of version range constraints: implicit, lower bound and upper bound. The fourth form provides lower *and* upper bounds on the version.
+
+In this example, the implicit range is used to indicate that the package :ref:`depends on <dependencies>` *any* ``python`` *with* ``3`` *as the major version number* (e.g., ``3.13.5``).
+The other two range constraints are shown in the :ref:`conflict <packaging_conflicts>` with the dependency package ``foo``.
+The lower bound *at version* ``1.2.3`` *or newer* is **triggered** for builds of the package at *any version up to and including* ``4.5``.
+For an example of the fourth form, suppose the dependency in this example had been ``python@3.6:3``.
+In this case, the package would depend on *any version of* ``python`` *from* ``3.6`` *on so long as the major version number is* ``3``.
+
+While you can constrain the spec to a single version -- using the ``@=<version>`` form of ``specifier`` -- **ranges are preferred** even if they would only match a single version currently defined in the package.
+Using ranges helps avoid overly constrained dependencies, patches, and conflicts.
+They also come in handy when, for example, users define versions in :ref:`packages-config` that include custom suffixes.
+For example, if the package defines the version ``1.2.3``, we know from :ref:`version-comparison`, that a user-defined version ``1.2.3-custom`` will satisfy the version constraint ``@1.2.3``.
+
+.. warning::
+
+   Specific ``@=`` versions should only be used in **exceptional cases**, such as when the package has a versioning scheme that omits the zero in the first patch release.
+   For example, suppose a package defines versions: ``3.1``, ``3.1.1`` and ``3.1.2``.
+   Then the specifier ``@=3.1`` is the correct way to select only ``3.1``, whereas ``@3.1`` would be satisfied by all three versions.
 
 
 .. _variants:

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2028,7 +2028,7 @@ Spack makes it possible to express such constraints with the ``conflicts`` direc
 
 The ``when`` argument is a spec that triggers the conflict.
 
-The ``msg`` argument allows you to provide a custom error message that Spack prints when the spec to be installed matches the spec and ``when`` arguments.
+The ``msg`` argument allows you to provide a custom error message that Spack prints when the spec to be installed satisfies the conflict spec and ``when`` trigger.
 
 Adding the following to a package:
 
@@ -2042,7 +2042,7 @@ Adding the following to a package:
 
 expresses that the current package *cannot be built* with Intel oneAPI compilers up through any version ``2024`` when trying to install the package with a version up to ``1.2``.
 
-If the ``when`` argument is omitted, then the conflict is *always active* for specs matching the first, or conflict, spec.
+If the ``when`` argument is omitted, then the conflict is *always triggered* for specs satisfying the conflict spec.
 For example,
 
 .. code-block:: python
@@ -2051,7 +2051,7 @@ For example,
 
 means the package cannot be installed with both variants enabled.
 
-Similarly, you can indicate a conflict based on where the build is being performed.
+Similarly, a conflict can be based on where the build is being performed.
 For example,
 
 .. code-block:: python
@@ -2076,9 +2076,9 @@ Requires
 Sometimes packages can be built only with specific options.
 In those cases the ``requires`` directive can be used.
 It allows for complex conditions involving more than a single spec through the ability to specify multiple required specs before keyword arguments.
-It supports the same optional ``when`` and ``msg`` arguments as ``conflicts`` (see :ref:`packaging_conflicts`).
-It also allows for a ``policy`` argument, which is used to determine how the multiple required specs apply.
-The values for ``policy`` may be either ``any_of`` or ``one_of`` (default) and have the same semantics described in :ref:`package-requirements`.
+The same optional ``when`` and ``msg`` arguments as ``conflicts`` are supported (see :ref:`packaging_conflicts`).
+The directive also supports a ``policy`` argument for determining how the multiple required specs apply.
+Values for ``policy`` may be either ``any_of`` or ``one_of`` (default) and have the same semantics described for their equivalents in :ref:`package-requirements`.
 
 .. hint::
 
@@ -2101,14 +2101,14 @@ Similarly, suppose a package only builds for the ``x86_64`` target:
 
     requires("target=x86_64:", msg="package is only available on x86_64")
 
-Or the package must be built with a GCC or Clang that supports C++ 20, which you could ensure by adding the following ``requires`` directive:
+Or the package must be built with a GCC or Clang that supports C++ 20, which you could ensure by adding the following:
 
 .. code-block:: python
 
     requires(
         "%gcc@10:", "%clang@16:",
         policy="one_of",
-        msg="builds only with GCC or Clang that support C++ 20",
+        msg="builds only with a GCC or Clang that support C++ 20",
     )
 
 .. note::

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -279,7 +279,7 @@ There are different types of variants:
 
          ~debug
 
-   .. tab-item:: Single-valued Variants.
+   .. tab-item:: Single-valued Variants
 
       Often used to set defaults.
       For example, a package might have a ``compression`` variant that determines the default compression algorithm, which users could set to:
@@ -427,6 +427,9 @@ The six compiler flags are injected in the same order as implicit make commands
 in GNU Autotools. If all flags are set, the order is
 ``$cppflags $cflags|$cxxflags $ldflags <command> $ldlibs`` for C and C++, and
 ``$fflags $cppflags $ldflags <command> $ldlibs`` for Fortran.
+
+
+.. _architecture_specifiers:
 
 -----------------------
 Architecture specifiers


### PR DESCRIPTION
Supersedes #48773 

It is very handy during PR reviews and discussions to be able to provide links to the ``conflicts`` and ``requires`` documentation and more complex examples are often needed.

This PR splits the two sections with some restructuring of each, adds a lot of relevant references and adds/updates examples to illustrate slightly more complex specs.