### PR TITLE
make toolchains.yaml a standalone doc, and group config docs

### DIFF
--- a/lib/spack/docs/advanced_topics.rst
+++ b/lib/spack/docs/advanced_topics.rst
@@ -4,70 +4,7 @@
 
 .. meta::
    :description lang=en:
-      Explore advanced topics in Spack, including defining and using toolchains, auditing packages and configuration, and verifying installations.
-
-.. _toolchains:
-
-Defining and Using Toolchains
-=============================
-
-Spack lets you specify compilers on the CLI with, e.g., ``%gcc`` or ``%c,cxx=clang %fortran=gcc``, and you can specify flags with ``cflags``, ``cxxflags``, and ``fflags``.
-Depending on how complex your compiler setup is, it can be cumbersome to specify all of your preferences on the CLI.
-Spack has a special type of configuration called ``toolchains``, which let you encapsulate the configuration for compilers, other libraries, and flags into a single name that you can reference as though it were one option.
-
-Toolchains are referenced by name like a direct dependency, using the ``%`` sigil.
-They are defined under the ``toolchains`` section of the configuration:
-
-.. code-block:: yaml
-
-   toolchains:
-     llvm_gfortran:
-     - spec: cflags=-O3
-     - spec: '%c=llvm'
-       when: '%c'
-     - spec: '%cxx=llvm'
-       when: '%cxx'
-     - spec: '%fortran=gcc'
-       when: '%fortran'
-
-A toolchain that uses *conditional dependencies*, when constraining a virtual provider, can be applied to any node - regardless of whether it *needs* that virtual dependency.
-The *guarantee* that the toolchain gives is that *if* the virtual is needed, then the constraint is applied.
-
-The ``llvm_gfortran`` toolchain, for instance, enforces using ``llvm`` for the C and C++ languages, and ``gcc`` for Fortran, when these languages are needed.
-It also adds ``cflags=-O3`` unconditionally.
-
-Toolchains can be used to simplify the construction of a list of specs using :ref:`environment-spec-matrices`, when the list includes packages with different language requirements:
-
-.. code-block:: yaml
-
-   specs:
-   - matrix:
-     - [kokkos, hdf5~cxx+fortran, py-scipy]
-     - ["%llvm_gfortran"]
-
-Note that in this case we can use a single matrix, and the user doesn't need to know exactly which package requires which language.
-If we had to enforce compilers directly, we would need 3 matrices, since:
-
-* ``kokkos`` depends on C and C++, but not Fortran
-* ``hdf5~cxx+fortran`` depends on C and Fortran, but not C++
-* ``py-scipy`` depends on C, C++, and Fortran
-
-Different toolchains could be used independently or even in the same spec.
-If we had a toolchain named ``gcc_all`` that enforces using ``gcc`` for C, C++ and Fortran, we could write:
-
-.. code-block:: spec
-
-   $ spack install hdf5+fortran%llvm_gfortran ^mpich %gcc_all
-
-to install:
-
-* An ``hdf5`` compiled with ``llvm`` for the C/C++ components, but with its Fortran components compiled with ``gfortran``,
-* Built against an MPICH installation compiled entirely with ``gcc`` for C, C++, and Fortran.
-
-.. note::
-
-   Toolchains are currently limited to using only direct dependencies (``%``) in their definition.
-   Transitive dependencies are not allowed.
+      Explore advanced topics in Spack, including auditing packages and configuration, and verifying installations.
 
 .. _audit-packages-and-configuration:
 

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -60,12 +60,6 @@ If you're new to Spack and want to start using it, see :doc:`getting_started`, o
 
 .. toctree::
    :maxdepth: 2
-   :caption: Advanced Topics
-
-   advanced_topics
-
-.. toctree::
-   :maxdepth: 2
    :caption: Links
 
    Tutorial (spack-tutorial.rtfd.io) <https://spack-tutorial.readthedocs.io>
@@ -74,23 +68,29 @@ If you're new to Spack and want to start using it, see :doc:`getting_started`, o
 
 .. toctree::
    :maxdepth: 2
-   :caption: Reference
+   :caption: Configuration
 
    configuration
    config_yaml
-   include_yaml
    packages_yaml
+   toolchains_yaml
    build_settings
-   environments
-   env_vars_yaml
-   containers
-   mirrors
-   module_file_support
    repositories
+   mirrors
+   chain
+   module_file_support
+   include_yaml
+   env_vars_yaml
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   environments
+   containers
    binary_caches
    bootstrapping
    command_index
-   chain
    extensions
    pipelines
    signing
@@ -107,6 +107,12 @@ If you're new to Spack and want to start using it, see :doc:`getting_started`, o
    build_systems
    contribution_guide
    developer_guide
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Advanced Topics
+
+   advanced_topics
 
 .. toctree::
    :maxdepth: 2

--- a/lib/spack/docs/toolchains_yaml.rst
+++ b/lib/spack/docs/toolchains_yaml.rst
@@ -1,0 +1,129 @@
+.. Copyright Spack Project Developers. See COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. meta::
+   :description lang=en:
+      Define named compiler sets (toolchains) in Spack to easily and consistently apply compiler choices for C, C++, and Fortran across different packages.
+
+.. _toolchains:
+
+Toolchains (toolchains.yaml)
+=============================
+
+Toolchains let you group a set of compiler constraints under a single, user-defined name.
+This allows you to reference a complex set of compiler choices for C, C++, Fortran, with a simple spec like ``%my_toolchain``.
+They are defined under the ``toolchains`` section of the configuration.
+
+.. seealso::
+
+   The sections :ref:`language-dependencies` and :ref:`explicit-binding-virtuals` provide more background on how Spack handles languages and compilers.
+
+Basic usage
+-----------
+
+As an example, the following configuration file defines a toolchain named ``llvm_gfortran``:
+
+.. code-block:: yaml
+   :caption: ~/.spack/toolchains.yaml
+
+   toolchains:
+     llvm_gfortran:
+     - spec: cflags=-O3
+     - spec: "%c=llvm"
+       when: "%c"
+     - spec: "%cxx=llvm"
+       when: "%cxx"
+     - spec: "%fortran=gcc"
+       when: "%fortran"
+
+The ``when`` clause in each entry determines if that line's ``spec`` is applied.
+In this example, it means that ``llvm`` is used as a compiler for the C and C++ languages, and ``gcc`` for Fortran, *whenever the package uses those languages*.
+It also adds ``cflags=-O3`` unconditionally.
+
+The toolchain can be referenced using
+
+.. code-block:: spec
+  
+   $ spack install my-package %llvm_gfortran
+
+Toolchains are useful for two reasons:
+
+1. **They reduce verbosity.**
+   Instead of multiple constraints ``%c,cxx=clang %fortran=gcc``, you can simply write ``%llvm_gfortran``.
+2. **They apply conditionally.**
+   You can use ``my-package %llvm_gfortran`` even if ``my-package`` is not written in Fortran.
+
+
+Pitfalls without toolchains
+---------------------------
+
+The conditional nature of toolchains is important, because it helps you avoid two common pitfalls when specifying compilers.
+
+1. Firstly, when you specify ``my-package %gcc``, your spec is **underconstrained**: Spack has to make ``my-package`` depend on ``gcc``, but the constraint does not rule out mixed compilers, such as ``gcc`` for C and ``llvm`` for C++.
+
+2. Secondly, when you specify ``my-package %c,cxx,fortran=gcc`` to be more explicit, your spec might be **overconstrained**.
+   You not only require ``gcc`` for all languages, but *also* that ``my-package`` uses *all* these languages.
+   This will cause a concretization error if ``my-package`` was written in C and C++, but not Fortran.
+
+Toolchains and matrices
+-----------------------
+
+Toolchains can be used to simplify the construction of a list of specs using :ref:`environment-spec-matrices`, when the list includes packages with different language requirements:
+
+.. code-block:: yaml
+
+   specs:
+   - matrix:
+     - [kokkos, hdf5~cxx+fortran, py-scipy]
+     - ["%llvm_gfortran"]
+
+Note that in this case we can use a single matrix, and the user doesn't need to know exactly which package requires which language.
+Without toolchains, it would be difficult to enforce compilers directly, because:
+
+* ``kokkos`` depends on C and C++, but not Fortran
+* ``hdf5~cxx+fortran`` depends on C and Fortran, but not C++
+* ``py-scipy`` depends on C, C++, and Fortran
+
+Combining toolchains
+--------------------
+
+Different toolchains can be used independently or even in the same spec.
+Consider the following configuration:
+
+.. code-block:: yaml
+   :caption: ~/.spack/toolchains.yaml
+
+   toolchains:
+     llvm_gfortran:
+     - spec: cflags=-O3
+     - spec: "%c=llvm"
+       when: "%c"
+     - spec: "%cxx=llvm"
+       when: "%cxx"
+     - spec: "%fortran=gcc"
+       when: "%fortran"
+     gcc_all:
+     - spec: "%c=gcc"
+       when: "%c"
+     - spec: "%cxx=gcc"
+       when: "%cxx"
+     - spec: "%fortran=gcc"
+       when: "%fortran"
+
+
+Now, you can use these toolchains in a single spec:
+
+.. code-block:: spec
+
+   $ spack install hdf5+fortran%llvm_gfortran ^mpich %gcc_all
+
+This will result in:
+
+* An ``hdf5`` compiled with ``llvm`` for the C/C++ components, but with its Fortran components compiled with ``gfortran``,
+* Built against an MPICH installation compiled entirely with ``gcc`` for C, C++, and Fortran.
+
+.. note::
+
+   Toolchains are currently limited to using only direct dependencies (``%``) in their definition.
+   Transitive dependencies are not allowed.

--- a/lib/spack/docs/toolchains_yaml.rst
+++ b/lib/spack/docs/toolchains_yaml.rst
@@ -39,7 +39,7 @@ As an example, the following configuration file defines a toolchain named ``llvm
 
 The ``when`` clause in each entry determines if that line's ``spec`` is applied.
 In this example, it means that ``llvm`` is used as a compiler for the C and C++ languages, and ``gcc`` for Fortran, *whenever the package uses those languages*.
-It also adds ``cflags=-O3`` unconditionally.
+The spec ``cflags=-O3`` is *always* required, because there is no ``when`` clause for that spec.
 
 The toolchain can be referenced using
 
@@ -47,12 +47,14 @@ The toolchain can be referenced using
   
    $ spack install my-package %llvm_gfortran
 
-Toolchains are useful for two reasons:
+Toolchains are useful for three reasons:
 
 1. **They reduce verbosity.**
    Instead of multiple constraints ``%c,cxx=clang %fortran=gcc``, you can simply write ``%llvm_gfortran``.
 2. **They apply conditionally.**
    You can use ``my-package %llvm_gfortran`` even if ``my-package`` is not written in Fortran.
+3. **They apply locally.**
+   Toolchains are used at the level of a single spec.
 
 
 Pitfalls without toolchains
@@ -65,25 +67,6 @@ The conditional nature of toolchains is important, because it helps you avoid tw
 2. Secondly, when you specify ``my-package %c,cxx,fortran=gcc`` to be more explicit, your spec might be **overconstrained**.
    You not only require ``gcc`` for all languages, but *also* that ``my-package`` uses *all* these languages.
    This will cause a concretization error if ``my-package`` was written in C and C++, but not Fortran.
-
-Toolchains and matrices
------------------------
-
-Toolchains can be used to simplify the construction of a list of specs using :ref:`environment-spec-matrices`, when the list includes packages with different language requirements:
-
-.. code-block:: yaml
-
-   specs:
-   - matrix:
-     - [kokkos, hdf5~cxx+fortran, py-scipy]
-     - ["%llvm_gfortran"]
-
-Note that in this case we can use a single matrix, and the user doesn't need to know exactly which package requires which language.
-Without toolchains, it would be difficult to enforce compilers directly, because:
-
-* ``kokkos`` depends on C and C++, but not Fortran
-* ``hdf5~cxx+fortran`` depends on C and Fortran, but not C++
-* ``py-scipy`` depends on C, C++, and Fortran
 
 Combining toolchains
 --------------------
@@ -122,6 +105,65 @@ This will result in:
 
 * An ``hdf5`` compiled with ``llvm`` for the C/C++ components, but with its Fortran components compiled with ``gfortran``,
 * Built against an MPICH installation compiled entirely with ``gcc`` for C, C++, and Fortran.
+
+Toolchains for other dependencies
+---------------------------------
+
+While toolchains are typically used to define compiler presets, they can be used for other dependencies as well.
+
+A common use case is to define a toolchain that also picks a specific MPI implementation.
+In the following example, we define a toolchain that uses ``openmpi@5`` as an MPI provider, and ``llvm@19`` as the compiler for C and C++:
+
+.. code-block:: yaml
+   :caption: ~/.spack/toolchains.yaml
+
+   toolchains:
+     clang_openmpi:
+     - spec: "%c=llvm@19"
+       when: "%c"
+     - spec: "%cxx=llvm@19"
+       when: "%cxx"
+     - spec: "%mpi=openmpi@5"
+       when: "%mpi"
+
+The general pattern in toolchains configuration is to use a ``when`` condition that specifies a direct dependency on a *virtual* package, and a ``spec`` that :ref:`requires a specific provider for that virtual <explicit-binding-virtuals>`.
+
+Notice that it's possible to achieve similar configuration with :doc:`packages.yaml <packages_yaml>`:
+
+.. code-block:: yaml
+   :caption: ~/.spack/packages.yaml
+
+   packages:
+     c:
+       require: [llvm@19]
+     cxx:
+       require: [llvm@19]
+     mpi:
+       require: [openmpi@5]
+
+The difference is that the toolchain can be applied **locally** in a spec, while the ``packages.yaml`` configuration is always global.
+This makes toolchains particularly useful in Spack environments.
+
+Toolchains in Spack environments
+--------------------------------
+
+Toolchains can be used to simplify the construction of a list of specs for Spack environments using :ref:`spec matrices <environment-spec-matrices>`, when the list includes packages with different language requirements:
+
+.. code-block:: yaml
+   :caption: spack.yaml
+
+   spack:
+     specs:
+     - matrix:
+       - [kokkos, hdf5~cxx+fortran, py-scipy]
+       - ["%llvm_gfortran"]
+
+Note that in this case we can use a single matrix, and the user doesn't need to know exactly which package requires which language.
+Without toolchains, it would be difficult to enforce compilers directly, because:
+
+* ``kokkos`` depends on C and C++, but not Fortran
+* ``hdf5~cxx+fortran`` depends on C and Fortran, but not C++
+* ``py-scipy`` depends on C, C++, and Fortran
 
 .. note::
 


### PR DESCRIPTION
* Move toolchains to its own page, and be consistent with (toolchains.yaml) in the title
* Use less jargon in the introduction of toolchains docs
* First sentence explains/defines toolchains immediately
* Improve motivation
* Add pitfalls *without toolchains*
* Add section about more general use of toolchains with mpi virtual/provider
* Compare to `packages.yaml` configuration

Other changes:

* Group config file docs into a section in the menu
* Move advanced topics down in the menu
