### PR TITLE
docs: fix rst syntax issues

### DIFF
--- a/lib/spack/docs/build_systems/octavepackage.rst
+++ b/lib/spack/docs/build_systems/octavepackage.rst
@@ -40,7 +40,7 @@ Dependencies
 ^^^^^^^^^^^^
 
 Usually, the homepage of a package will list dependencies, i.e.,
-``Dependencies:	Octave >= 3.6.0 struct >= 1.0.12``. The same information should
+``Dependencies: Octave >= 3.6.0 struct >= 1.0.12``. The same information should
 be available in the ``DESCRIPTION`` file in the root of each archive.
 
 External Documentation

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -80,7 +80,8 @@ space available in the temporary location than in the home directory. If the
 username is not already in the path, Spack will append the value of ``$user`` to
 the selected ``build_stage`` path.
 
-.. warning:: We highly recommend specifying ``build_stage`` paths that
+.. warning::
+   We highly recommend specifying ``build_stage`` paths that
    distinguish between staging and other activities to ensure
    ``spack clean`` does not inadvertently remove unrelated files.
    Spack prepends ``spack-stage-`` to temporary staging directory names to

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -442,12 +442,12 @@ Contributing computational resources to Spack's CI build farm is one way to help
 capabilities and offerings of the public Spack build caches. Currently, Spack utilizes Linux runners
 from AWS, Google, and the University of Oregon (UO).
 
-Runners require three key pieces:
+Runners require four key pieces:
+
 * Runner Registration Token
 * Accurate tags
 * OIDC Authentication script
 * GPG keys
-
 
 Minimum GitLab Runner Version: ``16.1.0``
 `Installation instructions <https://docs.gitlab.com/runner/install/>`_

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -737,7 +737,7 @@ File filtering functions
     hard-coded ``sed`` commands in their build.
 
     ``change_sed_delimiter`` finds all ``sed`` search/replace commands
-    and changes the delimiter.  e.g., if the file contains commands
+    and changes the delimiter. E.g., if the file contains commands
     that look like ``s///``, you can use this to change them to
     ``s@@@``.
 

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -331,9 +331,10 @@ This search order allows you to override built-in packages.
 If you have your own ``mpich`` in a repository ``my_custom_repo``, and ``my_custom_repo`` is listed before ``builtin`` in your ``repos.yaml``, Spack will use your version of ``mpich`` by default.
 
 Suppose your effective (merged) ``repos.yaml`` implies the following order:
-1.  ``proto`` (local repo at ``~/my_spack_repos/spack_repo/proto_repo``)
-2.  ``llnl`` (local repo at ``/usr/local/repos/spack_repo/llnl_repo``)
-3.  ``builtin`` (Spack's default packages from `spack/spack-packages`)
+
+1. ``proto`` (local repo at ``~/my_spack_repos/spack_repo/proto_repo``)
+2. ``llnl`` (local repo at ``/usr/local/repos/spack_repo/llnl_repo``)
+3. ``builtin`` (Spack's default packages from ``spack/spack-packages``)
 
 And the packages are:
 

--- a/lib/spack/docs/signing.rst
+++ b/lib/spack/docs/signing.rst
@@ -403,7 +403,7 @@ registered as specific *protected* runners on the spack/spack project. In
 addition to protected runners there are protected branches on the spack/spack
 project. These are the ``develop`` branch, any release branch (i.e. managed with
 the ``releases/v*`` wildcard) and any tag branch (managed with the ``v*``
-wildcard) Finally, Spack's pipeline generation code reserves certain tags to make
+wildcard). Finally, Spack's pipeline generation code reserves certain tags to make
 sure jobs are routed to the correct runners; these tags are ``public``,
 ``protected``, and ``notary``. Understanding how all this works together to
 protect secrets and provide integrity assurances can be a little confusing so

--- a/lib/spack/docs/windows.rst
+++ b/lib/spack/docs/windows.rst
@@ -188,7 +188,7 @@ at the start of this section. Also note that YAML files use spaces for indentati
 and not tabs, so ensure that this is the case when editing one directly.
 
 
-.. note:: Cygwin
+.. note::
    The use of Cygwin is not officially supported by Spack and is not tested.
    However, Spack will not prevent this, so if choosing to use Spack
    with Cygwin, know that no functionality is guaranteed.
@@ -205,7 +205,7 @@ Spack console via:
 
 If in the previous step, you did not have CMake or Ninja installed, running the command above should install both packages.
 
-.. note:: Spec Syntax Caveats
+.. note::
    Windows has a few idiosyncrasies when it comes to the Spack spec syntax and the use of certain shells
    See the Spack spec syntax doc for more information
 


### PR DESCRIPTION
* add leading whitespace before list
* replace a curious tab with space
* remove note headers that were actually rendered in the content paragraph
* fix one instance of punctuation / capitalization

