### PR TITLE
concretizer: fix direct dep w/ virtuals issue

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -539,6 +539,9 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
      imposed_constraint(ID, "depends_on", A1, A2, A3),
      internal_error("Build deps must land in exactly one duplicate").
 
+:- attr("direct_dependency", ParentNode, node_requirement("virtual_on_incoming_edges", ChildPkg, Virtual)),
+   not attr("virtual_on_edge", ParentNode, node(_, ChildPkg), Virtual).
+
 % If the parent is built, then we have a build_requirement on another node. For concrete nodes,
 % or external nodes, we don't since we are trimming their build dependencies.
 


### PR DESCRIPTION
Closes #51019.

The following (questionable but valid) config

```yaml
packages:
  all:
    prefer:
    - "%c=gcc"
    - "%cxx=gcc"
    - "%fortran=gcc"
```

exposes an issue in the solver where the "requirement weight" is
computed incorrectly.

It ~hallucinates~ makes up the following statement:

```lp
attr("direct_dependency",node(0,"tmux"),node_requirement("virtual_on_incoming_edges","gcc","cxx"))
```

even though `tmux` does not depend on `cxx`.

This leads to `condition_holds` for `%cxx=gcc`, even though this virtual
does not end up as a dependency of `tmux` in the solution.
