### PR TITLE
solver: fix building the default compiler

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1885,7 +1885,7 @@ opt_criterion(110, "number of packages to build (vs. reuse)").
 
 opt_criterion(100, "number of nodes from the same package").
 #minimize { 0@100: #true }.
-#minimize { ID@100,Package : attr("node", node(ID, Package)) }.
+#minimize { ID@100,Package : attr("node", node(ID, Package)), not self_build_requirement(_, node(ID, Package)) }.
 #minimize { ID@100,Package : attr("virtual_node", node(ID, Package)) }.
 #defined optimize_for_reuse/0.
 


### PR DESCRIPTION
Without this tweak, a new version of the default compiler would be built with a non-default compiler, because of the "multiple nodes from same package" penalty. Thus, make an exception for that specific case.

**Before:**
```console
$ spack -m spec gcc@14
 -   gcc@14.0 build_system=generic languages:='c,c++,fortran' arch=linux-ubuntu20.04-icelake %c,cxx=clang@12.0.0
 -       ^compiler-wrapper@1.0 build_system=generic arch=linux-ubuntu20.04-icelake 
[e]      ^glibc@2.31 build_system=autotools arch=linux-ubuntu20.04-icelake 
[e]      ^llvm@12.0.0+clang~flang+lld build_system=generic arch=linux-ubuntu20.04-icelake 
```

**After:**
```console
$ spack -m spec gcc@14
 -   gcc@14.0 build_system=generic languages:='c,c++,fortran' arch=linux-ubuntu20.04-icelake %c,cxx=gcc@15.1.0
 -       ^compiler-wrapper@1.0 build_system=generic arch=linux-ubuntu20.04-icelake 
[e]      ^gcc@15.1.0 build_system=generic languages:='c,c++,fortran' arch=linux-ubuntu20.04-icelake 
 -       ^gcc-runtime@15.1.0 build_system=generic arch=linux-ubuntu20.04-icelake 
[e]      ^glibc@2.31 build_system=autotools arch=linux-ubuntu20.04-icelake 
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
