### PR TITLE
docs: skip .venv/

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -228,7 +228,7 @@ gettext_uuid = False
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build", "_spack_root", ".spack-env", ".spack"]
+exclude_patterns = ["_build", "_spack_root", ".spack-env", ".spack", ".venv"]
 
 autodoc_mock_imports = ["llnl"]
 


### PR DESCRIPTION
I usually have a `.venv` dir in `lib/spack/docs`, which is .gitignore'd, but not ignored by sphinx.