### PR TITLE
repo: don't overwrite branch when initially cloning repo

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1710,7 +1710,9 @@ class RemoteRepoDescriptor(RepoDescriptor):
                             refs = git("ls-remote", "--symref", remote, "HEAD", output=str)
                             ref_match = re.search(r"refs/heads/(\S+)", refs)
                             if not ref_match:
-                                self.error = f"Unable to locate a default branch for {self.repository}"
+                                self.error = (
+                                    f"Unable to locate a default branch for {self.repository}"
+                                )
                                 return
                             self.branch = ref_match.group(1)
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1705,12 +1705,14 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         spack.util.git.init_git_repo(self.repository, remote=remote, git_exe=git)
 
                         # determine the default branch from ls-remote
-                        refs = git("ls-remote", "--symref", remote, "HEAD", output=str)
-                        ref_match = re.search(r"refs/heads/(\S+)", refs)
-                        if not ref_match:
-                            self.error = f"Unable to locate a default branch for {self.repository}"
-                            return
-                        self.branch = ref_match.group(1)
+                        # (if no branch, tag, or commit is specified)
+                        if not (self.commit or self.tag or self.branch):
+                            refs = git("ls-remote", "--symref", remote, "HEAD", output=str)
+                            ref_match = re.search(r"refs/heads/(\S+)", refs)
+                            if not ref_match:
+                                self.error = f"Unable to locate a default branch for {self.repository}"
+                                return
+                            self.branch = ref_match.group(1)
 
                     # determine the branch and remote if no config values exist
                     elif not (self.commit or self.tag or self.branch):


### PR DESCRIPTION
@becker33 identified a bug where v1.0 instances of Spack were not correctly defaulting to the stable release of the packages repository. That happened due to how we tried to find the default branch for a remote repository and were accidentally replacing any supplied branch with that of the dynamically determined branch.

This PR gates that dynamic logic behind a conditional statement if a branch, tag, or commit are NOT specified.