### PR TITLE
docs: simplify example specs

### DIFF
--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -51,14 +51,12 @@ Here's an example of an external configuration:
    packages:
      openmpi:
        externals:
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+       - spec: "openmpi@1.4.3~debug"
          prefix: /opt/openmpi-1.4.3
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+       - spec: "openmpi@1.4.3+debug"
          prefix: /opt/openmpi-1.4.3-debug
-       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
-         prefix: /opt/openmpi-1.6.5-intel
 
-This example lists three installations of OpenMPI, one built with GCC, one built with GCC and debug information, and another built with Intel.
+This example lists two installations of OpenMPI, one with debug information, and one without.
 If Spack is asked to build a package that uses one of these MPIs as a dependency, it will use the pre-installed OpenMPI in the given directory.
 Note that the specified path is the top-level install prefix, not the ``bin`` subdirectory.
 
@@ -94,7 +92,7 @@ This could be configured as follows:
    packages:
      mpich:
        externals:
-       - spec: mpich@3.3 %clang@12.0.0 +hwloc
+       - spec: mpich@3.3 +hwloc
          prefix: /path/to/mpich
          extra_attributes:
            environment:
@@ -177,12 +175,10 @@ The previous example could be modified to be:
    packages:
      openmpi:
        externals:
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+       - spec: "openmpi@1.4.3~debug"
          prefix: /opt/openmpi-1.4.3
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+       - spec: "openmpi@1.4.3+debug"
          prefix: /opt/openmpi-1.4.3-debug
-       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
-         prefix: /opt/openmpi-1.6.5-intel
        buildable: False
 
 The addition of the ``buildable`` flag tells Spack that it should never build its own version of OpenMPI from sources, and it will instead always rely on a pre-built OpenMPI.
@@ -211,12 +207,10 @@ Spack can be configured with every MPI provider not buildable individually, but 
        buildable: False
      openmpi:
        externals:
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+       - spec: "openmpi@1.4.3~debug"
          prefix: /opt/openmpi-1.4.3
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+       - spec: "openmpi@1.4.3+debug"
          prefix: /opt/openmpi-1.4.3-debug
-       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
-         prefix: /opt/openmpi-1.6.5-intel
 
 Spack can then use any of the listed external implementations of MPI to satisfy a dependency, and will choose depending on the compiler and architecture.
 
@@ -229,18 +223,15 @@ In cases where the concretizer is configured to reuse specs, and other ``mpi`` p
        buildable: False
        require:
        - one_of: [
-           "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64",
-           "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug",
-           "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
+           "openmpi@1.4.3~debug",
+           "openmpi@1.4.3+debug",
          ]
      openmpi:
        externals:
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+       - spec: "openmpi@1.4.3~debug"
          prefix: /opt/openmpi-1.4.3
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+       - spec: "openmpi@1.4.3+debug"
          prefix: /opt/openmpi-1.4.3-debug
-       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
-         prefix: /opt/openmpi-1.6.5-intel
 
 This configuration prevents any spec using MPI and originating from stores or buildcaches to be reused, unless it matches the requirements under ``packages:mpi:require``.
 For more information on requirements see :ref:`package-requirements`.


### PR DESCRIPTION
The specs in the first example of the `packages.yaml` section are overly complicated, and use a deprecated compiler. This PR simplifies the example.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
