### PR TITLE
docs: a few more updates for variants

### DIFF
--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -252,7 +252,7 @@ Using ``self.spec.satisfies``
 
 **Variants**.
 In the previous section of the packaging guide, we've seen :ref:`how to define variants <variants>`.
-As a packager, you are responsible for implementing the logic that translates the selected variant values into configure arguments.
+As a packager, you are responsible for implementing the logic that translates the selected variant values into build instructions the build system can understand.
 If you want to pass a flag to the configure script only if the package is built with a specific variant, you can do so like this:
 
 .. code-block:: python

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -246,9 +246,9 @@ Spack is unique in that it allows you to write a *single* ``package.py`` for all
 The central object in Spack that encodes the package's configuration is the **concrete spec**, which is available as ``self.spec`` in the package class.
 This is the object you need to query to make decisions about how to configure the build.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Using ``self.spec.satisfies``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
+Using ``self.spec``
+^^^^^^^^^^^^^^^^^^^
 
 **Variants**.
 In the previous section of the packaging guide, we've seen :ref:`how to define variants <variants>`.
@@ -301,6 +301,31 @@ Even if *multiple* values are selected, you can still use ``key=value`` to test 
 
 Notice that many build systems provide helper functions to make the above code more concise.
 See :ref:`the Autotools docs <autotools_helper_functions>` and :ref:`the CMake docs <cmake_args>`.
+
+Other than testing for certain variant values, you can also obtain the variant value directly with ``self.spec.variants["variant_name"].value``.
+This is useful when you want to pass the variant value as a command line argument to the build system.
+The type of this value depends on the variant type:
+
+* For boolean variants this is :data:`True` or :data:`False`.
+* For single-valued variants this is a :class:`str` value.
+* For multi-valued variants it is a tuple of :class:`str` values.
+
+An example of using this is shown below:
+
+.. code-block:: python
+
+   variant(
+       "cxxstd",
+       default="11",
+       values=("11", "14", "17", "20", "23"),
+       multi=False,
+       description="C++ standard",
+   )
+
+   def configure_args(self):
+       return [
+           f"--with-cxxstd={self.spec.variants['cxxstd'].value}"
+       ]
 
 **Versions**.
 Similarly, versions are often used to dynamically change the build configuration:

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -246,9 +246,9 @@ Spack is unique in that it allows you to write a *single* ``package.py`` for all
 The central object in Spack that encodes the package's configuration is the **concrete spec**, which is available as ``self.spec`` in the package class.
 This is the object you need to query to make decisions about how to configure the build.
 
-^^^^^^^^^^^^^^^^^^^
-Using ``self.spec``
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
+Querying ``self.spec``
+^^^^^^^^^^^^^^^^^^^^^^
 
 **Variants**.
 In the previous section of the packaging guide, we've seen :ref:`how to define variants <variants>`.

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1577,7 +1577,7 @@ be present on specs that otherwise satisfy the spec listed as the
 
 The ``when`` clause follows the same syntax and accepts the same
 values as the ``when`` argument of
-:py:func:`spack.package.depends_on`.
+:py:func:`~spack.package.depends_on`.
 
 ^^^^^^^^^^^^^^^
 Sticky Variants

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1415,8 +1415,11 @@ To define a *single-valued* variant, simply pass ``multi=False`` and a tuple of 
     class Blis(Package):
         ...
         variant(
-            "threads", default="none", description="Multithreading support",
-            values=("pthreads", "openmp", "none"), multi=False
+            "threads",
+            default="none",
+            values=("pthreads", "openmp", "none"),
+            multi=False,
+            description="Multithreading support",
         )
 
 This allows users to ``spack install blis threads=openmp``.
@@ -1447,14 +1450,14 @@ To define a *multi-valued* variant, simply pass ``multi=True`` instead:
     class Gcc(AutotoolsPackage):
         ...
         variant(
-            "languages", default="c,c++,fortran",
-            values=("ada", "brig", "c", "c++", "fortran",
-                    "go", "java", "jit", "lto", "objc", "obj-c++"),
+            "languages",
+            default="c,c++,fortran",
+            values=("ada", "brig", "c", "c++", "fortran", "objc"),
             multi=True,
-            description="Compilers and runtime libraries to build"
+            description="Compilers and runtime libraries to build",
         )
 
-This allows users to run ``spack install languages=c,c++,fortran`` where the values are separated by commas.
+This allows users to run ``spack install languages=c,c++`` where the values are separated by commas.
 
 
 """""""""""""""""""""""""""""""""""""""""""
@@ -1466,14 +1469,14 @@ Naively, one might think that this can be achieved by simply creating a multi-va
 
    .. code-block:: python
 
-      class Adios(AutotoolsPackage):
-         ...
-         variant(
-               "staging",
-               values=("dataspaces", "flexpath", "none"),
-               multi=True,
-               description="Enable dataspaces and/or flexpath staging transports"
-         )
+    class Adios(AutotoolsPackage):
+        ...
+        variant(
+            "staging",
+            values=("dataspaces", "flexpath", "none"),
+            multi=True,
+            description="Enable dataspaces and/or flexpath staging transports",
+        )
 
 but this does not prevent users from selecting the non-sensical option ``staging=dataspaces,none``.
 
@@ -1489,7 +1492,7 @@ The first validator function is :py:func:`~spack.package.any_combination_of`, wh
         variant(
             "staging",
             values=any_combination_of("flexpath", "dataspaces"),
-            description="Enable dataspaces and/or flexpath staging transports"
+            description="Enable dataspaces and/or flexpath staging transports",
         )
 
 This solves the issue by allowing the user to select either any combination of the values ``flexpath`` and ``dataspaces``, or ``none``.
@@ -1504,12 +1507,11 @@ The second validator function :py:func:`~spack.package.disjoint_sets` generalize
         variant(
             "process_managers",
             description="List of the process managers to activate",
-            values=disjoint_sets(
-                ("auto",), ("slurm",), ("hydra", "gforker", "remshell")
-            ).prohibit_empty_set().with_error(
-                "'slurm' or 'auto' cannot be activated along with "
-                "other process managers"
-            ).with_default("auto").with_non_feature_values("auto"),
+            values=disjoint_sets(("auto",), ("slurm",), ("hydra", "gforker", "remshell"))
+            .prohibit_empty_set()
+            .with_error("'slurm' or 'auto' cannot be activated along with other process managers")
+            .with_default("auto")
+            .with_non_feature_values("auto"),
         )
 
 In this case, examples of valid options are ``process_managers=auto``, ``process_managers=slurm``, and ``process_managers=hydra,remshell``, whereas ``process_managers=slurm,hydra`` is invalid, as it picks values from two different sets.
@@ -1530,17 +1532,21 @@ To model a similar situation we can use *conditional possible values* in the var
 .. code-block:: python
 
    variant(
-       "cxxstd", default="98",
+       "cxxstd",
+       default="98",
        values=(
-           "98", "11", "14",
+           "98",
+           "11",
+           "14",
            # C++17 is not supported by Boost < 1.63.0.
            conditional("17", when="@1.63.0:"),
            # C++20/2a is not support by Boost < 1.73.0
-           conditional("2a", "2b", when="@1.73.0:")
+           conditional("2a", "2b", when="@1.73.0:"),
        ),
        multi=False,
        description="Use the specified C++ standard when building.",
    )
+
 
 The snippet above allows ``98``, ``11`` and ``14`` as unconditional possible values for the
 ``cxxstd`` variant, while ``17`` requires a version greater or equal to ``1.63.0``

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1402,14 +1402,13 @@ For example, a package may depend on another package only if a certain variant i
 
 In this case, ``szip`` is modeled as an optional dependency of ``hdf5``, and users can run ``spack install hdf5 +szip`` to enable it.
 
-^^^^^^^^^^^^^^^^^^^^^
-Multi-valued variants
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Single- and multi-valued variants
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Boolean variants are most common, but sometimes a package has options that can take more than two values, or are better expressed with string values rather than booleans.
-This is where multi-valued variants come into play.
-Multi-valued variants take a tuple of *possible* values, and can be configured to allow either a *single value* or *multiple values* to be selected at the same time.
-For example:
+Other than boolean variants, Spack supports single- and multi-valued variants that can take one or more *string* values.
+
+To define a *single-valued* variant, simply pass ``multi=False`` and a tuple of possible values to the ``variant`` directive:
 
   .. code-block:: python
 
@@ -1441,7 +1440,7 @@ This constraint is enforced by the solver, and an error is emitted if a user spe
    In the example above, the value ``threads=none`` is a variant value like any other, and means that *no value is selected*.
    In Spack, all variants have to have a value, so ``none`` was chosen as a *convention* to indicate that no value is selected.
 
-In cases where **multiple values** can be selected at the same time, ``multi`` should be set to ``True``:
+To define a *multi-valued* variant, simply pass ``multi=True`` instead:
 
   .. code-block:: python
 
@@ -1463,7 +1462,7 @@ Complex validation logic for variant values
 """""""""""""""""""""""""""""""""""""""""""
 As noted above, the value ``none`` is a value like any other, which raises the question:
 what if a variant allows multiple values to be selected, *or* none at all?
-Naively, one might think that this can be achieved by simply setting ``multi=True`` and allowing the value ``none``:
+Naively, one might think that this can be achieved by simply creating a multi-valued variant that includes the value ``none``:
 
    .. code-block:: python
 
@@ -1476,7 +1475,7 @@ Naively, one might think that this can be achieved by simply setting ``multi=Tru
                description="Enable dataspaces and/or flexpath staging transports"
          )
 
-but this does not prevent users from selecting ``staging=dataspaces,none``, which is non-sensical.
+but this does not prevent users from selecting the non-sensical option ``staging=dataspaces,none``.
 
 In these cases, more advanced validation logic is required to prevent ``none`` from being selected along with any other value.
 Spack provides two validator functions to help with this, which can be passed to the ``values=`` argument of the ``variant`` directive.

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1402,13 +1402,13 @@ For example, a package may depend on another package only if a certain variant i
 
 In this case, ``szip`` is modeled as an optional dependency of ``hdf5``, and users can run ``spack install hdf5 +szip`` to enable it.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Single- and multi-valued variants
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
+Single-valued variants
+^^^^^^^^^^^^^^^^^^^^^^
 
 Other than boolean variants, Spack supports single- and multi-valued variants that can take one or more *string* values.
 
-To define a *single-valued* variant, simply pass ``multi=False`` and a tuple of possible values to the ``variant`` directive:
+To define a *single-valued* variant, simply pass a tuple of possible values to the ``variant`` directive, together with ``multi=False``:
 
   .. code-block:: python
 
@@ -1443,6 +1443,12 @@ This constraint is enforced by the solver, and an error is emitted if a user spe
    In the example above, the value ``threads=none`` is a variant value like any other, and means that *no value is selected*.
    In Spack, all variants have to have a value, so ``none`` was chosen as a *convention* to indicate that no value is selected.
 
+^^^^^^^^^^^^^^^^^^^^^
+Multi-valued variants
+^^^^^^^^^^^^^^^^^^^^^
+
+Like single-valued variants, multi-valued variants take one or more *string* values, but allow users to select multiple values at the same time.
+
 To define a *multi-valued* variant, simply pass ``multi=True`` instead:
 
   .. code-block:: python
@@ -1460,9 +1466,10 @@ To define a *multi-valued* variant, simply pass ``multi=True`` instead:
 This allows users to run ``spack install languages=c,c++`` where the values are separated by commas.
 
 
-"""""""""""""""""""""""""""""""""""""""""""
-Complex validation logic for variant values
-"""""""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""""""
+Advanced validation of multi-valued variants
+""""""""""""""""""""""""""""""""""""""""""""
+
 As noted above, the value ``none`` is a value like any other, which raises the question:
 what if a variant allows multiple values to be selected, *or* none at all?
 Naively, one might think that this can be achieved by simply creating a multi-valued variant that includes the value ``none``:
@@ -1518,9 +1525,9 @@ In this case, examples of valid options are ``process_managers=auto``, ``process
 
 Both validator functions return a :py:class:`~spack.variant.DisjointSetsOfValues` object, which defines chaining methods to further customize the behavior of the variant.
 
-"""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Conditional Possible Values
-"""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are cases where a variant may take multiple values, and the list of allowed values
 expands over time. Consider, for instance, the C++ standard with which we might compile

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1564,10 +1564,9 @@ and both ``2a`` and ``2b`` require a version greater or equal to ``1.73.0``.
 Conditional Variants
 ^^^^^^^^^^^^^^^^^^^^
 
-The variant directive accepts a ``when`` clause. The variant will only
-be present on specs that otherwise satisfy the spec listed as the
-``when`` clause. For example, the following class has a variant
-``bar`` when it is at version 2.0 or higher.
+The variant directive accepts a ``when`` clause.
+The variant will only be present on specs that otherwise satisfy the spec listed as the ``when`` clause.
+For example, the following package defines a variant ``bar`` that exists only when it is at version 2.0 or higher.
 
 .. code-block:: python
 
@@ -1575,9 +1574,6 @@ be present on specs that otherwise satisfy the spec listed as the
        ...
        variant("bar", default=False, when="@2.0:", description="help message")
 
-The ``when`` clause follows the same syntax and accepts the same
-values as the ``when`` argument of
-:py:func:`~spack.package.depends_on`.
 
 ^^^^^^^^^^^^^^^
 Sticky Variants

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1564,22 +1564,26 @@ and both ``2a`` and ``2b`` require a version greater or equal to ``1.73.0``.
 Conditional Variants
 ^^^^^^^^^^^^^^^^^^^^
 
-The variant directive accepts a ``when`` clause.
-The variant will only be present on specs that otherwise satisfy the spec listed as the ``when`` clause.
-For example, the following package defines a variant ``bar`` that exists only when it is at version 2.0 or higher.
+As new versions of packages are released, optional features may be added and removed.
+Sometimes, features are only available for a particular platform or architecture.
+
+To reduce the visual clutter in specs, packages can define variants *conditionally* using a ``when`` clause.
+The variant will only be present on specs that satisfy this condition.
+
+For example, the following package defines a variant ``bar`` that exists only when it is at version 2.0 or higher, and a variant ``baz`` that exists only on the Darwin platform:
 
 .. code-block:: python
 
    class Foo(Package):
        ...
-       variant("bar", default=False, when="@2.0:", description="help message")
+       variant("bar", default=False, when="@2.0:", ...)
+       variant("baz", default=True, when="platform=darwin", ...)
 
-.. note::
-
-   Conditional variants are a great way to reduce visual clutter, but they can also be a source of confusion: in Spack, the absence of a variant is different from a variant being disabled.
-   For example, a user might run ``spack install foo ~bar``, expecting it to allow version 1.0 (which does not have the ``bar`` feature) or version 2.0 (with the feature disabled).
-   However, the constraint ``~bar`` tells Spack that the ``bar`` variant *must exist* and be disabled.
-   This forces Spack to select version 2.0 or higher, where the variant is defined.
+Do note that conditional variants can also be a source of confusion.
+In Spack, the absence of a variant is different from it being disabled.
+For example, a user might run ``spack install foo ~bar``, expecting it to allow version 1.0 (which does not have the ``bar`` feature) and version 2.0 (with the feature disabled).
+However, the constraint ``~bar`` tells Spack that the ``bar`` variant *must exist* and be disabled.
+This forces Spack to select version 2.0 or higher, where the variant is defined.
 
 ^^^^^^^^^^^^^^^
 Sticky Variants

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1547,7 +1547,7 @@ To model a similar situation we can use *conditional possible values* in the var
            "14",
            # C++17 is not supported by Boost < 1.63.0.
            conditional("17", when="@1.63.0:"),
-           # C++20/2a is not support by Boost < 1.73.0
+           # C++20/2a is not supported by Boost < 1.73.0
            conditional("2a", "2b", when="@1.73.0:"),
        ),
        multi=False,

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1574,6 +1574,12 @@ For example, the following package defines a variant ``bar`` that exists only wh
        ...
        variant("bar", default=False, when="@2.0:", description="help message")
 
+.. note::
+
+   Conditional variants are a great way to reduce visual clutter, but they can also be a source of confusion: in Spack, the absence of a variant is different from a variant being disabled.
+   For example, a user might run ``spack install foo ~bar``, expecting it to allow version 1.0 (which does not have the ``bar`` feature) or version 2.0 (with the feature disabled).
+   However, the constraint ``~bar`` tells Spack that the ``bar`` variant *must exist* and be disabled.
+   This forces Spack to select version 2.0 or higher, where the variant is defined.
 
 ^^^^^^^^^^^^^^^
 Sticky Variants

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -165,31 +165,27 @@ A version specifier
 comes after a package name and starts with ``@``.
 It can be something abstract that matches multiple known versions or a specific version.
 
-The version specifier usually represents *a range of versions*, but can also be *a specific version*.
+The version specifier usually represents *a range of versions*:
 
-.. tab-set::
+.. code-block::
 
-   .. tab-item:: Range of Versions
+   # All versions between v1.0 and v1.5.
+   # This includes any v1.5.x version
+   @1.0:1.5
 
-      .. code-block::
+   # All versions up to and including v3
+   # This would include v3.4 etc.
+   @:3
 
-         # All versions between v1.0 and v1.5.
-         # This includes any v1.5.x version
-         @1.0:1.5
+   # All versions above and including v4.2
+   @4.2:
 
-         # All versions up to and including v3
-         # This would include v3.4 etc.
-         @:3
+but can also be *a specific version*:
 
-         # All versions above and including v4.2
-         @4.2:
+.. code-block:: text
 
-   .. tab-item:: Exact Version
-
-      .. code-block:: text
-
-         # Exactly version v3.2, will NOT match v3.2.1 etc.
-         @=3.2
+   # Exactly version v3.2, will NOT match v3.2.1 etc.
+   @=3.2
 
 
 As a shorthand, ``@3`` is equivalent to the range ``@3:3`` and includes any version with major version ``3``.
@@ -264,66 +260,70 @@ They are optional, as each package must provide default values for each variant 
 The variants available for a particular package are defined by the package author.
 ``spack info <package>`` will provide information on what build variants are available.
 
-There are different types of variants:
+There are different types of variants.
 
-.. tab-set::
+^^^^^^^^^^^^^^^^
+Boolean Variants
+^^^^^^^^^^^^^^^^
 
-   .. tab-item:: Boolean Variants
+Typically used to enable or disable a feature at compile time.
+For example, a package might have a ``debug`` variant that can be explicitly enabled with:
 
-      Typically used to enable or disable a feature at compile time.
-      For example, a package might have a ``debug`` variant that can be explicitly enabled with:
+.. code-block::
 
-      .. code-block::
+   +debug
 
-         +debug
+and disabled with
 
-      and disabled with
+.. code-block::
 
-      .. code-block::
+   ~debug
 
-         ~debug
+^^^^^^^^^^^^^^^^^^^^^^
+Single-valued Variants
+^^^^^^^^^^^^^^^^^^^^^^
 
-   .. tab-item:: Single-valued Variants
+Often used to set defaults.
+For example, a package might have a ``compression`` variant that determines the default compression algorithm, which users could set to:
 
-      Often used to set defaults.
-      For example, a package might have a ``compression`` variant that determines the default compression algorithm, which users could set to:
+.. code-block::
 
-      .. code-block::
+   compression=gzip
 
-         compression=gzip
+or
 
-      or
+.. code-block::
 
-      .. code-block::
+   compression=zstd
 
-         compression=zstd
+^^^^^^^^^^^^^^^^^^^^^
+Multi-valued Variants
+^^^^^^^^^^^^^^^^^^^^^
 
-   .. tab-item:: Multi-valued Variants
+A package might have a ``fabrics`` variant that determines which network fabrics to support.
+Users could activate multiple values at the same time. For instance:
 
-      A package might have a ``fabrics`` variant that determines which network fabrics to support.
-      Users could activate multiple values at the same time. For instance:
+.. code-block::
 
-      .. code-block::
+   fabrics=verbs,ofi
 
-         fabrics=verbs,ofi
+enables both InfiniBand verbs and OpenFabrics interfaces.
+The values are separated by commas.
 
-      enables both InfiniBand verbs and OpenFabrics interfaces.
-      The values are separated by commas.
+The meaning of ``fabrics=verbs,ofi`` is to enable *at least* the specified fabrics, but other fabrics may be enabled as well.
+If the intent is to enable *only* the specified fabrics, then the:
 
-      The meaning of ``fabrics=verbs,ofi`` is to enable *at least* the specified fabrics, but other fabrics may be enabled as well.
-      If the intent is to enable *only* the specified fabrics, then the:
+.. code-block::
 
-      .. code-block::
+   fabrics:=verbs,ofi
 
-         fabrics:=verbs,ofi
-
-      syntax should be used with the ``:=`` operator.
+syntax should be used with the ``:=`` operator.
 
 .. admonition:: Alternative ways to deactivate Boolean Variants
    :class: note
    :collapsible:
 
-   In certain shells, the ``~`` character is expanded to the home directory.
+   In certain shells, the ``~`` character expands to the home directory.
    To avoid these issues, avoid whitespace between the package name and the variant:
 
    .. code-block:: sh

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/conditional_values_in_variant/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/conditional_values_in_variant/package.py
@@ -26,7 +26,7 @@ class ConditionalValuesInVariant(Package):
             "14",
             # C++17 is not supported by Boost < 1.63.0.
             conditional("17", when="@1.63.0:"),
-            # C++20/2a is not support by Boost < 1.73.0
+            # C++20/2a is not supported by Boost < 1.73.0
             conditional("2a", when="@1.73.0:"),
         ),
         multi=False,


### PR DESCRIPTION
* The use of tabs in the Spec Syntax section makes it impossible to `Ctrl+F` because it's hidden, and prevents linking to these sections as they don't appear in the outline.
* Fix an issue where the packaging guide introduced single-valued variants incorrectly as multi-valued variants.
* Improve the section about conditional variants
* Document `self.spec.variants[...].value` for use in build configuration.