### PR TITLE
docs: update pygments theme and spec parsing

### DIFF
--- a/lib/spack/docs/_static/css/custom.css
+++ b/lib/spack/docs/_static/css/custom.css
@@ -51,3 +51,7 @@ div.version-switch select:hover {
     color: #fff3cd;
   }
 }
+
+.highlight .go {
+  color: #333;
+}

--- a/lib/spack/docs/advanced_topics.rst
+++ b/lib/spack/docs/advanced_topics.rst
@@ -58,7 +58,7 @@ If we had a toolchain named ``gcc_all`` that enforces using ``gcc`` for C, C++ a
 
 .. code-block:: spec
 
-   spack install hdf5+fortran%llvm_gfortran ^mpich %gcc_all
+   $ spack install hdf5+fortran%llvm_gfortran ^mpich %gcc_all
 
 to install:
 

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -116,7 +116,7 @@ use it during concretization and installation. That means that you can expect
 ``spack install ninja`` to fetch prebuilt packages from the mirror. Let's
 verify by reinstalling ninja:
 
-.. code-block:: console
+.. code-block:: spec
 
     $ spack uninstall ninja
     $ spack install ninja
@@ -214,7 +214,7 @@ You may also create your own key so that you may sign your own packages using
 
 .. code-block:: console
 
-   spack gpg create <name> <email>
+   $ spack gpg create <name> <email>
 
 By default, the key has no expiration, but it may be set with the ``--expires <date>`` flag.
 It is also recommended to add a comment as to the use of the key using the ``--comment <comment>`` flag.

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -100,7 +100,7 @@ to enable reuse for a single installation, or:
 
 .. code-block:: console
 
-   spack install --fresh <spec>
+   $ spack install --fresh <spec>
 
 to do a fresh install if ``reuse`` is enabled by default.
 

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -25,7 +25,7 @@ from typing import List
 from docutils.statemachine import StringList
 
 # ... other imports at the top of the file
-from pygments.lexer import RegexLexer
+from pygments.lexer import RegexLexer, default
 from pygments.token import *
 from sphinx.domains.python import PythonDomain
 from sphinx.ext.apidoc import main as sphinx_apidoc
@@ -104,23 +104,42 @@ from spack.spec_parser import SpecTokens
 
 
 class SpecLexer(RegexLexer):
-    """A custom lexer for Spack spec strings."""
+    """A custom lexer for Spack spec strings and spack commands."""
 
     name = "Spack spec"
     aliases = ["spec"]
     filenames = []
     tokens = {
         "root": [
-            # Command line / spack command prefix
-            (r"^(\s*\$?\s*spack\s+(?:[a-zA-Z0-9-]+\s+)?)", Text),
-            # Text from command line output
-            (r"^[A-Z].*$", Text),
-            # -- and ==> prefixes from command line output
-            (r"^[-=]+.*$", Text),
+            # Looks for `$ command`, which may need spec highlighting.
+            (r"^\$\s+", Generic.Prompt, "command"),
+            (r"#.*?\n", Comment.Single),
+            # Alternatively, we just get a literal spec string, so we move to spec mode. We just
+            # look ahead here, without consuming the spec string.
+            (r"(?=\S+)", Generic.Prompt, "spec"),
+        ],
+        "command": [
+            # A spack install command is followed by a spec string, which we highlight.
+            (
+                r"spack(?:\s+(?:-[eC]\s+\S+|--?\S+))*\s+(?:install|uninstall|spec|load|unload|find|info|list|versions|providers|mark|diff|add)(?: +(?:--?\S+)?)*",
+                Text,
+                "spec",
+            ),
             # Comment
-            (r"#.*$", Comment.Single),
-            # Probably a command line flag, not a variant.
-            (r"--[a-zA-Z0-9-]+", Text),
+            (r"\s+#.*?\n", Comment.Single, "command_output"),
+            # Escaped newline should leave us in this mode
+            (r".*?\\\n", Text),
+            # Otherwise, it's the end of the command
+            (r".*?\n", Text, "command_output"),
+        ],
+        "command_output": [
+            (r"^\$\s+", Generic.Prompt, "#pop"),  # new command
+            (r"#.*?\n", Comment.Single),  # comments
+            (r".*?\n", Generic.Output),  # command output
+        ],
+        "spec": [
+            # New line terminates the spec string
+            (r"\s*?$", Text, "#pop"),
             # Dependency, with optional virtual assignment specifier
             (SpecTokens.START_EDGE_PROPERTIES.regex, Name.Variable, "edge_properties"),
             (SpecTokens.DEPENDENCY.regex, Name.Variable),
@@ -140,14 +159,13 @@ class SpecLexer(RegexLexer):
             (SpecTokens.UNQUALIFIED_PACKAGE_NAME.regex, Name.Class),
             # DAG hash
             (SpecTokens.DAG_HASH.regex, Text),
-            # White spaces
-            (SpecTokens.WS.regex, Whitespace),
-            # Unexpected character(s)
-            (r".", Text),
+            (SpecTokens.WS.regex, Text),
+            # Also stop at unrecognized tokens (without consuming them)
+            default("#pop"),
         ],
         "edge_properties": [
             (SpecTokens.KEY_VALUE_PAIR.regex, Name.Function),
-            (SpecTokens.END_EDGE_PROPERTIES.regex, Name.Variable, "root"),
+            (SpecTokens.END_EDGE_PROPERTIES.regex, Name.Variable, "#pop"),
         ],
     }
 

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -122,32 +122,32 @@ class SpecLexer(RegexLexer):
             # Probably a command line flag, not a variant.
             (r"--[a-zA-Z0-9-]+", Text),
             # Dependency, with optional virtual assignment specifier
-            (SpecTokens.START_EDGE_PROPERTIES.regex, String, "edge_properties"),
-            (SpecTokens.DEPENDENCY.regex, String),
+            (SpecTokens.START_EDGE_PROPERTIES.regex, Name.Variable, "edge_properties"),
+            (SpecTokens.DEPENDENCY.regex, Name.Variable),
             # versions
-            (SpecTokens.GIT_VERSION.regex, Keyword.Constant),
-            (SpecTokens.VERSION.regex, Keyword.Constant),
-            (SpecTokens.VERSION_HASH_PAIR.regex, Keyword.Constant),
+            (SpecTokens.VERSION_HASH_PAIR.regex, Keyword.Pseudo),
+            (SpecTokens.GIT_VERSION.regex, Keyword.Pseudo),
+            (SpecTokens.VERSION.regex, Keyword.Pseudo),
             # variants
-            (SpecTokens.PROPAGATED_BOOL_VARIANT.regex, Name.Class),
-            (SpecTokens.BOOL_VARIANT.regex, Name.Class),
-            (SpecTokens.PROPAGATED_KEY_VALUE_PAIR.regex, Name.Class),
-            (SpecTokens.KEY_VALUE_PAIR.regex, Name.Class),
+            (SpecTokens.PROPAGATED_BOOL_VARIANT.regex, Name.Function),
+            (SpecTokens.BOOL_VARIANT.regex, Name.Function),
+            (SpecTokens.PROPAGATED_KEY_VALUE_PAIR.regex, Name.Function),
+            (SpecTokens.KEY_VALUE_PAIR.regex, Name.Function),
             # filename
-            (SpecTokens.FILENAME.regex, String),
+            (SpecTokens.FILENAME.regex, Text),
             # Package name
-            (SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME.regex, String),
-            (SpecTokens.UNQUALIFIED_PACKAGE_NAME.regex, String),
+            (SpecTokens.FULLY_QUALIFIED_PACKAGE_NAME.regex, Name.Class),
+            (SpecTokens.UNQUALIFIED_PACKAGE_NAME.regex, Name.Class),
             # DAG hash
-            (SpecTokens.DAG_HASH.regex, String),
+            (SpecTokens.DAG_HASH.regex, Text),
             # White spaces
             (SpecTokens.WS.regex, Whitespace),
             # Unexpected character(s)
             (r".", Text),
         ],
         "edge_properties": [
-            (SpecTokens.KEY_VALUE_PAIR.regex, Name.Class),
-            (SpecTokens.END_EDGE_PROPERTIES.regex, String, "root"),
+            (SpecTokens.KEY_VALUE_PAIR.regex, Name.Function),
+            (SpecTokens.END_EDGE_PROPERTIES.regex, Name.Variable, "root"),
         ],
     }
 
@@ -392,6 +392,8 @@ html_static_path = ["_static"]
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 html_last_updated_fmt = "%b %d, %Y"
+pygments_style = "default"
+pygments_dark_style = "monokai"
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -125,7 +125,7 @@ line with the ``--config-scope`` argument, or ``-C`` for short.
 For example, the following adds two configuration scopes, named
 ``scopea`` and ``scopeb``, to a ``spack spec`` command:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack -C ~/myscopes/scopea -C ~/myscopes/scopeb spec ncurses
 

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -33,20 +33,20 @@ If you already have a Spack environment installed on your system, you can
 share the binaries as an OCI-compatible container image. To get started, you
 just have to configure an OCI registry and run ``spack buildcache push``.
 
-.. code-block:: console
+.. code-block:: spec
 
    # Create and install an environment in the current directory
-   spack env create -d .
-   spack -e . add pkg-a pkg-b
-   spack -e . install
+   $ spack env create -d .
+   $ spack -e . add pkg-a pkg-b
+   $ spack -e . install
 
    # Configure the registry
-   spack -e . mirror add --oci-username-variable REGISTRY_USER \
+   $ spack -e . mirror add --oci-username-variable REGISTRY_USER \
                          --oci-password-variable REGISTRY_TOKEN \
                         container-registry oci://example.com/name/image
 
    # Push the image (do set REGISTRY_USER and REGISTRY_TOKEN)
-   spack -e . buildcache push --update-index --base-image ubuntu:22.04 --tag my_env container-registry
+   $ spack -e . buildcache push --update-index --base-image ubuntu:22.04 --tag my_env container-registry
 
 The resulting container image can then be run as follows:
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -256,7 +256,7 @@ environment has been activated. Otherwise it shows all specs in
 the Spack instance. The same rule applies to the ``install`` and
 ``uninstall`` commands.
 
-.. code-block:: console
+.. code-block:: spec
 
   $ spack find
   ==> 0 installed packages
@@ -328,14 +328,14 @@ currently active environment. An error is generated if there isn't an
 active environment. All environment-aware commands can also
 be called using the ``spack -e`` flag to specify the environment.
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack env activate myenv
    $ spack add mpileaks
 
 or
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack -e myenv add python
 
@@ -547,7 +547,7 @@ argument ``--include-concrete`` followed by the name or path of the environment
 you'd like to include. Here is an example of how to create a combined environment
 from the command line.
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack env create myenv
    $ spack -e myenv add python
@@ -582,7 +582,7 @@ If changes were made to the base environment and you want that reflected in the
 included environment you will need to re-concretize both the base environment and the
 included environment for the change to be implemented. For example:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack env create myenv
    $ spack -e myenv add python
@@ -610,7 +610,7 @@ Here we see that ``included_env`` has access to the python package through
 the ``myenv`` environment. But if we were to add another spec to ``myenv``,
 ``included_env`` will not be able to access the new information.
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack -e myenv add perl
    $ spack -e myenv concretize
@@ -1287,13 +1287,13 @@ other targets to depend on the environment installation.
 
 A typical workflow is as follows:
 
-.. code-block:: console
+.. code-block:: spec
 
-   spack env create -d .
-   spack -e . add perl
-   spack -e . concretize
-   spack -e . env depfile -o Makefile
-   make -j64
+   $ spack env create -d .
+   $ spack -e . add perl
+   $ spack -e . concretize
+   $ spack -e . env depfile -o Makefile
+   $ make -j64
 
 This generates a ``Makefile`` from a concretized environment in the
 current working directory, and ``make -j64`` installs the environment,

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -126,9 +126,9 @@ Spack can be made aware of extensions that are installed as part of a Python pac
 
   my-package/
   ├── src
-  │   ├── my_package
-  │   │   └── __init__.py
-  │   └── spack-scripting/  # the spack extensions
+  │   ├── my_package
+  │   │   └── __init__.py
+  │   └── spack-scripting/  # the spack extensions
   └── pyproject.toml
 
 adding the following to ``my_package``'s ``pyproject.toml`` will make the ``spack-scripting`` extension visible to Spack when ``my_package`` is installed:

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -49,13 +49,13 @@ List packages you can install
 
 Once Spack is ready you can list all the packages it knows about with the following command:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack list
 
 If you want to get more information on a specific package, for instance ``hdf5``, you can use:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack info hdf5
 
@@ -96,7 +96,7 @@ If no compilers were found, you need either to:
 
 Once a compiler is available you can proceed installing your first package:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install tcl
 
@@ -171,7 +171,7 @@ This works, but using such a long absolute path is not the most convenient way t
 
 The simplest way to have ``tclsh`` available on the command line is:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack load tcl
 
@@ -183,7 +183,7 @@ The environment of the current shell has now been modified, and you can run:
 
 directly. To undo these modifications, you can:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack unload tcl
 

--- a/lib/spack/docs/installing_prerequisites.rst
+++ b/lib/spack/docs/installing_prerequisites.rst
@@ -25,15 +25,15 @@ To install them, follow the instructions below.
 
             .. code-block:: console
 
-               apt update
-               apt install file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
+               $ apt update
+               $ apt install file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
 
          .. tab-item:: RHEL/AlmaLinux/Rocky Linux
 
             .. code-block:: console
 
-               dnf install epel-release
-               dnf install file bzip2 ca-certificates git gzip patch python3 tar unzip xz zstd gcc gcc-c++ gcc-gfortran
+               $ dnf install epel-release
+               $ dnf install file bzip2 ca-certificates git gzip patch python3 tar unzip xz zstd gcc gcc-c++ gcc-gfortran
 
    .. tab-item:: macOS
 

--- a/lib/spack/docs/package_fundamentals.rst
+++ b/lib/spack/docs/package_fundamentals.rst
@@ -40,7 +40,7 @@ You can search for available packages on the `packages.spack.io <https://package
 The ``spack list`` command prints out a list of all of the packages Spack
 can install:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack list
 
@@ -52,7 +52,7 @@ A pattern can be used to narrow the list, and the following rules apply:
 
 To search for all packages whose names contain the word ``sql`` you can run the following command:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack list sql
 
@@ -60,7 +60,7 @@ A few options are also provided for more specific searches.
 For instance, it is possible to search the description of packages for a match.
 A way to list all the packages whose names or descriptions contain the word ``quantum`` is the following:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack list -d quantum
 
@@ -75,7 +75,7 @@ To get more information about a particular package from `spack list`, use
 `spack info`.  Just supply the name of a package:
 
 .. command-output:: spack info mpich
-   :language: console
+   :language: spec
 
 Most of the information is self-explanatory.
 The *safe versions* are versions for which Spack knows the checksum.
@@ -94,7 +94,7 @@ To see *more* available versions of a package, run ``spack versions``.
 For example:
 
 .. command-output:: spack versions libelf
-   :language: console
+   :language: spec
 
 There are two sections in the output.  *Safe versions* are versions
 for which Spack has a checksum on file.  It can verify that these
@@ -116,10 +116,12 @@ You can see what packages provide a particular virtual package using ``spack pro
 If you wanted to see what packages provide ``mpi``, you would just run:
 
 .. command-output:: spack providers mpi
+   :language: spec
 
 And if you *only* wanted to see packages that provide MPI-2, you would add a version specifier to the spec:
 
 .. command-output:: spack providers mpi@2
+   :language: spec
 
 Notice that the package versions that provide insufficient MPI versions are now filtered out.
 
@@ -137,7 +139,7 @@ Installing and Uninstalling
 For example, to install the latest version of the ``mpileaks``
 package, you might type this:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install mpileaks
 
@@ -148,7 +150,7 @@ installs it in its own directory under ``$SPACK_ROOT/opt``. You'll see
 a number of messages from Spack, a lot of build output, and a message
 that the package is installed.
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install mpileaks
    ... dependency build output ...
@@ -173,7 +175,7 @@ Building a specific version
 Spack can also build *specific versions* of a package. To do this,
 just add ``@`` after the package name, followed by a version:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install mpich@3.0.4
 
@@ -207,7 +209,7 @@ you update Spack frequently.
 In case you want the latest versions and configurations to be installed instead,
 you can add the ``--fresh`` option:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install --fresh mpich
 
@@ -234,7 +236,7 @@ To uninstall a package, run ``spack uninstall <package>``. This will ask
 the user for confirmation before completely removing the directory
 in which the package was installed.
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack uninstall mpich
 
@@ -244,7 +246,7 @@ uninstalled, Spack will refuse to uninstall it.
 To uninstall a package and every package that depends on it, you may give the
 ``--dependents`` option.
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack uninstall --dependents mpich
 
@@ -253,7 +255,7 @@ confirmation, will uninstall them in the correct order.
 
 A command like
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack uninstall mpich
 
@@ -266,7 +268,7 @@ matching packages.
 
 You may force uninstall a package with the ``--force`` option
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack uninstall --force mpich
 
@@ -329,7 +331,7 @@ can be marked manually as explicitly or implicitly installed by using
 ``spack mark``. This can be used in combination with ``spack gc`` to clean up
 packages that are no longer required.
 
-.. code-block:: console
+.. code-block:: spec
 
   $ spack install m4
   ==> 29005: Installing libsigsegv
@@ -386,7 +388,7 @@ installed before updating Spack. If there is no new version for either of the
 packages, ``spack install`` will simply mark them as explicitly installed, and
 ``spack gc`` will not remove them.
 
-.. code-block:: console
+.. code-block:: spec
 
   $ spack install m4
   ==> 62843: Installing libsigsegv
@@ -481,7 +483,7 @@ of the same package with different specs.
 
 Running ``spack find`` with no arguments lists installed packages:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack find
    ==> 74 installed packages.
@@ -539,7 +541,7 @@ installations of ``libdwarf@20130729`` above. We can look at them
 in more detail using ``spack find --deps`` and by asking only to show
 ``libdwarf`` packages:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack find --deps libdwarf
    ==> 2 installed packages.
@@ -555,7 +557,7 @@ become complicated for packages with many dependencies. If you just
 want to know whether two packages' dependencies differ, you can use
 ``spack find --long``:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack find --long libdwarf
    ==> 2 installed packages.
@@ -569,7 +571,7 @@ are the same, then the packages have the same dependency configuration.
 If you want to know the path where each package is installed, you can
 use ``spack find --paths``:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack find --paths
    ==> 74 installed packages.
@@ -586,7 +588,7 @@ use ``spack find --paths``:
 You can restrict your search to a particular package by supplying its
 name:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack find --paths libelf
    -- linux-debian7-x86_64 / gcc@4.4.7 --------------------------------
@@ -603,7 +605,7 @@ Spec queries
 package. If you want to find only libelf versions greater than version
 0.8.12, you could say:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack find libelf@0.8.12:
    -- linux-debian7-x86_64 / gcc@4.4.7 --------------------------------
@@ -612,7 +614,7 @@ package. If you want to find only libelf versions greater than version
 Finding just the versions of libdwarf built with a particular version
 of libelf would look like this:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack find --long libdwarf ^libelf@0.8.12
    ==> 1 installed packages.
@@ -665,7 +667,7 @@ Alternatively, if you want something even more machine readable, you can
 output each spec as JSON records using ``spack find --json``. This will
 output metadata on specs and all dependencies as JSON:
 
-.. code-block:: console
+.. code-block:: spec
 
     $ spack find --json sqlite@3.28.0
     [
@@ -737,14 +739,14 @@ It's often the case that you have two versions of a spec that you need to
 disambiguate. Let's say that we've installed two variants of zlib, one with
 and one without the optimize variant:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install zlib
    $ spack install zlib -optimize
 
 When we do ``spack find``, we see the two versions.
 
-.. code-block:: console
+.. code-block:: spec
 
     $ spack find zlib
     ==> 2 installed packages
@@ -755,7 +757,7 @@ When we do ``spack find``, we see the two versions.
 Let's say we want to uninstall ``zlib``.
 We run the command and quickly encounter a problem because two versions are installed.
 
-.. code-block:: console
+.. code-block:: spec
 
     $ spack uninstall zlib
     ==> Error: zlib matches multiple packages:
@@ -845,7 +847,7 @@ And you can add as many attributes as you'd like with multiple `--attribute` arg
 data as JSON (and possibly pipe into an output file), just add ``--json``:
 
 
-.. code-block:: console
+.. code-block:: spec
 
     $ spack diff --json python@2.7.8 python@3.8.11
 
@@ -879,7 +881,7 @@ If you sourced the appropriate shell script, as shown in :ref:`getting_started`,
 For example, this will add the ``mpich`` package built with ``gcc`` to
 your path:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install mpich %gcc@4.4.7
 
@@ -896,7 +898,7 @@ modules configuration.
 When you no longer want to use a package, you can type unload or
 unuse similarly:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack unload mpich %gcc@4.4.7
 
@@ -908,7 +910,7 @@ Ambiguous specs
 If a spec used with load/unload is ambiguous (i.e., more than one
 installed package matches it), then Spack will warn you:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack load libelf
    ==> Error: libelf matches multiple packages.
@@ -923,7 +925,7 @@ identify one package. For example, above, the key differentiator is
 that one ``libelf`` is built with the Intel compiler, while the other
 used ``gcc``. You could therefore just type:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack load libelf %intel
 
@@ -931,7 +933,7 @@ To identify just the one built with the Intel compiler. If you want to be
 *very* specific, you can load it by its hash. For example, to load the
 first ``libelf`` above, you would run:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack load /qmm4kso
 
@@ -963,7 +965,7 @@ Spack can install a large number of Python packages. Their names are
 typically prefixed with ``py-``. Installing and using them is no
 different from any other package:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install py-numpy
    $ spack load py-numpy
@@ -990,7 +992,7 @@ a Spack environment with ``numpy`` in the current working directory. It also
 puts a filesystem view in ``./view``, which is a more traditional combined
 prefix for all packages in the environment.
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack env create --with-view view --dir .
    $ spack -e . add py-numpy

--- a/lib/spack/docs/package_fundamentals.rst
+++ b/lib/spack/docs/package_fundamentals.rst
@@ -775,10 +775,9 @@ between properties for two packages. Let's try it out.
 Because the only difference we see in the ``spack find`` view is the hash, let's use
 ``spack diff`` to look for more detail. We will provide the two hashes:
 
-.. code-block:: console
+.. code-block:: diff
 
     $ spack diff /efzjziy /sl7m27m
-    ==> Warning: This interface is subject to change.
 
     --- zlib@1.2.11efzjziyc3dmb5h5u5azsthgbgog5mj7g
     +++ zlib@1.2.11sl7m27mzkbejtkrajigj3a3m37ygv4u2
@@ -791,15 +790,13 @@ The output is colored and written in the style of a git diff. This means that yo
 can copy and paste it into a GitHub markdown as a code block with language "diff"
 and it will render nicely! Here is an example:
 
-.. code-block:: md
+.. code-block:: diff
 
-    ```diff
     --- zlib@1.2.11/efzjziyc3dmb5h5u5azsthgbgog5mj7g
     +++ zlib@1.2.11/sl7m27mzkbejtkrajigj3a3m37ygv4u2
     @@ variant_value @@
     -  zlib optimize False
     +  zlib optimize True
-    ```
 
 Awesome! Now let's read the diff. It tells us that our first zlib was built with ``~optimize``
 (``False``) and the second was built with ``+optimize`` (``True``). You can't see it in the docs
@@ -811,31 +808,29 @@ installation spec. Running ``spack diff A B`` means we'll see which spec attribu
 ``B`` but not on ``A`` (green) and which are on ``A`` but not on ``B`` (red). Here is another
 example with an additional difference type, ``version``:
 
-.. code-block:: console
+.. code-block:: diff
 
-    $ spack diff python@2.7.8 python@3.8.11
-    ==> Warning: This interface is subject to change.
+   $ spack diff python@2.7.8 python@3.8.11
 
-    --- python@2.7.8/tsxdi6gl4lihp25qrm4d6nys3nypufbf
-    +++ python@3.8.11/yjtseru4nbpllbaxb46q7wfkyxbuvzxx
-    @@ variant_value @@
-    -  python patches a8c52415a8b03c0e5f28b5d52ae498f7a7e602007db2b9554df28cd5685839b8
-    +  python patches 0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87
-    @@ version @@
-    -  openssl 1.0.2u
-    +  openssl 1.1.1k
-    -  python 2.7.8
-    +  python 3.8.11
+   --- python@2.7.8/tsxdi6gl4lihp25qrm4d6nys3nypufbf
+   +++ python@3.8.11/yjtseru4nbpllbaxb46q7wfkyxbuvzxx
+   @@ variant_value @@
+   -  python patches a8c52415a8b03c0e5f28b5d52ae498f7a7e602007db2b9554df28cd5685839b8
+   +  python patches 0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87
+   @@ version @@
+   -  openssl 1.0.2u
+   +  openssl 1.1.1k
+   -  python 2.7.8
+   +  python 3.8.11
 
 Let's say that we were only interested in one kind of attribute above, ``version``.
 We can ask the command to only output this attribute. To do this, you'd add
 the ``--attribute`` for attribute parameter, which defaults to all. Here is how you
 would filter to show just versions:
 
-.. code-block:: console
+.. code-block:: diff
 
     $ spack diff --attribute version python@2.7.8 python@3.8.11
-    ==> Warning: This interface is subject to change.
 
     --- python@2.7.8/tsxdi6gl4lihp25qrm4d6nys3nypufbf
     +++ python@3.8.11/yjtseru4nbpllbaxb46q7wfkyxbuvzxx

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -417,7 +417,7 @@ not ``openmpi@3.9%clang``.
 If a custom message is provided, and the requirement is not satisfiable,
 Spack will print the custom error message:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack spec openmpi@3.9%clang
    ==> Error: in this example only 4.1.5 can build with other compilers

--- a/lib/spack/docs/packaging_guide_advanced.rst
+++ b/lib/spack/docs/packaging_guide_advanced.rst
@@ -64,7 +64,7 @@ Here is a simple example of a package that supports both CMake and Autotools:
 When defining a package like this, Spack automatically makes the ``build_system`` **variant** available, which can be used to pick the desired build system at install time.
 For example
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install example +feature build_system=cmake
 
@@ -72,7 +72,7 @@ makes Spack pick the ``CMakeBuilder`` class and runs ``cmake -DMY_FEATURE:BOOL=O
 
 Similarly
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install example +feature build_system=autotools
 

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -53,21 +53,21 @@ Once you have a fork, clone it:
 
 .. code-block:: console
 
-   git clone --depth=100 git@github.com:YOUR-USERNAME/spack-packages.git ~/spack-packages
-   cd ~/spack-packages
-   git remote add --track develop upstream git@github.com:spack/spack-packages.git
+   $ git clone --depth=100 git@github.com:YOUR-USERNAME/spack-packages.git ~/spack-packages
+   $ cd ~/spack-packages
+   $ git remote add --track develop upstream git@github.com:spack/spack-packages.git
 
 Then configure Spack to use your local repository:
 
 .. code-block:: console
 
-   spack repo set --destination ~/spack-packages builtin
+   $ spack repo set --destination ~/spack-packages builtin
 
 Before starting work, it's useful to create a new branch in your local repository.
 
 .. code-block:: console
 
-   git checkout -b add-my-package
+   $ git checkout -b add-my-package
 
 Lastly, verify that Spack is picking up the right repository by checking the location of a known package, like ``zlib``:
 
@@ -718,7 +718,7 @@ This has two effects.
 First, ``spack info`` will no longer advertise that version.
 Second, commands like ``spack install`` that fetch the package will require user approval:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install openssl@1.0.1e
    ==> Warning: openssl@1.0.1e is deprecated and may be removed in a future Spack release.
@@ -1427,7 +1427,7 @@ This allows users to ``spack install blis threads=openmp``.
 In the example above the argument ``multi=False`` indicates that only a **single value** can be selected at a time.
 This constraint is enforced by the solver, and an error is emitted if a user specifies two or more values at the same time:
 
-.. code-block:: console
+.. code-block:: spec
 
   $ spack spec blis threads=openmp,pthreads
   Input spec
@@ -2075,12 +2075,12 @@ To express this constraint in a package, the two virtual dependencies must be li
 
 .. code-block:: python
 
-   provides('blas', 'lapack')
+   provides("blas", "lapack")
 
 This makes it impossible to select ``openblas`` as a provider for one of the two virtual dependencies and not for the other.
 If you try to, Spack will report an error:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack spec netlib-scalapack  ^[virtuals=lapack] openblas ^[virtuals=blas] atlas
    ==> Error: concretization failed for the following reasons:
@@ -2474,25 +2474,29 @@ Inspecting patches
 If you want to better understand the patches that Spack applies to your
 packages, you can do that using ``spack spec``, ``spack find``, and other
 query commands.  Let's look at ``m4``.  If you run ``spack spec m4``, you
-can see the patches that would be applied to ``m4``::
+can see the patches that would be applied to ``m4``:
 
-  $ spack spec m4
-  Input spec
-  --------------------------------
-  m4
+.. code-block:: spec
 
-  Concretized
-  --------------------------------
-  m4@1.4.18%apple-clang@9.0.0 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv arch=darwin-highsierra-x86_64
-      ^libsigsegv@2.11%apple-clang@9.0.0 arch=darwin-highsierra-x86_64
+   $ spack spec m4
+   Input spec
+   --------------------------------
+   m4
+ 
+   Concretized
+   --------------------------------
+   m4@1.4.18%apple-clang@9.0.0 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv arch=darwin-highsierra-x86_64
+       ^libsigsegv@2.11%apple-clang@9.0.0 arch=darwin-highsierra-x86_64
 
 You can also see patches that have been applied to installed packages
-with ``spack find -v``::
+with ``spack find -v``:
 
-  $ spack find -v m4
-  ==> 1 installed package
-  -- darwin-highsierra-x86_64 / apple-clang@9.0.0 -----------------
-  m4@1.4.18 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv
+.. code-block:: spec
+
+   $ spack find -v m4
+   ==> 1 installed package
+   -- darwin-highsierra-x86_64 / apple-clang@9.0.0 -----------------
+   m4@1.4.18 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv
 
 .. _cmd-spack-resource:
 

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2137,7 +2137,7 @@ For example, suppose the package ``foo`` declares this:
 
 Suppose a user invokes ``spack install`` like this:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install foo ^mpich@1.0
 

--- a/lib/spack/docs/packaging_guide_testing.rst
+++ b/lib/spack/docs/packaging_guide_testing.rst
@@ -127,7 +127,7 @@ a successfully installed package has the required files and/or directories.
 
 For example, running:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install --test=root reframe
 
@@ -219,7 +219,7 @@ and its ``Makefile`` has a standard ``check`` target. So Spack will
 automatically run ``make check`` after the ``build`` phase when it
 is installed using the ``--test`` option, such as:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install --test=root libelf
 
@@ -301,7 +301,7 @@ location will depend on whether the spec installed successfully.
 A successful installation results in the build and stage logs being copied
 to the ``.spack`` subdirectory of the spec's prefix. For example,
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install --test=root zlib@1.2.13
    ...
@@ -311,7 +311,7 @@ to the ``.spack`` subdirectory of the spec's prefix. For example,
 If the installation fails due to build-time test failures, then both logs will
 be left in the build stage directory as illustrated below:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack install --test=root zlib@1.2.13
    ...

--- a/lib/spack/docs/replace_conda_homebrew.rst
+++ b/lib/spack/docs/replace_conda_homebrew.rst
@@ -34,7 +34,7 @@ Next, we can add a list of packages we would like to install into our environmen
 Let's say we want a newer version of Bash than the one that comes with macOS, and we want a few Python libraries.
 We can run:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack -e myenv add bash@5 python py-numpy py-scipy py-matplotlib
 

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -314,9 +314,9 @@ Packages differing only by namespace will have different hashes:
 
 All Spack commands that take a package :ref:`spec <sec-specs>` also accept a fully qualified spec with a namespace, allowing you to be specific:
 
-.. code-block:: console
+.. code-block:: spec
 
-  spack uninstall llnl.comp.mpich
+  $ spack uninstall llnl.comp.mpich
 
 -------------------------------------
 Search Order and Overriding Packages
@@ -359,7 +359,7 @@ You can force a particular repository's package using a fully qualified name:
 
 To see which repositories will be used for a build *before* installing, use ``spack spec -N``:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack spec -N hdf5
    llnl.hdf5@1.10.0

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -494,7 +494,7 @@ or can't build binaries for that target at all, it will exit with a meaningful e
 Conversely, if an old compiler is selected for a newer microarchitecture, Spack will optimize for the best match it can find instead
 of failing:
 
-.. code-block:: spec
+.. code-block:: console
 
    $ spack arch
    linux-ubuntu18.04-broadwell
@@ -639,7 +639,7 @@ For example, let's say that you accidentally installed two different
 ``mvapich2`` installations. If you want to uninstall one of them but don't
 know what the difference is, you can run:
 
-.. code-block:: spec
+.. code-block:: console
 
    $ spack find --long mvapich2
    ==> 2 installed packages.

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -159,7 +159,7 @@ A version specifier
 
 .. code-block:: spec
 
-   pkg@<specifier>
+   pkg@specifier
 
 comes after a package name and starts with ``@``.
 It can be something abstract that matches multiple known versions or a specific version.
@@ -494,7 +494,7 @@ or can't build binaries for that target at all, it will exit with a meaningful e
 Conversely, if an old compiler is selected for a newer microarchitecture, Spack will optimize for the best match it can find instead
 of failing:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack arch
    linux-ubuntu18.04-broadwell
@@ -639,7 +639,7 @@ For example, let's say that you accidentally installed two different
 ``mvapich2`` installations. If you want to uninstall one of them but don't
 know what the difference is, you can run:
 
-.. code-block:: console
+.. code-block:: spec
 
    $ spack find --long mvapich2
    ==> 2 installed packages.
@@ -692,7 +692,7 @@ Users can select which virtuals to use from which dependency by specifying the `
 
 .. code-block:: spec
 
-   spack install mpich %[virtuals=c,cxx] clang %[virtuals=fortran] gcc
+   $ spack install mpich %[virtuals=c,cxx] clang %[virtuals=fortran] gcc
 
 The command above tells Spack to use ``clang`` to provide the ``c`` and ``cxx`` virtuals, and ``gcc`` to provide the ``fortran`` virtual.
 
@@ -701,7 +701,7 @@ For instance, an equivalent formulation of the command above is:
 
 .. code-block:: spec
 
-   spack install mpich %c,cxx=clang %fortran=gcc
+   $ spack install mpich %c,cxx=clang %fortran=gcc
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -713,6 +713,6 @@ We can express conditional constraint by specifying the ``when`` edge attribute:
 
 .. code-block:: spec
 
-   spack install hdf5 ^[when=+mpi] mpich@3.1
+   $ spack install hdf5 ^[when=+mpi] mpich@3.1
 
 This tells Spack that hdf5 should depend on ``mpich@3.1`` if it is configured with MPI support.

--- a/lib/spack/docs/windows.rst
+++ b/lib/spack/docs/windows.rst
@@ -164,8 +164,8 @@ the Spack terminal, run the following commands:
 
 .. code-block:: console
 
-   spack external find cmake
-   spack external find ninja
+   $ spack external find cmake
+   $ spack external find ninja
 
 The ``spack external find <name>`` will find executables on your system
 with the same name given. The command will store the items found in
@@ -209,9 +209,9 @@ Step 4: Use Spack
 Once the configuration is complete, it is time to give the installation a test.  Install a basic package through the
 Spack console via:
 
-.. code-block:: console
+.. code-block:: spec
 
-   spack install cpuinfo
+   $ spack install cpuinfo
 
 If in the previous step, you did not have CMake or Ninja installed, running the command above should install both packages.
 

--- a/lib/spack/docs/windows.rst
+++ b/lib/spack/docs/windows.rst
@@ -114,7 +114,7 @@ in a Windows CMD prompt.
 
 .. code-block:: console
 
-   git clone https://github.com/spack/spack.git
+   $ git clone https://github.com/spack/spack.git
 
 .. note::
    If you chose to install Spack into a directory on Windows that is set up to require Administrative
@@ -139,7 +139,7 @@ To configure Spack, first run the following command inside the Spack console:
 
 .. code-block:: console
 
-   spack compiler find
+   $ spack compiler find
 
 This creates a ``.staging`` directory in our Spack prefix, along with a ``windows`` subdirectory
 containing a ``packages.yaml`` file. On a fresh Windows installation with the above packages


### PR DESCRIPTION
* Fix an issue in the order of regexes for versions (`git=1.2.3` has to go first)
* Fix parsing of `spack install <spec>` commands (do not parse their output as specs, only the command line argument)
* Use a more standard pygments theme

Spec parsing in docs has two modes (spack command, or literal spec):

```rst
.. code-block:: spec

   $ spack install <spec>
   <output>
```

```rst
.. code-block:: spec

   <spec>
```