### PR TITLE
config edit: allow editing malformed spack.yaml file

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -219,7 +219,16 @@ def config_edit(args):
     the active environment.
     """
     spack_env = os.environ.get(ev.spack_env_var)
-    if spack_env and not args.scope:
+    env_error = ev.environment._active_environment_error
+
+    if env_error and args.scope:
+        # Cannot use scopes beyond the environment itself with a failed environment
+        raise env_error
+    elif env_error:
+        # The rest of the config system wasn't set up fully, but spack.main was allowed
+        # to progress so the user can open the malformed environment file
+        config_file = env_error.filename
+    elif spack_env and not args.scope:
         # Don't use the scope object for envs, as `config edit` can be called
         # for a malformed environment. Use SPACK_ENV to find spack.yaml.
         config_file = ev.manifest_file(spack_env)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -58,6 +58,10 @@ spack_env_view_var = "SPACK_ENV_VIEW"
 #: currently activated environment
 _active_environment: Optional["Environment"] = None
 
+# This is used in spack.main to bypass env failures if the command is `spack config edit`
+# It is used in spack.cmd.config to get the path to a failed env for `spack config edit`
+#: Validation error for a currently activate environment that failed to parse
+_active_environment_error: Optional[spack.config.ConfigFormatError] = None
 
 #: default path where environments are stored in the spack tree
 default_env_path = os.path.join(spack.paths.var_path, "environments")

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -587,7 +587,7 @@ def _read_yaml(str_or_file):
         data = syaml.load_config(str_or_file)
     except syaml.SpackYAMLError as e:
         raise SpackEnvironmentConfigError(
-            f"Invalid environment configuration detected: {e.message}"
+            f"Invalid environment configuration detected: {e.message}", e.filename
         )
 
     filename = getattr(str_or_file, "name", None)
@@ -3026,3 +3026,6 @@ class SpackEnvironmentViewError(SpackEnvironmentError):
 
 class SpackEnvironmentConfigError(SpackEnvironmentError):
     """Class for Spack environment-specific configuration errors."""
+    def __init__(self, msg, filename):
+        self.filename = filename
+        super().__init__(msg)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -3026,6 +3026,7 @@ class SpackEnvironmentViewError(SpackEnvironmentError):
 
 class SpackEnvironmentConfigError(SpackEnvironmentError):
     """Class for Spack environment-specific configuration errors."""
+
     def __init__(self, msg, filename):
         self.filename = filename
         super().__init__(msg)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -987,8 +987,6 @@ def _main(argv=None):
             # `spack config edit` can still work with a bad environment.
             e.print_context()
             env_format_error = e
-        except Exception as e:
-            raise
 
     def add_environment_scope(priority):
         if env_format_error:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -989,6 +989,11 @@ def _main(argv=None):
             env_format_error = e
 
     def add_environment_scope(priority):
+        if env_format_error:
+            # Allow command to continue without env in case it is `spack config edit`
+            # All other cases will raise in `finish_parse_and_run`
+            spack.environment.environment._active_environment_error = env_format_error
+            return
         # do not call activate here, as it has a lot of expensive function calls to deal
         # with mutation of spack.config.CONFIG -- but we are still building the config.
         env.manifest.prepare_config_scope(priority)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -982,11 +982,13 @@ def _main(argv=None):
     if not args.no_env:
         try:
             env = spack.cmd.find_environment(args)
-        except spack.config.ConfigFormatError as e:
+        except (spack.config.ConfigFormatError, ev.SpackEnvironmentConfigError) as e:
             # print the context but delay this exception so that commands like
             # `spack config edit` can still work with a bad environment.
             e.print_context()
             env_format_error = e
+        except Exception as e:
+            raise
 
     def add_environment_scope(priority):
         if env_format_error:

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -148,6 +148,25 @@ contains "usage: spack env deactivate " spack env deactivate no_such_environment
 contains "usage: spack env deactivate " spack env deactivate -h
 contains "usage: spack env deactivate " spack env deactivate --help
 
+title "Testing 'spack config edit'"
+echo "Testing 'spack config edit' with malformed spack.yaml"
+spack env activate --temp
+bad_yaml_env=$(spack location -e)
+mv $bad_yaml_env/spack.yaml $bad_yaml_env/.backup
+echo "bad_yaml" > $bad_yaml_env/spack.yaml
+EDITOR=cat contains "Error: " spack config edit  # error message prints first
+EDITOR=cat contains "bad_yaml" spack config edit  # followed by call to EDITOR
+
+echo "testing 'spack config edit' with non-complying spack.yaml"
+cat > $bad_yaml_env/spack.yaml <<EOF
+spack:
+  foo: bar
+EOF
+EDITOR=cat contains "Error: " spack config edit  # error message prints first
+EDITOR=cat contains "foo: bar" spack config edit  # followed by call to EDITOR
+mv $bad_yaml_env/.backup $bad_yaml_env/spack.yaml
+despacktivate
+
 title 'Testing activate and deactivate together'
 echo "Testing 'spack env activate spack_test_env'"
 succeeds spack env activate spack_test_env


### PR DESCRIPTION
Fixes #41470 (`spack config edit` fails if the `spack.yaml` file is malformed).

When spack.yaml generates a ConfigFormatError and the command is `spack config edit`, we cache that error as `spack.environment.environment._active_environment_error`.

In `spack config edit`, raise if there is an active environment error and the command would not edit the `spack.yaml` file. If it is editing the `spack.yaml` file, get the filename from the cached error since there is no properly active environment.