### PR TITLE
solver: catch invalid dependencies during concretization

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -195,7 +195,7 @@ condition_set(LiteralNode, BuildNode) :- build_dependency_of_literal_node(Litera
 
 % Generate a comprehensible error for cases like 'foo ^bar' where 'bar' is a build dependency
 % of a transitive dependency of 'foo'
-error(1, "{0} is not a direct 'build' dependency, or transitive 'link' or 'run' dependency of any root", Literal)
+error(1, "{0} is not a direct 'build' or 'test' dependency, or transitive 'link' or 'run' dependency of any root", Literal)
   :- literal_node(RootPackage, node(X, Literal)),
      not depends_on(node(min_dupe_id, RootPackage), node(X, Literal)),
      not unification_set("root", node(X, Literal)).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -193,6 +193,13 @@ build_dependency_of_literal_node(LiteralNode, node(X, BuildDependency)) :-
 condition_set(node(min_dupe_id, Root), LiteralNode) :- literal_node(Root, LiteralNode).
 condition_set(LiteralNode, BuildNode) :- build_dependency_of_literal_node(LiteralNode, BuildNode).
 
+% Generate a comprehensible error for cases like 'foo ^bar' where 'bar' is a build dependency
+% of a transitive dependency of 'foo'
+error(1, "{0} is not a direct 'build' dependency, or transitive 'link' or 'run' dependency of any root", Literal)
+  :- literal_node(RootPackage, node(X, Literal)),
+     not depends_on(node(min_dupe_id, RootPackage), node(X, Literal)),
+     not unification_set("root", node(X, Literal)).
+
 :- build_dependency_of_literal_node(LiteralNode, BuildNode),
    not attr("depends_on", LiteralNode, BuildNode, "build").
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4052,3 +4052,12 @@ packages:
         s = spack.concretize.concretize_one(spec_str)
         assert s.external
         assert s.prefix == "/path/mpich/gcc"
+
+
+@pytest.mark.regression("51146,51067")
+def test_caret_in_input_cannot_set_transitive_build_dependencies(default_mock_concretization):
+    """Tests that a caret in the input spec does not set transitive build dependencies, and errors
+    with an appropriate message.
+    """
+    with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="transitive 'link' or"):
+        _ = default_mock_concretization("multivalue-variant ^gmake")


### PR DESCRIPTION
fixes #51146
fixes #51067

Improve error handling to detect and report cases where a caret in the input spec incorrectly references transitive build dependencies.

**Example**
```
$ spack spec paraview+qt+python+hdf5+raytracing %gcc ^ispc@1.19.0
==> Error: failed to concretize `paraview+hdf5+python+qt+raytracing %gcc ^ispc@1.19.0` for the following reasons:
     1. ispc is not a direct 'build' dependency, or transitive 'link' or 'run' dependency of any root
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
