### PR TITLE
docs: remove sphinx_design

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -258,7 +258,6 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
-    "sphinx_design",
     "sphinxcontrib.programoutput",
 ]
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -19,27 +19,25 @@ You can clone it from the `GitHub repository <https://github.com/spack/spack>`_ 
    $ git clone --depth=2 https://github.com/spack/spack.git
 
 This will create a directory called ``spack``.
-Once you have cloned Spack, we recommend sourcing the appropriate script for your shell:
+Once you have cloned Spack, we recommend sourcing the appropriate script for your shell.
 
-.. tab-set::
+For *bash*, *zsh* and *sh* users:
 
-   .. tab-item:: bash/zsh/sh
+.. code-block:: console
 
-      .. code-block:: console
+   $ . spack/share/spack/setup-env.sh
 
-         $ . spack/share/spack/setup-env.sh
+For *csh* and *tcsh* users:
 
-   .. tab-item:: tcsh/csh
+.. code-block:: console
 
-      .. code-block:: console
+   $ source spack/share/spack/setup-env.csh
 
-         $ source spack/share/spack/setup-env.csh
+For *fish* users:
 
-   .. tab-item:: fish
+.. code-block:: console
 
-      .. code-block:: console
-
-         $ . spack/share/spack/setup-env.fish
+   $ . spack/share/spack/setup-env.fish
 
 Now you're ready to use Spack!
 
@@ -198,16 +196,12 @@ Next steps
 This section helped you get Spack installed and running quickly.
 There are further resources in the documentation that cover both basic and advanced topics in more detail:
 
-.. tab-set::
+Basic Usage
+   1. :ref:`basic-usage`
+   2. :ref:`compiler-config`
+   3. :ref:`spack-environments-basic-usage`
 
-   .. tab-item:: Basic Usage
-
-      1. :ref:`basic-usage`
-      2. :ref:`compiler-config`
-      3. :ref:`spack-environments-basic-usage`
-
-   .. tab-item:: Advanced Topics
-
-      1. :ref:`toolchains`
-      2. :ref:`audit-packages-and-configuration`
-      3. :ref:`verify-installations`
+Advanced Topics
+   1. :ref:`toolchains`
+   2. :ref:`audit-packages-and-configuration`
+   3. :ref:`verify-installations`

--- a/lib/spack/docs/installing_prerequisites.rst
+++ b/lib/spack/docs/installing_prerequisites.rst
@@ -55,7 +55,8 @@ If the output is:
 
    /Applications/Xcode.app/Contents/Developer
 
-you already have the full Xcode suite installed. If the output is:
+you already have the full Xcode suite installed.
+If the output is:
 
 .. code-block:: none
 

--- a/lib/spack/docs/installing_prerequisites.rst
+++ b/lib/spack/docs/installing_prerequisites.rst
@@ -14,61 +14,59 @@ Spack Prerequisites
 Spack relies on a few basic utilities to be present on the system where it runs, depending on the operating system.
 To install them, follow the instructions below.
 
-.. tab-set::
+Linux
+-----
 
-   .. tab-item:: Linux
+For **Debian** and **Ubuntu** users:
 
-      .. tab-set::
+.. code-block:: console
 
-         .. tab-item:: Debian/Ubuntu
+   $ apt update
+   $ apt install file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
 
-            .. code-block:: console
+For **RHEL**, **AlmaLinux**, and **Rocky Linux** users:
 
-               $ apt update
-               $ apt install file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
+.. code-block:: console
 
-         .. tab-item:: RHEL/AlmaLinux/Rocky Linux
+   $ dnf install epel-release
+   $ dnf install file bzip2 ca-certificates git gzip patch python3 tar unzip xz zstd gcc gcc-c++ gcc-gfortran
 
-            .. code-block:: console
+macOS
+-----
 
-               $ dnf install epel-release
-               $ dnf install file bzip2 ca-certificates git gzip patch python3 tar unzip xz zstd gcc gcc-c++ gcc-gfortran
+On macOS, the Command Line Tools package is required, and a full Xcode suite may be necessary for some packages such as Qt and apple-gl.
+To install Xcode you can use the following command:
 
-   .. tab-item:: macOS
+.. code-block:: console
 
-      On macOS, the Command Line Tools package is required, and a full Xcode suite may be necessary for some packages such as Qt and apple-gl.
-      To install Xcode you can use the following command:
+   $ xcode-select --install
 
-      .. code-block:: console
+For most packages, the Xcode command-line tools are sufficient.
+However, some packages like ``qt`` require the full Xcode suite.
+You can check to see which you have installed by running:
 
-         $ xcode-select --install
+.. code-block:: console
 
-      For most packages, the Xcode command-line tools are sufficient.
-      However, some packages like ``qt`` require the full Xcode suite.
-      You can check to see which you have installed by running:
+   $ xcode-select -p
 
-      .. code-block:: console
+If the output is:
 
-         $ xcode-select -p
+.. code-block:: none
 
-      If the output is:
+   /Applications/Xcode.app/Contents/Developer
 
-      .. code-block:: none
+you already have the full Xcode suite installed. If the output is:
 
-         /Applications/Xcode.app/Contents/Developer
+.. code-block:: none
 
-      you already have the full Xcode suite installed. If the output is:
+   /Library/Developer/CommandLineTools
 
-      .. code-block:: none
+you only have the command-line tools installed.
+The full Xcode suite can be installed through the App Store.
+Make sure you launch the Xcode application and accept the license agreement before using Spack.
+It may ask you to install additional components.
+Alternatively, the license can be accepted through the command line:
 
-         /Library/Developer/CommandLineTools
+.. code-block:: console
 
-      you only have the command-line tools installed.
-      The full Xcode suite can be installed through the App Store.
-      Make sure you launch the Xcode application and accept the license agreement before using Spack.
-      It may ask you to install additional components.
-      Alternatively, the license can be accepted through the command line:
-
-      .. code-block:: console
-
-         $ sudo xcodebuild -license accept
+   $ sudo xcodebuild -license accept

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,7 +1,6 @@
 sphinx==8.2.3
 sphinxcontrib-programoutput==0.18
 sphinx-copybutton==0.5.2
-sphinx_design==0.6.1
 # fork of furo with a few changes that are not merged upstream
 git+https://github.com/haampie/furo.git@c1d161cb9e04b481ec3331db981aacfa132ecaa6#egg=furo
 python-levenshtein==0.27.1


### PR DESCRIPTION
The `sphinx_design` extension is used for tabs, but it has drawbacks:

* it requires two instead of one clicks to copy the instructions from `installing_prerequisites.rst` and `getting_started.rst` (first the right tab, then the copy button)
* they prevent Ctrl-F search of their hidden contents
* generating PDFs?
* their contents cannot be easily linked to (notably macOS prereqs)
* they pull in about 90 redundant css selectors of the form `.sd-something *` that
  cause 200ms cpu time for the package api page on a desktop computer (according to chrome devtools)
* they pull in another 10kb of js/css, with the css being a blocking
  request preventing the page to render earlier

In my opinion, a documentation website should just be static content and we're better off without