### PR TITLE
solver: add an xfail test for the issue of `commit=` not accounted in the hash

### DIFF
--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4065,6 +4065,7 @@ def test_caret_in_input_cannot_set_transitive_build_dependencies(default_mock_co
 
 @pytest.mark.regression("51167")
 @pytest.mark.require_provenance
+@pytest.mark.xfail(reason="This is a bug in the solver, related to how we ")
 def test_commit_variant_enters_the_hash(mutable_config, mock_packages, monkeypatch):
     """Tests that an implicit commit variant, obtained from resolving the commit sha of a branch,
     enters the hash of the spec.

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4065,7 +4065,7 @@ def test_caret_in_input_cannot_set_transitive_build_dependencies(default_mock_co
 
 @pytest.mark.regression("51167")
 @pytest.mark.require_provenance
-@pytest.mark.xfail(reason="This is a bug in the solver, related to how we ")
+@pytest.mark.xfail(reason="This is a bug in the solver, related to the 'commit=' variant")
 def test_commit_variant_enters_the_hash(mutable_config, mock_packages, monkeypatch):
     """Tests that an implicit commit variant, obtained from resolving the commit sha of a branch,
     enters the hash of the spec.

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4061,3 +4061,35 @@ def test_caret_in_input_cannot_set_transitive_build_dependencies(default_mock_co
     """
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="transitive 'link' or"):
         _ = default_mock_concretization("multivalue-variant ^gmake")
+
+
+@pytest.mark.regression("51167")
+@pytest.mark.require_provenance
+def test_commit_variant_enters_the_hash(mutable_config, mock_packages, monkeypatch):
+    """Tests that an implicit commit variant, obtained from resolving the commit sha of a branch,
+    enters the hash of the spec.
+    """
+
+    first_call = True
+
+    def _mock_resolve(pkg_self) -> None:
+        if first_call:
+            pkg_self.spec.variants["commit"] = spack.variant.SingleValuedVariant(
+                "commit", f"{'b' * 40}"
+            )
+            return
+
+        pkg_self.spec.variants["commit"] = spack.variant.SingleValuedVariant(
+            "commit", f"{'a' * 40}"
+        )
+
+    monkeypatch.setattr(spack.package_base.PackageBase, "resolve_binary_provenance", _mock_resolve)
+
+    before = spack.concretize.concretize_one("git-ref-package@develop")
+    first_call = False
+    after = spack.concretize.concretize_one("git-ref-package@develop")
+
+    assert before.package.needs_commit(before.version)
+    assert before.satisfies(f"commit={'b' * 40}")
+    assert after.satisfies(f"commit={'a' * 40}")
+    assert before.dag_hash() != after.dag_hash()


### PR DESCRIPTION
Solving the issue requires a bit of refactoring to git logic, so I'll leave it to @psakievich Here's a unit test in case it's useful.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
