### PR TITLE
solver/asp.py: evaluate hashes in requirements

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2193,6 +2193,7 @@ class SpackSolverSetup:
 
             for input_spec in requirement_grp:
                 spec = spack.spec.Spec(input_spec)
+                spec.replace_hash()
                 if not spec.name:
                     spec.name = pkg_name
                 spec.attach_git_version_lookup()


### PR DESCRIPTION
Currently, Spack does not respect requirements specifying a hash.

This PR fixes it by evaluating the hash before constructing the requirement condition in solver/asp.py

Includes regression test.
