### PR TITLE
WIP: Robust file list argument support

### DIFF
--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -2088,7 +2088,11 @@ class HeaderList(FileList):
         Returns:
             str: A joined list of include flags
         """
-        return " ".join(["-I" + x for x in self.directories])
+        return " ".join(self.include_flags_list)
+    
+    @property
+    def include_flags_list(self):
+        return ["-I" + x for x in self.directories]
 
     @property
     def macro_definitions(self):
@@ -2263,7 +2267,11 @@ class LibraryList(FileList):
         Returns:
             str: A joined list of search flags
         """
-        return " ".join(["-L" + x for x in self.directories])
+        return " ".join(self.search_flags_list)
+    
+    @property
+    def search_flags_list(self):
+        return ["-L" + x for x in self.directories]
 
     @property
     def link_flags(self):
@@ -2276,7 +2284,11 @@ class LibraryList(FileList):
         Returns:
             str: A joined list of link flags
         """
-        return " ".join(["-l" + name for name in self.names])
+        return " ".join(self.link_flags_list)
+
+    @property
+    def link_flags_list(self):
+        return ["-l" + name for name in self.names]
 
     @property
     def ld_flags(self):
@@ -2290,6 +2302,10 @@ class LibraryList(FileList):
             str: A joined list of search flags and link flags
         """
         return self.search_flags + " " + self.link_flags
+    
+    @property
+    def ld_flags_list(self):
+        return self.search_flags_list + self.link_flags_list
 
 
 def find_system_libraries(libraries, shared=True):

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -1961,6 +1961,27 @@ class FileList(collections.abc.Sequence):
             list: A list of base-names
         """
         return list(dedupe(os.path.basename(x) for x in self.files))
+    
+    def _quote_when_required(self, item):
+        """Returns item with proper quoting and escaping of reserved characters"""
+        """Returns args with each arg in double quotes if neccesary
+        Necessity determined by:
+            - path with a space on any platform
+            - path with a reserved character on Windows
+        """
+
+        def quote(arg):
+            return '"'+arg+'"'
+
+        def has_space(arg):
+            return " " in arg
+
+        def has_reserved(arg):
+            if not sys.platform == "win32":
+                return False
+            return True if re.search(r"[ <>^:\"|?*]", arg) else False
+
+        return quote(item) if has_space(item) or has_reserved(item) else item
 
     def __getitem__(self, item):
         cls = type(self)

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -1961,7 +1961,7 @@ class FileList(collections.abc.Sequence):
             list: A list of base-names
         """
         return list(dedupe(os.path.basename(x) for x in self.files))
-    
+
     def _quote_when_required(self, item):
         """Returns item with proper quoting and escaping of reserved characters"""
         """Returns args with each arg in double quotes if neccesary
@@ -1971,7 +1971,7 @@ class FileList(collections.abc.Sequence):
         """
 
         def quote(arg):
-            return '"'+arg+'"'
+            return '"' + arg + '"'
 
         def has_space(arg):
             return " " in arg
@@ -2110,7 +2110,7 @@ class HeaderList(FileList):
             str: A joined list of include flags
         """
         return " ".join(self.include_flags_list)
-    
+
     @property
     def include_flags_list(self):
         return ["-I" + x for x in self.directories]
@@ -2289,7 +2289,7 @@ class LibraryList(FileList):
             str: A joined list of search flags
         """
         return " ".join(self.search_flags_list)
-    
+
     @property
     def search_flags_list(self):
         return ["-L" + x for x in self.directories]
@@ -2323,7 +2323,7 @@ class LibraryList(FileList):
             str: A joined list of search flags and link flags
         """
         return self.search_flags + " " + self.link_flags
-    
+
     @property
     def ld_flags_list(self):
         return self.search_flags_list + self.link_flags_list


### PR DESCRIPTION
`LibraryList` and `HeaderList` classes in `llnl/util/filesystem` expose the `search_flags`, `include_flags`, etc methods, which produce strings of all the libraries/headers, etc the class is aware of prefixed with the appropriate argument flag for the context. This has a couple of problems.

1. If passed directly to a command line utility/the system, any special characters in these library/header paths (e.g. a space, special path character, etc) could cause errors.
2. Packages that use these flags via `pkg.libs` or `pkg.headers` often just split the produced search/include flags string anyway. This is naive and incorrect if there are spaces in the paths and required a good deal of extra handling to get right.

This PR:

* adds a list api to `LibraryList` and `HeaderList` that allows for accessing each of `search_flags`, `include_flags`, etc as lists
* adds support for composing these lists (and the subsequent strings) using the proper quotes and escapes