### PR TITLE
docs: monkeypatch classproperty.__get__ for sphinx

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -119,7 +119,12 @@ class CustomPygmentsBridge(PygmentsBridge):
 PygmentsBridge.html_formatter = NoWhitespaceHtmlFormatter
 
 
+from spack.llnl.util.lang import classproperty
 from spack.spec_parser import SpecTokens
+
+# replace classproperty.__get__ to return `self` so Sphinx can document it correctly. Otherwise
+# it evaluates the callback, and it documents the result, which is not what we want.
+classproperty.__get__ = lambda self, instance, owner: self
 
 
 class SpecLexer(RegexLexer):

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -1069,6 +1069,7 @@ class classproperty(Generic[ClassPropertyType]):
 
     def __init__(self, callback: Callable[[Any], ClassPropertyType]) -> None:
         self.callback = callback
+        self.__doc__ = callback.__doc__
 
     def __get__(self, instance, owner) -> ClassPropertyType:
         return self.callback(owner)


### PR DESCRIPTION
This is a bit of a hack, but our `@classproperty` in `PackageBase` cannot be
documented easily, because Sphinx runs the function instead of keeping a
reference to the descriptor. That's because of `__get__` unconditionally
evaluating the wrapped function, and the whole point of class property.

I guess Sphinx *could* have used `PackageBase.__dict__["module"]`, and maybe it
does, but if I try to implement a custom documenter, I only get the return
value of the wrapped function and not the descriptor. This hack looks much
simpler.

This should help with:

* https://spack--51186.org.readthedocs.build/en/51186/package_api.html#spack.package.PackageBase.package_dir
* https://spack--51186.org.readthedocs.build/en/51186/package_api.html#spack.package.PackageBase.module
* https://spack--51186.org.readthedocs.build/en/51186/package_api.html#spack.package.PackageBase.namespace
* https://spack--51186.org.readthedocs.build/en/51186/package_api.html#spack.package.PackageBase.fullname
* https://spack--51186.org.readthedocs.build/en/51186/package_api.html#spack.package.PackageBase.fullnames
* https://spack--51186.org.readthedocs.build/en/51186/package_api.html#spack.package.PackageBase.name
* https://spack--51186.org.readthedocs.build/en/51186/package_api.html#spack.package.PackageBase.global_license_dir