### PR TITLE
concretize.lp: fix `target_not_supported` warning

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1687,8 +1687,8 @@ error(10, "{0} compiler '{2}@{3}' incompatible with 'target={1}'", Package, Targ
      target_not_supported(Compiler, Version, Target),
      build(node(X, Package)).
 
-#defined target_supported/2.
-#defined target_not_supported/2.
+#defined target_supported/3.
+#defined target_not_supported/3.
 
 % if a target is set explicitly, respect it
 attr("node_target", PackageNode, Target)


### PR DESCRIPTION
Silence the following warning:

```
concretize.lp:1687:6-53: info: atom does not occur in any rule head:
  target_not_supported(Compiler,Version,Target)
```

caused by a missing `#defined atom/n.` statement.