### PR TITLE
Include scope override

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -813,6 +813,7 @@ def override(
 #: python code that evaluates to a boolean and or explicit specification
 #: as optional.
 class IncludePath(NamedTuple):
+    scope: str
     path: str
     when: str
     sha256: str
@@ -829,13 +830,14 @@ def included_path(entry: Union[str, dict]) -> IncludePath:
         not conditionally included
     """
     if isinstance(entry, str):
-        return IncludePath(path=entry, sha256="", when="", optional=False)
+        return IncludePath(scope="", path=entry, sha256="", when="", optional=False)
 
     path = entry["path"]
     sha256 = entry.get("sha256", "")
     when = entry.get("when", "")
+    scope = entry.get("scope", "")
     optional = entry.get("optional", False)
-    return IncludePath(path=path, sha256=sha256, when=when, optional=optional)
+    return IncludePath(scope=scope, path=path, sha256=sha256, when=when, optional=optional)
 
 
 def include_path_scope(include: IncludePath, parent_scope: ConfigScope) -> Optional[ConfigScope]:
@@ -860,29 +862,33 @@ def include_path_scope(include: IncludePath, parent_scope: ConfigScope) -> Optio
         if not config_path:
             raise ConfigFileError(f"Unable to fetch remote configuration from {include.path}")
 
-        # Try to use the relative path to create the included scope name
-        parent_path = getattr(parent_scope, "path", None)
-        if parent_path and str(parent_path) == os.path.commonprefix([parent_path, config_path]):
-            included_name = os.path.relpath(config_path, parent_path)
+        if include.scope:
+            config_name = include.scope
         else:
-            included_name = config_path
+            # Try to use the relative path to create the included scope name
+            parent_path = getattr(parent_scope, "path", "")
+            common_prefix = os.path.commonprefix([parent_path, config_path])
+            if parent_path and str(parent_path) == common_prefix:
+                included_name = os.path.relpath(config_path, parent_path)
+            else:
+                included_name = config_path
 
-        if sys.platform == "win32":
-            # Clean windows path for use in config name that looks nicer
-            # ie. The path: C:\\some\\path\\to\\a\\file
-            # becomes C/some/path/to/a/file
-            included_name = included_name.replace("\\", "/")
-            included_name = included_name.replace(":", "")
+            if sys.platform == "win32":
+                # Clean windows path for use in config name that looks nicer
+                # ie. The path: C:\\some\\path\\to\\a\\file
+                # becomes C/some/path/to/a/file
+                included_name = included_name.replace("\\", "/")
+                included_name = included_name.replace(":", "")
+
+            config_name = f"{parent_scope.name}:{included_name}"
 
         if os.path.isdir(config_path):
             # directories are treated as regular ConfigScopes
-            config_name = f"{parent_scope.name}:{included_name}"
             tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
             return DirectoryConfigScope(config_name, config_path)
 
         if os.path.exists(config_path):
             # files are assumed to be SingleFileScopes
-            config_name = f"{parent_scope.name}:{included_name}"
             tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
             return SingleFileScope(config_name, config_path, spack.schema.merged.schema)
 

--- a/lib/spack/spack/schema/include.py
+++ b/lib/spack/spack/schema/include.py
@@ -23,6 +23,7 @@ properties: Dict[str, Any] = {
                         "path": {"type": "string"},
                         "sha256": {"type": "string"},
                         "optional": {"type": "boolean"},
+                        "scope": {"type": "string"},
                     },
                     "required": ["path"],
                     "additionalProperties": False,

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1416,3 +1416,20 @@ def test_config_include_similar_name(tmp_path: pathlib.Path):
     assert len(config.matching_scopes("^test$")) == 1
     assert len(config.matching_scopes("^test:a/config$")) == 1
     assert len(config.matching_scopes("^test:b/config$")) == 1
+
+
+def test_config_include_scope(tmp_path: pathlib.Path):
+    config_a = tmp_path / "a" / "config"
+
+    os.makedirs(config_a)
+    with open(config_a / "config.yaml", "w", encoding="utf-8") as fd:
+        syaml.dump_config({"config": {"install_tree": {"root": str(tmp_path)}}}, fd)
+
+    with open(tmp_path / "include.yaml", "w", encoding="utf-8") as fd:
+        syaml.dump_config({"include": [{"path": str(config_a), "scope": "a-scope"}]}, fd)
+
+    config = spack.config.create_from(spack.config.DirectoryConfigScope("test", str(tmp_path)))
+
+    # Ensure all of the scopes are found
+    assert len(config.matching_scopes("test")) == 1
+    assert len(config.matching_scopes("a-scope")) == 1


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Currently included scopes are named from the parent scope and the relative path to the parent scope. This change allows for naming an included config scope with a user specified name. This makes it possible for users to include arbitrary directories with short semantic names.

ie. `.spack/configs/include.yaml`
```
include:
  - path: /path/to/my/project/configs/
    scope: project
```

Currently the scope naming looks like this

```
$ spack config scopes
...
user:/path/to/my/project/configs/
user:/path/to/my/project/configs/:deployment
user:/path/to/my/project/configs/:develop

```

The output renaming the included scope to `project` would look like this

```
$ spack config scopes
...
project
project:deployment
project:develop
```