### PR TITLE
docs: fix headings

### DIFF
--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -8,7 +8,6 @@
 
 .. _containers:
 
-================
 Container Images
 ================
 

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -127,7 +127,7 @@ or refer to the full manual below.
    Spack API Docs <spack>
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`


### PR DESCRIPTION
* index.rst: turn second h1 heading into h2 (there should be only one for the document)
* containers.rst: simple style fix