### PR TITLE
docs: enable google search console

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -310,6 +310,9 @@ html_theme_options = {"logo_only": True}
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = ["_themes"]
 
+# Google Search Console verification file
+html_extra_path = ["google5fda5f94b4ffb8de.html"]
+
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 # html_title = None

--- a/lib/spack/docs/google5fda5f94b4ffb8de.html
+++ b/lib/spack/docs/google5fda5f94b4ffb8de.html
@@ -1,0 +1,1 @@
+google-site-verification: google5fda5f94b4ffb8de.html


### PR DESCRIPTION
Allows me to enable google search console to see if there are certain indexing issues with the docs.