### PR TITLE
docs: do no mention cross compile

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -127,10 +127,10 @@ If instead the option is set to:
        granularity: generic
 
 Spack will consider only generic microarchitectures.
-For instance, when running on a Haswell node, Spack will consider ``haswell`` as the best target in the former case and ``x86_64_v3`` as the best target in the latter case.
+For instance, when running on a Haswell machine, Spack will consider ``haswell`` as the best target in the former case and ``x86_64_v3`` as the best target in the latter case.
 
 The ``host_compatible`` option is a Boolean option that determines whether or not the microarchitectures considered during the solve are constrained to be compatible with the host Spack is currently running on.
-For instance, if this option is set to ``true``, a user cannot concretize for ``target=icelake`` while running on a Haswell node.
+For instance, if this option is set to ``true``, a user cannot concretize for ``target=icelake`` while running on a Haswell machine.
 
 Duplicate Nodes
 ---------------

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -225,7 +225,7 @@ Platform-specific Configuration
 There is often a need for platform-specific configuration settings.
 For example, on most platforms, GCC is the preferred compiler.
 However, on macOS (darwin), Clang often works for more packages, and is set as the default compiler.
-This configuration is set in ``$(prefix)/etc/spack/defaults/darwin/packages.yaml``, which is included as by ``$(prefix)/etc/spack/defaults/include.yaml``.
+This configuration is set in ``$(prefix)/etc/spack/defaults/darwin/packages.yaml``, which is included by ``$(prefix)/etc/spack/defaults/include.yaml``.
 Since it is an included configuration of the ``defaults`` scope, settings in the ``defaults`` scope will take precedence.
 You can override the values by specifying settings in ``system``, ``site``, ``user``, or ``custom``, where scope precedence is:
 

--- a/lib/spack/docs/features.rst
+++ b/lib/spack/docs/features.rst
@@ -25,7 +25,7 @@ Custom versions & configurations
 --------------------------------
 
 Spack allows installation to be customized.
-Users can specify the version, compile-time options, and cross-compile platform, all on the command line.
+Users can specify the version, compile-time options, and target architecture, all on the command line.
 
 .. code-block:: spec
 
@@ -41,7 +41,7 @@ Users can specify the version, compile-time options, and cross-compile platform,
    # Add compiler flags using the conventional names
    $ spack install hdf5@1.14.6 cflags="-O3 -floop-block"
 
-   # Cross-compile for a different micro-architecture with target=
+   # Target a specific micro-architecture
    $ spack install hdf5@1.14.6 target=icelake
 
 Users can specify as many or as few options as they care about.

--- a/lib/spack/docs/features.rst
+++ b/lib/spack/docs/features.rst
@@ -51,7 +51,7 @@ Customize dependencies
 ----------------------
 
 Spack allows *dependencies* of a particular installation to be customized extensively.
-Users can specify both *direct* dependencies of a node, using the ``%`` sigil, or *transitive* dependencies, using the ``^`` sigil:
+Users can specify both *direct* dependencies of a package, using the ``%`` sigil, or *transitive* dependencies, using the ``^`` sigil:
 
 .. code-block:: spec
 

--- a/lib/spack/docs/package_fundamentals.rst
+++ b/lib/spack/docs/package_fundamentals.rst
@@ -163,7 +163,7 @@ To do this, just add ``@`` after the package name, followed by a version:
 Any number of versions of the same package can be installed at once without interfering with each other.
 This is useful for multi-user sites, as installing a version that one user needs will not disrupt existing installations for other users.
 
-In addition to different versions, Spack can customize the compiler, compile-time options (variants), compiler flags, and platform (for cross-compiles) of an installation.
+In addition to different versions, Spack can customize the compiler, compile-time options (variants), compiler flags, and target architecture of an installation.
 Spack is unique in that it can also configure the *dependencies* a package is built with.
 For example, two configurations of the same version of a package, one built with boost 1.39.0, and the other version built with version 1.43.0, can coexist.
 

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -1298,7 +1298,7 @@ E.g., in openmpi, you'll find this:
 .. literalinclude:: .spack/spack-packages/repos/spack_repo/builtin/packages/openmpi/package.py
    :pyobject: Openmpi.setup_dependent_package
 
-That code allows the ``openmpi`` package to associate an ``mpicc`` property with the ``openmpi`` node in the DAG, so that dependents can access it.
+That code allows the ``openmpi`` package to associate an ``mpicc`` property with the ``openmpi`` spec in the DAG, so that dependents can access it.
 ``mvapich2`` and ``mpich`` do similar things.
 So, no matter what MPI you're using, spec["mpi"].mpicc gets you the location of the MPI compilers.
 This allows us to have a fairly simple polymorphic interface for information about virtual dependencies like MPI.

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -123,7 +123,7 @@ For example, these two specs represent exactly the same configuration:
    mpileaks ^callpath@1.0 ^libelf@0.8.3
    mpileaks ^libelf@0.8.3 ^callpath@1.0
 
-Direct dependencies specified with ``%`` associate with the most recent transitive node, or with the root of the DAG.
+Direct dependencies specified with ``%`` apply either to the most recent transitive dependency (``^``), or, if none, to the root package in the spec.
 So in the spec:
 
 .. code-block:: spec

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -44,8 +44,7 @@ line is a spec for a particular installation of the mpileaks package.
    if it comes immediately after the compiler name.  Otherwise it will be
    associated with the current package spec.
 
-6. The architecture to build with.  This is needed on machines where
-   cross-compilation is required
+6. The architecture to build with.
 """
 import collections
 import collections.abc


### PR DESCRIPTION
The docs give the wrong impression that Spack can do cross compilation.

Also avoid the overloaded word `node`, which is rarely used. Common is spec/package.

