### PR TITLE
Docs: Add package review guide and roles and responsibilities

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -36,8 +36,10 @@ search:
     config_yaml.html: 5
     configuring_compilers.html: 5
     containers.html: 5
+    roles_and_responsibilities.html: 5
     contribution_guide.html: 5
     developer_guide.html: 5
+    package_review_guide.html: 5
     env_vars_yaml.html: 5
     environments.html: 5
     extensions.html: 5

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -104,8 +104,8 @@ If you're new to Spack and want to start using it, see :doc:`getting_started`, o
    packaging_guide_build
    packaging_guide_testing
    packaging_guide_advanced
-   roles_and_responsibilities
    build_systems
+   roles_and_responsibilities
    contribution_guide
    developer_guide
    package_review_guide

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -108,6 +108,7 @@ If you're new to Spack and want to start using it, see :doc:`getting_started`, o
    build_systems
    contribution_guide
    developer_guide
+   package_review_guide
 
 .. toctree::
    :maxdepth: 2

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -100,6 +100,7 @@ If you're new to Spack and want to start using it, see :doc:`getting_started`, o
    :maxdepth: 2
    :caption: Contributing
 
+   roles_and_responsibilities
    packaging_guide_creation
    packaging_guide_build
    packaging_guide_testing

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -100,11 +100,11 @@ If you're new to Spack and want to start using it, see :doc:`getting_started`, o
    :maxdepth: 2
    :caption: Contributing
 
-   roles_and_responsibilities
    packaging_guide_creation
    packaging_guide_build
    packaging_guide_testing
    packaging_guide_advanced
+   roles_and_responsibilities
    build_systems
    contribution_guide
    developer_guide

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -205,7 +205,7 @@ In this case, check Python package dependencies by following the build system `g
 
     In general, refer to the relevant dependencies section, if any, for the package’s `build system <https://spack.readthedocs.io/en/latest/build_systems.html>`_ for guidance.
 
-Updating Language and Compiler Dependencies
+Updating language and compiler dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When `language and compiler dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#language-and-compiler-dependencies>`_ were introduced, their ``depends_on`` directives were derived from the source for existing packages.

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -16,7 +16,7 @@ Package reviews are performed with the goals of minimizing build errors and maki
 This section establishes guidelines to help reviewers assess and merge pull requests (PRs) to Spack’s community `package repository <https://github.com/spack/spack-packages>`_.
 It describes the considerations and actions to be taken when reviewing new and updated `Spack packages <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#structure-of-a-package>`_.
 
-Inappropriate Package
+Inappropriate package
 ---------------------
 
 It is rare that a package would be considered inappropriate for inclusion in the public `Spack package <https://github.com/spack/spack-packages>`_ repository.
@@ -27,14 +27,14 @@ Should you find the software is not appropriate, explain to the :ref:`Package Co
 Ask that the package be removed from the PR if it is one of multiple affected files; otherwise suggest the PR be closed.
 In both cases, explain the reason for the request.
 
-CORE Perl Modules
+CORE Perl modules
 ~~~~~~~~~~~~~~~~~
 
 In general, modules that are part of the standard installation for all listed Perl versions (i.e., ``CORE``) should *not* be implemented or contributed as Spack packages.
 Details on the exceptions and process for checking Perl modules can be found in the `Perl <https://spack.readthedocs.io/en/latest/build_systems/perlpackage.html#suitable_perl_modules>`_ build system documentation.
 
-url, url_for_version, or URL Equivalent
----------------------------------------
+``url``, ``url_for_version``, or URL equivalent
+-----------------------------------------------
 
 Changes to URLs may invalidate existing versions, which should be checked when there is a URL-related modification.
 All packages have a URL, though for some `build systems <https://spack.readthedocs.io/en/latest/build_systems.html>`_ it is derived automatically and not visible in the package.
@@ -64,8 +64,8 @@ As these examples illlustrate, it is sometimes possible to add a ``url_for_versi
 
 If older versions are no longer available and there is a chance someone has the package in a build cache, the usual approach is to first suggest `deprecating <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ them in the package.
 
-Maintainers Directive
-----------------------
+``maintainers`` directive
+-------------------------
 
 **Action.**
 If the new package does not have a `maintainers <https://spack.readthedocs.io/en/latest/packaging_guide.html#maintainers>`_ directive, ask the :ref:`Package Contributor <package-contributors>` to consider adding themselves.
@@ -76,16 +76,16 @@ This request is optional for existing packages.
 
    Be prepared for them to refuse.
 
-License Directive
------------------
+``license`` directive
+---------------------
 
 **Action.**
 If the new package does not have a `license <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#license-information>`_  directive, ask the :ref:`Package Contributor <package-contributors>` to investigate and add it.
 
 This request is optional for existing packages.
 
-Version Directives
-------------------
+``version`` directives
+----------------------
 
 In general, Spack packages are expected to be built from source code.
 There are a few exceptions (e.g., `BundlePackage <https://spack.readthedocs.io/en/latest/build_systems/bundlepackage.html#bundlepackage>`_).
@@ -139,7 +139,7 @@ Checksums, commits, tags, and branches
   **Action.**
   In these cases it is acceptable to rely on the package's Maintainers, if any.
 
-Deprecating Versions
+Deprecating versions
 ~~~~~~~~~~~~~~~~~~~~
 
 If someone is deprecating versions, it is good to find out why.
@@ -148,12 +148,12 @@ Sometimes there are concerns, such as security or lack of availability.
 **Action.**
 Suggest the Package Contributor review the `deprecation guidelines <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ before finalizing the changes if they haven't already explained why they made the choice in the PR description or comments.
 
-Variant Directives
-------------------
+``variant`` directives
+----------------------
 
 `Variants <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#variants>`_ represent build options so any changes involving these directives should be reflected elsewhere in the package.
 
-Adding or Modifying Variants
+Adding or modifying variants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Action.**
@@ -164,7 +164,7 @@ The most common uses are additions and changes to:
 * configure options; and/or
 * build arguments.
 
-Removing or Disabling Variants
+Removing or disabling variants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the variant is still relevant to listed version directives, it may be preferable to adjust or add `conditions <https://spack.readthedocs.io/en/latest/packaging_guide.html#conditional-variants>`_.
@@ -179,12 +179,12 @@ Consider asking why the variant (or build option) is being removed and suggest m
 
 .. _depends_on_reviews:
 
-``depends_on`` Directives
+``depends_on`` directives
 -------------------------
 
 `Dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#dependencies>`_ represent software that must be installed before the package builds or is able to work correctly.
 
-Updating Dependencies
+Updating dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
 It is important that dependencies reflect the requirements of listed versions.
@@ -216,12 +216,12 @@ Unfortunately, the generated dependencies are not always complete.
 If these dependencies are being updated, ask if the :ref:`Package Contributor <package-contributors>` can confirm all of the generated dependencies and remove the ``# generated`` comments.
 Definitely make sure Contributors do **not** include ``# generated`` on the dependencies they are adding to the package.
 
-Failed Automated Checks
+Failed automated checks
 -----------------------
 
 All PRs are expected to pass **at least the required** automated checks.
 
-Style Failures
+Style failures
 ~~~~~~~~~~~~~~
 
 The PR may fail one or more style checks.
@@ -230,7 +230,7 @@ The PR may fail one or more style checks.
 If the failure is due to issues raised by the ``black`` style checker *and* the PR is otherwise ready to be merged, you can add ``@spackbot fix style`` in a comment to see if Spack will fix the errors.
 Otherwise, inform the Package Contributor that they need to address the style failures.
 
-CI Stack Failures
+CI stack failures
 ~~~~~~~~~~~~~~~~~
 
 Existing packages **may** be included in GitLab CI pipelines through inclusion in one or more `stacks <https://github.com/spack/spack-packages/tree/develop/stacks>`_.

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -179,8 +179,8 @@ Consider asking why the variant (or build option) is being removed and suggest m
 
 .. _depends_on_reviews:
 
-Depends_on Directives
----------------------
+``depends_on`` Directives
+-------------------------
 
 `Dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#dependencies>`_ represent software that must be installed before the package builds or is able to work correctly.
 

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -13,11 +13,49 @@ Package Review Guide
 
 Package reviews are performed with the goals of minimizing build errors and making packages as **uniform and stable** as possible.
 
-This section establishes guidelines to help reviewers assess and merge pull requests (PRs) to Spack’s community `package repository <https://github.com/spack/spack-packages>`_.
+This section establishes guidelines to help assess Spack community `package repository <https://github.com/spack/spack-packages>`_ pull requests (PRs).
 It describes the considerations and actions to be taken when reviewing new and updated `Spack packages <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#structure-of-a-package>`_.
+In some cases, there are possible solutions to common issues.
 
-Inappropriate package
+How to use this guide
 ---------------------
+
+Whether you are a :ref:`Package Reviewer <package-reviewers>`, :ref:`Maintainer <package-maintainers>`, or :ref:`Committer <committers>`, this guide highlights relevant aspects to consider when reviewing package pull requests.
+While this guide provides information on what to look for, the changes themselves should drive the actual review.
+
+Reviewing a new package?
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the pull request includes a new package, then focus on answering the following questions:
+
+* Should the :ref:`package <suitable_package>` be added to the repository?
+* Does the package :ref:`structure <review_structure>` conform to conventions?
+* Are the directives and their options correct?
+* Do all :ref:`automated checks <review_automated_checks>` pass?
+  If not, are there easy-to-resolve CI and/or test issues?
+* Is there :ref:`confirmation <review_build_success>` that every version builds successfully on at least one platform?
+
+Refer to the relevant sections below for more guidance.
+
+Reviewing changes to an existing package?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the pull request includes changes to an existing package, then focus on answering the following questions:
+
+* Are there any changes to the package :ref:`structure <review_structure>` and, if so, do they conform to conventions?
+* If there are new or updated directives, then are they and their options correct?
+* If there are changes to the ``url`` or its equivalent, are the older versions still correct?
+* If there are changes to the ``git`` or equivalent URL, do older branches exist in the new location?
+* Do all :ref:`automated checks <review_automated_checks>` pass?
+  If not, are there easy-to-resolve CI and/or test issues?
+* Is there :ref:`confirmation <review_build_success>` that every new version builds successfully on at least one platform?
+
+Refer to the relevant sections below for more guidance.
+
+.. _suitable_package:
+
+Package suitability
+-------------------
 
 It is rare that a package would be considered inappropriate for inclusion in the public `Spack package <https://github.com/spack/spack-packages>`_ repository.
 One exception is making packages for standard Perl modules.
@@ -32,6 +70,8 @@ CORE Perl modules
 
 In general, modules that are part of the standard installation for all listed Perl versions (i.e., ``CORE``) should *not* be implemented or contributed as Spack packages.
 Details on the exceptions and process for checking Perl modules can be found in the `Perl <https://spack.readthedocs.io/en/latest/build_systems/perlpackage.html#suitable_perl_modules>`_ build system documentation.
+
+.. _review_structure:
 
 Package structure
 -----------------
@@ -84,6 +124,14 @@ As these examples illlustrate, it is sometimes possible to add a ``url_for_versi
 
 If older versions are no longer available and there is a chance someone has the package in a build cache, the usual approach is to first suggest `deprecating <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ them in the package.
 
+``git``, ``hg``, ``svn``, or ``cvs``
+------------------------------------
+
+If the :ref:`repository-specific URL <vcs-fetch>` for fetching branches or the version control system (VCS) equivalent changes, there is a risk that the listed versions are no longer accessible.
+
+**Action.**
+You may need to check the new source repository to confirm the presence of all of the listed versions.
+
 .. _maintainers_reviews:
 
 ``maintainers`` directive
@@ -126,12 +174,12 @@ The goal of reviewing version directives is to confirm that versions are listed 
 ``version`` directive order
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Version directives should be listed in descending order, from newest to oldest.
-If branch versions are provided, they should be listed first.
+`Spack convention <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#versions-and-urls>`_ holds that version directives should be listed in descending order, from newest to oldest.
+If branch versions are provided, then they should be listed first.
 
 **Action.**
 When versions are being added, check the ordering of the directives.
-If any of the directives do not match the `Spack convention <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#versions-and-urls>`_, then request that the directives be re-ordered.
+Request that the directives be  re-ordered if any of the directives do not conform to the convention.
 
 Checksums, commits, tags, and branches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -255,6 +303,8 @@ Unfortunately, the generated dependencies are not always complete.
 If these dependencies are being updated, ask if the :ref:`Package Contributor <package-contributors>` can confirm all of the generated dependencies and remove the ``# generated`` comments.
 Definitely make sure Contributors do **not** include ``# generated`` on the dependencies they are adding to the package.
 
+.. _review_automated_checks:
+
 Failed automated checks
 -----------------------
 
@@ -296,3 +346,21 @@ It is worth checking at least a sampling of the failed job logs, if present, to 
   Look at the package implementation to see if the tests are using a batch scheduler or there appear to be too many or long running tests.
   If that is the case, then a pull request should be created in the ``spack/spack-packages`` repository that adds the package to the ``broken-tests-packages`` list in the `ci configuration <https://spack.readthedocs.io/en/latest/pipelines.html#ci-yaml>`_.
   Once the fix PR is merged, then the affected PR can be rebased to pick up the change.
+
+.. _review_build_success:
+
+Successful builds
+-----------------
+
+Is there evidence that the package builds successfully on at least one platform?
+For a new package, we would ideally have confirmation for every version; whereas, we would want confirmation of only the affected versions for changes to an existing package.
+
+Acceptable forms of confirmation are **one or more of**:
+
+* the :ref:`Contributor <package-contributors>` or another reviewer explicitly confirms a successful build of each new version of the software on at least one platform;
+* the software is built successfully by Spack CI by at least one of the CI stacks; and
+* at least one :ref:`Maintainer <package-maintainers>` confirms they are able to successfully build the software.
+
+.. note::
+
+   When builds are confirmed by individuals, we would prefer the output of ``spack debug report`` be included in either the PR description or a comment.

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -22,12 +22,15 @@ Inappropriate Package
 It is rare that a package would be considered inappropriate for inclusion in the public `Spack package <https://github.com/spack/spack-packages>`_ repository.
 One exception is making packages for standard Perl modules.
 
-Explain to the :ref:`Package Contributor <package-contributors>` in a comment or your review if the package should be removed from the PR and why.
+**Action.**
+Should you find the software is not appropriate, explain to the :ref:`Package Contributor <package-contributors>` in a comment or your review.
+Ask that the package be removed from the PR if it is one of multiple affected files; otherwise suggest the PR be closed.
+In both cases, explain the reason for the request.
 
 CORE Perl Modules
 ~~~~~~~~~~~~~~~~~
 
-In general, modules that are part of the standard installation for all listed Perl versions should *not* be implemented or contributed as Spack packages.
+In general, modules that are part of the standard installation for all listed Perl versions (i.e., ``CORE``) should *not* be implemented or contributed as Spack packages.
 Details on the exceptions and process for checking Perl modules can be found in the `Perl <https://spack.readthedocs.io/en/latest/build_systems/perlpackage.html#suitable_perl_modules>`_ build system documentation.
 
 url, url_for_version, or URL Equivalent
@@ -43,6 +46,7 @@ Reasons `versions <https://spack.readthedocs.io/en/latest/packaging_guide_creati
 * extrapolation of the derived URL no longer matches that of older versions; and
 * the older versions are no longer available.
 
+**Action.**
 Checking existing version directives with checksums can usually be done manually with the modified package using `spack checksum <https://spack.readthedocs.io/en/latest/command_index.html#spack-checksum>`_.
 
 **Solutions.**
@@ -56,16 +60,17 @@ This commonly happens with Python packages.
 For example, the case of one or more letters in the package name may change at some point (e.g., `py-sphinx <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_sphinx/package.py>`_).
 Also, dashes may be replaced with underscores (e.g., `py-scitkit-build <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_scikit_build/package.py>`_).
 In some cases, both changes can occur for the same package.
-As these examples illlustrate, it is sometimes possible to add a ``url_for_version`` method to override the default derived URL to ensure the correct URL is returned.
+As these examples illlustrate, it is sometimes possible to add a ``url_for_version`` method to override the default derived URL to ensure the correct one is returned.
 
 If older versions are no longer available and there is a chance someone has the package in a build cache, the usual approach is to first suggest `deprecating <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ them in the package.
 
 Maintainers Directive
 ----------------------
 
+**Action.**
 If the new package does not have a `maintainers <https://spack.readthedocs.io/en/latest/packaging_guide.html#maintainers>`_ directive, ask the :ref:`Package Contributor <package-contributors>` to consider adding themselves.
 
-This request is an optional for existing packages.
+This request is optional for existing packages.
 
 .. tip::
 
@@ -74,50 +79,65 @@ This request is an optional for existing packages.
 License Directive
 -----------------
 
+**Action.**
 If the new package does not have a `license <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#license-information>`_  directive, ask the :ref:`Package Contributor <package-contributors>` to investigate and add it.
 
-This is an optional request for existing packages.
+This request is optional for existing packages.
 
 Version Directives
 ------------------
 
-Spack packages are, with a few exceptions (e.g., `BundlePackage <https://spack.readthedocs.io/en/latest/build_systems/bundlepackage.html#bundlepackage>`_), expected to be built from source code.
+In general, Spack packages are expected to be built from source code.
+There are a few exceptions (e.g., `BundlePackage <https://spack.readthedocs.io/en/latest/build_systems/bundlepackage.html#bundlepackage>`_).
 Typically every package will have at least one `version directive <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#source-code-and-versions>`_.
 
+**Action.**
 The goal of reviewing this information is to confirm the existence and correctness of updated and new versions **and** that the versions are listed in descending order from newest to oldest.
-Additions and removals of version directives should also trigger a review of :ref:`dependencies <depends_on_reviews>`.
+The process for correctness checking depends on the arguments and nature of the software's downloads (see below).
+Additions and removals of version directives should generally trigger a review of :ref:`dependencies <depends_on_reviews>`.
 
 Checksums, commits, tags, and branches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Checksums, commits, and tags.**
-Normally these arguments are automatically validated by GitHub Actions using `spack ci verify-versions <https://spack.readthedocs.io/en/latest/command_index.html#spack-ci-verify-versions>`_.
-Review the PR's ``verify-checksums`` precheck to confirm.
-If necessary, checksums can usually be manually confirmed using `spack checksum <https://spack.readthedocs.io/en/latest/command_index.html#spack-checksum>`_.
+Checksums, commits, and tags.
+  Normally these version arguments are automatically validated by GitHub Actions using `spack ci verify-versions <https://spack.readthedocs.io/en/latest/command_index.html#spack-ci-verify-versions>`_.
 
-.. warning::
+  **Action.**
+  Review the PR's ``verify-checksums`` precheck to confirm.
+  If necessary, checksums can usually be manually confirmed using `spack checksum <https://spack.readthedocs.io/en/latest/command_index.html#spack-checksum>`_.
 
-   From a security and reproducibility standpoint, it is important that Spack be able to verify downloaded source.
-   This is accomplished using a hash (e.g., checksum or commit).
-   See `checksum verification <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#checksum-verification>`_ for more information.
+  .. warning::
 
-   Exceptions are allowed in rare cases, such as software supplied from reputable vendors.
-   When in doubt, ask others with merge privileges for advice.
+     From a security and reproducibility standpoint, it is important that Spack be able to verify downloaded source.
+     This is accomplished using a hash (e.g., checksum or commit).
+     See `checksum verification <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#checksum-verification>`_ for more information.
 
-**Tags.**
-If a ``tag`` is provided without a ``commit``, the downloaded software will not be trusted.
-Suggest that the ``commit`` argument be included in the ``version`` directive.
+     Exceptions are allowed in rare cases, such as software supplied from reputable vendors.
+     When in doubt, ask others with merge privileges for advice.
 
-**Branches.**
-Confirming branches exist, on the other hand, often involves checking the source repository.
+Tags.
+  If a ``tag`` is provided without a ``commit``, the downloaded software will not be trusted.
 
-In general, the name of a branch version should match the name of the branch in the repository.
-Sometimes they do not match when people are not aware of how Spack handles `version ordering <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#version-comparison>`_.
-If there is a mismatch, especially for the most common branch names (e.g., `develop`, `main`, and `master`), ask why and suggest the arguments be changed such that they match the actual branch name.
+  **Action.**
+  Suggest that the ``commit`` argument be included in the ``version`` directive.
 
-**Manual downloads.**
-Edge cases, such as manually downloaded software, may be difficult to confirm.
-In these cases it is acceptable to rely on the package's Maintainers, if any.
+Branches.
+  Confirming branches involves checking that they exist in the repository *and* that the version and branch names are consistent.
+
+  **Action.**
+  Confirming branch existence, on the other hand, often involves checking the source repository.
+
+  In general, the version and branch names should match.
+  When they do not, it is sometimes the result of people not being aware of how Spack handles `version ordering <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#version-comparison>`_.
+
+  **Action.**
+  If there is a name mismatch, especially for the most common branch names (e.g., `develop`, `main`, and `master`), ask why and suggest the arguments be changed such that they match the actual branch name.
+
+Manual downloads.
+  Edge cases, such as manually downloaded software, may be difficult to confirm.
+
+  **Action.**
+  In these cases it is acceptable to rely on the package's Maintainers, if any.
 
 Deprecating Versions
 ~~~~~~~~~~~~~~~~~~~~
@@ -125,6 +145,7 @@ Deprecating Versions
 If someone is deprecating versions, it is good to find out why.
 Sometimes there are concerns, such as security or lack of availability.
 
+**Action.**
 Suggest the Package Contributor review the `deprecation guidelines <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ before finalizing the changes if they haven't already explained why they made the choice in the PR description or comments.
 
 Variant Directives
@@ -135,8 +156,9 @@ Variant Directives
 Adding or Modifying Variants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Action.**
 Confirm that new or modified variants are actually used in the package.
-The most common uses are additions or changes to:
+The most common uses are additions and changes to:
 
 * dependencies;
 * configure options; and/or
@@ -146,11 +168,13 @@ Removing or Disabling Variants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the variant is still relevant to listed version directives, it may be preferable to adjust or add `conditions <https://spack.readthedocs.io/en/latest/packaging_guide.html#conditional-variants>`_.
-Consider asking why the variant (or build option) is being removed and suggest making it conditional when it's still relevant.
+
+**Action.**
+Consider asking why the variant (or build option) is being removed and suggest making it conditional when it is still relevant.
 
 .. warning::
 
-    If the default value of a variant is changed, there is a risk that other packages relying on that value will no longer build as others expect.
+    If the default value of a variant is changed in the PR, then there is a risk that other packages relying on that value will no longer build as others expect.
     This may be something worth noting in the review.
 
 .. _depends_on_reviews:
@@ -164,12 +188,15 @@ Updating Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
 It is important that dependencies reflect the requirements of listed versions.
-So they only need to be checked in a review when versions are being added or removed or the dependencies are being changed.
-Dependencies affected by such changes should be confirmed, when possible, and *at least* when the Package Contributor is not a Maintainer of the package.
+They only need to be checked in a review when versions are being added or removed or the dependencies are being changed.
 
+**Action.**
+Dependencies affected by such changes should be confirmed, when possible, and *at least* when the :ref:`Package Contributor <package-contributors>` is not a :ref:`Maintainer <package-maintainers>` of the package.
+
+**Solutions.**
 In some cases, the needed change may be as simple as ensuring the version range and or variant options in the dependency are accurate.
-In others, one or more of the dependencies needed by new versions may be missing.
-Or there may be dependencies that are no longer relevant should the versions requiring them be removed.
+In others, one or more of the dependencies needed by new versions are missing and need to be added.
+Or there may be dependencies that are no longer relevant when versions requiring them are removed, meaning the dependencies should be removed as well.
 
 For example, it is not uncommon for Python package dependencies to be out of date when new versions are added.
 In this case, check Python package dependencies by following the build system `guidelines <https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html#dependencies>`_.
@@ -182,10 +209,11 @@ Updating Language and Compiler Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When `language and compiler dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#language-and-compiler-dependencies>`_ were introduced, their ``depends_on`` directives were derived from the source for existing packages.
-These dependencies are flagged with “# generated” comments.
+These dependencies are flagged with ``# generated`` comments.
 Unfortunately, the generated dependencies are not always complete.
 
-If these types of dependencies are being updated, ask if the Package Contributor can confirming the generated dependencies and remove the ``# generated`` comments.
+**Action.**
+If these dependencies are being updated, ask if the :ref:`Package Contributor <package-contributors>` can confirm all of the generated dependencies and remove the ``# generated`` comments.
 Definitely make sure Contributors do **not** include ``# generated`` on the dependencies they are adding to the package.
 
 Failed Automated Checks
@@ -198,6 +226,7 @@ Style Failures
 
 The PR may fail one or more style checks.
 
+**Action.**
 If the failure is due to issues raised by the ``black`` style checker *and* the PR is otherwise ready to be merged, you can add ``@spackbot fix style`` in a comment to see if Spack will fix the errors.
 Otherwise, inform the Package Contributor that they need to address the style failures.
 
@@ -205,19 +234,24 @@ CI Stack Failures
 ~~~~~~~~~~~~~~~~~
 
 Existing packages **may** be included in GitLab CI pipelines through inclusion in one or more `stacks <https://github.com/spack/spack-packages/tree/develop/stacks>`_.
-It is worth checking at least a sampling of the failed job logs, if present, to determine the possible cause.
+
+**Action.**
+It is worth checking at least a sampling of the failed job logs, if present, to determine the possible cause and take or suggest an action accordingly.
 
 **CI runners.**
-Sometimes CI runners timeout or the pods become unavailable.
+Sometimes CI runners time out or the pods become unavailable.
 
+**Action.**
 If that is the case, the resolution may be as simple as restarting the pipeline by adding a ``@spackbot run pipeline`` comment.
+Otherwise, the Contributor will need to investigate and resolve the problem.
 
 **Stand-alone tests.**
 Sometimes `stand-alone tests <https://spack.readthedocs.io/en/latest/packaging_guide_testing.html#stand-alone-tests>`_, which are performed after successful builds, could be causing the build job to time out.
-If the tests take too long, the issue could be that the package is running too many or long running tests.
+If the tests take too long, the issue could be that the package is running too many and/or long running tests.
 Or the tests may be trying to use resources (e.g., a batch scheduler) that are not available on runners.
 Determination of the problem may require looking at the implementation of the test.
 
+**Action.**
 If tests are to blame, then a `new issue <https://github.com/spack/spack-packages/issues>`_ should be created -- if there is not one already -- to flag the package.
-A `pull request <https://github.com/spack/spack-packages/pulls>`_ should also be created that adds the package to the **broken-tests-packages** list in the `ci configuration <https://spack.readthedocs.io/en/latest/pipelines.html#ci-yaml>`_.
+A pull request should also be created in the ``spack/spack-packages`` repository that adds the package to the ``broken-tests-packages`` list in the `ci configuration <https://spack.readthedocs.io/en/latest/pipelines.html#ci-yaml>`_.
 Then, after the hopefully temporary fix is merged, the PR being reviewed can be rebased to pick up the change.

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -21,7 +21,7 @@ How to use this guide
 ---------------------
 
 Whether you are a :ref:`Package Reviewer <package-reviewers>`, :ref:`Maintainer <package-maintainers>`, or :ref:`Committer <committers>`, this guide highlights relevant aspects to consider when reviewing package pull requests.
-If you are a ref:`Package Contributor <package-contributors>` (or simply ``Contributor``), you may also find the information and solutions useful in your work.
+If you are a :ref:`Package Contributor <package-contributors>` (or simply ``Contributor``), you may also find the information and solutions useful in your work.
 While we provide information on what to look for, the changes themselves should drive the actual review process.
 
 .. note::

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -58,7 +58,7 @@ Alternatively, especially for older versions, the version-specific URL can be ad
 Sometimes the derived URLs of versions on the hosting system can vary.
 This commonly happens with Python packages.
 For example, the case of one or more letters in the package name may change at some point (e.g., `py-sphinx <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_sphinx/package.py>`_).
-Also, dashes may be replaced with underscores (e.g., `py-scitkit-build <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_scikit_build/package.py>`_).
+Also, dashes may be replaced with underscores (e.g., `py-scikit-build <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_scikit_build/package.py>`_).
 In some cases, both changes can occur for the same package.
 As these examples illlustrate, it is sometimes possible to add a ``url_for_version`` method to override the default derived URL to ensure the correct one is returned.
 

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -36,34 +36,34 @@ url, url_for_version, or URL Equivalent
 Changes to URLs may invalidate existing versions, which should be checked when there is a URL-related modification.
 All packages have a URL, though for some `build systems <https://spack.readthedocs.io/en/latest/build_systems.html>`_ it is derived automatically and not visible in the package.
 
-Reasons for `invalid versions <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#versions-and-urls>`_ include:
+Reasons `versions <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#versions-and-urls>`_ may become invalid include:
 
 * the new URL does not support Spack version extrapolation;
-* the addition of or changes to ``url_for_version`` checks the ``spec``'s version instead of the ``version`` argument or does not cover the listed or older versions;
+* the addition of or changes to ``url_for_version`` involve checks of the ``spec``'s version instead of the ``version`` argument or the (usually older) versions are not covered;
 * extrapolation of the derived URL no longer matches that of older versions; and
 * the older versions are no longer available.
 
 Checking existing version directives with checksums can usually be done manually with the modified package using `spack checksum <https://spack.readthedocs.io/en/latest/command_index.html#spack-checksum>`_.
 
 **Solutions.**
-Options for resolving the problem that can be suggested for investigation depends on the issues.
+Options for resolving the problem that can be suggested for investigation depend on the source.
 
 In simpler cases involving ``url`` or ``url_for_version``, invalid versions can sometimes be corrected by ensuring all versions are covered by ``url_for_version``.
 Alternatively, especially for older versions, the version-specific URL can be added as an argument to the ``version`` directive.
 
 Sometimes the derived URLs of versions on the hosting system can vary.
 This commonly happens with Python packages.
-For example, the case of one or more letters in the package name can change (e.g., `py-sphinx <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_sphinx/package.py>`_).
+For example, the case of one or more letters in the package name may change at some point (e.g., `py-sphinx <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_sphinx/package.py>`_).
 Also, dashes may be replaced with underscores (e.g., `py-scitkit-build <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_scikit_build/package.py>`_).
 In some cases, both changes can occur for the same package.
-As these examples illlustrate, it is sometimes possible to add a ``url_for_version`` method to override the default derived URL process to ensure the correct URL is returned.
+As these examples illlustrate, it is sometimes possible to add a ``url_for_version`` method to override the default derived URL to ensure the correct URL is returned.
 
 If older versions are no longer available and there is a chance someone has the package in a build cache, the usual approach is to first suggest `deprecating <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ them in the package.
 
 Maintainers Directive
 ----------------------
 
-If the new package does not have a `maintainers <https://spack.readthedocs.io/en/latest/packaging_guide.html#maintainers>`_ directive, ask the :ref:`Package Contributor <package-contributors>` if he/she/they would be willing to add themselves.
+If the new package does not have a `maintainers <https://spack.readthedocs.io/en/latest/packaging_guide.html#maintainers>`_ directive, ask the :ref:`Package Contributor <package-contributors>` to consider adding themselves.
 
 This request is an optional for existing packages.
 
@@ -74,7 +74,7 @@ This request is an optional for existing packages.
 License Directive
 -----------------
 
-If the new package does not have a `license <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#license-information>`_  directive, ask the :ref:`Package Contributor <package-contributors>` if he/she/they would be willing to investigate and add it.
+If the new package does not have a `license <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#license-information>`_  directive, ask the :ref:`Package Contributor <package-contributors>` to investigate and add it.
 
 This is an optional request for existing packages.
 
@@ -92,8 +92,8 @@ Checksums, commits, tags, and branches
 
 **Checksums, commits, and tags.**
 Normally these arguments are automatically validated by GitHub Actions using `spack ci verify-versions <https://spack.readthedocs.io/en/latest/command_index.html#spack-ci-verify-versions>`_.
-Review the ``verify-checksums`` precheck to confirm.
-Checksums can usually be manually confirmed using `spack checksum <https://spack.readthedocs.io/en/latest/command_index.html#spack-checksum>`_.
+Review the PR's ``verify-checksums`` precheck to confirm.
+If necessary, checksums can usually be manually confirmed using `spack checksum <https://spack.readthedocs.io/en/latest/command_index.html#spack-checksum>`_.
 
 .. warning::
 
@@ -104,6 +104,7 @@ Checksums can usually be manually confirmed using `spack checksum <https://spack
    Exceptions are allowed in rare cases, such as software supplied from reputable vendors.
    When in doubt, ask others with merge privileges for advice.
 
+**Tags.**
 If a ``tag`` is provided without a ``commit``, the downloaded software will not be trusted.
 Suggest that the ``commit`` argument be included in the ``version`` directive.
 
@@ -116,13 +117,14 @@ If there is a mismatch, especially for the most common branch names (e.g., `deve
 
 **Manual downloads.**
 Edge cases, such as manually downloaded software, may be difficult to confirm.
-In these cases it is acceptable to rely on the package's maintainers, if any.
+In these cases it is acceptable to rely on the package's Maintainers, if any.
 
 Deprecating Versions
 ~~~~~~~~~~~~~~~~~~~~
 
-If someone is deprecating versions, it is good to know why.
-Sometimes there are concerns with `versions <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#source-code-and-versions>`_ , especially older ones.
+If someone is deprecating versions, it is good to find out why.
+Sometimes there are concerns, such as security or lack of availability.
+
 Suggest the Package Contributor review the `deprecation guidelines <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ before finalizing the changes if they haven't already explained why they made the choice in the PR description or comments.
 
 Variant Directives
@@ -144,7 +146,7 @@ Removing or Disabling Variants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the variant is still relevant to listed version directives, it may be preferable to adjust or add `conditions <https://spack.readthedocs.io/en/latest/packaging_guide.html#conditional-variants>`_.
-Consider asking why the variant (or build option) is being removed and mention the option to make it conditional.
+Consider asking why the variant (or build option) is being removed and suggest making it conditional when it's still relevant.
 
 .. warning::
 
@@ -163,13 +165,14 @@ Updating Dependencies
 
 It is important that dependencies reflect the requirements of listed versions.
 So they only need to be checked in a review when versions are being added or removed or the dependencies are being changed.
-In some cases, the needed change may be as simple as ensuring the version range and or variant options are accurate.
+Dependencies affected by such changes should be confirmed, when possible, and *at least* when the Package Contributor is not a Maintainer of the package.
+
+In some cases, the needed change may be as simple as ensuring the version range and or variant options in the dependency are accurate.
 In others, one or more of the dependencies needed by new versions may be missing.
-Or there may be dependencies that are no longer relevant as when the versions requiring them are removed.
-Dependencies affected by version directive changes should be confirmed, when possible, and *at least* when the Package Contributor is not a Maintainer of the package.
+Or there may be dependencies that are no longer relevant should the versions requiring them be removed.
 
 For example, it is not uncommon for Python package dependencies to be out of date when new versions are added.
-Check for missing dependencies by following the Python build system `guidelines <https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html#dependencies>`_.
+In this case, check Python package dependencies by following the build system `guidelines <https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html#dependencies>`_.
 
 .. tip::
 
@@ -178,12 +181,12 @@ Check for missing dependencies by following the Python build system `guidelines 
 Updating Language and Compiler Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-At one point `language and compiler dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#language-and-compiler-dependencies>`_ were derived for existing packages.
+When `language and compiler dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#language-and-compiler-dependencies>`_ were introduced, their ``depends_on`` directives were derived from the source for existing packages.
 These dependencies are flagged with “# generated” comments.
-Unfortunately, they are not always complete.
+Unfortunately, the generated dependencies are not always complete.
 
-If these types of dependencies are being updated, suggest that if the Package Contributor is confirming them, then the `# generated` comments should be removed from all such dependencies.
-Definitely make sure they do **not** include the comment on any they are adding to the package.
+If these types of dependencies are being updated, ask if the Package Contributor can confirming the generated dependencies and remove the ``# generated`` comments.
+Definitely make sure Contributors do **not** include ``# generated`` on the dependencies they are adding to the package.
 
 Failed Automated Checks
 -----------------------
@@ -195,8 +198,8 @@ Style Failures
 
 The PR may fail one or more style checks.
 
-If the failure is due to issues raised by the ``black`` style checker *and* the PR is otherwise ready to be merge, you can add a ``@spackbot fix style`` as a comment to see if Spack will fix the errors.
-Otherwise, add a comment to the Package Contributor that they need to address the style failures.
+If the failure is due to issues raised by the ``black`` style checker *and* the PR is otherwise ready to be merged, you can add ``@spackbot fix style`` in a comment to see if Spack will fix the errors.
+Otherwise, inform the Package Contributor that they need to address the style failures.
 
 CI Stack Failures
 ~~~~~~~~~~~~~~~~~
@@ -205,16 +208,16 @@ Existing packages **may** be included in GitLab CI pipelines through inclusion i
 It is worth checking at least a sampling of the failed job logs, if present, to determine the possible cause.
 
 **CI runners.**
-Sometimes CI runners can timeout or the pods become unavailable.
+Sometimes CI runners timeout or the pods become unavailable.
 
-If that is the case, the resolution may be as simple as restarting the pipeline by adding ``@spackbot run pipeline`` in a comment.
+If that is the case, the resolution may be as simple as restarting the pipeline by adding a ``@spackbot run pipeline`` comment.
 
 **Stand-alone tests.**
-Or `stand-alone tests <https://spack.readthedocs.io/en/latest/packaging_guide_testing.html#stand-alone-tests>`_) performed after successful builds could be to blame.
-If the tests take too long, the issue could be that the package is running too many or too resource intensive checks.
-Or the tests may be trying to use resources (e.g., a batch scheduler) that are not available.
+Sometimes `stand-alone tests <https://spack.readthedocs.io/en/latest/packaging_guide_testing.html#stand-alone-tests>`_, which are performed after successful builds, could be causing the build job to time out.
+If the tests take too long, the issue could be that the package is running too many or long running tests.
+Or the tests may be trying to use resources (e.g., a batch scheduler) that are not available on runners.
 Determination of the problem may require looking at the implementation of the test.
 
-If tests are to blame, then an `issue <https://github.com/spack/spack-packages/issues>`_ should be created to flag the package.
-A `pull request <https://github.com/spack/spack-packages/pulls>`_ should also be created that adds the package to the **broken-tests-packages** list in the `ci <https://spack.readthedocs.io/en/latest/pipelines.html#ci-yaml>`_ configuration.
+If tests are to blame, then a `new issue <https://github.com/spack/spack-packages/issues>`_ should be created -- if there is not one already -- to flag the package.
+A `pull request <https://github.com/spack/spack-packages/pulls>`_ should also be created that adds the package to the **broken-tests-packages** list in the `ci configuration <https://spack.readthedocs.io/en/latest/pipelines.html#ci-yaml>`_.
 Then, after the hopefully temporary fix is merged, the PR being reviewed can be rebased to pick up the change.

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -33,6 +33,26 @@ CORE Perl modules
 In general, modules that are part of the standard installation for all listed Perl versions (i.e., ``CORE``) should *not* be implemented or contributed as Spack packages.
 Details on the exceptions and process for checking Perl modules can be found in the `Perl <https://spack.readthedocs.io/en/latest/build_systems/perlpackage.html#suitable_perl_modules>`_ build system documentation.
 
+Package structure
+-----------------
+
+The `convention <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#structure-of-a-package>`_ for structuring Spack packages has metadata, or at least key properties, listed first followed by directives then methods:
+
+* :ref:`maintainers_reviews`;
+* :ref:`license_reviews`;
+* :ref:`version_reviews`;
+* :ref:`variant_reviews`;
+* :ref:`depends_on_reviews`;
+* :ref:`packaging_conflicts` and :ref:`packaging_requires` directives; then
+* methods.
+
+`Groupings <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#grouping-directives>`_ using ``with`` context managers can affect the order of dependency, conflict, and requires directives to some degree.
+However, they do cut down on visual clutter and make packages more readable.
+
+**Action.**
+If you see clear deviations from the convention, request that they be addressed.
+When in doubt, ask others with merge privileges for advice.
+
 ``url``, ``url_for_version``, or URL equivalent
 -----------------------------------------------
 
@@ -64,6 +84,8 @@ As these examples illlustrate, it is sometimes possible to add a ``url_for_versi
 
 If older versions are no longer available and there is a chance someone has the package in a build cache, the usual approach is to first suggest `deprecating <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ them in the package.
 
+.. _maintainers_reviews:
+
 ``maintainers`` directive
 -------------------------
 
@@ -76,6 +98,8 @@ This request is optional for existing packages.
 
    Be prepared for them to refuse.
 
+.. _license_reviews:
+
 ``license`` directive
 ---------------------
 
@@ -84,6 +108,8 @@ If the new package does not have a `license <https://spack.readthedocs.io/en/lat
 
 This request is optional for existing packages.
 
+.. _version_reviews:
+
 ``version`` directives
 ----------------------
 
@@ -91,10 +117,21 @@ In general, Spack packages are expected to be built from source code.
 There are a few exceptions (e.g., `BundlePackage <https://spack.readthedocs.io/en/latest/build_systems/bundlepackage.html#bundlepackage>`_).
 Typically every package will have at least one `version directive <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#source-code-and-versions>`_.
 
+The goal of reviewing version directives is to confirm that versions are listed in the proper order **and** that the arguments for new and updated versions are correct.
+
+.. note::
+
+   Additions and removals of version directives should generally trigger a review of :ref:`dependencies <depends_on_reviews>`.
+
+``version`` directive order
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Version directives should be listed in descending order, from newest to oldest.
+If branch versions are provided, they should be listed first.
+
 **Action.**
-The goal of reviewing this information is to confirm the existence and correctness of updated and new versions **and** that the versions are listed in descending order from newest to oldest.
-The process for correctness checking depends on the arguments and nature of the software's downloads (see below).
-Additions and removals of version directives should generally trigger a review of :ref:`dependencies <depends_on_reviews>`.
+When versions are being added, check the ordering of the directives.
+If any of the directives do not match the `Spack convention <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#versions-and-urls>`_, then request that the directives be re-ordered.
 
 Checksums, commits, tags, and branches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -147,6 +184,8 @@ Sometimes there are concerns, such as security or lack of availability.
 
 **Action.**
 Suggest the Package Contributor review the `deprecation guidelines <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ before finalizing the changes if they haven't already explained why they made the choice in the PR description or comments.
+
+.. _variant_reviews:
 
 ``variant`` directives
 ----------------------

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -22,7 +22,7 @@ Inappropriate Package
 It is rare that a package would be considered inappropriate for inclusion in the public `Spack package <https://github.com/spack/spack-packages>`_ repository.
 One exception is making packages for standard Perl modules.
 
-Explain to the :ref:`Contributor <package-contributors>` in a comment or your review if the package should be removed from the PR and why.
+Explain to the :ref:`Package Contributor <package-contributors>` in a comment or your review if the package should be removed from the PR and why.
 
 CORE Perl Modules
 ~~~~~~~~~~~~~~~~~
@@ -45,7 +45,8 @@ Reasons for `invalid versions <https://spack.readthedocs.io/en/latest/packaging_
 
 Checking existing version directives with checksums can usually be done manually with the modified package using `spack checksum <https://spack.readthedocs.io/en/latest/command_index.html#spack-checksum>`_.
 
-**Solutions.** Options for resolving the problem that can be suggested for investigation depends on the issues.
+**Solutions.**
+Options for resolving the problem that can be suggested for investigation depends on the issues.
 
 In simpler cases involving ``url`` or ``url_for_version``, invalid versions can sometimes be corrected by ensuring all versions are covered by ``url_for_version``.
 Alternatively, especially for older versions, the version-specific URL can be added as an argument to the ``version`` directive.
@@ -62,9 +63,7 @@ If older versions are no longer available and there is a chance someone has the 
 Maintainers Directive
 ----------------------
 
-If the new package does not have a **maintainers** directive, ask the
-:ref:`Package Contributor <package-contributors>` if he/she/they would be
-willing to add themselves as a `maintainer <https://spack.readthedocs.io/en/latest/packaging_guide.html#maintainers>`_.
+If the new package does not have a `maintainers <https://spack.readthedocs.io/en/latest/packaging_guide.html#maintainers>`_ directive, ask the :ref:`Package Contributor <package-contributors>` if he/she/they would be willing to add themselves.
 
 This request is an optional for existing packages.
 
@@ -75,9 +74,7 @@ This request is an optional for existing packages.
 License Directive
 -----------------
 
-If the new package does not have a **license** directive, ask the
-`Package Contributor <#package-contributors>`__ if he/she/they would be
-willing to check the source repository or homepage for the `license <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#license-information>`_ and add it to the package.
+If the new package does not have a `license <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#license-information>`_  directive, ask the :ref:`Package Contributor <package-contributors>` if he/she/they would be willing to investigate and add it.
 
 This is an optional request for existing packages.
 
@@ -126,7 +123,7 @@ Deprecating Versions
 
 If someone is deprecating versions, it is good to know why.
 Sometimes there are concerns with `versions <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#source-code-and-versions>`_ , especially older ones.
-Suggest the Contributor review the `deprecation guidelines <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ before finalizing the changes if they haven't already explained why they made the choice in the PR description or comments.
+Suggest the Package Contributor review the `deprecation guidelines <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ before finalizing the changes if they haven't already explained why they made the choice in the PR description or comments.
 
 Variant Directives
 ------------------
@@ -169,7 +166,7 @@ So they only need to be checked in a review when versions are being added or rem
 In some cases, the needed change may be as simple as ensuring the version range and or variant options are accurate.
 In others, one or more of the dependencies needed by new versions may be missing.
 Or there may be dependencies that are no longer relevant as when the versions requiring them are removed.
-Dependencies affected by version directive changes should be confirmed, when possible, and *at least* when the Contributor is not a Maintainer of the package.
+Dependencies affected by version directive changes should be confirmed, when possible, and *at least* when the Package Contributor is not a Maintainer of the package.
 
 For example, it is not uncommon for Python package dependencies to be out of date when new versions are added.
 Check for missing dependencies by following the Python build system `guidelines <https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html#dependencies>`_.
@@ -181,12 +178,11 @@ Check for missing dependencies by following the Python build system `guidelines 
 Updating Language and Compiler Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-At one point `language and compiler dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#language-and-compiler-dependencies>`_
-were derived for existing packages.
+At one point `language and compiler dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#language-and-compiler-dependencies>`_ were derived for existing packages.
 These dependencies are flagged with “# generated” comments.
 Unfortunately, they are not always complete.
 
-If these types of dependencies are being updated, suggest that if the Contributor is confirming them, then the `# generated` comments should be removed from all such dependencies.
+If these types of dependencies are being updated, suggest that if the Package Contributor is confirming them, then the `# generated` comments should be removed from all such dependencies.
 Definitely make sure they do **not** include the comment on any they are adding to the package.
 
 Failed Automated Checks
@@ -200,7 +196,7 @@ Style Failures
 The PR may fail one or more style checks.
 
 If the failure is due to issues raised by the ``black`` style checker *and* the PR is otherwise ready to be merge, you can add a ``@spackbot fix style`` as a comment to see if Spack will fix the errors.
-Otherwise, add a comment to the Contributor that they need to address the style failures.
+Otherwise, add a comment to the Package Contributor that they need to address the style failures.
 
 CI Stack Failures
 ~~~~~~~~~~~~~~~~~

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -99,7 +99,7 @@ Additions and removals of version directives should generally trigger a review o
 Checksums, commits, tags, and branches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Checksums, commits, and tags.
+**Checksums, commits, and tags**
   Normally these version arguments are automatically validated by GitHub Actions using `spack ci verify-versions <https://spack.readthedocs.io/en/latest/command_index.html#spack-ci-verify-versions>`_.
 
   **Action.**
@@ -115,14 +115,14 @@ Checksums, commits, and tags.
      Exceptions are allowed in rare cases, such as software supplied from reputable vendors.
      When in doubt, ask others with merge privileges for advice.
 
-Tags.
+**Tags**
   If a ``tag`` is provided without a ``commit``, the downloaded software will not be trusted.
 
   **Action.**
   Suggest that the ``commit`` argument be included in the ``version`` directive.
 
-Branches.
-  Confirming branches involves checking that they exist in the repository *and* that the version and branch names are consistent.
+**Branches**
+  Confirming new branch versions involves checking that the branches exist in the repository *and* that the version and branch names are consistent.
 
   **Action.**
   Confirming branch existence, on the other hand, often involves checking the source repository.
@@ -133,7 +133,7 @@ Branches.
   **Action.**
   If there is a name mismatch, especially for the most common branch names (e.g., `develop`, `main`, and `master`), ask why and suggest the arguments be changed such that they match the actual branch name.
 
-Manual downloads.
+**Manual downloads**
   Edge cases, such as manually downloaded software, may be difficult to confirm.
 
   **Action.**
@@ -238,20 +238,22 @@ Existing packages **may** be included in GitLab CI pipelines through inclusion i
 **Action.**
 It is worth checking at least a sampling of the failed job logs, if present, to determine the possible cause and take or suggest an action accordingly.
 
-**CI runners.**
-Sometimes CI runners time out or the pods become unavailable.
+**CI Runner Failures**
+  Sometimes CI runners time out or the pods become unavailable.
 
-**Action.**
-If that is the case, the resolution may be as simple as restarting the pipeline by adding a ``@spackbot run pipeline`` comment.
-Otherwise, the Contributor will need to investigate and resolve the problem.
+  **Action.**
+  If that is the case, the resolution may be as simple as restarting the pipeline by adding a ``@spackbot run pipeline`` comment.
+  Otherwise, the Contributor will need to investigate and resolve the problem.
 
-**Stand-alone tests.**
-Sometimes `stand-alone tests <https://spack.readthedocs.io/en/latest/packaging_guide_testing.html#stand-alone-tests>`_, which are performed after successful builds, could be causing the build job to time out.
-If the tests take too long, the issue could be that the package is running too many and/or long running tests.
-Or the tests may be trying to use resources (e.g., a batch scheduler) that are not available on runners.
-Determination of the problem may require looking at the implementation of the test.
+**Stand-alone Test Failures**
+  Sometimes `stand-alone tests <https://spack.readthedocs.io/en/latest/packaging_guide_testing.html#stand-alone-tests>`_ could be causing the build job to time out.
+  If the tests take too long, the issue could be that the package is running too many and/or long running tests.
+  Or the tests may be trying to use resources (e.g., a batch scheduler) that are not available on runners.
 
-**Action.**
-If tests are to blame, then a `new issue <https://github.com/spack/spack-packages/issues>`_ should be created -- if there is not one already -- to flag the package.
-A pull request should also be created in the ``spack/spack-packages`` repository that adds the package to the ``broken-tests-packages`` list in the `ci configuration <https://spack.readthedocs.io/en/latest/pipelines.html#ci-yaml>`_.
-Then, after the hopefully temporary fix is merged, the PR being reviewed can be rebased to pick up the change.
+  **Action.**
+  If the tests for a package are hanging, at a minimum create a `new issue <https://github.com/spack/spack-packages/issues>`_, if there is not one already, to flag the package.
+
+  **(Temporary) Solution.**
+  Look at the package implementation to see if the tests are using a batch scheduler or there appear to be too many or long running tests.
+  If that is the case, then a pull request should be created in the ``spack/spack-packages`` repository that adds the package to the ``broken-tests-packages`` list in the `ci configuration <https://spack.readthedocs.io/en/latest/pipelines.html#ci-yaml>`_.
+  Once the fix PR is merged, then the affected PR can be rebased to pick up the change.

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -28,7 +28,7 @@ CORE Perl Modules
 ~~~~~~~~~~~~~~~~~
 
 In general, modules that are part of the standard installation for all listed Perl versions should *not* be implemented or contributed as Spack packages.
-Details on the exceptions and process for checking Perl modules can be found in the `Perl <https://spack.readthedocs.io/en/latest/build_systems/perlpackage.html>`_ build system documentation.
+Details on the exceptions and process for checking Perl modules can be found in the `Perl <https://spack.readthedocs.io/en/latest/build_systems/perlpackage.html#suitable_perl_modules>`_ build system documentation.
 
 url, url_for_version, or URL Equivalent
 ---------------------------------------

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -1,0 +1,224 @@
+.. Copyright Spack Project Developers. See COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. meta::
+   :description lang=en:
+      This is a guide for people who review package pull requests and includes criteria for them to be merged into the develop branch.
+
+.. _package-review-guide:
+
+Package Review Guide
+====================
+
+Package reviews are performed with the goals of minimizing build errors and making packages as **uniform and stable** as possible.
+
+This section establishes guidelines to help reviewers assess and merge pull requests (PRs) to Spack’s community `package repository <https://github.com/spack/spack-packages>`_.
+It describes the considerations and actions to be taken when reviewing new and updated `Spack packages <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#structure-of-a-package>`_.
+
+Inappropriate Package
+---------------------
+
+It is rare that a package would be considered inappropriate for inclusion in the public `Spack package <https://github.com/spack/spack-packages>`_ repository.
+One exception is making packages for standard Perl modules.
+
+Explain to the :ref:`Contributor <package-contributors>` in a comment or your review if the package should be removed from the PR and why.
+
+CORE Perl Modules
+~~~~~~~~~~~~~~~~~
+
+In general, modules that are part of the standard installation for all listed Perl versions should *not* be implemented or contributed as Spack packages.
+Details on the exceptions and process for checking Perl modules can be found in the `Perl <https://spack.readthedocs.io/en/latest/build_systems/perlpackage.html>`_ build system documentation.
+
+url, url_for_version, or URL Equivalent
+---------------------------------------
+
+Changes to URLs may invalidate existing versions, which should be checked when there is a URL-related modification.
+All packages have a URL, though for some `build systems <https://spack.readthedocs.io/en/latest/build_systems.html>`_ it is derived automatically and not visible in the package.
+
+Reasons for `invalid versions <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#versions-and-urls>`_ include:
+
+* the new URL does not support Spack version extrapolation;
+* the addition of or changes to ``url_for_version`` checks the ``spec``'s version instead of the ``version`` argument or does not cover the listed or older versions;
+* extrapolation of the derived URL no longer matches that of older versions; and
+* the older versions are no longer available.
+
+Checking existing version directives with checksums can usually be done manually with the modified package using `spack checksum <https://spack.readthedocs.io/en/latest/command_index.html#spack-checksum>`_.
+
+**Solutions.** Options for resolving the problem that can be suggested for investigation depends on the issues.
+
+In simpler cases involving ``url`` or ``url_for_version``, invalid versions can sometimes be corrected by ensuring all versions are covered by ``url_for_version``.
+Alternatively, especially for older versions, the version-specific URL can be added as an argument to the ``version`` directive.
+
+Sometimes the derived URLs of versions on the hosting system can vary.
+This commonly happens with Python packages.
+For example, the case of one or more letters in the package name can change (e.g., `py-sphinx <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_sphinx/package.py>`_).
+Also, dashes may be replaced with underscores (e.g., `py-scitkit-build <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_scikit_build/package.py>`_).
+In some cases, both changes can occur for the same package.
+As these examples illlustrate, it is sometimes possible to add a ``url_for_version`` method to override the default derived URL process to ensure the correct URL is returned.
+
+If older versions are no longer available and there is a chance someone has the package in a build cache, the usual approach is to first suggest `deprecating <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ them in the package.
+
+Maintainers Directive
+----------------------
+
+If the new package does not have a **maintainers** directive, ask the
+:ref:`Package Contributor <package-contributors>` if he/she/they would be
+willing to add themselves as a `maintainer <https://spack.readthedocs.io/en/latest/packaging_guide.html#maintainers>`_.
+
+This request is an optional for existing packages.
+
+.. tip::
+
+   Be prepared for them to refuse.
+
+License Directive
+-----------------
+
+If the new package does not have a **license** directive, ask the
+`Package Contributor <#package-contributors>`__ if he/she/they would be
+willing to check the source repository or homepage for the `license <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#license-information>`_ and add it to the package.
+
+This is an optional request for existing packages.
+
+Version Directives
+------------------
+
+Spack packages are, with a few exceptions (e.g., `BundlePackage <https://spack.readthedocs.io/en/latest/build_systems/bundlepackage.html#bundlepackage>`_), expected to be built from source code.
+Typically every package will have at least one `version directive <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#source-code-and-versions>`_.
+
+The goal of reviewing this information is to confirm the existence and correctness of updated and new versions **and** that the versions are listed in descending order from newest to oldest.
+Additions and removals of version directives should also trigger a review of :ref:`dependencies <depends_on_reviews>`.
+
+Checksums, commits, tags, and branches
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Checksums, commits, and tags.**
+Normally these arguments are automatically validated by GitHub Actions using `spack ci verify-versions <https://spack.readthedocs.io/en/latest/command_index.html#spack-ci-verify-versions>`_.
+Review the ``verify-checksums`` precheck to confirm.
+Checksums can usually be manually confirmed using `spack checksum <https://spack.readthedocs.io/en/latest/command_index.html#spack-checksum>`_.
+
+.. warning::
+
+   From a security and reproducibility standpoint, it is important that Spack be able to verify downloaded source.
+   This is accomplished using a hash (e.g., checksum or commit).
+   See `checksum verification <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#checksum-verification>`_ for more information.
+
+   Exceptions are allowed in rare cases, such as software supplied from reputable vendors.
+   When in doubt, ask others with merge privileges for advice.
+
+If a ``tag`` is provided without a ``commit``, the downloaded software will not be trusted.
+Suggest that the ``commit`` argument be included in the ``version`` directive.
+
+**Branches.**
+Confirming branches exist, on the other hand, often involves checking the source repository.
+
+In general, the name of a branch version should match the name of the branch in the repository.
+Sometimes they do not match when people are not aware of how Spack handles `version ordering <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#version-comparison>`_.
+If there is a mismatch, especially for the most common branch names (e.g., `develop`, `main`, and `master`), ask why and suggest the arguments be changed such that they match the actual branch name.
+
+**Manual downloads.**
+Edge cases, such as manually downloaded software, may be difficult to confirm.
+In these cases it is acceptable to rely on the package's maintainers, if any.
+
+Deprecating Versions
+~~~~~~~~~~~~~~~~~~~~
+
+If someone is deprecating versions, it is good to know why.
+Sometimes there are concerns with `versions <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#source-code-and-versions>`_ , especially older ones.
+Suggest the Contributor review the `deprecation guidelines <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ before finalizing the changes if they haven't already explained why they made the choice in the PR description or comments.
+
+Variant Directives
+------------------
+
+`Variants <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#variants>`_ represent build options so any changes involving these directives should be reflected elsewhere in the package.
+
+Adding or Modifying Variants
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Confirm that new or modified variants are actually used in the package.
+The most common uses are additions or changes to:
+
+* dependencies;
+* configure options; and/or
+* build arguments.
+
+Removing or Disabling Variants
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the variant is still relevant to listed version directives, it may be preferable to adjust or add `conditions <https://spack.readthedocs.io/en/latest/packaging_guide.html#conditional-variants>`_.
+Consider asking why the variant (or build option) is being removed and mention the option to make it conditional.
+
+.. warning::
+
+    If the default value of a variant is changed, there is a risk that other packages relying on that value will no longer build as others expect.
+    This may be something worth noting in the review.
+
+.. _depends_on_reviews:
+
+Depends_on Directives
+---------------------
+
+`Dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#dependencies>`_ represent software that must be installed before the package builds or is able to work correctly.
+
+Updating Dependencies
+~~~~~~~~~~~~~~~~~~~~~
+
+It is important that dependencies reflect the requirements of listed versions.
+So they only need to be checked in a review when versions are being added or removed or the dependencies are being changed.
+In some cases, the needed change may be as simple as ensuring the version range and or variant options are accurate.
+In others, one or more of the dependencies needed by new versions may be missing.
+Or there may be dependencies that are no longer relevant as when the versions requiring them are removed.
+Dependencies affected by version directive changes should be confirmed, when possible, and *at least* when the Contributor is not a Maintainer of the package.
+
+For example, it is not uncommon for Python package dependencies to be out of date when new versions are added.
+Check for missing dependencies by following the Python build system `guidelines <https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html#dependencies>`_.
+
+.. tip::
+
+    In general, refer to the relevant dependencies section, if any, for the package’s `build system <https://spack.readthedocs.io/en/latest/build_systems.html>`_ for guidance.
+
+Updating Language and Compiler Dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+At one point `language and compiler dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#language-and-compiler-dependencies>`_
+were derived for existing packages.
+These dependencies are flagged with “# generated” comments.
+Unfortunately, they are not always complete.
+
+If these types of dependencies are being updated, suggest that if the Contributor is confirming them, then the `# generated` comments should be removed from all such dependencies.
+Definitely make sure they do **not** include the comment on any they are adding to the package.
+
+Failed Automated Checks
+-----------------------
+
+All PRs are expected to pass **at least the required** automated checks.
+
+Style Failures
+~~~~~~~~~~~~~~
+
+The PR may fail one or more style checks.
+
+If the failure is due to issues raised by the ``black`` style checker *and* the PR is otherwise ready to be merge, you can add a ``@spackbot fix style`` as a comment to see if Spack will fix the errors.
+Otherwise, add a comment to the Contributor that they need to address the style failures.
+
+CI Stack Failures
+~~~~~~~~~~~~~~~~~
+
+Existing packages **may** be included in GitLab CI pipelines through inclusion in one or more `stacks <https://github.com/spack/spack-packages/tree/develop/stacks>`_.
+It is worth checking at least a sampling of the failed job logs, if present, to determine the possible cause.
+
+**CI runners.**
+Sometimes CI runners can timeout or the pods become unavailable.
+
+If that is the case, the resolution may be as simple as restarting the pipeline by adding ``@spackbot run pipeline`` in a comment.
+
+**Stand-alone tests.**
+Or `stand-alone tests <https://spack.readthedocs.io/en/latest/packaging_guide_testing.html#stand-alone-tests>`_) performed after successful builds could be to blame.
+If the tests take too long, the issue could be that the package is running too many or too resource intensive checks.
+Or the tests may be trying to use resources (e.g., a batch scheduler) that are not available.
+Determination of the problem may require looking at the implementation of the test.
+
+If tests are to blame, then an `issue <https://github.com/spack/spack-packages/issues>`_ should be created to flag the package.
+A `pull request <https://github.com/spack/spack-packages/pulls>`_ should also be created that adds the package to the **broken-tests-packages** list in the `ci <https://spack.readthedocs.io/en/latest/pipelines.html#ci-yaml>`_ configuration.
+Then, after the hopefully temporary fix is merged, the PR being reviewed can be rebased to pick up the change.

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -21,34 +21,40 @@ How to use this guide
 ---------------------
 
 Whether you are a :ref:`Package Reviewer <package-reviewers>`, :ref:`Maintainer <package-maintainers>`, or :ref:`Committer <committers>`, this guide highlights relevant aspects to consider when reviewing package pull requests.
-While this guide provides information on what to look for, the changes themselves should drive the actual review.
+If you are a ref:`Package Contributor <package-contributors>` (or simply ``Contributor``), you may also find the information and solutions useful in your work.
+While we provide information on what to look for, the changes themselves should drive the actual review process.
 
-Reviewing a new package?
-~~~~~~~~~~~~~~~~~~~~~~~~
+.. note::
+
+   :ref:`Confirmation of successful package builds <build_success_reviews>` of **all** affected versions can reduce the amount of effort needed to review a PR.
+   However, packaging conventions and the combinatorial nature of versions and directives mean each change should still be checked.
+
+Reviewing a new package
+~~~~~~~~~~~~~~~~~~~~~~~
 
 If the pull request includes a new package, then focus on answering the following questions:
 
 * Should the :ref:`package <suitable_package>` be added to the repository?
-* Does the package :ref:`structure <review_structure>` conform to conventions?
+* Does the package :ref:`structure <structure_reviews>` conform to conventions?
 * Are the directives and their options correct?
-* Do all :ref:`automated checks <review_automated_checks>` pass?
-  If not, are there easy-to-resolve CI and/or test issues?
-* Is there :ref:`confirmation <review_build_success>` that every version builds successfully on at least one platform?
+* Do all :ref:`automated checks <automated_checks_reviews>` pass?
+  If not, are there easy-to-resolve CI and/or test issues that can be addressed or does the submitter need to investigate the failures?
+* Is there :ref:`confirmation <build_success_reviews>` that every version builds successfully on at least one platform?
 
 Refer to the relevant sections below for more guidance.
 
-Reviewing changes to an existing package?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Reviewing changes to an existing package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the pull request includes changes to an existing package, then focus on answering the following questions:
 
-* Are there any changes to the package :ref:`structure <review_structure>` and, if so, do they conform to conventions?
+* Are there any changes to the package :ref:`structure <structure_reviews>` and, if so, do they conform to conventions?
 * If there are new or updated directives, then are they and their options correct?
-* If there are changes to the ``url`` or its equivalent, are the older versions still correct?
-* If there are changes to the ``git`` or equivalent URL, do older branches exist in the new location?
-* Do all :ref:`automated checks <review_automated_checks>` pass?
-  If not, are there easy-to-resolve CI and/or test issues?
-* Is there :ref:`confirmation <review_build_success>` that every new version builds successfully on at least one platform?
+* If there are changes to the :ref:`url or its equivalent <url_equivalent_reviews>`, are the older versions still correct?
+* If there are changes to the :ref:`git or equivalent URL <vcs_url_reviews>`, do older branches exist in the new location?
+* Do all :ref:`automated checks <automated_checks_reviews>` pass?
+  If not, are there easy-to-resolve CI and/or test issues that can be addressed or does the submitter need to investigate the failures?
+* Is there :ref:`confirmation <build_success_reviews>` that every new version builds successfully on at least one platform?
 
 Refer to the relevant sections below for more guidance.
 
@@ -61,23 +67,24 @@ It is rare that a package would be considered inappropriate for inclusion in the
 One exception is making packages for standard Perl modules.
 
 **Action.**
-Should you find the software is not appropriate, explain to the :ref:`Package Contributor <package-contributors>` in a comment or your review.
-Ask that the package be removed from the PR if it is one of multiple affected files; otherwise suggest the PR be closed.
-In both cases, explain the reason for the request.
+Should you find the software is not appropriate, ask that the package be removed from the PR if it is one of multiple affected files or suggest the PR be closed.
+In either case, explain the reason for the request.
 
 CORE Perl modules
 ~~~~~~~~~~~~~~~~~
 
-In general, modules that are part of the standard installation for all listed Perl versions (i.e., ``CORE``) should *not* be implemented or contributed as Spack packages.
-Details on the exceptions and process for checking Perl modules can be found in the `Perl <https://spack.readthedocs.io/en/latest/build_systems/perlpackage.html#suitable_perl_modules>`_ build system documentation.
+In general, modules that are part of the standard installation for all listed Perl versions (i.e., ``CORE``) should **not be implemented or contributed**.
+Details on the exceptions and process for checking Perl modules can be found in the :ref:`Perl build system <suitable_perl_modules>` documentation.
 
-.. _review_structure:
+.. _structure_reviews:
 
 Package structure
 -----------------
 
-The `convention <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#structure-of-a-package>`_ for structuring Spack packages has metadata, or at least key properties, listed first followed by directives then methods:
+The `convention <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#structure-of-a-package>`_ for structuring Spack packages has metadata (key properties) listed first followed by directives then methods:
 
+* :ref:`url_equivalent_reviews`;
+* :ref:`vcs_url_reviews`;
 * :ref:`maintainers_reviews`;
 * :ref:`license_reviews`;
 * :ref:`version_reviews`;
@@ -93,13 +100,15 @@ However, they do cut down on visual clutter and make packages more readable.
 If you see clear deviations from the convention, request that they be addressed.
 When in doubt, ask others with merge privileges for advice.
 
+.. _url_equivalent_reviews:
+
 ``url``, ``url_for_version``, or URL equivalent
 -----------------------------------------------
 
 Changes to URLs may invalidate existing versions, which should be checked when there is a URL-related modification.
-All packages have a URL, though for some `build systems <https://spack.readthedocs.io/en/latest/build_systems.html>`_ it is derived automatically and not visible in the package.
+All packages have a URL, though for some :ref:`build-systems` it is derived automatically and not visible in the package.
 
-Reasons `versions <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#versions-and-urls>`_ may become invalid include:
+Reasons :ref:`versions <versions-and-fetching>` may become invalid include:
 
 * the new URL does not support Spack version extrapolation;
 * the addition of or changes to ``url_for_version`` involve checks of the ``spec``'s version instead of the ``version`` argument or the (usually older) versions are not covered;
@@ -122,7 +131,9 @@ Also, dashes may be replaced with underscores (e.g., `py-scikit-build <https://g
 In some cases, both changes can occur for the same package.
 As these examples illlustrate, it is sometimes possible to add a ``url_for_version`` method to override the default derived URL to ensure the correct one is returned.
 
-If older versions are no longer available and there is a chance someone has the package in a build cache, the usual approach is to first suggest `deprecating <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ them in the package.
+If older versions are no longer available and there is a chance someone has the package in a build cache, the usual approach is to first suggest :ref:`deprecating <deprecate>` them in the package.
+
+.. _vcs_url_reviews:
 
 ``git``, ``hg``, ``svn``, or ``cvs``
 ------------------------------------
@@ -138,11 +149,11 @@ You may need to check the new source repository to confirm the presence of all o
 -------------------------
 
 **Action.**
-If the new package does not have a `maintainers <https://spack.readthedocs.io/en/latest/packaging_guide.html#maintainers>`_ directive, ask the :ref:`Package Contributor <package-contributors>` to consider adding themselves.
+If the new package does not have a :ref:`maintainers <maintainers>` directive, ask the Contributor to add one.
 
-This request is optional for existing packages.
+.. note::
 
-.. tip::
+   This request is optional for existing packages.
 
    Be prepared for them to refuse.
 
@@ -152,9 +163,13 @@ This request is optional for existing packages.
 ---------------------
 
 **Action.**
-If the new package does not have a `license <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#license-information>`_  directive, ask the :ref:`Package Contributor <package-contributors>` to investigate and add it.
+If the new package does not have a :ref:`license <package_license>` directive, ask the Contributor to investigate and add it.
 
-This request is optional for existing packages.
+.. note::
+
+   This request is optional for existing packages.
+
+   Be prepared for them to refuse.
 
 .. _version_reviews:
 
@@ -162,10 +177,10 @@ This request is optional for existing packages.
 ----------------------
 
 In general, Spack packages are expected to be built from source code.
-There are a few exceptions (e.g., `BundlePackage <https://spack.readthedocs.io/en/latest/build_systems/bundlepackage.html#bundlepackage>`_).
-Typically every package will have at least one `version directive <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#source-code-and-versions>`_.
+There are a few exceptions (e.g., :ref:`BundlePackage <bundlepackage>`).
+Typically every package will have at least one :ref:`version <versions-and-fetching>` directive.
 
-The goal of reviewing version directives is to confirm that versions are listed in the proper order **and** that the arguments for new and updated versions are correct.
+The goals of reviewing version directives are to confirm that versions are listed in the proper order **and** that the arguments for new and updated versions are correct.
 
 .. note::
 
@@ -174,12 +189,16 @@ The goal of reviewing version directives is to confirm that versions are listed 
 ``version`` directive order
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`Spack convention <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#versions-and-urls>`_ holds that version directives should be listed in descending order, from newest to oldest.
-If branch versions are provided, then they should be listed first.
+By :ref:`convention <versions-and-fetching>` version directives should be listed in descending order, from newest to oldest.
+If branch versions are included, then they should be listed first.
 
 **Action.**
 When versions are being added, check the ordering of the directives.
 Request that the directives be  re-ordered if any of the directives do not conform to the convention.
+
+.. note::
+
+   Edge cases, such as manually downloaded software, may be difficult to confirm.
 
 Checksums, commits, tags, and branches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -195,7 +214,7 @@ Checksums, commits, tags, and branches
 
      From a security and reproducibility standpoint, it is important that Spack be able to verify downloaded source.
      This is accomplished using a hash (e.g., checksum or commit).
-     See `checksum verification <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#checksum-verification>`_ for more information.
+     See :ref:`checksum verification <checksum-verification>` for more information.
 
      Exceptions are allowed in rare cases, such as software supplied from reputable vendors.
      When in doubt, ask others with merge privileges for advice.
@@ -208,21 +227,21 @@ Checksums, commits, tags, and branches
 
 **Branches**
   Confirming new branch versions involves checking that the branches exist in the repository *and* that the version and branch names are consistent.
+  Let's take each in turn.
 
   **Action.**
-  Confirming branch existence, on the other hand, often involves checking the source repository.
+  Confirming branch existence often involves checking the source repository though is not necessary if there is confirmation that the branch was built successfully from the package.
 
   In general, the version and branch names should match.
-  When they do not, it is sometimes the result of people not being aware of how Spack handles `version ordering <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#version-comparison>`_.
+  When they do not, it is sometimes the result of people not being aware of how Spack handles :ref:`version-comparison`.
 
   **Action.**
-  If there is a name mismatch, especially for the most common branch names (e.g., `develop`, `main`, and `master`), ask why and suggest the arguments be changed such that they match the actual branch name.
+  If there is a name mismatch, especially for the most common branch names (e.g., ``develop``, ``main``, and ``master``), ask why and suggest the arguments be changed such that they match the actual branch name.
 
 **Manual downloads**
-  Edge cases, such as manually downloaded software, may be difficult to confirm.
 
   **Action.**
-  In these cases it is acceptable to rely on the package's Maintainers, if any.
+  Since these can be difficult to confirm, it is acceptable to rely on the package's Maintainers, if any.
 
 Deprecating versions
 ~~~~~~~~~~~~~~~~~~~~
@@ -231,14 +250,14 @@ If someone is deprecating versions, it is good to find out why.
 Sometimes there are concerns, such as security or lack of availability.
 
 **Action.**
-Suggest the Package Contributor review the `deprecation guidelines <https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions>`_ before finalizing the changes if they haven't already explained why they made the choice in the PR description or comments.
+Suggest the Contributor review the :ref:`deprecation guidelines <deprecate>` before finalizing the changes if they haven't already explained why they made the choice in the PR description or comments.
 
 .. _variant_reviews:
 
 ``variant`` directives
 ----------------------
 
-`Variants <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#variants>`_ represent build options so any changes involving these directives should be reflected elsewhere in the package.
+:ref:`Variants <variants>` represent build options so any changes involving these directives should be reflected elsewhere in the package.
 
 Adding or modifying variants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -247,7 +266,7 @@ Adding or modifying variants
 Confirm that new or modified variants are actually used in the package.
 The most common uses are additions and changes to:
 
-* dependencies;
+* :ref:`dependencies <depends_on_reviews>`;
 * configure options; and/or
 * build arguments.
 
@@ -262,14 +281,14 @@ Consider asking why the variant (or build option) is being removed and suggest m
 .. warning::
 
     If the default value of a variant is changed in the PR, then there is a risk that other packages relying on that value will no longer build as others expect.
-    This may be something worth noting in the review.
+    This may be worth noting in the review.
 
 .. _depends_on_reviews:
 
 ``depends_on`` directives
 -------------------------
 
-`Dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#dependencies>`_ represent software that must be installed before the package builds or is able to work correctly.
+:ref:`Dependencies <dependencies>` represent software that must be installed before the package builds or is able to work correctly.
 
 Updating dependencies
 ~~~~~~~~~~~~~~~~~~~~~
@@ -278,7 +297,7 @@ It is important that dependencies reflect the requirements of listed versions.
 They only need to be checked in a review when versions are being added or removed or the dependencies are being changed.
 
 **Action.**
-Dependencies affected by such changes should be confirmed, when possible, and *at least* when the :ref:`Package Contributor <package-contributors>` is not a :ref:`Maintainer <package-maintainers>` of the package.
+Dependencies affected by such changes should be confirmed, when possible, and *at least* when the Contributor is not a Maintainer of the package.
 
 **Solutions.**
 In some cases, the needed change may be as simple as ensuring the version range and or variant options in the dependency are accurate.
@@ -290,20 +309,20 @@ In this case, check Python package dependencies by following the build system `g
 
 .. tip::
 
-    In general, refer to the relevant dependencies section, if any, for the package’s `build system <https://spack.readthedocs.io/en/latest/build_systems.html>`_ for guidance.
+    In general, refer to the relevant dependencies section, if any, for the package’s :ref:`build-systems` for guidance.
 
 Updating language and compiler dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When `language and compiler dependencies <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#language-and-compiler-dependencies>`_ were introduced, their ``depends_on`` directives were derived from the source for existing packages.
-These dependencies are flagged with ``# generated`` comments.
-Unfortunately, the generated dependencies are not always complete.
+When :ref:`language and compiler dependencies <language-dependencies>` were introduced, their ``depends_on`` directives were derived from the source for existing packages.
+These dependencies are flagged with ``# generated`` comments when they have not been confirmed.
+Unfortunately, the generated dependencies are not always complete or necessarily required.
 
 **Action.**
-If these dependencies are being updated, ask if the :ref:`Package Contributor <package-contributors>` can confirm all of the generated dependencies and remove the ``# generated`` comments.
+If these dependencies are being updated, ask that the ``# generated`` comments be removed if the Contributor can confirm they are relevant.
 Definitely make sure Contributors do **not** include ``# generated`` on the dependencies they are adding to the package.
 
-.. _review_automated_checks:
+.. _automated_checks_reviews:
 
 Failed automated checks
 -----------------------
@@ -317,7 +336,7 @@ The PR may fail one or more style checks.
 
 **Action.**
 If the failure is due to issues raised by the ``black`` style checker *and* the PR is otherwise ready to be merged, you can add ``@spackbot fix style`` in a comment to see if Spack will fix the errors.
-Otherwise, inform the Package Contributor that they need to address the style failures.
+Otherwise, inform the Contributor that the style failures need to be addressed.
 
 CI stack failures
 ~~~~~~~~~~~~~~~~~
@@ -325,7 +344,7 @@ CI stack failures
 Existing packages **may** be included in GitLab CI pipelines through inclusion in one or more `stacks <https://github.com/spack/spack-packages/tree/develop/stacks>`_.
 
 **Action.**
-It is worth checking at least a sampling of the failed job logs, if present, to determine the possible cause and take or suggest an action accordingly.
+It is worth checking **at least a sampling** of the failed job logs, if present, to determine the possible cause and take or suggest an action accordingly.
 
 **CI Runner Failures**
   Sometimes CI runners time out or the pods become unavailable.
@@ -335,19 +354,19 @@ It is worth checking at least a sampling of the failed job logs, if present, to 
   Otherwise, the Contributor will need to investigate and resolve the problem.
 
 **Stand-alone Test Failures**
-  Sometimes `stand-alone tests <https://spack.readthedocs.io/en/latest/packaging_guide_testing.html#stand-alone-tests>`_ could be causing the build job to time out.
+  Sometimes :ref:`stand-alone tests <cmd-spack-test>` could be causing the build job to time out.
   If the tests take too long, the issue could be that the package is running too many and/or long running tests.
   Or the tests may be trying to use resources (e.g., a batch scheduler) that are not available on runners.
 
   **Action.**
-  If the tests for a package are hanging, at a minimum create a `new issue <https://github.com/spack/spack-packages/issues>`_, if there is not one already, to flag the package.
+  If the tests for a package are hanging, at a minimum create a `new issue <https://github.com/spack/spack-packages/issues>`_ if there is not one already, to flag the package.
 
   **(Temporary) Solution.**
   Look at the package implementation to see if the tests are using a batch scheduler or there appear to be too many or long running tests.
   If that is the case, then a pull request should be created in the ``spack/spack-packages`` repository that adds the package to the ``broken-tests-packages`` list in the `ci configuration <https://spack.readthedocs.io/en/latest/pipelines.html#ci-yaml>`_.
   Once the fix PR is merged, then the affected PR can be rebased to pick up the change.
 
-.. _review_build_success:
+.. _build_success_reviews:
 
 Successful builds
 -----------------
@@ -357,9 +376,12 @@ For a new package, we would ideally have confirmation for every version; whereas
 
 Acceptable forms of confirmation are **one or more of**:
 
-* the :ref:`Contributor <package-contributors>` or another reviewer explicitly confirms a successful build of each new version of the software on at least one platform;
-* the software is built successfully by Spack CI by at least one of the CI stacks; and
-* at least one :ref:`Maintainer <package-maintainers>` confirms they are able to successfully build the software.
+* the Contributor or another reviewer explicitly confirms that a successful build of **each new version on at least one platform**;
+* the software is built successfully by Spack CI by **at least one of the CI stacks**; and
+* **at least one Maintainer** explicitly confirms they are able to successfully build the software.
+
+Individuals are expected to update the PR description or add a comment to explicitly confirm the builds.
+You may need to check the CI stacks and/or outputs to confirm that there is a stack that builds the new version.
 
 .. note::
 

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2523,7 +2523,7 @@ In the example above ``Cp2k`` inherits the variants and conflicts defined by ``C
 Maintainers
 -----------
 
-Each package in Spack may have one or more maintainers, i.e. one or more GitHub accounts of people who want to be notified any time the package is modified.
+Each package in Spack may have one or more :ref:`<maintainers>`, i.e. one or more GitHub accounts of people who want to be notified any time the package is modified.
 
 When a pull request is submitted that updates the package, these people will be requested to review the PR.
 This is useful for developers who maintain a Spack package for their own software, as well as users who rely on a piece of software and want to ensure that the package doesn't break.

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -336,7 +336,7 @@ The remaining tasks to complete are as follows:
 #. Add a comma-separated list of maintainers.
 
    Add a list of GitHub accounts of people who want to be notified any time the package is modified.
-   See :ref:`package_maintainers`.
+   See :ref:`package-maintainers`.
 
 #. Change the ``license`` to the correct license.
 
@@ -2518,12 +2518,10 @@ These mixins should be used as additional base classes for your package, in addi
 
 In the example above ``Cp2k`` inherits the variants and conflicts defined by ``CudaPackage``.
 
-.. _package_maintainers:
-
 Maintainers
 -----------
 
-Each package in Spack may have one or more :ref:`<maintainers>`, i.e. one or more GitHub accounts of people who want to be notified any time the package is modified.
+Each package in Spack may have one or more :ref:`package-maintainers`, i.e. one or more GitHub accounts of people who want to be notified any time the package is modified.
 
 When a pull request is submitted that updates the package, these people will be requested to review the PR.
 This is useful for developers who maintain a Spack package for their own software, as well as users who rely on a piece of software and want to ensure that the package doesn't break.

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -336,7 +336,7 @@ The remaining tasks to complete are as follows:
 #. Add a comma-separated list of maintainers.
 
    Add a list of GitHub accounts of people who want to be notified any time the package is modified.
-   See :ref:`package-maintainers`.
+   See :ref:`maintainers`.
 
 #. Change the ``license`` to the correct license.
 
@@ -2518,22 +2518,26 @@ These mixins should be used as additional base classes for your package, in addi
 
 In the example above ``Cp2k`` inherits the variants and conflicts defined by ``CudaPackage``.
 
+.. _maintainers:
+
 Maintainers
 -----------
 
-Each package in Spack may have one or more :ref:`package-maintainers`, i.e. one or more GitHub accounts of people who want to be notified any time the package is modified.
+Each package in Spack may have one or more GitHub accounts for people who want to be notified whenever the package is modified.
+The list also provides contacts for people needing help with build errors.
 
-When a pull request is submitted that updates the package, these people will be requested to review the PR.
-This is useful for developers who maintain a Spack package for their own software, as well as users who rely on a piece of software and want to ensure that the package doesn't break.
-It also gives users a list of people to contact for help when someone reports a build error with the package.
-
-To add maintainers to a package, simply declare them with the ``maintainers`` directive:
+Adding maintainers is easy.
+After familiarizing yourself with the responsibilities of the :ref:`Package Maintainers <package-maintainers>` role, you simply need to declare their GitHub accounts in the ``maintainers`` directive:
 
 .. code-block:: python
 
-   maintainers("user1", "user2")
+   maintainers("github_user1", "github_user2")
 
-The list of maintainers is additive, and includes all the accounts eventually declared in base classes.
+.. warning::
+
+   Please do not add accounts without consent of the owner.
+
+The final list of maintainers includes accounts declared in the package's base classes.
 
 .. _package_license:
 

--- a/lib/spack/docs/roles_and_responsibilities.rst
+++ b/lib/spack/docs/roles_and_responsibilities.rst
@@ -48,7 +48,7 @@ As a Package Reviewer, you are **expected** to assess changes in PRs to the best
 Maintainers (Package Owners)
 ----------------------------
 
-Maintainers are individuals (technically GitHub accounts) who appear in a package’s `Maintainers <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#maintainers>`_ directive.
+Maintainers are individuals (technically GitHub accounts) who appear in a package’s :ref:`maintainers` directive.
 These are people who have agreed to be notified of and given the opportunity to review changes to packages.
 They are, from a Spack package perspective, `Code Owners <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners>`_ of the package, whether or not they “own” or work on the software that the package builds.
 
@@ -58,7 +58,7 @@ As a Maintainer, you are **expected**, when available, to:
 * confirm that packages successfully build on at least one platform; and
 * attempt to confirm that any updated or included tests pass.
 
-See :ref:`review_build_success` for acceptable forms of confirmation of build success.
+See :ref:`build_success_reviews` for acceptable forms of build success confirmation.
 
 .. note::
 

--- a/lib/spack/docs/roles_and_responsibilities.rst
+++ b/lib/spack/docs/roles_and_responsibilities.rst
@@ -28,11 +28,11 @@ Package Contributors
 
 Contributors submit changes to packages through PRs `Spack Package <https://github.com/spack/spack-packages>`_ repository Pull Requests (PRs).
 
-They are **expected** to test their changes on **at least one platform** outside of Spack’s Continuous Integration (CI) checks.
+As a Contributor, you are **expected** to test your changes on **at least one platform** outside of Spack’s Continuous Integration (CI) checks.
 
 .. note::
 
-   Including the output from ``spack debug report`` from the platform the software was installed from would be a quick way to help track information related to successful builds.
+   We also ask that you include the output from ``spack debug report`` from the platform you used to facilitate PR reviews.
 
 .. _package-reviewers:
 
@@ -41,7 +41,7 @@ Package Reviewers
 
 Anyone can review a PR so we encourage Spack’s community members to review and comment on those involving software in which they have expertise and/or interest.
 
-Package Reviewers are **expected** to assess changes in PRs to the best of their ability and knowledge with special consideration to the information contained in the :ref:`package-review-guide`.
+As a Package Reviewer, you are **expected** to assess changes in PRs to the best of your ability and knowledge with special consideration to the information contained in the :ref:`package-review-guide`.
 
 .. _package-maintainers:
 
@@ -52,21 +52,17 @@ Maintainers are individuals (technically GitHub accounts) who appear in a packag
 These are people who have agreed to be notified of and given the opportunity to review changes to packages.
 They are, from a Spack package perspective, `Code Owners <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners>`_ of the package, whether or not they “own” or work on the software that the package builds.
 
-Maintainers are **expected** to:
+As a Maintainer, you are **expected**, when available, to:
 
-* review PRs in a timely manner (reported in :ref:`committers`), when available, to confirm that the changes made to the package are reasonable;
+* review PRs in a timely manner (reported in :ref:`committers`) to confirm that the changes made to the package are reasonable;
 * confirm that packages successfully build on at least one platform; and
 * attempt to confirm that any updated or included tests pass.
 
-Acceptable forms of confirmation are **one or more of**:
-
-* the :ref:`Contributor <package-contributors>` explicitly confirms a successful build of the software on at least one platform (ideally in the PR description and includes ``spack debug report`` output);
-* the software is built successfully by Spack CI by at least one of the CI stacks; and
-* the Maintainer is able to successfully build the software (and ideally includes the ``spack debug report`` output in a comment on the PR).
+See :ref:`review_build_success` for acceptable forms of confirmation of build success.
 
 .. note::
 
-    If at least one maintainer approves a PR -– and if there are no objections from others -– then the PR can be merged by any of the :ref:`committers`.
+   If at least one maintainer approves a PR -– and there are no objections from others -– then the PR can be merged by any of the :ref:`committers`.
 
 .. _committers:
 
@@ -75,7 +71,7 @@ Committers
 
 Committers are vetted individuals who are allowed to merge PRs into the ``develop`` branch.
 
-Committers are **expected** to:
+As a Committer, you are **expected** to:
 
 * ensure **at least one review** is performed prior to merging (GitHub rules enforce this);
 * encourage **at least one** :ref:`Package Maintainer <package-maintainers>` (if any) to comment and/or review the PR;
@@ -85,7 +81,7 @@ Committers are **expected** to:
 
 .. note::
 
-   If there are no :ref:`package-maintainers` or the Maintainers have not commented or reviewed the PR within the allotted time, Committers are expected to conduct the review.
+   If there are no :ref:`package-maintainers` or the Maintainers have not commented or reviewed the PR within the allotted time, you will need to conduct the review.
 
 .. tip::
 

--- a/lib/spack/docs/roles_and_responsibilities.rst
+++ b/lib/spack/docs/roles_and_responsibilities.rst
@@ -1,0 +1,99 @@
+.. Copyright Spack Project Developers. See COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. meta::
+   :description lang=en:
+      A guide to distinguish the roles and responsibilities associated with managing the Spack Packages repository.
+
+.. _packaging-roles:
+
+Packaging Roles and Responsibilities
+====================================
+
+There are four roles related to `Spack Package <https://github.com/spack/spack-packages>`_ repository Pull Requests (PRs):
+
+#. :ref:`package contributor <package-contributors>`,
+#. :ref:`package reviewer <package-reviewers>`,
+#. :ref:`maintainer <maintainers>`, and
+#. :ref:`committer <committers>`.
+
+One person can assume multiple roles (e.g., a package contributor may also be a maintainer; a package reviewer may also be a committer).
+This section defines and describes the responsibilities of each role.
+
+.. _package-contributors:
+
+Package Contributors
+--------------------
+
+Contributors submit changes to packages through PRs `Spack Package <https://github.com/spack/spack-packages>`_ repository Pull Requests (PRs).
+
+They are **expected** to test their changes on **at least one platform** outside of Spack’s Continuous Integration (CI) checks.
+
+.. note::
+
+   Including the output from ``spack debug report`` from the platform the software was installed from would be a quick way to help track information related to successful builds.
+
+.. _package-reviewers:
+
+Package Reviewers
+-----------------
+
+Anyone can review a PR so we encourage Spack’s community members to review and comment on those involving software in which they have expertise and/or interest.
+
+Package reviewers are **expected** to assess changes in PRs to the best of their ability and knowledge with special consideration to the information contained in the :ref:`package-review-guide`.
+
+.. _maintainers:
+
+Maintainers (Package Owners)
+----------------------------
+
+Maintainers are individuals (technically GitHub accounts) who appear in a package’s `maintainers <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#maintainers>`_ list.
+These are people who have agreed to receive review assignments in terms of being notified of and given the opportunity to review changes to packages.
+They are, from a Spack package perspective, `Code Owners <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners>`_ of the package, whether or not they “own” or work on the software that the package builds.
+
+Maintainers are **expected** to:
+
+* review PRs in a timely manner (as described in :ref:`<committers>`) to confirm that the changes made to the package are reasonable;
+* confirm that packages successfully build on at least one platform; and
+* attempt to confirm that any updated or included tests pass.
+
+Acceptable forms of confirmation are:
+
+* the :ref:`Contributor <contributors>` explicitly confirms a successful build of the software on at least one platform (ideally in the PR description and includes ``spack debug report`` output);
+* the software is built successfully by Spack CI by at least one of the CI stacks; and
+* the maintainer is able to successfully build the software (and ideally includes the ``spack debug report`` output in a comment on the PR).
+
+.. note::
+
+    If at least one maintainer approves a PR -– and if there are no objections from others -– then the PR can be merged by a :ref:`Committer <committers>`.
+
+.. _committers:
+
+Committers
+----------
+
+Committers are vetted individuals who are allowed to merge PRs into the ``develop`` branch.
+
+Committers are **expected** to:
+
+* ensure **at least one review** is performed prior to merging (GitHub rules enforce this);
+* encourage **at least one** package maintainer (if any) to comment and/or review the PR;
+* allow package maintainers (if any) *up to* **one week** to comment or provide a review;
+* determine if the criteria defined in :ref:`package-review-guide` are met; and
+* **merge the reviewed PR** at their discretion.
+
+.. note::
+
+   If there are no :ref:`<maintainers>` or the maintainers have not commented or reviewed the PR within the allotted time, Committers are expected to conduct the review.
+
+.. tip::
+
+   The following criteria must be met in order to become a Committer:
+
+   * cannot be an anonymous account;
+   * must come from a known and trustworthy organization;
+   * demonstrated record of contribution to Spack;
+   * have an account on the Spack Slack workspace;
+   * be approved by the Onboarding subcommittee; and
+   * (proposed) be known to at least 3 members of the core development team.

--- a/lib/spack/docs/roles_and_responsibilities.rst
+++ b/lib/spack/docs/roles_and_responsibilities.rst
@@ -13,12 +13,12 @@ Packaging Roles and Responsibilities
 
 There are four roles related to `Spack Package <https://github.com/spack/spack-packages>`_ repository Pull Requests (PRs):
 
-#. :ref:`package contributor <package-contributors>`,
-#. :ref:`package reviewer <package-reviewers>`,
-#. :ref:`maintainer <maintainers>`, and
-#. :ref:`committer <committers>`.
+#. :ref:`package-contributors`,
+#. :ref:`package-reviewers`,
+#. :ref:`package-maintainers`, and
+#. :ref:`committers`.
 
-One person can assume multiple roles (e.g., a package contributor may also be a maintainer; a package reviewer may also be a committer).
+One person can assume multiple roles (e.g., a Package Contributor may also be a Maintainer; a Package Reviewer may also be a Committer).
 This section defines and describes the responsibilities of each role.
 
 .. _package-contributors:
@@ -43,7 +43,7 @@ Anyone can review a PR so we encourage Spack’s community members to review and
 
 Package reviewers are **expected** to assess changes in PRs to the best of their ability and knowledge with special consideration to the information contained in the :ref:`package-review-guide`.
 
-.. _maintainers:
+.. _package-maintainers:
 
 Maintainers (Package Owners)
 ----------------------------
@@ -54,19 +54,19 @@ They are, from a Spack package perspective, `Code Owners <https://docs.github.co
 
 Maintainers are **expected** to:
 
-* review PRs in a timely manner (as described in :ref:`<committers>`) to confirm that the changes made to the package are reasonable;
+* review PRs in a timely manner (as described in :ref:`committers`) to confirm that the changes made to the package are reasonable;
 * confirm that packages successfully build on at least one platform; and
 * attempt to confirm that any updated or included tests pass.
 
 Acceptable forms of confirmation are:
 
-* the :ref:`Contributor <contributors>` explicitly confirms a successful build of the software on at least one platform (ideally in the PR description and includes ``spack debug report`` output);
+* the :ref:`Contributor <package-contributors>` explicitly confirms a successful build of the software on at least one platform (ideally in the PR description and includes ``spack debug report`` output);
 * the software is built successfully by Spack CI by at least one of the CI stacks; and
-* the maintainer is able to successfully build the software (and ideally includes the ``spack debug report`` output in a comment on the PR).
+* the :ref:`Maintainer <package-maintainers>` is able to successfully build the software (and ideally includes the ``spack debug report`` output in a comment on the PR).
 
 .. note::
 
-    If at least one maintainer approves a PR -– and if there are no objections from others -– then the PR can be merged by a :ref:`Committer <committers>`.
+    If at least one maintainer approves a PR -– and if there are no objections from others -– then the PR can be merged by any :ref:`committers`.
 
 .. _committers:
 
@@ -85,7 +85,7 @@ Committers are **expected** to:
 
 .. note::
 
-   If there are no :ref:`<maintainers>` or the maintainers have not commented or reviewed the PR within the allotted time, Committers are expected to conduct the review.
+   If there are no :ref:`package-maintainers` or the maintainers have not commented or reviewed the PR within the allotted time, Committers are expected to conduct the review.
 
 .. tip::
 

--- a/lib/spack/docs/roles_and_responsibilities.rst
+++ b/lib/spack/docs/roles_and_responsibilities.rst
@@ -58,15 +58,15 @@ Maintainers are **expected** to:
 * confirm that packages successfully build on at least one platform; and
 * attempt to confirm that any updated or included tests pass.
 
-Acceptable forms of confirmation are one or more of:
+Acceptable forms of confirmation are **one or more of**:
 
 * the :ref:`Contributor <package-contributors>` explicitly confirms a successful build of the software on at least one platform (ideally in the PR description and includes ``spack debug report`` output);
 * the software is built successfully by Spack CI by at least one of the CI stacks; and
-* the :ref:`Maintainer <package-maintainers>` is able to successfully build the software (and ideally includes the ``spack debug report`` output in a comment on the PR).
+* the Maintainer is able to successfully build the software (and ideally includes the ``spack debug report`` output in a comment on the PR).
 
 .. note::
 
-    If at least one maintainer approves a PR -– and if there are no objections from others -– then the PR can be merged by any :ref:`committers`.
+    If at least one maintainer approves a PR -– and if there are no objections from others -– then the PR can be merged by any of the :ref:`committers`.
 
 .. _committers:
 
@@ -78,7 +78,7 @@ Committers are vetted individuals who are allowed to merge PRs into the ``develo
 Committers are **expected** to:
 
 * ensure **at least one review** is performed prior to merging (GitHub rules enforce this);
-* encourage **at least one** Package Maintainer (if any) to comment and/or review the PR;
+* encourage **at least one** :ref:`Package Maintainer <package-maintainers>` (if any) to comment and/or review the PR;
 * allow Package Maintainers (if any) **up to one week** to comment or provide a review;
 * determine if the criteria defined in :ref:`package-review-guide` are met; and
 * **merge the reviewed PR** at their discretion.

--- a/lib/spack/docs/roles_and_responsibilities.rst
+++ b/lib/spack/docs/roles_and_responsibilities.rst
@@ -41,24 +41,24 @@ Package Reviewers
 
 Anyone can review a PR so we encourage Spack’s community members to review and comment on those involving software in which they have expertise and/or interest.
 
-Package reviewers are **expected** to assess changes in PRs to the best of their ability and knowledge with special consideration to the information contained in the :ref:`package-review-guide`.
+Package Reviewers are **expected** to assess changes in PRs to the best of their ability and knowledge with special consideration to the information contained in the :ref:`package-review-guide`.
 
 .. _package-maintainers:
 
 Maintainers (Package Owners)
 ----------------------------
 
-Maintainers are individuals (technically GitHub accounts) who appear in a package’s `maintainers <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#maintainers>`_ list.
-These are people who have agreed to receive review assignments in terms of being notified of and given the opportunity to review changes to packages.
+Maintainers are individuals (technically GitHub accounts) who appear in a package’s `Maintainers <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#maintainers>`_ directive.
+These are people who have agreed to be notified of and given the opportunity to review changes to packages.
 They are, from a Spack package perspective, `Code Owners <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners>`_ of the package, whether or not they “own” or work on the software that the package builds.
 
 Maintainers are **expected** to:
 
-* review PRs in a timely manner (as described in :ref:`committers`) to confirm that the changes made to the package are reasonable;
+* review PRs in a timely manner (reported in :ref:`committers`), when available, to confirm that the changes made to the package are reasonable;
 * confirm that packages successfully build on at least one platform; and
 * attempt to confirm that any updated or included tests pass.
 
-Acceptable forms of confirmation are:
+Acceptable forms of confirmation are one or more of:
 
 * the :ref:`Contributor <package-contributors>` explicitly confirms a successful build of the software on at least one platform (ideally in the PR description and includes ``spack debug report`` output);
 * the software is built successfully by Spack CI by at least one of the CI stacks; and
@@ -78,14 +78,14 @@ Committers are vetted individuals who are allowed to merge PRs into the ``develo
 Committers are **expected** to:
 
 * ensure **at least one review** is performed prior to merging (GitHub rules enforce this);
-* encourage **at least one** package maintainer (if any) to comment and/or review the PR;
-* allow package maintainers (if any) *up to* **one week** to comment or provide a review;
+* encourage **at least one** Package Maintainer (if any) to comment and/or review the PR;
+* allow Package Maintainers (if any) **up to one week** to comment or provide a review;
 * determine if the criteria defined in :ref:`package-review-guide` are met; and
 * **merge the reviewed PR** at their discretion.
 
 .. note::
 
-   If there are no :ref:`package-maintainers` or the maintainers have not commented or reviewed the PR within the allotted time, Committers are expected to conduct the review.
+   If there are no :ref:`package-maintainers` or the Maintainers have not commented or reviewed the PR within the allotted time, Committers are expected to conduct the review.
 
 .. tip::
 


### PR DESCRIPTION
Depends on #51149 (for perl link)

This PR integrates content from the `Spack Package Merge Criteria` document into the `Contributing` section of the Spack documentation.

It separates the two major sections of the original document -- Roles and Responsibilities and Merge Criteria -- into separate sections within the Spack documentation. The merge criteria has been restructured into more of a review guide, with additional contents and lots of links to relevant areas of the Spack documentation.