### PR TITLE
docs: another pass over spack.package docs

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -249,7 +249,7 @@ class MakeExecutable(Executable):
         jobs_env_supports_jobserver: bool = False,
         **kwargs,
     ) -> Optional[str]:
-        """Runs this "make" executable in a subprocess.
+        """Runs this ``make`` executable in a subprocess.
 
         Args:
             parallel: if False, parallelism is disabled

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -165,7 +165,9 @@ def jobserver_enabled():
     return "MAKEFLAGS" in os.environ and "--jobserver" in os.environ["MAKEFLAGS"]
 
 
-def get_effective_jobs(jobs, parallel=True, supports_jobserver=False):
+def get_effective_jobs(
+    jobs, parallel: bool = True, supports_jobserver: bool = False
+) -> Optional[int]:
     """Return the number of jobs, or None if supports_jobserver and a jobserver is detected."""
     if not parallel or jobs <= 1 or env_flag(SPACK_NO_PARALLEL_MAKE):
         return 1

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -636,13 +636,16 @@ class BuilderWithDefaults(Builder):
 def apply_macos_rpath_fixups(builder: Builder):
     """On Darwin, make installed libraries more easily relocatable.
 
-    Some build systems (handrolled, autotools, makefiles) can set their own
-    rpaths that are duplicated by spack's compiler wrapper. This fixup
-    interrogates, and postprocesses if necessary, all libraries installed
-    by the code.
+    Some build systems (handrolled, autotools, makefiles) can set their own rpaths that are
+    duplicated by spack's compiler wrapper. This fixup interrogates, and postprocesses if
+    necessary, all libraries installed by the code.
 
-    It should be added as a @run_after to packaging systems (or individual
-    packages) that do not install relocatable libraries by default.
+    It should be added as a :func:`~spack.phase_callbacks.run_after` to packaging systems (or
+    individual packages) that do not install relocatable libraries by default.
+
+    Example::
+
+        run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)
 
     Args:
         builder: builder that installed the package

--- a/lib/spack/spack/compilers/libraries.py
+++ b/lib/spack/spack/compilers/libraries.py
@@ -317,10 +317,16 @@ def dynamic_linker_filter_for(node: spack.spec.Spec) -> Optional[DefaultDynamicL
 
 
 def compiler_spec(node: spack.spec.Spec) -> Optional[spack.spec.Spec]:
-    """Returns the compiler spec associated with the node passed as argument.
+    """Returns a compiler :class:`~spack.spec.Spec` associated with the node passed as argument.
 
-    The function looks for a "c", "cxx", and "fortran" compiler in that order,
-    and returns the first found. If none is found, returns None.
+    The function looks for a ``c``, ``cxx``, and ``fortran`` compiler in that order,
+    and returns the first found. If the node does not depend on any of these languages,
+    it returns :obj:`None`.
+
+    Use of this function is *discouraged*, because a single spec can have multiple compilers
+    associated with it, and this function only returns one of them. It can be better to refer to
+    compilers on a per-language basis, through the language virtuals: ``spec["c"]``,
+    ``spec["cxx"]``, and ``spec["fortran"]``.
     """
     for language in ("c", "cxx", "fortran"):
         candidates = node.dependencies(virtuals=[language])

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -889,7 +889,9 @@ def license(
 
 
 @directive("requirements")
-def requires(*requirement_specs: str, policy="one_of", when=None, msg=None):
+def requires(
+    *requirement_specs: str, policy="one_of", when: Optional[str] = None, msg: Optional[str] = None
+):
     """Declare that a spec must be satisfied for a package.
 
     For instance, a package whose Fortran code can only be compiled with GCC can declare::
@@ -902,9 +904,11 @@ def requires(*requirement_specs: str, policy="one_of", when=None, msg=None):
 
     Args:
         requirement_specs: spec expressing the requirement
+        policy: either ``"one_of"`` or ``"any_of"``. If ``"one_of"``, exactly one of the
+            requirements must be satisfied. If ``"any_of"``, at least one of the requirements must
+            be satisfied. Defaults to ``"one_of"``.
         when: optional constraint that triggers the requirement. If None the requirement
             is applied unconditionally.
-
         msg: optional user defined message
     """
 

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -706,7 +706,7 @@ def copy(src: str, dest: str, _permissions: bool = False) -> None:
 
 
 @system_path_filter
-def install(src: str, dest: str):
+def install(src: str, dest: str) -> None:
     """Install the file(s) ``src`` to the file or directory ``dest``.
 
     Same as :py:func:`copy` with the addition of setting proper
@@ -858,13 +858,13 @@ def install_tree(
 
 
 @system_path_filter
-def is_exe(path):
+def is_exe(path) -> bool:
     """Returns :obj:`True` iff the specified path exists, is a regular file, and has executable
     permissions for the current process."""
     return os.path.isfile(path) and os.access(path, os.X_OK)
 
 
-def has_shebang(path):
+def has_shebang(path) -> bool:
     """Returns whether a path has a shebang line. Returns False if the file cannot be opened."""
     try:
         with open(path, "rb") as f:
@@ -994,7 +994,7 @@ def longest_existing_parent(path: str) -> Tuple[str, List[str]]:
 
 
 @system_path_filter
-def force_remove(*paths):
+def force_remove(*paths: str) -> None:
     """Remove files without printing errors.  Like ``rm -f``, does NOT
     remove directories."""
     for path in paths:
@@ -1150,7 +1150,7 @@ def touchp(path):
 
 
 @system_path_filter
-def force_symlink(src, dest):
+def force_symlink(src: str, dest: str) -> None:
     """Create a symlink at ``dest`` pointing to ``src``. Similar to ``ln -sf``."""
     try:
         symlink(src, dest)
@@ -1160,7 +1160,7 @@ def force_symlink(src, dest):
 
 
 @system_path_filter
-def join_path(prefix, *args):
+def join_path(prefix, *args) -> str:
     """Alias for :func:`os.path.join`"""
     path = str(prefix)
     for elt in args:
@@ -2893,11 +2893,16 @@ def remove_directory_contents(dir):
 
 @contextmanager
 @system_path_filter
-def keep_modification_time(*filenames):
+def keep_modification_time(*filenames: str) -> Generator[None, None, None]:
     """
     Context manager to keep the modification timestamps of the input files.
     Tolerates and has no effect on non-existent files and files that are
     deleted by the nested code.
+
+    Example::
+
+        with keep_modification_time("file1.txt", "file2.txt"):
+            # do something that modifies file1.txt and file2.txt
 
     Parameters:
         *filenames: one or more files that must have their modification

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -915,11 +915,11 @@ def mkdirp(
             if not provided
         group: optional group for permissions of final created directory -- use OS
             default if not provided. Only used if world write permissions are not set
-        default_perms: one of 'parents' or 'args'. The default permissions that are set for
-            directories that are not themselves an argument for mkdirp. 'parents' means
+        default_perms: one of ``"parents"`` or ``"args"``. The default permissions that are set for
+            directories that are not themselves an argument for mkdirp. ``"parents"`` means
             intermediate directories get the permissions of their direct parent directory,
-            'args' means intermediate get the same permissions specified in the arguments to
-            mkdirp -- default value is 'args'
+            ``"args"`` means intermediate get the same permissions specified in the arguments to
+            mkdirp -- default value is ``"args"``
     """
     default_perms = default_perms or "args"
     paths = path_to_os_path(*paths)

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -130,6 +130,13 @@ def union_dicts(*dicts):
 def memoized(func):
     """Decorator that caches the results of a function, storing them in
     an attribute of that function.
+
+    Example::
+
+        @memoized
+        def expensive_computation(x):
+            # Some expensive computation
+            return result
     """
     return functools.lru_cache(maxsize=None)(func)
 

--- a/lib/spack/spack/mixins.py
+++ b/lib/spack/spack/mixins.py
@@ -35,7 +35,8 @@ def filter_compiler_wrappers(
 
     Args:
         *files: files to be filtered relative to the search root (install prefix by default).
-        after: specifies after which phase the files should be filtered (defaults to "install")
+        after: specifies after which phase the files should be filtered (defaults to
+            ``"install"``).
         relative_root: path relative to install prefix where to start searching for the files to be
             filtered. If not set the install prefix will be used as the search root. It is *highly
             recommended* to set this, as searching recursively from the installation prefix can be

--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -8,13 +8,13 @@ import re
 
 import spack.llnl.util.lang
 from spack.util.executable import Executable
-from spack.version import Version
+from spack.version import StandardVersion, Version
 
 from ._operating_system import OperatingSystem
 
 
 @spack.llnl.util.lang.memoized
-def macos_version():
+def macos_version() -> StandardVersion:
     """Get the current macOS version as a version object.
 
     This has three mechanisms for determining the macOS version, which is used
@@ -43,7 +43,7 @@ def macos_version():
     """
     env_ver = os.environ.get("MACOSX_DEPLOYMENT_TARGET", None)
     if env_ver:
-        return Version(env_ver)
+        return StandardVersion.from_string(env_ver)
 
     try:
         output = Executable("sw_vers")(output=str, fail_on_error=False)
@@ -53,11 +53,11 @@ def macos_version():
     else:
         match = re.search(r"ProductVersion:\s*([0-9.]+)", output)
         if match:
-            return Version(match.group(1))
+            return StandardVersion.from_string(match.group(1))
 
     # Fall back to python-reported version, which can be inaccurate around
     # macOS 11 (e.g. showing 10.16 for macOS 12)
-    return Version(py_platform.mac_ver()[0])
+    return StandardVersion.from_string(py_platform.mac_ver()[0])
 
 
 @spack.llnl.util.lang.memoized

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -119,13 +119,7 @@ from spack.mixins import filter_compiler_wrappers
 from spack.multimethod import default_args, when
 from spack.operating_systems.linux_distro import kernel_version
 from spack.operating_systems.mac_os import macos_version
-from spack.package_base import (
-    PackageBase,
-    build_system_flags,
-    env_flags,
-    inject_flags,
-    on_package_attributes,
-)
+from spack.package_base import PackageBase, on_package_attributes
 from spack.package_completions import (
     bash_completion_path,
     fish_completion_path,
@@ -233,6 +227,50 @@ def filter_system_paths(paths: Iterable[str]) -> List[str]:
         "spack.package.filter_system_paths is deprecated", category=SpackAPIWarning, stacklevel=2
     )
     return _filter_system_paths(paths)
+
+
+#: Assigning this to :attr:`spack.package_base.PackageBase.flag_handler` means that compiler flags
+#: are passed to the build system. This can be used in any package that derives from a build system
+#: class that implements :meth:`spack.package_base.PackageBase.flags_to_build_system_args`.
+#:
+#: See also :func:`env_flags` and :func:`inject_flags`.
+#:
+#: Example::
+#:
+#:     from spack.package import *
+#:
+#:     class MyPackage(CMakePackage):
+#:         flag_handler = build_system_flags
+build_system_flags = PackageBase.build_system_flags
+
+#: Assigning this to :attr:`spack.package_base.PackageBase.flag_handler` means that compiler flags
+#: are set as canonical environment variables.
+#:
+#: See also :func:`build_system_flags` and :func:`inject_flags`.
+#:
+#: Example::
+#:
+#:     from spack.package import *
+#:
+#:     class MyPackage(MakefilePackage):
+#:         flag_handler = env_flags
+env_flags = PackageBase.env_flags
+
+
+#: This is the default value of :attr:`spack.package_base.PackageBase.flag_handler`, which tells
+#: Spack to inject compiler flags through the compiler wrappers, which means that the build system
+#: will not see them directly. This is typically a good default, but in rare case you may need to
+#: use :func:`env_flags` or :func:`build_system_flags` instead.
+#:
+#: See also :func:`build_system_flags` and :func:`env_flags`.
+#:
+#: Example::
+#:
+#:     from spack.package import *
+#:
+#:     class MyPackage(MakefilePackage):
+#:         flag_handler = inject_flags
+inject_flags = PackageBase.inject_flags
 
 
 api: Dict[str, Tuple[str, ...]] = {

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -616,7 +616,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     patches: Dict[spack.spec.Spec, List[spack.patch.Patch]]
     #: Class level dictionary populated by :func:`~spack.directives.variant` directives
     variants: Dict[spack.spec.Spec, Dict[str, spack.variant.Variant]]
-    languages: Dict[spack.spec.Spec, Set[str]]
     #: Class level dictionary populated by :func:`~spack.directives.license` directives
     licenses: Dict[spack.spec.Spec, str]
     #: Class level dictionary populated by :func:`~spack.directives.can_splice` directives

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -600,6 +600,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: Class level dictionary populated by :func:`~spack.directives.depends_on` and
     #: :func:`~spack.directives.extends` directives
     dependencies: Dict[spack.spec.Spec, Dict[str, spack.dependency.Dependency]]
+    #: Class level dictionary populated by :func:`~spack.directives.extends` directives
+    extendees: Dict[str, Tuple[spack.spec.Spec, spack.spec.Spec]]
     #: Class level dictionary populated by :func:`~spack.directives.conflicts` directives
     conflicts: Dict[spack.spec.Spec, List[Tuple[spack.spec.Spec, Optional[str]]]]
     #: Class level dictionary populated by :func:`~spack.directives.requires` directives

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2017,29 +2017,19 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     @classmethod
     def inject_flags(cls: Type[Pb], name: str, flags: Iterable[str]) -> FLAG_HANDLER_RETURN_TYPE:
-        """
-        flag_handler that injects all flags through the compiler wrapper.
-        """
+        """See :func:`spack.package.inject_flags`."""
         return flags, None, None
 
     @classmethod
     def env_flags(cls: Type[Pb], name: str, flags: Iterable[str]) -> FLAG_HANDLER_RETURN_TYPE:
-        """
-        flag_handler that adds all flags to canonical environment variables.
-        """
+        """See :func:`spack.package.env_flags`."""
         return None, flags, None
 
     @classmethod
     def build_system_flags(
         cls: Type[Pb], name: str, flags: Iterable[str]
     ) -> FLAG_HANDLER_RETURN_TYPE:
-        """
-        flag_handler that passes flags to the build system arguments.  Any
-        package using `build_system_flags` must also implement
-        `flags_to_build_system_args`, or derive from a class that
-        implements it.  Currently, AutotoolsPackage and CMakePackage
-        implement it.
-        """
+        """See :func:`spack.package.build_system_flags`."""
         return None, None, flags
 
     def setup_run_environment(self, env: spack.util.environment.EnvironmentModifications) -> None:
@@ -2322,11 +2312,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         Get the rpath args as a string, with -Wl,-rpath, for each element
         """
         return " ".join("-Wl,-rpath,%s" % p for p in self.rpath)
-
-
-inject_flags = PackageBase.inject_flags
-env_flags = PackageBase.env_flags
-build_system_flags = PackageBase.build_system_flags
 
 
 def deprecated_version(pkg: PackageBase, version: Union[str, StandardVersion]) -> bool:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -593,34 +593,40 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     compiler = DeprecatedCompiler()
 
-    #
-    # These are default values for instance variables.
-    #
-
-    # Declare versions dictionary as placeholder for values.
-    # This allows analysis tools to correctly interpret the class attributes.
+    #: Class level dictionary populated by :func:`~spack.directives.version` directives
     versions: dict
+    #: Class level dictionary populated by :func:`~spack.directives.resource` directives
     resources: Dict[spack.spec.Spec, List[Resource]]
+    #: Class level dictionary populated by :func:`~spack.directives.depends_on` and
+    #: :func:`~spack.directives.extends` directives
     dependencies: Dict[spack.spec.Spec, Dict[str, spack.dependency.Dependency]]
+    #: Class level dictionary populated by :func:`~spack.directives.conflicts` directives
     conflicts: Dict[spack.spec.Spec, List[Tuple[spack.spec.Spec, Optional[str]]]]
+    #: Class level dictionary populated by :func:`~spack.directives.requires` directives
     requirements: Dict[
         spack.spec.Spec, List[Tuple[Tuple[spack.spec.Spec, ...], str, Optional[str]]]
     ]
+    #: Class level dictionary populated by :func:`~spack.directives.provides` directives
     provided: Dict[spack.spec.Spec, Set[spack.spec.Spec]]
+    #: Class level dictionary populated by :func:`~spack.directives.provides` directives
     provided_together: Dict[spack.spec.Spec, List[Set[str]]]
+    #: Class level dictionary populated by :func:`~spack.directives.patch` directives
     patches: Dict[spack.spec.Spec, List[spack.patch.Patch]]
+    #: Class level dictionary populated by :func:`~spack.directives.variant` directives
     variants: Dict[spack.spec.Spec, Dict[str, spack.variant.Variant]]
     languages: Dict[spack.spec.Spec, Set[str]]
+    #: Class level dictionary populated by :func:`~spack.directives.license` directives
     licenses: Dict[spack.spec.Spec, str]
+    #: Class level dictionary populated by :func:`~spack.directives.can_splice` directives
     splice_specs: Dict[spack.spec.Spec, Tuple[spack.spec.Spec, Union[None, str, List[str]]]]
-
-    #: Store whether a given Spec source/binary should not be redistributed.
+    #: Class level dictionary populated by :func:`~spack.directives.redistribute` directives
     disable_redistribute: Dict[spack.spec.Spec, DisableRedistribute]
 
     #: Must be defined as a fallback for old specs that don't have the `build_system` variant
     default_buildsystem: str
 
-    # Use :attr:`default_buildsystem` instead of this attribute, which is deprecated
+    #: Use :attr:`~spack.package_base.PackageBase.default_buildsystem` instead of this attribute,
+    #: which is deprecated
     legacy_buildsystem: str
 
     #: Must be defined in derived classes. Used when reporting the build system to users
@@ -628,24 +634,24 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     #: By default, packages are not virtual
     #: Virtual packages override this attribute
-    virtual = False
+    virtual: bool = False
 
     #: Most Spack packages are used to install source or binary code while
     #: those that do not can be used to install a set of other Spack packages.
-    has_code = True
+    has_code: bool = True
 
     #: By default we build in parallel.  Subclasses can override this.
-    parallel = True
+    parallel: bool = True
 
     #: By default do not run tests within package's install()
-    run_tests = False
+    run_tests: bool = False
 
     #: Most packages are NOT extendable. Set to True if you want extensions.
-    extendable = False
+    extendable: bool = False
 
     #: When True, add RPATHs for the entire DAG. When False, add RPATHs only
     #: for immediate dependencies.
-    transitive_rpaths = True
+    transitive_rpaths: bool = True
 
     #: List of shared objects that should be replaced with a different library at
     #: runtime. Typically includes stub libraries like ``libcuda.so``. When linking
@@ -677,7 +683,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: Boolean. Set to ``True`` for packages that require a manual download.
     #: This is currently used by package sanity tests and generation of a
     #: more meaningful fetch failure error.
-    manual_download = False
+    manual_download: bool = False
 
     #: Set of additional options used when fetching package versions.
     fetch_options: Dict[str, Any] = {}
@@ -685,29 +691,29 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #
     # Set default licensing information
     #
-    #: Boolean. If set to ``True``, this software requires a license.
+    #: If set to ``True``, this software requires a license.
     #: If set to ``False``, all of the ``license_*`` attributes will
     #: be ignored. Defaults to ``False``.
-    license_required = False
+    license_required: bool = False
 
-    #: String. Contains the symbol used by the license manager to denote
+    #: Contains the symbol used by the license manager to denote
     #: a comment. Defaults to ``#``.
-    license_comment = "#"
+    license_comment: str = "#"
 
-    #: List of strings. These are files that the software searches for when
+    #: These are files that the software searches for when
     #: looking for a license. All file paths must be relative to the
     #: installation directory. More complex packages like Intel may require
     #: multiple licenses for individual components. Defaults to the empty list.
     license_files: List[str] = []
 
-    #: List of strings. Environment variables that can be set to tell the
+    #: Environment variables that can be set to tell the
     #: software where to look for a license if it is not in the usual location.
     #: Defaults to the empty list.
     license_vars: List[str] = []
 
-    #: String. A URL pointing to license setup instructions for the software.
+    #: A URL pointing to license setup instructions for the software.
     #: Defaults to the empty string.
-    license_url = ""
+    license_url: str = ""
 
     #: Verbosity level, preserved across installs.
     _verbose = None
@@ -719,9 +725,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     list_url: ClassProperty[Optional[str]] = None
 
     #: Link depth to which list_url should be searched for new versions
-    list_depth = 0
+    list_depth: int = 0
 
-    #: List of strings which contains GitHub usernames of package maintainers.
+    #: List of GitHub usernames of package maintainers.
     #: Do not include @ here in order not to unnecessarily ping the users.
     maintainers: List[str] = []
 
@@ -733,9 +739,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: TestSuite instance used to manage stand-alone tests for 1+ specs.
     test_suite: Optional[Any] = None
 
-    def __init__(self, spec):
+    def __init__(self, spec: spack.spec.Spec) -> None:
         # this determines how the package should be built.
-        self.spec: spack.spec.Spec = spec
+        self.spec = spec
 
         # Allow custom staging paths for packages
         self.path = None
@@ -752,7 +758,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # init internal variables
         self._stage: Optional[stg.StageComposite] = None
-        self._patch_stages = []  # need to track patch stages separately, in order to apply them
+        # need to track patch stages separately, in order to apply them
+        self._patch_stages: List[stg.Stage] = []
         self._fetcher = None
         self._tester: Optional[Any] = None
 
@@ -988,15 +995,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         return last_url
 
-    def url_for_version(self, version):
-        """Returns a URL from which the specified version of this package
-        may be downloaded.
+    def url_for_version(self, version: Union[str, StandardVersion]) -> str:
+        """Returns a URL from which the specified version of this package may be downloaded.
 
-        version: class Version
-            The version for which a URL is sought.
-
-        See Class Version (version.py)
-        """
+        Arguments:
+            version: The version for which a URL is sought."""
         return self._implement_all_urls_for_version(version)[0]
 
     def _update_external_dependencies(
@@ -1159,15 +1162,13 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         return urls
 
-    def find_valid_url_for_version(self, version):
-        """Returns a URL from which the specified version of this package
-        may be downloaded after testing whether the url is valid. Will try
-        url, urls, and list_url before failing.
+    def find_valid_url_for_version(self, version: StandardVersion) -> Optional[str]:
+        """Returns a URL from which the specified version of this package may be downloaded after
+        testing whether the url is valid. Will try ``url``, ``urls``, and :attr:`list_url`
+        before failing.
 
-        version: class Version
-            The version for which a URL is sought.
-
-        See Class Version (version.py)
+        Arguments:
+            version: The version for which a URL is sought.
         """
         urls = self.all_urls_for_version(version)
 
@@ -1425,10 +1426,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     # TODO: allow more than one active extendee.
     @property
-    def extendee_spec(self):
-        """
-        Spec of the extendee of this package, or None if it is not an extension
-        """
+    def extendee_spec(self) -> Optional[spack.spec.Spec]:
+        """Spec of the extendee of this package, or None if it is not an extension."""
         if not self.extendees:
             return None
 
@@ -1464,7 +1463,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             # If not, then it's an extension if it *could* be an extension
             return bool(self.extendees)
 
-    def extends(self, spec):
+    def extends(self, spec: spack.spec.Spec) -> bool:
         """
         Returns True if this package extends the given spec.
 
@@ -1477,9 +1476,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         if spec.name not in self.extendees:
             return False
         s = self.extendee_spec
-        return s and spec.satisfies(s)
+        return s is not None and spec.satisfies(s)
 
-    def provides(self, vpkg_name):
+    def provides(self, vpkg_name: str) -> bool:
         """
         True if this package provides a virtual package with the specified name
         """
@@ -2277,7 +2276,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     ) -> Dict[StandardVersion, str]:
         """Find remote versions of this package.
 
-        Uses ``list_url`` and any other URLs listed in the package file.
+        Uses :attr:`list_url` and any other URLs listed in the package file.
 
         Returns:
             a dictionary mapping versions to URLs

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2249,7 +2249,7 @@ class Spec:
 
     @property
     def cshort_spec(self):
-        """Returns an auto-colorized version of :py:attr:`short_spec`."""
+        """Returns an auto-colorized version of :attr:`short_spec`."""
         return self.cformat("{name}{@version}{variants}{ arch=architecture}{/hash:7}")
 
     @property
@@ -4258,12 +4258,12 @@ class Spec:
 
     @property
     def spack_root(self):
-        """Special field for using ``{spack_root}`` in :py:meth:`format`."""
+        """Special field for using ``{spack_root}`` in :meth:`format`."""
         return spack.paths.spack_root
 
     @property
     def spack_install(self):
-        """Special field for using ``{spack_install}`` in :py:meth:`format`."""
+        """Special field for using ``{spack_install}`` in :meth:`format`."""
         return spack.store.STORE.layout.root
 
     def format_path(
@@ -4272,16 +4272,15 @@ class Spec:
         format_string: str,
         _path_ctor: Optional[Callable[[Any], pathlib.PurePath]] = None,
     ) -> str:
-        """Given a `format_string` that is intended as a path, generate a string
-        like from :py:meth:`format`, but eliminate extra path separators introduced by
-        formatting of Spec properties.
+        """Given a `format_string` that is intended as a path, generate a string like from
+        :meth:`format`, but eliminate extra path separators introduced by formatting of Spec
+        properties.
 
         Path separators explicitly added to the string are preserved, so for example
-        ``{name}/{version}`` would generate a directory based on the Spec's name, and
-        a subdirectory based on its version; this function guarantees though that
-        the resulting string would only have two directories (i.e. that if under
-        normal circumstances that ``str(self.version)`` would contain a path
-        separator, it would not in this case).
+        ``{name}/{version}`` would generate a directory based on the Spec's name, and a
+        subdirectory based on its version; this function guarantees though that the resulting
+        string would only have two directories (i.e. that if under normal circumstances that
+        ``str(self.version)`` would contain a path separator, it would not in this case).
         """
         format_component_with_sep = r"\{[^}]*[/\\][^}]*}"
         if re.search(format_component_with_sep, format_string):
@@ -4588,14 +4587,14 @@ class Spec:
                 break
 
     def splice(self, other: "Spec", transitive: bool = True) -> "Spec":
-        """Returns a new, spliced concrete :py:class:`Spec` with the ``other`` dependency and,
+        """Returns a new, spliced concrete :class:`Spec` with the ``other`` dependency and,
         optionally, its dependencies.
 
         Args:
             other: alternate dependency
             transitive: include other's dependencies
 
-        Returns: a concrete, spliced version of the current :py:class:`Spec`
+        Returns: a concrete, spliced version of the current :class:`Spec`
 
         When transitive is :data:`True`, use the dependencies from ``other`` to reconcile
         conflicting dependencies. When transitive is :data:`False`, use dependencies from self.
@@ -4628,7 +4627,7 @@ class Spec:
            | \\
            Z<-H'*
 
-        Provenance of the build is tracked through the :py:attr:`build_spec` property
+        Provenance of the build is tracked through the :attr:`build_spec` property
         of the spliced spec and any correspondingly modified dependency specs.
         The build specs are set to that of the original spec, so the original
         spec's provenance is preserved unchanged."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1353,7 +1353,7 @@ def tree(
         depth: print the depth from the root
         hashes: if True, print the hash of each node
         hashlen: length of the hash to be printed
-        cover: either "nodes" or "edges"
+        cover: either ``"nodes"`` or ``"edges"``
         indent: extra indentation for the tree being printed
         format: format to be used to print each node
         deptypes: dependency types to be represented in the tree
@@ -2410,9 +2410,8 @@ class Spec:
     ) -> Dict[str, Any]:
         """Create a dictionary representing the state of this Spec.
 
-        ``to_node_dict`` creates the content that is eventually hashed by
-        Spack to create identifiers like the DAG hash (see
-        :py:func:`dag_hash()`).  Example result of ``to_node_dict`` for the
+        This method creates the content that is eventually hashed by Spack to create identifiers
+        like the DAG hash (see :meth:`dag_hash()`). Example result of this function for the
         ``sqlite`` package::
 
             {
@@ -2452,14 +2451,11 @@ class Spec:
             }
 
 
-        Note that the dictionary returned does *not* include the hash of
-        the *root* of the spec, though it does include hashes for each
-        dependency, and (optionally) the package file corresponding to
-        each node.
+        Note that the dictionary returned does *not* include the hash of the *root* of the spec,
+        though it does include hashes for each dependency and its own package hash.
 
-        See :py:func:`to_dict()` for a "complete" spec hash, with hashes for
-        each node and nodes for each dependency (instead of just their
-        hashes).
+        See :meth:`to_dict()` for a "complete" spec hash, with hashes for each node and nodes for
+        each dependency (instead of just their hashes).
 
         Arguments:
             hash: type of hash to generate.
@@ -2625,18 +2621,11 @@ class Spec:
                 }
             }
 
-        Note that this dictionary starts with the 'spec' key, and what
-        follows is a list starting with the root spec, followed by its
-        dependencies in preorder.  Each node in the list also has a
-        'hash' key that contains the hash of the node *without* the hash
-        field included.
+        Note that this dictionary starts with the ``spec`` key, and what follows is a list starting
+        with the root spec, followed by its dependencies in preorder.
 
-        In the example, the package content hash is not included in the
-        spec, but if ``package_hash`` were true there would be an
-        additional field on each node called ``package_hash``.
-
-        :py:func:`from_dict()` can be used to read back in a spec that has been
-        converted to a dictionary, serialized, and read back in.
+        The method :meth:`from_dict()` can be used to read back in a spec that has been converted
+        to a dictionary, serialized, and read back in.
         """
         node_list = []  # Using a list to preserve preorder traversal for hash.
         hash_set = set()
@@ -2660,9 +2649,8 @@ class Spec:
     def node_dict_with_hashes(
         self, hash: ht.SpecHashDescriptor = ht.dag_hash  # type: ignore[has-type]
     ) -> Dict[str, Any]:
-        """Returns a node_dict of this spec with the dag hash added.  If this
-        spec is concrete, the full hash is added as well.  If 'build' is in
-        the hash_type, the build hash is also added."""
+        """Returns a node dict of this spec with the dag hash, and the provided hash (if not
+        the dag hash)."""
         node = self.to_node_dict(hash)
         # All specs have at least a DAG hash
         node[ht.dag_hash.name] = self.dag_hash()
@@ -4270,12 +4258,12 @@ class Spec:
 
     @property
     def spack_root(self):
-        """Special field for using ``{spack_root}`` in :py:func:`format`."""
+        """Special field for using ``{spack_root}`` in :py:meth:`format`."""
         return spack.paths.spack_root
 
     @property
     def spack_install(self):
-        """Special field for using ``{spack_install}`` in :py:func:`format`."""
+        """Special field for using ``{spack_install}`` in :py:meth:`format`."""
         return spack.store.STORE.layout.root
 
     def format_path(
@@ -4285,14 +4273,14 @@ class Spec:
         _path_ctor: Optional[Callable[[Any], pathlib.PurePath]] = None,
     ) -> str:
         """Given a `format_string` that is intended as a path, generate a string
-        like from `Spec.format`, but eliminate extra path separators introduced by
+        like from :py:meth:`format`, but eliminate extra path separators introduced by
         formatting of Spec properties.
 
         Path separators explicitly added to the string are preserved, so for example
-        "{name}/{version}" would generate a directory based on the Spec's name, and
+        ``{name}/{version}`` would generate a directory based on the Spec's name, and
         a subdirectory based on its version; this function guarantees though that
         the resulting string would only have two directories (i.e. that if under
-        normal circumstances that `str(Spec.version)` would contain a path
+        normal circumstances that ``str(self.version)`` would contain a path
         separator, it would not in this case).
         """
         format_component_with_sep = r"\{[^}]*[/\\][^}]*}"
@@ -4399,7 +4387,7 @@ class Spec:
             depth: print the depth from the root
             hashes: if True, print the hash of each node
             hashlen: length of the hash to be printed
-            cover: either "nodes" or "edges"
+            cover: either ``"nodes"`` or ``"edges"``
             indent: extra indentation for the tree being printed
             format: format to be used to print each node
             deptypes: dependency types to be represented in the tree
@@ -4600,16 +4588,16 @@ class Spec:
                 break
 
     def splice(self, other: "Spec", transitive: bool = True) -> "Spec":
-        """Returns a new, spliced concrete Spec with the "other" dependency and,
+        """Returns a new, spliced concrete :py:class:`Spec` with the ``other`` dependency and,
         optionally, its dependencies.
 
         Args:
             other: alternate dependency
             transitive: include other's dependencies
 
-        Returns: a concrete, spliced version of the current Spec
+        Returns: a concrete, spliced version of the current :py:class:`Spec`
 
-        When transitive is :data:`True`, use the dependencies from "other" to reconcile
+        When transitive is :data:`True`, use the dependencies from ``other`` to reconcile
         conflicting dependencies. When transitive is :data:`False`, use dependencies from self.
 
         For example, suppose we have the following dependency graph:
@@ -4640,7 +4628,7 @@ class Spec:
            | \\
            Z<-H'*
 
-        Provenance of the build is tracked through the "build_spec" property
+        Provenance of the build is tracked through the :py:attr:`build_spec` property
         of the spliced spec and any correspondingly modified dependency specs.
         The build specs are set to that of the original spec, so the original
         spec's provenance is preserved unchanged."""

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -32,7 +32,7 @@ def repro_dir(tmp_path: pathlib.Path):
         yield result
 
 
-def test_get_added_versions_new_checksum(mock_git_package_changes):
+def test_filter_added_checksums_new_checksum(mock_git_package_changes):
     repo, filename, commits = mock_git_package_changes
 
     checksum_versions = {
@@ -43,14 +43,12 @@ def test_get_added_versions_new_checksum(mock_git_package_changes):
     }
 
     with fs.working_dir(repo.packages_path):
-        added_versions = ci.get_added_versions(
-            checksum_versions, filename, from_ref=commits[-1], to_ref=commits[-2]
-        )
-        assert len(added_versions) == 1
-        assert added_versions[0] == Version("2.1.5")
+        assert ci.filter_added_checksums(
+            checksum_versions.keys(), filename, from_ref=commits[-1], to_ref=commits[-2]
+        ) == ["3f6576971397b379d4205ae5451ff5a68edf6c103b2f03c4188ed7075fbb5f04"]
 
 
-def test_get_added_versions_new_commit(mock_git_package_changes):
+def test_filter_added_checksums_new_commit(mock_git_package_changes):
     repo, filename, commits = mock_git_package_changes
 
     checksum_versions = {
@@ -62,11 +60,9 @@ def test_get_added_versions_new_commit(mock_git_package_changes):
     }
 
     with fs.working_dir(repo.packages_path):
-        added_versions = ci.get_added_versions(
+        assert ci.filter_added_checksums(
             checksum_versions, filename, from_ref=commits[-2], to_ref=commits[-3]
-        )
-        assert len(added_versions) == 1
-        assert added_versions[0] == Version("2.1.6")
+        ) == ["74253725f884e2424a0dd8ae3f69896d5377f325"]
 
 
 def test_pipeline_dag(config, repo_builder: RepoBuilder):

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -273,7 +273,7 @@ def test_package_license():
 
 
 class BaseTestPackage(PackageBase):
-    extendees = None  # currently a required attribute for is_extension()
+    extendees = {}  # currently a required attribute for is_extension()
 
 
 def test_package_version_fails():

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -569,7 +569,7 @@ class EnvironmentModifications:
         Args:
             name: name of the environment variable
             value: flags to be appended
-            sep: separator for the flags (default: " ")
+            sep: separator for the flags (default: ``" "``)
         """
         value = _validate_value(name, value)
         item = AppendFlagsEnv(name, value, separator=sep, trace=self._trace())
@@ -590,7 +590,7 @@ class EnvironmentModifications:
         Args:
             name: name of the environment variable
             value: flags to be removed
-            sep: separator for the flags (default: " ")
+            sep: separator for the flags (default: ``" "``)
         """
         value = _validate_value(name, value)
         item = RemoveFlagsEnv(name, value, separator=sep, trace=self._trace())

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -653,7 +653,7 @@ def disjoint_sets(*sets: Tuple[str, ...]) -> DisjointSetsOfValues:
     See also :func:`any_combination_of` and :func:`auto_or_any_combination_of`.
 
     Args:
-        *sets:
+        *sets: sets of allowed values, each set is a tuple of strings
 
     Returns:
         a properly initialized instance of :class:`~spack.variant.DisjointSetsOfValues`

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -585,8 +585,8 @@ class DisjointSetsOfValues(collections.abc.Sequence):
         return _disjoint_set_validator
 
 
-def _a_single_value_or_a_combination(single_value, *values):
-    error = "the value '" + single_value + "' is mutually exclusive with any of the other values"
+def _a_single_value_or_a_combination(single_value: str, *values: str) -> DisjointSetsOfValues:
+    error = f"the value '{single_value}' is mutually exclusive with any of the other values"
     return (
         DisjointSetsOfValues((single_value,), values)
         .with_default(single_value)
@@ -600,12 +600,14 @@ def _a_single_value_or_a_combination(single_value, *values):
 # TODO: a common namespace (like 'multi') in the future.
 
 
-def any_combination_of(*values):
+def any_combination_of(*values: str) -> DisjointSetsOfValues:
     """Multi-valued variant that allows either any combination of the specified values, or none
      at all (using ``variant=none``). The literal value ``none`` is used as sentinel for the empty
      set, since in the spec DSL we have to always specify a value for a variant.
 
     It is up to the package implementation to handle the value ``none`` specially, if at all.
+
+    See also :func:`auto_or_any_combination_of` and :func:`disjoint_sets`.
 
     Args:
         *values: allowed variant values
@@ -620,9 +622,11 @@ def any_combination_of(*values):
     return _a_single_value_or_a_combination("none", *values)
 
 
-def auto_or_any_combination_of(*values):
-    """Multi-valued variant that allows any combination of a set of values
-    (but not the empty set) or `"auto"`.
+def auto_or_any_combination_of(*values: str) -> DisjointSetsOfValues:
+    """Multi-valued variant that allows any combination of a set of values (but not the empty set)
+    or ``auto``.
+
+    See also :func:`any_combination_of` and :func:`disjoint_sets`.
 
     Args:
         *values: allowed variant values
@@ -640,15 +644,13 @@ def auto_or_any_combination_of(*values):
     return _a_single_value_or_a_combination("auto", *values)
 
 
-#: Multi-valued variant that allows any combination picking
-#: from one of multiple disjoint sets
-def disjoint_sets(*sets):
-    """Multi-valued variant that allows any combination picking from one
-    of multiple disjoint sets of values, and also allows the user to specify
-    'none' (as a string) to choose none of them.
+def disjoint_sets(*sets: Tuple[str, ...]) -> DisjointSetsOfValues:
+    """Multi-valued variant that allows any combination picking from one of multiple disjoint sets
+    of values, and also allows the user to specify ``none`` to choose none of them.
 
-    It is up to the package implementation to handle the value 'none'
-    specially, if at all.
+    It is up to the package implementation to handle the value ``none`` specially, if at all.
+
+    See also :func:`any_combination_of` and :func:`auto_or_any_combination_of`.
 
     Args:
         *sets:


### PR DESCRIPTION
- docs: mostly trivial docstring updates for improved docs
- docs: improve documentation of the somewhat mysterious `build_system_flags`, `env_flags`, `inject_flags` functions
- package_base.py: add `PackageBase.extendees` typehint
- package_base.py: remove unset `PackageBase.languages` typehint
- ci.py: fix a few issues related to typing exposed by the changes above
