### PR TITLE
spec_anatomy.svg: make it work on dark theme

### DIFF
--- a/lib/spack/docs/images/spec_anatomy.svg
+++ b/lib/spack/docs/images/spec_anatomy.svg
@@ -1,365 +1,45 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 860.37738 400"
-   version="1.1"
-   id="svg96"
-   sodipodi:docname="spec_anatomy.svg"
-   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
-   width="860.37738"
-   height="400">
-  <metadata
-     id="metadata102">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs100" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3840"
-     inkscape:window-height="2096"
-     id="namedview98"
-     showgrid="false"
-     inkscape:zoom="2.7383333"
-     inkscape:cx="452.465"
-     inkscape:cy="198.53926"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg96"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0" />
-  <!-- Background -->
-  <!-- Title -->
-  <text
-     x="429.95432"
-     y="30"
-     font-size="20"
-     font-weight="bold"
-     id="text4"
-     style="font-weight:bold;font-size:20px;font-family:Arial, sans-serif;text-anchor:middle;fill:#2c3e50">Spack Spec Anatomy</text>
-  <!-- Example spec -->
-  <text
-     x="60"
-     y="80"
-     font-size="16"
-     id="text6"
-     style="font-size:16px;font-family:Monaco, monospace;fill:#2c3e50">mpileaks@1.2:1.4 +debug ~qt target=x86_64_v3 %gcc@15.1.0 ^libelf@1.1 %gcc@14.2.0</text>
-  <!-- Component labels with arrows -->
-  <!-- Package name -->
-  <line
-     x1="110"
-     y1="100"
-     x2="110"
-     y2="130"
-     id="line8"
-     style="stroke:#e74c3c;stroke-width:2" />
-  <rect
-     x="60"
-     y="135"
-     width="100"
-     height="30"
-     rx="5"
-     id="rect10"
-     style="fill:#e74c3c" />
-  <text
-     x="110"
-     y="153"
-     font-size="12"
-     font-weight="bold"
-     id="text12"
-     style="font-weight:bold;font-size:12px;font-family:Arial, sans-serif;text-anchor:middle;fill:#ffffff">Package Name</text>
-  <!-- Version -->
-  <line
-     x1="200"
-     y1="100"
-     x2="200"
-     y2="171.63116"
-     id="line14"
-     style="stroke:#3498db;stroke-width:3.09044027" />
-  <g
-     id="g913"
-     transform="translate(0,2)">
-    <rect
-       style="fill:#3498db"
-       id="rect16"
-       rx="5"
-       height="30"
-       width="60"
-       y="173"
-       x="170" />
-    <text
-       style="font-weight:bold;font-size:12px;font-family:Arial, sans-serif;text-anchor:middle;fill:#ffffff"
-       id="text18"
-       font-weight="bold"
-       font-size="12"
-       y="191"
-       x="200">Version</text>
-  </g>
-  <!-- Variants -->
-  <line
-     x1="280"
-     y1="100"
-     x2="280"
-     y2="130"
-     id="line20"
-     style="stroke:#27ae60;stroke-width:2" />
-  <rect
-     x="240"
-     y="135"
-     width="80"
-     height="30"
-     rx="5"
-     id="rect22"
-     style="fill:#27ae60" />
-  <text
-     x="280"
-     y="153"
-     font-size="12"
-     font-weight="bold"
-     id="text24"
-     style="font-weight:bold;font-size:12px;font-family:Arial, sans-serif;text-anchor:middle;fill:#ffffff">Variants</text>
-  <!-- Architecture -->
-  <line
-     x1="410"
-     y1="100"
-     x2="410"
-     y2="171.26598"
-     id="line26"
-     style="stroke:#f39c12;stroke-width:3.08255267" />
-  <g
-     id="g917"
-     transform="translate(0,-2)">
-    <rect
-       style="fill:#f39c12"
-       id="rect28"
-       rx="5"
-       height="30"
-       width="100"
-       y="177"
-       x="360" />
-    <text
-       style="font-weight:bold;font-size:12px;font-family:Arial, sans-serif;text-anchor:middle;fill:#ffffff"
-       id="text30"
-       font-weight="bold"
-       font-size="12"
-       y="195"
-       x="410">Architecture</text>
-  </g>
-  <!-- Compiler -->
-  <line
-     x1="540"
-     y1="100"
-     x2="540"
-     y2="130"
-     id="line32"
-     style="stroke:#9b59b6;stroke-width:2" />
-  <rect
-     x="473.93182"
-     y="135"
-     width="134.32745"
-     height="30"
-     rx="6.716373"
-     id="rect34"
-     style="fill:#9b59b6;stroke-width:1.1589973" />
-  <text
-     x="540"
-     y="153"
-     font-size="12"
-     font-weight="bold"
-     id="text36"
-     style="font-weight:bold;font-size:12px;font-family:Arial, sans-serif;text-anchor:middle;fill:#ffffff">Direct Dependency</text>
-  <!-- Dependency -->
-  <line
-     x1="650"
-     y1="100"
-     x2="650"
-     y2="171.26598"
-     id="line38"
-     style="stroke:#e67e22;stroke-width:3.08255267" />
-  <g
-     id="g921"
-     transform="translate(0,-1.6311646)">
-    <rect
-       style="fill:#e67e22"
-       id="rect40"
-       rx="5"
-       height="30"
-       width="140"
-       y="176.63116"
-       x="590.22522" />
-    <text
-       style="font-weight:bold;font-size:12px;font-family:Arial, sans-serif;text-anchor:middle;fill:#ffffff"
-       id="text42"
-       font-weight="bold"
-       font-size="12"
-       y="194.63116"
-       x="660.22522">Transitive Dependency</text>
-  </g>
-  <!-- Dep Version -->
-  <text
-     x="750"
-     y="153"
-     font-size="10"
-     font-weight="bold"
-     id="text48"
-     style="font-weight:bold;font-size:10px;font-family:Arial, sans-serif;text-anchor:middle;fill:#ffffff">Ver</text>
-  <!-- Dep Compiler -->
-  <line
-     x1="760"
-     y1="100"
-     x2="760"
-     y2="130"
-     id="line50"
-     style="stroke:#9b59b6;stroke-width:2" />
-  <g
-     id="g925">
-    <rect
-       style="fill:#9b59b6"
-       id="rect52"
-       rx="5"
-       height="30"
-       width="140"
-       y="135"
-       x="690" />
-    <text
-       style="font-weight:bold;font-size:12px;font-family:Arial, sans-serif;text-anchor:middle;fill:#ffffff"
-       id="text54"
-       font-weight="bold"
-       font-size="12"
-       y="153"
-       x="760">Direct Dependency</text>
-  </g>
-  <!-- Legend -->
-  <text
-     x="60"
-     y="238"
-     font-size="16"
-     font-weight="bold"
-     id="text56"
-     style="font-weight:bold;font-size:16px;font-family:Arial, sans-serif;fill:#2c3e50">Spec Components:</text>
-  <!-- Component descriptions -->
-  <g
-     transform="translate(60,250)"
-     id="g94">
-    <circle
-       cx="10"
-       cy="10"
-       r="5"
-       id="circle58"
-       style="fill:#e74c3c" />
-    <text
-       x="25"
-       y="15"
-       font-size="14"
-       id="text62"
-       style="font-size:14px;font-family:Arial, sans-serif;fill:#2c3e50"><tspan
-   font-weight="bold"
-   id="tspan60"
-   style="font-weight:bold;font-family:Monaco, monospace">mpileaks</tspan>
- - Package name</text>
-    <circle
-       cx="10"
-       cy="35"
-       r="5"
-       id="circle64"
-       style="fill:#3498db" />
-    <text
-       x="25"
-       y="40"
-       font-size="14"
-       id="text68"
-       style="font-size:14px;font-family:Arial, sans-serif;fill:#2c3e50"><tspan
-   font-weight="bold"
-   id="tspan66"
-   style="font-weight:bold;font-family:Monaco, monospace">@1.2:1.4</tspan>
- - Version range (1.2 to 1.4 inclusive)</text>
-    <circle
-       cx="10"
-       cy="60"
-       r="5"
-       id="circle70"
-       style="fill:#27ae60" />
-    <text
-       x="25"
-       y="65"
-       font-size="14"
-       id="text74"
-       style="font-size:14px;font-family:Arial, sans-serif;fill:#2c3e50"><tspan
-   font-weight="bold"
-   id="tspan72"
-   style="font-weight:bold;font-family:Monaco, monospace">+debug ~qt</tspan>
- - Variants (enable debug, disable qt)</text>
-    <circle
-       cx="10"
-       cy="85"
-       r="5"
-       id="circle76"
-       style="fill:#f39c12" />
-    <text
-       x="25"
-       y="90"
-       font-size="14"
-       id="text80"
-       style="font-size:14px;font-family:Arial, sans-serif;fill:#2c3e50"><tspan
-   font-weight="bold"
-   id="tspan78"
-   style="font-weight:bold;font-family:Monaco, monospace">target=x86_64_v3</tspan>
- - Target architecture (x86-64 machine with AVX2 support)</text>
-    <circle
-       cx="10"
-       cy="110"
-       r="5"
-       id="circle82"
-       style="fill:#9b59b6" />
-    <text
-       x="25"
-       y="115"
-       font-size="14"
-       id="text86"
-       style="font-size:14px;font-family:Arial, sans-serif;fill:#2c3e50"><tspan
-   font-weight="bold"
-   id="tspan84"
-   style="font-weight:bold;font-family:Monaco, monospace">%gcc@14.2.0</tspan>
- - Direct dependency (typically, on a compiler)</text>
-    <circle
-       cx="10"
-       cy="135"
-       r="5"
-       id="circle88"
-       style="fill:#e67e22" />
-    <text
-       x="25"
-       y="140"
-       font-size="14"
-       id="text92"
-       style="font-size:14px;font-family:Arial, sans-serif;fill:#2c3e50"><tspan
-   font-weight="bold"
-   id="tspan90"
-   style="font-weight:bold;font-family:Monaco, monospace">^libelf</tspan>
- - Transitive dependency</text>
-  </g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 740 180" xmlns="http://www.w3.org/2000/svg">
+<style>
+text {
+font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+font-size: 12px;
+}
+.m {
+font-family: SFMono-Regular,Menlo,Consolas,Monaco,LiberationMono,LucidaConsole,monospace;
+font-size: 16px;
+}
+.l {
+font-weight: bold;
+text-anchor: middle;
+dominant-baseline: central;
+fill: #fff;
+}
+</style>
+<text x="10" y="30" fill="#2c3e50" class="m"><tspan fill="#e74c3c" font-weight="bold">mpileaks</tspan><tspan fill="#3498db">@1.2:1.4</tspan><tspan fill="#27ae60"> +debug ~qt</tspan><tspan fill="#f39c12"> target=x86_64_v3</tspan><tspan fill="#9b59b6" font-weight="bold"> %gcc</tspan><tspan fill="#3498db">@15</tspan><tspan fill="#e67e22" font-weight="bold"> ^libelf</tspan><tspan fill="#3498db">@1.1</tspan><tspan fill="#9b59b6" font-weight="bold"> %clang</tspan><tspan fill="#3498db">@20</tspan></text>
+
+<line x1="60" x2="60" y1="50" y2="85" stroke="#e74c3c" stroke-width="2"/>
+<rect x="10" y="85" width="100" height="30" rx="5" fill="#e74c3c"/>
+<text x="60" y="100" class="l">Package name</text>
+
+<line x1="130" x2="130" y1="50" y2="141" stroke="#3498db" stroke-width="2"/>
+<rect x="100" y="130" width="60" height="30" rx="5" fill="#3498db"/>
+<text x="130" y="145" class="l">Version</text>
+
+<line x1="230" x2="230" y1="50" y2="100" stroke="#27ae60" stroke-width="2"/>
+<rect x="190" y="85" width="80" height="30" rx="5" fill="#27ae60"/>
+<text x="230" y="100" class="l">Variants</text>
+
+<line x1="355" x2="355" y1="50" y2="150" stroke="#f39c12" stroke-width="2"/>
+<rect x="305" y="130" width="100" height="30" rx="5" fill="#f39c12"/>
+<text x="355" y="145" class="l">Architecture</text>
+
+<line x1="470" x2="470" y1="50" y2="100" stroke="#9b59b6" stroke-width="2"/>
+<rect x="404" y="85" width="130" height="30" rx="5" fill="#9b59b6"/>
+<text x="470" y="100" class="l">Direct dependency</text>
+
+<line x1="560" x2="560" y1="50" y2="150" stroke="#e67e22" stroke-width="2"/>
+<rect x="485" y="130" width="150" height="30" rx="5" fill="#e67e22"/>
+<text x="560" y="145" class="l">Transitive dependency</text>
+
 </svg>

--- a/lib/spack/docs/images/spec_anatomy.svg
+++ b/lib/spack/docs/images/spec_anatomy.svg
@@ -1,45 +1,33 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 740 180" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 740 180">
 <style>
-text {
-font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
-font-size: 12px;
+text{
+font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+font-size:12px;
 }
-.m {
-font-family: SFMono-Regular,Menlo,Consolas,Monaco,LiberationMono,LucidaConsole,monospace;
-font-size: 16px;
-}
-.l {
-font-weight: bold;
-text-anchor: middle;
-dominant-baseline: central;
-fill: #fff;
+.l{
+font-weight:700;
+text-anchor:middle;
+dominant-baseline:central;
+fill:#fff;
 }
 </style>
-<text x="10" y="30" fill="#2c3e50" class="m"><tspan fill="#e74c3c" font-weight="bold">mpileaks</tspan><tspan fill="#3498db">@1.2:1.4</tspan><tspan fill="#27ae60"> +debug ~qt</tspan><tspan fill="#f39c12"> target=x86_64_v3</tspan><tspan fill="#9b59b6" font-weight="bold"> %gcc</tspan><tspan fill="#3498db">@15</tspan><tspan fill="#e67e22" font-weight="bold"> ^libelf</tspan><tspan fill="#3498db">@1.1</tspan><tspan fill="#9b59b6" font-weight="bold"> %clang</tspan><tspan fill="#3498db">@20</tspan></text>
-
-<line x1="60" x2="60" y1="50" y2="85" stroke="#e74c3c" stroke-width="2"/>
-<rect x="10" y="85" width="100" height="30" rx="5" fill="#e74c3c"/>
+<text x="10" y="30" fill="#2c3e50" style="font-family:SFMono-Regular,Menlo,Consolas,Monaco,LiberationMono,LucidaConsole,monospace;font-size:16px"><tspan fill="#e74c3c" font-weight="bold">mpileaks</tspan><tspan fill="#3498db">@1.2:1.4</tspan><tspan fill="#27ae60"> +debug ~qt</tspan><tspan fill="#f39c12"> target=x86_64_v3</tspan><tspan fill="#9b59b6" font-weight="bold"> %gcc</tspan><tspan fill="#3498db">@15</tspan><tspan fill="#e67e22" font-weight="bold"> ^libelf</tspan><tspan fill="#3498db">@1.1</tspan><tspan fill="#9b59b6" font-weight="bold"> %clang</tspan><tspan fill="#3498db">@20</tspan></text>
+<path stroke="#e74c3c" stroke-width="2" d="M60 50v35"/>
+<rect width="100" height="30" x="10" y="85" fill="#e74c3c" rx="5"/>
 <text x="60" y="100" class="l">Package name</text>
-
-<line x1="130" x2="130" y1="50" y2="141" stroke="#3498db" stroke-width="2"/>
-<rect x="100" y="130" width="60" height="30" rx="5" fill="#3498db"/>
+<path stroke="#3498db" stroke-width="2" d="M130 50v91"/>
+<rect width="60" height="30" x="100" y="130" fill="#3498db" rx="5"/>
 <text x="130" y="145" class="l">Version</text>
-
-<line x1="230" x2="230" y1="50" y2="100" stroke="#27ae60" stroke-width="2"/>
-<rect x="190" y="85" width="80" height="30" rx="5" fill="#27ae60"/>
+<path stroke="#27ae60" stroke-width="2" d="M230 50v50"/>
+<rect width="80" height="30" x="190" y="85" fill="#27ae60" rx="5"/>
 <text x="230" y="100" class="l">Variants</text>
-
-<line x1="355" x2="355" y1="50" y2="150" stroke="#f39c12" stroke-width="2"/>
-<rect x="305" y="130" width="100" height="30" rx="5" fill="#f39c12"/>
+<path stroke="#f39c12" stroke-width="2" d="M355 50v100"/>
+<rect width="100" height="30" x="305" y="130" fill="#f39c12" rx="5"/>
 <text x="355" y="145" class="l">Architecture</text>
-
-<line x1="470" x2="470" y1="50" y2="100" stroke="#9b59b6" stroke-width="2"/>
-<rect x="404" y="85" width="130" height="30" rx="5" fill="#9b59b6"/>
+<path stroke="#9b59b6" stroke-width="2" d="M470 50v50"/>
+<rect width="130" height="30" x="404" y="85" fill="#9b59b6" rx="5"/>
 <text x="470" y="100" class="l">Direct dependency</text>
-
-<line x1="560" x2="560" y1="50" y2="150" stroke="#e67e22" stroke-width="2"/>
-<rect x="485" y="130" width="150" height="30" rx="5" fill="#e67e22"/>
+<path stroke="#e67e22" stroke-width="2" d="M560 50v100"/>
+<rect width="150" height="30" x="485" y="130" fill="#e67e22" rx="5"/>
 <text x="560" y="145" class="l">Transitive dependency</text>
-
 </svg>

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -26,19 +26,20 @@ Here is an example of using a complex spec to install a very specific configurat
 
 .. code-block:: spec
 
-   $ spack install mpileaks@1.2:1.4 +debug ~qt target=x86_64_v3 %gcc@15.1.0 ^libelf@1.1 %gcc@14.2.0
+   $ spack install mpileaks@1.2:1.4 +debug ~qt target=x86_64_v3 %gcc@15 ^libelf@1.1 %clang@20
 
 The figure below helps getting a sense of the various parts that compose this spec:
 
 .. figure:: images/spec_anatomy.svg
+   :alt: Spack spec with annotations
 
-If used to install a package, this will install:
+When installing this, you will get:
 
-* The ``mpileaks`` library at some version between ``1.2`` and ``1.4`` (inclusive),
+* The ``mpileaks`` package at some version between ``1.2`` and ``1.4`` (inclusive),
 * with ``debug`` options enabled, and without ``qt`` support,
-* for an ``x86_64_v3`` architecture,
-* built using ``gcc`` at version ``15.1.0``,
-* depending on ``libelf`` at version ``1.1``, built with ``gcc`` at version ``14.2.0``.
+* optimized for an ``x86_64_v3`` architecture,
+* built using ``gcc`` at version ``15``,
+* depending on ``libelf`` at version ``1.1``, built with ``clang`` at version ``20``.
 
 Most specs will not be as complicated as this one, but this is a good example of what is possible with specs.
 There are a few general rules that we can already infer from this first example:


### PR DESCRIPTION
Currently the dark theme renders makes the svg unreadable. Simplify so it can render on both dark and light background.