### PR TITLE
memoized: replace custom implementation with `functools.lru_cache(maxsize=None)`

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -424,7 +424,7 @@ def _config_mutator(method):
 
     @functools.wraps(method)
     def _method(self, *args, **kwargs):
-        self._get_config_memoized.cache.clear()
+        self._get_config_memoized.cache_clear()
         return method(self, *args, **kwargs)
 
     return _method

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -127,19 +127,6 @@ def union_dicts(*dicts):
     return result
 
 
-# Used as a sentinel that disambiguates tuples passed in *args from coincidentally
-# matching tuples formed from kwargs item pairs.
-_kwargs_separator = (object(),)
-
-
-def stable_args(*args, **kwargs):
-    """A key factory that performs a stable sort of the parameters."""
-    key = args
-    if kwargs:
-        key += _kwargs_separator + tuple(sorted(kwargs.items()))
-    return key
-
-
 def memoized(func):
     """Decorator that caches the results of a function, storing them in
     an attribute of that function.

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -144,25 +144,7 @@ def memoized(func):
     """Decorator that caches the results of a function, storing them in
     an attribute of that function.
     """
-    func.cache = {}
-
-    @functools.wraps(func)
-    def _memoized_function(*args, **kwargs):
-        key = stable_args(*args, **kwargs)
-
-        try:
-            return func.cache[key]
-        except KeyError:
-            ret = func(*args, **kwargs)
-            func.cache[key] = ret
-            return ret
-        except TypeError as e:
-            # TypeError is raised when indexing into a dict if the key is unhashable.
-            raise UnhashableArguments(
-                "args + kwargs '{}' was not hashable for function '{}'".format(key, func.__name__)
-            ) from e
-
-    return _memoized_function
+    return functools.lru_cache(maxsize=None)(func)
 
 
 def list_modules(directory, **kwargs):

--- a/lib/spack/spack/platforms/_functions.py
+++ b/lib/spack/spack/platforms/_functions.py
@@ -26,7 +26,7 @@ def reset():
     """The result of the host search is memoized. In case it needs to be recomputed
     we must clear the cache, which is what this function does.
     """
-    _host.cache.clear()
+    _host.cache_clear()
 
 
 @spack.llnl.util.lang.memoized

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 import pytest
 
 import spack.llnl.util.lang
-from spack.llnl.util.lang import dedupe, match_predicate, memoized, pretty_date, stable_args
+from spack.llnl.util.lang import dedupe, match_predicate, memoized, pretty_date
 
 
 @pytest.fixture()
@@ -221,28 +221,6 @@ def test_key_ordering():
     assert hash(a) == hash(a2)
     assert hash(b) == hash(b)
     assert hash(b) == hash(b2)
-
-
-@pytest.mark.parametrize(
-    "args1,kwargs1,args2,kwargs2",
-    [
-        # Ensure tuples passed in args are disambiguated from equivalent kwarg items.
-        (("a", 3), {}, (), {"a": 3})
-    ],
-)
-def test_unequal_args(args1, kwargs1, args2, kwargs2):
-    assert stable_args(*args1, **kwargs1) != stable_args(*args2, **kwargs2)
-
-
-@pytest.mark.parametrize(
-    "args1,kwargs1,args2,kwargs2",
-    [
-        # Ensure that kwargs are stably sorted.
-        ((), {"a": 3, "b": 4}, (), {"b": 4, "a": 3})
-    ],
-)
-def test_equal_args(args1, kwargs1, args2, kwargs2):
-    assert stable_args(*args1, **kwargs1) == stable_args(*args2, **kwargs2)
 
 
 @pytest.mark.parametrize("args, kwargs", [((1,), {}), ((), {"a": 3}), ((1,), {"a": 3})])

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -252,9 +252,8 @@ def test_memoized(args, kwargs):
         return "return-value"
 
     assert f(*args, **kwargs) == "return-value"
-    key = stable_args(*args, **kwargs)
-    assert list(f.cache.keys()) == [key]
-    assert f.cache[key] == "return-value"
+    assert f(*args, **kwargs) == "return-value"
+    assert f.cache_info().hits == 1
 
 
 @pytest.mark.parametrize("args, kwargs", [(([1],), {}), ((), {"a": [1]})])
@@ -265,12 +264,8 @@ def test_memoized_unhashable(args, kwargs):
     def f(*args, **kwargs):
         return None
 
-    with pytest.raises(spack.llnl.util.lang.UnhashableArguments) as exc_info:
+    with pytest.raises(TypeError, match="unhashable type:"):
         f(*args, **kwargs)
-    exc_msg = str(exc_info.value)
-    key = stable_args(*args, **kwargs)
-    assert str(key) in exc_msg
-    assert "function 'f'" in exc_msg
 
 
 def test_dedupe():


### PR DESCRIPTION
According [to docs](https://docs.python.org/3/library/functools.html#functools.lru_cache) this is available since Python 3.2, so we can use it,  and align our implementation with the standard library.

There is a slight change in the implementation details, since to clear the cache we now have to:
```python
func.cache_clear()
```
instead of:
```python
func.cache.clear()
```
This is not part of the API contract, so there is no attempt here to deprecate the previous behavior.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
