### PR TITLE
Fix non path-based package repositories in environments

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -438,6 +438,9 @@ def _rewrite_relative_repos_paths_on_relocation(env, init_file_dir):
         if not repos_specs:
             return
         for name, entry in list(repos_specs.items()):
+            # only rewrite when we have a path-based repository
+            if not isinstance(entry, str):
+                continue
             repo_path = substitute_path_variables(entry)
             expanded_path = spack.util.path.canonicalize_path(repo_path, default_wd=init_file_dir)
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4596,10 +4596,14 @@ def test_env_view_ignores_different_file_conflicts(
 
 @pytest.mark.regression("51054")
 def test_non_str_repos(installed_environment):
-    with installed_environment(textwrap.dedent(f"""
+    with installed_environment(
+        textwrap.dedent(
+            f"""
         spack:
           repos:
             builtin:
               branch: develop
-    """.strip())) as test:
+    """.strip()
+        )
+    ) as test:
         pass

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -8,7 +8,6 @@ import io
 import os
 import pathlib
 import shutil
-import textwrap
 from argparse import Namespace
 from typing import Any, Dict, Optional
 
@@ -4597,13 +4596,10 @@ def test_env_view_ignores_different_file_conflicts(
 @pytest.mark.regression("51054")
 def test_non_str_repos(installed_environment):
     with installed_environment(
-        textwrap.dedent(
-            f"""
-        spack:
-          repos:
-            builtin:
-              branch: develop
-    """.strip()
-        )
-    ) as test:
+        """\
+spack:
+  repos:
+    builtin:
+      branch: develop"""
+    ):
         pass

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -8,6 +8,7 @@ import io
 import os
 import pathlib
 import shutil
+import textwrap
 from argparse import Namespace
 from typing import Any, Dict, Optional
 
@@ -4591,3 +4592,14 @@ def test_env_view_ignores_different_file_conflicts(
         prefix_dependent = e.matching_spec("view-ignore-conflict").prefix
     # The dependent's file is linked into the view
     assert readlink(tmp_path / "view" / "bin" / "x") == prefix_dependent.bin.x
+
+
+@pytest.mark.regression("51054")
+def test_non_str_repos(installed_environment):
+    with installed_environment(textwrap.dedent(f"""
+        spack:
+          repos:
+            builtin:
+              branch: develop
+    """.strip())) as test:
+        pass


### PR DESCRIPTION
fixes #51054

Fixes environments with non path-based repositories, e.g. something like
```
spack:
  repos:
    builtin:
      branch: develop
```
This is a bug introduced in #49084 and reported in #51054.