### PR TITLE
Allow definition of a custom command wrapper

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -44,6 +44,13 @@ if [ -n "${_sp_initializing:-}" ]; then
 fi
 export _sp_initializing=true
 
+_spack_cmd_shell_wrapper() {
+  if [ $(declare -F _spack_cmd_wrapper_$1) ]; then
+    _spack_cmd_wrapper_$1 "$@"
+  else
+    command $_spack_cmd "$@"
+  fi
+}
 
 _spack_shell_wrapper() {
     # Store DYLD_* variables from spack shell function
@@ -189,7 +196,9 @@ _spack_shell_wrapper() {
             fi
             ;;
         *)
-            command spack $_sp_flags $_sp_subcommand "$@"
+            # Define _spack_cmd as spack and the main command flags
+            _spack_cmd="spack $_sp_flags"
+            _spack_cmd_shell_wrapper $_sp_subcommand "$@"
             ;;
     esac
 }


### PR DESCRIPTION
Command extensions are currently limited to being executed using the rules defined in the default shell wrapper. Allow defining a bash function that may override the default behavior.

Adds shell API `_spack_cmd` which should be used to call the main spack command with the correct command arguments.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Attempt to implement: https://github.com/spack/spack/issues/51115
