### PR TITLE
tutorial: update branch from v0.23 to v1.0

### DIFF
--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -23,7 +23,7 @@ level = "long"
 
 
 # tutorial configuration parameters
-tutorial_branch = "releases/v0.23"
+tutorial_branch = "releases/v1.0"
 tutorial_mirror = "file:///mirror"
 tutorial_key = os.path.join(spack.paths.share_path, "keys", "tutorial.pub")
 


### PR DESCRIPTION
Ensure `spack tutorial` clones `v1.0` instead of `v0.23`.