### PR TITLE
repo add: allow add of existing remote package repo by path

### DIFF
--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -494,6 +494,10 @@ To register package repositories from local paths or a remote Git repositories w
      $ spack repo add ~/my_spack_projects/spack_repo/myorg/projectx
      ==> Added repo to config with name 'myorg.projectx'.
 
+  .. warning::
+    The local path **must** fall within a *remote* Git package repository.
+    A properly configured :ref:`spack-repo-index.yaml <package_repo_index>` file must be present under the repository root.
+
   For example, suppose the above path is to an existing repository with the structure in :ref:`cmd-spack-repo-create` that was cloned from GitHub using ssh and the url ``git@github.com:myorg/my_spack_projects.git``.
   The configuration resulting from adding its local path would be:
 
@@ -505,27 +509,24 @@ To register package repositories from local paths or a remote Git repositories w
         destination:  ~/my_spack_projects
         git: git@github.com:myorg/my_spack_projects.git
 
-  Should the repository include multiple package repositories in the form of :ref:`nested namespaces <nested_repo_namespaces>` but you want to register individually, you can provide the path as follows:
+  Should a repository include multiple package repositories in the form of :ref:`nested namespaces <nested_repo_namespaces>` but you want to register only one, you can provide the package repository-specific path as follows:
 
   .. code-block:: console
 
      $ spack repo add /path/to/my_pkgs/repos/spack_repo/llnl/pls
      ==> Added repo to config with name 'llnl.pls'
 
-  And the following entry will be added to the repository:
+  Then the following entry will be added to the repository configuration:
 
   .. code-block:: yaml
 
-    # ~/.spack/repos.yaml after the command
+    # ~/.spack/repos.yaml after the command and ignoring other repositories
     repos:
       llnl.pls:
         destination: /path/to/my_pkgs
-        git: https://github.com/my_pkgs.git
+        git: https://github.com/myorg/my_pkgs.git
         paths:
         - repos/spack_repo/llnl/pls
-
-  .. warning::
-    The local path **must** fall within a *remote* Git package repository **and** a properly configured :ref:`spack-repo-index.yaml <package_repo_index>` file must be present under the repository root.
 
 * **For a Git repository:** Provide the Git URL.
 

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -491,6 +491,18 @@ To register package repositories from local paths or a remote Git repositories w
      $ spack repo add ~/my_spack_projects/spack_repo/myorg/projectx
      ==> Added repo to config with name 'myorg.projectx'.
 
+  If the local path falls within a *remote* Git package repository, the url is automatically extracted.
+  For example, suppose the above path is to an existing repository with the structure in :ref:`cmd-spack-repo-create` that was cloned from GitHub using ssh and the url ``git@github.com:myorg/my_spack_projects.git``.
+  The configuration resulting from adding its local path would be:
+
+  .. code-block:: yaml
+
+    # ~/.spack/repos.yaml after the command
+    repos:
+      myorg.projectx:
+        destination:  ~/my_spack_projects
+        git: git@github.com:myorg/my_spack_projects.git
+
 * **For a Git repository:** Provide the Git URL.
 
   .. code-block:: console

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -176,9 +176,10 @@ The ``spack repo update`` command will update the repo on disk to match the curr
 If the repo is pinned to a commit or tag, it will ensure the repo on disk reflects that commit or tag.
 If the repo is pinned to a branch or unpinned, ``spack repo update`` will pull the most recent state of the branch (the default branch if unpinned).
 
+.. _package_repo_index:
+
 Git repositories need a package repo index
 """"""""""""""""""""""""""""""""""""""""""
-
 A single Git repository can contain one or more Spack package repositories.
 To enable Spack to discover these, the root of the Git repository should contain a ``spack-repo-index.yaml`` file.
 This file lists the relative paths to package repository roots within the git repo.
@@ -286,6 +287,8 @@ This accomplishes two things:
    The ``namespace`` defined in the package repository's ``repo.yaml`` is the **authoritative source** for the namespace.
    It is *not* derived from the local configuration in ``repos.yaml``.
    This means that the namespace is determined by the repository maintainer, not by the user or local configuration.
+
+.. _nested_repo_namespaces:
 
 Nested Namespaces for Organizations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -491,7 +494,6 @@ To register package repositories from local paths or a remote Git repositories w
      $ spack repo add ~/my_spack_projects/spack_repo/myorg/projectx
      ==> Added repo to config with name 'myorg.projectx'.
 
-  If the local path falls within a *remote* Git package repository, the url is automatically extracted.
   For example, suppose the above path is to an existing repository with the structure in :ref:`cmd-spack-repo-create` that was cloned from GitHub using ssh and the url ``git@github.com:myorg/my_spack_projects.git``.
   The configuration resulting from adding its local path would be:
 
@@ -502,6 +504,28 @@ To register package repositories from local paths or a remote Git repositories w
       myorg.projectx:
         destination:  ~/my_spack_projects
         git: git@github.com:myorg/my_spack_projects.git
+
+  Should the repository include multiple package repositories in the form of :ref:`nested namespaces <nested_repo_namespaces>` but you want to register individually, you can provide the path as follows:
+
+  .. code-block:: console
+
+     $ spack repo add /path/to/my_pkgs/repos/spack_repo/llnl/pls
+     ==> Added repo to config with name 'llnl.pls'
+
+  And the following entry will be added to the repository:
+
+  .. code-block:: yaml
+
+    # ~/.spack/repos.yaml after the command
+    repos:
+      llnl.pls:
+        destination: /path/to/my_pkgs
+        git: https://github.com/my_pkgs.git
+        paths:
+        - repos/spack_repo/llnl/pls
+
+  .. warning::
+    The local path **must** fall within a *remote* Git package repository **and** a properly configured :ref:`spack-repo-index.yaml <package_repo_index>` file must be present under the repository root.
 
 * **For a Git repository:** Provide the Git URL.
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -19,11 +19,14 @@ import spack.util.path
 import spack.util.spack_yaml
 from spack.cmd.common import arguments
 from spack.error import SpackError
+from spack.llnl.util.filesystem import working_dir
 from spack.llnl.util.tty import color
 
 description = "manage package source repositories"
 section = "config"
 level = "long"
+
+git = spack.util.git.git(required=True)
 
 
 def setup_parser(subparser: argparse.ArgumentParser):
@@ -169,6 +172,22 @@ def repo_create(args):
     tty.msg("To register it with spack, run this command:", "spack repo add %s" % full_path)
 
 
+def _get_git_info(path):
+    try:
+        with working_dir(path):
+            url = git(
+                "config", "--get", "remote.origin.url", output=str, fail_on_error=False
+            ).strip()
+            if url is not None:
+                root = git("rev-parse", "--show-toplevel", output=str, fail_on_error=False).strip()
+                return url, root
+    except:
+        # Ignore the results and assume there is no git repository
+        pass
+
+    return None, None
+
+
 def _add_repo(
     path_or_repo: str,
     name: Optional[str],
@@ -190,23 +209,33 @@ def _add_repo(
     entry: Union[str, Dict[str, Any]]
     colon_idx = path_or_repo.find(":")
 
+    fetch = False
     if colon_idx > 1 and "/" not in path_or_repo[:colon_idx]:  # git URL
+        fetch = True
         entry = {"git": path_or_repo}
         if len(paths) >= 1:
             entry["paths"] = paths
         if destination:
             entry["destination"] = destination
     else:  # local path
-        if destination:
-            raise SpackError("The 'destination' argument is only valid for git repositories")
-        elif paths:
-            raise SpackError("The --paths flag is only valid for git repositories")
-        entry = spack.util.path.canonicalize_path(path_or_repo)
+        path = spack.util.path.canonicalize_path(path_or_repo)
+
+        # Determine if the path is to an existing git clone or local directory
+        url, root = _get_git_info(path)
+        if url is not None:
+            path_or_repo = path
+            entry = {"git": url, "destination": root}
+        else:
+            if destination:
+                raise SpackError("The 'destination' argument is only valid for git repositories")
+            elif paths:
+                raise SpackError("The --paths flag is only valid for git repositories")
+            entry = path
 
     descriptor = spack.repo.parse_config_descriptor(
         name or "<unnamed>", entry, lock=spack.repo.package_repository_lock()
     )
-    descriptor.initialize(git=spack.util.executable.which("git"))
+    descriptor.initialize(fetch=fetch, git=git)
 
     packages_repos = descriptor.construct(cache=spack.caches.MISC_CACHE)
 
@@ -517,8 +546,6 @@ def repo_update(args: Any) -> int:
 
             updated_entry[active_flag] = args.commit or args.tag or args.branch
             scope_repos[name] = updated_entry
-
-        git = spack.util.git.git(required=True)
 
         previous_commit = descriptor.get_commit(git=git)
         descriptor.update(git=git, remote=args.remote)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -19,7 +19,6 @@ import spack.util.path
 import spack.util.spack_yaml
 from spack.cmd.common import arguments
 from spack.error import SpackError
-from spack.llnl.util.filesystem import working_dir
 from spack.llnl.util.tty import color
 
 description = "manage package source repositories"
@@ -170,29 +169,6 @@ def repo_create(args):
     tty.msg("To register it with spack, run this command:", "spack repo add %s" % full_path)
 
 
-def _get_git_info(path):
-    git = spack.util.git.git(required=True)
-    if git is None:
-        tty.debug(
-            "Cannot determine if {path} is a git repository. Unable to instantiate a `git` executable."
-        )
-        return None, None
-
-    try:
-        with working_dir(path):
-            url = git(
-                "config", "--get", "remote.origin.url", output=str, fail_on_error=False
-            ).strip()
-            if url is not None:
-                root = git("rev-parse", "--show-toplevel", output=str, fail_on_error=False).strip()
-                return url, root
-    except Exception:
-        # Ignore the results and assume there is no git repository
-        pass
-
-    return None, None
-
-
 def _add_repo(
     path_or_repo: str,
     name: Optional[str],
@@ -226,7 +202,7 @@ def _add_repo(
         path = spack.util.path.canonicalize_path(path_or_repo)
 
         # Determine if the path is to an existing git clone or local directory
-        url, root = _get_git_info(path)
+        url, root = spack.util.git.git_url_root(path)
         if url is not None:
             path_or_repo = path
             entry = {"git": url, "destination": root}

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -202,10 +202,11 @@ def _add_repo(
         path = spack.util.path.canonicalize_path(path_or_repo)
 
         # Determine if the path is to an existing git clone or local directory
+        # and whether the repository index file exists.
         result = spack.util.git.git_url_root(path)
         if result is not None:
+            entry = spack.repo.local_repo_entry(path, result)
             path_or_repo = path
-            entry = {"git": result[0], "destination": result[1]}
         else:
             if destination:
                 raise SpackError("The 'destination' argument is only valid for git repositories")
@@ -238,7 +239,11 @@ def _add_repo(
     elif len(usable_repos) == 1:
         key = next(iter(usable_repos.values())).namespace
     else:
-        raise SpackError("Multiple package repositories found, please specify a name with --name.")
+        raise SpackError(
+            f"{path_or_repo} contains multiple package repositories. "
+            "Registering them together requires a unique repository name. "
+            "Try again with the --name option."
+        )
 
     if key in existing:
         raise SpackError(f"A repository with the name '{key}' already exists.")

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -202,10 +202,10 @@ def _add_repo(
         path = spack.util.path.canonicalize_path(path_or_repo)
 
         # Determine if the path is to an existing git clone or local directory
-        url, root = spack.util.git.git_url_root(path)
-        if url is not None:
+        result = spack.util.git.git_url_root(path)
+        if result is not None:
             path_or_repo = path
-            entry = {"git": url, "destination": root}
+            entry = {"git": result[0], "destination": result[1]}
         else:
             if destination:
                 raise SpackError("The 'destination' argument is only valid for git repositories")

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -26,8 +26,6 @@ description = "manage package source repositories"
 section = "config"
 level = "long"
 
-git = spack.util.git.git(required=True)
-
 
 def setup_parser(subparser: argparse.ArgumentParser):
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="repo_command")
@@ -173,6 +171,13 @@ def repo_create(args):
 
 
 def _get_git_info(path):
+    git = spack.util.git.git(required=True)
+    if git is None:
+        tty.debug(
+            "Cannot determine if {path} is a git repository. Unable to instantiate a `git` executable."
+        )
+        return None, None
+
     try:
         with working_dir(path):
             url = git(
@@ -181,7 +186,7 @@ def _get_git_info(path):
             if url is not None:
                 root = git("rev-parse", "--show-toplevel", output=str, fail_on_error=False).strip()
                 return url, root
-    except:
+    except Exception:
         # Ignore the results and assume there is no git repository
         pass
 
@@ -235,7 +240,7 @@ def _add_repo(
     descriptor = spack.repo.parse_config_descriptor(
         name or "<unnamed>", entry, lock=spack.repo.package_repository_lock()
     )
-    descriptor.initialize(fetch=fetch, git=git)
+    descriptor.initialize(fetch=fetch, git=spack.util.executable.which("git"))
 
     packages_repos = descriptor.construct(cache=spack.caches.MISC_CACHE)
 
@@ -546,6 +551,8 @@ def repo_update(args: Any) -> int:
 
             updated_entry[active_flag] = args.commit or args.tag or args.branch
             scope_repos[name] = updated_entry
+
+        git = spack.util.git.git(required=True)
 
         previous_commit = descriptor.get_commit(git=git)
         descriptor.update(git=git, remote=args.remote)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -57,7 +57,6 @@ import spack.util.lock
 import spack.util.naming as nm
 import spack.util.path
 import spack.util.spack_yaml as syaml
-from spack.llnl.util.filesystem import working_dir
 
 PKG_MODULE_PREFIX_V1 = "spack.pkg."
 PKG_MODULE_PREFIX_V2 = "spack_repo."
@@ -209,7 +208,7 @@ class GitExe:
         self.packages_dir = packages_path
 
     def __call__(self, *args, **kwargs) -> str:
-        with working_dir(self.packages_dir):
+        with fs.working_dir(self.packages_dir):
             return self._git_cmd(*args, **kwargs, output=str)
 
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -66,6 +66,69 @@ _API_REGEX = re.compile(r"^v(\d+)\.(\d+)$")
 SPACK_REPO_INDEX_FILE_NAME = "spack-repo-index.yaml"
 
 
+def repo_index_path(destination: str) -> str:
+    return os.path.join(destination, SPACK_REPO_INDEX_FILE_NAME)
+
+
+def read_repo_index_file(destination: str) -> Dict[str, Any]:
+    """Read and validate the repository index file rooted at destination
+
+    Args:
+        destination: root directory that should contain the index file
+
+    Returns: dictionary of validated repository index contents
+
+    Raises:
+        AssertionError: file does not contain properly formatted index data
+    """
+    repo_index_file = repo_index_path(destination)
+    assert os.path.exists(repo_index_file), f"Required {repo_index_file} is missing"
+
+    with open(repo_index_file, encoding="utf-8") as f:
+        index_data = syaml.load(f)
+
+    assert "repo_index" in index_data, f"{repo_index_file}: missing 'repo_index' key"
+    repo_index = index_data["repo_index"]
+    assert isinstance(repo_index, dict), f"{repo_index_file}: 'repo_index' must be a dictionary"
+
+    assert "paths" in repo_index, f"{repo_index_file}: missing 'paths' key in 'repo_index'"
+    sub_paths = repo_index["paths"]
+    assert isinstance(
+        sub_paths, list
+    ), f"{repo_index_file}: 'paths' under 'repo_index' must be a list"
+
+    # validate that the entries are relative paths
+    if not all(isinstance(p, str) and p[0] != os.sep for p in sub_paths):
+        raise AssertionError(
+            f"{repo_index_file}: invalid repo index file format: "
+            "expected a list of relative paths."
+        )
+
+    return repo_index
+
+
+def local_repo_entry(path: str, result: Tuple[str, str]) -> Dict[str, Any]:
+    git, destination = result
+
+    try:
+        repo_index = read_repo_index_file(destination)
+
+        entry: Dict[str, Any] = {"destination": destination, "git": git}
+
+        paths: List[str] = []
+        for rel_path in repo_index["paths"]:
+            if path.endswith(rel_path):
+                paths.append(rel_path)
+
+        if paths:
+            entry["paths"] = paths
+
+    except (OSError, syaml.SpackYAMLError, AssertionError) as e:
+        raise spack.error.SpackError(str(e))
+
+    return entry
+
+
 def package_repository_lock() -> spack.util.lock.Lock:
     """Lock for process safety when cloning remote package repositories"""
     return spack.util.lock.Lock(
@@ -1776,26 +1839,13 @@ class RemoteRepoDescriptor(RepoDescriptor):
         if self.relative_paths is not None:
             return
 
-        repo_index_file = os.path.join(self.destination, SPACK_REPO_INDEX_FILE_NAME)
         try:
-            with open(repo_index_file, encoding="utf-8") as f:
-                index_data = syaml.load(f)
-            assert "repo_index" in index_data, "missing 'repo_index' key"
-            repo_index = index_data["repo_index"]
-            assert isinstance(repo_index, dict), "'repo_index' must be a dictionary"
-            assert "paths" in repo_index, "missing 'paths' key in 'repo_index'"
-            sub_paths = repo_index["paths"]
-            assert isinstance(sub_paths, list), "'paths' under 'repo_index' must be a list"
+            repo_index = read_repo_index_file(self.destination)
         except (OSError, syaml.SpackYAMLError, AssertionError) as e:
-            self.error = f"failed to read {repo_index_file}: {e}"
+            self.error = f"failed to read {repo_index_path(self.destination)}: {e}"
             return
 
-        # validate that this is a list of relative paths.
-        if not isinstance(sub_paths, list) or not all(isinstance(p, str) for p in sub_paths):
-            self.error = "invalid repo index file format: expected a list of relative paths."
-            return
-
-        self.relative_paths = sub_paths
+        self.relative_paths = repo_index["paths"]
 
     def __repr__(self):
         return (

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -15,6 +15,7 @@ import spack.environment as ev
 import spack.main
 import spack.repo
 import spack.repo_migrate
+import spack.util.git
 from spack.error import SpackError
 from spack.llnl.util.filesystem import working_dir
 from spack.main import SpackCommand

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -320,6 +320,38 @@ def test_add_repo_destination_with_local_path(tmp_path: pathlib.Path):
         )
 
 
+def test_add_repo_local_git_repo_path(monkeypatch):
+    """Test _add_repo succeeds when the local path is in a git repository."""
+    config = make_repo_config()
+    url = "git@github.com:user/repo.git"
+    path = "/some/path"
+    name = "local_git_test"
+
+    def mock_parse_config_descriptor(name, entry, lock):
+        # Verify the entry has the expected git structure
+        assert "git" in entry
+        assert entry["git"] == url
+        return MockDescriptor({path: MockRepo("git_repo")})
+
+    def _git_url_root(*args, **kwargs):
+        return url, path
+
+    monkeypatch.setattr(spack.repo, "parse_config_descriptor", mock_parse_config_descriptor)
+    monkeypatch.setattr(spack.util.git, "git_url_root", _git_url_root)
+
+    key = spack.cmd.repo._add_repo(
+        path, name=name, scope=None, paths=[], destination=None, config=config
+    )
+
+    assert key == name
+    repos = config.get("repos", scope=None)
+    assert name in repos
+    # Check that the git url and root were automatically populated for the
+    # (mock) local git path.
+    assert repos[name]["git"] == url
+    assert repos[name]["destination"] == path
+
+
 def test_add_repo_computed_key_already_exists(tmp_path: pathlib.Path, monkeypatch):
     """Test _add_repo raises error when computed key already exists in config."""
 

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -321,12 +321,21 @@ def test_add_repo_destination_with_local_path(tmp_path: pathlib.Path):
         )
 
 
-def test_add_repo_local_git_repo_path(monkeypatch):
+def test_add_repo_local_git_repo_path(tmp_path: pathlib.Path, monkeypatch):
     """Test _add_repo succeeds when the local path is in a git repository."""
     config = make_repo_config()
     url = "git@github.com:user/repo.git"
-    path = "/some/path"
+    path = str(tmp_path)
     name = "local_git_test"
+
+    with open(spack.repo.repo_index_path(path), "w", encoding="utf-8") as f:
+        f.write(
+            f"""\
+repo_index:
+  paths:
+  - repos{os.sep}spack_repo{os.sep}builtin
+"""
+        )
 
     def mock_parse_config_descriptor(name, entry, lock):
         # Verify the entry has the expected git structure

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -495,17 +495,15 @@ def test_add_repo_no_usable_repositories_error(monkeypatch):
 
 
 def test_add_repo_multiple_repos_no_name_error(monkeypatch):
-    """Test that _add_repo raises SpackError when multiple repositories found without
-    specifying --name."""
+    """Test that _add_repo raises SpackError when multiple repositories found (without
+    specifying --name)."""
 
     def mock_parse_config_descriptor(name, entry, lock):
         return MockDescriptor({"/path1": MockRepo("repo1"), "/path2": MockRepo("repo2")})
 
     monkeypatch.setattr(spack.repo, "parse_config_descriptor", mock_parse_config_descriptor)
 
-    with pytest.raises(
-        SpackError, match="Multiple package repositories found, please specify a name"
-    ):
+    with pytest.raises(SpackError, match="contains multiple package repositories"):
         spack.cmd.repo._add_repo(
             "/path/with/multiple/repos",
             name=None,  # No name specified

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -8,6 +8,7 @@ import pytest
 
 import spack
 import spack.environment
+import spack.error
 import spack.package_base
 import spack.paths
 import spack.repo
@@ -962,3 +963,45 @@ def test_unknownpkgerror_match_fails():
 def test_unknownpkgerror_str_repo():
     """Ensure reasonable error message when repo is a string."""
     assert "not found in repository" in str(spack.repo.UnknownPackageError("pkg_a", "my_repo"))
+
+
+index_fmt = """\
+repo_index:
+  {}
+"""
+
+
+def test_local_repo_entry(tmp_path: pathlib.Path):
+    destination = str(tmp_path)
+    result = ("https://example.com/fake.git", destination)
+    index_path = spack.repo.repo_index_path(destination)
+    path = os.path.join("repos", "spack_repo", "test")
+    with open(index_path, "w", encoding="utf-8") as f:
+        f.write(index_fmt.format(f"paths:\n  - {path}"))
+
+    entry = spack.repo.local_repo_entry(os.path.join(destination, path), result)
+    assert len(entry["paths"]) == 1
+    assert entry["paths"][0] == path
+
+
+@pytest.mark.parametrize(
+    "contents,message",
+    [
+        ("", f"{spack.repo.SPACK_REPO_INDEX_FILE_NAME} is missing"),
+        ("invalid_info", "missing 'repo_index' key"),
+        ("repo_index: []", "must be a dictionary"),
+        (index_fmt.format("git: unchecks-url"), "missing 'paths' key"),
+        (index_fmt.format(f"paths: repos{os.sep}spack_repo"), "must be a list"),
+        (index_fmt.format(f"paths:\n  - {os.sep}repos"), "relative paths"),
+    ],
+)
+def test_local_repo_entry_fails(tmp_path: pathlib.Path, contents, message):
+    destination = str(tmp_path)
+    result = ("https://example.com/fake.git", destination)
+    index_path = spack.repo.repo_index_path(destination)
+    if contents:
+        with open(index_path, "w", encoding="utf-8") as f:
+            f.write(contents)
+
+    with pytest.raises(spack.error.SpackError, match=message):
+        spack.repo.local_repo_entry(destination, result)

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -25,9 +25,6 @@ def test_git_not_found(monkeypatch):
     with pytest.raises(exe.CommandNotFoundError):
         spack.util.git.git(required=True)
 
-    url, root = spack.util.git.git_url_root("/path/is/irrelevant")
-    assert url is None and root is None
-
 
 def test_modified_files(mock_git_package_changes):
     repo, filename, commits = mock_git_package_changes
@@ -88,18 +85,33 @@ def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info
 
 
 def test_not_git_repo(tmp_path: pathlib.Path):
-    url, root = spack.util.git.git_url_root(str(tmp_path))
-    assert url is None and root is None
+    result = spack.util.git.git_url_root(str(tmp_path))
+    assert result is None
 
 
-def test_git_url_root(monkeypatch):
-    repo_path = os.path.dirname(os.path.abspath(__file__))
-
+def test_git_url_root(tmp_path: pathlib.Path):
     # Ensure both the url and root have values.
-    url, root = spack.util.git.git_url_root(repo_path)
-    assert url is not None and root is not None
+    def _git(*args, **kwargs):
+        if "config" in args:
+            return "https://mock.com/mock.git"
 
-    # Ensure missing git returns no url or root
+        if "rev-parse" in args:
+            return str(tmp_path)
+
+        return None
+
+    result = spack.util.git.git_url_root(str(tmp_path), _git)
+    assert result is not None
+    assert result[0] is not None and result[1] is not None
+
+
+def test_git_url_root_missing_git(
+    monkeypatch, tmp_path: pathlib.Path, capfd: pytest.CaptureFixture
+):
     monkeypatch.setattr(spack.util.git, "_find_git", _mock_find_git)
-    url, root = spack.util.git.git_url_root(repo_path)
-    assert url is None and root is None
+
+    result = spack.util.git.git_url_root(str(tmp_path))
+    assert result is None
+
+    captured = capfd.readouterr()
+    assert "spack requires 'git'" in captured.err

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 import pathlib
 from typing import Optional
 
@@ -11,10 +12,11 @@ import spack.util.git
 from spack.llnl.util.filesystem import working_dir
 
 
-def test_git_not_found(monkeypatch):
-    def _mock_find_git() -> Optional[str]:
-        return None
+def _mock_find_git() -> Optional[str]:
+    return None
 
+
+def test_git_not_found(monkeypatch):
     monkeypatch.setattr(spack.util.git, "_find_git", _mock_find_git)
 
     git = spack.util.git.git(required=False)
@@ -22,6 +24,9 @@ def test_git_not_found(monkeypatch):
 
     with pytest.raises(exe.CommandNotFoundError):
         spack.util.git.git(required=True)
+
+    url, root = spack.util.git.git_url_root("/path/is/irrelevant")
+    assert url is None and root is None
 
 
 def test_modified_files(mock_git_package_changes):
@@ -80,3 +85,21 @@ def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info
 
         with pytest.raises(exe.ProcessError):
             spack.util.git.pull_checkout_branch("main")
+
+
+def test_not_git_repo(tmp_path: pathlib.Path):
+    url, root = spack.util.git.git_url_root(str(tmp_path))
+    assert url is None and root is None
+
+
+def test_git_url_root(monkeypatch):
+    repo_path = os.path.dirname(os.path.abspath(__file__))
+
+    # Ensure both the url and root have values.
+    url, root = spack.util.git.git_url_root(repo_path)
+    assert url is not None and root is not None
+
+    # Ensure missing git returns no url or root
+    monkeypatch.setattr(spack.util.git, "_find_git", _mock_find_git)
+    url, root = spack.util.git.git_url_root(repo_path)
+    assert url is None and root is None

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
 import pathlib
 from typing import Optional
 
@@ -90,17 +89,24 @@ def test_not_git_repo(tmp_path: pathlib.Path):
 
 
 def test_git_url_root(tmp_path: pathlib.Path):
-    # Ensure both the url and root have values.
-    def _git(*args, **kwargs):
-        if "config" in args:
-            return "https://mock.com/mock.git"
+    # Confirm both the url and root have values.
 
-        if "rev-parse" in args:
-            return str(tmp_path)
+    class MockGit(spack.util.executable.Executable):
+        def __init__(self):
+            pass
 
-        return None
+        def __call__(self, *args, **kwargs) -> str:  # type: ignore
+            action = args[0]
 
-    result = spack.util.git.git_url_root(str(tmp_path), _git)
+            if action == "config":
+                return "https://mock.com/mock.git"
+
+            if action == "rev-parse":
+                return str(tmp_path)
+
+            return ""
+
+    result = spack.util.git.git_url_root(str(tmp_path), MockGit())
     assert result is not None
     assert result[0] is not None and result[1] is not None
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -160,37 +160,29 @@ def get_commit_sha(path: str, ref: str) -> Optional[str]:
     return None
 
 
-def git_url_root(path: str) -> Tuple[Optional[str], Optional[str]]:
+def git_url_root(path: str, git_exe: Optional[exe.Executable] = None) -> Optional[Tuple[str, str]]:
     """Retrieve the git 'origin' URL and root directory for the path.
 
     Args:
       path: presumably a path within a git repository
+      git_exe: instance of 'git' to use
 
     Returns: the URL and root directory for a path in a git repository;
-        otherwise, returns None, None
+        otherwise, returns None
     """
-    git_exe = git(required=False)
-    if git_exe is None:
-        tty.debug(
-            f"Cannot determine if {path} is within a git repository since "
-            "unable to instantiate a `git` executable so assuming not."
-        )
-        return None, None
-
     try:
+        git_exe = git_exe or git(required=True)
+
         with working_dir(path):
             url = git_exe(
                 "config", "--get", "remote.origin.url", output=str, fail_on_error=False
             ).strip()
-            if url is not None and url:
+            if url:
                 root = git_exe(
                     "rev-parse", "--show-toplevel", output=str, fail_on_error=False
                 ).strip()
                 return url, root
     except Exception as e:
-        tty.debug(
-            f"Cannot determine the git URL and or root for {path}: {e}."
-            " Assuming not within a git repository."
-        )
+        tty.error(f"Cannot determine the git URL or root for {path}: {e}")
 
-    return None, None
+    return None

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -5,12 +5,14 @@
 
 import os
 import sys
-from typing import List, Optional, overload
+from typing import List, Optional, Tuple, overload
 
 from spack.vendor.typing_extensions import Literal
 
 import spack.llnl.util.lang
+import spack.llnl.util.tty as tty
 import spack.util.executable as exe
+from spack.llnl.util.filesystem import working_dir
 
 
 @spack.llnl.util.lang.memoized
@@ -156,3 +158,39 @@ def get_commit_sha(path: str, ref: str) -> Optional[str]:
             continue
 
     return None
+
+
+def git_url_root(path: str) -> Tuple[Optional[str], Optional[str]]:
+    """Retrieve the git 'origin' URL and root directory for the path.
+
+    Args:
+      path: presumably a path within a git repository
+
+    Returns: the URL and root directory for a path in a git repository;
+        otherwise, returns None, None
+    """
+    git_exe = git(required=False)
+    if git_exe is None:
+        tty.debug(
+            f"Cannot determine if {path} is within a git repository since "
+            "unable to instantiate a `git` executable so assuming not."
+        )
+        return None, None
+
+    try:
+        with working_dir(path):
+            url = git_exe(
+                "config", "--get", "remote.origin.url", output=str, fail_on_error=False
+            ).strip()
+            if url is not None and url:
+                root = git_exe(
+                    "rev-parse", "--show-toplevel", output=str, fail_on_error=False
+                ).strip()
+                return url, root
+    except Exception as e:
+        tty.debug(
+            f"Cannot determine the git URL and or root for {path}: {e}."
+            " Assuming not within a git repository."
+        )
+
+    return None, None


### PR DESCRIPTION
It is annoying to not get more information from an existing clone of (a fork of the) package repository. This PR allows the path to be provided and the remote git information extracted and displayed with the "standard" commands.

Before:
```
$ spack repo list
[+] builtin    v2.2    $HOME/.spack/package_repos/fncqgg4/repos/spack_repo/builtin

$ spack config get repos
repos:
  builtin:
    git: https://github.com/spack/spack-packages.git

$ spack repo add $spack-packages/repos/spack_repo/builtin
==> Added repo to config with name 'builtin'.

$ spack repo list
[+] builtin        $spack-packages/repos/spack_repo/builtin

$ spack config get repos
repos:
  builtin: $spack-packages/repos/spack_repo/builtin
```

After:
```
$ spack repo list
[+] builtin    v2.2    $HOME/.spack/package_repos/fncqgg4/repos/spack_repo/builtin

$ spack config get repos
repos:
  builtin:
    git: https://github.com/spack/spack-packages.git

$ spack repo add $spack-packages/repos/spack_repo/builtin
==> Added repo to config with name 'builtin'.

$ spack repo list
[+] builtin    v2.2    $spack-packages/repos/spack_repo/builtin

$ spack config get repos
repos:
  builtin:
    git: git@github.com:GITHUB-USERNAME/spack-packages.git
    destination: $spack-packages
```