### PR TITLE
solver: improve how optimization is presented

### DIFF
--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -55,22 +55,25 @@ def _process_result(result, show, required_format, kwargs):
     opt, _, _ = min(result.answers)
     if ("opt" in show) and (not required_format):
         tty.msg("Best of %d considered solutions." % result.nmodels)
-        tty.msg("Optimization Criteria:")
 
-        maxlen = max(len(s[2]) for s in result.criteria)
-        color.cprint("@*{  Priority  Criterion %sInstalled  ToBuild}" % ((maxlen - 10) * " "))
+        print()
+        maxlen = max(len(s.name) for s in result.criteria)
+        color.cprint("@*{  Priority  Criterion %sValue}" % ((maxlen - 10) * " "))
 
-        fmt = "  @K{%%-8d}  %%-%ds%%9s  %%7s" % maxlen
-        for i, (installed_cost, build_cost, name) in enumerate(result.criteria, 1):
-            color.cprint(
-                fmt
-                % (
-                    i,
-                    name,
-                    "-" if build_cost is None else installed_cost,
-                    installed_cost if build_cost is None else build_cost,
-                )
-            )
+        for i, criterion in enumerate(result.criteria, 1):
+            if criterion.kind == asp.OptimizationKind.CONCRETE:
+                lc = "@b"
+            elif criterion.kind == asp.OptimizationKind.BUILD:
+                lc = "@g"
+            else:
+                lc = "@y"
+            color.cprint(f"  @K{{{i:<8}}}  {lc}{{{criterion.name:<{maxlen}}}}{criterion.value:>5}")
+        print()
+        print()
+        color.cprint("  @*{Legend:}")
+        color.cprint("    @g{Specs to be built}")
+        color.cprint("    @b{Concrete specs}")
+        color.cprint("    @y{Other criteria}")
         print()
 
     # dump the solutions as concretized specs

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -58,20 +58,25 @@ def _process_result(result, show, required_format, kwargs):
 
         print()
         maxlen = max(len(s.name) for s in result.criteria)
-        color.cprint("@*{  Priority  Criterion %sValue}" % ((maxlen - 10) * " "))
+        color.cprint("@*{  Priority  Value  Criterion}")
 
         for i, criterion in enumerate(result.criteria, 1):
-            if criterion.kind == asp.OptimizationKind.CONCRETE:
+            value = f"@K{{{criterion.value:>5}}}"
+            grey_out = True
+            if criterion.value > 0:
+                value = f"@*{{{criterion.value:>5}}}"
+                grey_out = False
+
+            if grey_out:
+                lc = "@K"
+            elif criterion.kind == asp.OptimizationKind.CONCRETE:
                 lc = "@b"
             elif criterion.kind == asp.OptimizationKind.BUILD:
                 lc = "@g"
             else:
                 lc = "@y"
 
-            value = f"@K{{{criterion.value:>5}}}"
-            if criterion.value > 0:
-                value = f"@*{{{criterion.value:>5}}}"
-            color.cprint(f"  @K{{{i:<8}}}  {lc}{{{criterion.name:<{maxlen}}}}{value}")
+            color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
         print()
         print()
         color.cprint("  @*{Legend:}")

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -72,7 +72,7 @@ def _process_result(result, show, required_format, kwargs):
         print()
         color.cprint("  @*{Legend:}")
         color.cprint("    @g{Specs to be built}")
-        color.cprint("    @b{Concrete specs}")
+        color.cprint("    @b{Reused specs}")
         color.cprint("    @y{Other criteria}")
         print()
 

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -67,7 +67,11 @@ def _process_result(result, show, required_format, kwargs):
                 lc = "@g"
             else:
                 lc = "@y"
-            color.cprint(f"  @K{{{i:<8}}}  {lc}{{{criterion.name:<{maxlen}}}}{criterion.value:>5}")
+
+            value = f"@K{{{criterion.value:>5}}}"
+            if criterion.value > 0:
+                value = f"@*{{{criterion.value:>5}}}"
+            color.cprint(f"  @K{{{i:<8}}}  {lc}{{{criterion.name:<{maxlen}}}}{value}")
         print()
         print()
         color.cprint("  @*{Legend:}")

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -164,30 +164,40 @@ build_priority_offset = 200
 fixed_priority_offset = 100
 
 
+class OptimizationKind(enum.Enum):
+    BUILD = enum.auto()
+    CONCRETE = enum.auto()
+    OTHER = enum.auto()
+
+
+class OptimizationCriteria(NamedTuple):
+    """A named tuple describing an optimization criteria."""
+
+    priority: int
+    value: int
+    name: str
+    kind: OptimizationKind
+
+
 def build_criteria_names(costs, arg_tuples):
     """Construct an ordered mapping from criteria names to costs."""
     # pull optimization criteria names out of the solution
     priorities_names = []
 
-    num_fixed = 0
-    num_high_fixed = 0
     for args in arg_tuples:
         priority, name = args[:2]
         priority = int(priority)
 
-        # add the priority of this opt criterion and its name
-        priorities_names.append((priority, name))
-
-        # if the priority is less than fixed_priority_offset, then it
-        # has an associated build priority -- the same criterion but for
-        # nodes that we have to build.
+        # Add the priority of this opt criterion and its name
         if priority < fixed_priority_offset:
+            # if the priority is less than fixed_priority_offset, then it
+            # has an associated build priority -- the same criterion but for
+            # nodes that we have to build.
+            priorities_names.append((priority, name, OptimizationKind.CONCRETE))
             build_priority = priority + build_priority_offset
-            priorities_names.append((build_priority, name))
-        elif priority >= high_fixed_priority_offset:
-            num_high_fixed += 1
+            priorities_names.append((build_priority, name, OptimizationKind.BUILD))
         else:
-            num_fixed += 1
+            priorities_names.append((priority, name, OptimizationKind.OTHER))
 
     # sort the criteria by priority
     priorities_names = sorted(priorities_names, reverse=True)
@@ -197,33 +207,10 @@ def build_criteria_names(costs, arg_tuples):
     error_criteria = len(costs) - len(priorities_names)
     costs = costs[error_criteria:]
 
-    # split list into three parts: build criteria, fixed criteria, non-build criteria
-    num_criteria = len(priorities_names)
-    num_build = (num_criteria - num_fixed - num_high_fixed) // 2
-
-    build_start_idx = num_high_fixed
-    fixed_start_idx = num_high_fixed + num_build
-    installed_start_idx = num_high_fixed + num_build + num_fixed
-
-    high_fixed = priorities_names[:build_start_idx]
-    build = priorities_names[build_start_idx:fixed_start_idx]
-    fixed = priorities_names[fixed_start_idx:installed_start_idx]
-    installed = priorities_names[installed_start_idx:]
-
-    # mapping from priority to index in cost list
-    indices = dict((p, i) for i, (p, n) in enumerate(priorities_names))
-
-    # make a list that has each name with its build and non-build costs
-    criteria = [(cost, None, name) for cost, (p, name) in zip(costs[:build_start_idx], high_fixed)]
-    criteria += [
-        (cost, None, name)
-        for cost, (p, name) in zip(costs[fixed_start_idx:installed_start_idx], fixed)
+    return [
+        OptimizationCriteria(priority, value, name, status)
+        for (priority, name, status), value in zip(priorities_names, costs)
     ]
-
-    for (i, name), (b, _) in zip(installed, build):
-        criteria.append((costs[indices[i]], costs[indices[b]], name))
-
-    return criteria
 
 
 def specify(spec):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -164,10 +164,15 @@ build_priority_offset = 200
 fixed_priority_offset = 100
 
 
-class OptimizationKind(enum.Enum):
-    BUILD = enum.auto()
-    CONCRETE = enum.auto()
-    OTHER = enum.auto()
+class OptimizationKind:
+    """Enum for the optimization KIND of a criteria.
+
+    It's not using enum.Enum since it must be serializable.
+    """
+
+    BUILD = 0
+    CONCRETE = 1
+    OTHER = 2
 
 
 class OptimizationCriteria(NamedTuple):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1889,9 +1889,14 @@ class TestConcretize:
             # version_declared("pkg-b","0.9",1,"package_py").
             # version_declared("pkg-b","1.0",2,"installed").
             # version_declared("pkg-b","0.9",3,"installed").
-            v_weights = [x for x in result.criteria if x[2] == "version badness (non roots)"][0]
-            reused_weights, built_weights, _ = v_weights
-            assert reused_weights > 2 and built_weights == 0
+            weights = {}
+            for x in [x for x in result.criteria if x.name == "version badness (non roots)"]:
+                if x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
+                    weights["reused"] = x.value
+                else:
+                    weights["built"] = x.value
+
+            assert weights["reused"] > 2 and weights["built"] == 0
 
             result_spec = result.specs[0]
             assert result_spec.satisfies("^pkg-b@1.0")


### PR DESCRIPTION
Show optimization criteria in the same column, ordered by the most relevant to the least relevant. Color lines according to what they refer to. Highlight non-zero optimization values.

<img width="80%" height="auto" alt="Screenshot from 2025-08-21 22-55-14" src="https://github.com/user-attachments/assets/2f89bdce-cb0c-4148-81db-b966a4a19acf" />

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
