### PR TITLE
cmd (find,spec): mv --format into arguments.py; add example

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -404,6 +404,19 @@ def concurrent_packages():
 
 
 @arg
+def format():
+    return Args(
+        "--format",
+        action="store",
+        default=None,
+        help=(
+            "output specs with the specified format string\n"
+            "e.g. {name}{@version}{compiler_flags}{variants}{/hash:7}\n"
+        ),
+    )
+
+
+@arg
 def install_status():
     return Args(
         "-I",

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -26,12 +26,9 @@ level = "short"
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     format_group = subparser.add_mutually_exclusive_group()
-    format_group.add_argument(
-        "--format",
-        action="store",
-        default=None,
-        help="output specs with the specified format string",
-    )
+
+    arguments.add_common_arguments(subparser, ["format"])
+
     format_group.add_argument(
         "-H",
         "--hashes",

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -53,12 +53,7 @@ for further documentation regarding the spec syntax, see:
         const="json",
         help="print concrete spec as JSON",
     )
-    format_group.add_argument(
-        "--format",
-        action="store",
-        default=None,
-        help="print concrete spec with the specified format string",
-    )
+    arguments.add_common_arguments(subparser, ["format"])
     subparser.add_argument(
         "-c",
         "--cover",

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2949,7 +2949,7 @@ complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -d 'print c
 complete -c spack -n '__fish_spack_using_command solve' -s j -l json -f -a format
 complete -c spack -n '__fish_spack_using_command solve' -s j -l json -d 'print concrete spec as JSON'
 complete -c spack -n '__fish_spack_using_command solve' -l format -r -f -a format
-complete -c spack -n '__fish_spack_using_command solve' -l format -r -d 'print concrete spec with the specified format string'
+complete -c spack -n '__fish_spack_using_command solve' -l format -r -d 'output specs with the specified format string'
 complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -f -a 'nodes edges paths'
 complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
 complete -c spack -n '__fish_spack_using_command solve' -s t -l types -f -a types
@@ -2985,7 +2985,7 @@ complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -d 'print co
 complete -c spack -n '__fish_spack_using_command spec' -s j -l json -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -s j -l json -d 'print concrete spec as JSON'
 complete -c spack -n '__fish_spack_using_command spec' -l format -r -f -a format
-complete -c spack -n '__fish_spack_using_command spec' -l format -r -d 'print concrete spec with the specified format string'
+complete -c spack -n '__fish_spack_using_command spec' -l format -r -d 'output specs with the specified format string'
 complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -f -a 'nodes edges paths'
 complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
 complete -c spack -n '__fish_spack_using_command spec' -s t -l types -f -a types


### PR DESCRIPTION
This PR adds a single line of help to the `--format` arguments for `spack find` and `spack spec`.

Help now should look like this:
```
usage: spack spec [-hlLNtfU] [-I | --no-install-status] [-y | -j | --format FORMAT] [-c {nodes,edges,paths}] [--reuse] [--fresh-roots] [--deprecated] ...

show what would be installed, given a spec

positional arguments:
  specs                 one or more package specs

options:
  --format FORMAT       print concrete spec with the specified format string
                        e.g. {name}{@version}{compiler_flags}{variants}{/hash:7}
  --no-install-status   do not show install status annotations
  -I, --install-status  show install status of packages
                        [+] installed       [^] installed in an upstream
                         -  not installed   [-] missing dep of installed package
```