### PR TITLE
docs: use xrefs to `spack.package` where possible & improve multi-valued variants section

### DIFF
--- a/lib/spack/docs/packaging_guide_advanced.rst
+++ b/lib/spack/docs/packaging_guide_advanced.rst
@@ -405,7 +405,7 @@ the definition of the ``executables`` attribute is still required):
 
 This method takes as input a set of discovered executables (which match
 those specified by the user) as well as a common prefix shared by all
-of those executables. The function must return one or more :py:class:`spack.spec.Spec` associated
+of those executables. The function must return one or more :py:class:`spack.package.Spec` associated
 with the executables (it can also return ``None`` to indicate that no
 provided executables are associated with the package).
 

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -369,8 +369,8 @@ A more advanced example where we explicitly pass libraries and headers to the co
            f"--with-libxml2-include={self.spec['libxml2'].headers.include_flags}",
        ]
 
-The ``libs`` attribute is a :class:`LibraryList <spack.llnl.util.filesystem.LibraryList>` object that can be used to get a list of libraries by path, but also to get the appropriate linker flags.
-Similarly, the ``headers`` attribute is a :class:`HeaderList <spack.llnl.util.filesystem.HeaderList>`, which also has methods to get the relevant include flags.
+The ``libs`` attribute is a :class:`~spack.package.LibraryList` object that can be used to get a list of libraries by path, but also to get the appropriate linker flags.
+Similarly, the ``headers`` attribute is a :class:`~spack.package.HeaderList`, which also has methods to get the relevant include flags.
 
 .. _blas_lapack_scalapack:
 
@@ -480,12 +480,12 @@ The arguments are:
 ``self``
     This is the package object, which extends ``CMakePackage``.
     For API docs on Package objects, see
-    :py:class:`Package <spack.package_base.PackageBase>`.
+    :py:class:`Package <spack.package.PackageBase>`.
 
 ``spec``
     This is the concrete spec object created by Spack from an abstract spec supplied by the user.
     It describes what should be installed.
-    It will be of type :py:class:`Spec <spack.spec.Spec>`.
+    It will be of type :py:class:`Spec <spack.package.Spec>`.
 
 ``prefix``
     This is where your package should install its files.
@@ -531,7 +531,7 @@ Spack makes some of these executables available as global functions, making it e
 The ``python()`` and ``make()`` functions in this example invoke the ``python3`` and ``make`` executables, respectively.
 Naturally, you may wonder where these variables come from, since they are not imported from anywhere --- your editor may even underline them in red because they are not defined in the package module.
 
-The answer lies in the ``python`` and ``make`` dependencies, which implement the :meth:`~spack.package_base.PackageBase.setup_dependent_package` method in their package classes.
+The answer lies in the ``python`` and ``make`` dependencies, which implement the :meth:`~spack.package.PackageBase.setup_dependent_package` method in their package classes.
 This sets up Python variables that can be used in the package class of dependents.
 
 There is a good reason that it's the *dependency* that sets up these variables, rather than the package itself.
@@ -559,7 +559,7 @@ Not all dependencies set up such variables for dependent packages, in which case
           cython = which("cython", required=True)
           cython("setup.py", "build_ext", "--inplace")
 
-All executables in Spack are instances of :class:`~spack.util.executable.Executable`, see its API docs for more details.
+All executables in Spack are instances of :class:`~spack.package.Executable`, see its API docs for more details.
 
 
 .. _attribute_parallel:
@@ -638,7 +638,7 @@ This is already part of the boilerplate for packages created with ``spack create
 File filtering functions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:py:func:`filter_file(regex, repl, *filenames, **kwargs) <spack.llnl.util.filesystem.filter_file>`
+:py:func:`filter_file(regex, repl, *filenames, **kwargs) <spack.package.filter_file>`
   Works like ``sed`` but with Python regular expression syntax.  Takes
   a regular expression, a replacement, and a set of files.  ``repl``
   can be a raw string or a callable function.  If it is a raw string,
@@ -676,7 +676,7 @@ File filtering functions
         filter_file("CXX='c++'", "CXX='%s'" % self.compiler.cxx,
                     prefix.bin.mpicxx)
 
-:py:func:`change_sed_delimiter(old_delim, new_delim, *filenames) <spack.llnl.util.filesystem.change_sed_delimiter>`
+:py:func:`change_sed_delimiter(old_delim, new_delim, *filenames) <spack.package.change_sed_delimiter>`
     Some packages, like TAU, have a build system that can't install
     into directories with, e.g. "@" in the name, because they use
     hard-coded ``sed`` commands in their build.
@@ -698,14 +698,14 @@ File filtering functions
 File functions
 ^^^^^^^^^^^^^^
 
-:py:func:`ancestor(dir, n=1) <spack.llnl.util.filesystem.ancestor>`
+:py:func:`ancestor(dir, n=1) <spack.package.ancestor>`
   Get the n\ :sup:`th` ancestor of the directory ``dir``.
 
-:py:func:`can_access(path) <spack.llnl.util.filesystem.can_access>`
+:py:func:`can_access(path) <spack.package.can_access>`
   True if we can read and write to the file at ``path``.  Same as
   native Python ``os.access(file_name, os.R_OK|os.W_OK)``.
 
-:py:func:`install(src, dest) <spack.llnl.util.filesystem.install>`
+:py:func:`install(src, dest) <spack.package.install>`
   Install a file to a particular location.  For example, install a
   header into the ``include`` directory under the install ``prefix``:
 
@@ -713,14 +713,14 @@ File functions
 
      install("my-header.h", prefix.include)
 
-:py:func:`join_path(*paths) <spack.llnl.util.filesystem.join_path>`
+:py:func:`join_path(*paths) <spack.package.join_path>`
   An alias for ``os.path.join``. This joins paths using the OS path separator.
 
-:py:func:`mkdirp(*paths) <spack.llnl.util.filesystem.mkdirp>`
+:py:func:`mkdirp(*paths) <spack.package.mkdirp>`
   Create each of the directories in ``paths``, creating any parent
   directories if they do not exist.
 
-:py:func:`working_dir(dirname, kwargs) <spack.llnl.util.filesystem.working_dir>`
+:py:func:`working_dir(dirname, kwargs) <spack.package.working_dir>`
   This is a Python `Context Manager
   <https://docs.python.org/2/library/contextlib.html>`_ that makes it
   easier to work with subdirectories in builds.  You use this with the
@@ -762,7 +762,7 @@ File functions
      The ``create=True`` keyword argument causes the command to create
      the directory if it does not exist.
 
-:py:func:`touch(path) <spack.llnl.util.filesystem.touch>`
+:py:func:`touch(path) <spack.package.touch>`
   Create an empty file at ``path``.
 
 
@@ -834,7 +834,7 @@ Prefix objects
 
 You can find the installation directory of package in Spack by using the ``self.prefix`` attribute of the package object.
 In :ref:`overriding-phases`, we saw that the ``install()`` method has a ``prefix`` argument, which is the same as ``self.prefix``.
-This variable behaves like a string, but it is actually an instance of the :py:class:`Prefix <spack.util.prefix.Prefix>` class, which provides some additional functionality to make it easier to work with file paths in Spack.
+This variable behaves like a string, but it is actually an instance of the :py:class:`Prefix <spack.package.Prefix>` class, which provides some additional functionality to make it easier to work with file paths in Spack.
 
 In particular, you can use the ``.`` operator to join paths together, creating nested directory structures:
 
@@ -911,12 +911,12 @@ Package specific environment variables
 Spack provides a few methods to help package authors set environment variables programmatically.
 In total there are four such methods, distinguishing between the build and run environments, and between the package itself and its dependents:
 
-1. :meth:`setup_build_environment(env, spec) <spack.builder.BaseBuilder.setup_build_environment>`
-2. :meth:`setup_dependent_build_environment(env, dependent_spec) <spack.builder.BaseBuilder.setup_dependent_build_environment>`
-3. :meth:`setup_run_environment(env) <spack.package_base.PackageBase.setup_run_environment>`
-4. :meth:`setup_dependent_run_environment(env, dependent_spec) <spack.package_base.PackageBase.setup_dependent_run_environment>`
+1. :meth:`setup_build_environment(env, spec) <spack.package.BaseBuilder.setup_build_environment>`
+2. :meth:`setup_dependent_build_environment(env, dependent_spec) <spack.package.BaseBuilder.setup_dependent_build_environment>`
+3. :meth:`setup_run_environment(env) <spack.package.PackageBase.setup_run_environment>`
+4. :meth:`setup_dependent_run_environment(env, dependent_spec) <spack.package.PackageBase.setup_dependent_run_environment>`
 
-All these methods take an ``env`` argument, which is an instance of the :class:`EnvironmentModifications <spack.util.environment.EnvironmentModifications>` class.
+All these methods take an ``env`` argument, which is an instance of the :class:`EnvironmentModifications <spack.package.EnvironmentModifications>` class.
 
 The ``setup_build_environment`` method is for certain build systems (e.g. ``PythonPackage``) roughly equivalent to the ``configure_args`` or ``cmake_args`` methods.
 It allows you to set environment variables that are needed during the build of the package itself, and can be used to inform the build system about the package's configuration and where to find dependencies:
@@ -960,7 +960,7 @@ Setting package module variables
 
 Apart from modifying environment variables of the dependent package, you can also define Python
 variables to be used by the dependent. This is done by implementing
-:meth:`setup_dependent_package <spack.package_base.PackageBase.setup_dependent_package>`. An
+:meth:`setup_dependent_package <spack.package.PackageBase.setup_dependent_package>`. An
 example of this can be found in the ``Python`` package:
 
 .. literalinclude:: .spack/spack-packages/repos/spack_repo/builtin/packages/python/package.py
@@ -1015,7 +1015,7 @@ However, there are two cases in which you may need to deal with compiler flags i
 2. The build system *needs to be aware* of the user-specified compiler flags to prevent a build failure.
    This is less common, but there are examples of packages that fail to build when ``-O3`` is used for a specific source file.
 
-In these cases, you can implement the :meth:`flag_handler <spack.package_base.PackageBase.flag_handler>` method in your package class.
+In these cases, you can implement the :meth:`flag_handler <spack.package.PackageBase.flag_handler>` method in your package class.
 This method has a curious return type, but once you understand it, it is quite powerful.
 
 Here is a simple example:

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1583,7 +1583,7 @@ be present on specs that otherwise satisfy the spec listed as the
 
 The ``when`` clause follows the same syntax and accepts the same
 values as the ``when`` argument of
-:py:func:`spack.directives.depends_on`.
+:py:func:`spack.package.depends_on`.
 
 ^^^^^^^^^^^^^^^
 Sticky Variants

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1370,7 +1370,7 @@ features, which often come at the expense of additional dependencies or
 longer build times. To be flexible enough and support a wide variety of
 use cases, Spack allows you to expose to the end-user the ability to choose
 which features should be activated in a package at the time it is installed.
-The mechanism to be employed is the :py:func:`spack.directives.variant` directive.
+The mechanism to be employed is the :py:func:`~spack.package.variant` directive.
 
 ^^^^^^^^^^^^^^^^
 Boolean variants
@@ -1408,7 +1408,7 @@ that the boolean variant is set to ``True``, while ``~shared`` means it is set
 to ``False``.
 Another common example is the optional activation of an extra dependency
 which requires to use the variant in the ``when`` argument of
-:py:func:`spack.directives.depends_on`:
+:py:func:`~spack.package.depends_on`:
 
   ..  code-block:: python
 
@@ -1424,10 +1424,10 @@ dependency of ``hdf5``.
 Multi-valued variants
 ^^^^^^^^^^^^^^^^^^^^^
 
-If need be, Spack can go beyond Boolean variants and permit an arbitrary
+If need be, Spack can go beyond boolean variants and permit an arbitrary
 number of allowed values. This might be useful when modeling
 options that are tightly related to each other.
-The values in this case are passed to the :py:func:`spack.directives.variant`
+The values in this case are passed to the :py:func:`~spack.package.variant`
 directive as a tuple:
 
   .. code-block:: python
@@ -1490,13 +1490,10 @@ Within a package recipe a multi-valued variant is tested using a ``key=value`` s
 """""""""""""""""""""""""""""""""""""""""""
 Complex validation logic for variant values
 """""""""""""""""""""""""""""""""""""""""""
-To cover complex use cases, the :py:func:`spack.directives.variant` directive
-could accept as the ``values`` argument a full-fledged object which has
-``default`` and other arguments of the directive embedded as attributes.
+Some multi-valued variants require more advanced validation logic, for which Spack provides two validator functions.
+These can be passed to the ``values=`` argument of the ``variant`` directive.
 
-An example, already implemented in Spack's core, is :py:class:`spack.variant.DisjointSetsOfValues`.
-This class is used to implement a few convenience functions, like
-:py:func:`spack.variant.any_combination_of`:
+The first validator function is :py:func:`~spack.package.any_combination_of`, which can be used as follows:
 
   ..  code-block:: python
 
@@ -1508,11 +1505,10 @@ This class is used to implement a few convenience functions, like
             description="Enable dataspaces and/or flexpath staging transports"
         )
 
-that allows any combination of the specified values, and also allows the
-user to specify ``"none"`` (as a string) to choose none of them.
-The objects returned by these functions can be modified at will by chaining
-method calls to change the default value, customize the error message or
-other similar operations:
+This is very similar to ordinary multi-valued variants, but crucially it allows users to pick neither of the two values, using ``staging=none`` (the default).
+In other words, the valid options are either ``staging=none`` to select nothing, or ``staging=dataspaces``, ``staging=flexpath``, and ``staging=dataspaces,flexpath``.
+
+The second validator function :py:func:`~spack.package.disjoint_sets`, which generalizes this concept further:
 
   .. code-block:: python
 
@@ -1528,6 +1524,10 @@ other similar operations:
                 "other process managers"
             ).with_default("auto").with_non_feature_values("auto"),
         )
+
+In this case, examples of valid options are ``process_managers=auto``, ``process_managers=slurm``, and ``process_managers=hydra,remshell``, whereas ``process_managers=slurm,hydra`` is invalid, as it picks values from two different sets.
+
+Both validator functions return a :py:class:`~spack.variant.DisjointSetsOfValues` object, which defines chaining methods to further customize the behavior of the variant.
 
 """""""""""""""""""""""""""
 Conditional Possible Values

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1508,6 +1508,12 @@ The first validator function is :py:func:`~spack.package.any_combination_of`, wh
 This is very similar to ordinary multi-valued variants, but crucially it allows users to pick neither of the two values, using ``staging=none`` (the default).
 In other words, the valid options are either ``staging=none`` to select nothing, or ``staging=dataspaces``, ``staging=flexpath``, and ``staging=dataspaces,flexpath``.
 
+.. note::
+
+   The variant value ``none`` is a value like any other.
+   By convention, it indicates that no value is selected for the variant.
+   Variant values are always strings, so the value ``none`` is not related to the Python :py:data:`None` object.
+
 The second validator function :py:func:`~spack.package.disjoint_sets`, which generalizes this concept further:
 
   .. code-block:: python

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -601,11 +601,11 @@ def _a_single_value_or_a_combination(single_value, *values):
 
 
 def any_combination_of(*values):
-    """Multi-valued variant that allows any combination of the specified
-    values, and also allows the user to specify 'none' (as a string) to choose
-    none of them.
+    """Multi-valued variant that allows either any combination of the specified values, or none
+     at all (using ``variant=none``). The literal value ``none`` is used as sentinel for the empty
+     set, since in the spec DSL we have to always specify a value for a variant.
 
-    It is up to the package implementation to handle the value `"none"` specially, if at all.
+    It is up to the package implementation to handle the value ``none`` specially, if at all.
 
     Args:
         *values: allowed variant values


### PR DESCRIPTION
The packaging guide should always refer to `spack.package` when possible, to prevent people from importing private Spack API.

The only thing that is indirectly exposed from internals is the class `DisjointSetsOfValues`. I don't think that's terrible, just that we have to keep in mind that this is effectively also public API...