### PR TITLE
git_fetch: make sparse path mirror projections unique

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -890,6 +890,7 @@ class GitFetchStrategy(VCSFetchStrategy):
 
     def mirror_id(self):
         if self.commit:
+            provenance_id = self.commit
             repo_path = urllib.parse.urlparse(self.url).path
             if self.git_sparse_paths:
                 sparse_paths = []
@@ -897,9 +898,9 @@ class GitFetchStrategy(VCSFetchStrategy):
                     sparse_paths.extend(self.git_sparse_paths())
                 else:
                     sparse_paths.extend(self.git_sparse_paths)
-                path, ext = os.path.splitext(repo_path)
-                repo_path = "{0}_{1}{2}".format(path, "_".join(sparse_paths), ext)
-            result = os.path.sep.join(["git", repo_path, self.commit])
+                sparse_hash = hash(tuple(sparse_paths))
+                provenance_id = f"{provenance_id}_{sparse_hash}"
+            result = os.path.sep.join(["git", repo_path, provenance_id])
             return result
 
     def _repo_info(self):

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -23,6 +23,7 @@ in order to build it.  They need to define the following methods:
 """
 import copy
 import functools
+import hashlib
 import http.client
 import os
 import re
@@ -898,7 +899,8 @@ class GitFetchStrategy(VCSFetchStrategy):
                     sparse_paths.extend(self.git_sparse_paths())
                 else:
                     sparse_paths.extend(self.git_sparse_paths)
-                sparse_hash = hash(tuple(sparse_paths))
+                sparse_string = "_".join(sparse_paths)
+                sparse_hash = hashlib.sha1(sparse_string.encode("utf-8")).hexdigest()
                 provenance_id = f"{provenance_id}_{sparse_hash}"
             result = os.path.sep.join(["git", repo_path, provenance_id])
             return result

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -891,6 +891,14 @@ class GitFetchStrategy(VCSFetchStrategy):
     def mirror_id(self):
         if self.commit:
             repo_path = urllib.parse.urlparse(self.url).path
+            if self.git_sparse_paths:
+                sparse_paths = []
+                if callable(self.git_sparse_paths):
+                    sparse_paths.extend(self.git_sparse_paths())
+                else:
+                    sparse_paths.extend(self.git_sparse_paths)
+                path, ext = os.path.splitext(repo_path)
+                repo_path = "{0}_{1}{2}".format(path, "_".join(sparse_paths), ext)
             result = os.path.sep.join(["git", repo_path, self.commit])
             return result
 

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -434,9 +434,8 @@ def test_git_sparse_paths_partial_clone(
 
 
 @pytest.mark.regression("50699")
-@pytest.mark.disable_clean_stage_check
 def test_git_sparse_path_have_unique_mirror_projections(
-    git, mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
+    git, mock_git_repository, mutable_mock_repo, monkeypatch
 ):
     """
     Confirm two packages with different sparse paths have different stages
@@ -448,8 +447,6 @@ def test_git_sparse_path_have_unique_mirror_projections(
     gold_commit = git("-C", repo_path, "rev-parse", "many_dirs", output=str).strip()
     s_a = spack.concretize.concretize_one(f"git-sparse-a commit={gold_commit}")
     s_b = spack.concretize.concretize_one(f"git-sparse-b commit={gold_commit}")
-    s_a.package.do_stage()
-    s_b.package.do_stage()
     assert s_a.package.stage[0].mirror_layout.path != s_b.package.stage[0].mirror_layout.path
 
 

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -13,6 +13,7 @@ import spack.concretize
 import spack.config
 import spack.error
 import spack.fetch_strategy
+import spack.package_base
 import spack.platforms
 import spack.repo
 from spack.fetch_strategy import GitFetchStrategy
@@ -430,6 +431,32 @@ def test_git_sparse_paths_partial_clone(
 
         # fixture file is in the sparse-path expansion tree
         assert os.path.isfile(t.file)
+
+
+@pytest.mark.regression("50699")
+@pytest.mark.disable_clean_stage_check
+@pytest.mark.require_provenance
+def test_git_sparse_path_have_unique_stages(
+    git,
+    mock_git_repository,
+    git_version,
+    default_mock_concretization,
+    mutable_mock_repo,
+    monkeypatch,
+):
+    """
+    Confirm two packages with different sparse paths have different stages
+    """
+    repo_path = mock_git_repository.path
+    monkeypatch.setattr(
+        spack.package_base.PackageBase, "git", f"file://{repo_path}", raising=False
+    )
+    gold_commit = git("-C", repo_path, "rev-parse", "main", output=str).strip()
+    s_a = spack.concretize.concretize_one(f"git-sparse-a commit={gold_commit}")
+    s_b = spack.concretize.concretize_one(f"git-sparse-b commit={gold_commit}")
+    s_a.package.do_stage()
+    s_b.package.do_stage()
+    assert s_a.package.stage[0].mirror_layout.path != s_b.package.stage[0].mirror_layout.path
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -438,7 +438,9 @@ def test_git_sparse_path_have_unique_mirror_projections(
     git, mock_git_repository, mutable_mock_repo, monkeypatch
 ):
     """
-    Confirm two packages with different sparse paths have different stages
+    Confirm two packages with different sparse paths but the same git commit
+    have different mirror projections so tarfiles in the mirror are unique
+    and don't get overwritten
     """
     repo_path = mock_git_repository.path
     monkeypatch.setattr(

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -442,7 +442,7 @@ def test_git_sparse_path_have_unique_mirror_projections(
     """
     repo_path = mock_git_repository.path
     monkeypatch.setattr(
-        spack.package_base.PackageBase, "git", f"file://{repo_path}", raising=False
+        spack.package_base.PackageBase, "git", pathlib.Path(repo_path).as_uri(), raising=False
     )
     gold_commit = git("-C", repo_path, "rev-parse", "many_dirs", output=str).strip()
     s_a = spack.concretize.concretize_one(f"git-sparse-a commit={gold_commit}")

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -435,14 +435,8 @@ def test_git_sparse_paths_partial_clone(
 
 @pytest.mark.regression("50699")
 @pytest.mark.disable_clean_stage_check
-@pytest.mark.require_provenance
-def test_git_sparse_path_have_unique_stages(
-    git,
-    mock_git_repository,
-    git_version,
-    default_mock_concretization,
-    mutable_mock_repo,
-    monkeypatch,
+def test_git_sparse_path_have_unique_mirror_projections(
+    git, mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
 ):
     """
     Confirm two packages with different sparse paths have different stages
@@ -451,7 +445,7 @@ def test_git_sparse_path_have_unique_stages(
     monkeypatch.setattr(
         spack.package_base.PackageBase, "git", f"file://{repo_path}", raising=False
     )
-    gold_commit = git("-C", repo_path, "rev-parse", "main", output=str).strip()
+    gold_commit = git("-C", repo_path, "rev-parse", "many_dirs", output=str).strip()
     s_a = spack.concretize.concretize_one(f"git-sparse-a commit={gold_commit}")
     s_b = spack.concretize.concretize_one(f"git-sparse-b commit={gold_commit}")
     s_a.package.do_stage()

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparse_a/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparse_a/package.py
@@ -14,7 +14,7 @@ class GitSparseA(Package):
 
     # ----------------------------
     # -- mock_git_repository
-    version("main", branch="main")
+    version("main", branch="many_dirs")
     homepage = "http://www.git-fetch-example.com"
 
     submodules = True

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparse_a/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparse_a/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class GitSparseA(Package):
+    """Partal clone of the mock_git_repository fixture"""
+
+    # git='to-be-filled-in-by-test'
+
+    # ----------------------------
+    # -- mock_git_repository
+    version("main", branch="main")
+    homepage = "http://www.git-fetch-example.com"
+
+    submodules = True
+    git_sparse_paths = ["dir0"]

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparse_b/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparse_b/package.py
@@ -14,7 +14,7 @@ class GitSparseB(Package):
 
     # ----------------------------
     # -- mock_git_repository
-    version("main", branch="main")
+    version("main", branch="many_dirs")
     homepage = "http://www.git-fetch-example.com"
 
     submodules = False

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparse_b/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparse_b/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class GitSparseB(Package):
+    """Partal clone of the mock_git_repository fixture"""
+
+    # git='to-be-filled-in-by-test'
+
+    # ----------------------------
+    # -- mock_git_repository
+    version("main", branch="main")
+    homepage = "http://www.git-fetch-example.com"
+
+    submodules = False
+    git_sparse_paths = ["dir1"]


### PR DESCRIPTION
For two packages sharing the same commit plus sparse paths the mirror layout is overriding one another. This PR is to resolve the issue. This should be back-ported to 1.0.1 since it affects the ability to generate a mirror correctly.

See #50699

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
