### PR TITLE
Package API: various improvements to docstrings/typehints/docs

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -363,7 +363,7 @@ def depends_on(
         when: condition when this dependency applies
         type: One or more of ``"build"``, ``"run"``, ``"test"``, or ``"link"`` (either a string or
             tuple). Defaults to ``("build", "link")``.
-        patches: single result of ``patch()`` directive, a
+        patches: single result of :py:func:`patch` directive, a
             ``str`` to be passed to ``patch``, or a list of these
     """
     dep_spec = spack.spec.Spec(spec)
@@ -505,10 +505,10 @@ def can_splice(
             target.
 
         match_variants: A list of variants that must match between target spec and current package,
-            with special value '*' which matches all variants. Example: a ``json`` variant is
+            with special value ``*`` which matches all variants. Example: a ``json`` variant is
             defined on two packages, and they are ABI-compatible whenever they agree on
             the json variant (regardless of whether it is turned on or off). Note that this cannot
-            be applied to multi-valued variants and multi-valued variants will be skipped by '*'.
+            be applied to multi-valued variants and multi-valued variants will be skipped by ``*``.
     """
 
     def _execute_can_splice(pkg: Type[spack.package_base.PackageBase]):

--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Definitions that control how Spack creates Spec hashes."""
 
+from typing import Any, Callable, List, Optional
+
 import spack.deptypes as dt
 import spack.repo
 
-HASHES = []
+HASHES: List["SpecHashDescriptor"] = []
 
 
 class SpecHashDescriptor:
@@ -19,7 +21,13 @@ class SpecHashDescriptor:
 
     We currently use different hashes for different use cases."""
 
-    def __init__(self, depflag: dt.DepFlag, package_hash, name, override=None):
+    def __init__(
+        self,
+        depflag: dt.DepFlag,
+        package_hash: bool,
+        name: str,
+        override: Optional[Callable[[Any], str]] = None,
+    ):
         self.depflag = depflag
         self.package_hash = package_hash
         self.name = name

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -399,9 +399,7 @@ class FileFilter:
     multiple times to perform search-and-replace operations using Python regular expressions,
     similar to ``sed``.
 
-    Example usage:
-
-    .. code-block:: python
+    Example usage::
 
         foo_c = FileFilter("foo.c")
         foo_c.filter(r"#define FOO", "#define BAR")
@@ -433,7 +431,7 @@ class FileFilter:
         )
 
 
-def change_sed_delimiter(old_delim, new_delim, *filenames):
+def change_sed_delimiter(old_delim: str, new_delim: str, *filenames: str) -> None:
     """Find all sed search/replace commands and change the delimiter.
 
     e.g., if the file contains seds that look like ``'s///'``, you can
@@ -444,8 +442,8 @@ def change_sed_delimiter(old_delim, new_delim, *filenames):
     Handling those is left for future work.
 
     Parameters:
-        old_delim (str): The delimiter to search for
-        new_delim (str): The delimiter to replace with
+        old_delim: The delimiter to search for
+        new_delim: The delimiter to replace with
         *filenames: One or more files to search and replace
     """
     assert len(old_delim) == 1
@@ -677,7 +675,7 @@ def copy(src: str, dest: str, _permissions: bool = False) -> None:
     Parameters:
         src: the file(s) to copy
         dest: the destination file or directory
-        _permissions (bool): for internal use only
+        _permissions: for internal use only
 
     Raises:
         OSError: if ``src`` does not match any files or directories
@@ -1015,9 +1013,7 @@ def working_dir(dirname: str, *, create: bool = False):
         dirname: the directory to change to
         create: if :obj:`True`, create the directory if it does not exist
 
-    Example usage:
-
-    .. code-block:: python
+    Example usage::
 
        with working_dir("/path/to/dir"):
            # do something in /path/to/dir
@@ -1606,7 +1602,7 @@ def readonly_file_handler(ignore_errors=False):
 
 
 @system_path_filter
-def remove_linked_tree(path):
+def remove_linked_tree(path: str) -> None:
     """Removes a directory and its contents.
 
     If the directory is a symlink, follows the link and removes the real
@@ -1615,9 +1611,9 @@ def remove_linked_tree(path):
     This method will force-delete files on Windows
 
     Parameters:
-        path (str): Directory to be removed
+        path: Directory to be removed
     """
-    kwargs = {"ignore_errors": True}
+    kwargs: dict = {"ignore_errors": True}
 
     # Windows readonly files cannot be removed by Python
     # directly.
@@ -1704,13 +1700,13 @@ def find_first(root: str, files: Union[Iterable[str], str], bfs_depth: int = 2) 
     until depth bfs_depth, after which depth-first search is used.
 
     Parameters:
-        root (str): The root directory to start searching from
-        files (str or Iterable): File pattern(s) to search for
-        bfs_depth (int): (advanced) parameter that specifies at which
+        root: The root directory to start searching from
+        files: File pattern(s) to search for
+        bfs_depth: (advanced) parameter that specifies at which
             depth to switch to depth-first search.
 
     Returns:
-        str or None: The matching file or None when no file is found.
+        The matching file or :data:`None` when no file is found.
     """
     if isinstance(files, str):
         files = [files]
@@ -1729,7 +1725,7 @@ def find(
     matching file is returned only once at lowest depth in case multiple paths exist due to
     symlinked directories.
 
-    Accepts any glob characters accepted by fnmatch:
+    Accepts any glob characters accepted by :py:func:`fnmatch.fnmatch`:
 
     ==========  ====================================
     Pattern     Meaning
@@ -1924,41 +1920,41 @@ class FileList(collections.abc.Sequence):
     Provides a few convenience methods to manipulate file paths.
     """
 
-    def __init__(self, files):
+    def __init__(self, files: Union[str, Iterable[str]]) -> None:
         if isinstance(files, str):
             files = [files]
 
         self.files = list(dedupe(files))
 
     @property
-    def directories(self):
+    def directories(self) -> List[str]:
         """Stable de-duplication of the directories where the files reside.
 
-        >>> l = LibraryList(['/dir1/liba.a', '/dir2/libb.a', '/dir1/libc.a'])
+        >>> l = LibraryList(["/dir1/liba.a", "/dir2/libb.a", "/dir1/libc.a"])
         >>> l.directories
-        ['/dir1', '/dir2']
-        >>> h = HeaderList(['/dir1/a.h', '/dir1/b.h', '/dir2/c.h'])
+        ["/dir1", "/dir2"]
+        >>> h = HeaderList(["/dir1/a.h", "/dir1/b.h", "/dir2/c.h"])
         >>> h.directories
-        ['/dir1', '/dir2']
+        ["/dir1", "/dir2"]
 
         Returns:
-            list: A list of directories
+            A list of directories
         """
         return list(dedupe(os.path.dirname(x) for x in self.files if os.path.dirname(x)))
 
     @property
-    def basenames(self):
+    def basenames(self) -> List[str]:
         """Stable de-duplication of the base-names in the list
 
-        >>> l = LibraryList(['/dir1/liba.a', '/dir2/libb.a', '/dir3/liba.a'])
+        >>> l = LibraryList(["/dir1/liba.a", "/dir2/libb.a", "/dir3/liba.a"])
         >>> l.basenames
-        ['liba.a', 'libb.a']
-        >>> h = HeaderList(['/dir1/a.h', '/dir2/b.h', '/dir3/a.h'])
+        ["liba.a", "libb.a"]
+        >>> h = HeaderList(["/dir1/a.h", "/dir2/b.h", "/dir3/a.h"])
         >>> h.basenames
-        ['a.h', 'b.h']
+        ["a.h", "b.h"]
 
         Returns:
-            list: A list of base-names
+            A list of base-names
         """
         return list(dedupe(os.path.basename(x) for x in self.files))
 
@@ -1980,7 +1976,7 @@ class FileList(collections.abc.Sequence):
     def __len__(self):
         return len(self.files)
 
-    def joined(self, separator=" "):
+    def joined(self, separator: str = " ") -> str:
         return separator.join(self.files)
 
     def __repr__(self):
@@ -2010,7 +2006,7 @@ class HeaderList(FileList):
         self._directories = None
 
     @property
-    def directories(self):
+    def directories(self) -> List[str]:
         """Directories to be searched for header files."""
         values = self._directories
         if values is None:
@@ -2041,31 +2037,31 @@ class HeaderList(FileList):
         return values
 
     @property
-    def headers(self):
+    def headers(self) -> List[str]:
         """Stable de-duplication of the headers.
 
         Returns:
-            list: A list of header files
+            A list of header files
         """
         return self.files
 
     @property
-    def names(self):
+    def names(self) -> List[str]:
         """Stable de-duplication of header names in the list without extensions
 
-        >>> h = HeaderList(['/dir1/a.h', '/dir2/b.h', '/dir3/a.h'])
+        >>> h = HeaderList(["/dir1/a.h", "/dir2/b.h", "/dir3/a.h"])
         >>> h.names
-        ['a', 'b']
+        ["a", "b"]
 
         Returns:
-            list: A list of files without extensions
+            A list of files without extensions
         """
         names = []
 
         for x in self.basenames:
             name = x
 
-            # Valid extensions include: ['.cuh', '.hpp', '.hh', '.h']
+            # Valid extensions include: [".cuh", ".hpp", ".hh", ".h"]
             for ext in [".cuh", ".hpp", ".hh", ".h"]:
                 i = name.rfind(ext)
                 if i != -1:
@@ -2078,84 +2074,84 @@ class HeaderList(FileList):
         return list(dedupe(names))
 
     @property
-    def include_flags(self):
+    def include_flags(self) -> str:
         """Include flags
 
-        >>> h = HeaderList(['/dir1/a.h', '/dir1/b.h', '/dir2/c.h'])
+        >>> h = HeaderList(["/dir1/a.h", "/dir1/b.h", "/dir2/c.h"])
         >>> h.include_flags
-        '-I/dir1 -I/dir2'
+        "-I/dir1 -I/dir2"
 
         Returns:
-            str: A joined list of include flags
+            A joined list of include flags
         """
         return " ".join(["-I" + x for x in self.directories])
 
     @property
-    def macro_definitions(self):
+    def macro_definitions(self) -> str:
         """Macro definitions
 
-        >>> h = HeaderList(['/dir1/a.h', '/dir1/b.h', '/dir2/c.h'])
-        >>> h.add_macro('-DBOOST_LIB_NAME=boost_regex')
-        >>> h.add_macro('-DBOOST_DYN_LINK')
+        >>> h = HeaderList(["/dir1/a.h", "/dir1/b.h", "/dir2/c.h"])
+        >>> h.add_macro("-DBOOST_LIB_NAME=boost_regex")
+        >>> h.add_macro("-DBOOST_DYN_LINK")
         >>> h.macro_definitions
-        '-DBOOST_LIB_NAME=boost_regex -DBOOST_DYN_LINK'
+        "-DBOOST_LIB_NAME=boost_regex -DBOOST_DYN_LINK"
 
         Returns:
-            str: A joined list of macro definitions
+            A joined list of macro definitions
         """
         return " ".join(self._macro_definitions)
 
     @property
-    def cpp_flags(self):
+    def cpp_flags(self) -> str:
         """Include flags + macro definitions
 
-        >>> h = HeaderList(['/dir1/a.h', '/dir1/b.h', '/dir2/c.h'])
+        >>> h = HeaderList(["/dir1/a.h", "/dir1/b.h", "/dir2/c.h"])
         >>> h.cpp_flags
-        '-I/dir1 -I/dir2'
-        >>> h.add_macro('-DBOOST_DYN_LINK')
+        "-I/dir1 -I/dir2"
+        >>> h.add_macro("-DBOOST_DYN_LINK")
         >>> h.cpp_flags
-        '-I/dir1 -I/dir2 -DBOOST_DYN_LINK'
+        "-I/dir1 -I/dir2 -DBOOST_DYN_LINK"
 
         Returns:
-            str: A joined list of include flags and macro definitions
+            A joined list of include flags and macro definitions
         """
         cpp_flags = self.include_flags
         if self.macro_definitions:
             cpp_flags += " " + self.macro_definitions
         return cpp_flags
 
-    def add_macro(self, macro):
+    def add_macro(self, macro: str) -> None:
         """Add a macro definition
 
         Parameters:
-            macro (str): The macro to add
+            macro: The macro to add
         """
         self._macro_definitions.append(macro)
 
 
-def find_headers(headers, root, recursive=False):
+def find_headers(headers: Union[str, List[str]], root: str, recursive: bool = False) -> HeaderList:
     """Returns an iterable object containing a list of full paths to
     headers if found.
 
-    Accepts any glob characters accepted by fnmatch:
+    Accepts any glob characters accepted by :py:func:`fnmatch.fnmatch`:
 
-    =======  ====================================
-    Pattern  Meaning
-    =======  ====================================
-    *        matches everything
-    ?        matches any single character
-    [seq]    matches any character in ``seq``
-    [!seq]   matches any character not in ``seq``
-    =======  ====================================
+    ==========  ====================================
+    Pattern     Meaning
+    ==========  ====================================
+    ``*``       matches one or more characters
+    ``?``       matches any single character
+    ``[seq]``   matches any character in ``seq``
+    ``[!seq]``  matches any character not in ``seq``
+    ==========  ====================================
 
     Parameters:
-        headers (str or list): Header name(s) to search for
-        root (str): The root directory to start searching from
-        recursive (bool): if False search only root folder,
-            if True descends top-down from the root. Defaults to False.
+        headers: Header name(s) to search for
+        root: The root directory to start searching from
+        recursive: if :data:`False` search only root folder,
+            if :data:`True` descends top-down from the root. Defaults to :data:`False`.
 
     Returns:
-        HeaderList: The headers that have been found
+        The headers that have been found
     """
     if isinstance(headers, str):
         headers = [headers]
@@ -2189,12 +2185,12 @@ def find_headers(headers, root, recursive=False):
 
 
 @system_path_filter
-def find_all_headers(root):
+def find_all_headers(root: str) -> HeaderList:
     """Convenience function that returns the list of all headers found
     in the directory passed as argument.
 
     Args:
-        root (str): directory where to look recursively for header files
+        root: directory where to look recursively for header files
 
     Returns:
         List of all headers found in ``root`` and subdirectories.
@@ -2210,24 +2206,24 @@ class LibraryList(FileList):
     """
 
     @property
-    def libraries(self):
+    def libraries(self) -> List[str]:
         """Stable de-duplication of library files.
 
         Returns:
-            list: A list of library files
+            A list of library files
         """
         return self.files
 
     @property
-    def names(self):
+    def names(self) -> List[str]:
         """Stable de-duplication of library names in the list
 
-        >>> l = LibraryList(['/dir1/liba.a', '/dir2/libb.a', '/dir3/liba.so'])
+        >>> l = LibraryList(["/dir1/liba.a", "/dir2/libb.a", "/dir3/liba.so"])
         >>> l.names
-        ['a', 'b']
+        ["a", "b"]
 
         Returns:
-            list: A list of library names
+            A list of library names
         """
         names = []
 
@@ -2253,46 +2249,46 @@ class LibraryList(FileList):
         return list(dedupe(names))
 
     @property
-    def search_flags(self):
+    def search_flags(self) -> str:
         """Search flags for the libraries
 
-        >>> l = LibraryList(['/dir1/liba.a', '/dir2/libb.a', '/dir1/liba.so'])
+        >>> l = LibraryList(["/dir1/liba.a", "/dir2/libb.a", "/dir1/liba.so"])
         >>> l.search_flags
-        '-L/dir1 -L/dir2'
+        "-L/dir1 -L/dir2"
 
         Returns:
-            str: A joined list of search flags
+            A joined list of search flags
         """
         return " ".join(["-L" + x for x in self.directories])
 
     @property
-    def link_flags(self):
+    def link_flags(self) -> str:
         """Link flags for the libraries
 
-        >>> l = LibraryList(['/dir1/liba.a', '/dir2/libb.a', '/dir1/liba.so'])
+        >>> l = LibraryList(["/dir1/liba.a", "/dir2/libb.a", "/dir1/liba.so"])
         >>> l.link_flags
-        '-la -lb'
+        "-la -lb"
 
         Returns:
-            str: A joined list of link flags
+            A joined list of link flags
         """
         return " ".join(["-l" + name for name in self.names])
 
     @property
-    def ld_flags(self):
+    def ld_flags(self) -> str:
         """Search flags + link flags
 
-        >>> l = LibraryList(['/dir1/liba.a', '/dir2/libb.a', '/dir1/liba.so'])
+        >>> l = LibraryList(["/dir1/liba.a", "/dir2/libb.a", "/dir1/liba.so"])
         >>> l.ld_flags
-        '-L/dir1 -L/dir2 -la -lb'
+        "-L/dir1 -L/dir2 -la -lb"
 
         Returns:
-            str: A joined list of search flags and link flags
+            A joined list of search flags and link flags
         """
         return self.search_flags + " " + self.link_flags
 
 
-def find_system_libraries(libraries, shared=True):
+def find_system_libraries(libraries: Union[str, List[str]], shared: bool = True) -> LibraryList:
     """Searches the usual system library locations for ``libraries``.
 
     Search order is as follows:
@@ -2304,24 +2300,24 @@ def find_system_libraries(libraries, shared=True):
     5. ``/usr/local/lib64``
     6. ``/usr/local/lib``
 
-    Accepts any glob characters accepted by fnmatch:
+    Accepts any glob characters accepted by :py:func:`fnmatch.fnmatch`:
 
-    =======  ====================================
-    Pattern  Meaning
-    =======  ====================================
-    *        matches everything
-    ?        matches any single character
-    [seq]    matches any character in ``seq``
-    [!seq]   matches any character not in ``seq``
-    =======  ====================================
+    ==========  ====================================
+    Pattern     Meaning
+    ==========  ====================================
+    ``*``       matches one or more characters
+    ``?``       matches any single character
+    ``[seq]``   matches any character in ``seq``
+    ``[!seq]``  matches any character not in ``seq``
+    ==========  ====================================
 
     Parameters:
-        libraries (str or list): Library name(s) to search for
-        shared (bool): if True searches for shared libraries,
-            otherwise for static. Defaults to True.
+        libraries: Library name(s) to search for
+        shared: if :data:`True` searches for shared libraries,
+            otherwise for static. Defaults to :data:`True`.
 
     Returns:
-        LibraryList: The libraries that have been found
+        The libraries that have been found
     """
     if isinstance(libraries, str):
         libraries = [libraries]
@@ -2331,7 +2327,7 @@ def find_system_libraries(libraries, shared=True):
         message = message.format(find_system_libraries.__name__, type(libraries))
         raise TypeError(message)
 
-    libraries_found = []
+    libraries_found = LibraryList([])
     search_locations = [
         "/lib64",
         "/lib",
@@ -2352,37 +2348,42 @@ def find_system_libraries(libraries, shared=True):
 
 
 def find_libraries(
-    libraries, root, shared=True, recursive=False, runtime=True, max_depth: Optional[int] = None
-):
+    libraries: Union[str, List[str]],
+    root: str,
+    shared: bool = True,
+    recursive: bool = False,
+    runtime: bool = True,
+    max_depth: Optional[int] = None,
+) -> LibraryList:
     """Returns an iterable of full paths to libraries found in a root dir.
 
-    Accepts any glob characters accepted by fnmatch:
+    Accepts any glob characters accepted by :py:func:`fnmatch.fnmatch`:
 
-    =======  ====================================
-    Pattern  Meaning
-    =======  ====================================
-    *        matches everything
-    ?        matches any single character
-    [seq]    matches any character in ``seq``
-    [!seq]   matches any character not in ``seq``
-    =======  ====================================
+    ==========  ====================================
+    Pattern     Meaning
+    ==========  ====================================
+    ``*``       matches one or more characters
+    ``?``       matches any single character
+    ``[seq]``   matches any character in ``seq``
+    ``[!seq]``  matches any character not in ``seq``
+    ==========  ====================================
 
     Parameters:
-        libraries (str or list): Library name(s) to search for
-        root (str): The root directory to start searching from
-        shared (bool): if True searches for shared libraries,
-            otherwise for static. Defaults to True.
-        recursive (bool): if False search only root folder,
-            if True descends top-down from the root. Defaults to False.
-        max_depth (int): if set, don't search below this depth. Cannot be set
-            if recursive is False
-        runtime (bool): Windows only option, no-op elsewhere. If true,
-            search for runtime shared libs (.DLL), otherwise, search
-            for .Lib files. If shared is false, this has no meaning.
-            Defaults to True.
+        libraries: Library name(s) to search for
+        root: The root directory to start searching from
+        shared: if :data:`True` searches for shared libraries,
+            otherwise for static. Defaults to :data:`True`.
+        recursive: if :data:`False` search only root folder,
+            if :data:`True` descends top-down from the root. Defaults to :data:`False`.
+        max_depth: if set, don't search below this depth. Cannot be set
+            if recursive is :data:`False`
+        runtime: Windows only option, no-op elsewhere. If :data:`True`,
+            search for runtime shared libs (``.DLL``), otherwise, search
+            for ``.Lib`` files. If ``shared`` is :data:`False`, this has no meaning.
+            Defaults to :data:`True`.
 
     Returns:
-        LibraryList: The libraries that have been found
+        The libraries that have been found
     """
 
     if isinstance(libraries, str):
@@ -2443,29 +2444,31 @@ def find_libraries(
     return LibraryList(found_libs)
 
 
-def find_all_shared_libraries(root, recursive=False, runtime=True):
+def find_all_shared_libraries(
+    root: str, recursive: bool = False, runtime: bool = True
+) -> LibraryList:
     """Convenience function that returns the list of all shared libraries found
     in the directory passed as argument.
 
-    See documentation for `spack.llnl.util.filesystem.find_libraries` for more information
+    See documentation for :py:func:`find_libraries` for more information
     """
     return find_libraries("*", root=root, shared=True, recursive=recursive, runtime=runtime)
 
 
-def find_all_static_libraries(root, recursive=False):
+def find_all_static_libraries(root: str, recursive: bool = False) -> LibraryList:
     """Convenience function that returns the list of all static libraries found
     in the directory passed as argument.
 
-    See documentation for `spack.llnl.util.filesystem.find_libraries` for more information
+    See documentation for :py:func:`find_libraries` for more information
     """
     return find_libraries("*", root=root, shared=False, recursive=recursive)
 
 
-def find_all_libraries(root, recursive=False):
+def find_all_libraries(root: str, recursive: bool = False) -> LibraryList:
     """Convenience function that returns the list of all libraries found
     in the directory passed as argument.
 
-    See documentation for `spack.llnl.util.filesystem.find_libraries` for more information
+    See documentation for :py:func:`find_libraries` for more information
     """
 
     return find_all_shared_libraries(root, recursive=recursive) + find_all_static_libraries(

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -226,7 +226,6 @@ class when:
                 # do something special when this is built with OpenMPI for
                 # its MPI implementations.
 
-
             def install(self, prefix):
                 # Do common install stuff
                 self.setup()

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -648,12 +648,12 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     transitive_rpaths = True
 
     #: List of shared objects that should be replaced with a different library at
-    #: runtime. Typically includes stub libraries like libcuda.so. When linking
+    #: runtime. Typically includes stub libraries like ``libcuda.so``. When linking
     #: against a library listed here, the dependent will only record its soname
     #: or filename, not its absolute path, so that the dynamic linker will search
     #: for it. Note: accepts both file names and directory names, for example
-    #: ``["libcuda.so", "stubs"]`` will ensure libcuda.so and all libraries in the
-    #: stubs directory are not bound by path."""
+    #: ``["libcuda.so", "stubs"]`` will ensure ``libcuda.so`` and all libraries in the
+    #: ``stubs`` directory are not bound by path.
     non_bindable_shared_objects: List[str] = []
 
     #: List of fnmatch patterns of library file names (specifically DT_NEEDED entries) that are not
@@ -924,10 +924,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """Keep ``-Werror`` flags, matches ``config:flags:keep_werror`` to override config.
 
         Valid return values are:
+
         * ``"all"``: keep all ``-Werror`` flags.
         * ``"specific"``: keep only ``-Werror=specific-warning`` flags.
         * ``"none"``: filter out all ``-Werror*`` flags.
-        * ``None``: respect the user's configuration (``"none"`` by default).
+        * :data:`None`: respect the user's configuration (``"none"`` by default).
         """
         if self.spec.satisfies("%nvhpc@:23.3"):
             # Filtering works by replacing -Werror with -Wno-error, but older nvhpc and
@@ -1543,13 +1544,13 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         spack.store.STORE.layout.remove_install_directory(self.spec)
 
     @property
-    def download_instr(self):
+    def download_instr(self) -> str:
         """
         Defines the default manual download instructions.  Packages can
         override the property to provide more information.
 
         Returns:
-            (str):  default manual download instructions
+            default manual download instructions
         """
         required = (
             f"Manual download is required for {self.spec.name}. " if self.manual_download else ""
@@ -1998,7 +1999,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         self.tester.stand_alone_tests(kwargs, timeout=timeout)
 
-    def unit_test_check(self):
+    def unit_test_check(self) -> bool:
         """Hook for unit tests to assert things about package internals.
 
         Unit tests can override this function to perform checks after
@@ -2007,11 +2008,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         The overridden function may indicate that the install procedure
         should terminate early (before updating the database) by
-        returning ``False`` (or any value such that ``bool(result)`` is
-        ``False``).
+        returning :data:`False` (or any value such that ``bool(result)`` is
+        :data:`False`).
 
         Return:
-            (bool): ``True`` to continue, ``False`` to skip ``install()``
+            :data:`True` to continue, :data:`False` to skip ``install()``
         """
         return True
 
@@ -2279,7 +2280,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         Uses ``list_url`` and any other URLs listed in the package file.
 
         Returns:
-            dict: a dictionary mapping versions to URLs
+            a dictionary mapping versions to URLs
         """
         if not self.all_urls:
             return {}

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1588,7 +1588,7 @@ class Spec:
     @property
     def is_develop(self):
         """Return whether the Spec represents a user-developed package
-        in a Spack ``Environment`` (i.e. using `spack develop`).
+        in a Spack Environment (i.e. using `spack develop`).
         """
         return bool(self.variants.get("dev_path", False))
 
@@ -1635,7 +1635,7 @@ class Spec:
 
     def edges_from_dependents(
         self,
-        name=None,
+        name: Optional[str] = None,
         depflag: dt.DepFlag = dt.ALL,
         *,
         virtuals: Optional[Union[str, Sequence[str]]] = None,
@@ -1644,7 +1644,7 @@ class Spec:
         to parents.
 
         Args:
-            name (str): filter dependents by package name
+            name: filter dependents by package name
             depflag: allowed dependency types
             virtuals: allowed virtuals
         """
@@ -1654,7 +1654,7 @@ class Spec:
 
     def edges_to_dependencies(
         self,
-        name=None,
+        name: Optional[str] = None,
         depflag: dt.DepFlag = dt.ALL,
         *,
         virtuals: Optional[Union[str, Sequence[str]]] = None,
@@ -1702,7 +1702,7 @@ class Spec:
 
     def dependencies(
         self,
-        name=None,
+        name: Optional[str] = None,
         deptype: Union[dt.DepTypes, dt.DepFlag] = dt.ALL,
         *,
         virtuals: Optional[Union[str, Sequence[str]]] = None,
@@ -1721,12 +1721,12 @@ class Spec:
         ]
 
     def dependents(
-        self, name=None, deptype: Union[dt.DepTypes, dt.DepFlag] = dt.ALL
+        self, name: Optional[str] = None, deptype: Union[dt.DepTypes, dt.DepFlag] = dt.ALL
     ) -> List["Spec"]:
         """Return a list of direct dependents (nodes in the DAG).
 
         Args:
-            name (str): filter dependents by package name
+            name: filter dependents by package name
             deptype: allowed dependency types
         """
         if not isinstance(deptype, dt.DepFlag):
@@ -2249,7 +2249,7 @@ class Spec:
 
     @property
     def cshort_spec(self):
-        """Returns an auto-colorized version of ``self.short_spec``."""
+        """Returns an auto-colorized version of :py:attr:`short_spec`."""
         return self.cformat("{name}{@version}{variants}{ arch=architecture}{/hash:7}")
 
     @property
@@ -2269,11 +2269,11 @@ class Spec:
     def set_prefix(self, value: str) -> None:
         self._prefix = spack.util.prefix.Prefix(spack.llnl.path.convert_to_platform_path(value))
 
-    def spec_hash(self, hash):
+    def spec_hash(self, hash: ht.SpecHashDescriptor) -> str:
         """Utility method for computing different types of Spec hashes.
 
         Arguments:
-            hash (spack.hash_types.SpecHashDescriptor): type of hash to generate.
+            hash: type of hash to generate.
         """
         # TODO: currently we strip build dependencies by default.  Rethink
         # this when we move to using package hashing on all specs.
@@ -2405,55 +2405,66 @@ class Spec:
 
         self._dup(self.lookup_hash())
 
-    def to_node_dict(self, hash=ht.dag_hash):
+    def to_node_dict(
+        self, hash: ht.SpecHashDescriptor = ht.dag_hash  # type: ignore[has-type]
+    ) -> Dict[str, Any]:
         """Create a dictionary representing the state of this Spec.
 
         ``to_node_dict`` creates the content that is eventually hashed by
         Spack to create identifiers like the DAG hash (see
-        ``dag_hash()``).  Example result of ``to_node_dict`` for the
+        :py:func:`dag_hash()`).  Example result of ``to_node_dict`` for the
         ``sqlite`` package::
 
             {
-                'sqlite': {
-                    'version': '3.28.0',
-                    'arch': {
-                        'platform': 'darwin',
-                        'platform_os': 'mojave',
-                        'target': 'x86_64',
+                "name": "sqlite",
+                "version": "3.46.0",
+                "arch": {"platform": "linux", "platform_os": "ubuntu24.04", "target": "x86_64_v3"},
+                "namespace": "builtin",
+                "parameters": {
+                    "build_system": "autotools",
+                    "column_metadata": True,
+                    "dynamic_extensions": True,
+                    "fts": True,
+                    "functions": False,
+                    "rtree": True,
+                    "cflags": [],
+                    "cppflags": [],
+                    "cxxflags": [],
+                    "fflags": [],
+                    "ldflags": [],
+                    "ldlibs": [],
+                },
+                "package_hash": "umcghjlve5347o3q2odo7vfcso2zhxdzmfdba23nkdhe5jntlhia====",
+                "dependencies": [
+                    {
+                        "name": "compiler-wrapper",
+                        "hash": "c5bxlim3zge4snwrwtd6rzuvq2unek6s",
+                        "parameters": {"deptypes": ("build",), "virtuals": ()},
                     },
-                    'namespace': 'builtin',
-                    'parameters': {
-                        'fts': 'true',
-                        'functions': 'false',
-                        'cflags': [],
-                        'cppflags': [],
-                        'cxxflags': [],
-                        'fflags': [],
-                        'ldflags': [],
-                        'ldlibs': [],
+                    {
+                        "name": "gcc",
+                        "hash": "6dzveld2rtt2dkhklxfnery5wbtb5uus",
+                        "parameters": {"deptypes": ("build",), "virtuals": ("c",)},
                     },
-                    'dependencies': {
-                        'readline': {
-                            'hash': 'zvaa4lhlhilypw5quj3akyd3apbq5gap',
-                            'type': ['build', 'link'],
-                        }
-                    },
-                }
+                    ...
+                ],
+                "annotations": {"original_specfile_version": 5},
             }
+
 
         Note that the dictionary returned does *not* include the hash of
         the *root* of the spec, though it does include hashes for each
         dependency, and (optionally) the package file corresponding to
         each node.
 
-        See ``to_dict()`` for a "complete" spec hash, with hashes for
+        See :py:func:`to_dict()` for a "complete" spec hash, with hashes for
         each node and nodes for each dependency (instead of just their
         hashes).
 
         Arguments:
-            hash (spack.hash_types.SpecHashDescriptor) type of hash to generate.
+            hash: type of hash to generate.
         """
-        d = {"name": self.name}
+        d: Dict[str, Any] = {"name": self.name}
 
         if self.versions:
             d.update(self.versions.to_dict())
@@ -2464,7 +2475,7 @@ class Spec:
         if self.namespace:
             d["namespace"] = self.namespace
 
-        params = dict(sorted(v.yaml_entry() for v in self.variants.values()))
+        params: Dict[str, Any] = dict(sorted(v.yaml_entry() for v in self.variants.values()))
 
         # Only need the string compiler flag for yaml file
         params.update(
@@ -2557,66 +2568,61 @@ class Spec:
 
         return d
 
-    def to_dict(self, hash=ht.dag_hash):
+    def to_dict(
+        self, hash: ht.SpecHashDescriptor = ht.dag_hash  # type: ignore[has-type]
+    ) -> Dict[str, Any]:
         """Create a dictionary suitable for writing this spec to YAML or JSON.
 
-        This dictionaries like the one that is ultimately written to a
-        ``spec.json`` file in each Spack installation directory.  For
-        example, for sqlite::
+        This dictionary is like the one that is ultimately written to a ``spec.json`` file in each
+        Spack installation directory.  For example, for sqlite::
 
             {
-            "spec": {
-                "_meta": {
-                "version": 2
-                },
-                "nodes": [
-                {
-                    "name": "sqlite",
-                    "version": "3.34.0",
-                    "arch": {
-                    "platform": "darwin",
-                    "platform_os": "catalina",
-                    "target": "x86_64"
-                    },
-                    "compiler": {
-                    "name": "apple-clang",
-                    "version": "11.0.0"
-                    },
-                    "namespace": "builtin",
-                    "parameters": {
-                    "column_metadata": true,
-                    "fts": true,
-                    "functions": false,
-                    "rtree": false,
-                    "cflags": [],
-                    "cppflags": [],
-                    "cxxflags": [],
-                    "fflags": [],
-                    "ldflags": [],
-                    "ldlibs": []
-                    },
-                    "dependencies": [
-                    {
-                        "name": "readline",
-                        "hash": "4f47cggum7p4qmp3xna4hi547o66unva",
-                        "type": [
-                        "build",
-                        "link"
-                        ]
-                    },
-                    {
-                        "name": "zlib",
-                        "hash": "uvgh6p7rhll4kexqnr47bvqxb3t33jtq",
-                        "type": [
-                        "build",
-                        "link"
-                        ]
-                    }
+                "spec": {
+                    "_meta": {"version": 5},
+                    "nodes": [
+                        {
+                            "name": "sqlite",
+                            "version": "3.46.0",
+                            "arch": {
+                                "platform": "linux",
+                                "platform_os": "ubuntu24.04",
+                                "target": "x86_64_v3"
+                            },
+                            "namespace": "builtin",
+                            "parameters": {
+                                "build_system": "autotools",
+                                "column_metadata": True,
+                                "dynamic_extensions": True,
+                                "fts": True,
+                                "functions": False,
+                                "rtree": True,
+                                "cflags": [],
+                                "cppflags": [],
+                                "cxxflags": [],
+                                "fflags": [],
+                                "ldflags": [],
+                                "ldlibs": [],
+                            },
+                            "package_hash": "umcghjlve5347o...xdzmfdba23nkdhe5jntlhia====",
+                            "dependencies": [
+                                {
+                                    "name": "compiler-wrapper",
+                                    "hash": "c5bxlim3zge4snwrwtd6rzuvq2unek6s",
+                                    "parameters": {"deptypes": ("build",), "virtuals": ()},
+                                },
+                                {
+                                    "name": "gcc",
+                                    "hash": "6dzveld2rtt2dkhklxfnery5wbtb5uus",
+                                    "parameters": {"deptypes": ("build",), "virtuals": ("c",)},
+                                },
+                                ...
+                            ],
+                            "annotations": {"original_specfile_version": 5},
+                            "hash": "a2ubvvqnula6zdppckwqrjf3zmsdzpoh",
+                        },
+                        ...
                     ],
-                    "hash": "tve45xfqkfgmzwcyfetze2z6syrg7eaf",
-                },
-                    # ... more node dicts for readline and its dependencies ...
-                ]
+                }
             }
 
         Note that this dictionary starts with the 'spec' key, and what
@@ -2629,15 +2635,8 @@ class Spec:
         spec, but if ``package_hash`` were true there would be an
         additional field on each node called ``package_hash``.
 
-        ``from_dict()`` can be used to read back in a spec that has been
+        :py:func:`from_dict()` can be used to read back in a spec that has been
         converted to a dictionary, serialized, and read back in.
-
-        Arguments:
-            deptype (tuple or str): dependency types to include when
-                traversing the spec.
-            package_hash (bool): whether to include package content
-                hashes in the dictionary.
-
         """
         node_list = []  # Using a list to preserve preorder traversal for hash.
         hash_set = set()
@@ -2658,7 +2657,9 @@ class Spec:
 
         return {"spec": {"_meta": {"version": SPECFILE_FORMAT_VERSION}, "nodes": node_list}}
 
-    def node_dict_with_hashes(self, hash=ht.dag_hash):
+    def node_dict_with_hashes(
+        self, hash: ht.SpecHashDescriptor = ht.dag_hash  # type: ignore[has-type]
+    ) -> Dict[str, Any]:
         """Returns a node_dict of this spec with the dag hash added.  If this
         spec is concrete, the full hash is added as well.  If 'build' is in
         the hash_type, the build hash is also added."""
@@ -2718,7 +2719,7 @@ class Spec:
         return new_spec
 
     @staticmethod
-    def from_literal(spec_dict, normal=True):
+    def from_literal(spec_dict: dict, normal: bool = True) -> "Spec":
         """Builds a Spec from a dictionary containing the spec literal.
 
         The dictionary must have a single top level key, representing the root,
@@ -2728,62 +2729,53 @@ class Spec:
         Spec and the dependency types.
 
         Args:
-            spec_dict (dict): the dictionary containing the spec literal
-            normal (bool): if True the same key appearing at different levels
+            spec_dict: the dictionary containing the spec literal
+            normal: if :data:`True` the same key appearing at different levels
                 of the ``spec_dict`` will map to the same object in memory.
 
         Examples:
-            A simple spec ``foo`` with no dependencies:
+            A simple spec ``foo`` with no dependencies::
 
-            .. code-block:: python
+                {"foo": None}
 
-                {'foo': None}
+            A spec ``foo`` with a ``(build, link)`` dependency ``bar``::
 
-            A spec ``foo`` with a ``(build, link)`` dependency ``bar``:
+                {"foo":
+                    {"bar:build,link": None}
+                }
 
-            .. code-block:: python
+            A spec with a diamond dependency and various build types::
 
-                {'foo':
-                    {'bar:build,link': None}}
-
-            A spec with a diamond dependency and various build types:
-
-            .. code-block:: python
-
-                {'dt-diamond': {
-                    'dt-diamond-left:build,link': {
-                        'dt-diamond-bottom:build': None
+                {"dt-diamond": {
+                    "dt-diamond-left:build,link": {
+                        "dt-diamond-bottom:build": None
                     },
-                    'dt-diamond-right:build,link': {
-                        'dt-diamond-bottom:build,link,run': None
+                    "dt-diamond-right:build,link": {
+                        "dt-diamond-bottom:build,link,run": None
                     }
                 }}
 
             The same spec with a double copy of ``dt-diamond-bottom`` and
-            no diamond structure:
+            no diamond structure::
 
-            .. code-block:: python
-
-                {'dt-diamond': {
-                    'dt-diamond-left:build,link': {
-                        'dt-diamond-bottom:build': None
+                Spec.from_literal({"dt-diamond": {
+                    "dt-diamond-left:build,link": {
+                        "dt-diamond-bottom:build": None
                     },
-                    'dt-diamond-right:build,link': {
-                        'dt-diamond-bottom:build,link,run': None
+                    "dt-diamond-right:build,link": {
+                        "dt-diamond-bottom:build,link,run": None
                     }
                 }, normal=False}
 
-            Constructing a spec using a Spec object as key:
+            Constructing a spec using a Spec object as key::
 
-            .. code-block:: python
-
-                mpich = Spec('mpich')
-                libelf = Spec('libelf@1.8.11')
+                mpich = Spec("mpich")
+                libelf = Spec("libelf@1.8.11")
                 expected_normalized = Spec.from_literal({
-                    'mpileaks': {
-                        'callpath': {
-                            'dyninst': {
-                                'libdwarf': {libelf: None},
+                    "mpileaks": {
+                        "callpath": {
+                            "dyninst": {
+                                "libdwarf": {libelf: None},
                                 libelf: None
                             },
                             mpich: None
@@ -2976,11 +2968,8 @@ class Spec:
         return True
 
     @staticmethod
-    def ensure_no_deprecated(root):
-        """Raise if a deprecated spec is in the dag.
-
-        Args:
-            root (Spec): root spec to be analyzed
+    def ensure_no_deprecated(root: "Spec") -> None:
+        """Raise if a deprecated spec is in the dag of the given root spec.
 
         Raises:
             spack.spec.SpecDeprecatedError: if any deprecated spec is found
@@ -3123,11 +3112,8 @@ class Spec:
                 substitute_abstract_variants(spec)
 
     @staticmethod
-    def ensure_valid_variants(spec):
-        """Ensures that the variant attached to a spec are valid.
-
-        Args:
-            spec (Spec): spec to be analyzed
+    def ensure_valid_variants(spec: "Spec") -> None:
+        """Ensures that the variant attached to the given spec are valid.
 
         Raises:
             spack.variant.UnknownVariantError: on the first unknown variant found
@@ -3771,8 +3757,8 @@ class Spec:
         """Make a copy of this spec.
 
         Args:
-            deps: Defaults to True. If boolean, controls
-                whether dependencies are copied (copied if True). If a
+            deps: Defaults to :data:`True`. If boolean, controls
+                whether dependencies are copied (copied if :data:`True`). If a
                 DepTypes or DepFlag is provided, *only* matching dependencies are copied.
             kwargs: additional arguments for internal use (passed to ``_dup``).
 
@@ -3791,7 +3777,7 @@ class Spec:
 
             Only build and run dependencies::
 
-                deps=('build', 'run'):
+                deps=("build", "run"):
 
         """
         clone = Spec.__new__(Spec)
@@ -4084,25 +4070,29 @@ class Spec:
         If the attribute in a format specifier evaluates to ``None``, then the format
         specifier will evaluate to the empty string, ``""``.
 
-        Commonly used attributes of the Spec for format strings include::
+        Commonly used attributes of the Spec for format strings include:
 
-            name
-            version
-            compiler_flags
-            compilers
-            variants
-            architecture
-            architecture.platform
-            architecture.os
-            architecture.target
-            prefix
-            namespace
+        .. code-block:: text
 
-        Some additional special-case properties can be added::
+           name
+           version
+           compiler_flags
+           compilers
+           variants
+           architecture
+           architecture.platform
+           architecture.os
+           architecture.target
+           prefix
+           namespace
 
-            hash[:len]    The DAG hash with optional length argument
-            spack_root    The spack root directory
-            spack_install The spack install directory
+        Some additional special-case properties can be added:
+
+        .. code-block:: text
+
+           hash[:len]    The DAG hash with optional length argument
+           spack_root    The spack root directory
+           spack_install The spack install directory
 
         The ``^`` sigil can be used to access dependencies by name.
         ``s.format({^mpi.name})`` will print the name of the MPI implementation in the
@@ -4110,22 +4100,22 @@ class Spec:
 
         The ``@``, ``%``, and ``/`` sigils can be used to include the sigil with the
         printed string. These sigils may only be used with the appropriate attributes,
-        listed below::
+        listed below:
 
-            @        ``{@version}``, ``{@compiler.version}``
-            %        ``{%compiler}``, ``{%compiler.name}``
-            /        ``{/hash}``, ``{/hash:7}``, etc
+        * ``@``: ``{@version}``, ``{@compiler.version}``
+        * ``%``: ``{%compiler}``, ``{%compiler.name}``
+        * ``/``: ``{/hash}``, ``{/hash:7}``, etc
 
         The ``@`` sigil may also be used for any other property named ``version``.
         Sigils printed with the attribute string are only printed if the attribute
         string is non-empty, and are colored according to the color of the attribute.
 
         Variants listed by name naturally print with their sigil. For example,
-        ``spec.format('{variants.debug}')`` prints either ``+debug`` or ``~debug``
+        ``spec.format("{variants.debug}")`` prints either ``+debug`` or ``~debug``
         depending on the name of the variant. Non-boolean variants print as
         ``name=value``. To print variant names or values independently, use
-        ``spec.format('{variants.<name>.name}')`` or
-        ``spec.format('{variants.<name>.value}')``.
+        ``spec.format("{variants.<name>.name}")`` or
+        ``spec.format("{variants.<name>.value}")``.
 
         There are a few attributes on specs that can be specified as key-value pairs
         that are *not* variants, e.g.: ``os``, ``arch``, ``architecture``, ``target``,
@@ -4136,11 +4126,13 @@ class Spec:
         When formatting specs, key-value pairs are separated from preceding parts of the
         spec by whitespace. To avoid printing extra whitespace when the formatted
         attribute is not set, you can add whitespace to the key *inside* the braces of
-        the format string, e.g.::
+        the format string, e.g.:
 
-            { namespace=namespace}
+        .. code-block:: text
 
-        This evaluates to `` namespace=builtin`` if ``namespace`` is set to ``builtin``,
+           { namespace=namespace}
+
+        This evaluates to ``" namespace=builtin"`` if ``namespace`` is set to ``builtin``,
         and to ``""`` if ``namespace`` is ``None``.
 
         Spec format strings use ``\`` as the escape character. Use ``\{`` and ``\}`` for
@@ -4278,12 +4270,12 @@ class Spec:
 
     @property
     def spack_root(self):
-        """Special field for using ``{spack_root}`` in Spec.format()."""
+        """Special field for using ``{spack_root}`` in :py:func:`format`."""
         return spack.paths.spack_root
 
     @property
     def spack_install(self):
-        """Special field for using ``{spack_install}`` in Spec.format()."""
+        """Special field for using ``{spack_install}`` in :py:func:`format`."""
         return spack.store.STORE.layout.root
 
     def format_path(
@@ -4617,8 +4609,8 @@ class Spec:
 
         Returns: a concrete, spliced version of the current Spec
 
-        When transitive is "True", use the dependencies from "other" to reconcile
-        conflicting dependencies. When transitive is "False", use dependencies from self.
+        When transitive is :data:`True`, use the dependencies from "other" to reconcile
+        conflicting dependencies. When transitive is :data:`False`, use dependencies from self.
 
         For example, suppose we have the following dependency graph:
 
@@ -4630,8 +4622,8 @@ class Spec:
 
         Spec ``T`` depends on ``H`` and ``Z``, and ``H`` also depends on ``Z``. Now we want to use
         a different ``H``, called ``H'``. This function can be used to splice in ``H'`` to
-        create a new spec, called ``T*``. If ``H'`` was built with ``Z'``, then transitive
-        "True" will ensure ``H'`` and ``T*`` both depend on ``Z'``:
+        create a new spec, called ``T*``. If ``H'`` was built with ``Z'``, then ``transitive=True``
+        will ensure ``H'`` and ``T*`` both depend on ``Z'``:
 
         .. code-block:: text
 
@@ -4639,7 +4631,7 @@ class Spec:
            | \\
            Z'<-H'
 
-        If transitive is "False", then ``H'`` and ``T*`` will both depend on
+        If ``transitive=False``, then ``H'`` and ``T*`` will both depend on
         the original ``Z``, resulting in a new ``H'*``:
 
         .. code-block:: text

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -514,15 +514,15 @@ def substitute_version(path: str, new_version) -> str:
 
     .. code-block:: python
 
-       substitute_version('http://www.mr511.de/software/libelf-0.8.13.tar.gz', '2.9.3')
-       >>> 'http://www.mr511.de/software/libelf-2.9.3.tar.gz'
+       substitute_version("http://www.mr511.de/software/libelf-0.8.13.tar.gz", "2.9.3")
+       >>> "http://www.mr511.de/software/libelf-2.9.3.tar.gz"
 
     Complex example:
 
     .. code-block:: python
 
-       substitute_version('https://www.hdfgroup.org/ftp/HDF/releases/HDF4.2.12/src/hdf-4.2.12.tar.gz', '2.3')
-       >>> 'https://www.hdfgroup.org/ftp/HDF/releases/HDF2.3/src/hdf-2.3.tar.gz'
+       substitute_version("https://www.hdfgroup.org/ftp/HDF/releases/HDF4.2.12/src/hdf-4.2.12.tar.gz", "2.3")
+       >>> "https://www.hdfgroup.org/ftp/HDF/releases/HDF2.3/src/hdf-2.3.tar.gz"
     """
     (name, ns, nl, noffs, ver, vs, vl, voffs) = substitution_offsets(path)
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -717,7 +717,8 @@ class EnvironmentModifications:
         return len(old_mods) != len(new_mods)
 
     def is_unset(self, variable_name: str) -> bool:
-        """Returns True if the last modification to a variable is to unset it, False otherwise."""
+        """Returns :data:`True` if the last modification to a variable is to unset it,
+        :data:`False` otherwise."""
         modifications = self.group_by_name()
         if variable_name not in modifications:
             return False

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -437,10 +437,10 @@ def which(
     Parameters:
         *args: one or more executables to search for
         path: the path to search. Defaults to ``PATH``
-        required: if set to True, raise an error if executable not found
+        required: if set to :data:`True`, raise an error if executable not found
 
     Returns:
-        Executable: The first executable that is found in the path
+        The first executable that is found in the path or :data:`None` if not found.
     """
     exe = which_string(*args, path=path, required=required)
     return Executable(exe) if exe is not None else None

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -19,13 +19,13 @@ def fix_darwin_install_name(path: str) -> None:
 
     There are two parts of this task:
 
-    1. Use ``install_name("-id", ...)`` to change install name of a single lib
-    2. Use ``install_name("-change", ...)`` to change the cross linking between libs.
+    1. Use ``install_name -id  ...`` to change install name of a single lib
+    2. Use ``install_name -change  ...`` to change the cross linking between libs.
        The function assumes that all libraries are in one folder and currently won't follow
        subfolders.
 
     Parameters:
-        path: directory in which .dylib files are located
+        path: directory in which ``.dylib`` files are located
     """
     libs = glob.glob(os.path.join(path, "*.dylib"))
     install_name_tool = Executable("install_name_tool")

--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -28,8 +28,8 @@ class Prefix(str):
     >>> prefix.join("dashed-directory").bin64
     /usr/dashed-directory/bin64
 
-    Prefix objects behave identically to strings. In fact, they subclass ``str``, so operators like
-    ``+`` are legal::
+    Prefix objects behave identically to strings. In fact, they subclass :class:`str`, so operators
+    like ``+`` are legal::
 
         print("foobar " + prefix)
 

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -312,7 +312,7 @@ class WindowsRegistryView:
                             all keys meeting stop condition. If false, once stop
                             condition is met, the key that triggered the condition '
                             is returned.
-            recusrive: boolean value, if True perform a recursive search of subkeys
+            recursive: boolean value, if True perform a recursive search of subkeys
         Return:
             the key if stop_condition is triggered, or None if not
         """
@@ -331,13 +331,13 @@ class WindowsRegistryView:
                     queue.extend(key.subkeys)
             return collection if collection else None
 
-    def find_subkey(self, subkey_name, recursive=True):
+    def find_subkey(self, subkey_name: str, recursive: bool = True):
         """Perform a BFS of subkeys until desired key is found
         Returns None or RegistryKey object corresponding to requested key name
 
         Args:
-            subkey_name (str): subkey to be searched for
-            recursive (bool):  perform a recursive search
+            subkey_name: subkey to be searched for
+            recursive:  perform a recursive search
         Return:
             the desired subkey as a RegistryKey object, or none
         """
@@ -345,13 +345,13 @@ class WindowsRegistryView:
             WindowsRegistryView.KeyMatchConditions.name_matcher(subkey_name), recursive=recursive
         )
 
-    def find_matching_subkey(self, subkey_name, recursive=True):
+    def find_matching_subkey(self, subkey_name: str, recursive: bool = True):
         """Perform a BFS of subkeys until a key matching subkey name regex is found
         Returns None or the first RegistryKey object corresponding to requested key name
 
         Args:
-            subkey_name (str): subkey to be searched for
-            recursive (bool):  perform a recursive search
+            subkey_name: subkey to be searched for
+            recursive:  perform a recursive search
         Return:
             the desired subkey as a RegistryKey object, or none
         """
@@ -359,12 +359,12 @@ class WindowsRegistryView:
             WindowsRegistryView.KeyMatchConditions.regex_matcher(subkey_name), recursive=recursive
         )
 
-    def find_subkeys(self, subkey_name, recursive=True):
+    def find_subkeys(self, subkey_name: str, recursive: bool = True):
         """Exactly the same as find_subkey, except this function tries to match
         a regex to multiple keys
 
         Args:
-            subkey_name (str)
+            subkey_name: subkey to be searched for
         Return:
             the desired subkeys as a list of RegistryKey object, or none
         """
@@ -373,14 +373,14 @@ class WindowsRegistryView:
             WindowsRegistryView.KeyMatchConditions.regex_matcher(subkey_name), **kwargs
         )
 
-    def find_value(self, val_name, recursive=True):
+    def find_value(self, val_name: str, recursive: bool = True):
         """
         If non recursive, return RegistryValue object corresponding to name
 
         Args:
-            val_name (str): name of value desired from registry
-            recursive (bool): optional argument, if True, the registry is searched recursively
-                              for the value of name val_name, else only the current key is searched
+            val_name: name of value desired from registry
+            recursive: optional argument, if True, the registry is searched recursively
+                       for the value of name val_name, else only the current key is searched
         Return:
             The desired registry value as a RegistryValue object if it exists, otherwise, None
         """


### PR DESCRIPTION
* Fix typos
* Fix rst rendering issues
* Use `"` instead of `'` more consistently
* Update outdated examples of `Spec.to_node*`
* Improve cross references with `:py:func:`
* Replace verbose and redundant return type in docstring with type hints
* Add missing typehints for improved documentation