### PR TITLE
solver: fix issue when `llvm` is not a pure build dependency

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -667,7 +667,7 @@ attr("hash", node(X, BuildDependency), BuildHash) :-
 
 1 { attr("provider_set", node(X, BuildDependency), node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1 :-
   attr("direct_dependency", ParentNode, node_requirement("provider_set", BuildDependency, Virtual)),
-  build_requirement(ParentNode, node(X, BuildDependency)).
+  direct_dependency(ParentNode, node(X, BuildDependency)).
 
 % Reconstruct virtual dependencies for reused specs
 attr("virtual_on_edge", node(X, A1), node(Y, A2), Virtual)

--- a/lib/spack/spack/solver/direct_dependency.lp
+++ b/lib/spack/spack/solver/direct_dependency.lp
@@ -16,6 +16,9 @@
 } 1 :- attr("direct_dependency", PackageNode, node_requirement("node", DirectDependency)),
        concrete(PackageNode).
 
+direct_dependency(ParentNode, ChildNode) :- build_requirement(ParentNode, ChildNode).
+direct_dependency(ParentNode, ChildNode) :- runtime_requirement(ParentNode, ChildNode).
+
 %%%%
 % Build requirement
 %%%%

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3851,6 +3851,18 @@ def test_use_compiler_by_hash(mock_packages, mutable_database, mutable_config):
         ("emacs +native", ["%[virtuals=c deptypes=build,link] gcc"], []),
         ("emacs +native %gcc", ["%[virtuals=c deptypes=build,link] gcc"], []),
         ("emacs +native %[virtuals=c] gcc", ["%[virtuals=c deptypes=build,link] gcc"], []),
+        # Package that depends on llvm as a library and also needs C and C++ compilers
+        (
+            "llvm-client",
+            ["%[virtuals=c,cxx deptypes=build] gcc", "%[deptypes=build,link] llvm"],
+            ["%c=llvm"],
+        ),
+        (
+            "llvm-client %c,cxx=gcc",
+            ["%[virtuals=c,cxx deptypes=build] gcc", "%[deptypes=build,link] llvm"],
+            ["%c=llvm"],
+        ),
+        ("llvm-client %c,cxx=llvm", ["%[virtuals=c,cxx deptypes=build,link] llvm"], ["%gcc"]),
     ],
 )
 def test_specifying_direct_dependencies(

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/llvm_client/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/llvm_client/package.py
@@ -1,0 +1,19 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class LlvmClient(CMakePackage):
+    """A client package that depends on llvm and needs C and C++ compilers."""
+
+    git = "https://github.com/mycpptutorial/helloworld-cmake"
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    version("develop", branch="master")
+
+    depends_on("llvm")


### PR DESCRIPTION
fixes #51058
fixes #51062

#50565 regressed this case by missing the fact that a "provider_set" on the direct dependency must be honored even if the direct dependency turns out to be needed at runtime.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
