### PR TITLE
docs: avoid misuse of "begs the question"

### DIFF
--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1461,7 +1461,7 @@ This allows users to run ``spack install languages=c,c++,fortran`` where the val
 """""""""""""""""""""""""""""""""""""""""""
 Complex validation logic for variant values
 """""""""""""""""""""""""""""""""""""""""""
-As noted above, the value ``none`` is a value like any other, which begs the question:
+As noted above, the value ``none`` is a value like any other, which raises the question:
 what if a variant allows multiple values to be selected, *or* none at all?
 Naively, one might think that this can be achieved by simply setting ``multi=True`` and allowing the value ``none``:
 


### PR DESCRIPTION
docs/packaging_guide_creation: "begs the question" -> "raises the question"

"beg the question" and "raise the question" are not synonyms. "begging the question" means committing the fallacy of assuming the conclusion in the premises.

e.g. Spack is great because it is so user friendly

This is begging the question, because it asserts the conclusion without actually addressing the real question (how/why is spack user friendly).

In all other cases in which a statement makes for an obvious next question, "raises the question" is correct.
