### PR TITLE
test: fix tests using non-mock configuration

### DIFF
--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -438,7 +438,7 @@ def test_git_sparse_paths_partial_clone(
 
 @pytest.mark.regression("50699")
 def test_git_sparse_path_have_unique_mirror_projections(
-    git, mock_git_repository, mutable_mock_repo, monkeypatch
+    git, mock_git_repository, mutable_mock_repo, monkeypatch, mutable_config
 ):
     """
     Confirm two packages with different sparse paths but the same git commit

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -331,8 +331,8 @@ def test_deserialize_preserves_package_attribute(default_mock_concretization):
 
 
 @pytest.mark.require_provenance
-def test_binary_provenance_commit_version(mock_packages):
-    spec = spack.concretize.concretize_one("git-ref-package@stable")
+def test_binary_provenance_commit_version(default_mock_concretization):
+    spec = default_mock_concretization("git-ref-package@stable")
     assert spec.satisfies(f"commit={'c' * 40}")
 
 


### PR DESCRIPTION
These two tests are influenced by user configuration.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
