### PR TITLE
docs: add meta description

### DIFF
--- a/lib/spack/docs/advanced_topics.rst
+++ b/lib/spack/docs/advanced_topics.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Explore advanced topics in Spack, including defining and using toolchains, auditing packages and configuration, and verifying installations.
+
 .. _toolchains:
 
 =============================

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Discover how to create, use, and manage build caches in Spack to share pre-built binary packages and speed up installations.
+
 .. _binary_caches:
 
 ============

--- a/lib/spack/docs/bootstrapping.rst
+++ b/lib/spack/docs/bootstrapping.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how Spack's bootstrapping feature automatically fetches and installs essential build tools when they are not available on the host system.
+
 .. _bootstrapping:
 
 =============

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -2,6 +2,9 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Understand how to control the build process in Spack by customizing package-specific build settings and environment variables.
 
 .. _concretizer-options:
 

--- a/lib/spack/docs/build_systems.rst
+++ b/lib/spack/docs/build_systems.rst
@@ -2,6 +2,9 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      An overview of the build systems supported by Spack, with links to detailed documentation for each system.
 
 .. _build-systems:
 

--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      An overview of the Autotools build system in Spack for packages that use GNU Autotools.
+
 .. _autotoolspackage:
 
 ---------

--- a/lib/spack/docs/build_systems/bundlepackage.rst
+++ b/lib/spack/docs/build_systems/bundlepackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Discover how to create meta-packages known as "bundles" in Spack to group multiple packages together for a single installation.
+
 .. _bundlepackage:
 
 ------

--- a/lib/spack/docs/build_systems/cachedcmakepackage.rst
+++ b/lib/spack/docs/build_systems/cachedcmakepackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn about the CachedCMakePackage build system in Spack for CMake-based projects.
+
 .. _cachedcmakepackage:
 
 -----------

--- a/lib/spack/docs/build_systems/cmakepackage.rst
+++ b/lib/spack/docs/build_systems/cmakepackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to package software that uses the CMake build system with Spack, covering common practices and customization options for CMake-based packages.
+
 .. _cmakepackage:
 
 ------

--- a/lib/spack/docs/build_systems/cudapackage.rst
+++ b/lib/spack/docs/build_systems/cudapackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to packaging CUDA applications with Spack, including helpers for managing CUDA dependencies and architecture-specific builds.
+
 .. _cudapackage:
 
 ------

--- a/lib/spack/docs/build_systems/custompackage.rst
+++ b/lib/spack/docs/build_systems/custompackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to creating custom build systems in Spack for packaging software with its own build scripts or adding support for new build systems.
+
 .. _custompackage:
 
 --------------------

--- a/lib/spack/docs/build_systems/inteloneapipackage.rst
+++ b/lib/spack/docs/build_systems/inteloneapipackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to using the Intel oneAPI packages in Spack, including how to build with icx, use the oneAPI Spack environment, and configure externally installed oneAPI tools.
+
 .. _inteloneapipackage:
 
 

--- a/lib/spack/docs/build_systems/luapackage.rst
+++ b/lib/spack/docs/build_systems/luapackage.rst
@@ -2,6 +2,11 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+
+.. meta::
+   :description lang=en:
+      Learn about the Lua build system in Spack for packages using rockspec files.
+
 .. _luapackage:
 
 ------

--- a/lib/spack/docs/build_systems/makefilepackage.rst
+++ b/lib/spack/docs/build_systems/makefilepackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to using the Makefile build system in Spack for packages that use plain Makefiles.
+
 .. _makefilepackage:
 
 --------

--- a/lib/spack/docs/build_systems/mavenpackage.rst
+++ b/lib/spack/docs/build_systems/mavenpackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn about the Maven build system in Spack for building and managing Java-based projects.
+
 .. _mavenpackage:
 
 ------

--- a/lib/spack/docs/build_systems/mesonpackage.rst
+++ b/lib/spack/docs/build_systems/mesonpackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to use the Meson build system in Spack for projects that use Meson for their build process.
+
 .. _mesonpackage:
 
 ------

--- a/lib/spack/docs/build_systems/octavepackage.rst
+++ b/lib/spack/docs/build_systems/octavepackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn about the Octave build system in Spack for installing Octave packages.
+
 .. _octavepackage:
 
 ------

--- a/lib/spack/docs/build_systems/perlpackage.rst
+++ b/lib/spack/docs/build_systems/perlpackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to using the Perl build system in Spack for installing Perl modules.
+
 .. _perlpackage:
 
 ------

--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to packaging Python libraries with Spack, covering PyPI downloads, dependency management, and build system integration.
+
 .. _pythonpackage:
 
 ------

--- a/lib/spack/docs/build_systems/qmakepackage.rst
+++ b/lib/spack/docs/build_systems/qmakepackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn about the QMake build system in Spack, a script generator for Qt-based projects.
+
 .. _qmakepackage:
 
 ------

--- a/lib/spack/docs/build_systems/racketpackage.rst
+++ b/lib/spack/docs/build_systems/racketpackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn about the Racket build system in Spack for installing Racket packages and modules.
+
 .. _racketpackage:
 
 ------

--- a/lib/spack/docs/build_systems/rocmpackage.rst
+++ b/lib/spack/docs/build_systems/rocmpackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn about the ROCmPackage helper in Spack, which provides standard variants, dependencies, and conflicts for building packages that target AMD GPUs.
+
 .. _rocmpackage:
 
 ------

--- a/lib/spack/docs/build_systems/rpackage.rst
+++ b/lib/spack/docs/build_systems/rpackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to packaging R libraries and applications with Spack, including support for CRAN, Bioconductor, and GitHub sources.
+
 .. _rpackage:
 
 ------

--- a/lib/spack/docs/build_systems/rubypackage.rst
+++ b/lib/spack/docs/build_systems/rubypackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Discover the Ruby build system in Spack for installing Ruby gems, with support for gemspec, Rakefile, and pre-packaged .gem files.
+
 .. _rubypackage:
 
 ------

--- a/lib/spack/docs/build_systems/sconspackage.rst
+++ b/lib/spack/docs/build_systems/sconspackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn about the SCons build system in Spack, a Python-based tool that handles building and linking without relying on Makefiles.
+
 .. _sconspackage:
 
 ------

--- a/lib/spack/docs/build_systems/sippackage.rst
+++ b/lib/spack/docs/build_systems/sippackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to using the SIP build system in Spack for creating Python bindings for C and C++ libraries.
+
 .. _sippackage:
 
 ------

--- a/lib/spack/docs/build_systems/sourceforgepackage.rst
+++ b/lib/spack/docs/build_systems/sourceforgepackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Discover how to use the SourceforgePackage mixin in Spack to automatically generate download URLs for packages hosted on SourceForge.
+
 .. _sourceforgepackage:
 
 -----------

--- a/lib/spack/docs/build_systems/wafpackage.rst
+++ b/lib/spack/docs/build_systems/wafpackage.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Explore the Waf build system in Spack, a Python-based tool for configuring and building software projects without Makefiles.
+
 .. _wafpackage:
 
 ------

--- a/lib/spack/docs/chain.rst
+++ b/lib/spack/docs/chain.rst
@@ -2,7 +2,9 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-.. chain:
+.. meta::
+   :description lang=en:
+      Learn how to chain Spack installations by pointing one Spack instance to another to use its installed packages.
 
 =============================================
 Chaining Spack Installations (upstreams.yaml)

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -4,6 +4,10 @@
 
 .. _config-yaml:
 
+.. meta::
+   :description lang=en:
+      A detailed guide to the config.yaml file in Spack, which allows you to set core configuration options like installation paths, build parallelism, and trusted sources.
+
 ============================
 Spack Settings (config.yaml)
 ============================

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to configure Spack using its flexible YAML-based system. This guide covers the different configuration scopes and provides links to detailed documentation for each configuration file, helping you customize Spack to your specific needs.
+
 .. _configuration:
 
 ===================

--- a/lib/spack/docs/configuring_compilers.rst
+++ b/lib/spack/docs/configuring_compilers.rst
@@ -4,7 +4,7 @@
 
 .. meta::
    :description lang=en:
-      Discover how to configure compilers in Spack, whether by specifying them as externals, installing them in the Spack store, or making them available through a buildcache.
+      Discover how to configure compilers in Spack, whether by specifying them as externals, or by installing them with Spack.
 
 .. _compiler-config:
 

--- a/lib/spack/docs/configuring_compilers.rst
+++ b/lib/spack/docs/configuring_compilers.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Discover how to configure compilers in Spack, whether by specifying them as externals, installing them in the Spack store, or making them available through a buildcache.
+
 .. _compiler-config:
 
 =====================

--- a/lib/spack/docs/configuring_compilers.rst
+++ b/lib/spack/docs/configuring_compilers.rst
@@ -293,5 +293,3 @@ Once the compiler is installed, you can start using it without additional config
 .. code-block:: console
 
    $ spack install hdf5~mpi %gcc@14
-
-The same holds true for compilers that are made available from build caches, when reusing them is allowed.

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to turn Spack environments into container images, either by copying existing installations or by generating recipes for Docker and Singularity.
+
 .. _containers:
 
 ================

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide for developers and administrators on contributing new packages, features, or bug fixes to Spack, covering Git workflows, pull requests, and continuous integration testing.
+
 .. _contribution-guide:
 
 ==================

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A comprehensive guide for developers working on Spack itself, covering the directory structure, code organization, and key concepts like specs and packages.
+
 .. _developer_guide:
 
 ===============

--- a/lib/spack/docs/env_vars_yaml.rst
+++ b/lib/spack/docs/env_vars_yaml.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to modify shell environment variables within a Spack environment using the env_vars.yaml file.
+
 .. _env-vars-yaml:
 
 =============================================

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to use Spack environments to manage reproducible software stacks, making it easy to share and recreate specific sets of packages and their dependencies.
+
 .. _environments:
 
 =====================================

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -2,7 +2,9 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-.. extensions:
+.. meta::
+   :description lang=en:
+      Discover how to extend Spack's core functionality by creating custom commands and plugins.
 
 =================
 Custom Extensions

--- a/lib/spack/docs/features.rst
+++ b/lib/spack/docs/features.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      An overview of the key features that distinguish Spack from other package managers, including simple installation, custom configurations, and non-destructive installs.
+
 ================
 Feature Overview
 ================

--- a/lib/spack/docs/frequently_asked_questions.rst
+++ b/lib/spack/docs/frequently_asked_questions.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Find answers to common questions about Spack, covering topics like version and variant selection, package preferences, and concretizer behavior.
+
 ==========================
 Frequently Asked Questions
 ==========================

--- a/lib/spack/docs/getting_help.rst
+++ b/lib/spack/docs/getting_help.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Find out how to get help with Spack, including using the spack help command.
+
 ============
 Getting Help
 ============

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A beginner's guide to Spack, walking you through the initial setup, basic commands, and core concepts to get you started with managing software.
+
 .. _getting_started:
 
 ===============

--- a/lib/spack/docs/gpu_configuration.rst
+++ b/lib/spack/docs/gpu_configuration.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to configuring Spack to use external GPU support, including ROCm and CUDA installations, as well as the OpenGL API.
+
 ==========================
 Using External GPU Support
 ==========================

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to use include directives to modularize your Spack YAML configuration files for better organization and reusability.
+
 .. _include-yaml:
 
 ===============================

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -7,6 +7,10 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. meta::
+   :description lang=en:
+      Documentation of Spack, a flexible package manager for high-performance computing, designed to support multiple versions and configurations of software on a wide variety of platforms.
+
 ===================
 Spack
 ===================

--- a/lib/spack/docs/installing_prerequisites.rst
+++ b/lib/spack/docs/installing_prerequisites.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Find instructions on how to install the necessary prerequisites for Spack on various operating systems, including Linux and macOS.
+
 .. _verify-spack-prerequisites:
 
 ===================

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Discover how to set up and manage mirrors in Spack to provide a local repository of tarballs for offline package fetching.
+
 .. _mirrors:
 
 ======================

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to configure and customize module file generation in Spack for Environment Modules and Lmod.
+
 .. _modules:
 
 ======================

--- a/lib/spack/docs/package_api.rst
+++ b/lib/spack/docs/package_api.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      An overview of the Spack Package API, a stable interface for package authors to interact with the Spack framework.
+
 Spack Package API v2.2
 ======================
 

--- a/lib/spack/docs/package_fundamentals.rst
+++ b/lib/spack/docs/package_fundamentals.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn the fundamental Spack commands for managing software packages, including how to find, inspect, install, and remove them.
+
 .. _basic-usage:
 
 ====================

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -2,6 +2,9 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to customizing package settings in Spack using the packages.yaml file, including configuring compilers, specifying external packages, package requirements, and permissions.
 
 .. _packages-config:
 

--- a/lib/spack/docs/packaging_guide_advanced.rst
+++ b/lib/spack/docs/packaging_guide_advanced.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Advanced topics in Spack packaging, covering packages with multiple build systems, making packages discoverable with spack external find, and specifying ABI compatibility.
+
 .. list-table::
    :widths: 25 25 25 25
    :header-rows: 0

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to customizing the build process in Spack, covering installation procedures, build systems, and how to control the build with spec objects and environment variables.
+
 .. list-table::
    :widths: 25 25 25 25
    :header-rows: 0

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide for developers and administrators on how to package software for Spack, covering the structure of a package, creating and editing packages, and defining dependencies and variants.
+
 .. list-table::
    :widths: 25 25 25 25
    :header-rows: 0

--- a/lib/spack/docs/packaging_guide_testing.rst
+++ b/lib/spack/docs/packaging_guide_testing.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to adding tests to Spack packages to ensure correct installation and functionality.
+
 .. list-table::
    :widths: 25 25 25 25
    :header-rows: 0

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to generate and run automated build pipelines in Spack for CI instances, enabling the building and deployment of binaries and reporting to CDash.
+
 .. _pipelines:
 
 ============

--- a/lib/spack/docs/replace_conda_homebrew.rst
+++ b/lib/spack/docs/replace_conda_homebrew.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to use Spack environments to manage single-user installations, similar to Homebrew and Conda.
+
 .. _spack-environments-basic-usage:
 
 ==================

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Learn how to set up and manage package repositories in Spack, enabling you to maintain custom packages and override built-in ones.
+
 .. _repositories:
 
 =================================

--- a/lib/spack/docs/signing.rst
+++ b/lib/spack/docs/signing.rst
@@ -2,6 +2,11 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      Understand the Spack package signing process, which ensures data integrity for official packages from automated CI pipelines through cryptographic signing.
+
+
 .. _signing:
 
 =====================

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -2,6 +2,10 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A detailed guide to the Spack spec syntax for describing package constraints, including versions, variants, and dependencies.
+
 .. _sec-specs:
 
 ===========

--- a/lib/spack/docs/windows.rst
+++ b/lib/spack/docs/windows.rst
@@ -2,6 +2,9 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. meta::
+   :description lang=en:
+      A guide to setting up and using Spack on Windows, including installing prerequisites and configuring the environment.
 
 .. _windows_support:
 


### PR DESCRIPTION
Add meta tags to docs, with a short summary of the page, for SEO reasons and display in search engines, which is currently questionable:

<img width="677" height="150" alt="image" src="https://github.com/user-attachments/assets/edcfc6a6-06e2-45aa-b522-d703835421dc" />
