### PR TITLE
spack create: conform to isort

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -53,6 +53,7 @@ package_template = '''\
 # ----------------------------------------------------------------------------
 
 {package_class_import}
+
 from spack.package import *
 
 


### PR DESCRIPTION
Current `spack create` format does not pass isort tests.