### PR TITLE
docs: hide sphinx link in footer

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -359,7 +359,7 @@ html_last_updated_fmt = "%b %d, %Y"
 # html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-# html_show_sphinx = False
+html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 # html_show_copyright = True


### PR DESCRIPTION
We really like the Furo theme, but the footer is a bit verbose on external links.