### PR TITLE
docs: update readthedocs ranking

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,19 +19,44 @@ search:
   ranking:
     spack.html: -10
     spack.*.html: -10
+    spack_repo.html: -10
+    spack_repo.*.html: -10
     _modules/*: -10
     command_index.html: -9
-    basic_usage.html: 5
-    configuration.html: 5
+    features.html: 5
+    getting_started.html: 5
+    spec_syntax.html: 5
+    installing_prerequisites.html: 5
+    windows.html: 5
+    package_fundamentals.html: 5
+    configuring_compilers.html: 5
+    replace_conda_homebrew.html: 5
+    frequently_asked_questions.html: 5
+    getting_help.html: 5
+    advanced_topics.html: 5
     config_yaml.html: 5
+    include_yaml.html: 5
     packages_yaml.html: 5
     build_settings.html: 5
     environments.html: 5
+    env_vars_yaml.html: 5
     containers.html: 5
     mirrors.html: 5
     module_file_support.html: 5
     repositories.html: 5
     binary_caches.html: 5
+    bootstrapping.html: 5
     chain.html: 5
+    extensions.html: 5
     pipelines.html: 5
-    packaging_guide.html: 5
+    signing.html: 5
+    gpu_configuration.html: 5
+    packaging_guide_creation.html: 5
+    packaging_guide_build.html: 5
+    packaging_guide_testing.html: 5
+    packaging_guide_advanced.html: 5
+    build_systems.html: 5
+    build_systems/*.html: 5
+    contribution_guide.html: 5
+    developer_guide.html: 5
+    package_api.html: 5


### PR DESCRIPTION
Ranking is for server side search. Current ranking was outdated because
the packaging guide was split into multiple pages and some new pages
were added.
