### PR TITLE
Docs: add references to toolchains in other docs

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -101,11 +101,11 @@ Custom scopes
 
 In addition to the ``defaults``, ``system``, ``site``, and ``user`` scopes, you may add configuration scopes directly on the command line with the ``--config-scope`` argument, or ``-C`` for short.
 
-For example, the following adds two configuration scopes, named ``scopea`` and ``scopeb``, to a ``spack spec`` command:
+For example, the following adds two configuration scopes, named ``scope-a`` and ``scope-b``, to a ``spack spec`` command:
 
 .. code-block:: spec
 
-   $ spack -C ~/myscopes/scopea -C ~/myscopes/scopeb spec ncurses
+   $ spack -C ~/myscopes/scope-a -C ~/myscopes/scope-b spec ncurses
 
 Custom scopes come *after* the ``spack`` command and *before* the subcommand, and they specify a single path to a directory containing configuration files.
 You can add the same configuration files to that directory that you can add to any other scope (e.g., ``config.yaml``, ``packages.yaml``, etc.).
@@ -118,7 +118,7 @@ If multiple scopes are provided:
 Example: scopes for release and development
 """""""""""""""""""""""""""""""""""""""""""
 
-Suppose that you need to support simultaneous building of release and development versions of ``mypackage``, where ``mypackage`` depends on ``packagea``, which in turn depends on ``packageb``.
+Suppose that you need to support simultaneous building of release and development versions of ``mypackage``, where ``mypackage`` depends on ``pkg-a``, which in turn depends on ``pkg-b``.
 You could create the following files:
 
 .. code-block:: yaml
@@ -127,9 +127,9 @@ You could create the following files:
    packages:
        mypackage:
            prefer: ["@1.7"]
-       packagea:
+       pkg-a:
            prefer: ["@2.3"]
-       packageb:
+       pkg-b:
            prefer: ["@0.8"]
 
 .. code-block:: yaml
@@ -138,24 +138,24 @@ You could create the following files:
    packages:
        mypackage:
            prefer: ["@develop"]
-       packagea:
+       pkg-a:
            prefer: ["@develop"]
-       packageb:
+       pkg-b:
            prefer: ["@develop"]
 
 You can switch between ``release`` and ``develop`` configurations using configuration arguments.
-You would type ``spack -C ~/myscopes/release`` when you want to build the designated release versions of ``mypackage``, ``packagea``, and ``packageb``, and you would type ``spack -C ~/myscopes/develop`` when you want to build all of these packages at the ``develop`` version.
+You would type ``spack -C ~/myscopes/release`` when you want to build the designated release versions of ``mypackage``, ``pkg-a``, and ``pkg-b``, and you would type ``spack -C ~/myscopes/develop`` when you want to build all of these packages at the ``develop`` version.
 
 Example: swapping MPI providers
 """""""""""""""""""""""""""""""
 
-Suppose that you need to build two software packages, ``packagea`` and ``packageb``.
-``packagea`` is Python 2-based, and ``packageb`` is Python 3-based.
-``packagea`` only builds with OpenMPI, and ``packageb`` only builds with MPICH.
-You can create different configuration scopes for use with ``packagea`` and ``packageb``:
+Suppose that you need to build two software packages, ``pkg-a`` and ``pkg-b``.
+``pkg-a`` is Python 2-based, and ``pkg-b`` is Python 3-based.
+``pkg-a`` only builds with OpenMPI, and ``pkg-b`` only builds with MPICH.
+You can create different configuration scopes for use with ``pkg-a`` and ``pkg-b``:
 
 .. code-block:: yaml
-   :caption: ~/myscopes/packgea/packages.yaml
+   :caption: ~/myscopes/pkg-a/packages.yaml
 
    packages:
        python:
@@ -164,7 +164,7 @@ You can create different configuration scopes for use with ``packagea`` and ``pa
            require: [openmpi]
 
 .. code-block:: yaml
-   :caption: ~/myscopes/packageb/packages.yaml
+   :caption: ~/myscopes/pkg-b/packages.yaml
 
    packages:
        python:

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -118,7 +118,7 @@ If multiple scopes are provided:
 Example: scopes for release and development
 """""""""""""""""""""""""""""""""""""""""""
 
-Suppose that you need to support simultaneous building of release and development versions of ``mypackage``, where ``mypackage`` depends on ``A``, which in turn depends on ``B``.
+Suppose that you need to support simultaneous building of release and development versions of ``mypackage``, where ``mypackage`` depends on ``packagea``, which in turn depends on ``packageb``.
 You could create the following files:
 
 .. code-block:: yaml
@@ -126,25 +126,25 @@ You could create the following files:
 
    packages:
        mypackage:
-           version: [1.7]
-       A:
-           version: [2.3]
-       B:
-           version: [0.8]
+           prefer: ["@1.7"]
+       packagea:
+           prefer: ["@2.3"]
+       packageb:
+           prefer: ["@0.8"]
 
 .. code-block:: yaml
    :caption: ~/myscopes/develop/packages.yaml
 
    packages:
        mypackage:
-           version: [develop]
-       A:
-           version: [develop]
-       B:
-           version: [develop]
+           prefer: ["@develop"]
+       packagea:
+           prefer: ["@develop"]
+       packageb:
+           prefer: ["@develop"]
 
 You can switch between ``release`` and ``develop`` configurations using configuration arguments.
-You would type ``spack -C ~/myscopes/release`` when you want to build the designated release versions of ``mypackage``, ``A``, and ``B``, and you would type ``spack -C ~/myscopes/develop`` when you want to build all of these packages at the ``develop`` version.
+You would type ``spack -C ~/myscopes/release`` when you want to build the designated release versions of ``mypackage``, ``packagea``, and ``packageb``, and you would type ``spack -C ~/myscopes/develop`` when you want to build all of these packages at the ``develop`` version.
 
 Example: swapping MPI providers
 """""""""""""""""""""""""""""""
@@ -159,20 +159,18 @@ You can create different configuration scopes for use with ``packagea`` and ``pa
 
    packages:
        python:
-           version: [2.7.11]
-       all:
-           providers:
-               mpi: [openmpi]
+           require: ["@2.7.11"]
+       mpi:
+           require: [openmpi]
 
 .. code-block:: yaml
    :caption: ~/myscopes/packageb/packages.yaml
 
    packages:
        python:
-           version: [3.5.2]
-       all:
-           providers:
-               mpi: [mpich]
+           require: ["@3.5.2"]
+       mpi:
+           require: [mpich]
 
 
 .. _plugin-scopes:

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -21,6 +21,7 @@ Here is a quick list of them, in case you want to skip directly to specific docs
 * :ref:`modules.yaml <modules>`
 * :ref:`packages.yaml <packages-config>` (including :ref:`compiler configuration <compiler-config>`)
 * :ref:`repos.yaml <repositories>`
+* :ref:`toolchains.yaml <toolchains>`
 
 You can also add any of these as inline configuration in the YAML manifest file (``spack.yaml``) describing an :ref:`environment <environment-configuration>`.
 

--- a/lib/spack/docs/configuring_compilers.rst
+++ b/lib/spack/docs/configuring_compilers.rst
@@ -275,3 +275,8 @@ Once the compiler is installed, you can start using it without additional config
 .. code-block:: spec
 
    $ spack install hdf5~mpi %gcc@14
+
+Mixing Compilers
+----------------
+
+For more options on configuring Spack to mix different compilers for different languages, see :ref:`the toolchains configuration docs <toolchains>`.


### PR DESCRIPTION
Refer to toolchains from compiler configuration docs
Add toolchains to list of sections in config docs

Fixes a couple of old-style configs in the config docs while I'm at it.