### PR TITLE
spack edit -b: support specifying build_system repos/namespace

### DIFF
--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -12,6 +12,7 @@ import spack.llnl.util.tty as tty
 import spack.paths
 import spack.repo
 import spack.util.editor
+from typing import Optional, Union
 
 description = "open package files in $EDITOR"
 section = "packaging"
@@ -76,8 +77,10 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument("package", nargs="*", default=None, help="package name")
 
 
-def locate_package(name: str, repo: spack.repo.Repo) -> str:
-    path = repo.filename_for_package_name(name)
+def locate_package(name: str, repo: Optional[spack.repo.Repo]) -> str:
+    # if not given a repo, use the full repo path to choose one
+    repo_like: Union[spack.repo.Repo, spack.repo.RepoPath] = repo or spack.repo.PATH
+    path: str = repo_like.filename_for_package_name(name)
 
     try:
         with open(path, "r", encoding="utf-8"):
@@ -86,6 +89,28 @@ def locate_package(name: str, repo: spack.repo.Repo) -> str:
         if e.errno == errno.ENOENT:
             raise spack.repo.UnknownPackageError(name) from e
         tty.die(f"Cannot edit package: {e}")
+
+
+def locate_build_system(name: str, repo: Optional[spack.repo.Repo]) -> str:
+    # If given a fullname for a build system, split it into namespace and name
+    namespace = None
+    if "." in name:
+        namespace, name = name.rsplit(".", 1)
+
+    # If given a namespace and a repo, they better match
+    # If not given a repo, use the namespace
+    # If repo and no namespace, just use the first one available
+    if namespace and repo:
+        if repo.namespace != namespace:
+            msg = f"{namespace}.{name}: namespace conflicts with repo '{repo.namespace}'"
+            msg += " specified from --repo or --namespace argument"
+            raise ValueError(msg)
+    elif namespace:
+        repo = spack.repo.PATH.get_repo(namespace)
+    elif not repo:
+        repo = spack.repo.PATH.first_repo()
+
+    return locate_file(name, repo.build_systems_path)
 
 
 def locate_file(name: str, path: str) -> str:
@@ -118,23 +143,6 @@ def locate_file(name: str, path: str) -> str:
     return files[0]
 
 
-def repo_from_args(args):
-    if args.repo:
-        return spack.repo.from_path(args.repo)
-    elif args.namespace:
-        return spack.repo.PATH.get_repo(args.namespace)
-    elif args.package and not args.path:
-        # for package names, we can take a RepoPath and find which repo they're in
-        return spack.repo.PATH
-    else:
-        # If there's a fullname for a build system, use the first one
-        for name in args.package:
-            if "." in name:
-                return spack.repo.PATH.get_repo(name.rsplit(".", 1)[0])
-        # for build systems or packages_path, just take the first repo
-        return spack.repo.PATH.first_repo()
-
-
 def edit(parser, args):
     names = args.package
 
@@ -144,16 +152,23 @@ def edit(parser, args):
         spack.util.editor.editor(*paths)
         return
 
-    repo = repo_from_args(args)
+    # Cannot set repo = spack.repo.PATH.first_repo() as default because packages and build_systems
+    # can include repo information as part of their fullname
+    repo = None
+    if args.namespace:
+        repo = spack.repo.PATH.get_repo(args.namespace)
+    elif args.repo:
+        repo = spack.repo.from_path(args.repo)
+    # default_repo used when no name provided
+    default_repo = repo or spack.repo.PATH.first_repo()
+
     if args.path == "BUILD_SYSTEM":
-        # Ignore namespaces -- we've already found the repo
-        names = [name.rsplit(".", 1)[-1] for name in names]
-        root = repo.build_systems_path
-        paths = [locate_file(name, root) for name in names] if names else [root]
+        if names:
+            paths = [locate_build_system(n, repo) for n in names]
+        else:
+            paths = [default_repo.build_systems_path]
         spack.util.editor.editor(*paths)
-    elif names:
-        paths = [locate_package(name, repo) for name in names]
-        spack.util.editor.editor(*paths)
-    else:
-        # By default open the directory where packages live
-        spack.util.editor.editor(repo.packages_path)
+        return
+
+    paths = [locate_package(n, repo) for n in names] if names else [default_repo.packages_path]
+    spack.util.editor.editor(*paths)

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -18,26 +18,19 @@ section = "packaging"
 level = "short"
 
 
-class ComputeBuildSystemPathAction(argparse.Action):
-    """Compute the path to the build system directory. This is done lazily so that we use the
-    correct spack.repo.PATH when the command is run."""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, os.path.join(spack.repo.PATH.repos[0].root, "build_systems"))
-
-
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     excl_args = subparser.add_mutually_exclusive_group()
 
     # Various types of Spack files that can be edited
     # Edits package files by default
+    # build systems require separate logic to find
     excl_args.add_argument(
         "-b",
         "--build-system",
         dest="path",
-        action=ComputeBuildSystemPathAction,
-        nargs=0,
-        help="edit the build system with the supplied name",
+        action="store_const",
+        const="BUILD_SYSTEM",  # placeholder for path that requires computing late
+        help="edit the build system with the supplied name or fullname",
     )
     excl_args.add_argument(
         "-c",
@@ -72,9 +65,13 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="edit the main spack module with the supplied name",
     )
 
-    # Options for editing packages
-    excl_args.add_argument("-r", "--repo", default=None, help="path to repo to edit package in")
-    excl_args.add_argument("-N", "--namespace", default=None, help="namespace of package to edit")
+    # Options for editing packages and build systems
+    subparser.add_argument(
+        "-r", "--repo", default=None, help="path to repo to edit package or build system in"
+    )
+    subparser.add_argument(
+        "-N", "--namespace", default=None, help="namespace of package or build system to edit"
+    )
 
     subparser.add_argument("package", nargs="*", default=None, help="package name")
 
@@ -121,22 +118,42 @@ def locate_file(name: str, path: str) -> str:
     return files[0]
 
 
+def repo_from_args(args):
+    if args.repo:
+        return spack.repo.from_path(args.repo)
+    elif args.namespace:
+        return spack.repo.PATH.get_repo(args.namespace)
+    elif args.package and not args.path:
+        # for package names, we can take a RepoPath and find which repo they're in
+        return spack.repo.PATH
+    else:
+        # If there's a fullname for a build system, use the first one
+        for name in args.package:
+            if "." in name:
+                return spack.repo.PATH.get_repo(name.rsplit(".", 1)[0])
+        # for build systems or packages_path, just take the first repo
+        return spack.repo.PATH.first_repo()
+
+
 def edit(parser, args):
     names = args.package
 
-    # If `--command`, `--test`, or `--module` is chosen, edit those instead
-    if args.path:
+    # If `--command`, `--test`, `--docs`, or `--module` is chosen, edit those instead
+    if args.path and args.path != "BUILD_SYSTEM":
         paths = [locate_file(name, args.path) for name in names] if names else [args.path]
         spack.util.editor.editor(*paths)
+        return
+
+    repo = repo_from_args(args)
+    if args.path == "BUILD_SYSTEM":
+        # Ignore namespaces -- we've already found the repo
+        names = [name.rsplit(".", 1)[-1] for name in names]
+        root = repo.build_systems_path
+        paths = [locate_file(name, root) for name in names] if names else [root]
+        spack.util.editor.editor(*paths)
     elif names:
-        if args.repo:
-            repo = spack.repo.from_path(args.repo)
-        elif args.namespace:
-            repo = spack.repo.PATH.get_repo(args.namespace)
-        else:
-            repo = spack.repo.PATH
         paths = [locate_package(name, repo) for name in names]
         spack.util.editor.editor(*paths)
     else:
         # By default open the directory where packages live
-        spack.util.editor.editor(spack.repo.PATH.repos[0].packages_path)
+        spack.util.editor.editor(repo.packages_path)

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -111,6 +111,7 @@ def locate_build_system(name: str, repo: Optional[spack.repo.Repo]) -> str:
     if not repo:
         repo = spack.repo.PATH.first_repo()
 
+    assert repo
     return locate_file(name, repo.build_systems_path)
 
 

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -6,13 +6,13 @@ import argparse
 import errno
 import glob
 import os
+from typing import Optional, Union
 
 import spack.cmd
 import spack.llnl.util.tty as tty
 import spack.paths
 import spack.repo
 import spack.util.editor
-from typing import Optional, Union
 
 description = "open package files in $EDITOR"
 section = "packaging"
@@ -98,16 +98,17 @@ def locate_build_system(name: str, repo: Optional[spack.repo.Repo]) -> str:
         namespace, name = name.rsplit(".", 1)
 
     # If given a namespace and a repo, they better match
-    # If not given a repo, use the namespace
-    # If repo and no namespace, just use the first one available
     if namespace and repo:
         if repo.namespace != namespace:
             msg = f"{namespace}.{name}: namespace conflicts with repo '{repo.namespace}'"
             msg += " specified from --repo or --namespace argument"
             raise ValueError(msg)
-    elif namespace:
+
+    if namespace:
         repo = spack.repo.PATH.get_repo(namespace)
-    elif not repo:
+
+    # If not given a namespace, use the default
+    if not repo:
         repo = spack.repo.PATH.first_repo()
 
     return locate_file(name, repo.build_systems_path)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1061,6 +1061,7 @@ class Repo:
             config.get("subdirectory", packages_dir_name), root, self.package_api
         )
         self.packages_path = os.path.join(self.root, self.subdirectory)
+        self.build_systems_path = os.path.join(self.root, "build_systems")
 
         check(
             os.path.isdir(self.packages_path),

--- a/lib/spack/spack/test/cmd/edit.py
+++ b/lib/spack/spack/test/cmd/edit.py
@@ -5,6 +5,7 @@
 import os
 import pathlib
 
+import spack.paths
 import spack.repo
 import spack.util.editor
 from spack.main import SpackCommand

--- a/lib/spack/spack/test/cmd/edit.py
+++ b/lib/spack/spack/test/cmd/edit.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import pathlib
 
 import spack.repo
 import spack.util.editor
@@ -43,3 +44,23 @@ def test_edit_files(monkeypatch, mock_packages):
     monkeypatch.setattr(spack.util.editor, "editor", editor)
     edit("--build-system", "autotools", "cmake")
     assert called
+
+
+def test_edit_non_default_build_system(monkeypatch, mock_packages, mutable_config):
+    called = False
+
+    def editor(*args: str, **kwargs):
+        nonlocal called
+        called = True
+        from spack_repo.builtin_mock.build_systems import autotools, cmake  # type: ignore
+
+        assert os.path.samefile(args[0], autotools.__file__)
+        assert os.path.samefile(args[1], cmake.__file__)
+
+    monkeypatch.setattr(spack.util.editor, "editor", editor)
+
+    # set up an additional repo
+    extra_repo_dir = pathlib.Path(spack.paths.test_repos_path) / "spack_repo" / "requirements_test"
+    with spack.repo.use_repositories(str(extra_repo_dir), override=False):
+        edit("--build-system", "builtin_mock.autotools", "builtin_mock.cmake")
+        assert called

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1500,7 +1500,7 @@ complete -c spack -n '__fish_spack_using_command_pos_remainder 0 edit' -f -a '(_
 complete -c spack -n '__fish_spack_using_command edit' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command edit' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command edit' -s b -l build-system -f -a path
-complete -c spack -n '__fish_spack_using_command edit' -s b -l build-system -d 'edit the build system with the supplied name'
+complete -c spack -n '__fish_spack_using_command edit' -s b -l build-system -d 'edit the build system with the supplied name or fullname'
 complete -c spack -n '__fish_spack_using_command edit' -s c -l command -f -a path
 complete -c spack -n '__fish_spack_using_command edit' -s c -l command -d 'edit the command with the supplied name'
 complete -c spack -n '__fish_spack_using_command edit' -s d -l docs -f -a path
@@ -1510,9 +1510,9 @@ complete -c spack -n '__fish_spack_using_command edit' -s t -l test -d 'edit the
 complete -c spack -n '__fish_spack_using_command edit' -s m -l module -f -a path
 complete -c spack -n '__fish_spack_using_command edit' -s m -l module -d 'edit the main spack module with the supplied name'
 complete -c spack -n '__fish_spack_using_command edit' -s r -l repo -r -f -a repo
-complete -c spack -n '__fish_spack_using_command edit' -s r -l repo -r -d 'path to repo to edit package in'
+complete -c spack -n '__fish_spack_using_command edit' -s r -l repo -r -d 'path to repo to edit package or build system in'
 complete -c spack -n '__fish_spack_using_command edit' -s N -l namespace -r -f -a namespace
-complete -c spack -n '__fish_spack_using_command edit' -s N -l namespace -r -d 'namespace of package to edit'
+complete -c spack -n '__fish_spack_using_command edit' -s N -l namespace -r -d 'namespace of package or build system to edit'
 
 # spack env
 set -g __fish_spack_optspecs_spack_env h/help


### PR DESCRIPTION
Currently, there is no way to use `spack edit -b` to edit a build system that is not in the highest priority repo. This is a problem for users with multiple repos, as they often use the build systems from `builtin`.

This PR supports specifying the repo or namespace for a build system passed to `spack edit -b`.

Things it does not support:
- autodetecting which repo a builtin comes from
- specifying different repos for multiple build systems in one `spack edit -b` command

Those are not supported because they would require more substantial additions to the `spack.repo.RepoPath` object, and it's dubious whether the usefulness for this command is worth the additional maintenance burden in the code

Includes regression test.
