### PR TITLE
docs: stop talking about python 2

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -150,27 +150,26 @@ Example: swapping MPI providers
 """""""""""""""""""""""""""""""
 
 Suppose that you need to build two software packages, ``pkg-a`` and ``pkg-b``.
-``pkg-a`` is Python 2-based, and ``pkg-b`` is Python 3-based.
-``pkg-a`` only builds with OpenMPI, and ``pkg-b`` only builds with MPICH.
+For ``pkg-b`` you want a newer Python version and a different MPI implementation than for ``pkg-a``.
 You can create different configuration scopes for use with ``pkg-a`` and ``pkg-b``:
 
 .. code-block:: yaml
    :caption: ~/myscopes/pkg-a/packages.yaml
 
    packages:
-       python:
-           require: ["@2.7.11"]
-       mpi:
-           require: [openmpi]
+     python:
+       require: ["@3.11"]
+     mpi:
+       require: [openmpi]
 
 .. code-block:: yaml
    :caption: ~/myscopes/pkg-b/packages.yaml
 
    packages:
-       python:
-           require: ["@3.5.2"]
-       mpi:
-           require: [mpich]
+     python:
+       require: ["@3.13"]
+     mpi:
+       require: [mpich]
 
 
 .. _plugin-scopes:
@@ -189,10 +188,10 @@ Consider the Python package ``my_package`` that includes Spack configurations:
 
   my-package/
   ├── src
-  │   ├── my_package
-  │   │   ├── __init__.py
-  │   │   └── spack/
-  │   │   │   └── config.yaml
+  │   ├── my_package
+  │   │   ├── __init__.py
+  │   │   └── spack/
+  │   │   │   └── config.yaml
   └── pyproject.toml
 
 Adding the following to ``my_package``'s ``pyproject.toml`` will make ``my_package``'s ``spack/`` configurations visible to Spack when ``my_package`` is installed:

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -61,7 +61,7 @@ While you can certainly wait for the results of these tests after submitting a P
    If this is the case, please file an issue.
 
 
-We currently test against Python 2.7 and 3.6-3.10 on both macOS and Linux and perform three types of tests:
+We currently test against Python 3.6 and up on both macOS and Linux and perform three types of tests:
 
 .. _cmd-spack-unit-test:
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -474,14 +474,12 @@ Without any arguments, it is similar to a normal interactive Python shell, excep
 .. code-block:: console
 
    $ spack python
-   Spack version 0.10.0
-   Python 2.7.13, Linux x86_64
    >>> from spack.version import Version
-   >>> a = Version('1.2.3')
-   >>> b = Version('1_2_3')
+   >>> a = Version("1.2.3")
+   >>> b = Version("1_2_3")
    >>> a == b
    True
-   >>> c = Version('1.2.3b')
+   >>> c = Version("1.2.3b")
    >>> c > a
    True
    >>>
@@ -491,14 +489,6 @@ If you prefer using an IPython interpreter, given that IPython is installed, you
 .. code-block:: console
 
    $ spack python -i ipython
-   Python 3.8.3 (default, May 19 2020, 18:47:26)
-   Type 'copyright', 'credits' or 'license' for more information
-   IPython 7.17.0 -- An enhanced Interactive Python. Type '?' for help.
-
-
-   Spack version 0.16.0
-   Python 3.8.3, Linux x86_64
-
    In [1]:
 
 

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2400,14 +2400,14 @@ Now, a user can install, and activate, the ``lua-lpeg`` package for either lua o
 Adding additional constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Some packages produce a Python extension, but are only compatible with Python 3, or with Python 2.
+Some packages produce a Python extension, but require a minimum version of Python to work correctly.
 In those cases, a ``depends_on()`` declaration should be made in addition to the ``extends()`` declaration:
 
 .. code-block:: python
 
    class Icebin(Package):
        extends("python", when="+python")
-       depends_on("python@3:", when="+python")
+       depends_on("python@3.12:", when="+python")
 
 Many packages produce Python extensions for *some* variants, but not others: they should extend ``python`` only if the appropriate variant(s) are selected.
 This may be accomplished with conditional ``extends()`` declarations:


### PR DESCRIPTION
It makes the docs look outdated, and may raise the question whether the
rest of the contents are current.

Something similar could be done for gcc@4 and gcc@5, but that's a bit more
involved.

also replace what is apparently "No-Break Space" with normal blanks