### PR TITLE
Concretizer: fix missing apostrophe in error message

### DIFF
--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -92,7 +92,7 @@ error(1, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, Constrain
      attr("version", node(ID, Package), Version),
      not pkg_fact(Package, version_satisfies(Constraint, Version)).
 
-error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}", Package, Constraint1, Constraint2, startcauses, Cause1, C1ID, Cause2, C2ID)
+error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}'", Package, Constraint1, Constraint2, startcauses, Cause1, C1ID, Cause2, C2ID)
   :- attr("node_version_satisfies", node(ID, Package), Constraint1),
      pkg_fact(TriggerPkg1, condition_effect(Cause1, EffectID1)),
      imposed_constraint(EffectID1, "node_version_satisfies", Package, Constraint1),


### PR DESCRIPTION
### Before

```
     3. Cannot satisfy 'py-setuptools@41.2:' and 'py-setuptools@:67
```

### After

```
     3. Cannot satisfy 'py-setuptools@41.2:' and 'py-setuptools@:67'
```