### PR TITLE
docs: add missing section header when no highlights in title

### DIFF
--- a/lib/spack/docs/_static/js/versions.js
+++ b/lib/spack/docs/_static/js/versions.js
@@ -110,10 +110,8 @@ function initSearch(currentVersion) {
       html += `<h2><a href="${result.domain}${result.path}">${title}</a></h2>`;
 
       result.blocks?.forEach(block => {
-        const blockTitle = block.highlights?.title?.[0];
-        if (blockTitle) {
-          html += `<h3><a href="${result.domain}${result.path}#${block.id}">${blockTitle}</a></h3>`;
-        }
+        const blockTitle = block.highlights?.title?.[0] ?? block.title;
+        html += `<h3><a href="${result.domain}${result.path}#${block.id}">${blockTitle}</a></h3>`;
         html += block.highlights?.content?.map(content => `<p>${content}</p>`).join('') ?? '';
       });
 

--- a/lib/spack/docs/_static/js/versions.js
+++ b/lib/spack/docs/_static/js/versions.js
@@ -31,6 +31,8 @@ function initVersionSelector(config) {
 }
 
 function initSearch(currentVersion) {
+  // Numeric versions are PRs which have no search results; use latest instead.
+  const searchVersion = /^\d+$/.test(currentVersion) ? 'latest' : currentVersion;
   let searchTimeout;
   let originalContent;
   const searchInput = document.querySelector(".sidebar-search");
@@ -81,7 +83,7 @@ function initSearch(currentVersion) {
   }
 
   function performSearch(query) {
-    const fullQuery = `project:spack/${currentVersion} ${query}`;
+    const fullQuery = `project:spack/${searchVersion} ${query}`;
     const searchUrl = `/_/api/v3/search/?q=${encodeURIComponent(fullQuery)}`;
 
     fetch(searchUrl)


### PR DESCRIPTION
Currently no links are displayed to the page's subsection when none of the
search terms appear in the section title.

In that case, the original title without highlights should be displayed.

Also make search work on PRs.
