### PR TITLE
externals: Model as concrete specs and add dependency definitions

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -95,3 +95,10 @@ concretizer:
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.
   concretization_cache:
     enable: true
+
+  # Options to control the behavior of the concretizer with external specs
+  externals:
+    # Either 'architecture_only', to complete external specs with just the architecture of the
+    # current host, or 'default_variants' to complete external specs also with missing variants,
+    # using their default value.
+    completion: default_variants

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -18,6 +18,25 @@ The default configuration is the following:
 .. literalinclude:: _spack_root/etc/spack/defaults/concretizer.yaml
    :language: yaml
 
+
+Completion of external nodes
+----------------------------
+
+:ref:`The external packages <sec-external-packages>` available from the ``packages.yaml`` configuration file are usually reporting only a few of the variants defined in the corresponding recipe.
+Users can configure how Spack deals with missing information for externals via the ``concretizer:externals:completion`` attribute:
+
+.. code-block:: yaml
+
+   concretizer:
+     externals:
+       completion: default_variants
+
+This attribute currently allows two possible values:
+
+- ``architecture_only``: only the mandatory architectural information is completed on externals
+- ``default_variants``: external specs are also completed with missing variants, using their default values
+
+
 Reuse Already Installed Packages
 --------------------------------
 

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -102,6 +102,55 @@ Specific limitations include:
 * The logic does not search through module files, it can only detect packages with executables defined in ``PATH``; you can help Spack locate externals which use module files by loading any associated modules for packages that you want Spack to know about before running ``spack external find``.
 * Spack does not overwrite existing entries in the package configuration: If there is an external defined for a spec at any configuration scope, then Spack will not add a new external entry (``spack config blame packages`` can help locate all external entries).
 
+Specifying dependencies among external packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Dependency relationships among external packages can also be be modeled in your ``packages.yaml`` configuration file.
+For instance, the following configuration describes an ``mpileaks`` external that depends on ``callpath`` and on ``mpich``:
+
+.. code-block:: yaml
+
+   # Specification for the following DAG:
+   #
+   # o mpileaks@2.3
+   # |\
+   # | o callpath@1.0
+   # |/
+   # o mpich@3.0.4
+   packages:
+     mpileaks:
+       externals:
+       - spec: "mpileaks@2.3~debug+opt"
+         prefix: /user/path
+         dependencies:
+         - external_id: callpath_id
+           deptypes: link
+         - external_id: mpich_id
+           deptypes:
+           - "build"
+           - "link"
+           virtuals: "mpi"
+     callpath:
+       externals:
+       - spec: "callpath@1.0"
+         prefix: /user/path
+         external_id: callpath_id
+         dependencies:
+         - external_id: mpich_id
+           deptypes:
+           - "build"
+           - "link"
+           virtuals: "mpi"
+     mpich:
+       externals:
+       - spec: "mpich@3.0.4"
+         prefix: /user/path
+         external_id: mpich_id
+
+The ``external_id`` attribute is a unique string identifier of the external node being described.
+The ``dependencies`` attribute is a list of objects, where you can specify the ``external_id`` of the dependency and optionally the dependency types (``deptypes``), and the ``virtuals``, along the edge.
+
+
 Prevent packages from being built from sources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -123,9 +123,9 @@ For instance, the following configuration describes an ``mpileaks`` external tha
        - spec: "mpileaks@2.3~debug+opt"
          prefix: /user/path
          dependencies:
-         - external_id: callpath_id
+         - id: callpath_id
            deptypes: link
-         - external_id: mpich_id
+         - id: mpich_id
            deptypes:
            - "build"
            - "link"
@@ -134,9 +134,9 @@ For instance, the following configuration describes an ``mpileaks`` external tha
        externals:
        - spec: "callpath@1.0"
          prefix: /user/path
-         external_id: callpath_id
+         id: callpath_id
          dependencies:
-         - external_id: mpich_id
+         - id: mpich_id
            deptypes:
            - "build"
            - "link"
@@ -145,10 +145,10 @@ For instance, the following configuration describes an ``mpileaks`` external tha
        externals:
        - spec: "mpich@3.0.4"
          prefix: /user/path
-         external_id: mpich_id
+         id: mpich_id
 
-The ``external_id`` attribute is a unique string identifier of the external node being described.
-The ``dependencies`` attribute is a list of objects, where you can specify the ``external_id`` of the dependency and optionally the dependency types (``deptypes``), and the ``virtuals``, along the edge.
+The ``id`` attribute is a unique string identifier of the external node being described.
+The ``dependencies`` attribute is a list of objects, where you can specify the ``id`` of the dependency and optionally the dependency types (``deptypes``), and the ``virtuals``, along the edge.
 
 
 Prevent packages from being built from sources

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -105,8 +105,47 @@ Specific limitations include:
 Specifying dependencies among external packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Dependency relationships among external packages can also be be modeled in your ``packages.yaml`` configuration file.
+Dependency relationships among external packages can also be be modeled in your ``packages.yaml`` configuration file, by adding a ``dependencies:`` section to your external.
 For instance, the following configuration describes an ``mpileaks`` external that depends on ``callpath`` and on ``mpich``:
+
+.. code-block:: yaml
+
+   # Specification for the following DAG:
+   #
+   # o mpileaks@2.3
+   # |\
+   # | o callpath@1.0
+   # |/
+   # o mpich@3.0.4
+   packages:
+     mpileaks:
+       externals:
+       - spec: "mpileaks@2.3~debug+opt"
+         prefix: /user/path
+         dependencies:
+         - spec: callpath
+           deptypes: link
+         - spec: mpich
+           virtuals: "mpi"
+     callpath:
+       externals:
+       - spec: "callpath@1.0"
+         prefix: /user/path
+         dependencies:
+         - spec: mpich
+           virtuals: "mpi"
+     mpich:
+       externals:
+       - spec: "mpich@3.0.4"
+         prefix: /user/path
+
+The specs mentioned in the ``dependencies:`` section must be constrained enough to identify a single external dependency.
+If the dependency spec matches no external, or more than one external, Spack will raise an error.
+The dependency type is specified in the optional ``deptypes`` field, and defaults to ``build,link``.
+Virtuals provided on edges are specified in the optional ``virtuals`` field.
+
+For a more structured output, it is also possible to assign an ``id`` to an extenal node, and refer to an external spec by ``id`` when specifying dependencies.
+The config above written using ``id`` instead of specs looks like:
 
 .. code-block:: yaml
 
@@ -146,10 +185,6 @@ For instance, the following configuration describes an ``mpileaks`` external tha
        - spec: "mpich@3.0.4"
          prefix: /user/path
          id: mpich_id
-
-The ``id`` attribute is a unique string identifier of the external node being described.
-The ``dependencies`` attribute is a list of objects, where you can specify the ``id`` of the dependency and optionally the dependency types (``deptypes``), and the ``virtuals``, along the edge.
-
 
 Prevent packages from being built from sources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -102,90 +102,6 @@ Specific limitations include:
 * The logic does not search through module files, it can only detect packages with executables defined in ``PATH``; you can help Spack locate externals which use module files by loading any associated modules for packages that you want Spack to know about before running ``spack external find``.
 * Spack does not overwrite existing entries in the package configuration: If there is an external defined for a spec at any configuration scope, then Spack will not add a new external entry (``spack config blame packages`` can help locate all external entries).
 
-Specifying dependencies among external packages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Dependency relationships among external packages can also be be modeled in your ``packages.yaml`` configuration file, by adding a ``dependencies:`` section to your external.
-For instance, the following configuration describes an ``mpileaks`` external that depends on ``callpath`` and on ``mpich``:
-
-.. code-block:: yaml
-
-   # Specification for the following DAG:
-   #
-   # o mpileaks@2.3
-   # |\
-   # | o callpath@1.0
-   # |/
-   # o mpich@3.0.4
-   packages:
-     mpileaks:
-       externals:
-       - spec: "mpileaks@2.3~debug+opt"
-         prefix: /user/path
-         dependencies:
-         - spec: callpath
-           deptypes: link
-         - spec: mpich
-           virtuals: "mpi"
-     callpath:
-       externals:
-       - spec: "callpath@1.0"
-         prefix: /user/path
-         dependencies:
-         - spec: mpich
-           virtuals: "mpi"
-     mpich:
-       externals:
-       - spec: "mpich@3.0.4"
-         prefix: /user/path
-
-The specs mentioned in the ``dependencies:`` section must be constrained enough to identify a single external dependency.
-If the dependency spec matches no external, or more than one external, Spack will raise an error.
-The dependency type is specified in the optional ``deptypes`` field, and defaults to ``build,link``.
-Virtuals provided on edges are specified in the optional ``virtuals`` field.
-
-For a more structured output, it is also possible to assign an ``id`` to an extenal node, and refer to an external spec by ``id`` when specifying dependencies.
-The config above written using ``id`` instead of specs looks like:
-
-.. code-block:: yaml
-
-   # Specification for the following DAG:
-   #
-   # o mpileaks@2.3
-   # |\
-   # | o callpath@1.0
-   # |/
-   # o mpich@3.0.4
-   packages:
-     mpileaks:
-       externals:
-       - spec: "mpileaks@2.3~debug+opt"
-         prefix: /user/path
-         dependencies:
-         - id: callpath_id
-           deptypes: link
-         - id: mpich_id
-           deptypes:
-           - "build"
-           - "link"
-           virtuals: "mpi"
-     callpath:
-       externals:
-       - spec: "callpath@1.0"
-         prefix: /user/path
-         id: callpath_id
-         dependencies:
-         - id: mpich_id
-           deptypes:
-           - "build"
-           - "link"
-           virtuals: "mpi"
-     mpich:
-       externals:
-       - spec: "mpich@3.0.4"
-         prefix: /user/path
-         id: mpich_id
-
 Prevent packages from being built from sources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -260,6 +176,133 @@ In cases where the concretizer is configured to reuse specs, and other ``mpi`` p
 This configuration prevents any spec using MPI and originating from stores or buildcaches to be reused, unless it matches the requirements under ``packages:mpi:require``.
 For more information on requirements see :ref:`package-requirements`.
 
+Specifying dependencies among external packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+External packages frequently have dependencies on other software components.
+Explicitly modeling these relationships provides Spack with a more complete representation of the software stack.
+This ensures that:
+
+- Runtime environments include all necessary components.
+- Build-time dependencies are accurately represented.
+
+This comprehensive view, in turn, enables Spack to more reliably build software that depends on these externals.
+
+Spack provides two methods for configuring dependency relationships among externals, each offering different trade-offs between conciseness and explicit control:
+
+- An "inline" spec syntax.
+- A structured YAML configuration that is more verbose but also more explicit.
+
+The following sections will detail both approaches.
+
+Dependencies using inline spec syntax
+"""""""""""""""""""""""""""""""""""""
+
+Spack allows you to define external package dependencies using the standard spec syntax directly within your package configuration.
+This approach is concise and leverages the familiar spec syntax that you already use elsewhere in Spack.
+
+When configuring an external package with dependencies using the spec syntax, you can include dependency specifications directly in the main ``spec:`` field:
+
+.. code-block:: yaml
+
+   # Specification for the following DAG:
+   #
+   # o mpileaks@2.3
+   # |\
+   # | o callpath@1.0
+   # |/
+   # o mpich@3.0.4
+   packages:
+     mpileaks:
+       externals:
+       - spec: "mpileaks@2.3~debug+opt %mpich@3 %callpath"
+         prefix: /user/path
+     callpath:
+       externals:
+       - spec: "callpath@1.0 %mpi=mpich"
+         prefix: /user/path
+     mpich:
+       externals:
+       - spec: "mpich@3.0.4"
+         prefix: /user/path
+
+In this example ``mpileaks`` depends on both ``mpich`` and ``callpath``.
+Spack will parse the ``mpileaks`` spec string, and create the appropriate dependency relationships automatically.
+
+Users *need* to ensure that each dependency maps exactly to a single other external package.
+In case multiple externals can satisfy the same dependency, or in case no external can satisfy a dependency, Spack will error and point to the configuration line causing the issue.
+
+Whenever no information is given about the dependency type, Spack will infer it from the current package recipe.
+For instance, the dependencies in the configuration above are inferred to be of ``build,link`` type from the recipe of ``mpileaks`` and ``callpath``:
+
+.. code-block:: console
+
+   $ spack -m spec --types -l --cover edges mpileaks
+   [e]  oelprl6  [    ]  mpileaks@2.3~debug+opt+shared+static build_system=generic platform=linux os=ubuntu20.04 target=icelake
+   [e]  jdhzy2t  [bl  ]      ^callpath@1.0 build_system=generic platform=linux os=ubuntu20.04 target=icelake
+   [e]  pgem3yp  [bl  ]          ^mpich@3.0.4~debug build_system=generic platform=linux os=ubuntu20.04 target=icelake
+   [e]  pgem3yp  [bl  ]      ^mpich@3.0.4~debug build_system=generic platform=linux os=ubuntu20.04 target=icelake
+
+When inferring the dependency types, Spack will also infer virtuals if they are not already specified.
+
+This method's conciseness comes with a strict requirement: each dependency must resolve to a single, unambiguous external package.
+This makes the approach suitable for simple or temporary configurations.
+In larger, more dynamic environments, however, it can become a maintenance challenge, as adding new external packages over time may require frequent updates to existing specs to preserve their uniqueness.
+
+Dependencies using YAML configuration
+"""""""""""""""""""""""""""""""""""""
+
+While the spec syntax offers a concise way to specify dependencies, Spack's YAML-based explicit dependency configuration provides more control and clarity, especially for complex dependency relationships.
+This approach uses the ``dependencies:`` field to precisely define each dependency relationship.
+The example in the previous section, written using the YAML configuration, becomes:
+
+.. code-block:: yaml
+
+   # Specification for the following DAG:
+   #
+   # o mpileaks@2.3
+   # |\
+   # | o callpath@1.0
+   # |/
+   # o mpich@3.0.4
+   packages:
+     mpileaks:
+       externals:
+       - spec: "mpileaks@2.3~debug+opt"
+         prefix: /user/path
+         dependencies:
+         - id: callpath_id
+           deptypes: link
+         - spec: mpich
+           deptypes:
+           - "build"
+           - "link"
+           virtuals: "mpi"
+     callpath:
+       externals:
+       - spec: "callpath@1.0"
+         prefix: /user/path
+         id: callpath_id
+         dependencies:
+         - spec: mpich
+           deptypes:
+           - "build"
+           - "link"
+           virtuals: "mpi"
+     mpich:
+       externals:
+       - spec: "mpich@3.0.4"
+         prefix: /user/path
+
+Each dependency can be specified either by:
+
+- A ``spec:`` that matches an available external package, like in the previous case, or by
+- An ``id`` that explicitly references another external package.
+
+Using the ``id`` provides an unambiguous reference to a specific external package, which is essential for differentiating between externals that have similar specs but differ, for example, only by their installation prefix.
+
+The dependency types can be specified in the optional ``deptypes`` field, while virtuals can be specified in the optional ``virtuals`` field.
+As before, when the dependency types are not specified, Spack will infer them from the package recipe.
 
 .. _extra-attributes-for-externals:
 

--- a/lib/spack/spack/archspec.py
+++ b/lib/spack/spack/archspec.py
@@ -57,3 +57,7 @@ def microarchitecture_flags_from_target(
         return target.optimization_flags(compiler.package.archspec_name(), version_number)
     except ValueError:
         return ""
+
+
+#: The host target family, like x86_64 or aarch64
+HOST_TARGET_FAMILY = spack.vendor.archspec.cpu.host().family

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -109,7 +109,7 @@ class BootstrapEnvironment(spack.environment.Environment):
         env = spack.tengine.make_environment()
         template = env.get_template("bootstrap/spack.yaml")
         context = {
-            "python_spec": spec_for_current_python(),
+            "python_spec": f"{spec_for_current_python()}+ctypes",
             "python_prefix": sys.exec_prefix,
             "architecture": spack.vendor.archspec.cpu.host().family,
             "environment_path": self.environment_root(),

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -13,6 +13,7 @@ import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.color as color
 import spack.repo
+import spack.solver.reuse
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
@@ -87,11 +88,17 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="don't show full list of installed specs in an environment",
     )
-    subparser.add_argument(
+    concretized_vs_packages = subparser.add_mutually_exclusive_group()
+    concretized_vs_packages.add_argument(
         "-c",
         "--show-concretized",
         action="store_true",
         help="show concretized specs in an environment",
+    )
+    concretized_vs_packages.add_argument(
+        "--show-configured-externals",
+        action="store_true",
+        help="show externals defined in the 'packages' section of the configuration",
     )
     subparser.add_argument(
         "-f",
@@ -321,8 +328,12 @@ def display_env(env, args, decorator, results):
 
 def _find_query(args, env):
     q_args = query_arguments(args)
-    concretized_but_not_installed = list()
-    if env:
+    concretized_but_not_installed = []
+    if args.show_configured_externals:
+        results = spack.solver.reuse.SpecFilter.from_packages_yaml(
+            spack.config.CONFIG, include=[], exclude=[]
+        ).selected_specs()
+    elif env:
         all_env_specs = env.all_specs()
         if args.constraint:
             init_specs = cmd.parse_specs(args.constraint)

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -120,6 +120,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="show only specs that were installed as dependencies",
     )
     subparser.add_argument(
+        "-e",
+        "--external",
+        action="store_true",
+        help="show only specs that are marked as externals",
+    )
+    subparser.add_argument(
         "-u",
         "--unknown",
         action="store_true",
@@ -336,6 +342,9 @@ def _find_query(args, env):
                     results.append(spec)
     else:
         results = args.specs(**q_args)
+
+    if args.external:
+        results = [s for s in results if s.external]
 
     # use groups by default except with format.
     if args.groups is None:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -111,7 +111,8 @@ CONFIG_DEFAULTS = {
         "build_jobs": min(16, cpus_available()),
         "build_stage": "$tempdir/spack-stage",
         "license_dir": spack.paths.default_license_dir,
-    }
+    },
+    "concretizer": {"externals": {"completion": "default_variants"}},
 }
 
 #: metavar to use for commands that accept scopes

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -648,9 +648,13 @@ class Configuration:
         """
         return self._get_config_memoized(section, scope=scope, _merged_scope=_merged_scope)
 
-    def deepcopy_as_builtin(self, section: str, scope: Optional[str] = None) -> Dict[str, Any]:
+    def deepcopy_as_builtin(
+        self, section: str, scope: Optional[str] = None, *, line_info: bool = False
+    ) -> Dict[str, Any]:
         """Get a deep copy of a section with native Python types, excluding YAML metadata."""
-        return syaml.deepcopy_as_builtin(self.get_config(section, scope=scope))
+        return syaml.deepcopy_as_builtin(
+            self.get_config(section, scope=scope), line_info=line_info
+        )
 
     @lang.memoized
     def _get_config_memoized(

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -22,10 +22,3 @@ class ConfigScopePriority(enum.IntEnum):
     ENVIRONMENT = 2
     CUSTOM = 3
     COMMAND_LINE = 4
-
-
-class PackageTags(enum.StrEnum):
-    """Common package tags used throughout the codebase"""
-
-    COMPILER = "compiler"
-    BUILD_TOOLS = "build-tools"

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -22,3 +22,10 @@ class ConfigScopePriority(enum.IntEnum):
     ENVIRONMENT = 2
     CUSTOM = 3
     COMMAND_LINE = 4
+
+
+class PackageTags(enum.StrEnum):
+    """Common package tags used throughout the codebase"""
+
+    COMPILER = "compiler"
+    BUILD_TOOLS = "build-tools"

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -67,6 +67,27 @@ def complete_architecture(node: spack.spec.Spec) -> None:
         node.compiler_flags.setdefault(flag_type, [])
 
 
+def complete_variants_and_architecture(node: spack.spec.Spec) -> None:
+    """Completes a node with variants and architecture information."""
+    complete_architecture(node)
+    pkg_class = spack.repo.PATH.get_pkg_class(node.name)
+    variants_dict = pkg_class.variants.copy()
+
+    progress = True
+    while progress:
+        progress = False
+        current_keys = list(variants_dict.keys())
+        for key in current_keys:
+            if not node.satisfies(key):
+                continue
+            applicable_variants = variants_dict.pop(key)
+            for v in applicable_variants.values():
+                if not node.satisfies(f"{v.name}=*"):
+                    # Cannot use Spec.constrain, because we lose information on the variant type
+                    node.variants[v.name] = v.make_default()
+            progress = True
+
+
 def extract_dicts_from_configuration(packages_yaml) -> List[ExternalDict]:
     """Extracts external specs from a configuration dictionary."""
     result = []
@@ -120,7 +141,7 @@ class ExternalSpecsParser:
         self,
         external_dicts: List[ExternalDict],
         *,
-        complete_node: Callable[[spack.spec.Spec], None] = complete_architecture,
+        complete_node: Callable[[spack.spec.Spec], None] = complete_variants_and_architecture,
         allow_nonexisting: bool = True,
     ):
         """Initializes a class to manage and process external specifications.

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -211,6 +211,17 @@ class ExternalSpecsParser:
             current_node, current_dict = entry.spec, entry.config
             line_info = _line_info(current_dict)
             spec_str = current_dict["spec"]
+
+            # Compute the dependency types for this spec
+            pkg_class, deptypes_by_package = spack.repo.PATH.get_pkg_class(current_node.name), {}
+            for when, by_name in pkg_class.dependencies.items():
+                if not current_node.satisfies(when):
+                    continue
+                for name, dep in by_name.items():
+                    if name not in deptypes_by_package:
+                        deptypes_by_package[name] = dep.depflag
+                    deptypes_by_package[name] |= dep.depflag
+
             for dependency_dict in current_dict.get("dependencies", []):
                 dependency_id = dependency_dict.get("id")
                 if not dependency_id:
@@ -224,12 +235,29 @@ class ExternalSpecsParser:
                     )
 
                 dependency_node = self.specs_by_external_id[dependency_id].spec
-                depflag = spack.deptypes.canonicalize(
-                    dependency_dict.get("deptypes", spack.deptypes.DEFAULT_TYPES)
-                )
+
+                # Compute dependency types and virtuals
+                depflag = spack.deptypes.NONE
+                if "deptypes" in dependency_dict:
+                    depflag = spack.deptypes.canonicalize(dependency_dict["deptypes"])
+
                 virtuals: Tuple[str, ...] = ()
                 if "virtuals" in dependency_dict:
                     virtuals = tuple(dependency_dict["virtuals"].split(","))
+
+                # Infer dependency types and virtuals if the user didn't specify them
+                if depflag == spack.deptypes.NONE and not virtuals:
+                    # Infer the deptype if only '%' was used in the spec
+                    inferred_virtuals = []
+                    for name, current_flag in deptypes_by_package.items():
+                        if not dependency_node.intersects(name):
+                            continue
+                        depflag |= current_flag
+                        if spack.repo.PATH.is_virtual(name):
+                            inferred_virtuals.append(name)
+                    virtuals = tuple(inferred_virtuals)
+                elif depflag == spack.deptypes.NONE:
+                    depflag = spack.deptypes.DEFAULT
 
                 current_node._add_dependency(dependency_node, depflag=depflag, virtuals=virtuals)
 
@@ -245,59 +273,18 @@ class ExternalSpecsParser:
                     f"in the 'dependencies' field{line_info}"
                 )
 
-            # Add a Python dependency to Python extensions
-            pkg_class = spack.repo.PATH.get_pkg_class(current_node.name)
-            if (
-                "dependencies" not in current_dict
-                and not current_node.dependencies()
-                and any([c.__name__ == "PythonExtension" for c in pkg_class.__mro__])
-            ):
-                warnings.warn(
-                    f"Spack is trying attach a Python dependency to '{spec_str}'. This feature is "
-                    f"deprecated, and will be removed in v1.2. Please make the dependency "
-                    f"explicit in your configuration."
-                )
-                current_dict.setdefault("dependencies", []).append(
-                    {"spec": "python", "deptypes": ["build", "run"]}
-                )
-
-            # Compute the dependency types for this spec
-            deptypes_by_package = {}
-            for when, by_name in pkg_class.dependencies.items():
-                if not current_node.satisfies(when):
-                    continue
-                for name, dep in by_name.items():
-                    if name not in deptypes_by_package:
-                        deptypes_by_package[name] = dep.depflag
-                    deptypes_by_package[name] |= dep.depflag
-
             # Transform inline entries like 'mpich %gcc' to a canonical form using 'dependencies'
             for edge in current_node.edges_to_dependencies():
-                # Fallback to the same defaults as "depends_on"
-                deptypes, virtuals = ["build", "link"], ""
-                if edge.depflag == 0 and not edge.virtuals:
-                    # Infer the deptype if only '%' was used in the spec
-                    inferred_deptypes, inferred_virtuals = spack.deptypes.NONE, []
-                    for name, current_flag in deptypes_by_package.items():
-                        if not edge.spec.intersects(name):
-                            continue
-                        inferred_deptypes |= current_flag
-                        if spack.repo.PATH.is_virtual(name):
-                            inferred_virtuals.append(name)
-                    virtuals = ",".join(inferred_virtuals)
-                    if inferred_deptypes != spack.deptypes.NONE:
-                        deptypes = spack.deptypes.flag_to_tuple(inferred_deptypes)
+                entry: DependencyDict = {"spec": str(edge.spec)}
 
                 # Handle entries with more options specified
                 if edge.depflag != 0:
-                    deptypes = spack.deptypes.flag_to_tuple(edge.depflag)
+                    entry["deptypes"] = spack.deptypes.flag_to_tuple(edge.depflag)
 
                 if edge.virtuals:
-                    virtuals = ",".join(edge.virtuals)
+                    entry["virtuals"] = ",".join(edge.virtuals)
 
-                current_dict.setdefault("dependencies", []).append(
-                    {"spec": str(edge.spec), "deptypes": deptypes, "virtuals": virtuals}
-                )
+                current_dict.setdefault("dependencies", []).append(entry)
             current_node.clear_edges()
 
             # Map a spec: to id:
@@ -369,6 +356,21 @@ class ExternalSpecsParser:
                 )
 
             self.complete_node(node)
+
+            # Add a Python dependency to Python extensions that don't specify it
+            pkg_class = spack.repo.PATH.get_pkg_class(node.name)
+            if (
+                "dependencies" not in external_dict
+                and not node.dependencies()
+                and any([c.__name__ == "PythonExtension" for c in pkg_class.__mro__])
+            ):
+                warnings.warn(
+                    f"Spack is trying attach a Python dependency to '{node}'. This feature is "
+                    f"deprecated, and will be removed in v1.2. Please make the dependency "
+                    f"explicit in your configuration."
+                )
+                external_dict.setdefault("dependencies", []).append({"spec": "python"})
+
             # Normalize internally so that each node has a unique id
             spec_and_config = ExternalSpecAndConfig(spec=node, config=external_dict)
             self.specs_by_external_id[eid] = spec_and_config

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -13,6 +13,7 @@ import spack.deptypes
 import spack.repo
 import spack.spec
 from spack.error import SpackError
+from spack.llnl.util import tty
 
 
 class DependencyDict(TypedDict, total=False):
@@ -194,10 +195,10 @@ class ExternalSpecsParser:
             try:
                 node = node_from_dict(external_dict)
             except spack.spec.UnsatisfiableArchitectureSpecError:
-                warnings.warn(
-                    f"cannot constrain external spec '{external_dict['spec']}' with target "
-                    f"'{external_dict['required_target']}'. This spec will not be considered "
-                    f"during concretization."
+                tty.debug(
+                    f"[{__name__}] skipping external spec '{external_dict['spec']}' because it"
+                    f" cannot be constrained with the required target "
+                    f"'{external_dict['required_target']}'."
                 )
                 continue
             except ExternalSpecError as e:

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -17,6 +17,7 @@ from spack.error import SpackError
 
 class DependencyDict(TypedDict, total=False):
     id: str
+    spec: str
     deptypes: spack.deptypes.DepTypes
     virtuals: str
 
@@ -207,11 +208,14 @@ class ExternalSpecsParser:
             self.specs_by_name.setdefault(node.name, []).append(spec_and_config)
             self.nodes.append(node)
 
-        # Guess how to convert old entries like 'mpich %gcc' to a dependency in the dict
+        # Map dependencies specified as specs to id
         for eid, entry in self.specs_by_external_id.items():
             current_node = entry.spec
             current_dict = entry.config
+            is_legacy = False
+            # Guess how to convert old entries like 'mpich %gcc' to a dependency in the dict
             for edge in current_node.edges_to_dependencies():
+                is_legacy = True
                 # We don't want to accept foo %[deptypes=build,link] mpich as a spec
                 if edge.depflag != 0:
                     raise ExternalDependencyError(
@@ -248,6 +252,37 @@ class ExternalSpecsParser:
                     {"id": selected.config["id"], "deptypes": "build", "virtuals": "c"}
                 )
             current_node.clear_edges()
+            if is_legacy:
+                # Legacy specs are not allowed to have a "dependencies:" section
+                continue
+
+            # Map a spec: to id:
+            for dependency_dict in current_dict.get("dependencies", []):
+                if "id" in dependency_dict:
+                    continue
+
+                if "spec" not in dependency_dict:
+                    raise ExternalDependencyError(
+                        f"the spec {current_dict['spec']} needs to specify either the id or the "
+                        f"spec of its dependencies."
+                    )
+
+                query_spec = spack.spec.Spec(dependency_dict["spec"])
+                candidates = [
+                    x for x in self.specs_by_name[query_spec.name] if x.spec.satisfies(query_spec)
+                ]
+                if len(candidates) == 0:
+                    raise ExternalDependencyError(
+                        f"the spec {current_dict['spec']} depends on {query_spec}, but there is "
+                        f"no such external spec in packages.yaml."
+                    )
+                elif len(candidates) > 1:
+                    raise ExternalDependencyError(
+                        f"the spec {current_dict['spec']} depends on {query_spec}, but there are "
+                        f"multiple external specs in packages.yaml that satisfy it."
+                    )
+
+                dependency_dict["id"] = candidates[0].config["id"]
 
         # Attach dependencies to externals
         for eid, entry in self.specs_by_external_id.items():

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -1,0 +1,101 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from typing import Any, Callable, Dict, List, Union
+
+from spack.vendor.typing_extensions import TypedDict
+
+import spack.archspec
+import spack.spec
+
+
+class ExternalDict(TypedDict, total=False):
+    """Dictionary representation of an external spec."""
+
+    spec: str
+    prefix: str
+    modules: List[str]
+    extra_attributes: Dict[str, Any]
+    external_id: str
+
+
+def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
+    """Returns an external spec node from a dictionary representation."""
+    extra_attributes = external_dict.get("extra_attributes", {})
+    result = spack.spec.Spec(
+        # Allow `@x.y.z` instead of `@=x.y.z`
+        str(spack.spec.parse_with_version_concrete(external_dict["spec"])),
+        external_path=external_dict.get("prefix"),
+        external_modules=external_dict.get("modules"),
+    )
+    result.extra_attributes = extra_attributes
+    return result
+
+
+def complete_architecture(node: spack.spec.Spec) -> None:
+    """Completes a node with architecture information."""
+    if node.architecture:
+        node.architecture.complete_with_defaults()
+    else:
+        node.constrain(spack.spec.Spec.default_arch())
+    node.architecture.target = spack.archspec.HOST_TARGET_FAMILY
+
+
+def extract_dicts_from_configuration(packages_yaml) -> List[ExternalDict]:
+    """Extracts external specs from a configuration dictionary."""
+    result = []
+    for name, entry in packages_yaml.items():
+        result.extend([current for current in entry.get("externals", [])])
+    return result
+
+
+class ExternalSpecsParser:
+    def __init__(
+        self,
+        external_dicts: List[ExternalDict],
+        *,
+        complete_node: Callable[[spack.spec.Spec], None] = complete_architecture,
+    ):
+        self.external_dicts = external_dicts
+        self.specs_by_external_id: Dict[str, spack.spec.Spec] = {}
+        self.specs_by_name: Dict[str, List[spack.spec.Spec]] = {}
+        self.nodes: List[spack.spec.Spec] = []
+        # Fill the data structures above (can be done lazily)
+        self.complete_node = complete_node
+        self._parse()
+
+    def _parse(self) -> None:
+        for external_dict in self.external_dicts:
+            node = node_from_dict(external_dict)
+            self.complete_node(node)
+            external_id = external_dict.get("external_id")
+            if external_id:
+                self.specs_by_external_id[external_id] = node
+            self.specs_by_name.setdefault(node.name, []).append(node)
+            self.nodes.append(node)
+
+        # TODO (externals as concrete specs): attach dependencies here
+
+        for node in self.nodes:
+            node._finalize_concretization()
+
+    def get_specs_for_package(self, package_name: str) -> List[spack.spec.Spec]:
+        """Returns the external specs for a given package name."""
+        return self.specs_by_name.get(package_name, [])
+
+    def all_specs(self) -> List[spack.spec.Spec]:
+        """Returns all the external specs."""
+        return self.nodes
+
+    def query(self, query: Union[str, spack.spec.Spec]) -> List[spack.spec.Spec]:
+        """Returns the external specs matching a query spec."""
+        result = []
+        for node in self.nodes:
+            if node.satisfies(query):
+                result.append(node)
+        return result
+
+
+def external_spec(config: ExternalDict) -> spack.spec.Spec:
+    """Returns an external spec from a dictionary representation."""
+    return ExternalSpecsParser([config]).all_specs()[0]

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -16,7 +16,7 @@ from spack.error import SpackError
 
 
 class DependencyDict(TypedDict, total=False):
-    external_id: str
+    id: str
     deptypes: spack.deptypes.DepTypes
     virtuals: str
 
@@ -28,7 +28,7 @@ class ExternalDict(TypedDict, total=False):
     prefix: str
     modules: List[str]
     extra_attributes: Dict[str, Any]
-    external_id: str
+    id: str
     dependencies: List[DependencyDict]
     required_target: str
 
@@ -192,7 +192,7 @@ class ExternalSpecsParser:
             if not package_exists:
                 raise ValueError(f"Package '{node.name}' does not exist")
 
-            eid = external_dict.setdefault("external_id", str(uuid.uuid4()))
+            eid = external_dict.setdefault("id", str(uuid.uuid4()))
             if eid in self.specs_by_external_id:
                 other_node = self.specs_by_external_id[eid].spec
                 raise DuplicateExternalError(
@@ -245,11 +245,7 @@ class ExternalSpecsParser:
                     f"'{selected.config['spec']}'. If this is incorrect, fix your packages.yaml."
                 )
                 current_dict.setdefault("dependencies", []).append(
-                    {
-                        "external_id": selected.config["external_id"],
-                        "deptypes": "build",
-                        "virtuals": "c",
-                    }
+                    {"id": selected.config["id"], "deptypes": "build", "virtuals": "c"}
                 )
             current_node.clear_edges()
 
@@ -259,7 +255,7 @@ class ExternalSpecsParser:
             current_dict = entry.config
 
             for dependency_dict in current_dict.get("dependencies", []):
-                dependency_id = dependency_dict.get("external_id")
+                dependency_id = dependency_dict.get("id")
                 if not dependency_id:
                     raise ExternalDependencyError(
                         f"A dependency for {current_dict['spec']} does not have an external id"

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -145,8 +145,9 @@ class ExternalSpecsParser:
                 node = node_from_dict(external_dict)
             except spack.spec.UnsatisfiableArchitectureSpecError:
                 warnings.warn(
-                    f"cannot constrain external spec {external_dict['spec']}"
-                    f" with target {external_dict['required_target']}"
+                    f"cannot constrain external spec '{external_dict['spec']}' with target "
+                    f"'{external_dict['required_target']}'. This spec will not be considered "
+                    f"during concretization."
                 )
                 continue
 
@@ -185,14 +186,14 @@ class ExternalSpecsParser:
                 # We don't want to accept foo %[deptypes=build,link] mpich as a spec
                 if edge.depflag != 0:
                     raise ExternalDependencyError(
-                        f"The external spec {current_dict['spec']} has an invalid dependency"
+                        f"The external spec '{current_dict['spec']}' has an invalid dependency"
                         f" specification. Fix your packages.yaml configuration."
                     )
 
                 if edge.spec.name not in self.specs_by_name:
                     raise ExternalDependencyError(
-                        f"The external spec {current_dict['spec']} depends on {edge.spec.name},"
-                        f" but there is no such external spec in packages.yaml."
+                        f"The external spec '{current_dict['spec']}' depends on "
+                        f"'{edge.spec.name}', but there is no such external spec in packages.yaml."
                     )
 
                 candidates = [
@@ -203,14 +204,17 @@ class ExternalSpecsParser:
                 ]
                 if not candidates:
                     raise ExternalDependencyError(
-                        f"The external spec {current_dict['spec']} depends on {edge.spec},"
-                        f" but there is no {edge.spec.name} that satisfies the request "
+                        f"The external spec '{current_dict['spec']}' depends on '{edge.spec}',"
+                        f" but there is no '{edge.spec.name}' that satisfies the request "
                         f"in packages.yaml."
                     )
 
                 candidates.sort(key=lambda x: x.spec)  # type: ignore
                 selected = candidates[-1]
-                # FIXME (externals as concrete): issue a warning for this case
+                warnings.warn(
+                    f"the external spec '{current_dict['spec']}' has been guessed to depend on "
+                    f"'{selected.config['spec']}'. If this is incorrect, fix your packages.yaml."
+                )
                 current_dict.setdefault("dependencies", []).append(
                     {
                         "external_id": selected.config["external_id"],

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -4,7 +4,7 @@
 import re
 import uuid
 import warnings
-from typing import Any, Callable, Dict, List, NamedTuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Union
 
 from spack.vendor.typing_extensions import TypedDict
 
@@ -42,6 +42,11 @@ def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
         external_path=external_dict.get("prefix"),
         external_modules=external_dict.get("modules"),
     )
+    if not result.versions.concrete:
+        raise ExternalSpecError(
+            f"The external spec '{external_dict['spec']}' doesn't have a concrete version."
+        )
+
     result.extra_attributes = extra_attributes
     if "required_target" in external_dict:
         result.constrain(f"target={external_dict['required_target']}")
@@ -150,6 +155,9 @@ class ExternalSpecsParser:
                     f"during concretization."
                 )
                 continue
+            except ExternalSpecError as e:
+                warnings.warn(f"{e} Fix your packages.yaml configuration.")
+                continue
 
             package_exists = spack.repo.PATH.exists(node.name)
 
@@ -245,7 +253,9 @@ class ExternalSpecsParser:
                 depflag = spack.deptypes.canonicalize(
                     dependency_dict.get("deptypes", spack.deptypes.DEFAULT_TYPES)
                 )
-                virtuals = tuple(dependency_dict.get("virtuals", "").split(","))
+                virtuals: Tuple[str, ...] = ()
+                if "virtuals" in dependency_dict:
+                    virtuals = tuple(dependency_dict["virtuals"].split(","))
 
                 current_node._add_dependency(dependency_node, depflag=depflag, virtuals=virtuals)
 
@@ -280,4 +290,8 @@ class DuplicateExternalError(SpackError):
 
 
 class ExternalDependencyError(SpackError):
+    """Raised when a dependency on an external package is specified wrongly."""
+
+
+class ExternalSpecError(SpackError):
     """Raised when a dependency on an external package is specified wrongly."""

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -46,10 +46,15 @@ def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
 def complete_architecture(node: spack.spec.Spec) -> None:
     """Completes a node with architecture information."""
     if node.architecture:
+        if not node.architecture.target:
+            node.architecture.target = spack.archspec.HOST_TARGET_FAMILY
         node.architecture.complete_with_defaults()
     else:
         node.constrain(spack.spec.Spec.default_arch())
-    node.architecture.target = spack.archspec.HOST_TARGET_FAMILY
+        node.architecture.target = spack.archspec.HOST_TARGET_FAMILY
+
+    for flag_type in spack.spec.FlagMap.valid_compiler_flags():
+        node.compiler_flags.setdefault(flag_type, [])
 
 
 def extract_dicts_from_configuration(packages_yaml) -> List[ExternalDict]:

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -12,6 +12,7 @@ import spack.archspec
 import spack.deptypes
 import spack.repo
 import spack.spec
+from spack.enums import PackageTags
 from spack.error import SpackError
 from spack.llnl.util import tty
 
@@ -234,15 +235,24 @@ class ExternalSpecsParser:
                 current_node._add_dependency(dependency_node, depflag=depflag, virtuals=virtuals)
 
     def _ensure_dependencies_have_single_id(self):
+        possible_compilers = spack.repo.PATH.packages_with_tags(PackageTags.COMPILER)
         for eid, entry in self.specs_by_external_id.items():
             current_node, current_dict = entry.spec, entry.config
             spec_str = current_dict["spec"]
             line_info = _line_info(current_dict)
 
+            if current_node.dependencies() and "dependencies" in current_dict:
+                raise ExternalSpecError(
+                    f"the spec {spec_str} cannot specify dependencies both in the root spec and"
+                    f"in the 'dependencies' field{line_info}"
+                )
+
             # Add a Python dependency to Python extensions
             pkg_class = spack.repo.PATH.get_pkg_class(current_node.name)
-            if "dependencies" not in current_dict and any(
-                [c.__name__ == "PythonExtension" for c in pkg_class.__mro__]
+            if (
+                "dependencies" not in current_dict
+                and not current_node.dependencies()
+                and any([c.__name__ == "PythonExtension" for c in pkg_class.__mro__])
             ):
                 warnings.warn(
                     f"Spack is trying attach a Python dependency to '{spec_str}'. This feature is "
@@ -253,15 +263,27 @@ class ExternalSpecsParser:
                     {"spec": "python", "deptypes": ["build", "run"]}
                 )
 
-            # Transform inline entries like 'mpich %gcc' to a canonical form
+            # Transform inline entries like 'mpich %gcc' to a canonical form using 'dependencies:'
             for edge in current_node.edges_to_dependencies():
-                # We don't want to accept foo %[deptypes=build,link] mpich as a spec
+                # In general, use the same defaults as "depends_on"
+                deptypes, virtuals = ["build", "link"], ""
+                if (
+                    edge.depflag == 0
+                    and not edge.virtuals
+                    and edge.spec.name in possible_compilers
+                ):
+                    # Default for backward compatibility with old configs
+                    deptypes, virtuals = "build", "c"
+
+                # Handle entries with more options specified
                 if edge.depflag != 0:
-                    raise ExternalDependencyError(
-                        f"The external spec '{spec_str}' cannot specify deptypes{line_info}"
-                    )
+                    deptypes = spack.deptypes.flag_to_tuple(edge.depflag)
+
+                if edge.virtuals:
+                    virtuals = ",".join(edge.virtuals)
+
                 current_dict.setdefault("dependencies", []).append(
-                    {"spec": str(edge.spec), "deptypes": "build", "virtuals": "c"}
+                    {"spec": str(edge.spec), "deptypes": deptypes, "virtuals": virtuals}
                 )
             current_node.clear_edges()
 

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Union
 from spack.vendor.typing_extensions import TypedDict
 
 import spack.archspec
+import spack.repo
 import spack.spec
 
 
@@ -55,11 +56,25 @@ class ExternalSpecsParser:
         external_dicts: List[ExternalDict],
         *,
         complete_node: Callable[[spack.spec.Spec], None] = complete_architecture,
+        allow_nonexisting: bool = True,
     ):
+        """Initializes a class to manage and process external specifications.
+
+        Args:
+            external_dicts: list of ExternalDict objects to provide external specifications.
+            complete_node: a callable that completes a node with missing variants, targets, etc.
+                Defaults to `complete_architecture`.
+            allow_nonexisting: whether to allow non-existing packages. Defaults to True.
+
+        Raises:
+            spack.repo.UnknownPackageError: if a package does not exist,
+                and allow_nonexisting is False.
+        """
         self.external_dicts = external_dicts
         self.specs_by_external_id: Dict[str, spack.spec.Spec] = {}
         self.specs_by_name: Dict[str, List[spack.spec.Spec]] = {}
         self.nodes: List[spack.spec.Spec] = []
+        self.allow_nonexisting = allow_nonexisting
         # Fill the data structures above (can be done lazily)
         self.complete_node = complete_node
         self._parse()
@@ -67,6 +82,17 @@ class ExternalSpecsParser:
     def _parse(self) -> None:
         for external_dict in self.external_dicts:
             node = node_from_dict(external_dict)
+            package_exists = spack.repo.PATH.exists(node.name)
+
+            # If we allow non-existing packages, just continue
+            if not package_exists and self.allow_nonexisting:
+                continue
+
+            if not package_exists and not self.allow_nonexisting:
+                raise spack.repo.UnknownPackageError(node.name, repo=spack.repo.PATH)
+
+            if not package_exists:
+                raise ValueError(f"Package '{node.name}' does not exist")
             self.complete_node(node)
             external_id = external_dict.get("external_id")
             if external_id:

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -1,7 +1,9 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import re
 import uuid
+import warnings
 from typing import Any, Callable, Dict, List, NamedTuple, Union
 
 from spack.vendor.typing_extensions import TypedDict
@@ -28,6 +30,7 @@ class ExternalDict(TypedDict, total=False):
     extra_attributes: Dict[str, Any]
     external_id: str
     dependencies: List[DependencyDict]
+    required_target: str
 
 
 def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
@@ -40,6 +43,8 @@ def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
         external_modules=external_dict.get("modules"),
     )
     result.extra_attributes = extra_attributes
+    if "required_target" in external_dict:
+        result.constrain(f"target={external_dict['required_target']}")
     return result
 
 
@@ -60,9 +65,44 @@ def complete_architecture(node: spack.spec.Spec) -> None:
 def extract_dicts_from_configuration(packages_yaml) -> List[ExternalDict]:
     """Extracts external specs from a configuration dictionary."""
     result = []
+    default_required_target = ""
+    if "all" in packages_yaml:
+        default_required_target = _required_target(packages_yaml["all"])
+
     for name, entry in packages_yaml.items():
-        result.extend([current for current in entry.get("externals", [])])
+        pkg_required_target = _required_target(entry) or default_required_target
+        partial_result = [current for current in entry.get("externals", [])]
+        if pkg_required_target:
+            for partial in partial_result:
+                partial["required_target"] = pkg_required_target
+        result.extend(partial_result)
     return result
+
+
+_TARGET_RE = re.compile(r"target=(\S+)")
+
+
+def _required_target(entry) -> str:
+    if "require" not in entry:
+        return ""
+
+    requirements = entry["require"]
+    if not isinstance(requirements, list):
+        requirements = [requirements]
+
+    results = []
+    for requirement in requirements:
+        if not isinstance(requirement, str):
+            continue
+
+        matches = _TARGET_RE.match(requirement)
+        if matches:
+            results.append(matches.group(1))
+
+    if len(results) == 1:
+        return results[0]
+
+    return ""
 
 
 class ExternalSpecAndConfig(NamedTuple):
@@ -101,7 +141,15 @@ class ExternalSpecsParser:
 
     def _parse(self) -> None:
         for external_dict in self.external_dicts:
-            node = node_from_dict(external_dict)
+            try:
+                node = node_from_dict(external_dict)
+            except spack.spec.UnsatisfiableArchitectureSpecError:
+                warnings.warn(
+                    f"cannot constrain external spec {external_dict['spec']}"
+                    f" with target {external_dict['required_target']}"
+                )
+                continue
+
             package_exists = spack.repo.PATH.exists(node.name)
 
             # If we allow non-existing packages, just continue

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -1,13 +1,15 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from typing import Any, Callable, Dict, List, Union
+import uuid
+from typing import Any, Callable, Dict, List, NamedTuple, Union
 
 from spack.vendor.typing_extensions import TypedDict
 
 import spack.archspec
 import spack.repo
 import spack.spec
+from spack.error import SpackError
 
 
 class ExternalDict(TypedDict, total=False):
@@ -50,6 +52,11 @@ def extract_dicts_from_configuration(packages_yaml) -> List[ExternalDict]:
     return result
 
 
+class ExternalSpecAndConfig(NamedTuple):
+    spec: spack.spec.Spec
+    config: ExternalDict
+
+
 class ExternalSpecsParser:
     def __init__(
         self,
@@ -71,7 +78,7 @@ class ExternalSpecsParser:
                 and allow_nonexisting is False.
         """
         self.external_dicts = external_dicts
-        self.specs_by_external_id: Dict[str, spack.spec.Spec] = {}
+        self.specs_by_external_id: Dict[str, ExternalSpecAndConfig] = {}
         self.specs_by_name: Dict[str, List[spack.spec.Spec]] = {}
         self.nodes: List[spack.spec.Spec] = []
         self.allow_nonexisting = allow_nonexisting
@@ -93,10 +100,18 @@ class ExternalSpecsParser:
 
             if not package_exists:
                 raise ValueError(f"Package '{node.name}' does not exist")
+
+            eid = external_dict.setdefault("external_id", str(uuid.uuid4()))
+            if eid in self.specs_by_external_id:
+                other_node = self.specs_by_external_id[eid].spec
+                raise DuplicateExternalError(
+                    f"Specs {node} and {other_node} have the same external id {eid}."
+                    f" Fix your packages.yaml configuration."
+                )
+
             self.complete_node(node)
-            external_id = external_dict.get("external_id")
-            if external_id:
-                self.specs_by_external_id[external_id] = node
+            # Normalize internally so that each node has a unique id
+            self.specs_by_external_id[eid] = ExternalSpecAndConfig(spec=node, config=external_dict)
             self.specs_by_name.setdefault(node.name, []).append(node)
             self.nodes.append(node)
 
@@ -125,3 +140,7 @@ class ExternalSpecsParser:
 def external_spec(config: ExternalDict) -> spack.spec.Spec:
     """Returns an external spec from a dictionary representation."""
     return ExternalSpecsParser([config]).all_specs()[0]
+
+
+class DuplicateExternalError(SpackError):
+    """Raised when a duplicate external is detected."""

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -1,6 +1,19 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+This module turns the configuration data in the ``packages`` section into a list of concrete specs.
+
+This is mainly done by the ``ExternalSpecsParser`` class, which is responsible for:
+
+ 1. Transforming an intermediate representation of the YAML configuration into a set of nodes
+ 2. Ensuring the dependency specifications are not ambiguous
+ 3. Inferring missing information about the external specs (e.g. architecture, deptypes)
+ 4. Wiring up the external specs to their dependencies
+
+The helper function ``extract_dicts_from_configuration`` is used to transform the configuration
+into the intermediate representation.
+"""
 import re
 import uuid
 import warnings

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -7,9 +7,16 @@ from typing import Any, Callable, Dict, List, NamedTuple, Union
 from spack.vendor.typing_extensions import TypedDict
 
 import spack.archspec
+import spack.deptypes
 import spack.repo
 import spack.spec
 from spack.error import SpackError
+
+
+class DependencyDict(TypedDict, total=False):
+    external_id: str
+    deptypes: spack.deptypes.DepTypes
+    virtuals: str
 
 
 class ExternalDict(TypedDict, total=False):
@@ -20,6 +27,7 @@ class ExternalDict(TypedDict, total=False):
     modules: List[str]
     extra_attributes: Dict[str, Any]
     external_id: str
+    dependencies: List[DependencyDict]
 
 
 def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
@@ -115,7 +123,30 @@ class ExternalSpecsParser:
             self.specs_by_name.setdefault(node.name, []).append(node)
             self.nodes.append(node)
 
-        # TODO (externals as concrete specs): attach dependencies here
+        # Attach dependencies to externals
+        for eid, entry in self.specs_by_external_id.items():
+            current_node = entry.spec
+            current_dict = entry.config
+
+            for dependency_dict in current_dict.get("dependencies", []):
+                dependency_id = dependency_dict.get("external_id")
+                if not dependency_id:
+                    raise ExternalDependencyError(
+                        f"A dependency for {current_dict['spec']} does not have an external id"
+                    )
+                elif dependency_id not in self.specs_by_external_id:
+                    raise ExternalDependencyError(
+                        f"A dependency for {current_dict['spec']} has an external id "
+                        f"{dependency_id} that is not defined in packages.yaml"
+                    )
+
+                dependency_node = self.specs_by_external_id[dependency_id].spec
+                depflag = spack.deptypes.canonicalize(
+                    dependency_dict.get("deptypes", spack.deptypes.DEFAULT_TYPES)
+                )
+                virtuals = tuple(dependency_dict.get("virtuals", "").split(","))
+
+                current_node._add_dependency(dependency_node, depflag=depflag, virtuals=virtuals)
 
         for node in self.nodes:
             node._finalize_concretization()
@@ -144,3 +175,7 @@ def external_spec(config: ExternalDict) -> spack.spec.Spec:
 
 class DuplicateExternalError(SpackError):
     """Raised when a duplicate external is detected."""
+
+
+class ExternalDependencyError(SpackError):
+    """Raised when a dependency on an external package is specified wrongly."""

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -23,7 +23,11 @@ class DependencyDict(TypedDict, total=False):
 
 
 class ExternalDict(TypedDict, total=False):
-    """Dictionary representation of an external spec."""
+    """Dictionary representation of an external spec.
+
+    This representation mostly follows the one used in the configuration files, with a few
+    exceptions needed to support specific features.
+    """
 
     spec: str
     prefix: str
@@ -31,6 +35,7 @@ class ExternalDict(TypedDict, total=False):
     extra_attributes: Dict[str, Any]
     id: str
     dependencies: List[DependencyDict]
+    # Not in the external schema. This field represents a target requirement from configuration.
     required_target: str
 
 
@@ -55,7 +60,11 @@ def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
 
 
 def complete_architecture(node: spack.spec.Spec) -> None:
-    """Completes a node with architecture information."""
+    """Completes a node with architecture information.
+
+    Undefined targets are set to the default host target family (e.g. ``x86_64``).
+    The operating system and platform are set based on the current host.
+    """
     if node.architecture:
         if not node.architecture.target:
             node.architecture.target = spack.archspec.HOST_TARGET_FAMILY
@@ -69,28 +78,37 @@ def complete_architecture(node: spack.spec.Spec) -> None:
 
 
 def complete_variants_and_architecture(node: spack.spec.Spec) -> None:
-    """Completes a node with variants and architecture information."""
+    """Completes a node with variants and architecture information.
+
+    Architecture is completed first, delegating to ``complete_architecture``.
+    Variants are then added to the node, using their default value.
+    """
     complete_architecture(node)
     pkg_class = spack.repo.PATH.get_pkg_class(node.name)
     variants_dict = pkg_class.variants.copy()
+    changed = True
 
-    progress = True
-    while progress:
-        progress = False
-        current_keys = list(variants_dict.keys())
-        for key in current_keys:
-            if not node.satisfies(key):
+    while variants_dict and changed:
+        changed = False
+        items = list(variants_dict.items())  # copy b/c loop modifies dict
+
+        for when, variants_by_name in items:
+            if not node.satisfies(when):
                 continue
-            applicable_variants = variants_dict.pop(key)
-            for v in applicable_variants.values():
-                if not node.satisfies(f"{v.name}=*"):
+            variants_dict.pop(when)
+            for name, vdef in variants_by_name.items():
+                if name not in node.variants:
                     # Cannot use Spec.constrain, because we lose information on the variant type
-                    node.variants[v.name] = v.make_default()
-            progress = True
+                    node.variants[name] = vdef.make_default()
+            changed = True
 
 
 def extract_dicts_from_configuration(packages_yaml) -> List[ExternalDict]:
-    """Extracts external specs from a configuration dictionary."""
+    """Transforms the packages.yaml configuration into a list of external dictionaries.
+
+    The default required target is extracted from ``packages:all:require``, if present.
+    Any package-specific required target overrides the default.
+    """
     result = []
     default_required_target = ""
     if "all" in packages_yaml:
@@ -110,6 +128,9 @@ _TARGET_RE = re.compile(r"target=([^\s:]+)")
 
 
 def _required_target(entry) -> str:
+    """Parses the YAML configuration for a single external spec and returns the required target
+    if defined. Returns an empty string otherwise.
+    """
     if "require" not in entry:
         return ""
 
@@ -138,6 +159,8 @@ class ExternalSpecAndConfig(NamedTuple):
 
 
 class ExternalSpecsParser:
+    """Transforms a list of external dicts into a list of specs."""
+
     def __init__(
         self,
         external_dicts: List[ExternalDict],
@@ -145,7 +168,7 @@ class ExternalSpecsParser:
         complete_node: Callable[[spack.spec.Spec], None] = complete_variants_and_architecture,
         allow_nonexisting: bool = True,
     ):
-        """Initializes a class to manage and process external specifications.
+        """Initializes a class to manage and process external specifications in ``packages.yaml``.
 
         Args:
             external_dicts: list of ExternalDict objects to provide external specifications.
@@ -189,9 +212,6 @@ class ExternalSpecsParser:
 
             if not package_exists and not self.allow_nonexisting:
                 raise spack.repo.UnknownPackageError(node.name, repo=spack.repo.PATH)
-
-            if not package_exists:
-                raise ValueError(f"Package '{node.name}' does not exist")
 
             eid = external_dict.setdefault("id", str(uuid.uuid4()))
             if eid in self.specs_by_external_id:

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -12,7 +12,6 @@ import spack.archspec
 import spack.deptypes
 import spack.repo
 import spack.spec
-from spack.enums import PackageTags
 from spack.error import SpackError
 from spack.llnl.util import tty
 
@@ -235,7 +234,6 @@ class ExternalSpecsParser:
                 current_node._add_dependency(dependency_node, depflag=depflag, virtuals=virtuals)
 
     def _ensure_dependencies_have_single_id(self):
-        possible_compilers = spack.repo.PATH.packages_with_tags(PackageTags.COMPILER)
         for eid, entry in self.specs_by_external_id.items():
             current_node, current_dict = entry.spec, entry.config
             spec_str = current_dict["spec"]
@@ -263,17 +261,32 @@ class ExternalSpecsParser:
                     {"spec": "python", "deptypes": ["build", "run"]}
                 )
 
-            # Transform inline entries like 'mpich %gcc' to a canonical form using 'dependencies:'
+            # Compute the dependency types for this spec
+            deptypes_by_package = {}
+            for when, by_name in pkg_class.dependencies.items():
+                if not current_node.satisfies(when):
+                    continue
+                for name, dep in by_name.items():
+                    if name not in deptypes_by_package:
+                        deptypes_by_package[name] = dep.depflag
+                    deptypes_by_package[name] |= dep.depflag
+
+            # Transform inline entries like 'mpich %gcc' to a canonical form using 'dependencies'
             for edge in current_node.edges_to_dependencies():
-                # In general, use the same defaults as "depends_on"
+                # Fallback to the same defaults as "depends_on"
                 deptypes, virtuals = ["build", "link"], ""
-                if (
-                    edge.depflag == 0
-                    and not edge.virtuals
-                    and edge.spec.name in possible_compilers
-                ):
-                    # Default for backward compatibility with old configs
-                    deptypes, virtuals = "build", "c"
+                if edge.depflag == 0 and not edge.virtuals:
+                    # Infer the deptype if only '%' was used in the spec
+                    inferred_deptypes, inferred_virtuals = spack.deptypes.NONE, []
+                    for name, current_flag in deptypes_by_package.items():
+                        if not edge.spec.intersects(name):
+                            continue
+                        inferred_deptypes |= current_flag
+                        if spack.repo.PATH.is_virtual(name):
+                            inferred_virtuals.append(name)
+                    virtuals = ",".join(inferred_virtuals)
+                    if inferred_deptypes != spack.deptypes.NONE:
+                        deptypes = spack.deptypes.flag_to_tuple(inferred_deptypes)
 
                 # Handle entries with more options specified
                 if edge.depflag != 0:

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -239,6 +239,20 @@ class ExternalSpecsParser:
             spec_str = current_dict["spec"]
             line_info = _line_info(current_dict)
 
+            # Add a Python dependency to Python extensions
+            pkg_class = spack.repo.PATH.get_pkg_class(current_node.name)
+            if "dependencies" not in current_dict and any(
+                [c.__name__ == "PythonExtension" for c in pkg_class.__mro__]
+            ):
+                warnings.warn(
+                    f"Spack is trying attach a Python dependency to '{spec_str}'. This feature is "
+                    f"deprecated, and will be removed in v1.2. Please make the dependency "
+                    f"explicit in your configuration."
+                )
+                current_dict.setdefault("dependencies", []).append(
+                    {"spec": "python", "deptypes": ["build", "run"]}
+                )
+
             # Transform inline entries like 'mpich %gcc' to a canonical form
             for edge in current_node.edges_to_dependencies():
                 # We don't want to accept foo %[deptypes=build,link] mpich as a spec

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -105,7 +105,7 @@ def extract_dicts_from_configuration(packages_yaml) -> List[ExternalDict]:
     return result
 
 
-_TARGET_RE = re.compile(r"target=(\S+)")
+_TARGET_RE = re.compile(r"target=([^\s:]+)")
 
 
 def _required_target(entry) -> str:

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -238,48 +238,18 @@ class ExternalSpecsParser:
             current_node, current_dict = entry.spec, entry.config
             spec_str = current_dict["spec"]
             line_info = _line_info(current_dict)
-            is_legacy = False
-            # Guess how to convert old entries like 'mpich %gcc' to a dependency in the dict
+
+            # Transform inline entries like 'mpich %gcc' to a canonical form
             for edge in current_node.edges_to_dependencies():
-                is_legacy = True
                 # We don't want to accept foo %[deptypes=build,link] mpich as a spec
                 if edge.depflag != 0:
                     raise ExternalDependencyError(
                         f"The external spec '{spec_str}' cannot specify deptypes{line_info}"
                     )
-
-                if edge.spec.name not in self.specs_by_name:
-                    raise ExternalDependencyError(
-                        f"The external spec '{spec_str}' depends on {edge.spec.name}', but there "
-                        f"is no such external spec in packages.yaml{line_info}"
-                    )
-
-                candidates = [
-                    x
-                    for x in self.specs_by_name[edge.spec.name]
-                    if x.spec.satisfies(edge.spec)
-                    and x.spec.architecture.satisfies(current_node.architecture)
-                ]
-                if not candidates:
-                    raise ExternalDependencyError(
-                        f"The external spec '{spec_str}' depends on '{edge.spec}', but there is no"
-                        f" '{edge.spec.name}' that meets the requests in packages.yaml{line_info}"
-                    )
-
-                candidates.sort(key=lambda x: x.spec)  # type: ignore
-                selected = candidates[-1]
-                warnings.warn(
-                    f"the external spec '{spec_str}' has been guessed to depend on "
-                    f"'{selected.config['spec']}'. If this is incorrect, modify the spec "
-                    f"definition{line_info}"
-                )
                 current_dict.setdefault("dependencies", []).append(
-                    {"id": selected.config["id"], "deptypes": "build", "virtuals": "c"}
+                    {"spec": str(edge.spec), "deptypes": "build", "virtuals": "c"}
                 )
             current_node.clear_edges()
-            if is_legacy:
-                # Legacy specs are not allowed to have a "dependencies:" section
-                continue
 
             # Map a spec: to id:
             for dependency_dict in current_dict.get("dependencies", []):
@@ -294,17 +264,22 @@ class ExternalSpecsParser:
 
                 query_spec = spack.spec.Spec(dependency_dict["spec"])
                 candidates = [
-                    x for x in self.specs_by_name[query_spec.name] if x.spec.satisfies(query_spec)
+                    x
+                    for x in self.specs_by_name.get(query_spec.name, [])
+                    if x.spec.satisfies(query_spec)
                 ]
                 if len(candidates) == 0:
                     raise ExternalDependencyError(
-                        f"the spec {spec_str} depends on {query_spec}, but there is no such "
+                        f"the spec '{spec_str}' depends on '{query_spec}', but there is no such "
                         f"external spec in packages.yaml{line_info}"
                     )
                 elif len(candidates) > 1:
+                    candidates_str = (
+                        f" [candidates are {', '.join([str(x.spec) for x in candidates])}]"
+                    )
                     raise ExternalDependencyError(
-                        f"the spec {spec_str} depends on {query_spec}, but there are multiple "
-                        f"external specs in packages.yaml that satisfy it{line_info}"
+                        f"the spec '{spec_str}' depends on '{query_spec}', but there are multiple "
+                        f"external specs that could satisfy the request{candidates_str}{line_info}"
                     )
 
                 dependency_dict["id"] = candidates[0].config["id"]

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -51,7 +51,7 @@ def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
     )
     if not result.versions.concrete:
         raise ExternalSpecError(
-            f"The external spec '{external_dict['spec']}' doesn't have a concrete version."
+            f"The external spec '{external_dict['spec']}' doesn't have a concrete version"
         )
 
     result.extra_attributes = extra_attributes
@@ -125,6 +125,11 @@ def extract_dicts_from_configuration(packages_yaml) -> List[ExternalDict]:
     return result
 
 
+def _line_info(config_dict: Any) -> str:
+    result = getattr(config_dict, "line_info", "")
+    return "" if not result else f" [{result}]"
+
+
 _TARGET_RE = re.compile(r"target=([^\s:]+)")
 
 
@@ -193,31 +198,29 @@ class ExternalSpecsParser:
     def _parse(self) -> None:
         # Parse all nodes without creating edges among them
         self._parse_all_nodes()
-
         # Map dependencies specified as specs to a single id
         self._ensure_dependencies_have_single_id()
-
         # Attach dependencies to externals
         self._create_edges()
-
+        # Mark the specs as concrete
         for node in self.nodes:
             node._finalize_concretization()
 
     def _create_edges(self):
         for eid, entry in self.specs_by_external_id.items():
-            current_node = entry.spec
-            current_dict = entry.config
-
+            current_node, current_dict = entry.spec, entry.config
+            line_info = _line_info(current_dict)
+            spec_str = current_dict["spec"]
             for dependency_dict in current_dict.get("dependencies", []):
                 dependency_id = dependency_dict.get("id")
                 if not dependency_id:
                     raise ExternalDependencyError(
-                        f"A dependency for {current_dict['spec']} does not have an external id"
+                        f"A dependency for {spec_str} does not have an external id{line_info}"
                     )
                 elif dependency_id not in self.specs_by_external_id:
                     raise ExternalDependencyError(
-                        f"A dependency for {current_dict['spec']} has an external id "
-                        f"{dependency_id} that is not defined in packages.yaml"
+                        f"A dependency for {spec_str} has an external id "
+                        f"{dependency_id} that cannot be found in packages.yaml{line_info}"
                     )
 
                 dependency_node = self.specs_by_external_id[dependency_id].spec
@@ -232,8 +235,9 @@ class ExternalSpecsParser:
 
     def _ensure_dependencies_have_single_id(self):
         for eid, entry in self.specs_by_external_id.items():
-            current_node = entry.spec
-            current_dict = entry.config
+            current_node, current_dict = entry.spec, entry.config
+            spec_str = current_dict["spec"]
+            line_info = _line_info(current_dict)
             is_legacy = False
             # Guess how to convert old entries like 'mpich %gcc' to a dependency in the dict
             for edge in current_node.edges_to_dependencies():
@@ -241,14 +245,13 @@ class ExternalSpecsParser:
                 # We don't want to accept foo %[deptypes=build,link] mpich as a spec
                 if edge.depflag != 0:
                     raise ExternalDependencyError(
-                        f"The external spec '{current_dict['spec']}' has an invalid dependency"
-                        f" specification. Fix your packages.yaml configuration."
+                        f"The external spec '{spec_str}' cannot specify deptypes{line_info}"
                     )
 
                 if edge.spec.name not in self.specs_by_name:
                     raise ExternalDependencyError(
-                        f"The external spec '{current_dict['spec']}' depends on "
-                        f"'{edge.spec.name}', but there is no such external spec in packages.yaml."
+                        f"The external spec '{spec_str}' depends on {edge.spec.name}', but there "
+                        f"is no such external spec in packages.yaml{line_info}"
                     )
 
                 candidates = [
@@ -259,16 +262,16 @@ class ExternalSpecsParser:
                 ]
                 if not candidates:
                     raise ExternalDependencyError(
-                        f"The external spec '{current_dict['spec']}' depends on '{edge.spec}',"
-                        f" but there is no '{edge.spec.name}' that satisfies the request "
-                        f"in packages.yaml."
+                        f"The external spec '{spec_str}' depends on '{edge.spec}', but there is no"
+                        f" '{edge.spec.name}' that meets the requests in packages.yaml{line_info}"
                     )
 
                 candidates.sort(key=lambda x: x.spec)  # type: ignore
                 selected = candidates[-1]
                 warnings.warn(
-                    f"the external spec '{current_dict['spec']}' has been guessed to depend on "
-                    f"'{selected.config['spec']}'. If this is incorrect, fix your packages.yaml."
+                    f"the external spec '{spec_str}' has been guessed to depend on "
+                    f"'{selected.config['spec']}'. If this is incorrect, modify the spec "
+                    f"definition{line_info}"
                 )
                 current_dict.setdefault("dependencies", []).append(
                     {"id": selected.config["id"], "deptypes": "build", "virtuals": "c"}
@@ -285,8 +288,8 @@ class ExternalSpecsParser:
 
                 if "spec" not in dependency_dict:
                     raise ExternalDependencyError(
-                        f"the spec {current_dict['spec']} needs to specify either the id or the "
-                        f"spec of its dependencies."
+                        f"the spec {spec_str} needs to specify either the id or the spec "
+                        f"of its dependencies{line_info}"
                     )
 
                 query_spec = spack.spec.Spec(dependency_dict["spec"])
@@ -295,31 +298,32 @@ class ExternalSpecsParser:
                 ]
                 if len(candidates) == 0:
                     raise ExternalDependencyError(
-                        f"the spec {current_dict['spec']} depends on {query_spec}, but there is "
-                        f"no such external spec in packages.yaml."
+                        f"the spec {spec_str} depends on {query_spec}, but there is no such "
+                        f"external spec in packages.yaml{line_info}"
                     )
                 elif len(candidates) > 1:
                     raise ExternalDependencyError(
-                        f"the spec {current_dict['spec']} depends on {query_spec}, but there are "
-                        f"multiple external specs in packages.yaml that satisfy it."
+                        f"the spec {spec_str} depends on {query_spec}, but there are multiple "
+                        f"external specs in packages.yaml that satisfy it{line_info}"
                     )
 
                 dependency_dict["id"] = candidates[0].config["id"]
 
-    def _parse_all_nodes(self):
-        """Parses all the nodes from the external dicts, but doesn't add any edge."""
+    def _parse_all_nodes(self) -> None:
+        """Parses all the nodes from the external dicts but doesn't add any edge."""
         for external_dict in self.external_dicts:
+            line_info = _line_info(external_dict)
             try:
                 node = node_from_dict(external_dict)
             except spack.spec.UnsatisfiableArchitectureSpecError:
                 spec_str, target_str = external_dict["spec"], external_dict["required_target"]
                 tty.debug(
-                    f"[{__name__}] Skipping external spec '{spec_str}' "
-                    f"because it cannot be constrained with the required target '{target_str}'."
+                    f"[{__name__}]{line_info} Skipping external spec '{spec_str}' because it "
+                    f"cannot be constrained with the required target '{target_str}'."
                 )
                 continue
             except ExternalSpecError as e:
-                warnings.warn(f"{e}")
+                warnings.warn(f"{e}{line_info}")
                 continue
 
             package_exists = spack.repo.PATH.exists(node.name)
@@ -329,14 +333,15 @@ class ExternalSpecsParser:
                 continue
 
             if not package_exists and not self.allow_nonexisting:
-                raise spack.repo.UnknownPackageError(node.name, repo=spack.repo.PATH)
+                raise ExternalSpecError(f"Package '{node.name}' does not exist{line_info}")
 
             eid = external_dict.setdefault("id", str(uuid.uuid4()))
             if eid in self.specs_by_external_id:
-                other_node = self.specs_by_external_id[eid].spec
+                other_node = self.specs_by_external_id[eid]
+                other_line_info = _line_info(other_node.config)
                 raise DuplicateExternalError(
-                    f"Specs {node} and {other_node} have the same external id {eid}."
-                    f" Fix your packages.yaml configuration."
+                    f"Specs {node} and {other_node.spec} cannot have the same external id {eid}"
+                    f"{line_info}{other_line_info}"
                 )
 
             self.complete_node(node)

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -36,7 +36,7 @@ class ExternalDict(TypedDict, total=False):
     extra_attributes: Dict[str, Any]
     id: str
     dependencies: List[DependencyDict]
-    # Not in the external schema. This field represents a target requirement from configuration.
+    # Target requirement from configuration. Not in the external schema
     required_target: str
 
 

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -191,45 +191,46 @@ class ExternalSpecsParser:
         self._parse()
 
     def _parse(self) -> None:
-        for external_dict in self.external_dicts:
-            try:
-                node = node_from_dict(external_dict)
-            except spack.spec.UnsatisfiableArchitectureSpecError:
-                tty.debug(
-                    f"[{__name__}] skipping external spec '{external_dict['spec']}' because it"
-                    f" cannot be constrained with the required target "
-                    f"'{external_dict['required_target']}'."
+        # Parse all nodes without creating edges among them
+        self._parse_all_nodes()
+
+        # Map dependencies specified as specs to a single id
+        self._ensure_dependencies_have_single_id()
+
+        # Attach dependencies to externals
+        self._create_edges()
+
+        for node in self.nodes:
+            node._finalize_concretization()
+
+    def _create_edges(self):
+        for eid, entry in self.specs_by_external_id.items():
+            current_node = entry.spec
+            current_dict = entry.config
+
+            for dependency_dict in current_dict.get("dependencies", []):
+                dependency_id = dependency_dict.get("id")
+                if not dependency_id:
+                    raise ExternalDependencyError(
+                        f"A dependency for {current_dict['spec']} does not have an external id"
+                    )
+                elif dependency_id not in self.specs_by_external_id:
+                    raise ExternalDependencyError(
+                        f"A dependency for {current_dict['spec']} has an external id "
+                        f"{dependency_id} that is not defined in packages.yaml"
+                    )
+
+                dependency_node = self.specs_by_external_id[dependency_id].spec
+                depflag = spack.deptypes.canonicalize(
+                    dependency_dict.get("deptypes", spack.deptypes.DEFAULT_TYPES)
                 )
-                continue
-            except ExternalSpecError as e:
-                warnings.warn(f"{e} Fix your packages.yaml configuration.")
-                continue
+                virtuals: Tuple[str, ...] = ()
+                if "virtuals" in dependency_dict:
+                    virtuals = tuple(dependency_dict["virtuals"].split(","))
 
-            package_exists = spack.repo.PATH.exists(node.name)
+                current_node._add_dependency(dependency_node, depflag=depflag, virtuals=virtuals)
 
-            # If we allow non-existing packages, just continue
-            if not package_exists and self.allow_nonexisting:
-                continue
-
-            if not package_exists and not self.allow_nonexisting:
-                raise spack.repo.UnknownPackageError(node.name, repo=spack.repo.PATH)
-
-            eid = external_dict.setdefault("id", str(uuid.uuid4()))
-            if eid in self.specs_by_external_id:
-                other_node = self.specs_by_external_id[eid].spec
-                raise DuplicateExternalError(
-                    f"Specs {node} and {other_node} have the same external id {eid}."
-                    f" Fix your packages.yaml configuration."
-                )
-
-            self.complete_node(node)
-            # Normalize internally so that each node has a unique id
-            spec_and_config = ExternalSpecAndConfig(spec=node, config=external_dict)
-            self.specs_by_external_id[eid] = spec_and_config
-            self.specs_by_name.setdefault(node.name, []).append(spec_and_config)
-            self.nodes.append(node)
-
-        # Map dependencies specified as specs to id
+    def _ensure_dependencies_have_single_id(self):
         for eid, entry in self.specs_by_external_id.items():
             current_node = entry.spec
             current_dict = entry.config
@@ -305,35 +306,45 @@ class ExternalSpecsParser:
 
                 dependency_dict["id"] = candidates[0].config["id"]
 
-        # Attach dependencies to externals
-        for eid, entry in self.specs_by_external_id.items():
-            current_node = entry.spec
-            current_dict = entry.config
-
-            for dependency_dict in current_dict.get("dependencies", []):
-                dependency_id = dependency_dict.get("id")
-                if not dependency_id:
-                    raise ExternalDependencyError(
-                        f"A dependency for {current_dict['spec']} does not have an external id"
-                    )
-                elif dependency_id not in self.specs_by_external_id:
-                    raise ExternalDependencyError(
-                        f"A dependency for {current_dict['spec']} has an external id "
-                        f"{dependency_id} that is not defined in packages.yaml"
-                    )
-
-                dependency_node = self.specs_by_external_id[dependency_id].spec
-                depflag = spack.deptypes.canonicalize(
-                    dependency_dict.get("deptypes", spack.deptypes.DEFAULT_TYPES)
+    def _parse_all_nodes(self):
+        """Parses all the nodes from the external dicts, but doesn't add any edge."""
+        for external_dict in self.external_dicts:
+            try:
+                node = node_from_dict(external_dict)
+            except spack.spec.UnsatisfiableArchitectureSpecError:
+                spec_str, target_str = external_dict["spec"], external_dict["required_target"]
+                tty.debug(
+                    f"[{__name__}] Skipping external spec '{spec_str}' "
+                    f"because it cannot be constrained with the required target '{target_str}'."
                 )
-                virtuals: Tuple[str, ...] = ()
-                if "virtuals" in dependency_dict:
-                    virtuals = tuple(dependency_dict["virtuals"].split(","))
+                continue
+            except ExternalSpecError as e:
+                warnings.warn(f"{e}")
+                continue
 
-                current_node._add_dependency(dependency_node, depflag=depflag, virtuals=virtuals)
+            package_exists = spack.repo.PATH.exists(node.name)
 
-        for node in self.nodes:
-            node._finalize_concretization()
+            # If we allow non-existing packages, just continue
+            if not package_exists and self.allow_nonexisting:
+                continue
+
+            if not package_exists and not self.allow_nonexisting:
+                raise spack.repo.UnknownPackageError(node.name, repo=spack.repo.PATH)
+
+            eid = external_dict.setdefault("id", str(uuid.uuid4()))
+            if eid in self.specs_by_external_id:
+                other_node = self.specs_by_external_id[eid].spec
+                raise DuplicateExternalError(
+                    f"Specs {node} and {other_node} have the same external id {eid}."
+                    f" Fix your packages.yaml configuration."
+                )
+
+            self.complete_node(node)
+            # Normalize internally so that each node has a unique id
+            spec_and_config = ExternalSpecAndConfig(spec=node, config=external_dict)
+            self.specs_by_external_id[eid] = spec_and_config
+            self.specs_by_name.setdefault(node.name, []).append(spec_and_config)
+            self.nodes.append(node)
 
     def get_specs_for_package(self, package_name: str) -> List[spack.spec.Spec]:
         """Returns the external specs for a given package name."""

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -92,7 +92,7 @@ class ExternalSpecsParser:
         """
         self.external_dicts = external_dicts
         self.specs_by_external_id: Dict[str, ExternalSpecAndConfig] = {}
-        self.specs_by_name: Dict[str, List[spack.spec.Spec]] = {}
+        self.specs_by_name: Dict[str, List[ExternalSpecAndConfig]] = {}
         self.nodes: List[spack.spec.Spec] = []
         self.allow_nonexisting = allow_nonexisting
         # Fill the data structures above (can be done lazily)
@@ -124,9 +124,53 @@ class ExternalSpecsParser:
 
             self.complete_node(node)
             # Normalize internally so that each node has a unique id
-            self.specs_by_external_id[eid] = ExternalSpecAndConfig(spec=node, config=external_dict)
-            self.specs_by_name.setdefault(node.name, []).append(node)
+            spec_and_config = ExternalSpecAndConfig(spec=node, config=external_dict)
+            self.specs_by_external_id[eid] = spec_and_config
+            self.specs_by_name.setdefault(node.name, []).append(spec_and_config)
             self.nodes.append(node)
+
+        # Guess how to convert old entries like 'mpich %gcc' to a dependency in the dict
+        for eid, entry in self.specs_by_external_id.items():
+            current_node = entry.spec
+            current_dict = entry.config
+            for edge in current_node.edges_to_dependencies():
+                # We don't want to accept foo %[deptypes=build,link] mpich as a spec
+                if edge.depflag != 0:
+                    raise ExternalDependencyError(
+                        f"The external spec {current_dict['spec']} has an invalid dependency"
+                        f" specification. Fix your packages.yaml configuration."
+                    )
+
+                if edge.spec.name not in self.specs_by_name:
+                    raise ExternalDependencyError(
+                        f"The external spec {current_dict['spec']} depends on {edge.spec.name},"
+                        f" but there is no such external spec in packages.yaml."
+                    )
+
+                candidates = [
+                    x
+                    for x in self.specs_by_name[edge.spec.name]
+                    if x.spec.satisfies(edge.spec)
+                    and x.spec.architecture.satisfies(current_node.architecture)
+                ]
+                if not candidates:
+                    raise ExternalDependencyError(
+                        f"The external spec {current_dict['spec']} depends on {edge.spec},"
+                        f" but there is no {edge.spec.name} that satisfies the request "
+                        f"in packages.yaml."
+                    )
+
+                candidates.sort(key=lambda x: x.spec)  # type: ignore
+                selected = candidates[-1]
+                # FIXME (externals as concrete): issue a warning for this case
+                current_dict.setdefault("dependencies", []).append(
+                    {
+                        "external_id": selected.config["external_id"],
+                        "deptypes": "build",
+                        "virtuals": "c",
+                    }
+                )
+            current_node.clear_edges()
 
         # Attach dependencies to externals
         for eid, entry in self.specs_by_external_id.items():
@@ -158,7 +202,8 @@ class ExternalSpecsParser:
 
     def get_specs_for_package(self, package_name: str) -> List[spack.spec.Spec]:
         """Returns the external specs for a given package name."""
-        return self.specs_by_name.get(package_name, [])
+        result = self.specs_by_name.get(package_name, [])
+        return [x.spec for x in result]
 
     def all_specs(self) -> List[spack.spec.Spec]:
         """Returns all the external specs."""

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -104,6 +104,15 @@ properties: Dict[str, Any] = {
                     "entry_limit": {"type": "integer", "minimum": 0},
                 },
             },
+            "externals": {
+                "type": "object",
+                "properties": {
+                    "completion": {
+                        "type": "string",
+                        "enum": ["architecture_only", "default_variants"],
+                    }
+                },
+            },
         },
     }
 }

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -173,6 +173,7 @@ properties: Dict[str, Any] = {
                             "spec": {"type": "string"},
                             "prefix": {"type": "string"},
                             "modules": {"type": "array", "items": {"type": "string"}},
+                            "external_id": {"type": "string"},
                             "extra_attributes": {
                                 "type": "object",
                                 "additionalProperties": {"type": "string"},
@@ -185,6 +186,23 @@ properties: Dict[str, Any] = {
                                     "extra_rpaths": extra_rpaths,
                                     "implicit_rpaths": implicit_rpaths,
                                     "flags": flags,
+                                },
+                            },
+                            "dependencies": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "external_id": {"type": "string"},
+                                        "deptypes": {
+                                            "oneOf": [
+                                                {"type": "string"},
+                                                {"type": "array", "items": {"type": "string"}},
+                                            ]
+                                        },
+                                        "virtuals": {"type": "string"},
+                                    },
+                                    "required": ["external_id"],
                                 },
                             },
                         },

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -173,7 +173,7 @@ properties: Dict[str, Any] = {
                             "spec": {"type": "string"},
                             "prefix": {"type": "string"},
                             "modules": {"type": "array", "items": {"type": "string"}},
-                            "external_id": {"type": "string"},
+                            "id": {"type": "string"},
                             "extra_attributes": {
                                 "type": "object",
                                 "additionalProperties": {"type": "string"},
@@ -193,7 +193,7 @@ properties: Dict[str, Any] = {
                                 "items": {
                                     "type": "object",
                                     "properties": {
-                                        "external_id": {"type": "string"},
+                                        "id": {"type": "string"},
                                         "deptypes": {
                                             "oneOf": [
                                                 {"type": "string"},
@@ -202,7 +202,7 @@ properties: Dict[str, Any] = {
                                         },
                                         "virtuals": {"type": "string"},
                                     },
-                                    "required": ["external_id"],
+                                    "required": ["id"],
                                 },
                             },
                         },

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -194,6 +194,7 @@ properties: Dict[str, Any] = {
                                     "type": "object",
                                     "properties": {
                                         "id": {"type": "string"},
+                                        "spec": {"type": "string"},
                                         "deptypes": {
                                             "oneOf": [
                                                 {"type": "string"},
@@ -202,7 +203,6 @@ properties: Dict[str, Any] = {
                                         },
                                         "virtuals": {"type": "string"},
                                     },
-                                    "required": ["id"],
                                 },
                             },
                         },

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -88,7 +88,7 @@ from .core import (
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector
-from .runtimes import RuntimePropertyRecorder, external_config_with_implicit_externals, all_libcs
+from .runtimes import RuntimePropertyRecorder, all_libcs, external_config_with_implicit_externals
 from .versions import DeclaredVersion, Provenance, concretization_version_order
 
 GitOrStandardVersion = Union[spack.version.GitVersion, spack.version.StandardVersion]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -59,7 +59,6 @@ import spack.spec
 import spack.store
 import spack.util.crypto
 import spack.util.hash
-import spack.util.libc
 import spack.util.lock as lk
 import spack.util.module_cmd as md
 import spack.util.path
@@ -89,8 +88,8 @@ from .core import (
 )
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
-from .reuse import ReusableSpecsSelector, SpecFilter
-from .runtimes import RuntimePropertyRecorder, external_config_with_implicit_externals
+from .reuse import ReusableSpecsSelector
+from .runtimes import RuntimePropertyRecorder, external_config_with_implicit_externals, all_libcs
 from .versions import DeclaredVersion, Provenance, concretization_version_order
 
 GitOrStandardVersion = Union[spack.version.GitVersion, spack.version.StandardVersion]
@@ -241,22 +240,6 @@ def remove_facts(
         return list(filter(lambda x: x.args[0] not in to_be_removed, facts))
 
     return _remove
-
-
-def all_libcs() -> Set[spack.spec.Spec]:
-    """Return a set of all libc specs targeted by any configured compiler. If none, fall back to
-    libc determined from the current Python process if dynamically linked."""
-    libcs = set()
-    for c in spack.compilers.config.all_compilers_from(spack.config.CONFIG):
-        candidate = CompilerPropertyDetector(c).default_libc()
-        if candidate is not None:
-            libcs.add(candidate)
-
-    if libcs:
-        return libcs
-
-    libc = spack.util.libc.libc_from_current_python_process()
-    return {libc} if libc else set()
 
 
 def libc_is_compatible(lhs: spack.spec.Spec, rhs: spack.spec.Spec) -> bool:
@@ -2266,30 +2249,6 @@ class SpackSolverSetup:
     def external_packages(self):
         """Facts on external packages, from packages.yaml and implicit externals."""
         self.gen.h1("External packages")
-        spec_filters = []
-        concretizer_yaml = spack.config.get("concretizer")
-        reuse_yaml = concretizer_yaml.get("reuse")
-        if isinstance(reuse_yaml, typing.Mapping):
-            default_include = reuse_yaml.get("include", [])
-            default_exclude = reuse_yaml.get("exclude", [])
-            for source in reuse_yaml.get("from", []):
-                if source["type"] != "external":
-                    continue
-
-                include = source.get("include", default_include)
-                if include:
-                    # Since libcs are implicit externals, we need to implicitly include them
-                    include = include + self.libcs
-                exclude = source.get("exclude", default_exclude)
-                spec_filters.append(
-                    SpecFilter(
-                        factory=lambda: [],
-                        is_usable=lambda x: True,
-                        include=include,
-                        exclude=exclude,
-                    )
-                )
-
         packages_yaml = external_config_with_implicit_externals(spack.config.CONFIG)
         for pkg_name, data in packages_yaml.items():
             if pkg_name == "all":
@@ -2299,98 +2258,10 @@ class SpackSolverSetup:
             if pkg_name not in self.pkgs:
                 continue
 
-            # Check if the external package is buildable. If it is
-            # not then "external(<pkg>)" is a fact, unless we can
-            # reuse an already installed spec.
             external_buildable = data.get("buildable", True)
-            externals = data.get("externals", [])
-            if not external_buildable or externals:
-                self.gen.h2(f"External package: {pkg_name}")
-
             if not external_buildable:
+                self.gen.h2(f"External package: {pkg_name}")
                 self.gen.fact(fn.buildable_false(pkg_name))
-
-            # Read a list of all the specs for this package
-            candidate_specs = [
-                spack.spec.parse_with_version_concrete(x["spec"]) for x in externals
-            ]
-
-            selected_externals = set()
-            if spec_filters:
-                for current_filter in spec_filters:
-                    current_filter.factory = lambda: candidate_specs
-                    selected_externals.update(current_filter.selected_specs())
-
-            # Emit facts for externals specs. Note that "local_idx" is the index of the spec
-            # in packages:<pkg_name>:externals. This means:
-            #
-            # packages:<pkg_name>:externals[local_idx].spec == spec
-            external_versions = []
-            for local_idx, spec in enumerate(candidate_specs):
-                msg = f"{spec.name} available as external when satisfying {spec}"
-
-                if any(x.satisfies(spec) for x in self.rejected_compilers):
-                    tty.debug(
-                        f"[{__name__}]: not considering {spec} as external, since "
-                        f"it's a non-working compiler"
-                    )
-                    continue
-
-                if spec_filters and spec not in selected_externals:
-                    continue
-
-                if not spec.versions.concrete:
-                    warnings.warn(f"cannot use the external spec {spec}: needs a concrete version")
-                    continue
-
-                def external_requirement(input_spec, requirements):
-                    result = []
-                    for asp_fn in requirements:
-                        if asp_fn.args[0] == "depends_on":
-                            continue
-                        if asp_fn.args[1] != input_spec.name:
-                            continue
-                        result.append(asp_fn)
-                    return result
-
-                def external_imposition(input_spec, requirements):
-                    result = []
-                    for asp_fn in requirements:
-                        if asp_fn.args[0] == "depends_on":
-                            continue
-                        elif asp_fn.args[0] == "direct_dependency":
-                            asp_fn.args = "external_build_requirement", *asp_fn.args[1:]
-                        if asp_fn.args[1] != input_spec.name:
-                            continue
-                        result.append(asp_fn)
-                    result.append(fn.attr("external_conditions_hold", input_spec.name, local_idx))
-                    return result
-
-                try:
-                    context = ConditionContext()
-                    context.transform_required = external_requirement
-                    context.transform_imposed = external_imposition
-                    self.condition(spec, spec, msg=msg, context=context)
-                except (spack.error.SpecError, RuntimeError) as e:
-                    warnings.warn(f"while setting up external spec {spec}: {e}")
-                    continue
-                external_versions.append((spec.version, local_idx))
-                self.possible_versions[spec.name].add(spec.version)
-                self.gen.newline()
-
-            # Order the external versions to prefer more recent versions
-            # even if specs in packages.yaml are not ordered that way
-            external_versions = [
-                (v, idx, external_id)
-                for idx, (v, external_id) in enumerate(sorted(external_versions, reverse=True))
-            ]
-            for version, idx, external_id in external_versions:
-                self.declared_versions[pkg_name].append(
-                    DeclaredVersion(version=version, idx=idx, origin=Provenance.EXTERNAL)
-                )
-
-            self.trigger_rules()
-            self.effect_rules()
 
     def preferred_variants(self, pkg_name):
         """Facts on concretization preferences, as read from packages.yaml"""
@@ -2598,6 +2469,8 @@ class SpackSolverSetup:
             if package_hash:
                 clauses.append(fn.attr("package_hash", spec.name, package_hash))
             clauses.append(fn.attr("hash", spec.name, spec.dag_hash()))
+            if spec.external:
+                clauses.append(fn.attr("external", spec.name))
 
         edges = spec.edges_from_dependents()
         virtuals = sorted(
@@ -3770,41 +3643,42 @@ class SpecBuilder:
             node_flag.flag_type, node_flag.flag, False, node_flag.flag_group, node_flag.source
         )
 
-    def external_spec_selected(self, node, idx):
-        """This means that the external spec and index idx has been selected for this package."""
-        packages_yaml = external_config_with_implicit_externals(spack.config.CONFIG)
-        spec_info = packages_yaml[node.pkg]["externals"][int(idx)]
-        self._specs[node].external_path = spec_info.get("prefix", None)
-        self._specs[node].external_modules = spack.spec.Spec._format_module_list(
-            spec_info.get("modules", None)
-        )
-        self._specs[node].extra_attributes = spec_info.get("extra_attributes", {})
-
-        # Annotate compiler specs from externals
-        external_spec = spack.spec.Spec(spec_info["spec"])
-        external_spec_deps = external_spec.dependencies()
-        if len(external_spec_deps) > 1:
-            raise InvalidExternalError(
-                f"external spec {spec_info['spec']} cannot have more than one dependency"
-            )
-        elif len(external_spec_deps) == 1:
-            compiler_str = external_spec_deps[0]
-            self._specs[node].annotations.with_compiler(spack.spec.Spec(compiler_str))
-
-        # Packages that are external - but normally depend on python -
-        # get an edge inserted to python as a post-concretization step
-        package = spack.repo.PATH.get_pkg_class(self._specs[node].fullname)(self._specs[node])
-        extendee_spec = package.extendee_spec
-        if (
-            extendee_spec
-            and extendee_spec.name == "python"
-            # More-general criteria like "depends on Python" pulls in things
-            # we don't want to apply this logic to (in particular LLVM, which
-            # is now a common external because that's how we detect Clang)
-            and any([c.__name__ == "PythonExtension" for c in package.__class__.__mro__])
-        ):
-            candidate_python_to_attach = self._specs.get(SpecBuilder.make_node(pkg="python"))
-            _attach_python_to_external(package, extendee_spec=candidate_python_to_attach)
+    # FIXME (externals as concrete): be sure to recover the Python case
+    # def external_spec_selected(self, node, idx):
+    #     """This means that the external spec and index idx has been selected for this package."""
+    #     packages_yaml = external_config_with_implicit_externals(spack.config.CONFIG)
+    #     spec_info = packages_yaml[node.pkg]["externals"][int(idx)]
+    #     self._specs[node].external_path = spec_info.get("prefix", None)
+    #     self._specs[node].external_modules = spack.spec.Spec._format_module_list(
+    #         spec_info.get("modules", None)
+    #     )
+    #     self._specs[node].extra_attributes = spec_info.get("extra_attributes", {})
+    #
+    #     # Annotate compiler specs from externals
+    #     external_spec = spack.spec.Spec(spec_info["spec"])
+    #     external_spec_deps = external_spec.dependencies()
+    #     if len(external_spec_deps) > 1:
+    #         raise InvalidExternalError(
+    #             f"external spec {spec_info['spec']} cannot have more than one dependency"
+    #         )
+    #     elif len(external_spec_deps) == 1:
+    #         compiler_str = external_spec_deps[0]
+    #         self._specs[node].annotations.with_compiler(spack.spec.Spec(compiler_str))
+    #
+    #     # Packages that are external - but normally depend on python -
+    #     # get an edge inserted to python as a post-concretization step
+    #     package = spack.repo.PATH.get_pkg_class(self._specs[node].fullname)(self._specs[node])
+    #     extendee_spec = package.extendee_spec
+    #     if (
+    #         extendee_spec
+    #         and extendee_spec.name == "python"
+    #         # More-general criteria like "depends on Python" pulls in things
+    #         # we don't want to apply this logic to (in particular LLVM, which
+    #         # is now a common external because that's how we detect Clang)
+    #         and any([c.__name__ == "PythonExtension" for c in package.__class__.__mro__])
+    #     ):
+    #         candidate_python_to_attach = self._specs.get(SpecBuilder.make_node(pkg="python"))
+    #         _attach_python_to_external(package, extendee_spec=candidate_python_to_attach)
 
     def depends_on(self, parent_node, dependency_node, type):
         dependency_spec = self._specs[dependency_node]
@@ -3953,7 +3827,6 @@ class SpecBuilder:
             # node attributes are handled next, since they instantiate nodes
             "node": -4,
             # evaluated last, so all nodes are fully constructed
-            "external_spec_selected": 1,
             "virtual_on_edge": 2,
         }
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -44,7 +44,6 @@ import spack.compilers.flags
 import spack.concretize
 import spack.config
 import spack.deptypes as dt
-import spack.detection
 import spack.environment as ev
 import spack.error
 import spack.llnl.util.lang
@@ -3553,7 +3552,6 @@ class SpecBuilder:
                 r"^.*_set$",
                 r"^compatible_libc$",
                 r"^dependency_holds$",
-                r"^external_conditions_hold$",
                 r"^package_hash$",
                 r"^root$",
                 r"^track_dependencies$",
@@ -3639,43 +3637,6 @@ class SpecBuilder:
         self._specs[node].compiler_flags.add_flag(
             node_flag.flag_type, node_flag.flag, False, node_flag.flag_group, node_flag.source
         )
-
-    # FIXME (externals as concrete): be sure to recover the Python case
-    # def external_spec_selected(self, node, idx):
-    #     """This means that the external spec and index idx has been selected for this package."""
-    #     packages_yaml = external_config_with_implicit_externals(spack.config.CONFIG)
-    #     spec_info = packages_yaml[node.pkg]["externals"][int(idx)]
-    #     self._specs[node].external_path = spec_info.get("prefix", None)
-    #     self._specs[node].external_modules = spack.spec.Spec._format_module_list(
-    #         spec_info.get("modules", None)
-    #     )
-    #     self._specs[node].extra_attributes = spec_info.get("extra_attributes", {})
-    #
-    #     # Annotate compiler specs from externals
-    #     external_spec = spack.spec.Spec(spec_info["spec"])
-    #     external_spec_deps = external_spec.dependencies()
-    #     if len(external_spec_deps) > 1:
-    #         raise InvalidExternalError(
-    #             f"external spec {spec_info['spec']} cannot have more than one dependency"
-    #         )
-    #     elif len(external_spec_deps) == 1:
-    #         compiler_str = external_spec_deps[0]
-    #         self._specs[node].annotations.with_compiler(spack.spec.Spec(compiler_str))
-    #
-    #     # Packages that are external - but normally depend on python -
-    #     # get an edge inserted to python as a post-concretization step
-    #     package = spack.repo.PATH.get_pkg_class(self._specs[node].fullname)(self._specs[node])
-    #     extendee_spec = package.extendee_spec
-    #     if (
-    #         extendee_spec
-    #         and extendee_spec.name == "python"
-    #         # More-general criteria like "depends on Python" pulls in things
-    #         # we don't want to apply this logic to (in particular LLVM, which
-    #         # is now a common external because that's how we detect Clang)
-    #         and any([c.__name__ == "PythonExtension" for c in package.__class__.__mro__])
-    #     ):
-    #         candidate_python_to_attach = self._specs.get(SpecBuilder.make_node(pkg="python"))
-    #         _attach_python_to_external(package, extendee_spec=candidate_python_to_attach)
 
     def depends_on(self, parent_node, dependency_node, type):
         dependency_spec = self._specs[dependency_node]
@@ -3995,100 +3956,6 @@ def _specs_with_commits(spec):
         " does not meet commit syntax requirements."
     )
     assert vn.is_git_commit_sha(spec.variants["commit"].value), invalid_commit_msg
-
-
-def _attach_python_to_external(
-    dependent_package, extendee_spec: Optional[spack.spec.Spec] = None
-) -> None:
-    """
-    Ensure all external python packages have a python dependency
-
-    If another package in the DAG depends on python, we use that
-    python for the dependency of the external. If not, we assume
-    that the external PythonPackage is installed into the same
-    directory as the python it depends on.
-    """
-    # TODO: Include this in the solve, rather than instantiating post-concretization
-    if "python" not in dependent_package.spec:
-        if extendee_spec:
-            python = extendee_spec
-        else:
-            python = _get_external_python_for_prefix(dependent_package)
-            if not python.concrete:
-                repo = spack.repo.PATH.repo_for_pkg(python)
-                python.namespace = repo.namespace
-
-                # Ensure architecture information is present
-                if not python.architecture:
-                    host_platform = spack.platforms.host()
-                    host_os = host_platform.default_operating_system()
-                    host_target = host_platform.default_target()
-                    python.architecture = spack.spec.ArchSpec(
-                        (str(host_platform), str(host_os), str(host_target))
-                    )
-                else:
-                    if not python.architecture.platform:
-                        python.architecture.platform = spack.platforms.host()
-                    platform = spack.platforms.by_name(python.architecture.platform)
-                    if not python.architecture.os:
-                        python.architecture.os = platform.default_operating_system()
-                    if not python.architecture.target:
-                        python.architecture.target = spack.vendor.archspec.cpu.host().family.name
-
-                python.external_path = dependent_package.spec.external_path
-                python._mark_concrete()
-        dependent_package.spec.add_dependency_edge(
-            python, depflag=dt.BUILD | dt.LINK | dt.RUN, virtuals=()
-        )
-
-
-def _get_external_python_for_prefix(python_package):
-    """
-    For an external package that extends python, find the most likely spec for the python
-    it depends on.
-
-    First search: an "installed" external that shares a prefix with this package
-    Second search: a configured external that shares a prefix with this package
-    Third search: search this prefix for a python package
-
-    Returns:
-        spack.spec.Spec: The external Spec for python most likely to be compatible with self.spec
-    """
-    python_externals_installed = [
-        s
-        for s in spack.store.STORE.db.query("python")
-        if s.prefix == python_package.spec.external_path
-    ]
-    if python_externals_installed:
-        return python_externals_installed[0]
-
-    python_external_config = spack.config.get("packages:python:externals", [])
-    python_externals_configured = [
-        spack.spec.parse_with_version_concrete(item["spec"])
-        for item in python_external_config
-        if item["prefix"] == python_package.spec.external_path
-    ]
-    if python_externals_configured:
-        return python_externals_configured[0]
-
-    python_externals_detection = spack.detection.by_path(
-        ["python"], path_hints=[python_package.spec.external_path], max_workers=1
-    )
-
-    python_externals_detected = [
-        spec
-        for spec in python_externals_detection.get("python", [])
-        if spec.external_path == python_package.spec.external_path
-    ]
-    python_externals_detected = [
-        spack.spec.parse_with_version_concrete(str(x)) for x in python_externals_detected
-    ]
-    if python_externals_detected:
-        return list(sorted(python_externals_detected, key=lambda x: x.version))[-1]
-
-    raise StopIteration(
-        "No external python could be detected for %s to depend on" % python_package.spec
-    )
 
 
 def _inject_patches_variant(root: spack.spec.Spec) -> None:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2257,8 +2257,7 @@ class SpackSolverSetup:
             if pkg_name not in self.pkgs:
                 continue
 
-            external_buildable = data.get("buildable", True)
-            if not external_buildable:
+            if not data.get("buildable", True):
                 self.gen.h2(f"External package: {pkg_name}")
                 self.gen.fact(fn.buildable_false(pkg_name))
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3016,10 +3016,7 @@ class SpackSolverSetup:
         check_packages_exist(specs)
         self.gen = ProblemInstanceBuilder()
 
-        # Compute possible compilers first, so we can record which dependencies they might inject
-        _ = spack.compilers.config.all_compilers(init_config=True)
-
-        # Get compilers from buildcache only if injected through "reuse" specs
+        # Get compilers from buildcaches only if injected through "reuse" specs
         supported_compilers = spack.compilers.config.supported_compilers()
         compilers_from_reuse = {
             x for x in reuse if x.name in supported_compilers and not x.external
@@ -4209,6 +4206,9 @@ class Solver:
     """
 
     def __init__(self):
+        # Compute possible compilers first, so we see them as externals
+        _ = spack.compilers.config.all_compilers(init_config=True)
+
         self._conc_cache = ConcretizationCache()
         self.driver = PyclingoDriver(conc_cache=self._conc_cache)
         self.selector = ReusableSpecsSelector(configuration=spack.config.CONFIG)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -653,14 +653,13 @@ compiler_penalty_from_reuse(Hash) :-
   compiler_from_reuse(Hash, DependencyPackage),
   not node_compiler(_, node(_, DependencyPackage)),
   % We don't want to give penalties if we're just installing binaries
-  has_built_packages().
+  will_build_packages().
 
 compiler_penalty_from_reuse(Hash) :-
   compiler_from_reuse(Hash, DependencyPackage),
   not 1 { attr("hash", node(X, DependencyPackage), Hash) : node_compiler(_, node(X, DependencyPackage)) },
   % We don't want to give penalties if we're just installing binaries
-  has_built_packages().
-
+  will_build_packages().
 
 
 error(100, "Cannot satisfy the request on {0} to have {1}={2}", BuildDependency, Variant, Value)
@@ -1603,10 +1602,10 @@ compiler_used_as_a_library(node(X, Child), Hash) :-
 %-----------------------------------------------------------------------------
 
 % Check whether the DAG has any built package
-has_built_packages() :- build(X).
+will_build_packages() :- build(X).
 
 % "gcc-runtime" is always built
-:- concrete(node(X, "gcc-runtime")), has_built_packages().
+:- concrete(node(X, "gcc-runtime")), will_build_packages().
 
 % The "gcc" linked to "gcc-runtime" must be used by at least another package
 :- attr("depends_on", node(X, "gcc-runtime"), node(Y, "gcc"), "build"),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1056,7 +1056,7 @@ possible_provider_weight(node(ProviderID, Provider), VirtualNode, 100, "fallback
 external(PackageNode) :- attr("external", PackageNode).
 
 % if a package is not buildable, only concrete specs are allowed
-error(100, "Cannot build {0}, since it's marked non-buildable and no externals satisfy the requests", Package)
+error(100, "Cannot build {0}, since it is configured `buildable:false` and no externals satisfy the request", Package)
   :- buildable_false(Package),
      attr("node", node(ID, Package)),
      build(node(ID, Package)).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -58,8 +58,6 @@ duplicate_penalty(node(ID1, Package), 1, "version")
    internal_error("variant_value true for a non-node").
 :- attr("node_flag", PackageNode, _), not attr("node", PackageNode),
    internal_error("node_flag assigned for non-node").
-:- attr("external_spec_selected", PackageNode, _), not attr("node", PackageNode),
-   internal_error("external_spec_selected for non-node").
 :- attr("depends_on", ParentNode, _, _), not attr("node", ParentNode),
    internal_error("non-node depends on something").
 :- attr("depends_on", _, ChildNode, _), not attr("node", ChildNode),
@@ -205,7 +203,6 @@ literal_node(Root, node(min_dupe_id, Root)) :-  mentioned_in_literal(Root, Root)
 build_dependency_of_literal_node(LiteralNode, node(X, BuildDependency)) :-
   literal_node(Root, LiteralNode),
   build(LiteralNode),
-  not external(LiteralNode),
   build_requirement(LiteralNode, node(X, BuildDependency)),
   attr("direct_dependency", LiteralNode, node_requirement("node", BuildDependency)).
 
@@ -311,17 +308,8 @@ attr("deprecated", node(ID, Package), Version) :-
 error(100, "Package '{0}' needs the deprecated version '{1}', and this is not allowed", Package, Version)
   :- deprecated_versions_not_allowed(),
      attr("version", node(ID, Package), Version),
-     not external(node(ID, Package)),
-     not concrete(node(ID, Package)),
+     build(node(ID, Package)),
      pkg_fact(Package, deprecated_version(Version)).
-
-% we can't use the weight for an external version if we don't use the
-% corresponding external spec.
-:- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   pkg_fact(Package, version_declared(Version, Weight, "external")),
-   not external(node(ID, Package)),
-   internal_error("External weight used for built package").
 
 % we can't use a weight from an installed spec if we are building it
 % and vice-versa
@@ -637,7 +625,7 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
    not attr("virtual_on_edge", ParentNode, node(_, ChildPkg), Virtual).
 
 % If the parent is built, then we have a build_requirement on another node. For concrete nodes,
-% or external nodes, we don't since we are trimming their build dependencies.
+% we don't since we are trimming their build dependencies.
 
 % Concrete nodes
 :- attr("direct_dependency", ParentNode, node_requirement("node", BuildDependency)),
@@ -654,6 +642,26 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
    concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not attr("virtual_on_build_edge", ParentNode, BuildDependency, Virtual).
+
+% Give a penalty if reuse introduces a node compiled with a compiler that is not used otherwise
+compiler_from_reuse(Hash, DependencyPackage) :-
+  attr("concrete_build_dependency", ParentNode, DependencyPackage, Hash),
+  attr("virtual_on_build_edge", ParentNode, DependencyPackage, Virtual),
+  language(Virtual).
+
+compiler_penalty_from_reuse(Hash) :-
+  compiler_from_reuse(Hash, DependencyPackage),
+  not node_compiler(_, node(_, DependencyPackage)),
+  % We don't want to give penalties if we're just installing binaries
+  has_built_packages().
+
+compiler_penalty_from_reuse(Hash) :-
+  compiler_from_reuse(Hash, DependencyPackage),
+  not 1 { attr("hash", node(X, DependencyPackage), Hash) : node_compiler(_, node(X, DependencyPackage)) },
+  % We don't want to give penalties if we're just installing binaries
+  has_built_packages().
+
+
 
 error(100, "Cannot satisfy the request on {0} to have {1}={2}", BuildDependency, Variant, Value)
 :- attr("direct_dependency", ParentNode, node_requirement("variant_set", BuildDependency, Variant, Value)),
@@ -685,23 +693,6 @@ error(100, "Cannot satisfy the request on {0} to have the following hash {1}", B
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    attr("direct_dependency", ParentNode, node_requirement("hash", BuildDependency, BuildHash)),
    BuildHash != BuildDependencyHash.
-
-% External nodes
-:- attr("direct_dependency", ParentNode, node_requirement("node", BuildDependency)),
-   external(ParentNode),
-   not attr("external_build_requirement", ParentNode, node_requirement("node", BuildDependency)).
-
-candidate_external_version(Constraint, BuildDependency, Version)
-  :- attr("direct_dependency", ParentNode, node_requirement("node_version_satisfies", BuildDependency, Constraint)),
-     external(ParentNode),
-     pkg_fact(BuildDependency, version_satisfies(Constraint, Version)).
-
-error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, LiteralConstraint, ExternalConstraint)
-  :- attr("direct_dependency", ParentNode, node_requirement("node_version_satisfies", BuildDependency, LiteralConstraint)),
-     external(ParentNode),
-     attr("external_build_requirement", ParentNode, node_requirement("node_version_satisfies", BuildDependency, ExternalConstraint)),
-     not 1 { pkg_fact(BuildDependency, version_satisfies(ExternalConstraint, Version)) : candidate_external_version(LiteralConstraint, BuildDependency, Version) }.
-
 
 % Asking for gcc@10 %gcc@9 shouldn't give us back an external gcc@10, just because of the hack
 % we have on externals
@@ -839,11 +830,9 @@ concrete(PackageNode) :- attr("hash", PackageNode, _), attr("node", PackageNode)
 % Dependencies of any type imply that one package "depends on" another
 depends_on(PackageNode, DependencyNode) :- attr("depends_on", PackageNode, DependencyNode, _).
 
-% a dependency holds if its condition holds and if it is not external or
-% concrete. We chop off dependencies for externals, and dependencies of
-% concrete specs don't need to be resolved -- they arise from the concrete
-% specs themselves.
-attr("track_dependencies", Node) :- build(Node), not external(Node).
+% a dependency holds if its condition holds and if it is not concrete.
+% Dependencies of concrete specs don't need to be resolved -- they arise from the concrete specs themselves.
+attr("track_dependencies", Node) :- build(Node).
 
 % If a dependency holds on a package node, there must be one and only one dependency node satisfying it
 1 { attr("depends_on", PackageNode, node(0..Y-1, Dependency), Type) : max_dupes(Dependency, Y) } 1
@@ -921,8 +910,7 @@ error(1, Msg)
      condition_holds(ConstraintID, node(ID2, Package)),
      unification_set(X, node(ID2, Package)),
      unification_set(X, node(ID1, TriggerPackage)),
-     not external(node(ID, Package)),  % ignore conflicts for externals
-     not attr("hash", node(ID, Package), _).  % ignore conflicts for installed packages
+     build(node(ID, Package)).  % ignore conflicts for installed packages
 
 %-----------------------------------------------------------------------------
 % Virtual dependencies
@@ -947,8 +935,7 @@ error(100, "Package '{0}' needs to provide both '{1}' and '{2}' together, but pr
 % provider for that virtual then it depends on the provider
 node_depends_on_virtual(PackageNode, Virtual, Type)
   :- attr("dependency_holds", PackageNode, Virtual, Type),
-     virtual(Virtual),
-     not external(PackageNode).
+     virtual(Virtual).
 
 node_depends_on_virtual(PackageNode, Virtual) :- node_depends_on_virtual(PackageNode, Virtual, Type).
 
@@ -958,8 +945,7 @@ node_depends_on_virtual(PackageNode, Virtual) :- node_depends_on_virtual(Package
 attr("virtual_on_edge", PackageNode, ProviderNode, Virtual)
   :- attr("dependency_holds", PackageNode, Virtual, Type),
      attr("depends_on", PackageNode, ProviderNode, Type),
-     provider(ProviderNode, node(_, Virtual)),
-     not external(PackageNode).
+     provider(ProviderNode, node(_, Virtual)).
 
 % If a virtual node is in the answer set, it must be either a virtual root,
 % or used somewhere
@@ -1068,59 +1054,13 @@ possible_provider_weight(node(ProviderID, Provider), VirtualNode, 100, "fallback
 % External semantics
 %-----------------------------------------------------------------------------
 
-% if a package is external its version must be one of the external versions
-{ external_version(node(ID, Package), Version, Weight):
-    pkg_fact(Package, version_declared(Version, Weight, "external")) }
-    :- external(node(ID, Package)).
+external(PackageNode) :- attr("external", PackageNode).
 
-error(100, "Attempted to use external for '{0}' which does not satisfy any configured external spec version", Package)
-  :- external(node(ID, Package)),
-     not external_version(node(ID, Package), _, _).
-
-error(100, "Attempted to use external for '{0}' which does not satisfy a unique configured external spec version", Package)
-  :- external(node(ID, Package)),
-     2 { external_version(node(ID, Package), Version, Weight) }.
-
-version_weight(PackageNode, Weight) :- external_version(PackageNode, Version, Weight).
-attr("version", PackageNode, Version) :- external_version(PackageNode, Version, Weight).
-
-% if a package is not buildable, only externals or hashed specs are allowed
-external(node(ID, Package))
+% if a package is not buildable, only concrete specs are allowed
+error(100, "Cannot build {0}, since it's marked non-buildable and no externals satisfy the requests", Package)
   :- buildable_false(Package),
      attr("node", node(ID, Package)),
-     not attr("hash", node(ID, Package), _).
-
-% a package is a real_node if it is not external
-real_node(PackageNode) :- attr("node", PackageNode), not external(PackageNode).
-
-% a package is external if we are using an external spec for it
-external(PackageNode) :- attr("external_spec_selected", PackageNode, _).
-
-% we can't use the weight for an external version if we don't use the
-% corresponding external spec.
-:- attr("version",  node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   pkg_fact(Package, version_declared(Version, Weight, "external")),
-   not external(node(ID, Package)),
-   internal_error("External weight used for internal spec").
-
-% determine if an external spec has been selected
-attr("external_spec_selected", node(ID, Package), LocalIndex) :-
-    attr("external_conditions_hold", node(ID, Package), LocalIndex),
-    attr("node", node(ID, Package)),
-    not attr("hash", node(ID, Package), _).
-
-% At most a single external can be active for a given node
-:- attr("node", node(ID, Package)),
-   2 { attr("external_spec_selected", node(ID, Package), LocalIndex) }.
-
-% Allow clingo not to impose an external condition. This is needed to allow solving
-% for externals that are indistinguishable besides compiler "metadata" e.g.
-% mpich@4.2 %gcc vs. mpich@4.2 %clang
-{ do_not_impose(EffectID, node(X, Package)) } :-
-  trigger_condition_holds(TriggerID, node(X, Package)),
-  trigger_and_effect(Package, TriggerID, EffectID),
-  imposed_constraint(EffectID, "external_conditions_hold", Package, _).
+     build(node(ID, Package)).
 
 % Account for compiler annotation on externals
 :- not attr("root", ExternalNode),
@@ -1131,23 +1071,6 @@ attr("external_spec_selected", node(ID, Package), LocalIndex) :-
   :- not attr("root", ExternalNode),
      attr("external_build_requirement", ExternalNode, node_requirement("node", Compiler)),
      attr("external_build_requirement", ExternalNode, node_requirement("node_version_satisfies", Compiler, Constraint)).
-
-error(100, "Cannot use an external for {0}, because the {1} compiler is overspecified. Omit version requirement.", ExternalPackage, Compiler) :-
-    external(node(X, ExternalPackage)),
-    not attr("external_build_requirement", node(X, ExternalPackage), node_requirement("node_version_satisfies", Compiler, _)),
-    attr("external_build_requirement", ExternalNode, node_requirement("node", Compiler)),
-    attr("direct_dependency", node(X, ExternalPackage), node_requirement("node_version_satisfies", Compiler, Constraint)).
-
-% If we require a compiler on an external root, be sure it's mentioned in the external spec
-:- external(ExternalNode),
-   not attr("external_build_requirement", ExternalNode, node_requirement("node", Compiler)),
-   attr("direct_dependency", ExternalNode, node_requirement("node",Compiler)).
-
-% it cannot happen that a spec is external, but none of the external specs
-% conditions hold.
-error(100, "Attempted to use external for '{0}' which does not satisfy any configured external spec", Package)
- :- external(node(ID, Package)),
-    not attr("external_conditions_hold", node(ID, Package), _).
 
 %-----------------------------------------------------------------------------
 % Config required semantics
@@ -1487,10 +1410,6 @@ variant_not_default(node(ID, Package), Variant, Value)
     not attr("variant_set", node(ID, Package), Variant, Value),
     % variant values forced by propagation don't count as non-default
     not propagate(node(ID, Package), variant_value(Variant, Value, _)),
-    % variants set on externals that we could use don't count as non-default
-    % this makes spack prefer to use an external over rebuilding with the
-    % default configuration
-    not external_with_variant_set(node(ID, Package), Variant, Value),
     attr("node", node(ID, Package)).
 
 % A default variant value that is not used
@@ -1502,15 +1421,6 @@ variant_default_not_used(node(ID, Package), Variant, Value)
      % variant set explicitly don't count for this metric
      not attr("variant_set", node(ID, Package), Variant, _),
      attr("node", node(ID, Package)).
-
-% The variant is set in an external spec
-external_with_variant_set(node(NodeID, Package), Variant, Value)
- :- attr("variant_value", node(NodeID, Package), Variant, Value),
-    condition_requirement(TriggerID, "variant_value", Package, Variant, Value),
-    trigger_and_effect(Package, TriggerID, EffectID),
-    imposed_constraint(EffectID, "external_conditions_hold", Package, _),
-    external(node(NodeID, Package)),
-    attr("node", node(NodeID, Package)).
 
 % Treat 'none' in a special way - it cannot be combined with other
 % values even if the variant is multi-valued
@@ -1668,7 +1578,6 @@ error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Sour
 attr("node_version_satisfies", node(Y, Compiler), VersionRange) :-
    propagate(node(X, Package), node_version_satisfies(Compiler, VersionRange)),
    attr("depends_on", node(X, Package), node(Y, Compiler), "build"),
-   not external(node(X, Package)),
    not runtime(Package).
 
 attr("node_version_satisfies", node(X, Runtime), VersionRange) :-
@@ -1694,7 +1603,7 @@ compiler_used_as_a_library(node(X, Child), Hash) :-
 %-----------------------------------------------------------------------------
 
 % Check whether the DAG has any built package
-has_built_packages() :- build(X), not external(X).
+has_built_packages() :- build(X).
 
 % "gcc-runtime" is always built
 :- concrete(node(X, "gcc-runtime")), has_built_packages().
@@ -1799,8 +1708,7 @@ language_runtime("fortran-rt").
 error(10, "Only external, or concrete, compilers are allowed for the {0} language", Language)
   :- provider(ProviderNode, node(_, Language)),
      language(Language),
-     not external(ProviderNode),
-     not concrete(ProviderNode).
+     build(ProviderNode).
 
 error(10, "{0} compiler '{2}@{3}' incompatible with 'target={1}'", Package, Target, Compiler, Version)
   :- attr("node_target", node(X, Package), Target),
@@ -1958,7 +1866,6 @@ build(PackageNode) :- attr("node", PackageNode), not concrete(PackageNode).
 %   100 - 199   Unshifted priorities. Currently only includes minimizing #builds and minimizing dupes.
 %   0   -  99   Priorities for non-built nodes.
 
-treat_node_as_concrete(node(X, Package)) :- external(node(X, Package)).
 treat_node_as_concrete(node(X, Package)) :- attr("node", node(X, Package)), runtime(Package).
 
 build_priority(PackageNode, 200) :- build(PackageNode), attr("node", PackageNode), not treat_node_as_concrete(PackageNode).
@@ -2139,6 +2046,11 @@ opt_criterion(40, "preferred compilers").
       language(Virtual),
       build_priority(ProviderNode, Priority)
 }.
+
+opt_criterion(41, "compiler penalty from reuse").
+#minimize{ 0@241: #true }.
+#minimize{ 0@41: #true }.
+#minimize{1@41,Hash : compiler_penalty_from_reuse(Hash)}.
 
 opt_criterion(30, "non-preferred OS's").
 #minimize{ 0@230: #true }.

--- a/lib/spack/spack/solver/direct_dependency.lp
+++ b/lib/spack/spack/solver/direct_dependency.lp
@@ -7,8 +7,7 @@
   build_requirement(PackageNode, node(0..X-1, DirectDependency)) : max_dupes(DirectDependency, X);
   runtime_requirement(PackageNode, node(0..X-1, DirectDependency)) : max_dupes(DirectDependency, X)
 } 1 :- attr("direct_dependency", PackageNode, node_requirement("node", DirectDependency)),
-       not external(PackageNode),
-       not concrete(PackageNode).
+       build(PackageNode).
 
 1 {
   concrete_build_requirement(PackageNode, DirectDependency);

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -41,7 +41,6 @@
 #show node_has_variant/3.
 #show build/1.
 #show external/1.
-#show external_version/3.
 #show trigger_and_effect/3.
 #show unification_set/2.
 #show provider/2.

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -132,59 +132,6 @@ error(0, "'{0}' requires conflicting variant values 'Spec({1}={2})' and 'Spec({1
      condition_holds(Cause2, node(X, TriggerPkg2)),
      Value1 < Value2. % see[1] in concretize.lp
 
-% Externals have to specify external conditions
-error(0, "Attempted to use external for {0} which does not satisfy any configured external spec version", Package, startcauses, ExternalCause, CID)
-  :- external(node(ID, Package)),
-     attr("external_spec_selected", node(ID, Package), Index),
-     imposed_constraint(EID, "external_conditions_hold", Package, Index),
-     pkg_fact(TriggerPkg, condition_effect(ExternalCause, EID)),
-     condition_holds(ExternalCause, node(CID, TriggerPkg)),
-     not external_version(node(ID, Package), _, _).
-
-error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}') is an external constraint for {0} which was not satisfied", Package, Name, A1)
-  :- external(node(ID, Package)),
-     not attr("external_conditions_hold", node(ID, Package), _),
-     imposed_constraint(EID, "external_conditions_hold", Package, _),
-     trigger_and_effect(Package, TID, EID),
-     condition_requirement(TID, Name, A1),
-     not attr(Name, node(_, A1)).
-
-error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}', '{3}') is an external constraint for {0} which was not satisfied", Package, Name, A1, A2)
-  :- external(node(ID, Package)),
-     not attr("external_conditions_hold", node(ID, Package), _),
-     imposed_constraint(EID, "external_conditions_hold", Package, _),
-     trigger_and_effect(Package, TID, EID),
-     condition_requirement(TID, Name, A1, A2),
-     not attr(Name, node(_, A1), A2).
-
-error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}', '{3}', '{4}') is an external constraint for {0} which was not satisfied", Package, Name, A1, A2, A3)
-  :- external(node(ID, Package)),
-     not attr("external_conditions_hold", node(ID, Package), _),
-     imposed_constraint(EID, "external_conditions_hold", Package, _),
-     trigger_and_effect(Package, TID, EID),
-     condition_requirement(TID, Name, A1, A2, A3),
-     not attr(Name, node(_, A1), A2, A3).
-
-error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        'Spec({0} {1}={2})' is an external constraint for {0} which was not satisfied\n        'Spec({0} {1}={3})' required", Package, Variant, Value, OtherValue, startcauses, OtherValueCause, CID)
-  :- external(node(ID, Package)),
-     not attr("external_conditions_hold", node(ID, Package), _),
-     imposed_constraint(EID, "external_conditions_hold", Package, _),
-     trigger_and_effect(Package, TID, EID),
-     condition_requirement(TID, "variant_value", Package, Variant, Value),
-     not attr("variant_value", node(ID, Package), Variant, Value),
-     attr("variant_value", node(ID, Package), Variant, OtherValue),
-     imposed_constraint(EID2, "variant_set", Package, Variant, OtherValue),
-     pkg_fact(TriggerPkg, condition_effect(OtherValueCause, EID2)),
-     condition_holds(OtherValueCause, node(CID, TriggerPkg)).
-
-error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}', '{3}', '{4}', '{5}') is an external constraint for {0} which was not satisfied", Package, Name, A1, A2, A3, A4)
-  :- external(node(ID, Package)),
-     not attr("external_conditions_hold", node(ID, Package), _),
-     imposed_constraint(EID, "external_conditions_hold", Package, _),
-     trigger_and_effect(Package, TID, EID),
-     condition_requirement(TID, Name, A1, A2, A3, A4),
-     not attr(Name, node(_, A1), A2, A3, A4).
-
 % error message with causes for conflicts
 error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
   :- attr("node", node(ID, Package)),
@@ -194,8 +141,7 @@ error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
      condition_holds(ConstraintID, node(ID2, Package)),
      unification_set(X, node(ID2, Package)),
      unification_set(X, node(ID1, TriggerPackage)),
-     not external(node(ID, Package)),  % ignore conflicts for externals
-     not attr("hash", node(ID, Package), _).  % ignore conflicts for installed packages
+     build(node(ID, Package)).  % ignore conflicts for concrete packages
 
 % variables to show
 #show error/2.
@@ -245,5 +191,4 @@ error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
 #defined build/1.
 #defined node_has_variant/3.
 #defined provider/2.
-#defined external_version/3.
 #defined variant_single_value/2.

--- a/lib/spack/spack/solver/libc_compatibility.lp
+++ b/lib/spack/spack/solver/libc_compatibility.lp
@@ -29,7 +29,7 @@ error(100, "Cannot reuse {0} since we cannot determine libc compatibility", Reus
      not attr("compatible_libc", node(R, ReusedPackage), _, _).
 
 % The libc provider must be one that a compiler can target
-:- has_built_packages(),
+:- will_build_packages(),
    provider(node(X, LibcPackage), node(0, "libc")),
    attr("node", node(X, LibcPackage)),
    attr("version", node(X, LibcPackage), LibcVersion),

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -19,7 +19,7 @@ from spack.externals import (
     extract_dicts_from_configuration,
 )
 
-from .runtimes import external_config_with_implicit_externals, all_libcs
+from .runtimes import all_libcs, external_config_with_implicit_externals
 
 
 class SpecFilter:
@@ -214,7 +214,7 @@ class ReuseStrategy(enum.Enum):
 def _create_external_parser(
     configuration: spack.config.Configuration,
 ) -> Tuple[ExternalSpecsParser, Any]:
-    packages_yaml = _external_config_with_implicit_externals(configuration)
+    packages_yaml = external_config_with_implicit_externals(configuration)
     external_dicts = extract_dicts_from_configuration(packages_yaml)
     result = configuration.get("concretizer:externals:completion")
     if result == "default_variants":

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -8,6 +8,7 @@ from typing import Callable, List, Mapping
 import spack.binary_distribution
 import spack.config
 import spack.environment
+import spack.llnl.path
 import spack.repo
 import spack.spec
 import spack.store
@@ -155,9 +156,12 @@ def _is_reusable(spec: spack.spec.Spec, packages, local: bool) -> bool:
 
     for name in {spec.name, *provided}:
         for entry in packages.get(name, {}).get("externals", []):
+            expected_prefix = entry.get("prefix")
+            if expected_prefix is not None:
+                expected_prefix = spack.llnl.path.path_to_os_path(expected_prefix)[0]
             if (
                 spec.satisfies(entry["spec"])
-                and spec.external_path == entry.get("prefix")
+                and spec.external_path == expected_prefix
                 and spec.external_modules == entry.get("modules")
             ):
                 return True

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
 import functools
-from typing import Callable, List, Mapping
+from typing import Any, Callable, List, Mapping, Tuple
 
 import spack.binary_distribution
 import spack.config
@@ -12,7 +12,12 @@ import spack.llnl.path
 import spack.repo
 import spack.spec
 import spack.store
-from spack.externals import ExternalSpecsParser, extract_dicts_from_configuration
+from spack.externals import (
+    ExternalSpecsParser,
+    complete_architecture,
+    complete_variants_and_architecture,
+    extract_dicts_from_configuration,
+)
 
 from .runtimes import external_config_with_implicit_externals, all_libcs
 
@@ -99,9 +104,7 @@ class SpecFilter:
 
     @staticmethod
     def from_packages_yaml(configuration, *, include, exclude) -> "SpecFilter":
-        packages_yaml = _external_config_with_implicit_externals(configuration)
-        external_dicts = extract_dicts_from_configuration(packages_yaml)
-        parser = ExternalSpecsParser(external_dicts)
+        parser, packages_yaml = _create_external_parser(configuration)
         is_reusable = functools.partial(_is_reusable, packages=packages_yaml, local=True)
         return SpecFilter(
             parser.all_specs, is_usable=is_reusable, include=include, exclude=exclude
@@ -206,6 +209,21 @@ class ReuseStrategy(enum.Enum):
     ROOTS = enum.auto()
     DEPENDENCIES = enum.auto()
     NONE = enum.auto()
+
+
+def _create_external_parser(
+    configuration: spack.config.Configuration,
+) -> Tuple[ExternalSpecsParser, Any]:
+    packages_yaml = _external_config_with_implicit_externals(configuration)
+    external_dicts = extract_dicts_from_configuration(packages_yaml)
+    result = configuration.get("concretizer:externals:completion")
+    if result == "default_variants":
+        complete_fn = complete_variants_and_architecture
+    elif result == "architecture_only":
+        complete_fn = complete_architecture
+    else:
+        raise ValueError(f"Unknown value for concretizer:externals:completion: {result!r}")
+    return ExternalSpecsParser(external_dicts, complete_node=complete_fn), packages_yaml
 
 
 class ReusableSpecsSelector:

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -11,8 +11,9 @@ import spack.environment
 import spack.repo
 import spack.spec
 import spack.store
+from spack.externals import ExternalSpecsParser, extract_dicts_from_configuration
 
-from .runtimes import external_config_with_implicit_externals
+from .runtimes import external_config_with_implicit_externals, all_libcs
 
 
 class SpecFilter:
@@ -94,6 +95,16 @@ class SpecFilter:
             _specs_from_environment_included_concrete, env=env, included_concrete=included_concrete
         )
         return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
+
+    @staticmethod
+    def from_packages_yaml(configuration, *, include, exclude) -> "SpecFilter":
+        packages_yaml = _external_config_with_implicit_externals(configuration)
+        external_dicts = extract_dicts_from_configuration(packages_yaml)
+        parser = ExternalSpecsParser(external_dicts)
+        is_reusable = functools.partial(_is_reusable, packages=packages_yaml, local=True)
+        return SpecFilter(
+            parser.all_specs, is_usable=is_reusable, include=include, exclude=exclude
+        )
 
 
 def _has_runtime_dependencies(spec: spack.spec.Spec) -> bool:
@@ -204,8 +215,13 @@ class ReusableSpecsSelector:
         reuse_yaml = self.configuration.get("concretizer:reuse", False)
         self.reuse_sources = []
         if not isinstance(reuse_yaml, Mapping):
+            self.reuse_sources.append(
+                SpecFilter.from_packages_yaml(configuration, include=[], exclude=[])
+            )
             if reuse_yaml is False:
                 self.reuse_strategy = ReuseStrategy.NONE
+                return
+
             if reuse_yaml == "dependencies":
                 self.reuse_strategy = ReuseStrategy.DEPENDENCIES
             self.reuse_sources.extend(
@@ -225,6 +241,7 @@ class ReusableSpecsSelector:
                 ]
             )
         else:
+            has_external_source = False
             roots = reuse_yaml.get("roots", True)
             if roots is True:
                 self.reuse_strategy = ReuseStrategy.ROOTS
@@ -285,11 +302,24 @@ class ReusableSpecsSelector:
                             self.configuration, include=include, exclude=exclude
                         )
                     )
+                elif source["type"] == "external":
+                    has_external_source = True
+                    if include:
+                        # Since libcs are implicit externals, we need to implicitly include them
+                        include = include + sorted(all_libcs())  # type: ignore[type-var]
+                    self.reuse_sources.append(
+                        SpecFilter.from_packages_yaml(
+                            configuration, include=include, exclude=exclude
+                        )
+                    )
+
+            # If "external" is not specified, we assume that all externals have to be included
+            if not has_external_source:
+                self.reuse_sources.append(
+                    SpecFilter.from_packages_yaml(configuration, include=[], exclude=[])
+                )
 
     def reusable_specs(self, specs: List[spack.spec.Spec]) -> List[spack.spec.Spec]:
-        if self.reuse_strategy == ReuseStrategy.NONE:
-            return []
-
         result = []
         for reuse_source in self.reuse_sources:
             result.extend(reuse_source.selected_specs())

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -286,7 +286,7 @@ def external_config_with_implicit_externals(
 ) -> Dict[str, Any]:
     # Read packages.yaml and normalize it so that it will not contain entries referring to
     # virtual packages.
-    packages_yaml = configuration.deepcopy_as_builtin("packages")
+    packages_yaml = configuration.deepcopy_as_builtin("packages", line_info=True)
     _normalize_packages_yaml(packages_yaml)
 
     # Add externals for libc from compilers on Linux

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import itertools
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Set, Tuple
 
 import spack.compilers.config
 import spack.compilers.libraries
 import spack.config
 import spack.repo
 import spack.spec
+import spack.util.libc
 import spack.version
 
 from .core import SourceContext, fn, using_libc_compatibility
@@ -143,7 +144,6 @@ class RuntimePropertyRecorder:
                 _, provider, virtual = clause.args
                 clause.args = "virtual_on_edge", node_placeholder, provider, virtual
         body_str = ",\n".join(f"  {x}" for x in body_clauses)
-        body_str += f",\n  not external({node_variable})"
         body_str = body_str.replace(f'"{node_placeholder}"', f"{node_variable}")
         for old, replacement in when_substitutions.items():
             body_str = body_str.replace(old, replacement)
@@ -301,3 +301,19 @@ def external_config_with_implicit_externals(
             entry = {"spec": f"{libc}", "prefix": libc.external_path}
             packages_yaml.setdefault(libc.name, {}).setdefault("externals", []).append(entry)
     return packages_yaml
+
+
+def all_libcs() -> Set[spack.spec.Spec]:
+    """Return a set of all libc specs targeted by any configured compiler. If none, fall back to
+    libc determined from the current Python process if dynamically linked."""
+    libcs = set()
+    for c in spack.compilers.config.all_compilers_from(spack.config.CONFIG):
+        candidate = spack.compilers.libraries.CompilerPropertyDetector(c).default_libc()
+        if candidate is not None:
+            libcs.add(candidate)
+
+    if libcs:
+        return libcs
+
+    libc = spack.util.libc.libc_from_current_python_process()
+    return {libc} if libc else set()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3468,7 +3468,10 @@ class Spec:
                         return False
 
                 if current_node.original_spec_format() < 5 or (
-                    current_node.original_spec_format() >= 5 and current_node.external
+                    # If the current external node has dependencies, it has no annotations
+                    current_node.original_spec_format() >= 5
+                    and current_node.external
+                    and not current_node._dependencies
                 ):
                     compiler_spec = current_node.annotations.compiler_node_attribute
                     if compiler_spec is None:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1562,7 +1562,7 @@ class Spec:
         self.external_modules = Spec._format_module_list(external_modules)
 
         # This attribute is used to store custom information for external specs.
-        self.extra_attributes: dict = {}
+        self.extra_attributes: Dict[str, Any] = {}
 
         # This attribute holds the original build copy of the spec if it is
         # deployed differently than it was built. None signals that the spec

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2882,6 +2882,8 @@ class Spec:
             return
         self._concrete = value
         self._validate_version()
+        for variant in self.variants.values():
+            variant.concrete = True
 
     def _validate_version(self):
         # Specs that were concretized with just a git sha as version, without associated

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -761,11 +761,13 @@ def test_optimization_flags_are_using_node_target(default_mock_concretization, m
             """\
 gcc:
   externals:
-  - spec: gcc@14.2.0 languages=c
+  - spec: gcc@14.2.0 languages:=c,c++,fortran
     prefix: /fake/path1
     extra_attributes:
       compilers:
         c: /fake/path1
+        cxx: /fake/path1
+        fortran: /fake/path1
       extra_rpaths:
       - /extra/rpaths1
       - /extra/rpaths2
@@ -776,11 +778,13 @@ gcc:
             """\
 gcc:
   externals:
-  - spec: gcc@14.2.0 languages=c
+  - spec: gcc@14.2.0 languages=c,c++,fortran
     prefix: /fake/path1
     extra_attributes:
       compilers:
         c: /fake/path1
+        cxx: /fake/path1
+        fortran: /fake/path1
 """,
             None,
         ),

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4342,7 +4342,7 @@ def test_env_include_packages_url(
     """Test inclusion of a (GitHub) URL."""
     develop_url = "https://github.com/fake/fake/blob/develop/"
     default_packages = develop_url + "etc/fake/defaults/packages.yaml"
-    sha256 = "20c934ddd73a8e8128a349aab3ee4e80996d1574c404a6a6e36a34986114fce8"
+    sha256 = "8b3f2438e920d204949ff12c542805765e2bcef2e2fa06d80f08f65f56d7e44a"
     spack_yaml = tmp_path / "spack.yaml"
     with open(spack_yaml, "w", encoding="utf-8") as f:
         f.write(

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4342,7 +4342,7 @@ def test_env_include_packages_url(
     """Test inclusion of a (GitHub) URL."""
     develop_url = "https://github.com/fake/fake/blob/develop/"
     default_packages = develop_url + "etc/fake/defaults/packages.yaml"
-    sha256 = "6a1b26c857ca7e5bcd7342092e2f218da43d64b78bd72771f603027ea3c8b4af"
+    sha256 = "20c934ddd73a8e8128a349aab3ee4e80996d1574c404a6a6e36a34986114fce8"
     spack_yaml = tmp_path / "spack.yaml"
     with open(spack_yaml, "w", encoding="utf-8") as f:
         f.write(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -21,7 +21,6 @@ import spack.compilers.config
 import spack.concretize
 import spack.config
 import spack.deptypes as dt
-import spack.detection
 import spack.error
 import spack.hash_types as ht
 import spack.llnl.util.lang
@@ -2177,80 +2176,6 @@ class TestConcretize:
             assert s.satisfies(f"target={required_target}")
 
     target = spack.platforms.test.Test.default
-
-    @pytest.mark.parametrize(
-        "python_spec",
-        [
-            "python@configured",
-            "python@configured platform=test",
-            "python@configured os=debian",
-            "python@configured target=%s" % target,
-        ],
-    )
-    @pytest.mark.xfail(reason="FIXME: (externals as concrete)")
-    def test_external_python_extension_find_dependency_from_config(self, python_spec):
-        fake_path = os.path.sep + "fake"
-
-        external_conf = {
-            "py-extension1": {
-                "buildable": False,
-                "externals": [{"spec": "py-extension1@2.0", "prefix": fake_path}],
-            },
-            "python": {"externals": [{"spec": python_spec, "prefix": fake_path}]},
-        }
-        spack.config.set("packages", external_conf)
-
-        spec = spack.concretize.concretize_one("py-extension1")
-
-        assert "python" in spec["py-extension1"]
-        assert spec["python"].prefix == fake_path
-        # The spec is not equal to Spec("python@configured") because it gets a
-        # namespace and an external prefix before marking concrete
-        assert spec["python"].satisfies(python_spec)
-
-    @pytest.mark.xfail(reason="FIXME: (externals as concrete)")
-    def test_external_python_extension_find_dependency_from_detection(self, monkeypatch):
-        """Test that python extensions have access to a python dependency
-
-        when python isn't otherwise in the DAG"""
-        prefix = os.path.sep + "fake"
-        python_spec = Spec.from_detection("python@=detected", external_path=prefix)
-
-        def find_fake_python(classes, path_hints, **kwargs):
-            return {
-                "python": [Spec.from_detection("python@=detected", external_path=path_hints[0])]
-            }
-
-        monkeypatch.setattr(spack.detection, "by_path", find_fake_python)
-        external_conf = {
-            "py-extension1": {
-                "buildable": False,
-                "externals": [{"spec": "py-extension1@2.0", "prefix": "%s" % prefix}],
-            }
-        }
-        spack.config.set("packages", external_conf)
-
-        spec = spack.concretize.concretize_one("py-extension1")
-
-        assert "python" in spec["py-extension1"]
-        assert spec["python"].prefix == prefix
-        assert spec["python"].external
-        assert spec["python"].satisfies(python_spec)
-
-    @pytest.mark.xfail(reason="FIXME: (externals as concrete)")
-    def test_external_python_extension_find_unified_python(self):
-        """Test that python extensions use the same python as other specs in unified env"""
-        external_conf = {
-            "py-extension1": {
-                "buildable": False,
-                "externals": [{"spec": "py-extension1@2.0", "prefix": os.path.sep + "fake"}],
-            }
-        }
-        spack.config.set("packages", external_conf)
-
-        abstract_specs = [Spec(s) for s in ["py-extension1", "python"]]
-        specs = spack.concretize._concretize_specs_together(abstract_specs)
-        assert specs[0]["python"] == specs[1]["python"]
 
     @pytest.mark.regression("36190")
     @pytest.mark.parametrize(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4345,3 +4345,52 @@ def test_external_specs_with_dependencies(
     s = spack.concretize.concretize_one(spec_str)
     assert all(node.external for node in s.traverse())
     assert all(s.satisfies(c) for c in expected)
+
+
+@pytest.mark.parametrize(
+    "default_target,expected",
+    [
+        # Specific target requested
+        ("x86_64_v3", ["callpath target=x86_64_v3", "^mpich target=x86_64_v3"]),
+        # With ranges, be conservative by default
+        (":x86_64_v3", ["callpath target=x86_64", "^mpich target=x86_64"]),
+        ("x86_64:x86_64_v3", ["callpath target=x86_64", "^mpich target=x86_64"]),
+        ("x86_64:", ["callpath target=x86_64", "^mpich target=x86_64"]),
+    ],
+)
+@pytest.mark.skipif(
+    spack.vendor.archspec.cpu.host().family != "x86_64", reason="test data for x86_64"
+)
+def test_target_requirements(default_target, expected, mutable_config, mock_packages):
+    """Tests different scenarios where targets might be constrained by configuration and are not
+    specified in external specs
+    """
+    configuration = syaml.load_config(
+        f"""
+packages:
+  all:
+    require:
+    - "target={default_target}"
+  callpath:
+    buildable: false
+    externals:
+    - spec: "callpath@1.0"
+      prefix: /user/path
+      external_id: callpath_id
+      dependencies:
+      - external_id: mpich_id
+        deptypes:
+        - "build"
+        - "link"
+        virtuals: "mpi"
+  mpich:
+    externals:
+    - spec: "mpich@3.0.4"
+      prefix: /user/path
+      external_id: mpich_id
+"""
+    )
+    mutable_config.set("packages", configuration["packages"])
+    s = spack.concretize.concretize_one("callpath")
+    assert s.external
+    assert all(s.satisfies(x) for x in expected), s.tree()

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2178,6 +2178,28 @@ class TestConcretize:
 
     target = spack.platforms.test.Test.default
 
+    def test_external_python_extension_find_dependency_from_config(self, mutable_config, tmp_path):
+        """Tests that an external Python extension gets a dependency on Python."""
+        packages_yaml = f"""
+packages:
+  py-extension1:
+    buildable: false
+    externals:
+    - spec: py-extension1@2.0
+      prefix: {tmp_path / "py-extension1"}
+  python:
+    externals:
+    - spec: python@3.8.13
+      prefix: {tmp_path / "python"}
+"""
+        configuration = syaml.load_config(packages_yaml)
+        mutable_config.set("packages", configuration["packages"])
+        py_extension = spack.concretize.concretize_one("py-extension1")
+
+        assert py_extension.external
+        assert py_extension["python"].external
+        assert py_extension["python"].prefix == str(tmp_path / "python")
+
     @pytest.mark.regression("36190")
     @pytest.mark.parametrize(
         "specs",

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -40,6 +40,7 @@ import spack.util.file_cache
 import spack.util.hash
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
+from spack.externals import ExternalDependencyError
 from spack.installer import PackageInstaller
 from spack.solver.reuse import SpecFilter
 from spack.spec import Spec
@@ -3372,7 +3373,7 @@ def test_compiler_match_for_externals_is_taken_into_account(
 packages:
   libelf:
     externals:
-    - spec: "libelf@0.8.12 %gcc"
+    - spec: "libelf@0.8.12 %gcc@10"
       prefix: {tmp_path / 'gcc'}
     - spec: "libelf@0.8.13 %clang"
       prefix: {tmp_path / 'clang'}
@@ -3408,7 +3409,7 @@ packages:
     externals:
     - spec: "libelf@0.8.12 %gcc@10"
       prefix: {tmp_path / 'libelf-gcc10'}
-    - spec: "libelf@0.8.13 %gcc@9"
+    - spec: "libelf@0.8.13 %gcc@9.4.0"
       prefix: {tmp_path / 'libelf-gcc9'}
 """
     )
@@ -3496,7 +3497,7 @@ def test_input_analysis_and_conditional_requirements(default_mock_concretization
     [
         # Compilers are matched to some other external, so the compiler that picked is concrete
         ("gcc@10", ["%gcc", "%gcc@10"], ["%clang", "%gcc@9"]),
-        ("gcc@9", ["%gcc", "%gcc@9"], ["%clang", "%gcc@10"]),
+        ("gcc@9.4.0", ["%gcc", "%gcc@9"], ["%clang", "%gcc@10"]),
         ("clang", ["%clang", "%llvm+clang"], ["%gcc", "%gcc@9", "%gcc@10"]),
     ],
 )
@@ -3944,7 +3945,7 @@ def test_selecting_externals_with_compilers_as_root(mutable_config, mock_package
     packages_yaml = syaml.load_config(
         """
 packages:
-  gcc:
+  gcc::
     externals:
     - spec: "gcc@9.4.0 languages='c,c++'"
       prefix: /path
@@ -3952,7 +3953,7 @@ packages:
         compilers:
           c: /path/bin/gcc
           cxx: /path/bin/g++
-  llvm:
+  llvm::
     buildable: false
     externals:
     - spec: "llvm@20 +clang"
@@ -3994,19 +3995,10 @@ packages:
 @pytest.mark.not_on_windows("Tests use linux paths")
 @pytest.mark.regression("51001")
 @pytest.mark.parametrize(
-    "external_compiler,spec_str,expected_raising",
-    [
-        # Underspecify the compiler. This will select the best option, which is gcc@10
-        ("gcc", "mpich %gcc@9", True),
-        # Specify gcc@10 directly. This will raise too
-        ("gcc@10", "mpich %gcc@9", True),
-        # This is ok
-        ("gcc@9", "mpich %gcc@9.4", False),
-        ("gcc@9.4.0", "mpich %gcc@9", False),
-    ],
+    "external_compiler,spec_str", [("gcc@8", "mpich %gcc@8.4"), ("gcc@8.4.0", "mpich %gcc@8")]
 )
 def test_selecting_externals_with_compilers_and_versions(
-    external_compiler, spec_str, expected_raising, mutable_config, mock_packages
+    external_compiler, spec_str, mutable_config, mock_packages
 ):
     """Tests different scenarios of having a compiler specified with a version constraint, either
     in the input spec or in the external spec.
@@ -4016,7 +4008,7 @@ def test_selecting_externals_with_compilers_and_versions(
 packages:
   gcc:
     externals:
-    - spec: "gcc@9.4.0 languages='c,c++'"
+    - spec: "gcc@8.4.0 languages='c,c++'"
       prefix: /path
       extra_attributes:
         compilers:
@@ -4032,14 +4024,41 @@ packages:
 """
     )
     mutable_config.set("packages", packages_yaml["packages"])
+    s = spack.concretize.concretize_one(spec_str)
+    assert s.external
+    assert s.prefix == "/path/mpich/gcc"
 
-    if expected_raising:
-        with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="Cannot build mpich"):
-            _ = spack.concretize.concretize_one(spec_str)
-    else:
-        s = spack.concretize.concretize_one(spec_str)
-        assert s.external
-        assert s.prefix == "/path/mpich/gcc"
+
+@pytest.mark.regression("51001")
+@pytest.mark.parametrize(
+    "external_compiler,spec_str,error_match",
+    [
+        # Compiler is underspecified
+        ("gcc", "mpich %gcc", "there are multiple external specs"),
+        ("gcc@9", "mpich %gcc", "there are multiple external specs"),
+        # Compiler does not exist
+        ("%oneapi", "mpich %gcc@8", "there is no"),
+    ],
+)
+def test_errors_when_specifying_externals_with_compilers(
+    external_compiler, spec_str, error_match, mutable_config, mock_packages
+):
+    """Tests different errors that can occur in an external spec with a compiler specified."""
+    packages_yaml = syaml.load_config(
+        f"""
+packages:
+  mpich:
+    buildable: false
+    externals:
+    - spec: "mpich@3.4.3 %{external_compiler}"
+      prefix: /path/mpich/gcc
+    - spec: "mpich@3.4.3 %clang"
+      prefix: /path/mpich/clang
+"""
+    )
+    mutable_config.set("packages", packages_yaml["packages"])
+    with pytest.raises(ExternalDependencyError, match=error_match):
+        _ = spack.concretize.concretize_one(spec_str)
 
 
 @pytest.mark.regression("51146,51067")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -14,6 +14,7 @@ import pytest
 import spack.vendor.archspec.cpu
 import spack.vendor.jinja2
 
+import spack.archspec
 import spack.binary_distribution
 import spack.cmd
 import spack.compilers.config
@@ -158,6 +159,9 @@ def current_host(request, monkeypatch):
     cpu, _, is_preference = request.param.partition("-")
 
     monkeypatch.setattr(spack.platforms.Test, "default", cpu)
+    monkeypatch.setattr(
+        spack.archspec, "HOST_TARGET_FAMILY", spack.vendor.archspec.cpu.TARGETS["x86_64"]
+    )
     if not is_preference:
         target = spack.vendor.archspec.cpu.TARGETS[cpu]
         monkeypatch.setattr(spack.vendor.archspec.cpu, "host", lambda: target)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4303,9 +4303,9 @@ packages:
     - spec: "mpileaks@2.3~debug+opt"
       prefix: /user/path
       dependencies:
-      - external_id: callpath_id
+      - id: callpath_id
         deptypes: link
-      - external_id: mpich_id
+      - id: mpich_id
         deptypes:
         - "build"
         - "link"
@@ -4314,9 +4314,9 @@ packages:
     externals:
     - spec: "callpath@1.0"
       prefix: /user/path
-      external_id: callpath_id
+      id: callpath_id
       dependencies:
-      - external_id: mpich_id
+      - id: mpich_id
         deptypes:
         - "build"
         - "link"
@@ -4325,7 +4325,7 @@ packages:
     externals:
     - spec: "mpich@3.0.4"
       prefix: /user/path
-      external_id: mpich_id
+      id: mpich_id
 """,
             [
                 "%mpi=mpich@3.0.4",
@@ -4376,9 +4376,9 @@ packages:
     externals:
     - spec: "callpath@1.0"
       prefix: /user/path
-      external_id: callpath_id
+      id: callpath_id
       dependencies:
-      - external_id: mpich_id
+      - id: mpich_id
         deptypes:
         - "build"
         - "link"
@@ -4387,7 +4387,7 @@ packages:
     externals:
     - spec: "mpich@3.0.4"
       prefix: /user/path
-      external_id: mpich_id
+      id: mpich_id
 """
     )
     mutable_config.set("packages", configuration["packages"])

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4468,3 +4468,89 @@ packages:
     s = spack.concretize.concretize_one("callpath")
     assert s.external
     assert all(s.satisfies(x) for x in expected), s.tree()
+
+
+@pytest.mark.parametrize(
+    "spec_str,inline,yaml",
+    [
+        (
+            "cmake-client",
+            """
+packages:
+  cmake-client:
+    externals:
+    - spec: cmake-client@1.0 %cmake
+      prefix: /mock
+  cmake:
+    externals:
+    - spec: cmake@3.23.0
+      prefix: /mock
+""",
+            """
+packages:
+  cmake-client:
+    externals:
+    - spec: cmake-client@1.0
+      prefix: /mock
+      dependencies:
+      - spec: cmake
+  cmake:
+    externals:
+    - spec: cmake@3.23.0
+      prefix: /mock
+""",
+        ),
+        (
+            "mpileaks",
+            """
+packages:
+  mpileaks:
+    externals:
+    - spec: "mpileaks@2.3~debug+opt %mpi=mpich %[deptypes=link] callpath"
+      prefix: /user/path
+  callpath:
+    externals:
+    - spec: "callpath@1.0 %mpi=mpich"
+      prefix: /user/path
+  mpich:
+    externals:
+    - spec: "mpich@3.0.4"
+      prefix: /user/path
+""",
+            """
+packages:
+  mpileaks:
+    externals:
+    - spec: "mpileaks@2.3~debug+opt"
+      prefix: /user/path
+      dependencies:
+      - spec: callpath
+        deptypes: link
+      - spec: mpich
+        virtuals: "mpi"
+  callpath:
+    externals:
+    - spec: "callpath@1.0"
+      prefix: /user/path
+      dependencies:
+      - spec: mpich
+        virtuals: "mpi"
+  mpich:
+    externals:
+    - spec: "mpich@3.0.4"
+      prefix: /user/path
+""",
+        ),
+    ],
+)
+def test_external_inline_equivalent_to_yaml(spec_str, inline, yaml, mutable_config, mock_packages):
+    """Tests that the inline syntax for external specs is equivalent to the YAML syntax."""
+    configuration = syaml.load_config(inline)
+    mutable_config.set("packages", configuration["packages"])
+    inline_spec = spack.concretize.concretize_one(spec_str)
+
+    configuration = syaml.load_config(yaml)
+    mutable_config.set("packages", configuration["packages"])
+    yaml_spec = spack.concretize.concretize_one(spec_str)
+
+    assert inline_spec == yaml_spec

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4333,7 +4333,40 @@ packages:
                 "%[deptypes=link] callpath",
                 "%[deptypes=build,link] mpich",
             ],
-        )
+        ),
+        # Same, but using `spec:` instead of `id:` for dependencies
+        (
+            "mpileaks",
+            """
+packages:
+  mpileaks:
+    externals:
+    - spec: "mpileaks@2.3~debug+opt"
+      prefix: /user/path
+      dependencies:
+      - spec: callpath
+        deptypes: link
+      - spec: mpich
+        virtuals: "mpi"
+  callpath:
+    externals:
+    - spec: "callpath@1.0"
+      prefix: /user/path
+      dependencies:
+      - spec: mpich
+        virtuals: "mpi"
+  mpich:
+    externals:
+    - spec: "mpich@3.0.4"
+      prefix: /user/path
+""",
+            [
+                "%mpi=mpich@3.0.4",
+                "^callpath %mpi=mpich@3.0.4",
+                "%[deptypes=link] callpath",
+                "%[deptypes=build,link] mpich",
+            ],
+        ),
     ],
 )
 def test_external_specs_with_dependencies(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4265,3 +4265,83 @@ def test_concretization_cache_asp_canonicalization(asp_file):
             if line.startswith("-") and not line.startswith("---")
         ]
     )
+
+
+@pytest.mark.parametrize(
+    "node_completion,expected,not_expected",
+    [
+        ("architecture_only", ["+clang", "~flang", "platform=test"], ["lld=*"]),
+        (
+            "default_variants",
+            ["+clang", "~flang", "+lld", "platform=test"],
+            ["~clang", "+flang", "~lld"],
+        ),
+    ],
+)
+def test_external_node_completion_from_config(
+    node_completion, expected, not_expected, mutable_config, mock_packages
+):
+    """Tests the different options for external node completion in the configuration file."""
+    mutable_config.set("concretizer:externals:completion", node_completion)
+
+    s = spack.concretize.concretize_one("llvm")
+
+    assert s.external
+    assert all(s.satisfies(c) for c in expected)
+    assert all(not s.satisfies(c) for c in not_expected)
+
+
+@pytest.mark.parametrize(
+    "spec_str,packages_yaml,expected",
+    [
+        (
+            "mpileaks",
+            """
+packages:
+  mpileaks:
+    externals:
+    - spec: "mpileaks@2.3~debug+opt"
+      prefix: /user/path
+      dependencies:
+      - external_id: callpath_id
+        deptypes: link
+      - external_id: mpich_id
+        deptypes:
+        - "build"
+        - "link"
+        virtuals: "mpi"
+  callpath:
+    externals:
+    - spec: "callpath@1.0"
+      prefix: /user/path
+      external_id: callpath_id
+      dependencies:
+      - external_id: mpich_id
+        deptypes:
+        - "build"
+        - "link"
+        virtuals: "mpi"
+  mpich:
+    externals:
+    - spec: "mpich@3.0.4"
+      prefix: /user/path
+      external_id: mpich_id
+""",
+            [
+                "%mpi=mpich@3.0.4",
+                "^callpath %mpi=mpich@3.0.4",
+                "%[deptypes=link] callpath",
+                "%[deptypes=build,link] mpich",
+            ],
+        )
+    ],
+)
+def test_external_specs_with_dependencies(
+    spec_str, packages_yaml, expected, mutable_config, mock_packages
+):
+    """Tests that we can reconstruct external specs with dependencies."""
+    configuration = syaml.load_config(packages_yaml)
+    mutable_config.set("packages", configuration["packages"])
+    s = spack.concretize.concretize_one(spec_str)
+    assert all(node.external for node in s.traverse())
+    assert all(s.satisfies(c) for c in expected)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -35,13 +35,13 @@ import spack.solver.reuse
 import spack.solver.runtimes
 import spack.solver.versions
 import spack.spec
-import spack.store
 import spack.test.conftest
 import spack.util.file_cache
 import spack.util.hash
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack.installer import PackageInstaller
+from spack.solver.reuse import SpecFilter
 from spack.spec import Spec
 from spack.test.conftest import RepoBuilder
 from spack.version import Version, VersionList, ver
@@ -291,14 +291,14 @@ class Changing(Package):
 
 @pytest.fixture()
 def clang12_with_flags(compiler_factory):
-    c = compiler_factory(spec="llvm@12.2.0 os=redhat6")
+    c = compiler_factory(spec="llvm@12.2.0+clang os=redhat6")
     c["extra_attributes"]["flags"] = {"cflags": "-O3", "cxxflags": "-O3"}
     return c
 
 
 @pytest.fixture()
 def gcc11_with_flags(compiler_factory):
-    c = compiler_factory(spec="gcc@11.1.0 os=redhat6")
+    c = compiler_factory(spec="gcc@11.1.0 languages:=c,c++,fortran os=redhat6")
     c["extra_attributes"]["flags"] = {"cflags": "-O0 -g", "cxxflags": "-O0 -g", "fflags": "-O0 -g"}
     return c
 
@@ -483,11 +483,15 @@ class TestConcretize:
         information from the root even when partial architecture information
         is provided by an intermediate dependency.
         """
-        cnl_compiler = compiler_factory(spec="gcc@4.5.0 os=CNL target=nocona")
+        cnl_compiler = compiler_factory(
+            spec="gcc@4.5.0 os=CNL languages:=c,c++,fortran target=nocona"
+        )
         with spack.config.override("packages", {"gcc": {"externals": [cnl_compiler]}}):
             spec_str = "mpileaks os=CNL target=nocona %gcc@4.5.0 ^dyninst os=CNL ^callpath os=CNL"
             spec = spack.concretize.concretize_one(spec_str)
             for s in spec.traverse(root=False, deptype=("link", "run")):
+                if s.external:
+                    continue
                 assert s.architecture.target == spec.architecture.target
 
     def test_compiler_flags_from_user_are_grouped(self):
@@ -1602,7 +1606,7 @@ class TestConcretize:
         [
             ("sticky-variant@1.0+allow-gcc", True),
             ("sticky-variant@1.0~allow-gcc", False),
-            ("sticky-variant@1.0", False),
+            # FIXME (externals as concrete) ("sticky-variant@1.0", False),
         ],
     )
     def test_sticky_variant_in_external(self, spec, allow_gcc):
@@ -1874,17 +1878,22 @@ class TestConcretize:
                 solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
 
     @pytest.mark.regression("31148")
-    def test_version_weight_and_provenance(self):
+    def test_version_weight_and_provenance(self, mutable_config):
         """Test package preferences during concretization."""
         reusable_specs = [
             spack.concretize.concretize_one(spec_str) for spec_str in ("pkg-b@0.9", "pkg-b@1.0")
         ]
         root_spec = Spec("pkg-a foobar=bar")
 
+        external_specs = SpecFilter.from_packages_yaml(
+            mutable_config, include=[], exclude=[]
+        ).selected_specs()
         with spack.config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver()
             setup = spack.solver.asp.SpackSolverSetup()
-            result, _, _ = solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
+            result, _, _ = solver.driver.solve(
+                setup, [root_spec], reuse=reusable_specs + external_specs
+            )
             # Version badness should be > 0 only for reused specs. For instance, for pkg-b
             # the version provenance is:
             #
@@ -2163,23 +2172,6 @@ class TestConcretize:
         for s in spec.traverse(deptype=("link", "run")):
             assert s.satisfies(f"target={required_target}")
 
-    def test_external_python_extensions_have_dependency(self):
-        """Test that python extensions have access to a python dependency
-
-        when python is otherwise in the DAG"""
-        external_conf = {
-            "py-extension1": {
-                "buildable": False,
-                "externals": [{"spec": "py-extension1@2.0", "prefix": "/fake"}],
-            }
-        }
-        spack.config.set("packages", external_conf)
-
-        spec = spack.concretize.concretize_one("py-extension2")
-
-        assert "python" in spec["py-extension1"]
-        assert spec["python"] == spec["py-extension1"]["python"]
-
     target = spack.platforms.test.Test.default
 
     @pytest.mark.parametrize(
@@ -2191,6 +2183,7 @@ class TestConcretize:
             "python@configured target=%s" % target,
         ],
     )
+    @pytest.mark.xfail(reason="FIXME: (externals as concrete)")
     def test_external_python_extension_find_dependency_from_config(self, python_spec):
         fake_path = os.path.sep + "fake"
 
@@ -2211,41 +2204,7 @@ class TestConcretize:
         # namespace and an external prefix before marking concrete
         assert spec["python"].satisfies(python_spec)
 
-    def test_external_python_extension_find_dependency_from_installed(self, monkeypatch):
-        fake_path = os.path.sep + "fake"
-
-        external_conf = {
-            "py-extension1": {
-                "buildable": False,
-                "externals": [{"spec": "py-extension1@2.0", "prefix": fake_path}],
-            },
-            "python": {
-                "buildable": False,
-                "externals": [{"spec": "python@installed", "prefix": fake_path}],
-            },
-        }
-        spack.config.set("packages", external_conf)
-
-        # install python external
-        python = spack.concretize.concretize_one("python")
-
-        def query(*args, **kwargs):
-            return [python]
-
-        monkeypatch.setattr(spack.store.STORE.db, "query", query)
-
-        # ensure that we can't be faking this by getting it from config
-        external_conf.pop("python")
-        spack.config.set("packages", external_conf)
-
-        spec = spack.concretize.concretize_one("py-extension1")
-
-        assert "python" in spec["py-extension1"]
-        assert spec["python"].prefix == fake_path
-        # The spec is not equal to Spec("python@configured") because it gets a
-        # namespace and an external prefix before marking concrete
-        assert spec["python"].satisfies(python)
-
+    @pytest.mark.xfail(reason="FIXME: (externals as concrete)")
     def test_external_python_extension_find_dependency_from_detection(self, monkeypatch):
         """Test that python extensions have access to a python dependency
 
@@ -2274,6 +2233,7 @@ class TestConcretize:
         assert spec["python"].external
         assert spec["python"].satisfies(python_spec)
 
+    @pytest.mark.xfail(reason="FIXME: (externals as concrete)")
     def test_external_python_extension_find_unified_python(self):
         """Test that python extensions use the same python as other specs in unified env"""
         external_conf = {
@@ -2297,15 +2257,17 @@ class TestConcretize:
             ["v1-consumer ^conditional-provider@1:1 +disable-v1"],
         ],
     )
-    def test_result_specs_is_not_empty(self, specs):
+    def test_result_specs_is_not_empty(self, mutable_config, specs):
         """Check that the implementation of "result.specs" is correct in cases where we
         know a concretization exists.
         """
         specs = [Spec(s) for s in specs]
+        external_specs = SpecFilter.from_packages_yaml(
+            mutable_config, include=[], exclude=[]
+        ).selected_specs()
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
-        result, _, _ = solver.driver.solve(setup, specs, reuse=[])
-
+        result, _, _ = solver.driver.solve(setup, specs, reuse=external_specs)
         assert result.specs
 
     @pytest.mark.regression("38664")
@@ -2573,7 +2535,8 @@ class TestConcretize:
 
         # Exclude dyninst from reuse, so we expect that the old version is not taken into account
         with spack.config.override(
-            "concretizer:reuse", {"from": [{"type": "buildcache", "exclude": ["dyninst"]}]}
+            "concretizer:reuse",
+            {"from": [{"type": "buildcache", "exclude": ["dyninst"]}, {"type": "external"}]},
         ):
             result = spack.concretize.concretize_one(request_str)
 
@@ -3127,14 +3090,16 @@ def test_concretization_version_order():
             {"roots": True, "include": ["^mpich"]},
             ["^mpich"],
             ["^mpich2", "^zmpi"],
-            2,
+            # Reused from store + externals
+            2 + 15,
         ),
         (
             ["mpileaks"],
             {"roots": True, "include": ["externaltest"]},
             ["externaltest"],
             ["^mpich", "^mpich2", "^zmpi"],
-            1,
+            # Reused from store + externals
+            1 + 15,
         ),
     ],
 )
@@ -3152,16 +3117,27 @@ def test_filtering_reused_specs(
     assert len(specs) == expected_length
 
     for constraint in expected:
-        assert all(x.satisfies(constraint) for x in specs)
+        assert all(x.satisfies(constraint) for x in specs if not x.external)
 
     for constraint in not_expected:
-        assert all(not x.satisfies(constraint) for x in specs)
+        assert all(not x.satisfies(constraint) for x in specs if not x.external)
 
 
 @pytest.mark.usefixtures("mutable_database", "mock_store")
 @pytest.mark.parametrize(
     "reuse_yaml,expected_length",
-    [({"from": [{"type": "local"}]}, 19), ({"from": [{"type": "buildcache"}]}, 0)],
+    [
+        (
+            {"from": [{"type": "local"}]},
+            # Local store + externals
+            19 + 15,
+        ),
+        (
+            {"from": [{"type": "buildcache"}]},
+            # Local store + externals
+            0 + 15,
+        ),
+    ],
 )
 @pytest.mark.not_on_windows("Expected length is different on Windows")
 def test_selecting_reused_sources(
@@ -3190,7 +3166,7 @@ def test_selecting_reused_sources(
 def test_spec_filters(specs, include, exclude, expected):
     specs = [Spec(x) for x in specs]
     expected = [Spec(x) for x in expected]
-    f = spack.solver.asp.SpecFilter(
+    f = spack.solver.reuse.SpecFilter(
         factory=lambda: specs, is_usable=lambda x: True, include=include, exclude=exclude
     )
     assert f.selected_specs() == expected
@@ -3420,16 +3396,17 @@ def test_compiler_can_depend_on_themselves_to_build(
 def test_compiler_attribute_is_tolerated_in_externals(
     mutable_config, mock_packages, tmp_path: pathlib.Path
 ):
-    """Tests that we don't error out if an external specifies a compiler, even though externals
-    don't have dependencies.
+    """Tests that we don't error out if an external specifies a compiler in the old way,
+    provided that a suitable external compiler exists.
     """
     packages_yaml = syaml.load_config(
         f"""
 packages:
   cmake:
     externals:
-    - spec: "cmake@3.27.4 %gcc@14.1.0"
+    - spec: "cmake@3.27.4 %gcc@10"
       prefix: {tmp_path}
+    buildable: false
 """
     )
     mutable_config.set("packages", packages_yaml["packages"])
@@ -3588,9 +3565,10 @@ def test_input_analysis_and_conditional_requirements(default_mock_concretization
 @pytest.mark.parametrize(
     "compiler_str,expected,not_expected",
     [
-        # Compiler queries are as specific as the constraint on the external
+        # Compilers are matched to some other external, so the compiler that picked is concrete
         ("gcc@10", ["%gcc", "%gcc@10"], ["%clang", "%gcc@9"]),
-        ("gcc", ["%gcc"], ["%clang", "%gcc@9", "%gcc@10"]),
+        ("gcc@9", ["%gcc", "%gcc@9"], ["%clang", "%gcc@10"]),
+        ("clang", ["%clang", "%llvm+clang"], ["%gcc", "%gcc@9", "%gcc@10"]),
     ],
 )
 @pytest.mark.regression("49841")
@@ -3805,7 +3783,7 @@ def test_spec_parts_on_fresh_compilers(
       llvm::
         buildable: false
         externals:
-        - spec: "llvm+clang@20 {constraint_in_yaml}"
+        - spec: "llvm@20 +clang {constraint_in_yaml}"
           prefix: {tmp_path / 'llvm-20'}
     """
     )
@@ -4089,11 +4067,12 @@ packages:
 @pytest.mark.parametrize(
     "external_compiler,spec_str,expected_raising",
     [
-        # Overspecify the compiler in the input spec. This should raise, because we
-        # don't know if we can satisfy the constraint
+        # Underspecify the compiler. This will select the best option, which is gcc@10
         ("gcc", "mpich %gcc@9", True),
-        pytest.param("gcc@9", "mpich %gcc@9.4", True, marks=pytest.mark.xfail),
+        # Specify gcc@10 directly. This will raise too
+        ("gcc@10", "mpich %gcc@9", True),
         # This is ok
+        ("gcc@9", "mpich %gcc@9.4", False),
         ("gcc@9.4.0", "mpich %gcc@9", False),
     ],
 )
@@ -4126,9 +4105,7 @@ packages:
     mutable_config.set("packages", packages_yaml["packages"])
 
     if expected_raising:
-        with pytest.raises(
-            spack.solver.asp.UnsatisfiableSpecError, match="Omit version requirement"
-        ):
+        with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="Cannot build mpich"):
             _ = spack.concretize.concretize_one(spec_str)
     else:
         s = spack.concretize.concretize_one(spec_str)

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -21,16 +21,8 @@ version_error_messages = [
 ]
 
 external_error_messages = [
-    (
-        "Attempted to build package quantum-espresso which is not buildable and does not have"
-        " a satisfying external"
-    ),
-    (
-        "        'quantum-espresso~veritas' is an external constraint for quantum-espresso"
-        " which was not satisfied"
-    ),
-    "        'quantum-espresso+veritas' required",
-    "        required because quantum-espresso+veritas requested explicitly",
+    "Cannot build quantum-espresso, since it's marked non-buildable and "
+    "no externals satisfy the requests"
 ]
 
 variant_error_messages = [
@@ -64,7 +56,7 @@ def test_error_messages(error_messages, config_set, spec, mock_packages, mutable
         _ = spack.concretize.concretize_one(spec)
 
     for em in error_messages:
-        assert em in str(e.value)
+        assert em in str(e.value), str(e.value)
 
 
 def test_internal_error_handling_formatting(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -21,8 +21,8 @@ version_error_messages = [
 ]
 
 external_error_messages = [
-    "Cannot build quantum-espresso, since it's marked non-buildable and "
-    "no externals satisfy the requests"
+    "Cannot build quantum-espresso, since it is configured `buildable:false` and "
+    "no externals satisfy the request"
 ]
 
 variant_error_messages = [

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -78,7 +78,7 @@ def _compiler_cfg_one_entry_with_cflags(cflags):
 packages:
   gcc:
     externals:
-    - spec: gcc@12.100.100
+    - spec: gcc@12.100.100 languages:=c,c++
       prefix: /fake
       extra_attributes:
         compilers:

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1394,7 +1394,7 @@ packages:
   mpich:
     buildable: false
     externals:
-    - spec: "mpich@4.3.0 %gcc"
+    - spec: "mpich@4.3.0 %gcc@10"
       prefix: {tmp_path / "gcc"}
     - spec: "mpich@4.3.0 %clang"
       prefix: {tmp_path / "clang"}

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -19,6 +19,7 @@ import spack.util.spack_yaml as syaml
 import spack.version
 from spack.installer import PackageInstaller
 from spack.solver.asp import InternalConcretizerError, UnsatisfiableSpecError
+from spack.solver.reuse import SpecFilter
 from spack.spec import Spec
 from spack.util.url import path_to_file_url
 
@@ -1302,7 +1303,12 @@ packages:
 )
 @pytest.mark.regression("49847")
 def test_requirements_on_compilers_and_reuse(
-    concretize_scope, mock_packages, packages_yaml, expected_reuse, expected_contraints
+    concretize_scope,
+    mock_packages,
+    mutable_config,
+    packages_yaml,
+    expected_reuse,
+    expected_contraints,
 ):
     """Tests that we can require compilers with `%` in configuration files, and still get reuse
     of specs (even though reused specs have no build dependency in the ASP encoding).
@@ -1313,11 +1319,14 @@ def test_requirements_on_compilers_and_reuse(
     reused_nodes = list(reused_spec.traverse())
     update_packages_config(packages_yaml)
     root_specs = [Spec(input_spec)]
+    external_specs = SpecFilter.from_packages_yaml(
+        mutable_config, include=[], exclude=[]
+    ).selected_specs()
 
     with spack.config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
-        result, _, _ = solver.driver.solve(setup, root_specs, reuse=reused_nodes)
+        result, _, _ = solver.driver.solve(setup, root_specs, reuse=reused_nodes + external_specs)
         pkga = result.specs[0]
     is_pkgb_reused = pkga["pkg-b"].dag_hash() == reused_spec.dag_hash()
 

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -11,6 +11,7 @@ import spack.error
 import spack.installer
 import spack.package_base
 import spack.paths
+import spack.platforms
 import spack.repo
 import spack.solver.asp
 import spack.spec
@@ -1522,3 +1523,29 @@ packages:
     for node in mpileaks.traverse():
         assert node.satisfies(f"%[when=%c]c={current_preference}")
         assert node.satisfies(f"%[when=%cxx]cxx={current_preference}")
+
+
+def test_external_spec_completion_with_targets_required(
+    concretize_scope, mock_packages, tmp_path: pathlib.Path
+):
+    """Tests that we can concretize a spec needing externals, when we require a specific target,
+    without extra configuration.
+    """
+    current_platform = spack.platforms.host()
+    packages_yaml = f"""
+    packages:
+      all:
+        require:
+        - target={current_platform.default}
+      mpich:
+        buildable: false
+        externals:
+        - spec: "mpich@4.3.0"
+          prefix: {tmp_path / "mpich"}
+    """
+    update_packages_config(packages_yaml)
+
+    s = spack.spec.Spec("mpileaks")
+    concrete = spack.concretize.concretize_one(s)
+
+    assert concrete.satisfies(f"target={current_platform.default}")

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1475,7 +1475,12 @@ packages:
 )
 @pytest.mark.parametrize("constraint_kind", ["require", "prefer"])
 def test_language_preferences_and_reuse(
-    initial_preference, current_preference, constraint_kind, concretize_scope, mock_packages
+    initial_preference,
+    current_preference,
+    constraint_kind,
+    concretize_scope,
+    mutable_config,
+    mock_packages,
 ):
     """Tests that language preferences are respected when reusing specs."""
 
@@ -1488,16 +1493,29 @@ packages:
   cxx:
     {constraint_kind}:
     - {initial_preference}
+  llvm:
+    externals:
+    - spec: "llvm@15.0.0 +clang~flang ~lld"
+      prefix: /path1
+      extra_attributes:
+        compilers:
+          c: /path1/bin/clang
+          cxx: /path1/bin/clang++
 """
     update_packages_config(packages_yaml)
     initial_mpileaks = spack.concretize.concretize_one("mpileaks+debug")
     reused_nodes = list(initial_mpileaks.traverse())
+    external_specs = SpecFilter.from_packages_yaml(
+        mutable_config, include=[], exclude=[]
+    ).selected_specs()
 
     # Ask for just "mpileaks" and check the spec is reused
     with spack.config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
-        result, _, _ = solver.driver.solve(setup, [Spec("mpileaks")], reuse=reused_nodes)
+        result, _, _ = solver.driver.solve(
+            setup, [Spec("mpileaks")], reuse=reused_nodes + external_specs
+        )
         reused_mpileaks = result.specs[0]
 
     assert reused_mpileaks.dag_hash() == initial_mpileaks.dag_hash()
@@ -1511,12 +1529,22 @@ packages:
   cxx:
     {constraint_kind}:
     - {current_preference}
+  llvm:
+    externals:
+    - spec: "llvm@15.0.0 +clang~flang ~lld"
+      prefix: /path1
+      extra_attributes:
+        compilers:
+          c: /path1/bin/clang
+          cxx: /path1/bin/clang++
 """
     update_packages_config(packages_yaml)
     with spack.config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
-        result, _, _ = solver.driver.solve(setup, [Spec("mpileaks")], reuse=reused_nodes)
+        result, _, _ = solver.driver.solve(
+            setup, [Spec("mpileaks")], reuse=reused_nodes + external_specs
+        )
         mpileaks = result.specs[0]
 
     assert initial_mpileaks.dag_hash() != mpileaks.dag_hash()

--- a/lib/spack/spack/test/concretization/splicing.py
+++ b/lib/spack/spack/test/concretization/splicing.py
@@ -159,7 +159,7 @@ def test_virtual_multi_splices_in(original_spec, goal_spec, install_specs, mutab
     original = install_specs(original_spec)[0]
     mutable_config.set("packages", _make_specs_non_buildable(["depends-on-virtual-with-abi"]))
 
-    with pytest.raises(SolverError):
+    with pytest.raises(UnsatisfiableSpecError):
         spack.concretize.concretize_one(goal_spec)
 
     _enable_splicing()

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -34,6 +34,7 @@ import spack.util.path as spack_path
 import spack.util.spack_yaml as syaml
 from spack.enums import ConfigScopePriority
 from spack.llnl.util.filesystem import join_path, touch
+from spack.util.spack_yaml import DictWithLineInfo
 
 # sample config data
 config_low = {
@@ -1410,11 +1411,11 @@ def test_deepcopy_as_builtin(env_yaml):
     )
     config_copy = cfg.deepcopy_as_builtin("config")
     assert config_copy == cfg.get_config("config")
-    assert type(config_copy) is dict
+    assert type(config_copy) is DictWithLineInfo
     assert type(config_copy["verify_ssl"]) is bool
 
     packages_copy = cfg.deepcopy_as_builtin("packages")
-    assert type(packages_copy) is dict
-    assert type(packages_copy["all"]) is dict
+    assert type(packages_copy) is DictWithLineInfo
+    assert type(packages_copy["all"]) is DictWithLineInfo
     assert type(packages_copy["all"]["compiler"]) is list
     assert type(packages_copy["all"]["compiler"][0]) is str

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2238,7 +2238,7 @@ def _true(x):
 
 
 def _libc_from_python(self):
-    return spack.spec.Spec("glibc@=2.28")
+    return spack.spec.Spec("glibc@=2.28", external_path="/some/path")
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -60,19 +60,19 @@ packages:
   # Compilers
   gcc:
     externals:
-      - spec: "gcc@9.4.0 languages='c,c++' os={linux_os.name}{linux_os.version} target={target}"
+      - spec: "gcc@9.4.0 languages='c,c++' os={linux_os.name}{linux_os.version}"
         prefix: /path
         extra_attributes:
           compilers:
             c: /path/bin/gcc
             cxx: /path/bin/g++
-      - spec: "gcc@9.4.0 languages='c,c++' os=redhat6 target={target}"
+      - spec: "gcc@9.4.0 languages='c,c++' os=redhat6"
         prefix: /path
         extra_attributes:
           compilers:
             c: /path/bin/gcc
             cxx: /path/bin/g++
-      - spec: "gcc@10.2.1 languages='c,c++,fortran' os={linux_os.name}{linux_os.version} target={target}"
+      - spec: "gcc@10.2.1 languages='c,c++,fortran' os={linux_os.name}{linux_os.version}"
         prefix: /path
         extra_attributes:
           compilers:
@@ -81,7 +81,7 @@ packages:
             fortran: /path/bin/gfortran-10
   llvm:
     externals:
-      - spec: "llvm@15.0.0 +clang~flang os={linux_os.name}{linux_os.version} target={target}"
+      - spec: "llvm@15.0.0 +clang~flang os={linux_os.name}{linux_os.version}"
         prefix: /path
         extra_attributes:
           compilers:

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -66,7 +66,7 @@ packages:
           compilers:
             c: /path/bin/gcc
             cxx: /path/bin/g++
-      - spec: "gcc@9.4.0 languages='c,c++' os=redhat6"
+      - spec: "gcc@9.4.1 languages='c,c++' os=redhat6"
         prefix: /path
         extra_attributes:
           compilers:

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -184,6 +184,32 @@ def test_externals_with_duplicate_id():
                 "adios2": ["%[deptypes=build,link] bzip2@1.0.8"],
             },
         ),
+        # Old type specification for
+        # o mpileaks@2.2
+        # o gcc@15.0.1
+        (
+            [
+                [
+                    {"spec": "mpileaks@2.2 %gcc", "prefix": "/user/path"},
+                    {"spec": "gcc@14.2.1 languages=c,c++", "prefix": "/user/path"},
+                    {"spec": "gcc@15.0.1 languages=c,c++", "prefix": "/user/path"},
+                ],
+                {"mpileaks": ["%[deptypes=build] gcc@15"]},
+            ]
+        ),
+        # Old type specification for
+        # o mpileaks@2.2
+        # o gcc@14.2.1 <- selected because of the architecture of gcc@15
+        (
+            [
+                [
+                    {"spec": "mpileaks@2.2 %gcc", "prefix": "/user/path"},
+                    {"spec": "gcc@14.2.1 languages=c,c++", "prefix": "/user/path"},
+                    {"spec": "gcc@15.0.1 os=CNL languages=c,c++", "prefix": "/user/path"},
+                ],
+                {"mpileaks": ["%[deptypes=build] gcc@14"]},
+            ]
+        ),
     ],
 )
 def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expected_satisfies):

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -190,6 +190,29 @@ def test_externals_with_duplicate_id():
                 "adios2": ["%[deptypes=build,link] bzip2@1.0.8"],
             },
         ),
+        # Same, but specifying dependencies by spec: instead of id:
+        (
+            [
+                {
+                    "spec": "ascent@0.9.2+adios2+shared",
+                    "prefix": "/user/path",
+                    "dependencies": [
+                        {"spec": "adios2", "deptypes": "link"},
+                        {"spec": "bzip2", "deptypes": "run"},
+                    ],
+                },
+                {
+                    "spec": "adios2@2.7.1+shared",
+                    "prefix": "/user/path",
+                    "dependencies": [{"spec": "bzip2", "deptypes": ["build", "link"]}],
+                },
+                {"spec": "bzip2@1.0.8+shared", "prefix": "/user/path"},
+            ],
+            {
+                "ascent": ["%[deptypes=link] adios2@2.7.1", "%[deptypes=run] bzip2@1.0.8"],
+                "adios2": ["%[deptypes=build,link] bzip2@1.0.8"],
+            },
+        ),
         # Old type specification for
         # o mpileaks@2.2
         # o gcc@15.0.1

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -9,7 +9,7 @@ from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
 import spack.repo
-from spack.externals import ExternalDict, ExternalSpecsParser
+from spack.externals import ExternalDict, ExternalSpecsParser, DuplicateExternalError
 
 pytestmark = pytest.mark.usefixtures("config", "mock_packages")
 
@@ -55,6 +55,7 @@ def test_basic_parsing(externals_dict, expected_length, expected_queries):
     parser = ExternalSpecsParser(externals_dict)
 
     assert len(parser.all_specs()) == expected_length
+    assert len(parser.specs_by_external_id) == expected_length
     for node in parser.all_specs():
         assert node.concrete
 
@@ -99,3 +100,15 @@ def test_external_specs_parser_with_missing_packages():
 
     with pytest.raises(spack.repo.UnknownPackageError, match="Package 'baz' not found"):
         ExternalSpecsParser(externals_dict, allow_nonexisting=False)
+
+
+def test_externals_with_duplicate_id():
+    """Tests the parsing of external specs when some specs have the same id"""
+    externals_dict: List[ExternalDict] = [
+        {"spec": "gmake@1.0", "prefix": "/path/to/gmake1", "external_id": "gmake"},
+        {"spec": "gmake@2.0", "prefix": "/path/to/gmake2", "external_id": "gmake"},
+        {"spec": "gcc@1.0", "prefix": "/path/to/gcc", "external_id": "gcc"},
+    ]
+
+    with pytest.raises(DuplicateExternalError, match=" Fix your packages.yaml configuration"):
+        ExternalSpecsParser(externals_dict)

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -213,17 +213,20 @@ def test_externals_with_duplicate_id():
                 "adios2": ["%[deptypes=build,link] bzip2@1.0.8"],
             },
         ),
-        # Old type specification for
+        # Inline specification for
         # o mpileaks@2.2
+        # | \
+        # |  o callpath@1.0
+        # | /
         # o gcc@15.0.1
         (
             [
                 [
-                    {"spec": "mpileaks@2.2 %gcc@15", "prefix": "/user/path"},
-                    {"spec": "gcc@14.2.1 languages=c,c++", "prefix": "/user/path"},
+                    {"spec": "mpileaks@2.2 %gcc %callpath", "prefix": "/user/path"},
+                    {"spec": "callpath@1.0", "prefix": "/user/path"},
                     {"spec": "gcc@15.0.1 languages=c,c++", "prefix": "/user/path"},
                 ],
-                {"mpileaks": ["%[deptypes=build] gcc@15"]},
+                {"mpileaks": ["%[deptypes=build] gcc@15", "%[deptypes=build,link] callpath@1.0"]},
             ]
         ),
     ],

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -9,7 +9,13 @@ from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
 import spack.repo
-from spack.externals import DuplicateExternalError, ExternalDict, ExternalSpecsParser
+from spack.externals import (
+    DuplicateExternalError,
+    ExternalDict,
+    ExternalSpecsParser,
+    complete_architecture,
+    complete_variants_and_architecture,
+)
 
 pytestmark = pytest.mark.usefixtures("config", "mock_packages")
 
@@ -248,3 +254,39 @@ def test_externals_without_concrete_version(
     assert len(result) == expected_length
     for c in not_expected:
         assert all(not s.satisfies(c) for s in result)
+
+
+@pytest.mark.parametrize(
+    "externals_dict,completion_fn,expected,not_expected",
+    [
+        (
+            [{"spec": "mpileaks@2.3", "prefix": "/user/path"}],
+            complete_architecture,
+            {"mpileaks": ["platform=test"]},
+            {"mpileaks": ["debug=*", "opt=*", "shared=*", "static=*"]},
+        ),
+        (
+            [{"spec": "mpileaks@2.3", "prefix": "/user/path"}],
+            complete_variants_and_architecture,
+            {"mpileaks": ["platform=test", "~debug", "~opt", "+shared", "+static"]},
+            {"mpileaks": ["+debug", "+opt", "~shared", "~static"]},
+        ),
+    ],
+)
+def test_external_node_completion(
+    externals_dict: List[ExternalDict], completion_fn, expected, not_expected
+):
+    """Tests the completion of external specs with different node completion"""
+    parser = ExternalSpecsParser(externals_dict, complete_node=completion_fn)
+
+    for query_spec, expected_list in expected.items():
+        result = parser.query(query_spec)
+        assert len(result) == 1
+        for expected in expected_list:
+            assert result[0].satisfies(expected)
+
+    for query_spec, expected_list in not_expected.items():
+        result = parser.query(query_spec)
+        assert len(result) == 1
+        for expected in expected_list:
+            assert not result[0].satisfies(expected)

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -8,10 +8,10 @@ import pytest
 from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
-import spack.repo
 from spack.externals import (
     DuplicateExternalError,
     ExternalDict,
+    ExternalSpecError,
     ExternalSpecsParser,
     complete_architecture,
     complete_variants_and_architecture,
@@ -118,7 +118,7 @@ def test_external_specs_parser_with_missing_packages():
     assert len([x for x in external_specs if x.satisfies("gmake")]) == 2
     assert len([x for x in external_specs if x.satisfies("gcc")]) == 1
 
-    with pytest.raises(spack.repo.UnknownPackageError, match="Package 'baz' not found"):
+    with pytest.raises(ExternalSpecError, match="Package 'baz' does not exist"):
         ExternalSpecsParser(externals_dict, allow_nonexisting=False)
 
 
@@ -130,7 +130,7 @@ def test_externals_with_duplicate_id():
         {"spec": "gcc@1.0", "prefix": "/path/to/gcc", "id": "gcc"},
     ]
 
-    with pytest.raises(DuplicateExternalError, match=" Fix your packages.yaml configuration"):
+    with pytest.raises(DuplicateExternalError, match="cannot have the same external id"):
         ExternalSpecsParser(externals_dict)
 
 

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -8,6 +8,7 @@ import pytest
 from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
+import spack.repo
 from spack.externals import ExternalDict, ExternalSpecsParser
 
 pytestmark = pytest.mark.usefixtures("config", "mock_packages")
@@ -79,3 +80,22 @@ def test_external_specs_architecture_completion(
         assert node.architecture.platform == expected_platform
         assert node.architecture.os == expected_os
         assert node.target == expected_target
+
+
+def test_external_specs_parser_with_missing_packages():
+    """Tests the parsing of external specs when some packages are missing"""
+    externals_dict: List[ExternalDict] = [
+        {"spec": "gmake@1.0", "prefix": "/path/to/gmake1"},
+        {"spec": "gmake@2.0", "prefix": "/path/to/gmake2"},
+        {"spec": "gcc@1.0", "prefix": "/path/to/gcc"},
+        # This package does not exist in the builtin_mock repository
+        {"spec": "baz@1.0", "prefix": "/path/to/baz"},
+    ]
+
+    external_specs = ExternalSpecsParser(externals_dict, allow_nonexisting=True).all_specs()
+    assert len(external_specs) == 3
+    assert len([x for x in external_specs if x.satisfies("gmake")]) == 2
+    assert len([x for x in external_specs if x.satisfies("gcc")]) == 1
+
+    with pytest.raises(spack.repo.UnknownPackageError, match="Package 'baz' not found"):
+        ExternalSpecsParser(externals_dict, allow_nonexisting=False)

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -221,3 +221,30 @@ def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expect
         assert len(result) == 1
         for expected in expected_list:
             assert result[0].satisfies(expected)
+
+
+@pytest.mark.parametrize(
+    "externals_dicts,expected_length,not_expected",
+    [
+        (
+            [{"spec": "mpileaks", "prefix": "/user/path", "external_id": "mpileaks"}],
+            0,
+            ["mpileaks"],
+        ),
+        (
+            [{"spec": "mpileaks@2:", "prefix": "/user/path", "external_id": "mpileaks"}],
+            0,
+            ["mpileaks"],
+        ),
+    ],
+)
+def test_externals_without_concrete_version(
+    externals_dicts: List[ExternalDict], expected_length, not_expected
+):
+    """Tests parsing externals, when some dicts are malformed and don't have a concrete version"""
+    parser = ExternalSpecsParser(externals_dicts)
+    result = parser.all_specs()
+
+    assert len(result) == expected_length
+    for c in not_expected:
+        assert all(not s.satisfies(c) for s in result)

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -135,7 +135,7 @@ def test_externals_with_duplicate_id():
 
 
 @pytest.mark.parametrize(
-    "externals_dicts,expected_satisfies",
+    "externals_dicts,expected,not_expected",
     [
         # o ascent@0.9.2
         # o adios2@2.7.1
@@ -160,6 +160,7 @@ def test_externals_with_duplicate_id():
                 "ascent": ["%[deptypes=build,link] adios2@2.7.1"],
                 "adios2": ["%[deptypes=build,link] bzip2@1.0.8"],
             },
+            {},
         ),
         # o ascent@0.9.2
         # |\
@@ -189,6 +190,14 @@ def test_externals_with_duplicate_id():
                 "ascent": ["%[deptypes=link] adios2@2.7.1", "%[deptypes=run] bzip2@1.0.8"],
                 "adios2": ["%[deptypes=build,link] bzip2@1.0.8"],
             },
+            {
+                "ascent": [
+                    "%[deptypes=build] adios2@2.7.1",
+                    "%[deptypes=run] adios2@2.7.1",
+                    "%[deptypes=build] bzip2@1.0.8",
+                    "%[deptypes=link] bzip2@1.0.8",
+                ]
+            },
         ),
         # Same, but specifying dependencies by spec: instead of id:
         (
@@ -212,6 +221,14 @@ def test_externals_with_duplicate_id():
                 "ascent": ["%[deptypes=link] adios2@2.7.1", "%[deptypes=run] bzip2@1.0.8"],
                 "adios2": ["%[deptypes=build,link] bzip2@1.0.8"],
             },
+            {
+                "ascent": [
+                    "%[deptypes=build] adios2@2.7.1",
+                    "%[deptypes=run] adios2@2.7.1",
+                    "%[deptypes=build] bzip2@1.0.8",
+                    "%[deptypes=link] bzip2@1.0.8",
+                ]
+            },
         ),
         # Inline specification for
         # o mpileaks@2.2
@@ -227,19 +244,38 @@ def test_externals_with_duplicate_id():
                     {"spec": "gcc@15.0.1 languages=c,c++", "prefix": "/user/path"},
                 ],
                 {"mpileaks": ["%[deptypes=build] gcc@15", "%[deptypes=build,link] callpath@1.0"]},
+                {"mpileaks": ["%[deptypes=link] gcc@15"]},
+            ]
+        ),
+        # CMake dependency should be inferred of `deptypes=build`
+        # o cmake-client
+        # |
+        # o cmake@3.23.1
+        (
+            [
+                [
+                    {"spec": "cmake-client@1.0 %cmake", "prefix": "/user/path"},
+                    {"spec": "cmake@3.23.1", "prefix": "/user/path"},
+                ],
+                {"cmake-client": ["%[deptypes=build] cmake"]},
+                {"cmake-client": ["%[deptypes=link] cmake", "%[deptypes=run] cmake"]},
             ]
         ),
     ],
 )
-def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expected_satisfies):
+def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expected, not_expected):
     """Tests constructing externals with dependencies"""
     parser = ExternalSpecsParser(externals_dicts)
 
-    for query_spec, expected_list in expected_satisfies.items():
+    for query_spec, expected_list in expected.items():
         result = parser.query(query_spec)
         assert len(result) == 1
-        for expected in expected_list:
-            assert result[0].satisfies(expected)
+        assert all(result[0].satisfies(c) for c in expected_list)
+
+    for query_spec, not_expected_list in not_expected.items():
+        result = parser.query(query_spec)
+        assert len(result) == 1
+        assert all(not result[0].satisfies(c) for c in not_expected_list)
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -65,7 +65,21 @@ def test_basic_parsing(externals_dict, expected_length, expected_queries):
 
 @pytest.mark.parametrize(
     "externals_dict,expected_triplet",
-    [([{"spec": "gmake@1.0", "prefix": "/path/to/gmake1"}], ("test", "debian6", "aarch64"))],
+    [
+        ([{"spec": "gmake@1.0", "prefix": "/path/to/gmake1"}], ("test", "debian6", "aarch64")),
+        (
+            [{"spec": "gmake@1.0 target=icelake", "prefix": "/path/to/gmake1"}],
+            ("test", "debian6", "icelake"),
+        ),
+        (
+            [{"spec": "gmake@1.0 platform=linux target=icelake", "prefix": "/path/to/gmake1"}],
+            ("linux", "debian6", "icelake"),
+        ),
+        (
+            [{"spec": "gmake@1.0 os=rhel8", "prefix": "/path/to/gmake1"}],
+            ("test", "rhel8", "aarch64"),
+        ),
+    ],
 )
 def test_external_specs_architecture_completion(
     externals_dict: List[ExternalDict], expected_triplet, monkeypatch

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -219,24 +219,11 @@ def test_externals_with_duplicate_id():
         (
             [
                 [
-                    {"spec": "mpileaks@2.2 %gcc", "prefix": "/user/path"},
+                    {"spec": "mpileaks@2.2 %gcc@15", "prefix": "/user/path"},
                     {"spec": "gcc@14.2.1 languages=c,c++", "prefix": "/user/path"},
                     {"spec": "gcc@15.0.1 languages=c,c++", "prefix": "/user/path"},
                 ],
                 {"mpileaks": ["%[deptypes=build] gcc@15"]},
-            ]
-        ),
-        # Old type specification for
-        # o mpileaks@2.2
-        # o gcc@14.2.1 <- selected because of the architecture of gcc@15
-        (
-            [
-                [
-                    {"spec": "mpileaks@2.2 %gcc", "prefix": "/user/path"},
-                    {"spec": "gcc@14.2.1 languages=c,c++", "prefix": "/user/path"},
-                    {"spec": "gcc@15.0.1 os=CNL languages=c,c++", "prefix": "/user/path"},
-                ],
-                {"mpileaks": ["%[deptypes=build] gcc@14"]},
             ]
         ),
     ],

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -9,7 +9,7 @@ from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
 import spack.repo
-from spack.externals import ExternalDict, ExternalSpecsParser, DuplicateExternalError
+from spack.externals import DuplicateExternalError, ExternalDict, ExternalSpecsParser
 
 pytestmark = pytest.mark.usefixtures("config", "mock_packages")
 
@@ -112,3 +112,72 @@ def test_externals_with_duplicate_id():
 
     with pytest.raises(DuplicateExternalError, match=" Fix your packages.yaml configuration"):
         ExternalSpecsParser(externals_dict)
+
+
+@pytest.mark.parametrize(
+    "externals_dicts,expected_satisfies",
+    [
+        # o ascent@0.9.2
+        # o adios2@2.7.1
+        # o bzip2@1.0.8
+        (
+            [
+                {
+                    "spec": "ascent@0.9.2+adios2+shared",
+                    "prefix": "/user/path",
+                    "external_id": "ascent",
+                    "dependencies": [{"external_id": "adios2", "deptypes": ["build", "link"]}],
+                },
+                {
+                    "spec": "adios2@2.7.1+shared",
+                    "prefix": "/user/path",
+                    "external_id": "adios2",
+                    "dependencies": [{"external_id": "bzip2", "deptypes": ["build", "link"]}],
+                },
+                {"spec": "bzip2@1.0.8+shared", "prefix": "/user/path", "external_id": "bzip2"},
+            ],
+            {
+                "ascent": ["%[deptypes=build,link] adios2@2.7.1"],
+                "adios2": ["%[deptypes=build,link] bzip2@1.0.8"],
+            },
+        ),
+        # o ascent@0.9.2
+        # |\
+        # | o adios2@2.7.1
+        # |/
+        # o bzip2@1.0.8
+        (
+            [
+                {
+                    "spec": "ascent@0.9.2+adios2+shared",
+                    "prefix": "/user/path",
+                    "external_id": "ascent",
+                    "dependencies": [
+                        {"external_id": "adios2", "deptypes": "link"},
+                        {"external_id": "bzip2", "deptypes": "run"},
+                    ],
+                },
+                {
+                    "spec": "adios2@2.7.1+shared",
+                    "prefix": "/user/path",
+                    "external_id": "adios2",
+                    "dependencies": [{"external_id": "bzip2", "deptypes": ["build", "link"]}],
+                },
+                {"spec": "bzip2@1.0.8+shared", "prefix": "/user/path", "external_id": "bzip2"},
+            ],
+            {
+                "ascent": ["%[deptypes=link] adios2@2.7.1", "%[deptypes=run] bzip2@1.0.8"],
+                "adios2": ["%[deptypes=build,link] bzip2@1.0.8"],
+            },
+        ),
+    ],
+)
+def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expected_satisfies):
+    """Tests constructing externals with dependencies"""
+    parser = ExternalSpecsParser(externals_dicts)
+
+    for query_spec, expected_list in expected_satisfies.items():
+        result = parser.query(query_spec)
+        assert len(result) == 1
+        for expected in expected_list:
+            assert result[0].satisfies(expected)

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -125,9 +125,9 @@ def test_external_specs_parser_with_missing_packages():
 def test_externals_with_duplicate_id():
     """Tests the parsing of external specs when some specs have the same id"""
     externals_dict: List[ExternalDict] = [
-        {"spec": "gmake@1.0", "prefix": "/path/to/gmake1", "external_id": "gmake"},
-        {"spec": "gmake@2.0", "prefix": "/path/to/gmake2", "external_id": "gmake"},
-        {"spec": "gcc@1.0", "prefix": "/path/to/gcc", "external_id": "gcc"},
+        {"spec": "gmake@1.0", "prefix": "/path/to/gmake1", "id": "gmake"},
+        {"spec": "gmake@2.0", "prefix": "/path/to/gmake2", "id": "gmake"},
+        {"spec": "gcc@1.0", "prefix": "/path/to/gcc", "id": "gcc"},
     ]
 
     with pytest.raises(DuplicateExternalError, match=" Fix your packages.yaml configuration"):
@@ -145,16 +145,16 @@ def test_externals_with_duplicate_id():
                 {
                     "spec": "ascent@0.9.2+adios2+shared",
                     "prefix": "/user/path",
-                    "external_id": "ascent",
-                    "dependencies": [{"external_id": "adios2", "deptypes": ["build", "link"]}],
+                    "id": "ascent",
+                    "dependencies": [{"id": "adios2", "deptypes": ["build", "link"]}],
                 },
                 {
                     "spec": "adios2@2.7.1+shared",
                     "prefix": "/user/path",
-                    "external_id": "adios2",
-                    "dependencies": [{"external_id": "bzip2", "deptypes": ["build", "link"]}],
+                    "id": "adios2",
+                    "dependencies": [{"id": "bzip2", "deptypes": ["build", "link"]}],
                 },
-                {"spec": "bzip2@1.0.8+shared", "prefix": "/user/path", "external_id": "bzip2"},
+                {"spec": "bzip2@1.0.8+shared", "prefix": "/user/path", "id": "bzip2"},
             ],
             {
                 "ascent": ["%[deptypes=build,link] adios2@2.7.1"],
@@ -171,19 +171,19 @@ def test_externals_with_duplicate_id():
                 {
                     "spec": "ascent@0.9.2+adios2+shared",
                     "prefix": "/user/path",
-                    "external_id": "ascent",
+                    "id": "ascent",
                     "dependencies": [
-                        {"external_id": "adios2", "deptypes": "link"},
-                        {"external_id": "bzip2", "deptypes": "run"},
+                        {"id": "adios2", "deptypes": "link"},
+                        {"id": "bzip2", "deptypes": "run"},
                     ],
                 },
                 {
                     "spec": "adios2@2.7.1+shared",
                     "prefix": "/user/path",
-                    "external_id": "adios2",
-                    "dependencies": [{"external_id": "bzip2", "deptypes": ["build", "link"]}],
+                    "id": "adios2",
+                    "dependencies": [{"id": "bzip2", "deptypes": ["build", "link"]}],
                 },
-                {"spec": "bzip2@1.0.8+shared", "prefix": "/user/path", "external_id": "bzip2"},
+                {"spec": "bzip2@1.0.8+shared", "prefix": "/user/path", "id": "bzip2"},
             ],
             {
                 "ascent": ["%[deptypes=link] adios2@2.7.1", "%[deptypes=run] bzip2@1.0.8"],
@@ -232,16 +232,8 @@ def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expect
 @pytest.mark.parametrize(
     "externals_dicts,expected_length,not_expected",
     [
-        (
-            [{"spec": "mpileaks", "prefix": "/user/path", "external_id": "mpileaks"}],
-            0,
-            ["mpileaks"],
-        ),
-        (
-            [{"spec": "mpileaks@2:", "prefix": "/user/path", "external_id": "mpileaks"}],
-            0,
-            ["mpileaks"],
-        ),
+        ([{"spec": "mpileaks", "prefix": "/user/path", "id": "mpileaks"}], 0, ["mpileaks"]),
+        ([{"spec": "mpileaks@2:", "prefix": "/user/path", "id": "mpileaks"}], 0, ["mpileaks"]),
     ],
 )
 def test_externals_without_concrete_version(

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -1,0 +1,81 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from typing import List
+
+import pytest
+
+from spack.vendor.archspec.cpu import TARGETS
+
+import spack.archspec
+from spack.externals import ExternalDict, ExternalSpecsParser
+
+pytestmark = pytest.mark.usefixtures("config", "mock_packages")
+
+
+@pytest.mark.parametrize(
+    "externals_dict,expected_length,expected_queries",
+    [
+        # Empty dictionary case
+        ([], 0, {"gmake": 0}),
+        # Single spec case
+        (
+            [{"spec": "gmake@1.0", "prefix": "/path/to/gmake"}],
+            1,
+            {"gmake": 1, "gmake@1.0": 1, "gmake@2.0": 0},
+        ),
+        # Multiple specs case
+        (
+            [
+                {"spec": "gmake@1.0", "prefix": "/path/to/gmake1"},
+                {"spec": "gmake@2.0", "prefix": "/path/to/gmake2"},
+                {"spec": "gcc@1.0", "prefix": "/path/to/gcc"},
+            ],
+            3,
+            {"gmake": 2, "gmake@2": 1, "gcc": 1, "baz": 0},
+        ),
+        # Case with modules and extra attributes
+        (
+            [
+                {
+                    "spec": "gmake@1.0",
+                    "prefix": "/path/to/gmake",
+                    "modules": ["module1", "module2"],
+                    "extra_attributes": {"attr1": "value1"},
+                }
+            ],
+            1,
+            {"gmake": 1},
+        ),
+    ],
+)
+def test_basic_parsing(externals_dict, expected_length, expected_queries):
+    """Tests parsing external specs, in some basic cases"""
+    parser = ExternalSpecsParser(externals_dict)
+
+    assert len(parser.all_specs()) == expected_length
+    for node in parser.all_specs():
+        assert node.concrete
+
+    for query, expected in expected_queries.items():
+        assert len(parser.query(query)) == expected
+
+
+@pytest.mark.parametrize(
+    "externals_dict,expected_triplet",
+    [([{"spec": "gmake@1.0", "prefix": "/path/to/gmake1"}], ("test", "debian6", "aarch64"))],
+)
+def test_external_specs_architecture_completion(
+    externals_dict: List[ExternalDict], expected_triplet, monkeypatch
+):
+    """Tests the completion of external specs architectures when using the default behavior"""
+    monkeypatch.setattr(spack.archspec, "HOST_TARGET_FAMILY", TARGETS["aarch64"])
+    parser = ExternalSpecsParser(externals_dict)
+
+    expected_platform, expected_os, expected_target = expected_triplet
+
+    for node in parser.all_specs():
+        assert node.architecture is not None
+        assert node.architecture.platform == expected_platform
+        assert node.architecture.os == expected_os
+        assert node.target == expected_target

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -113,7 +113,7 @@ class TestLmod:
         self, factory, module_configuration, compiler_factory
     ):
         with spack.config.override(
-            "packages", {"llvm": {"externals": [compiler_factory(spec="llvm@3.3")]}}
+            "packages", {"llvm": {"externals": [compiler_factory(spec="llvm@3.3 +clang")]}}
         ):
             module_configuration("complex_hierarchy")
             module, spec = factory("intel-oneapi-compilers%clang@3.3")

--- a/lib/spack/spack/test/spack_yaml.py
+++ b/lib/spack/spack/test/spack_yaml.py
@@ -8,6 +8,7 @@ import pathlib
 import pytest
 
 import spack.util.spack_yaml as syaml
+from spack.util.spack_yaml import DictWithLineInfo
 
 
 @pytest.fixture()
@@ -168,7 +169,7 @@ a:
   2.0: "float key"
   1: "int key"
 """
-    allowed_types = {str, int, float, bool, type(None), dict, list}
+    allowed_types = {str, int, float, bool, type(None), DictWithLineInfo, list}
     original = syaml.load(yaml)
     copied = syaml.deepcopy_as_builtin(original)
     assert original == copied
@@ -182,7 +183,7 @@ a:
     while stack:
         obj = stack.pop()
         assert type(obj) in allowed_types
-        if type(obj) is dict:
+        if type(obj) is DictWithLineInfo:
             stack.extend(obj.keys())
             stack.extend(obj.values())
         elif type(obj) is list:

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -53,9 +53,9 @@ def test_rfc_remote_local_path_no_dest():
 
 
 packages_yaml_sha256 = (
-    "20c934ddd73a8e8128a349aab3ee4e80996d1574c404a6a6e36a34986114fce8"
+    "8b3f2438e920d204949ff12c542805765e2bcef2e2fa06d80f08f65f56d7e44a"
     if sys.platform != "win32"
-    else "40ee0957883caaddb8558be5af0df98ddf16ec72117696f9d64319975d353ebc"
+    else "a6cc145ade51aa03583392d9d58ea13c5c525c8147c31fde4cbe2114e5471818"
 )
 
 

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -53,9 +53,9 @@ def test_rfc_remote_local_path_no_dest():
 
 
 packages_yaml_sha256 = (
-    "6a1b26c857ca7e5bcd7342092e2f218da43d64b78bd72771f603027ea3c8b4af"
+    "20c934ddd73a8e8128a349aab3ee4e80996d1574c404a6a6e36a34986114fce8"
     if sys.platform != "win32"
-    else "ae3239d769f9e6dc137a998489b0d44c70b03e21de4ecd6a623a3463a1a5c3f4"
+    else "40ee0957883caaddb8558be5af0df98ddf16ec72117696f9d64319975d353ebc"
 )
 
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1232,7 +1232,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -e --external -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized --show-configured-externals -f --show-flags --show-full-compiler -x --explicit -X --implicit -e --external -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1232,7 +1232,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -e --external -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1834,7 +1834,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit e/external u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized show-configured-externals f/show-flags show-full-compiler x/explicit X/implicit e/external u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1868,6 +1868,8 @@ complete -c spack -n '__fish_spack_using_command find' -s r -l only-roots -f -a 
 complete -c spack -n '__fish_spack_using_command find' -s r -l only-roots -d 'don'"'"'t show full list of installed specs in an environment'
 complete -c spack -n '__fish_spack_using_command find' -s c -l show-concretized -f -a show_concretized
 complete -c spack -n '__fish_spack_using_command find' -s c -l show-concretized -d 'show concretized specs in an environment'
+complete -c spack -n '__fish_spack_using_command find' -l show-configured-externals -f -a show_configured_externals
+complete -c spack -n '__fish_spack_using_command find' -l show-configured-externals -d 'show externals defined in the '"'"'packages'"'"' section of the configuration'
 complete -c spack -n '__fish_spack_using_command find' -s f -l show-flags -f -a show_flags
 complete -c spack -n '__fish_spack_using_command find' -s f -l show-flags -d 'show spec compiler flags'
 complete -c spack -n '__fish_spack_using_command find' -l show-full-compiler -f -a show_full_compiler

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1834,7 +1834,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit e/external u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1876,6 +1876,8 @@ complete -c spack -n '__fish_spack_using_command find' -s x -l explicit -f -a ex
 complete -c spack -n '__fish_spack_using_command find' -s x -l explicit -d 'show only specs that were installed explicitly'
 complete -c spack -n '__fish_spack_using_command find' -s X -l implicit -f -a implicit
 complete -c spack -n '__fish_spack_using_command find' -s X -l implicit -d 'show only specs that were installed as dependencies'
+complete -c spack -n '__fish_spack_using_command find' -s e -l external -f -a external
+complete -c spack -n '__fish_spack_using_command find' -s e -l external -d 'show only specs that are marked as externals'
 complete -c spack -n '__fish_spack_using_command find' -s u -l unknown -f -a unknown
 complete -c spack -n '__fish_spack_using_command find' -s u -l unknown -d 'show only specs Spack does not have a package for'
 complete -c spack -n '__fish_spack_using_command find' -s m -l missing -f -a missing


### PR DESCRIPTION
refers to #49697
closes #36179
closes #38638
closes #41682

fixes #26034
fixes #28827
fixes #6420  see https://github.com/spack/spack/issues/6420#issuecomment-720156534


In this PR externals are treated as concrete specs so there is a 1:1 mapping between an entry in `packages.yaml` and any installed external spec, for a fixed repository.

Their YAML specification has been extended, following #49697, to allow modeling dependencies of external specs. This might be quite useful to better capture e.g. ROCm installations that are already installed on a given system, or in similar cases. 

To be backward compatible with external specs specifying a compiler, for instance `mpich %gcc@9`, Spack will match the compiler specification to an existing external. It will fail when the specification is ambiguous, or leads to no match.



<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
