### PR TITLE
docs: fix incorrect code blocks

### DIFF
--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -482,7 +482,7 @@ Defining ``with_or_without_verbs`` overrides the behavior of a
 ``--with-openib`` for older versions of the package and specifying an
 alternative dependency name:
 
-.. code-block::
+.. code-block:: text
 
    --with-openib=</path/to/rdma-core>
 

--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -63,7 +63,9 @@ to download it from. The vast majority of Python packages are hosted
 on `PyPI <https://pypi.org/>`_, which is
 :ref:`preferred over GitHub <pypi-vs-github>` for downloading
 packages. Search for the package name on PyPI to find the project
-page. The project page is usually located at::
+page. The project page is usually located at:
+
+.. code-block:: text
 
    https://pypi.org/project/<package-name>
 
@@ -74,7 +76,9 @@ hosted on GitHub and see if GitHub has source distributions. The
 project page usually has a "Homepage" and/or "Source code" link for
 this. If the project is closed-source, it may only have wheels
 available. For example, ``py-azureml-sdk`` is closed-source and can
-be downloaded from::
+be downloaded from:
+
+.. code-block:: text
 
    https://pypi.io/packages/py3/a/azureml_sdk/azureml_sdk-1.11.0-py3-none-any.whl
 
@@ -382,7 +386,9 @@ file is simply a zip file, and can be extracted using:
 
 The zip file will not contain a ``setup.py``, but it will contain a
 ``METADATA`` file which contains all the information you need to
-write a ``package.py`` build recipe. Check for lines like::
+write a ``package.py`` build recipe. Check for lines like:
+
+.. code-block:: text
 
    Requires-Python: >=3.5,<4
    Requires-Dist: azureml-core (~=1.11.0)

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -37,7 +37,7 @@ The default is ``$spack/opt/spack``.
 By default, Spack installs all packages into a unique directory relative to the install
 tree root with the following layout:
 
-.. code-block::
+.. code-block:: text
 
    {architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}
 

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -712,7 +712,9 @@ And one that allows you to move the default cache location:
 * ``SPACK_USER_CACHE_PATH``: Override the default path to use for user data
   (misc_cache, tests, reports, etc.)
 
-With these settings, if you want to isolate Spack in a CI environment, you can do this::
+With these settings, if you want to isolate Spack in a CI environment, you can do this:
 
-  export SPACK_DISABLE_LOCAL_CONFIG=true
-  export SPACK_USER_CACHE_PATH=/tmp/spack
+.. code-block:: console
+
+  $ export SPACK_DISABLE_LOCAL_CONFIG=true
+  $ export SPACK_USER_CACHE_PATH=/tmp/spack

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -581,7 +581,7 @@ template, the Spack environment must register the directory containing it and de
 The template extension can override two blocks, named ``build_stage`` and ``final_stage``, similarly to
 the example below:
 
-.. code-block::
+.. code-block:: text
    :emphasize-lines: 3,8
 
    {% extends "container/Dockerfile" %}

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -747,29 +747,31 @@ Release branches
 There are currently two types of Spack releases: :ref:`major releases
 <major-releases>` (``0.21.0``, ``0.22.0``, etc.) and :ref:`patch releases
 <patch-releases>` (``0.22.1``, ``0.22.2``, ``0.22.3``, etc.). Here is a
-diagram of how Spack release branches work::
+diagram of how Spack release branches work:
 
-    o    branch: develop  (latest version, v0.23.0.dev0)
-    |
-    o
-    | o  branch: releases/v0.22, tag: v0.22.1
-    o |
-    | o  tag: v0.22.0
-    o |
-    | o
-    |/
-    o
-    |
-    o
-    | o  branch: releases/v0.21, tag: v0.21.2
-    o |
-    | o  tag: v0.21.1
-    o |
-    | o  tag: v0.21.0
-    o |
-    | o
-    |/
-    o
+.. code-block:: text
+
+   o    branch: develop  (latest version, v0.23.0.dev0)
+   |
+   o
+   | o  branch: releases/v0.22, tag: v0.22.1
+   o |
+   | o  tag: v0.22.0
+   o |
+   | o
+   |/
+   o
+   |
+   o
+   | o  branch: releases/v0.21, tag: v0.21.2
+   o |
+   | o  tag: v0.21.1
+   o |
+   | o  tag: v0.21.0
+   o |
+   | o
+   |/
+   o
 
 The ``develop`` branch has the latest contributions, and nearly all pull
 requests target ``develop``. The ``develop`` branch will report that its

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -190,11 +190,13 @@ The order of precedence is:
 * ``VISUAL``: standard environment variable for full-screen editors like ``vim`` or ``emacs``;
 * ``EDITOR``: older environment variable for your editor.
 
-You can set any of these to the command you want to run, e.g., in ``bash`` you might run one of these::
+You can set any of these to the command you want to run, e.g., in ``bash`` you might run one of these:
 
-  export VISUAL=vim
-  export EDITOR="emacs -nw"
-  export SPACK_EDITOR=nano
+.. code-block:: console
+
+   $ export VISUAL=vim
+   $ export EDITOR="emacs -nw"
+   $ export SPACK_EDITOR=nano
 
 If Spack finds none of these variables set, it will look for ``vim``, ``vi``, ``emacs``, ``nano``, and ``notepad``, in that order.
 
@@ -424,9 +426,11 @@ Notice how you only have to specify the URL once, in the ``url`` field.
 Spack is smart enough to extrapolate the URL for each version based on the version number and download version ``8.2.0`` of the ``Foo`` package above from ``http://example.com/foo-8.2.0.tar.gz``.
 
 If the URL is particularly complicated or changes based on the release, you can override the default URL generation algorithm by defining your own ``url_for_version()`` function.
-For example, the download URL for OpenMPI contains the ``major.minor`` version in one spot and the ``major.minor.patch`` version in another::
+For example, the download URL for OpenMPI contains the ``major.minor`` version in one spot and the ``major.minor.patch`` version in another:
 
-    https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.bz2
+.. code-block:: text
+
+   https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.bz2
 
 In order to handle this, you can define a ``url_for_version()`` function
 like so:
@@ -2442,12 +2446,14 @@ can have multiple, differently-patched versions of a package installed at
 once.
 
 You can look up a patch by its sha256 hash (or a short version of it)
-using the ``spack resource show`` command::
+using the ``spack resource show`` command
 
-  $ spack resource show 3877ab54
-  3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00
-      path:       .../spack_repo/builtin/packages/m4/gnulib-pgi.patch
-      applies to: builtin.m4
+.. code-block:: console
+
+   $ spack resource show 3877ab54
+   3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00
+       path:       .../spack_repo/builtin/packages/m4/gnulib-pgi.patch
+       applies to: builtin.m4
 
 ``spack resource show`` looks up downloadable resources from package
 files by hash and prints out information about them.  Above, we see that
@@ -2457,16 +2463,18 @@ tells us where to find the patch.
 Things get more interesting if you want to know about dependency
 patches. For example, when ``dealii`` is built with ``boost@1.68.0``, it
 has to patch boost to work correctly.  If you didn't know this, you might
-wonder where the extra boost patches are coming from::
+wonder where the extra boost patches are coming from:
 
-  $ spack spec dealii ^boost@1.68.0 ^hdf5+fortran | grep "\^boost"
-      ^boost@1.68.0
-          ^boost@1.68.0%apple-clang@9.0.0+atomic+chrono~clanglibcpp cxxstd=default +date_time~debug+exception+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy patches=2ab6c72d03dec6a4ae20220a9dfd5c8c572c5294252155b85c6874d97c323199,b37164268f34f7133cbc9a4066ae98fda08adf51e1172223f6a969909216870f ~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave arch=darwin-highsierra-x86_64
-  $ spack resource show b37164268
-  b37164268f34f7133cbc9a4066ae98fda08adf51e1172223f6a969909216870f
-      path:       .../spack_repo/builtin/packages/dealii/boost_1.68.0.patch
-      applies to: builtin.boost
-      patched by: builtin.dealii
+.. code-block:: console
+
+   $ spack spec dealii ^boost@1.68.0 ^hdf5+fortran | grep "\^boost"
+       ^boost@1.68.0
+           ^boost@1.68.0%apple-clang@9.0.0+atomic+chrono~clanglibcpp cxxstd=default +date_time~debug+exception+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy patches=2ab6c72d03dec6a4ae20220a9dfd5c8c572c5294252155b85c6874d97c323199,b37164268f34f7133cbc9a4066ae98fda08adf51e1172223f6a969909216870f ~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave arch=darwin-highsierra-x86_64
+   $ spack resource show b37164268
+   b37164268f34f7133cbc9a4066ae98fda08adf51e1172223f6a969909216870f
+       path:       .../spack_repo/builtin/packages/dealii/boost_1.68.0.patch
+       applies to: builtin.boost
+       patched by: builtin.dealii
 
 Here you can see that the patch is applied to ``boost`` by ``dealii``,
 and that it lives in ``dealii``'s directory in Spack's ``builtin``

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -600,30 +600,30 @@ requests ``GET <URL>[:PORT][/PATH]?spec=<pkg_name@pkg_version +variant1+variant2
 
 example request.
 
-.. code-block::
+.. code-block:: text
 
-  https://my-dyn-mapping.spack.io/allocation?spec=zlib-ng@2.1.6 +compat+opt+shared+pic+new_strategies arch=linux-ubuntu20.04-x86_64_v3%gcc@12.0.0
+   https://my-dyn-mapping.spack.io/allocation?spec=zlib-ng@2.1.6 +compat+opt+shared+pic+new_strategies arch=linux-ubuntu20.04-x86_64_v3%gcc@12.0.0
 
 
 With an example response that updates kubernetes request variables, overrides the max retries for gitlab,
 and prepends a note about the modifications made by the my-dyn-mapping.spack.io service.
 
-.. code-block::
+.. code-block:: text
 
-  200 OK
+   200 OK
 
-  {
-    "variables":
-    {
-      "KUBERNETES_CPU_REQUEST": "500m",
-      "KUBERNETES_MEMORY_REQUEST": "2G",
-    },
-    "retry": { "max:": "1"}
-    "script+:":
-    [
-      "echo \"Job modified by my-dyn-mapping.spack.io\""
-    ]
-  }
+   {
+     "variables":
+     {
+       "KUBERNETES_CPU_REQUEST": "500m",
+       "KUBERNETES_MEMORY_REQUEST": "2G",
+     },
+     "retry": { "max:": "1"}
+     "script+:":
+     [
+       "echo \"Job modified by my-dyn-mapping.spack.io\""
+     ]
+   }
 
 
 The ci.yaml configuration section takes the URL endpoint as well as a number of options to configure how responses are handled.

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -22,21 +22,23 @@ This document describes how to set up and manage these package repositories.
 Structure of an Individual Package Repository
 ---------------------------------------------
 
-An individual Spack package repository is a directory structured as follows::
+An individual Spack package repository is a directory structured as follows:
 
-  /path/to/repos/                   # the top-level dir is added to the Python search path
-    spack_repo/                     # every package repository is part of the spack_repo Python module
-      myrepo/                       # directory for the 'myrepo' repository (matches namespace)
-        repo.yaml                   # configuration file for this package repository
-        packages/                   # directory containing package directories
-          hdf5/                     # directory for the hdf5 package
-            package.py              # the package recipe file
-          mpich/                    # directory for the mpich package
-            package.py              # the package recipe file
-            mpich-1.9-bugfix.patch  # example patch file
-          trilinos/
-            package.py
-      ...
+.. code-block:: text
+
+   /path/to/repos/                   # the top-level dir is added to the Python search path
+     spack_repo/                     # every package repository is part of the spack_repo Python module
+       myrepo/                       # directory for the 'myrepo' repository (matches namespace)
+         repo.yaml                   # configuration file for this package repository
+         packages/                   # directory containing package directories
+           hdf5/                     # directory for the hdf5 package
+             package.py              # the package recipe file
+           mpich/                    # directory for the mpich package
+             package.py              # the package recipe file
+             mpich-1.9-bugfix.patch  # example patch file
+           trilinos/
+             package.py
+       ...
 
 * ``repo.yaml``.
   This file contains metadata for this specific repository, for example:
@@ -159,26 +161,28 @@ If the repo is pinned to a branch or unpinned, ``spack repo update`` will pull t
 **Git repositories need a package repo index.**
 A single Git repository can contain one or more Spack package repositories. To enable Spack to discover these, the root of the Git repository should contain a ``spack-repo-index.yaml`` file. This file lists the relative paths to package repository roots within the git repo.
 
-For example, assume a Git repository at ``https://example.com/my_org/my_pkgs.git`` has the following structure::
+For example, assume a Git repository at ``https://example.com/my_org/my_pkgs.git`` has the following structure
 
-  my_pkgs.git/
-    spack-repo-index.yaml     # metadata file at the root of the Git repo
-    ...
-    spack_pkgs/
-      spack_repo/
-        my_org/
-          comp_sci_packages/  # package repository for computer science packages
-            repo.yaml
-            packages/
-              hdf5/
-                package.py
-              mpich/
-                package.py
-          physics_packages/   # package repository for physics packages
-            repo.yaml
-            packages/
-              gromacs/
-                package.py
+.. code-block:: text
+
+   my_pkgs.git/
+     spack-repo-index.yaml     # metadata file at the root of the Git repo
+     ...
+     spack_pkgs/
+       spack_repo/
+         my_org/
+           comp_sci_packages/  # package repository for computer science packages
+             repo.yaml
+             packages/
+               hdf5/
+                 package.py
+               mpich/
+                 package.py
+           physics_packages/   # package repository for physics packages
+             repo.yaml
+             packages/
+               gromacs/
+                 package.py
 
 The ``spack-repo-index.yaml`` in the root of ``https://example.com/my_org/my_pkgs.git`` should look like this:
 
@@ -254,21 +258,23 @@ Nested Namespaces for Organizations
 
 As we have already seen in the Git-based package repositories example above, you can create nested namespaces by using periods in the namespace name.
 For example, a repository for packages related to computation at LLNL might have the namespace ``llnl.comp``, while one for physical and life sciences could be ``llnl.pls``.
-On the file system, this requires a directory structure like this::
+On the file system, this requires a directory structure like this:
 
-  /path/to/repos/
-    spack_repo/
-      llnl/
-        comp/
-          repo.yaml  # Contains namespace: llnl.comp
-          packages/
-            mpich/
-              package.py
-        pls/
-          repo.yaml  # Contains namespace: llnl.pls
-          packages/
-            hdf5/
-              package.py
+.. code-block:: text
+
+   /path/to/repos/
+     spack_repo/
+       llnl/
+         comp/
+           repo.yaml  # Contains namespace: llnl.comp
+           packages/
+             mpich/
+               package.py
+         pls/
+           repo.yaml  # Contains namespace: llnl.pls
+           packages/
+             hdf5/
+               package.py
 
 Uniqueness
 ^^^^^^^^^^
@@ -420,14 +426,16 @@ To create the directory structure for a new, empty local repository:
   ==> To register it with spack, run this command:
     spack repo add ~/my_spack_projects/spack_repo/myorg/projectx
 
-This command creates the following structure::
+This command creates the following structure:
 
-  ~/my_spack_projects/
-    spack_repo/
-      myorg/
-        projectx/
-          repo.yaml      # Contains namespace: myorg.projectx
-          packages/      # Empty directory for new package.py files
+.. code-block:: text
+
+   ~/my_spack_projects/
+     spack_repo/
+       myorg/
+         projectx/
+           repo.yaml      # Contains namespace: myorg.projectx
+           packages/      # Empty directory for new package.py files
 
 The ``<target_dir>`` is where the ``spack_repo/<namespace_parts>`` hierarchy will be created.
 The ``<namespace>`` can be simple (e.g., ``myrepo``) or nested (e.g., ``myorg.projectx``), and Spack will create the corresponding directory structure.

--- a/lib/spack/docs/signing.rst
+++ b/lib/spack/docs/signing.rst
@@ -190,50 +190,54 @@ blobs.
 The manifest files can either be signed or unsigned, but are always given
 a name ending with ``.spec.manifest.json`` regardless. The difference between
 signed and unsigned manifests is simply that the signed version is wrapped in
-a gpg cleartext signature, as illustrated below::
+a gpg cleartext signature, as illustrated below:
 
-  -----BEGIN PGP SIGNED MESSAGE-----
-  Hash: SHA512
+.. code-block:: text
 
-  {
-    "version": 3,
-    "data": [
-      {
-        "contentLength": 10731083,
-        "mediaType": "application/vnd.spack.install.v2.tar+gzip",
-        "compression": "gzip",
-        "checksumAlgorithm": "sha256",
-        "checksum": "0f24aa6b5dd7150067349865217acd3f6a383083f9eca111d2d2fed726c88210"
-      },
-      {
-        "contentLength": 1000,
-        "mediaType": "application/vnd.spack.spec.v5+json",
-        "compression": "gzip",
-        "checksumAlgorithm": "sha256",
-        "checksum": "fba751c4796536737c9acbb718dad7429be1fa485f5585d450ab8b25d12ae041"
-      }
-    ]
-  }
-  -----BEGIN PGP SIGNATURE-----
+   -----BEGIN PGP SIGNED MESSAGE-----
+   Hash: SHA512
 
-  iQGzBAEBCgAdFiEEdbwFKBFJCcB24mB0GAEP+tc8mwcFAmf2rr4ACgkQGAEP+tc8
-  mwfefwv+KJs8MsQ5ovFaBdmyx5H/3k4rO4QHBzuSPOB6UaxErA9IyOB31iP6vNTU
-  HzYpxz6F5dJCJWmmNEMN/0+vjhMHEOkqd7M1l5reVcxduTF2yc4tBZUO2gienEHL
-  W0e+SnUznl1yc/aVpChUiahO2zToCsI8HZRNT4tu6iCnE/OpghqjsSdBOZHmSNDD
-  5wuuCxfDUyWI6ZlLclaaB7RdbCUUJf/iqi711J+wubvnDFhc6Ynwm1xai5laJ1bD
-  ev3NrSb2AAroeNFVo4iECA0fZC1OZQYzaRmAEhBXtCideGJ5Zf2Cp9hmCwNK8Hq6
-  bNt94JP9LqC3FCCJJOMsPyOOhMSA5MU44zyyzloRwEQpHHLuFzVdbTHA3dmTc18n
-  HxNLkZoEMYRc8zNr40g0yb2lCbc+P11TtL1E+5NlE34MX15mPewRCiIFTMwhCnE3
-  gFSKtW1MKustZE35/RUwd2mpJRf+mSRVCl1f1RiFjktLjz7vWQq7imIUSam0fPDr
-  XD4aDogm
-  =RrFX
-  -----END PGP SIGNATURE-----
+   {
+     "version": 3,
+     "data": [
+       {
+         "contentLength": 10731083,
+         "mediaType": "application/vnd.spack.install.v2.tar+gzip",
+         "compression": "gzip",
+         "checksumAlgorithm": "sha256",
+         "checksum": "0f24aa6b5dd7150067349865217acd3f6a383083f9eca111d2d2fed726c88210"
+       },
+       {
+         "contentLength": 1000,
+         "mediaType": "application/vnd.spack.spec.v5+json",
+         "compression": "gzip",
+         "checksumAlgorithm": "sha256",
+         "checksum": "fba751c4796536737c9acbb718dad7429be1fa485f5585d450ab8b25d12ae041"
+       }
+     ]
+   }
+   -----BEGIN PGP SIGNATURE-----
+
+   iQGzBAEBCgAdFiEEdbwFKBFJCcB24mB0GAEP+tc8mwcFAmf2rr4ACgkQGAEP+tc8
+   mwfefwv+KJs8MsQ5ovFaBdmyx5H/3k4rO4QHBzuSPOB6UaxErA9IyOB31iP6vNTU
+   HzYpxz6F5dJCJWmmNEMN/0+vjhMHEOkqd7M1l5reVcxduTF2yc4tBZUO2gienEHL
+   W0e+SnUznl1yc/aVpChUiahO2zToCsI8HZRNT4tu6iCnE/OpghqjsSdBOZHmSNDD
+   5wuuCxfDUyWI6ZlLclaaB7RdbCUUJf/iqi711J+wubvnDFhc6Ynwm1xai5laJ1bD
+   ev3NrSb2AAroeNFVo4iECA0fZC1OZQYzaRmAEhBXtCideGJ5Zf2Cp9hmCwNK8Hq6
+   bNt94JP9LqC3FCCJJOMsPyOOhMSA5MU44zyyzloRwEQpHHLuFzVdbTHA3dmTc18n
+   HxNLkZoEMYRc8zNr40g0yb2lCbc+P11TtL1E+5NlE34MX15mPewRCiIFTMwhCnE3
+   gFSKtW1MKustZE35/RUwd2mpJRf+mSRVCl1f1RiFjktLjz7vWQq7imIUSam0fPDr
+   XD4aDogm
+   =RrFX
+   -----END PGP SIGNATURE-----
 
 If a user has trusted the public key associated with the private key
 used to sign the above manifest file, the signature can be verified with
-gpg, as follows::
+gpg, as follows:
 
-  $ gpg --verify gcc-runtime-12.3.0-s2nqujezsce4x6uhtvxscu7jhewqzztx.spec.manifest.json
+.. code-block:: console
+
+   $ gpg --verify gcc-runtime-12.3.0-s2nqujezsce4x6uhtvxscu7jhewqzztx.spec.manifest.json
 
 When attempting to install a binary package that has been signed, spack will
 attempt to verify the signature with one of the trusted keys in its keyring,


### PR DESCRIPTION
Use of `::` at the end of a line or `.. code-block::` means "default
language", which is Python.

Fix cases where Python is the wrong language by using

```
.. code-block:: <lang>
```
