### PR TITLE
Fix build failure caused by missing symlinked assets

### DIFF
--- a/lib/spack/docs/_static/spack-logo-text.svg
+++ b/lib/spack/docs/_static/spack-logo-text.svg
@@ -1,1 +1,64 @@
-../_spack_root/share/spack/logo/spack-logo-text.svg
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="850" height="256"
+     viewBox="-128 -128 850 256"
+     version="1.1"
+     xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     xmlns:ev="http://www.w3.org/2001/xml-events">
+
+  <style>
+    .logo        { font-family:Arial; font-weight:bold; }
+    .diamond     { fill:#0f3a80; }
+    circle.back  { fill:#ffa600; stroke:#0f3a80; stroke-width:6; }
+    circle.front { fill:#ffffff; stroke:#0f3a80; stroke-width:6; }
+    line.back    { stroke:#ffa600; stroke-width:7; }
+    line.front   { stroke:#ffffff; stroke-width:7; }
+    line.shadow  { stroke:#0f3a80; stroke-width:7; }
+  </style>
+
+  <defs>
+    <!-- need two arrows b/c we can't sync color with the marked element -->
+    <marker id="barrow" markerWidth="4" markerHeight="3" refX=".05" refY="1.5"
+            orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,3 L4,1.5 z" fill="#ffa600"/>
+    </marker>
+    <marker id="farrow" markerWidth="4" markerHeight="3" refX=".05" refY="1.5"
+            orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,3 L4,1.5 z" fill="#ffffff"/>
+    </marker>
+  </defs>
+
+  <!-- rounded diamond shape -->
+  <rect x="-97" y="-97" width="194" height="194" rx="26" ry="26"
+        transform="rotate(45)" class="diamond"/>
+
+  <!-- background dependency structure -->
+  <line x1="-11" y1="-80" x2="-11" y2="-29" transform="rotate(42 -11 -80)"
+        class="back" marker-end="url(#barrow)"/>
+  <line x1="-80" y1="0"   x2="-80" y2="57"  transform="rotate(-45 -80 0)"
+        class="back" marker-end="url(#barrow)"/>
+  <line x1="-11" y1="-80" x2="-11" y2="28" class="back"
+        marker-end="url(#barrow)"/>
+
+  <circle cx="-11" cy="-80" r="23" class="back"/>
+  <circle cx="0"   cy="80"  r="23" class="back"/>
+  <circle cx="-80" cy="0"   r="23" class="back"/>
+
+  <!-- foreground dependency structure -->
+  <line x1="18" y1="-80" x2="18" y2="0" transform="rotate(42 17 -80)"
+        class="shadow"/>
+  <line x1="13" y1="-80" x2="13" y2="-5" transform="rotate(42 11 -80)"
+        class="front" marker-end="url(#farrow)"/>
+
+  <line x1="11" y1="-80" x2="11" y2="-29" transform="rotate(-42 11 -80)"
+        class="front" marker-end="url(#farrow)"/>
+  <line x1="80" y1="0"   x2="80" y2="57"  transform="rotate(45 80 0)"
+        class="front" marker-end="url(#farrow)"/>
+  <line x1="11" y1="-80" x2="11" y2="28"  class="front"
+        marker-end="url(#farrow)"/>
+
+  <circle cx="11" cy="-80" r="23" class="front"/>
+  <circle cx="80" cy="0"   r="23" class="front"/>
+
+  <text x="160" y="64" font-size="128pt" class="logo">Spack</text>
+</svg>

--- a/lib/spack/docs/_static/spack-logo-white-text.svg
+++ b/lib/spack/docs/_static/spack-logo-white-text.svg
@@ -1,1 +1,64 @@
-../_spack_root/share/spack/logo/spack-logo-white-text.svg
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="850" height="256"
+     viewBox="-128 -128 850 256"
+     version="1.1"
+     xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     xmlns:ev="http://www.w3.org/2001/xml-events">
+
+  <style>
+    .logo        { font-family:Arial; font-weight:bold; fill:#ffffff; }
+    .diamond     { fill:#ffffff; }
+    circle.back  { fill:#ffa600; stroke:#ffffff; stroke-width:6; }
+    circle.front { fill:#0e3d7e; stroke:#ffffff; stroke-width:6; }
+    line.back    { stroke:#ffa600; stroke-width:7; }
+    line.front   { stroke:#0e3d7e; stroke-width:7; }
+    line.shadow  { stroke:#ffffff; stroke-width:7; }
+  </style>
+
+  <defs>
+    <!-- need two arrows b/c we can't sync color with the marked element -->
+    <marker id="barrow" markerWidth="4" markerHeight="3" refX=".05" refY="1.5"
+            orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,3 L4,1.5 z" fill="#ffa600"/>
+    </marker>
+    <marker id="farrow" markerWidth="4" markerHeight="3" refX=".05" refY="1.5"
+            orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,3 L4,1.5 z" fill="#0e3d7e"/>
+    </marker>
+  </defs>
+
+  <!-- rounded diamond shape -->
+  <rect x="-97" y="-97" width="194" height="194" rx="26" ry="26"
+        transform="rotate(45)" class="diamond"/>
+
+  <!-- background dependency structure -->
+  <line x1="-11" y1="-80" x2="-11" y2="-29" transform="rotate(42 -11 -80)"
+        class="back" marker-end="url(#barrow)"/>
+  <line x1="-80" y1="0"   x2="-80" y2="57"  transform="rotate(-45 -80 0)"
+        class="back" marker-end="url(#barrow)"/>
+  <line x1="-11" y1="-80" x2="-11" y2="28" class="back"
+        marker-end="url(#barrow)"/>
+
+  <circle cx="-11" cy="-80" r="23" class="back"/>
+  <circle cx="0"   cy="80"  r="23" class="back"/>
+  <circle cx="-80" cy="0"   r="23" class="back"/>
+
+  <!-- foreground dependency structure -->
+  <line x1="18" y1="-80" x2="18" y2="0" transform="rotate(42 17 -80)"
+        class="shadow"/>
+  <line x1="13" y1="-80" x2="13" y2="-5" transform="rotate(42 11 -80)"
+        class="front" marker-end="url(#farrow)"/>
+
+  <line x1="11" y1="-80" x2="11" y2="-29" transform="rotate(-42 11 -80)"
+        class="front" marker-end="url(#farrow)"/>
+  <line x1="80" y1="0"   x2="80" y2="57"  transform="rotate(45 80 0)"
+        class="front" marker-end="url(#farrow)"/>
+  <line x1="11" y1="-80" x2="11" y2="28"  class="front"
+        marker-end="url(#farrow)"/>
+
+  <circle cx="11" cy="-80" r="23" class="front"/>
+  <circle cx="80" cy="0"   r="23" class="front"/>
+
+  <text x="160" y="64" font-size="128pt" class="logo">Spack</text>
+</svg>


### PR DESCRIPTION
This PR addresses the build failure during the Spack package wheel creation caused by Hatchling trying to include the file:

```
lib/spack/docs/_static/spack-logo-text.svg b/lib/spack/docs/_static/spack-logo-text.svg
lib/spack/docs/_static/spack-logo-text.svg b/lib/spack/docs/_static/spack-logo-white-text.svg
```
which are symlinks pointing to a directory `_spack_root` that is currently in `.gitignore` and thus missing in the build environment.

```
../_spack_root/share/spack/logo/spack-logo-text.svg
../_spack_root/share/spack/logo/spack-logo-white-text.svg
```

<img width="1524" height="398" alt="image" src="https://github.com/user-attachments/assets/70dcd719-40c8-4d8a-a120-691bfd444841" />


## Problem

- The file `spack-logo-text.svg` and `spack-logo-white-text.svg` are referenced via a symlink in the source tree.
- The target directory `_spack_root` is ignored by Git and not present in the build context.
- Hatchling's build process fails with a `FileNotFoundError` for the missing SVG files.

## Solution

- Replace the symlinks with actual copies of the required static assets inside the repository/package source directory.
- Ensure all required files for the build are committed and available during packaging.
- Alternatively, update the build configuration to handle or exclude symlinks to ignored paths.

## Testing

- Verified that the build completes successfully after replacing/removing the problematic symlink.
- Confirmed the resulting wheel includes the expected logo asset.

## Notes

This change ensures the Spack build is reproducible and does not depend on files outside the repository that might be ignored or missing.