### PR TITLE
spack diff: show runtime differences

### DIFF
--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -89,12 +89,16 @@ def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
     # specs and to descend into dependency hashes so we include all facts.
     a_facts = set(
         shift(func)
-        for func in setup.spec_clauses(a, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True)
+        for func in setup.spec_clauses(
+            a, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True
+        )
         if func.name == "attr"
     )
     b_facts = set(
         shift(func)
-        for func in setup.spec_clauses(b, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True)
+        for func in setup.spec_clauses(
+            b, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True
+        )
         if func.name == "attr"
     )
 

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -89,12 +89,12 @@ def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
     # specs and to descend into dependency hashes so we include all facts.
     a_facts = set(
         shift(func)
-        for func in setup.spec_clauses(a, body=True, expand_hashes=True, concrete_build_deps=True)
+        for func in setup.spec_clauses(a, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True)
         if func.name == "attr"
     )
     b_facts = set(
         shift(func)
-        for func in setup.spec_clauses(b, body=True, expand_hashes=True, concrete_build_deps=True)
+        for func in setup.spec_clauses(b, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True)
         if func.name == "attr"
     )
 

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -140,8 +140,9 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
         ["node", dep] in result["intersect"]
         for dep in ("mpileaks", "callpath", "dyninst", "libelf", "libdwarf", "mpich")
     )
+
     assert all(
-        len([diff for diff in result["intersect"] if diff[0] == attr]) == 8
+        len([diff for diff in result["intersect"] if diff[0] == attr]) == 9
         for attr in (
             "version",
             "node_target",

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -12,6 +12,7 @@ import spack.main
 import spack.paths
 import spack.repo
 import spack.util.spack_json as sjson
+import spack.version
 
 install_cmd = spack.main.SpackCommand("install")
 diff_cmd = spack.main.SpackCommand("diff")
@@ -95,6 +96,18 @@ def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):
     # ensure that hash diffs are in here the result
     assert ["hash", "mpileaks %s" % specA.dag_hash()] in c["a_not_b"]
     assert ["hash", "mpileaks %s" % specB.dag_hash()] in c["b_not_a"]
+
+
+def test_diff_runtimes(install_mockery, mock_fetch, mock_archive, mock_packages):
+    """Test that we can install two packages and diff them"""
+
+    specA = spack.concretize.concretize_one("mpileaks")
+    specB = specA.copy()
+    specB["gcc-runtime"].versions = spack.version.VersionList([spack.version.Version("0.0.0")])
+
+    # Specs should be the same as themselves
+    c = spack.cmd.diff.compare_specs(specA, specB, to_string=True)
+    assert ["version", "gcc-runtime 0.0.0"] in c["b_not_a"]
 
 
 def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):


### PR DESCRIPTION
Currently, differences in `gcc-runtime` or `glibc` packages are hidden by `spack diff`. This is an unintended artifact of how they are specially handled in the solver.

This PR adds an option to `SpecSolverSetup.spec_clauses` to include runtime specs that are not unified in the spec. The `spack diff` command calls `spec_clauses` with the new option, to ensure those differences are represented in the `spack diff` output.

Includes regression test.
