### PR TITLE
solver: explicitly track targets unsupported by compilers

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2685,7 +2685,7 @@ class SpackSolverSetup:
 
         Results are ordered most to least recent.
         """
-        supported = []
+        supported, unsupported = [], []
 
         for target in targets:
             try:
@@ -2696,11 +2696,11 @@ class SpackSolverSetup:
                     )
                 supported.append(target)
             except spack.vendor.archspec.cpu.UnsupportedMicroarchitecture:
-                continue
+                unsupported.append(target)
             except ValueError:
-                continue
+                unsupported.append(target)
 
-        return sorted(supported, reverse=True)
+        return supported, unsupported
 
     def platform_defaults(self):
         self.gen.h2("Default platform")
@@ -2775,10 +2775,9 @@ class SpackSolverSetup:
         uarch = spack.vendor.archspec.cpu.TARGETS.get(platform.default)
         best_targets = {uarch.family.name}
         for compiler in self.possible_compilers:
-            supported = self._supported_targets(compiler.name, compiler.version, candidate_targets)
-
-            if not supported:
-                continue
+            supported, unsupported = self._supported_targets(
+                compiler.name, compiler.version, candidate_targets
+            )
 
             for target in supported:
                 best_targets.add(target.name)
@@ -2786,9 +2785,16 @@ class SpackSolverSetup:
                     fn.compiler_supports_target(compiler.name, compiler.version, target.name)
                 )
 
-            self.gen.fact(
-                fn.compiler_supports_target(compiler.name, compiler.version, uarch.family.name)
-            )
+            if supported:
+                self.gen.fact(
+                    fn.compiler_supports_target(compiler.name, compiler.version, uarch.family.name)
+                )
+
+            for target in unsupported:
+                self.gen.fact(
+                    fn.target_not_supported(compiler.name, compiler.version, target.name)
+                )
+
             self.gen.newline()
 
         i = 0  # TODO compute per-target offset?

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2781,13 +2781,11 @@ class SpackSolverSetup:
 
             for target in supported:
                 best_targets.add(target.name)
-                self.gen.fact(
-                    fn.compiler_supports_target(compiler.name, compiler.version, target.name)
-                )
+                self.gen.fact(fn.target_supported(compiler.name, compiler.version, target.name))
 
             if supported:
                 self.gen.fact(
-                    fn.compiler_supports_target(compiler.name, compiler.version, uarch.family.name)
+                    fn.target_supported(compiler.name, compiler.version, uarch.family.name)
                 )
 
             for target in unsupported:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1684,7 +1684,7 @@ error(10, "{0} compiler '{2}@{3}' incompatible with 'target={1}'", Package, Targ
   :- attr("node_target", node(X, Package), Target),
      node_compiler(node(X, Package), node(Y, Compiler)),
      attr("version", node(Y, Compiler), Version),
-     not compiler_supports_target(Compiler, Version, Target),
+     target_not_supported(Compiler, Version, Target),
      build(node(X, Package)).
 
 #defined compiler_supports_target/2.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1666,7 +1666,7 @@ node_target_compatible(PackageNode, Target)
     target_compatible(Target, MyTarget).
 
 #defined target_satisfies/2.
-compiler(Compiler) :- compiler_supports_target(Compiler, _, _).
+compiler(Compiler) :- target_supported(Compiler, _, _).
 
 % Can't use targets on node if the compiler for the node doesn't support them
 language("c").
@@ -1687,7 +1687,8 @@ error(10, "{0} compiler '{2}@{3}' incompatible with 'target={1}'", Package, Targ
      target_not_supported(Compiler, Version, Target),
      build(node(X, Package)).
 
-#defined compiler_supports_target/2.
+#defined target_supported/2.
+#defined target_not_supported/2.
 
 % if a target is set explicitly, respect it
 attr("node_target", PackageNode, Target)


### PR DESCRIPTION
Tracks unsupported targets explicitly to avoid clingo having to figure out a negative statement.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
