### PR TITLE
docs: set <link rel="canonical" />

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -450,6 +450,9 @@ html_show_sphinx = False
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 # html_file_suffix = None
 
+# Base URL for the documentation, used to generate <link rel="canonical"/> for better indexing
+html_baseurl = "https://spack.readthedocs.io/en/latest/"
+
 # Output file base name for HTML help builder.
 htmlhelp_basename = "Spackdoc"
 


### PR DESCRIPTION
GoogleBot is crawling pages with `?highlight=...` query params as
separate pages.

Avoid that by using

```html
<link rel="canonical" href="[url without query params]" />
```
