### PR TITLE
web.py: better error on URLError

### DIFF
--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -383,7 +383,7 @@ def create_opener():
         urllib.request.ProxyHandler(),
         urllib.request.UnknownHandler(),
         urllib.request.HTTPHandler(),
-        urllib.request.HTTPSHandler(context=spack.util.web.ssl_create_default_context()),
+        spack.util.web.SpackHTTPSHandler(context=spack.util.web.ssl_create_default_context()),
         spack.util.web.SpackHTTPDefaultErrorHandler(),
         urllib.request.HTTPRedirectHandler(),
         urllib.request.HTTPErrorProcessor(),


### PR DESCRIPTION
On top of #51120.

Currently https connection issues result in questionable errors:

```
urllib.error.URLError: <urlopen error [SSL] record layer failure (_ssl.c:1028)>
```

With this change it's enriched with the HTTP verb and URL:

```
spack.util.web.DetailedURLError: GET https://localhost:5000/example errored with: [SSL] record layer failure (_ssl.c:1028)
```

Notice that we already have similar, improved errors that wrap HTTPError, but urllib *also* raises plain URLError if connection to the server fails (i.e. no HTTP response is received).
