### PR TITLE
.git-blame-ignore-revs: rst formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,5 @@
 603569e321013a1a63a637813c94c2834d0a0023
 # Formatted entire codebase with black 22
 f52f6e99dbf1131886a80112b8c79dfc414afb7c
+# Formatted all rst files
+1377d42c16c6912faa77259c0a1f665210ccfd85


### PR DESCRIPTION
Add the merge commit of #51144 to the list of ignored revs in git blame.