### PR TITLE
oci: allow http with `oci+http://` scheme

### DIFF
--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -338,15 +338,10 @@ will have the same effect as
 OCI / Docker V2 Registries as Build Cache
 -----------------------------------------
 
-Spack can also use OCI or Docker V2 registries such as Docker Hub, Quay.io,
-GitHub Packages, GitLab Container Registry, JFrog Artifactory, and others
-as build caches. This is a convenient way to share binaries using public
-infrastructure or to cache Spack-built binaries in GitHub Actions and
-GitLab CI.
+Spack can also use OCI or Docker V2 registries such as Docker Hub, Quay.io, GitHub Packages, GitLab Container Registry, JFrog Artifactory, and others as build caches.
+This is a convenient way to share binaries using public infrastructure or to cache Spack-built binaries in GitHub Actions and GitLab CI.
 
-To get started, configure an OCI mirror using ``oci://`` as the scheme
-and optionally specify variables that hold the username and password (or
-personal access token) for the registry:
+To get started, configure an OCI mirror using ``oci://`` as the scheme and optionally specify variables that hold the username and password (or personal access token) for the registry:
 
 .. code-block:: console
 
@@ -354,8 +349,8 @@ personal access token) for the registry:
                        --oci-password-variable REGISTRY_TOKEN \
                        my_registry oci://example.com/my_image
 
-Spack follows the naming conventions of Docker, with Docker Hub as the default
-registry. To use Docker Hub, you can omit the registry domain:
+Spack follows the naming conventions of Docker, with Docker Hub as the default registry.
+To use Docker Hub, you can omit the registry domain:
 
 .. code-block:: console
 
@@ -370,14 +365,15 @@ From here, you can use the mirror as any other build cache:
     $ spack buildcache push my_registry <specs...>  # push to the registry
     $ spack install <specs...>  # or install from the registry
 
-A unique feature of build caches on top of OCI registries is that it's incredibly
-easy to generate a runnable container image with the binaries installed. This
-is a great way to make applications available to users without requiring them to
-install Spack -- all you need is Docker, Podman, or any other OCI-compatible container
-runtime.
+.. note::
 
-To produce container images, all you need to do is add the ``--base-image`` flag
-when pushing to the build cache:
+   Spack defaults to ``https`` for OCI registries, and does not fall back to ``http`` in case of failure.
+   For local registries which use ``http`` instead of ``https``, you can specify ``oci+http://localhost:5000/my_image``.
+
+A unique feature of build caches on top of OCI registries is that it's incredibly easy to generate a runnable container image with the binaries installed.
+This is a great way to make applications available to users without requiring them to install Spack -- all you need is Docker, Podman, or any other OCI-compatible container runtime.
+
+To produce container images, all you need to do is add the ``--base-image`` flag when pushing to the build cache:
 
 .. code-block:: console
 
@@ -388,10 +384,9 @@ when pushing to the build cache:
     root@e4c2b6f6b3f4:/# ninja --version
     1.11.1
 
-If ``--base-image`` is not specified, distroless images are produced. In practice,
-you won't be able to run these as containers because they don't come with libc and
-other system dependencies. However, they are still compatible with tools like
-``skopeo``, ``podman``, and ``docker`` for pulling and pushing.
+If ``--base-image`` is not specified, distroless images are produced.
+In practice, you won't be able to run these as containers because they don't come with libc and other system dependencies.
+However, they are still compatible with tools like ``skopeo``, ``podman``, and ``docker`` for pulling and pushing.
 
 .. note::
     The Docker ``overlayfs2`` storage driver is limited to 128 layers, above which a

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -42,8 +42,8 @@ just have to configure an OCI registry and run ``spack buildcache push``.
 
    # Configure the registry
    $ spack -e . mirror add --oci-username-variable REGISTRY_USER \
-                         --oci-password-variable REGISTRY_TOKEN \
-                        container-registry oci://example.com/name/image
+                           --oci-password-variable REGISTRY_TOKEN \
+                           container-registry oci://example.com/name/image
 
    # Push the image (do set REGISTRY_USER and REGISTRY_TOKEN)
    $ spack -e . buildcache push --update-index --base-image ubuntu:22.04 --tag my_env container-registry

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -17,6 +17,7 @@ import spack.environment as ev
 import spack.error
 import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
+import spack.oci.image
 import spack.oci.oci
 import spack.spec
 import spack.stage
@@ -399,7 +400,7 @@ def push_fn(args):
         unsigned = not (args.key or args.signed)
 
     # For OCI images, we require dependencies to be pushed for now.
-    if mirror.push_url.startswith("oci://") and not unsigned:
+    if spack.oci.image.is_oci_url(mirror.push_url) and not unsigned:
         tty.warn(
             "Code signing is currently not supported for OCI images. "
             "Use --unsigned to silence this warning."
@@ -437,7 +438,7 @@ def push_fn(args):
                 )
 
     # Warn about possible old binary mirror layout
-    if not mirror.push_url.startswith("oci://"):
+    if not spack.oci.image.is_oci_url(mirror.push_url):
         check_mirror_for_layout(mirror)
 
     with spack.binary_distribution.make_uploader(

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -15,7 +15,7 @@ import spack.util.url as url_util
 from spack.error import MirrorError
 
 #: What schemes do we support
-supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oci")
+supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oci", "oci+http")
 
 
 def _url_or_path_to_url(url_or_path: str) -> str:

--- a/lib/spack/spack/oci/oci.py
+++ b/lib/spack/spack/oci/oci.py
@@ -7,7 +7,6 @@ import json
 import os
 import urllib.error
 import urllib.parse
-import urllib.request
 from http.client import HTTPResponse
 from typing import List, NamedTuple, Tuple
 from urllib.request import Request
@@ -214,10 +213,7 @@ def upload_manifest(
 
 def image_from_mirror(mirror: spack.mirrors.mirror.Mirror) -> ImageReference:
     """Given an OCI based mirror, extract the URL and image name from it"""
-    url = mirror.push_url
-    if not url.startswith("oci://"):
-        raise ValueError(f"Mirror {mirror} is not an OCI mirror")
-    return ImageReference.from_string(url[6:])
+    return ImageReference.from_url(mirror.push_url)
 
 
 def blob_exists(

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -367,10 +367,8 @@ def credentials_from_mirrors(
                 continue
 
             url = mirror.get_url(direction)
-            if not url.startswith("oci://"):
-                continue
             try:
-                parsed = ImageReference.from_string(url[6:])
+                parsed = ImageReference.from_url(url)
             except ValueError:
                 continue
             if parsed.domain == domain:
@@ -384,6 +382,7 @@ def create_opener():
     for handler in [
         urllib.request.ProxyHandler(),
         urllib.request.UnknownHandler(),
+        urllib.request.HTTPHandler(),
         urllib.request.HTTPSHandler(context=spack.util.web.ssl_create_default_context()),
         spack.util.web.SpackHTTPDefaultErrorHandler(),
         urllib.request.HTTPRedirectHandler(),

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -21,6 +21,7 @@ import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.mirrors.layout
 import spack.mirrors.utils
+import spack.oci.image
 import spack.resource
 import spack.spec
 import spack.util.crypto
@@ -501,7 +502,7 @@ class Stage(LockableStagingDir):
                     extension=extension,
                 )
                 for mirror in self.mirrors
-                if not mirror.fetch_url.startswith("oci://")  # no support for mirrors yet
+                if not spack.oci.image.is_oci_url(mirror.fetch_url)  # no support for mirrors yet
             )
 
         if not self.default_fetcher_only and self.mirror_layout and self.default_fetcher.cachable:

--- a/lib/spack/spack/test/oci/image.py
+++ b/lib/spack/spack/test/oci/image.py
@@ -83,3 +83,17 @@ def test_digest():
     # Missing algorithm
     with pytest.raises(ValueError):
         Digest.from_string(valid_digest)
+
+
+def test_url_with_scheme():
+    """Test that scheme=http translates to http:// URLs"""
+    http = ImageReference.from_string("localhost:1234/myimage:abc", scheme="http")
+    https = ImageReference.from_string("localhost:1234/myimage:abc", scheme="https")
+    default = ImageReference.from_string("localhost:1234/myimage:abc")
+
+    assert http != https
+    assert https == default
+
+    assert http.manifest_url() == "http://localhost:1234/v2/myimage/manifests/abc"
+    assert https.manifest_url() == "https://localhost:1234/v2/myimage/manifests/abc"
+    assert default.manifest_url() == "https://localhost:1234/v2/myimage/manifests/abc"

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -476,6 +476,13 @@ def test_image_from_mirror():
     assert image_from_mirror(mirror) == ImageReference.from_string("example.com/image")
 
 
+def test_image_from_mirror_with_http_scheme():
+    image = image_from_mirror(spack.mirrors.mirror.Mirror({"url": "oci+http://example.com/image"}))
+    assert image.scheme == "http"
+    assert image.with_tag("latest").scheme == "http"
+    assert image.with_digest(f"sha256:{1234:064x}").scheme == "http"
+
+
 def test_image_reference_str():
     """Test that with_digest() works with Digest and str."""
     digest_str = f"sha256:{1234:064x}"

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -88,8 +88,8 @@ def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> s
     try:
         # NOTE: we temporarily modify urllib internals so s3 and gs schemes are treated like http.
         # This is non-portable, and may be forward incompatible with future cpython versions.
-        urllib.parse.uses_netloc = [*uses_netloc, "s3", "gs", "oci"]
-        urllib.parse.uses_relative = [*uses_relative, "s3", "gs", "oci"]
+        urllib.parse.uses_netloc = [*uses_netloc, "s3", "gs", "oci", "oci+http"]
+        urllib.parse.uses_relative = [*uses_relative, "s3", "gs", "oci", "oci+http"]
         return urllib.parse.urljoin(base, "/".join(components), **kwargs)
     finally:
         urllib.parse.uses_netloc = uses_netloc


### PR DESCRIPTION
Until now, Spack only supported the OCI Distribution API over https, which
complicates testing on localhost:

```
docker run -p 5000:5000 registry
```

With this commit, users can force Spack to use `http://` using the
`oci+http://` scheme for the build cache:

```
spack mirror add local-registry oci+http://localhost:5000/image
```

It does *not* implement a fallback/downgrade of https -> http. `oci://` continues to be https-only.