### PR TITLE
docs: use not yet upstreamed changes to furo

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -2,7 +2,8 @@ sphinx==8.2.3
 sphinxcontrib-programoutput==0.18
 sphinx-copybutton==0.5.2
 sphinx_design==0.6.1
-furo==2025.7.19
+# fork of furo with a few changes that are not merged upstream
+git+https://github.com/haampie/furo.git@c1d161cb9e04b481ec3331db981aacfa132ecaa6#egg=furo
 python-levenshtein==0.27.1
 docutils==0.21.2
 pygments==2.19.2


### PR DESCRIPTION
Fetch the `furo` theme from a fork, namely the latest commit from
https://github.com/haampie/furo/tree/spack, which is basically
the same as `furo==2025.07.19` with the addition of 3 of my PRs
that were merged upstream, and one that was not merged:

* add `rel=nofollow` to the furo project page link, which may help with
  pagerank of our docs.

See https://github.com/pradyunsg/furo/compare/2025.07.19...haampie:furo:spack

