### PR TITLE
`spack info`: show conditional dependencies and licenses; allow filtering

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -153,7 +153,7 @@ def format_deptype(depflag: int) -> str:
 
 class DependencyFormatter(Formatter):
     def format_name(self, dep: spack.dependency.Dependency) -> str:
-        return dep.spec.format(color=color.get_color_when())
+        return dep.spec._long_spec(color=color.get_color_when())
 
     def format_values(self, dep: spack.dependency.Dependency) -> str:
         return str(format_deptype(dep.depflag))

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -370,7 +370,7 @@ def print_grouped_by_when(
 
     indent = 4
     for when, by_name in sorted(when_indexed_dictionary.items(), key=unconditional_first):
-        if not pkg.spec.intersects(when):
+        if not pkg.intersects(when):
             continue
 
         start_indent = indent
@@ -408,9 +408,19 @@ def print_by_name(
 
     indent = 4
 
+    def unconditional_first(definition: Any) -> SupportsRichComparison:
+        spec = getattr(definition, "spec", None)
+        if spec:
+            return (spec != spack.spec.Spec(spec.name), spec)
+        else:
+            return getattr(definition, "name", None)  # type: ignore[return-value]
+
     for subkey in spack.package_base._subkeys(when_indexed_dictionary):
-        for when, definition in spack.package_base._definitions(when_indexed_dictionary, subkey):
-            if not pkg.spec.intersects(when):
+        for when, definition in sorted(
+            spack.package_base._definitions(when_indexed_dictionary, subkey),
+            key=lambda t: unconditional_first(t[1]),
+        ):
+            if not pkg.intersects(when):
                 continue
 
             _print_definition(

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -23,6 +23,7 @@ import spack.spec
 import spack.variant
 import spack.version
 from spack.cmd.common import arguments
+import spack.llnl.util.tty as tty
 from spack.llnl.util.tty.colify import colify
 from spack.package_base import PackageBase
 from spack.util.typing import SupportsRichComparison
@@ -576,7 +577,9 @@ def print_virtuals(pkg: PackageBase, args: Namespace) -> None:
 def info(parser: argparse.ArgumentParser, args: Namespace) -> None:
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) > 1:
-        tty.die(f"spack info requires exactly one spec. Parsed {len(specs)}")
+        tty.die(f"`spack info` requires exactly one spec. Parsed {len(specs)}")
+    if len(specs) == 0:
+        tty.die("`spack info` requires a spec.")
 
     spec = specs[0]
     pkg_cls = spack.repo.PATH.get_pkg_class(spec.fullname)

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -583,6 +583,7 @@ def info(parser: argparse.ArgumentParser, args: Namespace) -> None:
 
     spec = specs[0]
     pkg_cls = spack.repo.PATH.get_pkg_class(spec.fullname)
+    pkg_cls.validate_variant_names(spec)
     pkg = pkg_cls(spec)
 
     # Output core package information

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -356,7 +356,7 @@ def _print_definition(
     formatted_name_and_values = f"{indent * ' '}{name_field}"
     if values_field:
         formatted_values = "\n".join(
-            textwrap.wrap(
+            spack.llnl.util.tty.color.cwrap(
                 values_field,
                 width=cols - 2,
                 initial_indent=value_indent,

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -90,8 +90,23 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "-a", "--all", action="store_true", default=False, help="output all package information"
     )
 
+    by = subparser.add_mutually_exclusive_group()
+    by.add_argument(
+        "--by-name",
+        dest="by_name",
+        action="store_true",
+        default=True,
+        help="list variants, dependency, etc. in name order, then by when condition",
+    )
+    by.add_argument(
+        "--by-when",
+        dest="by_name",
+        action="store_false",
+        default=False,
+        help="group variants, dependencies, etc. first by when condition, then by name",
+    )
+
     options = [
-        ("--by-name", "list variants in strict name order; don't group by condition"),
         ("--detectable", print_detectable.__doc__),
         ("--maintainers", print_maintainers.__doc__),
         ("--namespace", print_namespace.__doc__),

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1688,6 +1688,18 @@ def _from_merged_attrs(fetcher, pkg, version):
 
 
 def for_package_version(pkg, version=None):
+    saved_versions = None
+    if version is not None:
+        saved_versions = pkg.spec.versions
+
+    try:
+        return _for_package_version(pkg, version)
+    finally:
+        if saved_versions is not None:
+            pkg.spec.versions = saved_versions
+
+
+def _for_package_version(pkg, version=None):
     """Determine a fetch strategy based on the arguments supplied to
     version() in the package description."""
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -786,6 +786,19 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         except StopIteration:
             raise ValueError(f"No variant '{name}' on spec: {self.spec}")
 
+    @classmethod
+    def validate_variant_names(self, spec: spack.spec.Spec):
+        """Check that all variant names on Spec exist in this package.
+
+        Raises ``UnknownVariantError`` if invalid variants are on the spec.
+        """
+        names = self.variant_names()
+        for v in spec.variants:
+            if v not in names:
+                raise spack.variant.UnknownVariantError(
+                    f"No such variant '{v}' in package {self.name}", [v]
+                )
+
     @classproperty
     def package_dir(cls):
         """Directory where the package.py file lives."""

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -584,8 +584,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: which is deprecated
     legacy_buildsystem: str
 
-    #: Must be defined in derived classes. Used when reporting the build system to users
-    build_system_class: str
+    #: Used when reporting the build system to users
+    build_system_class: str = "PackageBase"
 
     #: By default, packages are not virtual
     #: Virtual packages override this attribute

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -447,14 +447,6 @@ def _num_definitions(when_indexed_dictionary: Dict[spack.spec.Spec, Dict[K, V]])
     return sum(len(dictionary) for dictionary in when_indexed_dictionary.values())
 
 
-def _precedence(obj) -> int:
-    """Get either a 'precedence' attribute or item from an object."""
-    precedence = getattr(obj, "precedence", None)
-    if precedence is None:
-        raise KeyError(f"Couldn't get precedence from {type(obj)}")
-    return precedence
-
-
 def _remove_overridden_defs(defs: List[Tuple[spack.spec.Spec, Any]]) -> None:
     """Remove definitions from the list if their when specs are satisfied by later ones.
 
@@ -503,7 +495,7 @@ def _definitions(
 
     # With multiple definitions, ensure precedence order and simplify overrides
     if len(defs) > 1:
-        defs.sort(key=lambda v: _precedence(v[1]))
+        defs.sort(key=lambda v: getattr(v[1], "precedence", 0))
         _remove_overridden_defs(defs)
 
     return defs

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 import pytest
 
-from spack.main import SpackCommand
+from spack.main import SpackCommand, SpackCommandError
 
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
 
@@ -14,6 +16,13 @@ info = SpackCommand("info")
 @pytest.mark.parametrize("extra_args", [[], ["--variants-by-name"]])
 def test_it_just_runs(extra_args):
     info(*extra_args, "vtk-m")
+
+
+# no specs, more than one spec
+@pytest.mark.parametrize("args", [[], ["vtk-m", "zmpi"]])
+def test_info_failures(args):
+    with pytest.raises(SpackCommandError):
+        info(*args)
 
 
 def test_info_noversion():
@@ -55,24 +64,77 @@ def test_info_fields(pkg_query, extra_args):
 
 
 @pytest.mark.parametrize(
-    "by_name,args,in_output,not_in_output",
+    "args,in_output,not_in_output",
     [
-        (True, ["licenses-1 +foo"], ["MIT"], ["Apache-2.0"]),
-        (True, ["licenses-1 ~foo"], ["Apache-2.0"], ["MIT"]),
-        (True, ["bowtie"], ["1.4.0", "1.3.0", "1.2.2", "1.2.0"], []),
-        (True, ["bowtie@1.2:"], ["1.4.0", "1.3.0", "1.2.2", "1.2.0"], []),
-        (True, ["bowtie@1.3:"], ["1.4.0", "1.3.0"], ["1.2.2", "1.2.0"]),
-        (True, ["bowtie@1.2"], ["1.2.2", "1.2.0"], ["1.3.0"]),  # 1.4.0 still shown as preferred
-        (False, ["licenses-1 +foo"], ["MIT"], ["Apache-2.0"]),
-        (False, ["licenses-1 ~foo"], ["Apache-2.0"], ["MIT"]),
-        (False, ["bowtie"], ["1.4.0", "1.3.0", "1.2.2", "1.2.0"], []),
-        (False, ["bowtie@1.2:"], ["1.4.0", "1.3.0", "1.2.2", "1.2.0"], []),
-        (False, ["bowtie@1.3:"], ["1.4.0", "1.3.0"], ["1.2.2", "1.2.0"]),
-        (False, ["bowtie@1.2"], ["1.2.2", "1.2.0"], ["1.3.0"]),  # 1.4.0 still shown as preferred
+        # no variants
+        (["package-base-extendee"], [r"Variants:\n\s*None"], []),
+        # test that long lines wrap around
+        (
+            ["long-boost-dependency+longdep"],
+            [
+                r"boost\+atomic\+chrono\+date_time\+filesystem\+graph\+iostreams\+locale\n"
+                r"\s*build, link"
+            ],
+            [],
+        ),
+        (
+            ["long-boost-dependency~longdep"],
+            [],
+            [
+                r"boost\+atomic\+chrono\+date_time\+filesystem\+graph\+iostreams\+locale\n"
+                r"\s*build, link"
+            ],
+        ),
+        # conditional licenses change output
+        (["licenses-1 +foo"], ["MIT"], ["Apache-2.0"]),
+        (["licenses-1 ~foo"], ["Apache-2.0"], ["MIT"]),
+        # filtering bowtie versions
+        (["bowtie"], ["1.4.0", "1.3.0", "1.2.2", "1.2.0"], []),
+        (["bowtie@1.2:"], ["1.4.0", "1.3.0", "1.2.2", "1.2.0"], []),
+        (["bowtie@1.3:"], ["1.4.0", "1.3.0"], ["1.2.2", "1.2.0"]),
+        (["bowtie@1.2"], ["1.2.2", "1.2.0"], ["1.3.0"]),  # 1.4.0 still shown as preferred
+        # many dependencies with suggestion to filter
+        (
+            ["many-conditional-deps"],
+            ["consider this for a simpler view:\n  spack info many-conditional-deps~cuda~rocm"],
+            [],
+        ),
+        (
+            ["many-conditional-deps ~cuda"],
+            ["consider this for a simpler view:\n  spack info many-conditional-deps~cuda~rocm"],
+            [],
+        ),
+        (
+            ["many-conditional-deps ~rocm"],
+            ["consider this for a simpler view:\n  spack info many-conditional-deps~cuda~rocm"],
+            [],
+        ),
+        (["many-conditional-deps ~cuda ~rocm"], [], ["consider this for a simpler view:"]),
+        # Ensure spack info knows that build_system is a single value variant
+        (
+            ["dual-cmake-autotools"],
+            [r"when\s*build_system=cmake", r"when\s*build_system=autotools"],
+            [],
+        ),
+        (
+            ["dual-cmake-autotools build_system=cmake"],
+            [r"when\s*build_system=cmake"],
+            [r"when\s*build_system=autotools"],
+        ),
+        # Ensure that gemerator=make implies build_system=cmake and therefore no autotools
+        (
+            ["dual-cmake-autotools generator=make"],
+            [r"when\s*build_system=cmake"],
+            [r"when\s*build_system=autotools"],
+        ),
     ],
 )
-def test_filtered_info(by_name, args, in_output, not_in_output):
-    by_name_arg = ["--by-name"] if by_name else []
+@pytest.mark.parametrize("by_name", [True, False])
+def test_info_output(by_name, args, in_output, not_in_output):
+    by_name_arg = ["--by-name"] if by_name else ["--by-when"]
     output = info(*(by_name_arg + args))
-    assert all(io in output for io in in_output)
-    assert all(nio not in output for nio in not_in_output)
+
+    for io in in_output:
+        assert re.search(io, output)
+    for nio in not_in_output:
+        assert not re.search(nio, output)

--- a/lib/spack/spack/test/llnl/util/tty/color.py
+++ b/lib/spack/spack/test/llnl/util/tty/color.py
@@ -1,0 +1,51 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+import textwrap
+
+import pytest
+
+import spack.llnl.util.tty.color as color
+
+test_text = [
+    "@r{The quick brown fox jumps over the lazy yellow dog.",
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt "
+    "ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco "
+    "laboris nisi ut aliquip ex ea commodo consequat.}",
+    "@c{none, gfx1010, gfx1011, gfx1012, gfx1013, gfx1030, gfx1031, gfx1032, gfx1033, gfx1034}",
+    "none, @c{gfx1010}, gfx1011, @r{gfx1012}, gfx1013, @b{gfx1030}, gfx1031, gfx1032, gfx1033",
+    "@c{none, 10, 100, 100a, 100f, 101, 101a, 101f, 103, 103a, 103f, 11, 12, 120, 120a, 120f}",
+    "@c{none, 10,     100, 100a,   100f, 101, 101a, 101f,    103, 103a,    103f, 11, 12, 120}",
+    "none, @c{10},     @b{100}, 100a,   @r{100f}, 101, @g{101a}, 101f,    @c{103}, 103a,    103f"
+    "@g{build}, @c{link}, @r{run}",
+]
+
+
+@pytest.mark.parametrize("cols", list(range(30, 101, 10)))
+@pytest.mark.parametrize("text", test_text)
+@pytest.mark.parametrize("indent", [0, 4, 8])
+def test_color_wrap(cols, text, indent):
+    colorized = color.colorize(text, color=True)  # True to force color
+    plain = color.csub(colorized)
+
+    spaces = indent * " "
+
+    color_wrapped = " ".join(
+        color.cwrap(colorized, width=cols, initial_indent=spaces, subsequent_indent=spaces)
+    )
+    plain_cwrapped = " ".join(
+        color.cwrap(plain, width=cols, initial_indent=spaces, subsequent_indent=spaces)
+    )
+    wrapped = " ".join(
+        textwrap.wrap(plain, width=cols, initial_indent=spaces, subsequent_indent=spaces)
+    )
+
+    # make sure the concatenated, non-indented wrapped version is the same as the
+    # original, modulo any spaces consumed while wrapping.
+    assert re.sub(r"\s+", " ", color_wrapped).lstrip() == re.sub(r"\s+", " ", colorized)
+
+    # make sure we wrap the same as textwrap
+    assert color.csub(color_wrapped) == wrapped
+    assert plain_cwrapped == wrapped

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1348,7 +1348,7 @@ _spack_help() {
 _spack_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -a --all --by-name --detectable --maintainers --namespace --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals --variants-by-name"
+        SPACK_COMPREPLY="-h --help -a --all --by-name --by-when --detectable --maintainers --namespace --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals --variants-by-name"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1348,7 +1348,7 @@ _spack_help() {
 _spack_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -a --all --detectable --maintainers --namespace --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals --variants-by-name"
+        SPACK_COMPREPLY="-h --help -a --all --by-name --detectable --maintainers --namespace --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals --variants-by-name"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2037,14 +2037,16 @@ complete -c spack -n '__fish_spack_using_command help' -l spec -f -a guide
 complete -c spack -n '__fish_spack_using_command help' -l spec -d 'help on the package specification syntax'
 
 # spack info
-set -g __fish_spack_optspecs_spack_info h/help a/all by-name detectable maintainers namespace no-dependencies no-variants no-versions phases tags tests virtuals variants-by-name
+set -g __fish_spack_optspecs_spack_info h/help a/all by-name by-when detectable maintainers namespace no-dependencies no-variants no-versions phases tags tests virtuals variants-by-name
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 info' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command info' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command info' -s a -l all -d 'output all package information'
 complete -c spack -n '__fish_spack_using_command info' -l by-name -f -a by_name
-complete -c spack -n '__fish_spack_using_command info' -l by-name -d 'list variants in strict name order; don'"'"'t group by condition'
+complete -c spack -n '__fish_spack_using_command info' -l by-name -d 'list variants, dependency, etc. in name order, then by when condition'
+complete -c spack -n '__fish_spack_using_command info' -l by-when -f -a by_name
+complete -c spack -n '__fish_spack_using_command info' -l by-when -d 'group variants, dependencies, etc. first by when condition, then by name'
 complete -c spack -n '__fish_spack_using_command info' -l detectable -f -a detectable
 complete -c spack -n '__fish_spack_using_command info' -l detectable -d 'output information on external detection'
 complete -c spack -n '__fish_spack_using_command info' -l maintainers -f -a maintainers

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2037,12 +2037,14 @@ complete -c spack -n '__fish_spack_using_command help' -l spec -f -a guide
 complete -c spack -n '__fish_spack_using_command help' -l spec -d 'help on the package specification syntax'
 
 # spack info
-set -g __fish_spack_optspecs_spack_info h/help a/all detectable maintainers namespace no-dependencies no-variants no-versions phases tags tests virtuals variants-by-name
-complete -c spack -n '__fish_spack_using_command_pos 0 info' -f -a '(__fish_spack_packages)'
+set -g __fish_spack_optspecs_spack_info h/help a/all by-name detectable maintainers namespace no-dependencies no-variants no-versions phases tags tests virtuals variants-by-name
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 info' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command info' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command info' -s a -l all -d 'output all package information'
+complete -c spack -n '__fish_spack_using_command info' -l by-name -f -a by_name
+complete -c spack -n '__fish_spack_using_command info' -l by-name -d 'list variants in strict name order; don'"'"'t group by condition'
 complete -c spack -n '__fish_spack_using_command info' -l detectable -f -a detectable
 complete -c spack -n '__fish_spack_using_command info' -l detectable -d 'output information on external detection'
 complete -c spack -n '__fish_spack_using_command info' -l maintainers -f -a maintainers
@@ -2063,8 +2065,7 @@ complete -c spack -n '__fish_spack_using_command info' -l tests -f -a tests
 complete -c spack -n '__fish_spack_using_command info' -l tests -d 'output relevant build-time and stand-alone tests'
 complete -c spack -n '__fish_spack_using_command info' -l virtuals -f -a virtuals
 complete -c spack -n '__fish_spack_using_command info' -l virtuals -d 'output virtual packages'
-complete -c spack -n '__fish_spack_using_command info' -l variants-by-name -f -a variants_by_name
-complete -c spack -n '__fish_spack_using_command info' -l variants-by-name -d 'list variants in strict name order; don'"'"'t group by condition'
+complete -c spack -n '__fish_spack_using_command info' -l variants-by-name -f -a by_name
 
 # spack install
 set -g __fish_spack_optspecs_spack_install h/help only= u/until= p/concurrent-packages= j/jobs= overwrite fail-fast keep-prefix keep-stage dont-restage use-cache no-cache cache-only use-buildcache= include-build-deps no-check-signature show-log-on-error source n/no-checksum v/verbose fake only-concrete add no-add clean dirty test= log-format= log-file= help-cdash cdash-upload-url= cdash-build= cdash-site= cdash-track= cdash-buildstamp= y/yes-to-all f/force U/fresh reuse fresh-roots deprecated

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
@@ -30,6 +30,7 @@ class CMakePackage(PackageBase):
     default_buildsystem = "cmake"
 
     build_system("cmake")
+
     depends_on("cmake", type="build", when="build_system=cmake")
 
     def flags_to_build_system_args(self, flags):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dual_cmake_autotools/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dual_cmake_autotools/package.py
@@ -1,0 +1,28 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin_mock.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class DualCmakeAutotools(AutotoolsPackage, CMakePackage):
+    """Package with two build systems."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/dual-cmake-autotools-1.0.tar.gz"
+
+    version("1.0")
+    build_system("autotools", "cmake", default="autotools")
+    variant(
+        "generator",
+        default="make",
+        values=("make", "ninja"),
+        description="the build system generator to use",
+        when="build_system=cmake",
+    )
+
+    with when("build_system=cmake"):
+        depends_on("cmake@3.5.1:", type="build")
+        depends_on("cmake@3.14.0:", type="build", when="@2.1.0:")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/licenses_1/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/licenses_1/package.py
@@ -17,3 +17,5 @@ class Licenses1(Package):
     license("Apache-2.0", when="~foo")
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    variant("foo", default=True, description="toggle license")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/long_boost_dependency/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/long_boost_dependency/package.py
@@ -1,0 +1,18 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class LongBoostDependency(Package):
+    """Simple package with one optional dependency"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0")
+
+    variant("longdep", description="enable boost dependency", default=True)
+
+    depends_on("boost+atomic+chrono+date_time+filesystem+graph+iostreams+locale", when="+longdep")
+    depends_on("boost", when="~longdep")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/many_conditional_deps/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/many_conditional_deps/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class ManyConditionalDeps(Package):
+    """Simple package with one optional dependency"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0")
+
+    variant("cuda", description="enable foo dependencies", default=True)
+    variant("rocm", description="enable bar dependencies", default=True)
+
+    for i in range(30):
+        depends_on(f"gpu-dep +cuda cuda_arch={i}", when=f"+cuda cuda_arch={i}")
+
+    for i in range(30):
+        depends_on(f"gpu-dep +rocm amdgpu_target={i}", when=f"+rocm amdgpu_target={i}")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/package_base_extendee/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/package_base_extendee/package.py
@@ -1,0 +1,13 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class PackageBaseExtendee(PackageBase):
+    """Simple package with one optional dependency"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0")


### PR DESCRIPTION
`spack info` has always shown dependencies grouped by type, but not conditional dependency information. While conditional deps are often very relevant, users have to read raw package files to see them. 

This PR generifies the code used to display variants and uses it for dependencies and licenses too. As with variants, dependencies are shown grouped by conditions, with unconditional dependencies first.  Users can supply the `--by-name` argument to list ordered first by name instead.

`--by-name` is meant to replace `--variants-by-name`. `--variants-by-name` still works but is suppressed from help and has the same function as `--by-name`.

`spack info gcc` before and after:

<img width="200" height="195" valign="top" alt="Screenshot 2025-08-10 at 10 28 36 PM" src="https://github.com/user-attachments/assets/5a20e90c-f485-4fd1-b833-9e0e49e5ebc2" />

<img width="200" height="1013" alt="Screenshot 2025-08-10 at 10 29 20 PM" src="https://github.com/user-attachments/assets/e72af675-e1ed-43f9-aa06-0e5138c417c2" />

As there is increasingly more information displayed by `spack info`, it can be useful to filter out variants, dependencies, versions, etc. that are irrelevant to certain package configurations.

This PR also allows `spack info` to take a spec instead of a package name, so users can run, e.g.:

```console
spack info hdf5@1.14
```

to get *only* information relevant to 1.14.x versions of `hdf5`.  Versions, dependencies, variants, and licenses are now filtered based on the input spec.

Before and after:

<img width="200" valign="top" height="429" alt="Screenshot 2025-08-10 at 10 33 03 PM" src="https://github.com/user-attachments/assets/b4401489-ab0b-4bea-8db3-bc01b37fc4b7" />

<img width="200" valign="top" height="302" alt="Screenshot 2025-08-10 at 10 33 22 PM" src="https://github.com/user-attachments/assets/087b6087-b4bd-42a0-a3d3-327decd097e6" />

- [x] generify when-grouping code to use a `Formatter` class
- [x] Rewrite variant code to use generic formatter.
- [x] Rewrite dependency code to use generic formatter.
- [x] Rewrite license code to use generic formatter.
- [x] add full type annotations to `cmd/info.py`
- [x] allow `spack info` to take a spec instead of a package name
- [x] filter `spack info` output versions, dependencies, variants, and licenses based on the input spec
- [x] tests