### PR TITLE
util/git::get_commit_sha: do not conflate git warnings with output

### DIFF
--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -146,7 +146,7 @@ def get_commit_sha(path: str, ref: str) -> Optional[str]:
                 path,
                 try_ref,
                 output=str,
-                error=str,
+                error=os.devnull,
                 extra_env={"GIT_TERMINAL_PROMPT": "0"},
             )
 


### PR DESCRIPTION
Saw a user error
```
Error: Internal Error: libfix's assigned commit X11 does not meet commit syntax requirements
```
This is caused by Spack trying to parse an X11 warning from `git ls-remote` as output and assigning it as the commit sha.

This PR fixes it by redirecting stderr to os.devnull.