### PR TITLE
repo list: escape color for path that can contain '@g' from 'git@github'

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -322,8 +322,9 @@ def repo_list(args):
 
         # Print aligned output
         for status, namespace, api, path in repo_info:
+            cpath = color.cescape(path)
             color.cprint(
-                f"{status} {namespace:<{max_namespace_width}} {api:<{max_api_width}} {path}"
+                f"{status} {namespace:<{max_namespace_width}} {api:<{max_api_width}} {cpath}"
             )
 
 


### PR DESCRIPTION
If a user adds a repo over ssh from git with `git@github.com:...` or similarly from gitlab, the coloring identifies the `@g` as a color sequence.

This PR fixes it by calling `color.cescape` on the path before printing.