### PR TITLE
packaging_guide_build.rst: link to spack.package module docs

### DIFF
--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -681,7 +681,7 @@ Spack's Python Package API
 Whenever you implement :ref:`overriding phases <overriding-phases>` or :ref:`before and after build phases <before_after_build_phases>`, you typically need to modify files, work with paths and run executables.
 Spack provides a number of convenience functions and classes of its own to make your life even easier, complementing the Python standard library.
 
-All of the functionality in this section is made available by importing the ``spack.package`` module.
+All of the functionality in this section is made available by importing the :mod:`spack.package` module.
 
 .. code-block:: python
 


### PR DESCRIPTION
This renders the inline code block `spack.package` the same, except it's also a link to the generated `spack.package` module docs.