### PR TITLE
Includes: support git includes

### DIFF
--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -16,7 +16,7 @@ Spack allows you to include configuration files through ``include.yaml``.
 Using the ``include:`` heading results in pulling in external configuration information to be used by any Spack command.
 Paths to configuration files may reside on the local file system, be a URL to a remote file, or be paths associated with a ``git`` repository.
 
-Included configuration files are required *unless* they are explicitly optional or the entry's condition evaluates to ``false``.
+Included configuration files are required *unless* they are explicitly optional or the entry's condition evaluates to ``False``.
 Optional includes are specified with the ``optional`` clause and conditional ones with the ``when`` clause.
 
 .. hint::

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -78,7 +78,7 @@ The `branch`, `commit`, or `tag` to be checked out is required.
 A list of relative paths in which to find the configuration files is also required.
 Inclusion of the repository (and its paths) can be optional or conditional.
 
-For example, suppose we want to only include the configuration and packages files from the `spack/spack-configs <https://github.com/spack/spack-configs>`_ repository, specifically those from ``USC``.
+For example, suppose we only want to include the ``config.yaml`` and ``packages.yaml`` files from the `spack/spack-configs <https://github.com/spack/spack-configs>`_ repository's ``USC/config`` directory when using the ``centos7`` operating system.
 We would then configure the ``include.yaml`` file as follows:
 
 .. code-block:: yaml
@@ -86,8 +86,9 @@ We would then configure the ``include.yaml`` file as follows:
    include:
    - git: https://github.com/spack/spack-configs
      branch: main
+     when: os == "centos7"
      paths:
      - USC/config/config.yaml
      - USC/config/packages.yaml
 
-This would result in the ``main`` branch of the repository being cloned and the settings in the files integrated into Spack's configuration.
+If the condition is satisfied, then the ``main`` branch of the repository will be cloned and the settings for the two files integrated into Spack's configuration.

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -14,9 +14,25 @@ Include Settings (include.yaml)
 
 Spack allows you to include configuration files through ``include.yaml``.
 Using the ``include:`` heading results in pulling in external configuration information to be used by any Spack command.
+Paths to configuration files may reside on the local file system, be a URL to a remote file, or be paths associated with a ``git`` repository.
 
 Included configuration files are required *unless* they are explicitly optional or the entry's condition evaluates to ``false``.
 Optional includes are specified with the ``optional`` clause and conditional ones with the ``when`` clause.
+
+.. hint::
+
+   The same conditions and variables in :ref:`Spec List References <spec-list-references>` can be used for conditional activation in the ``when`` clauses.
+
+.. warning::
+
+   Recursive includes are not currently processed in a breadth-first manner, so the value of a configuration option that is altered by multiple included files may not be what you expect.
+   This will be addressed in a future update.
+
+Local paths
+~~~~~~~~~~~
+
+Local configuration files can be specified by path or by their parent directory.
+Paths may be absolute, relative (to the configuration file including the path), or specified as URLs.
 For example,
 
 .. code-block:: yaml
@@ -28,30 +44,50 @@ For example,
    - path: /path/to/os-specific/config-dir
      when: os == "ventura"
 
-shows all three.
-The first entry, ``/path/to/a/required/config.yaml``, indicates that the included ``config.yaml`` file is required (so must exist).
+illustrates required, optional, and conditional includes, respectively.
+The first entry only provides a local path, ``/path/to/a/required/config.yaml``, meaning that the file is required (so must exist).
 Use of ``optional: true`` for ``/path/to/$os/$target/config`` means the path is only included if it exists.
 The condition ``os == "ventura"`` in the ``when`` clause for ``/path/to/os-specific/config-dir`` means the path is only included when the operating system (``os``) is ``ventura``.
 
-The same conditions and variables in :ref:`Spec List References <spec-list-references>` can be used for conditional activation in the ``when`` clauses.
+Remote file URLs
+~~~~~~~~~~~~~~~~
 
-Included files can be specified by path or by their parent directory.
-Paths may be absolute, relative to the including configuration file, or specified as URLs.
-Only the ``file``, ``ftp``, ``http``, and ``https`` schemes are supported.
+Only the ``file``, ``ftp``, ``http``, and ``https`` protocols (or schemes) are supported for remote file URLs.
 Spack-specific, environment, and user path variables can be used.
 (See :ref:`config-file-variables` for more information.)
 
-A ``sha256`` is required for remote file URLs and must be specified as follows:
+A ``sha256`` is required and must be specified as follows:
 
 .. code-block:: yaml
 
    include:
-   - path: https://github.com/path/to/raw/config/compilers.yaml
+   - path: https://github.com/path/to/raw/config/config.yaml
      sha256: 26e871804a92cd07bb3d611b31b4156ae93d35b6a6d6e0ef3a67871fcb1d258b
 
-Additionally, remote file URLs must link to the **raw** form of the file's contents (e.g., `GitHub <https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#viewing-or-copying-the-raw-file-content>`_ or `GitLab <https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository>`_).
+The ``config.yaml`` file would be cached locally to a special include location and its contents included in Spack's configuration.
 
 .. warning::
 
-   Recursive includes are not currently processed in a breadth-first manner, so the value of a configuration option that is altered by multiple included files may not be what you expect.
-   This will be addressed in a future update.
+   Remote file URLs must link to the **raw** form of the file's contents (e.g., `GitHub <https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#viewing-or-copying-the-raw-file-content>`_ or `GitLab <https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository>`_).
+
+``git`` repository files
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can also include configuration files from a ``git`` repository.
+The `branch`, `commit`, or `tag` to be checked out is required.
+A list of relative paths in which to find the configuration files is also required.
+Inclusion of the repository (and its paths) can be optional or conditional.
+
+For example, suppose we want to only include the configuration and packages files from the `spack/spack-configs <https://github.com/spack/spack-configs>`_ repository, specifically those from ``USC``.
+We would then configure the ``include.yaml`` file as follows:
+
+.. code-block:: yaml
+
+   include:
+   - git: https://github.com/spack/spack-configs
+     branch: main
+     paths:
+     - USC/config/config.yaml
+     - USC/config/packages.yaml
+
+This would result in the ``main`` branch of the repository being cloned and the settings in the files integrated into Spack's configuration.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -841,6 +841,7 @@ def override(
 #: as optional.
 class OptionalInclude:
     """Base properties for all includes."""
+
     when: str
     optional: bool
 
@@ -909,7 +910,9 @@ def included_path(entry: Union[str, dict]) -> Union[IncludePath, GitIncludePaths
     return GitIncludePaths(entry)
 
 
-def _single_include_path_scope(include: IncludePath, parent_scope: ConfigScope) -> Optional[ConfigScope]:
+def _single_include_path_scope(
+    include: IncludePath, parent_scope: ConfigScope
+) -> Optional[ConfigScope]:
     """Instantiate an appropriate configuration scope for the given path.
 
     Args:
@@ -964,12 +967,14 @@ def _single_include_path_scope(include: IncludePath, parent_scope: ConfigScope) 
     return None
 
 
-def _git_include_paths_scopes(include: GitIncludePaths, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
+def _git_include_paths_scopes(
+    include: GitIncludePaths, parent_scope: ConfigScope
+) -> Optional[List[ConfigScope]]:
     """Instantiate the appropriate configuration scopes for the given git include path(s).
 
     Args:
         include: optional include path
-        parent_scoppe: including scope
+        parent_scope: including scope
 
     Returns: list of configuration scopes
 
@@ -981,46 +986,50 @@ def _git_include_paths_scopes(include: GitIncludePaths, parent_scope: ConfigScop
     # circular dependencies
     import spack.spec
 
-    # TODO/TLD: Change this to process the list in include.paths
-    config_path = rfc_util.local_path(include.path, include.sha256, _include_cache_location)
-    if not config_path:
-        raise ConfigFileError(f"Unable to fetch remote configuration from {include.path}")
+    scopes = []
+    for path in include.paths:
+        # TODO/TLD: Change this to properly handle the fetch to local
+        config_path = rfc_util.local_path(path, include.sha256, _include_cache_location)
+        if not config_path:
+            raise ConfigFileError(f"Unable to fetch remote configuration from {path}")
 
-    # Try to use the relative path to create the included scope name
-    parent_path = getattr(parent_scope, "path", None)
-    if parent_path and str(parent_path) == os.path.commonprefix([parent_path, config_path]):
-        included_name = os.path.relpath(config_path, parent_path)
-    else:
-        included_name = config_path
+        # Try to use the relative path to create the included scope name
+        parent_path = getattr(parent_scope, "path", None)
+        if parent_path and str(parent_path) == os.path.commonprefix([parent_path, config_path]):
+            included_name = os.path.relpath(config_path, parent_path)
+        else:
+            included_name = config_path
 
-    if sys.platform == "win32":
-        # Clean windows path for use in config name that looks nicer
-        # ie. The path: C:\\some\\path\\to\\a\\file
-        # becomes C/some/path/to/a/file
-        included_name = included_name.replace("\\", "/")
-        included_name = included_name.replace(":", "")
+        if sys.platform == "win32":
+            # Clean windows path for use in config name that looks nicer
+            # ie. The path: C:\\some\\path\\to\\a\\file
+            # becomes C/some/path/to/a/file
+            included_name = included_name.replace("\\", "/")
+            included_name = included_name.replace(":", "")
 
-    # TODO/TBD: We don't support directory include scopes anymore
-    if os.path.isdir(config_path):
-        # directories are treated as regular ConfigScopes
-        config_name = f"{parent_scope.name}:{included_name}"
-        tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
-        return [DirectoryConfigScope(config_name, config_path)]
+        # TODO/TBD: We don't support directory include scopes anymore
+        if os.path.isdir(config_path):
+            # directories are treated as regular ConfigScopes
+            config_name = f"{parent_scope.name}:{included_name}"
+            tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
+            scopes.append(DirectoryConfigScope(config_name, config_path))
 
-    if os.path.exists(config_path):
-        # files are assumed to be SingleFileScopes
-        config_name = f"{parent_scope.name}:{included_name}"
-        tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
-        return [SingleFileScope(config_name, config_path, spack.schema.merged.schema)]
+        if os.path.exists(config_path):
+            # files are assumed to be SingleFileScopes
+            config_name = f"{parent_scope.name}:{included_name}"
+            tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
+            scopes.append(SingleFileScope(config_name, config_path, spack.schema.merged.schema))
 
-    if not include.optional:
-        path = f" at ({config_path})" if config_path != include.path else ""
-        raise ValueError(f"Required path ({include.path}) does not exist{path}")
+        if not include.optional:
+            include_path = f" at ({config_path})" if config_path != path else ""
+            raise ValueError(f"Required path ({path}) does not exist{include_path}")
 
     return []
 
 
-def include_path_scope(include: Union[IncludePath, GitIncludePaths], parent_scope: ConfigScope) -> Optional[ConfigScope]:
+def include_path_scope(
+    include: Union[IncludePath, GitIncludePaths], parent_scope: ConfigScope
+) -> Optional[ConfigScope]:
     """Instantiate an appropriate configuration scopes for the given paths.
 
     Args:
@@ -1039,11 +1048,11 @@ def include_path_scope(include: Union[IncludePath, GitIncludePaths], parent_scop
 
     if (not include.when) or spack.spec.eval_conditional(include.when):
         if isinstance(include, IncludePath):
-            #return [_single_include_path_scope(include, parent_scope)]
+            # return [_single_include_path_scope(include, parent_scope)]
             return _single_include_path_scope(include, parent_scope)
 
         if isinstance(include, GitIncludePaths):
-            #return _git_include_paths_scopes(include, parent_scope)
+            # return _git_include_paths_scopes(include, parent_scope)
             return _git_include_paths_scopes(include, parent_scope)[0]
 
     return None

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -151,18 +151,21 @@ class ConfigScope:
             includes = self.get_section("include")
             if includes:
                 include_paths = [included_path(data) for data in includes["include"]]
-                for path in include_paths:
-                    included_scope = include_path_scope(path, self)
-                    if not included_scope:
+                for include in include_paths:
+                    included_scopes = include.scopes(self)
+                    if not included_scopes:
                         continue
 
                     # Do not include duplicate scopes
-                    if any([included_scope.name == scope.name for scope in self._included_scopes]):
-                        tty.warn(f"Ignoring duplicate included scope: {included_scope.name}")
-                        continue
+                    for included_scope in included_scopes:
+                        if any(
+                            [included_scope.name == scope.name for scope in self._included_scopes]
+                        ):
+                            tty.warn(f"Ignoring duplicate included scope: {included_scope.name}")
+                            continue
 
-                    if included_scope not in self._included_scopes:
-                        self._included_scopes.append(included_scope)
+                        if included_scope not in self._included_scopes:
+                            self._included_scopes.append(included_scope)
 
         return self._included_scopes
 
@@ -849,6 +852,70 @@ class OptionalInclude:
         self.when = entry.get("when", "")
         self.optional = entry.get("optional", False)
 
+    def _scope(self, config_path: str, parent_scope: ConfigScope) -> Optional[ConfigScope]:
+        """Instantiate a configuration scope for the configuration path.
+
+        Args:
+            config_path: configuration path
+            parent_scope: including scope
+
+        Returns: configuration scopes
+
+        Raises:
+            ValueError: the required configuration path does not exist
+        """
+        # Try to use the relative path to create the included scope name
+        parent_path = getattr(parent_scope, "path", None)
+        if parent_path and str(parent_path) == os.path.commonprefix([parent_path, config_path]):
+            included_name = os.path.relpath(config_path, parent_path)
+        else:
+            included_name = config_path
+
+        if sys.platform == "win32":
+            # Clean windows path for use in config name that looks nicer
+            # ie. The path: C:\\some\\path\\to\\a\\file
+            # becomes C/some/path/to/a/file
+            included_name = included_name.replace("\\", "/")
+            included_name = included_name.replace(":", "")
+
+        if os.path.isdir(config_path):
+            # directories are treated as regular ConfigScopes
+            config_name = f"{parent_scope.name}:{included_name}"
+            tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
+            return DirectoryConfigScope(config_name, config_path)
+
+        if os.path.exists(config_path):
+            # files are assumed to be SingleFileScopes
+            config_name = f"{parent_scope.name}:{included_name}"
+            tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
+            return SingleFileScope(config_name, config_path, spack.schema.merged.schema)
+
+        if not self.optional:
+            raise ValueError(f"Required path ({config_path}) does not exist")
+
+        return None
+
+    @property
+    def satisfied(self):
+        # circular dependencies
+        import spack.spec
+
+        return (not self.when) or spack.spec.eval_conditional(self.when)
+
+    def scopes(self, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
+        """Instantiate configuration scopes.
+
+        Args:
+            parent_scope: including scope
+
+        Returns: configuration scopes IF the when condition is satisfied;
+            otherwise, ``None``.
+
+        Raises:
+            ValueError: the required configuration path does not exist
+        """
+        raise NotImplementedError("must be implemented in derived classes")
+
 
 class IncludePath(OptionalInclude):
     path: str
@@ -864,6 +931,29 @@ class IncludePath(OptionalInclude):
             f"IncludePath({self.path}, sha256={self.sha56}, "
             f"when={self.when}, optional={self.optional})"
         )
+
+    def scopes(self, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
+        """Instantiate a configuration scope for the included path.
+
+        Args:
+            parent_scope: including scope
+
+        Returns: configuration scopes IF the when condition is satisfied;
+            otherwise, ``None``.
+
+        Raises:
+            ConfigFileError: unable to access remote configuration file
+            ValueError: included path has an unsupported URL scheme, is required
+                but does not exist; configuration stage directory argument is missing
+        """
+        if not self.satisfied:
+            return None
+
+        config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location)
+        if not config_path:
+            raise ConfigFileError(f"Unable to fetch remote configuration from {self.path}")
+
+        return [self._scope(config_path, parent_scope)]
 
 
 class GitIncludePaths(OptionalInclude):
@@ -897,6 +987,33 @@ class GitIncludePaths(OptionalInclude):
             f"{identifier}, when={self.when}, optional={self.optional})"
         )
 
+    def scopes(self, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
+        """Instantiate configuration scopes for the included paths.
+
+        Args:
+            parent_scope: including scope
+
+        Returns: configuration scopes IF the when condition is satisfied;
+            otherwise, ``None``.
+
+        Raises:
+            ConfigFileError: unable to access remote configuration file(s)
+            ValueError: included path has an unsupported URL scheme, is required
+                but does not exist; configuration stage directory argument is missing
+        """
+        if not self.satisfied:
+            return None
+
+        scopes = []
+        for path in include.paths:
+            # TODO: Change this to fetch as is done for Git repositories
+            config_path = None
+            if not config_path:
+                raise ConfigFileError(f"Unable to fetch remote configuration from {path}")
+            scopes.append(self._scope(config_path, parent_scope))
+
+        return scopes
+
 
 def included_path(entry: Union[str, dict]) -> Union[IncludePath, GitIncludePaths]:
     """Convert the included paths entry into the appropriate optional include.
@@ -913,154 +1030,6 @@ def included_path(entry: Union[str, dict]) -> Union[IncludePath, GitIncludePaths
         return IncludePath(entry)
 
     return GitIncludePaths(entry)
-
-
-def _single_include_path_scope(
-    include: IncludePath, parent_scope: ConfigScope
-) -> Optional[ConfigScope]:
-    """Instantiate an appropriate configuration scope for the given path.
-
-    Args:
-        include: optional include path
-        parent_scope: including scope
-
-    Returns: configuration scope
-
-    Raises:
-        ValueError: included path has an unsupported URL scheme, is required
-            but does not exist; configuration stage directory argument is missing
-        ConfigFileError: unable to access remote configuration file(s)
-    """
-    # circular dependencies
-    import spack.spec
-
-    config_path = rfc_util.local_path(include.path, include.sha256, _include_cache_location)
-    if not config_path:
-        raise ConfigFileError(f"Unable to fetch remote configuration from {include.path}")
-
-    # Try to use the relative path to create the included scope name
-    parent_path = getattr(parent_scope, "path", None)
-    if parent_path and str(parent_path) == os.path.commonprefix([parent_path, config_path]):
-        included_name = os.path.relpath(config_path, parent_path)
-    else:
-        included_name = config_path
-
-    if sys.platform == "win32":
-        # Clean windows path for use in config name that looks nicer
-        # ie. The path: C:\\some\\path\\to\\a\\file
-        # becomes C/some/path/to/a/file
-        included_name = included_name.replace("\\", "/")
-        included_name = included_name.replace(":", "")
-
-    # TODO/TBD: We don't support directory include scopes anymore
-    if os.path.isdir(config_path):
-        # directories are treated as regular ConfigScopes
-        config_name = f"{parent_scope.name}:{included_name}"
-        tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
-        return DirectoryConfigScope(config_name, config_path)
-
-    if os.path.exists(config_path):
-        # files are assumed to be SingleFileScopes
-        config_name = f"{parent_scope.name}:{included_name}"
-        tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
-        return SingleFileScope(config_name, config_path, spack.schema.merged.schema)
-
-    if not include.optional:
-        path = f" at ({config_path})" if config_path != include.path else ""
-        raise ValueError(f"Required path ({include.path}) does not exist{path}")
-
-    return None
-
-
-def _git_include_paths_scopes(
-    include: GitIncludePaths, parent_scope: ConfigScope
-) -> Optional[List[ConfigScope]]:
-    """Instantiate the appropriate configuration scopes for the given git include path(s).
-
-    Args:
-        include: optional include path
-        parent_scope: including scope
-
-    Returns: list of configuration scopes
-
-    Raises:
-        ValueError: included path has an unsupported URL scheme, is required
-            but does not exist; configuration stage directory argument is missing
-        ConfigFileError: unable to access remote configuration file(s)
-    """
-    # circular dependencies
-    import spack.spec
-
-    scopes = []
-    for path in include.paths:
-        # TODO/TLD: Change this to properly handle the fetch to local
-        config_path = rfc_util.local_path(path, include.sha256, _include_cache_location)
-        if not config_path:
-            raise ConfigFileError(f"Unable to fetch remote configuration from {path}")
-
-        # Try to use the relative path to create the included scope name
-        parent_path = getattr(parent_scope, "path", None)
-        if parent_path and str(parent_path) == os.path.commonprefix([parent_path, config_path]):
-            included_name = os.path.relpath(config_path, parent_path)
-        else:
-            included_name = config_path
-
-        if sys.platform == "win32":
-            # Clean windows path for use in config name that looks nicer
-            # ie. The path: C:\\some\\path\\to\\a\\file
-            # becomes C/some/path/to/a/file
-            included_name = included_name.replace("\\", "/")
-            included_name = included_name.replace(":", "")
-
-        # TODO/TBD: We don't support directory include scopes anymore
-        if os.path.isdir(config_path):
-            # directories are treated as regular ConfigScopes
-            config_name = f"{parent_scope.name}:{included_name}"
-            tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
-            scopes.append(DirectoryConfigScope(config_name, config_path))
-
-        if os.path.exists(config_path):
-            # files are assumed to be SingleFileScopes
-            config_name = f"{parent_scope.name}:{included_name}"
-            tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
-            scopes.append(SingleFileScope(config_name, config_path, spack.schema.merged.schema))
-
-        if not include.optional:
-            include_path = f" at ({config_path})" if config_path != path else ""
-            raise ValueError(f"Required path ({path}) does not exist{include_path}")
-
-    return []
-
-
-def include_path_scope(
-    include: Union[IncludePath, GitIncludePaths], parent_scope: ConfigScope
-) -> Optional[ConfigScope]:
-    """Instantiate an appropriate configuration scopes for the given paths.
-
-    Args:
-        include: optional include path(s)
-        parent_scope: including scope
-
-    Returns: configuration scopes
-
-    Raises:
-        ValueError: included path has an unsupported URL scheme, is required
-            but does not exist; configuration stage directory argument is missing
-        ConfigFileError: unable to access remote configuration file(s)
-    """
-    # circular dependencies
-    import spack.spec
-
-    if (not include.when) or spack.spec.eval_conditional(include.when):
-        if isinstance(include, IncludePath):
-            # return [_single_include_path_scope(include, parent_scope)]
-            return _single_include_path_scope(include, parent_scope)
-
-        if isinstance(include, GitIncludePaths):
-            # return _git_include_paths_scopes(include, parent_scope)
-            return _git_include_paths_scopes(include, parent_scope)[0]
-
-    return None
 
 
 def config_paths_from_entry_points() -> List[Tuple[str, str]]:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -31,6 +31,7 @@ import copy
 import functools
 import os
 import os.path
+import pathlib
 import re
 import sys
 from collections import defaultdict
@@ -936,7 +937,7 @@ class IncludePath(OptionalInclude):
     def __repr__(self):
         return (
             f"IncludePath({self.path}, sha256={self.sha256}, "
-            f"when={self.when}, optional={self.optional})"
+            f"when='{self.when}', optional={self.optional})"
         )
 
     def scopes(self, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
@@ -954,7 +955,7 @@ class IncludePath(OptionalInclude):
                 but does not exist; configuration stage directory argument is missing
         """
         if not self.satisfied:
-            tty.debug(f"Include condition '{self.when}' is not satisfied")
+            tty.debug(f"Include condition is not satisfied in {self}")
             return None
 
         if self._scopes is not None:
@@ -962,14 +963,14 @@ class IncludePath(OptionalInclude):
             return self._scopes
 
         config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location)
-        if not config_path:
-            raise ConfigFileError(f"Unable to fetch remote configuration from {self.path}")
+        assert config_path
 
         self.destination = config_path
 
         scope = self._scope(self.destination, parent_scope)
         if scope is not None:
             self._scopes = [scope]
+
         return self._scopes
 
 
@@ -992,12 +993,12 @@ class GitIncludePaths(OptionalInclude):
 
         if not self.branch and not self.commit and not self.tag:
             raise spack.error.ConfigError(
-                "Git include paths must specify one or more of: branch, commit, tag"
+                "Git include paths ({self}) must specify one or more of: branch, commit, tag"
             )
 
         if not self.paths:
             raise spack.error.ConfigError(
-                "Git include paths must include one or more relative paths"
+                "Git include paths ({self}) must include one or more relative paths"
             )
 
     def __repr__(self):
@@ -1008,24 +1009,27 @@ class GitIncludePaths(OptionalInclude):
 
         return (
             f"GitIncludePaths({self.repo}, paths={self.paths}, "
-            f"{identifier}, when={self.when}, optional={self.optional})"
+            f"{identifier}, when='{self.when}', optional={self.optional})"
         )
+
+    def _destination(self):
+        dir_name = spack.util.hash.b32_hash(self.repo)[-7:]
+        return os.path.join(_include_cache_location(), dir_name)
 
     def _clone(self) -> Optional[str]:
         """Clone the repository."""
         if self.fetched:
-            tty.debug(f"Repository already cloned to {self.destination}")
+            tty.debug(f"Repository ({self.repo}) already cloned to {self.destination}")
             return self.destination
 
-        dir_name = spack.util.hash.b32_hash(self.repo)[-7:]
-        destination = os.path.join(_include_cache_location(), dir_name)
+        destination = self._destination()
         with filesystem.working_dir(destination, create=True):
             if not os.path.exists(".git"):
                 try:
                     spack.util.git.init_git_repo(self.repo)
                 except spack.util.executable.ProcessError as e:
                     raise spack.error.ConfigError(
-                        f"Unable to initialize repository '{self.repo}' under {destination}: {e}"
+                        f"Unable to initialize repository ({self.repo}) under {destination}: {e}"
                     )
 
             try:
@@ -1044,10 +1048,12 @@ class GitIncludePaths(OptionalInclude):
                         remote = "origin"
                     spack.util.git.pull_checkout_branch(self.branch, remote=remote)
                 else:
-                    raise spack.error.ConfigError(f"Unsupported options in {self}")
+                    raise spack.error.ConfigError(f"Missing or unsupported options in {self}")
 
             except spack.util.executable.ProcessError as e:
-                raise spack.error.ConfigError(f"Unable to check out {self} in {destination}: {e}")
+                raise spack.error.ConfigError(
+                    f"Unable to check out repository ({self}) in {destination}: {e}"
+                )
 
             # only set the destination on successful clone/checkout
             self.destination = destination
@@ -1072,7 +1078,7 @@ class GitIncludePaths(OptionalInclude):
                 but does not exist; configuration stage directory argument is missing
         """
         if not self.satisfied:
-            tty.debug(f"Include conditions '{self.when}' are not satisfied")
+            tty.debug(f"Include condition is not satisfied in {self}")
             return None
 
         if self._scopes is not None:
@@ -1081,7 +1087,7 @@ class GitIncludePaths(OptionalInclude):
 
         destination = self._clone()
         if destination is None:
-            raise ConfigFileError(f"Unable to cache the include: {self}")
+            raise spack.error.ConfigError(f"Unable to cache the include: {self}")
 
         scopes: List[ConfigScope] = []
         for relative_path in self.paths:
@@ -1096,7 +1102,7 @@ class GitIncludePaths(OptionalInclude):
         return self._scopes
 
 
-def included_path(entry: Union[str, dict]) -> Union[IncludePath, GitIncludePaths]:
+def included_path(entry: Union[str, pathlib.Path, dict]) -> Union[IncludePath, GitIncludePaths]:
     """Convert the included paths entry into the appropriate optional include.
 
     Args:
@@ -1104,8 +1110,8 @@ def included_path(entry: Union[str, dict]) -> Union[IncludePath, GitIncludePaths
 
     Returns: converted entry, where an empty ``when`` means the path is not conditionally included
     """
-    if isinstance(entry, str):
-        return IncludePath({"path": entry})
+    if isinstance(entry, (str, pathlib.Path)):
+        return IncludePath({"path": str(entry)})
 
     if entry.get("path", ""):
         return IncludePath(entry)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -60,6 +60,7 @@ import spack.schema.repos
 import spack.schema.toolchains
 import spack.schema.upstreams
 import spack.schema.view
+import spack.util.executable
 import spack.util.git
 import spack.util.hash
 import spack.util.remote_file_cache as rfc_util
@@ -934,7 +935,7 @@ class IncludePath(OptionalInclude):
 
     def __repr__(self):
         return (
-            f"IncludePath({self.path}, sha256={self.sha56}, "
+            f"IncludePath({self.path}, sha256={self.sha256}, "
             f"when={self.when}, optional={self.optional})"
         )
 
@@ -953,9 +954,11 @@ class IncludePath(OptionalInclude):
                 but does not exist; configuration stage directory argument is missing
         """
         if not self.satisfied:
+            tty.debug(f"Include condition '{self.when}' is not satisfied")
             return None
 
         if self._scopes is not None:
+            tty.debug(f"Using existing scopes: {[s.name for s in self._scopes]}")
             return self._scopes
 
         config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location)
@@ -989,7 +992,12 @@ class GitIncludePaths(OptionalInclude):
 
         if not self.branch and not self.commit and not self.tag:
             raise spack.error.ConfigError(
-                "Git include paths require one or more of: branch, commit, tag"
+                "Git include paths must specify one or more of: branch, commit, tag"
+            )
+
+        if not self.paths:
+            raise spack.error.ConfigError(
+                "Git include paths must include one or more relative paths"
             )
 
     def __repr__(self):
@@ -1003,27 +1011,47 @@ class GitIncludePaths(OptionalInclude):
             f"{identifier}, when={self.when}, optional={self.optional})"
         )
 
-    def _clone(self) -> None:
+    def _clone(self) -> Optional[str]:
         """Clone the repository."""
-        dir_name = spack.util.hash.b32_hash(self.repo)[-7:]
-        destination = os.path.join(_include_cache_location, dir_name)
-        try:
-            with fs.working_dir(destination, create=True):
-                if self.fetched:
-                    return
+        if self.fetched:
+            tty.debug(f"Repository already cloned to {self.destination}")
+            return self.destination
 
-                spack.util.git.init_git_repo(self.repo)
+        dir_name = spack.util.hash.b32_hash(self.repo)[-7:]
+        destination = os.path.join(_include_cache_location(), dir_name)
+        with filesystem.working_dir(destination, create=True):
+            if not os.path.exists(".git"):
+                try:
+                    spack.util.git.init_git_repo(self.repo)
+                except spack.util.executable.ProcessError as e:
+                    raise spack.error.ConfigError(
+                        f"Unable to initialize repository '{self.repo}' under {destination}: {e}"
+                    )
+
+            try:
                 if self.commit:
                     spack.util.git.pull_checkout_commit(self.commit)
                 elif self.tag:
-                    spack.util.git.pull_checkout_tag(self.tag, depth=2)
+                    spack.util.git.pull_checkout_tag(self.tag)
                 elif self.branch:
-                    spack.util.git.pull_checkout_branch(self.branch, depth=2)
+                    # if the branch already exists we should use the
+                    # previously configured remote
+                    try:
+                        git = spack.util.git.git(required=True)
+                        output = git("config", f"branch.{self.branch}.remote", output=str)
+                        remote = output.strip()
+                    except spack.util.executable.ProcessError:
+                        remote = "origin"
+                    spack.util.git.pull_checkout_branch(self.branch, remote=remote)
+                else:
+                    raise spack.error.ConfigError(f"Unsupported options in {self}")
 
+            except spack.util.executable.ProcessError as e:
+                raise spack.error.ConfigError(f"Unable to check out {self} in {destination}: {e}")
+
+            # only set the destination on successful clone/checkout
             self.destination = destination
-        except spack.util.executable.ProcessError:
-            self.error = f"Failed to clone repository {self.repo}"
-            return
+            return self.destination
 
     @property
     def fetched(self):
@@ -1044,20 +1072,25 @@ class GitIncludePaths(OptionalInclude):
                 but does not exist; configuration stage directory argument is missing
         """
         if not self.satisfied:
+            tty.debug(f"Include conditions '{self.when}' are not satisfied")
             return None
 
         if self._scopes is not None:
+            tty.debug(f"Using existing scopes: {[s.name for s in self._scopes]}")
             return self._scopes
 
+        destination = self._clone()
+        if destination is None:
+            raise ConfigFileError(f"Unable to cache the include: {self}")
+
         scopes: List[ConfigScope] = []
-        for path in self.paths:
-            config_path = self._clone()
-            if config_path is not None:
-                raise ConfigFileError(f"Unable to fetch remote configuration from {path}")
+        for relative_path in self.paths:
+            config_path = os.path.join(destination, relative_path)
             scope = self._scope(config_path, parent_scope)
             if scope is not None:
                 scopes.append(scope)
 
+        # cache the scopes if successfully able to process all of them
         if scopes:
             self._scopes = scopes
         return self._scopes

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -905,7 +905,7 @@ class OptionalInclude:
 
         return None
 
-    def satisfied(self):
+    def evaluate_condition(self) -> bool:
         # circular dependencies
         import spack.spec
 
@@ -957,7 +957,7 @@ class IncludePath(OptionalInclude):
             ValueError: included path has an unsupported URL scheme, is required
                 but does not exist; configuration stage directory argument is missing
         """
-        if not self.satisfied():
+        if not self.evaluate_condition():
             tty.debug(f"Include condition is not satisfied in {self}")
             return None
 
@@ -1089,7 +1089,7 @@ class GitIncludePaths(OptionalInclude):
             ValueError: included path has an unsupported URL scheme, is required
                 but does not exist; configuration stage directory argument is missing
         """
-        if not self.satisfied():
+        if not self.evaluate_condition():
             tty.debug(f"Include condition is not satisfied in {self}")
             return None
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1032,7 +1032,7 @@ class GitIncludePaths(OptionalInclude):
 
     def _clone(self) -> Optional[str]:
         """Clone the repository."""
-        if self.fetched:
+        if self.fetched():
             tty.debug(f"Repository ({self.repo}) already cloned to {self.destination}")
             return self.destination
 
@@ -1073,7 +1073,6 @@ class GitIncludePaths(OptionalInclude):
             self.destination = destination
             return self.destination
 
-    @property
     def fetched(self):
         return self.destination is not None and os.path.join(self.destination, ".git")
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -34,7 +34,7 @@ import os.path
 import re
 import sys
 from collections import defaultdict
-from typing import Any, Callable, Dict, Generator, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 from spack.vendor import jsonschema
 
@@ -60,6 +60,8 @@ import spack.schema.repos
 import spack.schema.toolchains
 import spack.schema.upstreams
 import spack.schema.view
+import spack.util.git
+import spack.util.hash
 import spack.util.remote_file_cache as rfc_util
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
@@ -953,7 +955,7 @@ class IncludePath(OptionalInclude):
         if not self.satisfied:
             return None
 
-        if self._scopes:
+        if self._scopes is not None:
             return self._scopes
 
         config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location)
@@ -961,7 +963,10 @@ class IncludePath(OptionalInclude):
             raise ConfigFileError(f"Unable to fetch remote configuration from {self.path}")
 
         self.destination = config_path
-        self._scopes = [self._scope(self.destination, parent_scope)]
+
+        scope = self._scope(self.destination, parent_scope)
+        if scope is not None:
+            self._scopes = [scope]
         return self._scopes
 
 
@@ -998,6 +1003,32 @@ class GitIncludePaths(OptionalInclude):
             f"{identifier}, when={self.when}, optional={self.optional})"
         )
 
+    def _clone(self) -> None:
+        """Clone the repository."""
+        dir_name = spack.util.hash.b32_hash(self.repo)[-7:]
+        destination = os.path.join(_include_cache_location, dir_name)
+        try:
+            with fs.working_dir(destination, create=True):
+                if self.fetched:
+                    return
+
+                spack.util.git.init_git_repo(self.repo)
+                if self.commit:
+                    spack.util.git.pull_checkout_commit(self.commit)
+                elif self.tag:
+                    spack.util.git.pull_checkout_tag(self.tag, depth=2)
+                elif self.branch:
+                    spack.util.git.pull_checkout_branch(self.branch, depth=2)
+
+            self.destination = destination
+        except spack.util.executable.ProcessError:
+            self.error = f"Failed to clone repository {self.repo}"
+            return
+
+    @property
+    def fetched(self):
+        return self.destination is not None and os.path.join(self.destination, ".git")
+
     def scopes(self, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
         """Instantiate configuration scopes for the included paths.
 
@@ -1015,16 +1046,17 @@ class GitIncludePaths(OptionalInclude):
         if not self.satisfied:
             return None
 
-        if self._scopes:
+        if self._scopes is not None:
             return self._scopes
 
-        scopes = []
-        for path in include.paths:
-            # TODO: Change this to fetch as is done for Git repositories
-            config_path = None
-            if not config_path:
+        scopes: List[ConfigScope] = []
+        for path in self.paths:
+            config_path = self._clone()
+            if config_path is not None:
                 raise ConfigFileError(f"Unable to fetch remote configuration from {path}")
-            scopes.append(self._scope(config_path, parent_scope))
+            scope = self._scope(config_path, parent_scope)
+            if scope is not None:
+                scopes.append(scope)
 
         if scopes:
             self._scopes = scopes

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -839,15 +839,61 @@ def override(
 #: Class for the relevance of an optional path conditioned on a limited
 #: python code that evaluates to a boolean and or explicit specification
 #: as optional.
-class IncludePath(NamedTuple):
-    path: str
+class OptionalInclude:
+    """Base properties for all includes."""
     when: str
-    sha256: str
     optional: bool
 
+    def __init__(self, entry: dict):
+        self.when = entry.get("when", "")
+        self.optional = entry.get("optional", False)
 
-def included_path(entry: Union[str, dict]) -> IncludePath:
-    """Convert the included path entry into an IncludePath.
+
+class IncludePath(OptionalInclude):
+    path: str
+    sha256: str
+
+    def __init__(self, entry: dict):
+        super().__init__(entry)
+        self.path = entry.get("path", "")
+        self.sha256 = entry.get("sha256", "")
+
+    def __repr__(self):
+        return (
+            f"IncludePath({self.path}, sha256={self.sha56}, "
+            f"when={self.when}, optional={self.optional})"
+        )
+
+
+class GitIncludePaths(OptionalInclude):
+    repo: str
+    branch: str
+    commit: str
+    tag: str
+    paths: List[str]
+
+    def __init__(self, entry: dict):
+        super().__init__(entry)
+        self.repo = entry.get("git", "")
+        self.branch = entry.get("branch", "")
+        self.commit = entry.get("commit", "")
+        self.tag = entry.get("tag", "")
+        self.paths = entry.get("paths", [])
+
+    def __repr__(self):
+        if self.branch:
+            identifier = f"branch={self.branch}"
+        else:
+            identifier = f"commit={self.commit}, tag={self.tag}"
+
+        return (
+            f"GitIncludePaths({self.repo}, paths={self.paths}, "
+            f"{identifier}, when={self.when}, optional={self.optional})"
+        )
+
+
+def included_path(entry: Union[str, dict]) -> Union[IncludePath, GitIncludePaths]:
+    """Convert the included paths entry into the appropriate optional include.
 
     Args:
         entry: include configuration entry
@@ -855,21 +901,20 @@ def included_path(entry: Union[str, dict]) -> IncludePath:
     Returns: converted entry, where an empty ``when`` means the path is not conditionally included
     """
     if isinstance(entry, str):
-        return IncludePath(path=entry, sha256="", when="", optional=False)
+        return IncludePath({"path": entry})
 
-    path = entry["path"]
-    sha256 = entry.get("sha256", "")
-    when = entry.get("when", "")
-    optional = entry.get("optional", False)
-    return IncludePath(path=path, sha256=sha256, when=when, optional=optional)
+    if entry.get("path", ""):
+        return IncludePath(entry)
+
+    return GitIncludePaths(entry)
 
 
-def include_path_scope(include: IncludePath, parent_scope: ConfigScope) -> Optional[ConfigScope]:
+def _single_include_path_scope(include: IncludePath, parent_scope: ConfigScope) -> Optional[ConfigScope]:
     """Instantiate an appropriate configuration scope for the given path.
 
     Args:
         include: optional include path
-        parent_name: name of including scope
+        parent_scope: including scope
 
     Returns: configuration scope
 
@@ -881,40 +926,125 @@ def include_path_scope(include: IncludePath, parent_scope: ConfigScope) -> Optio
     # circular dependencies
     import spack.spec
 
+    config_path = rfc_util.local_path(include.path, include.sha256, _include_cache_location)
+    if not config_path:
+        raise ConfigFileError(f"Unable to fetch remote configuration from {include.path}")
+
+    # Try to use the relative path to create the included scope name
+    parent_path = getattr(parent_scope, "path", None)
+    if parent_path and str(parent_path) == os.path.commonprefix([parent_path, config_path]):
+        included_name = os.path.relpath(config_path, parent_path)
+    else:
+        included_name = config_path
+
+    if sys.platform == "win32":
+        # Clean windows path for use in config name that looks nicer
+        # ie. The path: C:\\some\\path\\to\\a\\file
+        # becomes C/some/path/to/a/file
+        included_name = included_name.replace("\\", "/")
+        included_name = included_name.replace(":", "")
+
+    # TODO/TBD: We don't support directory include scopes anymore
+    if os.path.isdir(config_path):
+        # directories are treated as regular ConfigScopes
+        config_name = f"{parent_scope.name}:{included_name}"
+        tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
+        return DirectoryConfigScope(config_name, config_path)
+
+    if os.path.exists(config_path):
+        # files are assumed to be SingleFileScopes
+        config_name = f"{parent_scope.name}:{included_name}"
+        tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
+        return SingleFileScope(config_name, config_path, spack.schema.merged.schema)
+
+    if not include.optional:
+        path = f" at ({config_path})" if config_path != include.path else ""
+        raise ValueError(f"Required path ({include.path}) does not exist{path}")
+
+    return None
+
+
+def _git_include_paths_scopes(include: GitIncludePaths, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
+    """Instantiate the appropriate configuration scopes for the given git include path(s).
+
+    Args:
+        include: optional include path
+        parent_scoppe: including scope
+
+    Returns: list of configuration scopes
+
+    Raises:
+        ValueError: included path has an unsupported URL scheme, is required
+            but does not exist; configuration stage directory argument is missing
+        ConfigFileError: unable to access remote configuration file(s)
+    """
+    # circular dependencies
+    import spack.spec
+
+    # TODO/TLD: Change this to process the list in include.paths
+    config_path = rfc_util.local_path(include.path, include.sha256, _include_cache_location)
+    if not config_path:
+        raise ConfigFileError(f"Unable to fetch remote configuration from {include.path}")
+
+    # Try to use the relative path to create the included scope name
+    parent_path = getattr(parent_scope, "path", None)
+    if parent_path and str(parent_path) == os.path.commonprefix([parent_path, config_path]):
+        included_name = os.path.relpath(config_path, parent_path)
+    else:
+        included_name = config_path
+
+    if sys.platform == "win32":
+        # Clean windows path for use in config name that looks nicer
+        # ie. The path: C:\\some\\path\\to\\a\\file
+        # becomes C/some/path/to/a/file
+        included_name = included_name.replace("\\", "/")
+        included_name = included_name.replace(":", "")
+
+    # TODO/TBD: We don't support directory include scopes anymore
+    if os.path.isdir(config_path):
+        # directories are treated as regular ConfigScopes
+        config_name = f"{parent_scope.name}:{included_name}"
+        tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
+        return [DirectoryConfigScope(config_name, config_path)]
+
+    if os.path.exists(config_path):
+        # files are assumed to be SingleFileScopes
+        config_name = f"{parent_scope.name}:{included_name}"
+        tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
+        return [SingleFileScope(config_name, config_path, spack.schema.merged.schema)]
+
+    if not include.optional:
+        path = f" at ({config_path})" if config_path != include.path else ""
+        raise ValueError(f"Required path ({include.path}) does not exist{path}")
+
+    return []
+
+
+def include_path_scope(include: Union[IncludePath, GitIncludePaths], parent_scope: ConfigScope) -> Optional[ConfigScope]:
+    """Instantiate an appropriate configuration scopes for the given paths.
+
+    Args:
+        include: optional include path(s)
+        parent_scope: including scope
+
+    Returns: configuration scopes
+
+    Raises:
+        ValueError: included path has an unsupported URL scheme, is required
+            but does not exist; configuration stage directory argument is missing
+        ConfigFileError: unable to access remote configuration file(s)
+    """
+    # circular dependencies
+    import spack.spec
+
     if (not include.when) or spack.spec.eval_conditional(include.when):
-        config_path = rfc_util.local_path(include.path, include.sha256, _include_cache_location)
-        if not config_path:
-            raise ConfigFileError(f"Unable to fetch remote configuration from {include.path}")
+        if isinstance(include, IncludePath):
+            #return [_single_include_path_scope(include, parent_scope)]
+            return _single_include_path_scope(include, parent_scope)
 
-        # Try to use the relative path to create the included scope name
-        parent_path = getattr(parent_scope, "path", None)
-        if parent_path and str(parent_path) == os.path.commonprefix([parent_path, config_path]):
-            included_name = os.path.relpath(config_path, parent_path)
-        else:
-            included_name = config_path
-
-        if sys.platform == "win32":
-            # Clean windows path for use in config name that looks nicer
-            # ie. The path: C:\\some\\path\\to\\a\\file
-            # becomes C/some/path/to/a/file
-            included_name = included_name.replace("\\", "/")
-            included_name = included_name.replace(":", "")
-
-        if os.path.isdir(config_path):
-            # directories are treated as regular ConfigScopes
-            config_name = f"{parent_scope.name}:{included_name}"
-            tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
-            return DirectoryConfigScope(config_name, config_path)
-
-        if os.path.exists(config_path):
-            # files are assumed to be SingleFileScopes
-            config_name = f"{parent_scope.name}:{included_name}"
-            tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
-            return SingleFileScope(config_name, config_path, spack.schema.merged.schema)
-
-        if not include.optional:
-            path = f" at ({config_path})" if config_path != include.path else ""
-            raise ValueError(f"Required path ({include.path}) does not exist{path}")
+        if isinstance(include, GitIncludePaths):
+            #return _git_include_paths_scopes(include, parent_scope)
+            return _git_include_paths_scopes(include, parent_scope)[0]
 
     return None
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -847,10 +847,12 @@ class OptionalInclude:
 
     when: str
     optional: bool
+    _scopes: Optional[List[ConfigScope]]
 
     def __init__(self, entry: dict):
         self.when = entry.get("when", "")
         self.optional = entry.get("optional", False)
+        self._scopes = None
 
     def _scope(self, config_path: str, parent_scope: ConfigScope) -> Optional[ConfigScope]:
         """Instantiate a configuration scope for the configuration path.
@@ -920,11 +922,13 @@ class OptionalInclude:
 class IncludePath(OptionalInclude):
     path: str
     sha256: str
+    destination: Optional[str]
 
     def __init__(self, entry: dict):
         super().__init__(entry)
         self.path = entry.get("path", "")
         self.sha256 = entry.get("sha256", "")
+        self.destination = None
 
     def __repr__(self):
         return (
@@ -949,11 +953,16 @@ class IncludePath(OptionalInclude):
         if not self.satisfied:
             return None
 
+        if self._scopes:
+            return self._scopes
+
         config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location)
         if not config_path:
             raise ConfigFileError(f"Unable to fetch remote configuration from {self.path}")
 
-        return [self._scope(config_path, parent_scope)]
+        self.destination = config_path
+        self._scopes = [self._scope(self.destination, parent_scope)]
+        return self._scopes
 
 
 class GitIncludePaths(OptionalInclude):
@@ -962,6 +971,7 @@ class GitIncludePaths(OptionalInclude):
     commit: str
     tag: str
     paths: List[str]
+    destination: Optional[str]
 
     def __init__(self, entry: dict):
         super().__init__(entry)
@@ -970,6 +980,7 @@ class GitIncludePaths(OptionalInclude):
         self.commit = entry.get("commit", "")
         self.tag = entry.get("tag", "")
         self.paths = entry.get("paths", [])
+        self.destination = None
 
         if not self.branch and not self.commit and not self.tag:
             raise spack.error.ConfigError(
@@ -1004,6 +1015,9 @@ class GitIncludePaths(OptionalInclude):
         if not self.satisfied:
             return None
 
+        if self._scopes:
+            return self._scopes
+
         scopes = []
         for path in include.paths:
             # TODO: Change this to fetch as is done for Git repositories
@@ -1012,7 +1026,9 @@ class GitIncludePaths(OptionalInclude):
                 raise ConfigFileError(f"Unable to fetch remote configuration from {path}")
             scopes.append(self._scope(config_path, parent_scope))
 
-        return scopes
+        if scopes:
+            self._scopes = scopes
+        return self._scopes
 
 
 def included_path(entry: Union[str, dict]) -> Union[IncludePath, GitIncludePaths]:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -905,7 +905,6 @@ class OptionalInclude:
 
         return None
 
-    @property
     def satisfied(self):
         # circular dependencies
         import spack.spec
@@ -958,7 +957,7 @@ class IncludePath(OptionalInclude):
             ValueError: included path has an unsupported URL scheme, is required
                 but does not exist; configuration stage directory argument is missing
         """
-        if not self.satisfied:
+        if not self.satisfied():
             tty.debug(f"Include condition is not satisfied in {self}")
             return None
 
@@ -1090,7 +1089,7 @@ class GitIncludePaths(OptionalInclude):
             ValueError: included path has an unsupported URL scheme, is required
                 but does not exist; configuration stage directory argument is missing
         """
-        if not self.satisfied:
+        if not self.satisfied():
             tty.debug(f"Include condition is not satisfied in {self}")
             return None
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -925,6 +925,12 @@ class OptionalInclude:
         """
         raise NotImplementedError("must be implemented in derived classes")
 
+    @property
+    def paths(self) -> List[str]:
+        """Path(s) associated with the include."""
+
+        raise NotImplementedError("must be implemented in derived classes")
+
 
 class IncludePath(OptionalInclude):
     path: str
@@ -986,13 +992,19 @@ class IncludePath(OptionalInclude):
 
         return self._scopes
 
+    @property
+    def paths(self) -> List[str]:
+        """Path(s) associated with the include."""
+
+        return [self.path]
+
 
 class GitIncludePaths(OptionalInclude):
     repo: str
     branch: str
     commit: str
     tag: str
-    paths: List[str]
+    _paths: List[str]
     destination: Optional[str]
 
     def __init__(self, entry: dict):
@@ -1001,7 +1013,7 @@ class GitIncludePaths(OptionalInclude):
         self.branch = entry.get("branch", "")
         self.commit = entry.get("commit", "")
         self.tag = entry.get("tag", "")
-        self.paths = entry.get("paths", [])
+        self._paths = entry.get("paths", [])
         self.destination = None
 
         if not self.branch and not self.commit and not self.tag:
@@ -1009,7 +1021,7 @@ class GitIncludePaths(OptionalInclude):
                 "Git include paths ({self}) must specify one or more of: branch, commit, tag"
             )
 
-        if not self.paths:
+        if not self._paths:
             raise spack.error.ConfigError(
                 "Git include paths ({self}) must include one or more relative paths"
             )
@@ -1113,6 +1125,12 @@ class GitIncludePaths(OptionalInclude):
             self._scopes = scopes
         return self._scopes
 
+    @property
+    def paths(self) -> List[str]:
+        """Path(s) associated with the include."""
+
+        return self._paths
+
 
 def included_path(entry: Union[str, pathlib.Path, dict]) -> Union[IncludePath, GitIncludePaths]:
     """Convert the included paths entry into the appropriate optional include.
@@ -1129,6 +1147,22 @@ def included_path(entry: Union[str, pathlib.Path, dict]) -> Union[IncludePath, G
         return IncludePath(entry)
 
     return GitIncludePaths(entry)
+
+
+def paths_from_includes(includes: List[Union[str, dict]]) -> List[str]:
+    """The path(s) from the configured includes.
+
+    Args:
+        includes: include configuration information
+
+    Returns: list of path or an empty list if there are none
+    """
+
+    paths = []
+    for entry in includes:
+        include = included_path(entry)
+        paths.extend(include.paths)
+    return paths
 
 
 def config_paths_from_entry_points() -> List[Tuple[str, str]]:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -858,10 +858,11 @@ class OptionalInclude:
         self.optional = entry.get("optional", False)
         self._scopes = None
 
-    def _scope(self, config_path: str, parent_scope: ConfigScope) -> Optional[ConfigScope]:
+    def _scope(self, path: str, config_path: str, parent_scope: ConfigScope) -> Optional[ConfigScope]:
         """Instantiate a configuration scope for the configuration path.
 
         Args:
+            path: raw include path
             config_path: configuration path
             parent_scope: including scope
 
@@ -897,7 +898,8 @@ class OptionalInclude:
             return SingleFileScope(config_name, config_path, spack.schema.merged.schema)
 
         if not self.optional:
-            raise ValueError(f"Required path ({config_path}) does not exist")
+            dest = f" at ({config_path})" if config_path != path else ""
+            raise ValueError(f"Required path ({path}) does not exist{dest}")
 
         return None
 
@@ -967,7 +969,7 @@ class IncludePath(OptionalInclude):
 
         self.destination = config_path
 
-        scope = self._scope(self.destination, parent_scope)
+        scope = self._scope(self.path, self.destination, parent_scope)
         if scope is not None:
             self._scopes = [scope]
 
@@ -1092,7 +1094,7 @@ class GitIncludePaths(OptionalInclude):
         scopes: List[ConfigScope] = []
         for relative_path in self.paths:
             config_path = os.path.join(destination, relative_path)
-            scope = self._scope(config_path, parent_scope)
+            scope = self._scope(relative_path, config_path, parent_scope)
             if scope is not None:
                 scopes.append(scope)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -858,7 +858,9 @@ class OptionalInclude:
         self.optional = entry.get("optional", False)
         self._scopes = None
 
-    def _scope(self, path: str, config_path: str, parent_scope: ConfigScope) -> Optional[ConfigScope]:
+    def _scope(
+        self, path: str, config_path: str, parent_scope: ConfigScope
+    ) -> Optional[ConfigScope]:
         """Instantiate a configuration scope for the configuration path.
 
         Args:
@@ -964,9 +966,19 @@ class IncludePath(OptionalInclude):
             tty.debug(f"Using existing scopes: {[s.name for s in self._scopes]}")
             return self._scopes
 
-        config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location)
-        assert config_path
+        # Make sure to use the proper (default) working directory when obtaining
+        # the local path for a local file.
+        def work_dir():
+            if not os.path.isabs(self.path) and hasattr(parent_scope, "path"):
+                if os.path.isfile(parent_scope.path):
+                    return os.path.dirname(parent_scope.path)
+                if os.path.isdir(parent_scope.path):
+                    return parent_scope.path
+            return os.getcwd()
 
+        with filesystem.working_dir(work_dir()):
+            config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location)
+        assert config_path
         self.destination = config_path
 
         scope = self._scope(self.path, self.destination, parent_scope)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -881,6 +881,11 @@ class GitIncludePaths(OptionalInclude):
         self.tag = entry.get("tag", "")
         self.paths = entry.get("paths", [])
 
+        if not self.branch and not self.commit and not self.tag:
+            raise spack.error.ConfigError(
+                "Git include paths require one or more of: branch, commit, tag"
+            )
+
     def __repr__(self):
         if self.branch:
             identifier = f"branch={self.branch}"

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -35,6 +35,7 @@ import pathlib
 import re
 import sys
 from collections import defaultdict
+from itertools import chain
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 from spack.vendor import jsonschema
@@ -155,21 +156,17 @@ class ConfigScope:
             includes = self.get_section("include")
             if includes:
                 include_paths = [included_path(data) for data in includes["include"]]
-                for include in include_paths:
-                    included_scopes = include.scopes(self)
-                    if not included_scopes:
+
+                included_scopes = chain(*[include.scopes(self) for include in include_paths])
+
+                # Do not include duplicate scopes
+                for included_scope in included_scopes:
+                    if any([included_scope.name == scope.name for scope in self._included_scopes]):
+                        tty.warn(f"Ignoring duplicate included scope: {included_scope.name}")
                         continue
 
-                    # Do not include duplicate scopes
-                    for included_scope in included_scopes:
-                        if any(
-                            [included_scope.name == scope.name for scope in self._included_scopes]
-                        ):
-                            tty.warn(f"Ignoring duplicate included scope: {included_scope.name}")
-                            continue
-
-                        if included_scope not in self._included_scopes:
-                            self._included_scopes.append(included_scope)
+                    if included_scope not in self._included_scopes:
+                        self._included_scopes.append(included_scope)
 
         return self._included_scopes
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -851,12 +851,12 @@ class OptionalInclude:
 
     when: str
     optional: bool
-    _scopes: Optional[List[ConfigScope]]
+    _scopes: List[ConfigScope]
 
     def __init__(self, entry: dict):
         self.when = entry.get("when", "")
         self.optional = entry.get("optional", False)
-        self._scopes = None
+        self._scopes = []
 
     def _scope(
         self, path: str, config_path: str, parent_scope: ConfigScope
@@ -911,14 +911,14 @@ class OptionalInclude:
 
         return (not self.when) or spack.spec.eval_conditional(self.when)
 
-    def scopes(self, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
+    def scopes(self, parent_scope: ConfigScope) -> List[ConfigScope]:
         """Instantiate configuration scopes.
 
         Args:
             parent_scope: including scope
 
         Returns: configuration scopes IF the when condition is satisfied;
-            otherwise, ``None``.
+            otherwise, an empty list.
 
         Raises:
             ValueError: the required configuration path does not exist
@@ -943,14 +943,14 @@ class IncludePath(OptionalInclude):
             f"when='{self.when}', optional={self.optional})"
         )
 
-    def scopes(self, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
+    def scopes(self, parent_scope: ConfigScope) -> List[ConfigScope]:
         """Instantiate a configuration scope for the included path.
 
         Args:
             parent_scope: including scope
 
         Returns: configuration scopes IF the when condition is satisfied;
-            otherwise, ``None``.
+            otherwise, an empty list.
 
         Raises:
             ConfigFileError: unable to access remote configuration file
@@ -959,9 +959,9 @@ class IncludePath(OptionalInclude):
         """
         if not self.evaluate_condition():
             tty.debug(f"Include condition is not satisfied in {self}")
-            return None
+            return []
 
-        if self._scopes is not None:
+        if self._scopes:
             tty.debug(f"Using existing scopes: {[s.name for s in self._scopes]}")
             return self._scopes
 
@@ -1075,14 +1075,14 @@ class GitIncludePaths(OptionalInclude):
     def fetched(self):
         return self.destination is not None and os.path.join(self.destination, ".git")
 
-    def scopes(self, parent_scope: ConfigScope) -> Optional[List[ConfigScope]]:
+    def scopes(self, parent_scope: ConfigScope) -> List[ConfigScope]:
         """Instantiate configuration scopes for the included paths.
 
         Args:
             parent_scope: including scope
 
         Returns: configuration scopes IF the when condition is satisfied;
-            otherwise, ``None``.
+            otherwise, an empty list.
 
         Raises:
             ConfigFileError: unable to access remote configuration file(s)
@@ -1091,9 +1091,9 @@ class GitIncludePaths(OptionalInclude):
         """
         if not self.evaluate_condition():
             tty.debug(f"Include condition is not satisfied in {self}")
-            return None
+            return []
 
-        if self._scopes is not None:
+        if self._scopes:
             tty.debug(f"Using existing scopes: {[s.name for s in self._scopes]}")
             return self._scopes
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2660,35 +2660,32 @@ def initialize_environment_dir(
 
     # TODO: make this recursive
     includes = manifest[TOP_LEVEL_KEY].get("include", [])
-    for include in includes:
-        included_path = spack.config.included_path(include)
-        paths = [included_path.path] if hasattr(included_path, "path") else included_path.paths
+    paths = spack.config.paths_from_includes(includes)
+    for path in paths:
+        if os.path.isabs(path):
+            continue
 
-        for path in paths:
-            if os.path.isabs(path):
-                continue
+        abspath = pathlib.Path(os.path.normpath(environment_dir / path))
+        common_path = pathlib.Path(os.path.commonpath([environment_dir, abspath]))
+        if common_path != environment_dir:
+            tty.debug(f"Will not copy relative include file from outside environment: {path}")
+            continue
 
-            abspath = pathlib.Path(os.path.normpath(environment_dir / path))
-            common_path = pathlib.Path(os.path.commonpath([environment_dir, abspath]))
-            if common_path != environment_dir:
-                tty.debug(f"Will not copy relative include file from outside environment: {path}")
-                continue
+        orig_abspath = os.path.normpath(envfile.parent / path)
+        if os.path.isfile(orig_abspath):
+            fs.touchp(abspath)
+            shutil.copy(orig_abspath, abspath)
+            continue
 
-            orig_abspath = os.path.normpath(envfile.parent / path)
-            if os.path.isfile(orig_abspath):
-                fs.touchp(abspath)
-                shutil.copy(orig_abspath, abspath)
-                continue
+        if not os.path.exists(orig_abspath):
+            tty.warn(f"Skipping copy of non-existent include path: '{path}'")
+            continue
 
-            if not os.path.exists(orig_abspath):
-                tty.warn(f"Skipping copy of non-existent include path: '{path}'")
-                continue
+        if os.path.exists(abspath):
+            tty.warn(f"Skipping copy of directory over existing path: {path}")
+            continue
 
-            if os.path.exists(abspath):
-                tty.warn(f"Skipping copy of directory over existing path: {path}")
-                continue
-
-            shutil.copytree(orig_abspath, abspath, symlinks=True)
+        shutil.copytree(orig_abspath, abspath, symlinks=True)
 
 
 class EnvironmentManifestFile(collections.abc.Mapping):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2662,28 +2662,32 @@ def initialize_environment_dir(
     includes = manifest[TOP_LEVEL_KEY].get("include", [])
     for include in includes:
         included_path = spack.config.included_path(include)
-        path = included_path.path
-        if os.path.isabs(path):
-            continue
+        paths = [included_path.path] if hasattr(included_path, "path") else included_path.paths
 
-        abspath = pathlib.Path(os.path.normpath(environment_dir / path))
-        common_path = pathlib.Path(os.path.commonpath([environment_dir, abspath]))
-        if common_path != environment_dir:
-            tty.debug(f"Will not copy relative include file from outside environment: {path}")
-            continue
-
-        orig_abspath = os.path.normpath(envfile.parent / path)
-        if not os.path.exists(orig_abspath):
-            tty.warn(f"Included file does not exist; will not copy: '{path}'")
-            continue
-
-        if os.path.isfile(orig_abspath):
-            fs.touchp(abspath)
-            shutil.copy(orig_abspath, abspath)
-        else:
-            if os.path.exists(abspath):
-                tty.warn(f"Skipping copying duplicate directories: {path}")
+        for path in paths:
+            if os.path.isabs(path):
                 continue
+
+            abspath = pathlib.Path(os.path.normpath(environment_dir / path))
+            common_path = pathlib.Path(os.path.commonpath([environment_dir, abspath]))
+            if common_path != environment_dir:
+                tty.debug(f"Will not copy relative include file from outside environment: {path}")
+                continue
+
+            orig_abspath = os.path.normpath(envfile.parent / path)
+            if os.path.isfile(orig_abspath):
+                fs.touchp(abspath)
+                shutil.copy(orig_abspath, abspath)
+                continue
+
+            if not os.path.exists(orig_abspath):
+                tty.warn(f"Skipping copy of non-existent include path: '{path}'")
+                continue
+
+            if os.path.exists(abspath):
+                tty.warn(f"Skipping copy of directory over existing path: {path}")
+                continue
+
             shutil.copytree(orig_abspath, abspath, symlinks=True)
 
 

--- a/lib/spack/spack/schema/include.py
+++ b/lib/spack/spack/schema/include.py
@@ -16,6 +16,7 @@ properties: Dict[str, Any] = {
         "additionalProperties": False,
         "items": {
             "anyOf": [
+                # local or remote paths that may be optional or conditional
                 {
                     "type": "object",
                     "properties": {
@@ -27,7 +28,23 @@ properties: Dict[str, Any] = {
                     "required": ["path"],
                     "additionalProperties": False,
                 },
+                # local, required path
                 {"type": "string"},
+                # remote git paths that may be optional or conditional
+                {
+                    "type": "object",
+                    "properties": {
+                        "git": {"type": "string"},
+                        "branch": {"type": "string"},
+                        "commit": {"type": "string"},
+                        "tag": {"type": "string"},
+                        "paths": {"type": "array", "items": {"type": "string"}},
+                        "when": {"type": "string"},
+                        "optional": {"type": "boolean"},
+                    },
+                    "required": ["git", "paths"],
+                    "additionalProperties": False,
+                },
             ]
         },
     }

--- a/lib/spack/spack/schema/include.py
+++ b/lib/spack/spack/schema/include.py
@@ -16,6 +16,8 @@ properties: Dict[str, Any] = {
         "additionalProperties": False,
         "items": {
             "anyOf": [
+                # local, required path
+                {"type": "string"},
                 # local or remote paths that may be optional or conditional
                 {
                     "type": "object",
@@ -28,8 +30,6 @@ properties: Dict[str, Any] = {
                     "required": ["path"],
                     "additionalProperties": False,
                 },
-                # local, required path
-                {"type": "string"},
                 # remote git paths that may be optional or conditional
                 {
                     "type": "object",

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1438,7 +1438,9 @@ def test_included_path():
 
     # remote include
     entry = {
-        "git": "https://example.com/windows/configs.git", "tag": "v1.0", "paths": ["config.yaml"]
+        "git": "https://example.com/windows/configs.git",
+        "tag": "v1.0",
+        "paths": ["config.yaml"],
     }
     include = spack.config.included_path(entry)
     assert isinstance(include, spack.config.GitIncludePaths)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1436,7 +1436,7 @@ def test_included_path_string(
     assert isinstance(include, spack.config.IncludePath)
     assert include.path == str(path)
     assert not include.optional
-    assert include.satisfied
+    assert include.satisfied()
 
     parent_scope = mock_low_high_config.scopes["low"]
 
@@ -1484,7 +1484,7 @@ def test_included_path_conditional_bad_when(
     assert include.path == entry["path"]
     assert include.when == entry["when"]
     assert include.optional
-    assert not include.satisfied
+    assert not include.satisfied()
 
     scopes = include.scopes(mock_low_high_config.scopes["low"])
     captured = capsys.readouterr()[1]
@@ -1501,7 +1501,7 @@ def test_included_path_conditional_success(tmp_path: pathlib.Path, mock_low_high
     assert include.path == entry["path"]
     assert include.when == entry["when"]
     assert include.optional
-    assert include.satisfied
+    assert include.satisfied()
 
     scopes = include.scopes(mock_low_high_config.scopes["low"])
     assert scopes and len(scopes) == 1
@@ -1537,7 +1537,7 @@ def test_included_path_git_unsat(
     assert include.tag == entry["tag"]
     assert include.paths == entry["paths"]
     assert include.when == entry["when"]
-    assert not include.optional and not include.satisfied
+    assert not include.optional and not include.satisfied()
 
     scopes = include.scopes(mock_low_high_config.scopes["low"])
     captured = capsys.readouterr()[1]
@@ -1574,7 +1574,7 @@ def test_included_path_git(
     }
     include = spack.config.included_path(entry)
     assert isinstance(include, spack.config.GitIncludePaths)
-    assert not include.optional and include.satisfied
+    assert not include.optional and include.satisfied()
 
     destination = include._destination()
     assert not os.path.exists(destination)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1467,7 +1467,7 @@ def test_included_path_string_no_parent_path(
     FakeScope = collections.namedtuple("FakeScope", ["path"])
     parent_scope = FakeScope("")
 
-    assert include.scopes(parent_scope) is None  # type: ignore[arg-type]
+    assert not include.scopes(parent_scope)  # type: ignore[arg-type]
     destination = include.destination
     curr_dir = os.getcwd()
     assert curr_dir == os.path.commonprefix([curr_dir, destination])  # type: ignore[list-item]
@@ -1489,7 +1489,7 @@ def test_included_path_conditional_bad_when(
     scopes = include.scopes(mock_low_high_config.scopes["low"])
     captured = capsys.readouterr()[1]
     assert "condition is not satisfied" in captured
-    assert scopes is None
+    assert not scopes
 
 
 def test_included_path_conditional_success(tmp_path: pathlib.Path, mock_low_high_config):
@@ -1542,7 +1542,7 @@ def test_included_path_git_unsat(
     scopes = include.scopes(mock_low_high_config.scopes["low"])
     captured = capsys.readouterr()[1]
     assert "condition is not satisfied" in captured
-    assert scopes is None
+    assert not scopes
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1525,3 +1525,58 @@ def test_included_path_git_unsat(
     captured = capsys.readouterr()[1]
     assert "condition is not satisfied" in captured
     assert scopes is None
+
+
+@pytest.mark.parametrize(
+    "key,value", [("branch", "main"), ("commit", "abcdef123456"), ("tag", "v1.0")]
+)
+def test_included_path_git(tmp_path: pathlib.Path, mock_low_high_config, monkeypatch, key, value):
+    monkeypatch.setattr(spack.paths, "user_cache_path", str(tmp_path))
+
+    class MockIncludeGit(spack.util.executable.Executable):
+        def __init__(self, required: bool):
+            pass
+
+        def __call__(self, *args, **kwargs) -> str:  # type: ignore
+            action = args[0]
+
+            if action == "config":
+                return "origin"
+
+            return ""
+
+    paths = ["config.yaml", "packages.yaml"]
+    entry = {
+        "git": "https://example.com/windows/configs.git",
+        key: value,
+        "paths": paths,
+        "when": 'platform == "test"',
+    }
+    include = spack.config.included_path(entry)
+    assert isinstance(include, spack.config.GitIncludePaths)
+    assert not include.optional and include.satisfied
+
+    destination = include._destination()
+    assert not os.path.exists(destination)
+
+    # set up minimal git and repository operations
+    monkeypatch.setattr(spack.util.git, "git", MockIncludeGit)
+
+    def _init_repo(*args, **kwargs):
+        fs.mkdirp(fs.join_path(destination, ".git"))
+
+    def _checkout(*args, **kwargs):
+        # Make sure the files exist at the clone destination
+        with fs.working_dir(destination):
+            for p in paths:
+                fs.touch(p)
+
+    monkeypatch.setattr(spack.util.git, "init_git_repo", _init_repo)
+    monkeypatch.setattr(spack.util.git, f"pull_checkout_{key}", _checkout)
+
+    parent_scope = mock_low_high_config.scopes["low"]
+    scopes = include.scopes(parent_scope)
+    assert len(scopes) == len(paths)
+    for scope in scopes:
+        assert os.path.basename(scope.path) in paths
+        assert isinstance(scope, spack.config.SingleFileScope)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1436,7 +1436,7 @@ def test_included_path_string(
     assert isinstance(include, spack.config.IncludePath)
     assert include.path == str(path)
     assert not include.optional
-    assert include.satisfied()
+    assert include.evaluate_condition()
 
     parent_scope = mock_low_high_config.scopes["low"]
 
@@ -1484,7 +1484,7 @@ def test_included_path_conditional_bad_when(
     assert include.path == entry["path"]
     assert include.when == entry["when"]
     assert include.optional
-    assert not include.satisfied()
+    assert not include.evaluate_condition()
 
     scopes = include.scopes(mock_low_high_config.scopes["low"])
     captured = capsys.readouterr()[1]
@@ -1501,7 +1501,7 @@ def test_included_path_conditional_success(tmp_path: pathlib.Path, mock_low_high
     assert include.path == entry["path"]
     assert include.when == entry["when"]
     assert include.optional
-    assert include.satisfied()
+    assert include.evaluate_condition()
 
     scopes = include.scopes(mock_low_high_config.scopes["low"])
     assert scopes and len(scopes) == 1
@@ -1537,7 +1537,7 @@ def test_included_path_git_unsat(
     assert include.tag == entry["tag"]
     assert include.paths == entry["paths"]
     assert include.when == entry["when"]
-    assert not include.optional and not include.satisfied()
+    assert not include.optional and not include.evaluate_condition()
 
     scopes = include.scopes(mock_low_high_config.scopes["low"])
     captured = capsys.readouterr()[1]
@@ -1574,7 +1574,7 @@ def test_included_path_git(
     }
     include = spack.config.included_path(entry)
     assert isinstance(include, spack.config.GitIncludePaths)
-    assert not include.optional and include.satisfied()
+    assert not include.optional and include.evaluate_condition()
 
     destination = include._destination()
     assert not os.path.exists(destination)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1462,3 +1462,7 @@ def test_included_path_git_missing_arg():
     entry = {"git": "https://example.com/windows/configs.git", "paths": ["config.yaml"]}
     with pytest.raises(spack.error.ConfigError, match="specify one or more"):
         spack.config.included_path(entry)
+
+def test_included_optional_include_scopes():
+    with pytest.raises(NotImplementedError):
+        spack.config.OptionalInclude({}).scopes(spack.config.ConfigScope("fail"))

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1436,7 +1436,7 @@ def test_included_path():
     assert include.when == entry["when"]
     assert not include.sha256 and not include.optional
 
-    # remote include
+    # git include
     entry = {
         "git": "https://example.com/windows/configs.git",
         "tag": "v1.0",
@@ -1449,3 +1449,16 @@ def test_included_path():
     assert include.paths == entry["paths"]
     assert not include.when and not include.optional
     assert not include.branch and not include.commit
+
+    # add commit to tag to confirm can have both
+    entry["commit"] = "abcdef12345"
+    include = spack.config.included_path(entry)
+    assert isinstance(include, spack.config.GitIncludePaths)
+    assert include.commit == entry["commit"]
+
+
+def test_included_path_bad_git_args():
+    # must have one or more of: branch, tag and commit so fail if missing any
+    entry = {"git": "https://example.com/windows/configs.git", "paths": ["config.yaml"]}
+    with pytest.raises(spack.error.ConfigError, match="require one or more"):
+        spack.config.included_path(entry)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1418,3 +1418,32 @@ def test_deepcopy_as_builtin(env_yaml):
     assert type(packages_copy["all"]) is dict
     assert type(packages_copy["all"]["compiler"]) is list
     assert type(packages_copy["all"]["compiler"][0]) is str
+
+
+def test_included_path():
+    # String include
+    path = "/a/local/include.yaml"
+    include = spack.config.included_path(path)
+    assert isinstance(include, spack.config.IncludePath)
+    assert include.path == path
+    assert not include.when and not include.sha256 and not include.optional
+
+    # local conditional include
+    entry = {"path": "/a/local/include.yaml", "when": "platform=darwin"}
+    include = spack.config.included_path(entry)
+    assert isinstance(include, spack.config.IncludePath)
+    assert include.path == entry["path"]
+    assert include.when == entry["when"]
+    assert not include.sha256 and not include.optional
+
+    # remote include
+    entry = {
+        "git": "https://example.com/windows/configs.git", "tag": "v1.0", "paths": ["config.yaml"]
+    }
+    include = spack.config.included_path(entry)
+    assert isinstance(include, spack.config.GitIncludePaths)
+    assert include.repo == entry["git"]
+    assert include.tag == entry["tag"]
+    assert include.paths == entry["paths"]
+    assert not include.when and not include.optional
+    assert not include.branch and not include.commit

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1576,7 +1576,7 @@ def test_included_path_git(tmp_path: pathlib.Path, mock_low_high_config, monkeyp
 
     parent_scope = mock_low_high_config.scopes["low"]
     scopes = include.scopes(parent_scope)
-    assert len(scopes) == len(paths)
+    assert scopes and len(scopes) == len(paths)
     for scope in scopes:
-        assert os.path.basename(scope.path) in paths
         assert isinstance(scope, spack.config.SingleFileScope)
+        assert os.path.basename(scope.path) in paths  # type: ignore[union-attr]

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1457,8 +1457,8 @@ def test_included_path():
     assert include.commit == entry["commit"]
 
 
-def test_included_path_bad_git_args():
+def test_included_path_git_missing_arg():
     # must have one or more of: branch, tag and commit so fail if missing any
     entry = {"git": "https://example.com/windows/configs.git", "paths": ["config.yaml"]}
-    with pytest.raises(spack.error.ConfigError, match="require one or more"):
+    with pytest.raises(spack.error.ConfigError, match="specify one or more"):
         spack.config.included_path(entry)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1457,6 +1457,22 @@ def test_included_path_string(
     assert "Using existing scopes" in captured
 
 
+def test_included_path_string_no_parent_path(
+    tmp_path: pathlib.Path, config, ensure_debug, monkeypatch
+):
+    """Use a relative include path and no parent scope path so destination
+    will be rooted in the current working directory (usually SPACK_ROOT)."""
+    entry = {"path": "config.yaml", "optional": True}
+    include = spack.config.included_path(entry)
+    FakeScope = collections.namedtuple("FakeScope", ["path"])
+    parent_scope = FakeScope("")
+
+    assert include.scopes(parent_scope) is None  # type: ignore[arg-type]
+    destination = include.destination
+    curr_dir = os.getcwd()
+    assert curr_dir == os.path.commonprefix([curr_dir, destination])  # type: ignore[list-item]
+
+
 def test_included_path_conditional_bad_when(
     tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, capsys
 ):
@@ -1593,6 +1609,13 @@ def test_included_path_git(
         scopes = include.scopes(parent_scope)
         captured = capsys.readouterr()[1]
         assert "Using existing scopes" in captured
+
+    # A direct clone now returns already cloned destination and debug message.
+    # Again only need to run this test once.
+    if key == "tag":
+        assert include._clone() == include.destination
+        captured = capsys.readouterr()[1]
+        assert "already cloned" in captured
 
 
 def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, monkeypatch):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1420,49 +1420,108 @@ def test_deepcopy_as_builtin(env_yaml):
     assert type(packages_copy["all"]["compiler"][0]) is str
 
 
-def test_included_path():
-    # String include
-    path = "/a/local/include.yaml"
+def test_included_optional_include_scopes():
+    with pytest.raises(NotImplementedError):
+        spack.config.OptionalInclude({}).scopes(spack.config.ConfigScope("fail"))
+
+
+def test_included_path_string(
+    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, capsys
+):
+    path = tmp_path / "local" / "config.yaml"
+    path.parent.mkdir()
     include = spack.config.included_path(path)
     assert isinstance(include, spack.config.IncludePath)
-    assert include.path == path
-    assert not include.when and not include.sha256 and not include.optional
+    assert include.path == str(path)
+    assert not include.optional
+    assert include.satisfied
 
-    # local conditional include
-    entry = {"path": "/a/local/include.yaml", "when": "platform=darwin"}
+    parent_scope = mock_low_high_config.scopes["low"]
+
+    # Trigger failure when required path does not exist
+    with pytest.raises(ValueError, match="does not exist"):
+        include.scopes(parent_scope)
+
+    # First successful pass builds the scope
+    path.touch()
+    scopes = include.scopes(parent_scope)
+    assert scopes and len(scopes) == 1
+    assert isinstance(scopes[0], spack.config.SingleFileScope)
+
+    # Second pass uses the scopes previously built
+    assert include._scopes is not None
+    scopes = include.scopes(parent_scope)
+    captured = capsys.readouterr()[1]
+    assert "Using existing scopes" in captured
+
+
+def test_included_path_conditional_bad_when(
+    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, capsys
+):
+    path = tmp_path / "local"
+    path.mkdir()
+    entry = {"path": str(path), "when": 'platform == "nosuchplatform"', "optional": True}
     include = spack.config.included_path(entry)
     assert isinstance(include, spack.config.IncludePath)
     assert include.path == entry["path"]
     assert include.when == entry["when"]
-    assert not include.sha256 and not include.optional
+    assert include.optional
+    assert not include.satisfied
 
-    # git include
+    scopes = include.scopes(mock_low_high_config.scopes["low"])
+    captured = capsys.readouterr()[1]
+    assert "condition is not satisfied" in captured
+    assert scopes is None
+
+
+def test_included_path_conditional_success(tmp_path: pathlib.Path, mock_low_high_config):
+    path = tmp_path / "local"
+    path.mkdir()
+    entry = {"path": str(path), "when": 'platform == "test"', "optional": True}
+    include = spack.config.included_path(entry)
+    assert isinstance(include, spack.config.IncludePath)
+    assert include.path == entry["path"]
+    assert include.when == entry["when"]
+    assert include.optional
+    assert include.satisfied
+
+    scopes = include.scopes(mock_low_high_config.scopes["low"])
+    assert scopes and len(scopes) == 1
+    assert isinstance(scopes[0], spack.config.DirectoryConfigScope)
+
+
+def test_included_path_git_missing_args():
+    # must have one or more of: branch, tag and commit so fail if missing any
+    entry = {"git": "https://example.com/windows/configs.git", "paths": ["config.yaml"]}
+    with pytest.raises(spack.error.ConfigError, match="specify one or more"):
+        spack.config.included_path(entry)
+
+    # must have one or more paths
+    entry["tag"] = "v1.0"
+    entry["paths"] = []
+    with pytest.raises(spack.error.ConfigError, match="must include one or more"):
+        spack.config.included_path(entry)
+
+
+def test_included_path_git_unsat(
+    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, capsys
+):
+    paths = ["config.yaml", "packages.yaml"]
     entry = {
         "git": "https://example.com/windows/configs.git",
         "tag": "v1.0",
-        "paths": ["config.yaml"],
+        "paths": paths,
+        "when": 'platform == "nosuchplatform"',
     }
     include = spack.config.included_path(entry)
     assert isinstance(include, spack.config.GitIncludePaths)
     assert include.repo == entry["git"]
     assert include.tag == entry["tag"]
     assert include.paths == entry["paths"]
-    assert not include.when and not include.optional
-    assert not include.branch and not include.commit
+    assert include.when == entry["when"]
+    assert not include.optional and not include.satisfied
 
-    # add commit to tag to confirm can have both
-    entry["commit"] = "abcdef12345"
-    include = spack.config.included_path(entry)
-    assert isinstance(include, spack.config.GitIncludePaths)
-    assert include.commit == entry["commit"]
-
-
-def test_included_path_git_missing_arg():
-    # must have one or more of: branch, tag and commit so fail if missing any
-    entry = {"git": "https://example.com/windows/configs.git", "paths": ["config.yaml"]}
-    with pytest.raises(spack.error.ConfigError, match="specify one or more"):
-        spack.config.included_path(entry)
-
-def test_included_optional_include_scopes():
-    with pytest.raises(NotImplementedError):
-        spack.config.OptionalInclude({}).scopes(spack.config.ConfigScope("fail"))
+    scopes = include.scopes(mock_low_high_config.scopes["low"])
+    captured = capsys.readouterr()[1]
+    assert "condition is not satisfied" in captured
+    assert scopes is None

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1532,7 +1532,9 @@ def test_included_path_git_unsat(
 @pytest.mark.parametrize(
     "key,value", [("branch", "main"), ("commit", "abcdef123456"), ("tag", "v1.0")]
 )
-def test_included_path_git(tmp_path: pathlib.Path, mock_low_high_config, monkeypatch, key, value):
+def test_included_path_git(
+    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, key, value, capsys
+):
     monkeypatch.setattr(spack.paths, "user_cache_path", str(tmp_path))
 
     class MockIncludeGit(spack.util.executable.Executable):
@@ -1576,9 +1578,63 @@ def test_included_path_git(tmp_path: pathlib.Path, mock_low_high_config, monkeyp
     monkeypatch.setattr(spack.util.git, "init_git_repo", _init_repo)
     monkeypatch.setattr(spack.util.git, f"pull_checkout_{key}", _checkout)
 
+    # First successful pass builds the scope
     parent_scope = mock_low_high_config.scopes["low"]
     scopes = include.scopes(parent_scope)
     assert scopes and len(scopes) == len(paths)
     for scope in scopes:
         assert isinstance(scope, spack.config.SingleFileScope)
         assert os.path.basename(scope.path) in paths  # type: ignore[union-attr]
+
+    # Second pass uses the scopes previously built.
+    # Only need to do this for one of the parameters.
+    if key == "branch":
+        assert include._scopes is not None
+        scopes = include.scopes(parent_scope)
+        captured = capsys.readouterr()[1]
+        assert "Using existing scopes" in captured
+
+
+def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, monkeypatch):
+    monkeypatch.setattr(spack.paths, "user_cache_path", str(tmp_path))
+
+    paths = ["concretizer.yaml"]
+    entry = {
+        "git": "https://example.com/linux/configs.git",
+        "branch": "develop",
+        "paths": paths,
+        "when": 'platform == "test"',
+    }
+    include = spack.config.included_path(entry)
+    parent_scope = mock_low_high_config.scopes["low"]
+
+    # fail to initialize the repository
+    def _failing_init(*args, **kwargs):
+        raise spack.util.executable.ProcessError("mock init repo failure")
+
+    monkeypatch.setattr(spack.util.git, "init_git_repo", _failing_init)
+
+    with pytest.raises(spack.error.ConfigError, match="Unable to initialize"):
+        include.scopes(parent_scope)
+
+    # fail in git config (so use default remote) *and* git checkout
+    def _init_repo(*args, **kwargs):
+        fs.mkdirp(fs.join_path(include.destination, ".git"))
+
+    class MockIncludeGit(spack.util.executable.Executable):
+        def __init__(self, required: bool):
+            pass
+
+        def __call__(self, *args, **kwargs) -> str:  # type: ignore
+            raise spack.util.executable.ProcessError("mock git failure")
+
+    monkeypatch.setattr(spack.util.git, "init_git_repo", _init_repo)
+    monkeypatch.setattr(spack.util.git, "git", MockIncludeGit)
+
+    with pytest.raises(spack.error.ConfigError, match="Unable to check out"):
+        include.scopes(parent_scope)
+
+    # set up invalid option failure
+    include.branch = ""  # type: ignore[union-attr]
+    with pytest.raises(spack.error.ConfigError, match="Missing or unsupported options"):
+        include.scopes(parent_scope)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -30,6 +30,8 @@ import spack.schema.mirrors
 import spack.schema.repos
 import spack.spec
 import spack.store
+import spack.util.executable
+import spack.util.git
 import spack.util.path as spack_path
 import spack.util.spack_yaml as syaml
 from spack.enums import ConfigScopePriority


### PR DESCRIPTION
This PR allows the use of git options, like those supported for `repos.yaml`, in `include.yaml`.

This has been tested manually using configuration files from `https://github.com/spack/spack-configs/tree/main/USC/config`.

Example (from the updated docs):

```
include:
- git: https://github.com/spack/spack-configs
  branch: main
  when: os == "centos7"
  paths:
  - USC/config/config.yaml
  - USC/config/packages.yaml
```

TODO:
- [x] Add unit tests (at least of `git`) options (scopes)