### PR TITLE
environments: improve ux for error messages

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -575,7 +575,8 @@ def _env_untrack_or_remove(
             f"Really {'remove' if remove else 'untrack'} {environments} {envs}?", default=False
         )
         if not answer:
-            tty.die("Will not remove any environments")
+            tty.msg(f"Will not remove environment(s) {envs}")
+            return
 
     # keep track of the environments we remove for later printing the exit code
     removed_env_names = []

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -384,9 +384,9 @@ def install_with_active_env(env: ev.Environment, args, install_kwargs, reporter)
         specs_to_install = env.all_matching_specs(*specs)
         if not specs_to_install:
             msg = (
-                "Cannot install '{0}' because no matching specs are in the current environment."
-                " You can add specs to the environment with 'spack add {0}', or as part"
-                " of the install command with 'spack install --add {0}'"
+                "Cannot install '{0}' because no matching specs are in the current environment.\n"
+                " Specs can be added to the environment with 'spack add {0}',\n"
+                " or as part of the install command with 'spack install --add {0}'"
             ).format(" ".join(args.spec))
             tty.die(msg)
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -798,7 +798,7 @@ def test_install_no_add_in_env(
         # Assert using --no-add with a spec not in the env fails
         inst_out = install("--fake", "--no-add", "boost", fail_on_error=False, output=str)
 
-        assert "You can add specs to the environment with 'spack add " in inst_out
+        assert "Specs can be added to the environment with 'spack add " in inst_out
 
         # Without --add, ensure that two packages "a" get installed
         inst_out = install("--fake", "pkg-a", output=str)


### PR DESCRIPTION
This PR updates environment messaging for better user experience:

- Changes the message shown when the user chooses not to remove an environment from an error to a regular informational message.
- Updates the error displayed when attempting to install a spec before adding it to the environment to use third person and include line breaks.
