### PR TITLE
Backports: v1.0.2

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
   schedule:
     # nightly at 2:16 AM
-    - cron: '16 2 * * *'
+    - cron: "16 2 * * *"
 
 concurrency:
   group: bootstrap-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
@@ -46,7 +46,6 @@ jobs:
           source share/spack/setup-env.sh
           spack bootstrap disable github-actions-v0.6
           spack bootstrap disable github-actions-v0.5
-          spack external find cmake bison
           spack -d solve zlib
           tree ~/.spack/bootstrap/store/
 
@@ -55,12 +54,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: ['macos-13', 'macos-14', "ubuntu-latest"]
+        runner: ["macos-13", "macos-14", "ubuntu-latest"]
     steps:
       - name: Setup macOS
         if: ${{ matrix.runner != 'ubuntu-latest' }}
-        run: |
-          brew install cmake bison tree
+        run: brew install bison tree
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -73,7 +71,7 @@ jobs:
           source share/spack/setup-env.sh
           spack bootstrap disable github-actions-v0.6
           spack bootstrap disable github-actions-v0.5
-          spack external find --not-buildable cmake bison
+          export PATH="$(brew --prefix bison)/bin:$(brew --prefix cmake)/bin:$PATH"
           spack -d solve zlib
           tree $HOME/.spack/bootstrap/store/
 
@@ -82,7 +80,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: [ 'macos-13', 'macos-14', "ubuntu-latest" ]
+        runner: ["macos-13", "macos-14", "ubuntu-latest"]
     steps:
       - name: Setup macOS
         if: ${{ matrix.runner != 'ubuntu-latest' }}
@@ -110,7 +108,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: ['macos-13', 'macos-14', "ubuntu-latest"]
+        runner: ["macos-13", "macos-14", "ubuntu-latest"]
     steps:
       - name: Setup macOS
         if: ${{ matrix.runner != 'ubuntu-latest' }}
@@ -166,7 +164,6 @@ jobs:
           spack -d gpg list
           tree $HOME/.spack/bootstrap/store/
 
-
   windows:
     if: github.repository == 'spack/spack'
     runs-on: "windows-latest"
@@ -187,7 +184,6 @@ jobs:
           ./share/spack/setup-env.ps1
           spack bootstrap disable github-actions-v0.6
           spack bootstrap disable github-actions-v0.5
-          spack external find --not-buildable cmake bison
           spack -d solve zlib
           ./share/spack/qa/validate_last_exit.ps1
           tree $env:userprofile/.spack/bootstrap/store/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# v1.0.2 (2025-09-11)
+
+## Bug Fixes
+
+* `spack config edit` can now open malformed YAML files. (#51088)
+* `spack edit -b` supports specifying the repository path or its namespace. (#51084)
+* `spack repo list` escapes the color code for paths that contain `@g`. (#51178)
+* Fixed various issues on the solver:
+  * Improved the error message when an invalid dependency is specified in the input. (#51176)
+  * Build the preferred compiler with itself by default. (#51201)
+  * Fixed a performance regression when using `unify:when_possible`. (#51226)
+  * Fixed an issue with strong preferences, when provider details are given. (#51263)
+  * Fixed an issue when specifying flags on a package that appears multiple times in the DAG. (#51218) 
+* Fixed a regression for `zsh` in `spack env activate --prompt`. (#51258)
+* Fix a few cases where the `when` context manager was not dealing with direct dependencies correctly. (#51259)
+* Various fixes to string representations of specs. (#51207) 
+
+## Enhancements
+
+* Various improvements to the documentation (#51145, #51151, #51147, #51181, #51172, #51188, #51195)
+* Greatly improve the performance of `spack diff`. (#51270)
+* `spack solve` highlights optimization weights in a more intuitive way. (#51198)
+
 # v1.0.1 (2025-08-11)
 
 ## Bug Fixes

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -49,8 +49,6 @@ provided build cache, which can be a local directory or a remote URL.
 Here is an example where a build cache is created in a local directory named
 "spack-cache", to which we push the "ninja" spec:
 
-ninja-1.12.1-vmvycib6vmiofkdqgrblo7zsvp7odwut
-
 .. code-block:: console
 
     $ spack buildcache push ./spack-cache ninja

--- a/lib/spack/docs/build_systems/octavepackage.rst
+++ b/lib/spack/docs/build_systems/octavepackage.rst
@@ -44,7 +44,7 @@ Dependencies
 ^^^^^^^^^^^^
 
 Usually, the homepage of a package will list dependencies, i.e.,
-``Dependencies:	Octave >= 3.6.0 struct >= 1.0.12``. The same information should
+``Dependencies: Octave >= 3.6.0 struct >= 1.0.12``. The same information should
 be available in the ``DESCRIPTION`` file in the root of each archive.
 
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -84,7 +84,8 @@ space available in the temporary location than in the home directory. If the
 username is not already in the path, Spack will append the value of ``$user`` to
 the selected ``build_stage`` path.
 
-.. warning:: We highly recommend specifying ``build_stage`` paths that
+.. warning::
+   We highly recommend specifying ``build_stage`` paths that
    distinguish between staging and other activities to ensure
    ``spack clean`` does not inadvertently remove unrelated files.
    Spack prepends ``spack-stage-`` to temporary staging directory names to

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -22,6 +22,7 @@ case you want to skip directly to specific docs:
 * :ref:`modules.yaml <modules>`
 * :ref:`packages.yaml <packages-config>` (including :ref:`compiler configuration <compiler-config>`)
 * :ref:`repos.yaml <repositories>`
+* :ref:`toolchains.yaml <toolchains>`
 
 You can also add any of these as inline configuration in the YAML
 manifest file (``spack.yaml``) describing an :ref:`environment
@@ -122,12 +123,11 @@ In addition to the ``defaults``, ``system``, ``site``, and ``user``
 scopes, you may add configuration scopes directly on the command
 line with the ``--config-scope`` argument, or ``-C`` for short.
 
-For example, the following adds two configuration scopes, named
-``scopea`` and ``scopeb``, to a ``spack spec`` command:
+For example, the following adds two configuration scopes, named ``scope-a`` and ``scope-b``, to a ``spack spec`` command:
 
 .. code-block:: console
 
-   $ spack -C ~/myscopes/scopea -C ~/myscopes/scopeb spec ncurses
+   $ spack -C ~/myscopes/scope-a -C ~/myscopes/scope-b spec ncurses
 
 Custom scopes come *after* the ``spack`` command and *before* the
 subcommand, and they specify a single path to a directory containing
@@ -144,8 +144,7 @@ If multiple scopes are provided:
 Example: scopes for release and development
 """""""""""""""""""""""""""""""""""""""""""
 
-Suppose that you need to support simultaneous building of release and
-development versions of ``mypackage``, where ``mypackage`` depends on ``A``, which in turn depends on ``B``.
+Suppose that you need to support simultaneous building of release and development versions of ``mypackage``, where ``mypackage`` depends on ``pkg-a``, which in turn depends on ``pkg-b``.
 You could create the following files:
 
 .. code-block:: yaml
@@ -153,58 +152,52 @@ You could create the following files:
 
    packages:
        mypackage:
-           version: [1.7]
-       A:
-           version: [2.3]
-       B:
-           version: [0.8]
+           prefer: ["@1.7"]
+       pkg-a:
+           prefer: ["@2.3"]
+       pkg-b:
+           prefer: ["@0.8"]
 
 .. code-block:: yaml
    :caption: ~/myscopes/develop/packages.yaml
 
    packages:
        mypackage:
-           version: [develop]
-       A:
-           version: [develop]
-       B:
-           version: [develop]
+           prefer: ["@develop"]
+       pkg-a:
+           prefer: ["@develop"]
+       pkg-b:
+           prefer: ["@develop"]
 
-You can switch between ``release`` and ``develop`` configurations using
-configuration arguments. You would type ``spack -C ~/myscopes/release``
-when you want to build the designated release versions of ``mypackage``,
-``A``, and ``B``, and you would type ``spack -C ~/myscopes/develop`` when
-you want to build all of these packages at the ``develop`` version.
+You can switch between ``release`` and ``develop`` configurations using configuration arguments.
+You would type ``spack -C ~/myscopes/release`` when you want to build the designated release versions of ``mypackage``, ``pkg-a``, and ``pkg-b``, and you would type ``spack -C ~/myscopes/develop`` when you want to build all of these packages at the ``develop`` version.
 
 """""""""""""""""""""""""""""""
 Example: swapping MPI providers
 """""""""""""""""""""""""""""""
 
-Suppose that you need to build two software packages, ``packagea`` and
-``packageb``. ``packagea`` is Python 2-based, and ``packageb`` is Python
-3-based. ``packagea`` only builds with OpenMPI, and ``packageb`` only builds
-with MPICH. You can create different configuration scopes for use with
-``packagea`` and ``packageb``:
+Suppose that you need to build two software packages, ``pkg-a`` and ``pkg-b``.
+``pkg-a`` is Python 2-based, and ``pkg-b`` is Python 3-based.
+``pkg-a`` only builds with OpenMPI, and ``pkg-b`` only builds with MPICH.
+You can create different configuration scopes for use with ``pkg-a`` and ``pkg-b``:
 
 .. code-block:: yaml
-   :caption: ~/myscopes/packgea/packages.yaml
+   :caption: ~/myscopes/pkg-a/packages.yaml
 
    packages:
        python:
-           version: [2.7.11]
-       all:
-           providers:
-               mpi: [openmpi]
+           require: ["@2.7.11"]
+       mpi:
+           require: [openmpi]
 
 .. code-block:: yaml
-   :caption: ~/myscopes/packageb/packages.yaml
+   :caption: ~/myscopes/pkg-b/packages.yaml
 
    packages:
        python:
-           version: [3.5.2]
-       all:
-           providers:
-               mpi: [mpich]
+           require: ["@3.5.2"]
+       mpi:
+           require: [mpich]
 
 
 .. _plugin-scopes:

--- a/lib/spack/docs/configuring_compilers.rst
+++ b/lib/spack/docs/configuring_compilers.rst
@@ -293,3 +293,8 @@ Once the compiler is installed, you can start using it without additional config
 .. code-block:: console
 
    $ spack install hdf5~mpi %gcc@14
+
+Mixing Compilers
+----------------
+
+For more options on configuring Spack to mix different compilers for different languages, see :ref:`the toolchains configuration docs <toolchains>`.

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -8,7 +8,6 @@
 
 .. _containers:
 
-================
 Container Images
 ================
 

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -451,12 +451,12 @@ Contributing computational resources to Spack's CI build farm is one way to help
 capabilities and offerings of the public Spack build caches. Currently, Spack utilizes Linux runners
 from AWS, Google, and the University of Oregon (UO).
 
-Runners require three key pieces:
+Runners require four key pieces:
+
 * Runner Registration Token
 * Accurate tags
 * OIDC Authentication script
 * GPG keys
-
 
 Minimum GitLab Runner Version: ``16.1.0``
 `Installation instructions <https://docs.gitlab.com/runner/install/>`_

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -127,9 +127,8 @@ or refer to the full manual below.
    Spack Builtin Repo <spack_repo>
    Spack API Docs <spack>
 
-==================
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -60,19 +60,14 @@ Here's an example of an external configuration:
    packages:
      openmpi:
        externals:
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+       - spec: "openmpi@1.4.3~debug"
          prefix: /opt/openmpi-1.4.3
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+       - spec: "openmpi@1.4.3+debug"
          prefix: /opt/openmpi-1.4.3-debug
-       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
-         prefix: /opt/openmpi-1.6.5-intel
 
-This example lists three installations of OpenMPI, one built with GCC,
-one built with GCC and debug information, and another built with Intel.
-If Spack is asked to build a package that uses one of these MPIs as a
-dependency, it will use the pre-installed OpenMPI in
-the given directory. Note that the specified path is the top-level
-install prefix, not the ``bin`` subdirectory.
+This example lists two installations of OpenMPI, one with debug information, and one without.
+If Spack is asked to build a package that uses one of these MPIs as a dependency, it will use the pre-installed OpenMPI in the given directory.
+Note that the specified path is the top-level install prefix, not the ``bin`` subdirectory.
 
 ``packages.yaml`` can also be used to specify modules to load instead
 of the installation prefixes.  The following example says that module
@@ -118,7 +113,7 @@ follows:
    packages:
      mpich:
        externals:
-       - spec: mpich@3.3 %clang@12.0.0 +hwloc
+       - spec: mpich@3.3 +hwloc
          prefix: /path/to/mpich
          extra_attributes:
            environment:
@@ -222,12 +217,10 @@ be:
    packages:
      openmpi:
        externals:
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+       - spec: "openmpi@1.4.3~debug"
          prefix: /opt/openmpi-1.4.3
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+       - spec: "openmpi@1.4.3+debug"
          prefix: /opt/openmpi-1.4.3-debug
-       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
-         prefix: /opt/openmpi-1.6.5-intel
        buildable: False
 
 The addition of the ``buildable`` flag tells Spack that it should never build
@@ -264,12 +257,10 @@ but more conveniently:
        buildable: False
      openmpi:
        externals:
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+       - spec: "openmpi@1.4.3~debug"
          prefix: /opt/openmpi-1.4.3
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+       - spec: "openmpi@1.4.3+debug"
          prefix: /opt/openmpi-1.4.3-debug
-       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
-         prefix: /opt/openmpi-1.6.5-intel
 
 Spack can then use any of the listed external implementations of MPI
 to satisfy a dependency, and will choose depending on the compiler and
@@ -286,18 +277,15 @@ specs matching only the available externals:
        buildable: False
        require:
        - one_of: [
-           "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64",
-           "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug",
-           "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
+           "openmpi@1.4.3~debug",
+           "openmpi@1.4.3+debug",
          ]
      openmpi:
        externals:
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+       - spec: "openmpi@1.4.3~debug"
          prefix: /opt/openmpi-1.4.3
-       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+       - spec: "openmpi@1.4.3+debug"
          prefix: /opt/openmpi-1.4.3-debug
-       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
-         prefix: /opt/openmpi-1.6.5-intel
 
 This configuration prevents any spec using MPI and originating from stores or buildcaches to be reused,
 unless it matches the requirements under ``packages:mpi:require``. For more information on requirements see

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -750,7 +750,7 @@ File filtering functions
     hard-coded ``sed`` commands in their build.
 
     ``change_sed_delimiter`` finds all ``sed`` search/replace commands
-    and changes the delimiter.  e.g., if the file contains commands
+    and changes the delimiter. E.g., if the file contains commands
     that look like ``s///``, you can use this to change them to
     ``s@@@``.
 

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -100,20 +100,27 @@ The typical structure of a package is as follows:
    class Example(CMakePackage):
        """Example package"""  # package description
 
-       # metadata and directives
+       # Metadata and Directives
        homepage = "https://example.com"
        url = "https://example.com/example/v2.4.0.tar.gz"
 
        maintainers("github_user1", "github_user2")
 
+       license("UNKNOWN", checked_by="github_user1")
+
+       # version directives listed in order with the latest first
        version("2.4.0", sha256="845ccd79ed915fa2dedf3b2abde3fffe7f9f5673cc51be88e47e6432bd1408be")
        version("2.3.0", sha256="cd3274e0abcbc2dfb678d87595e9d3ab1c6954d7921d57a88a23cf4981af46c9")
 
+       # variant directives expose build options
        variant("feature", default=False, description="Enable a specific feature")
+       variant("codec", default=False, description="Build the CODEC executables")
 
+       # dependency directives declare required software
+       depends_on("cxx", type="build")
        depends_on("libfoo", when="+feature")
 
-       # build instructions
+       # Build Instructions
        def cmake_args(self):
            return [
                self.define_from_variant("BUILD_CODEC", "codec"),
@@ -123,7 +130,7 @@ The typical structure of a package is as follows:
 
 The package class is named after the package, and can roughly be divided into two parts:
 
-* **metadata and directives**: attributes and directives that describe the package, such as its homepage, versions, maintainers, dependencies, and variants.
+* **metadata and directives**: attributes and directives that describe the package, such as its homepage, maintainers, license, variants, and dependencies.
   This is the declarative part of the package.
 * **build instructions**: methods that define how to build and install the package, such as `cmake_args()`.
   This is the imperative part of the package.
@@ -286,6 +293,11 @@ Spack automatically creates a directory in the appropriate repository, generates
        # notify when the package is updated.
        # maintainers("github_user1", "github_user2")
 
+       # FIXME: Add the SPDX identifier of the project's license below.
+       # See https://spdx.org/licenses/ for a list. Upon manually verifying
+       # the license, set checked_by to your Github username.
+       license("UNKNOWN", checked_by="github_user1")
+
        version("6.2.1", sha256="eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c")
 
        # FIXME: Add dependencies if required.
@@ -313,8 +325,8 @@ For most Autotools packages, this is sufficient. If you need to add additional a
 
 In the generated package, the download ``url`` attribute is already set.
 All the things you still need to change are marked with ``FIXME`` labels.
-You can delete the commented instructions between the license and the first import statement after reading them.
-The rest of the tasks you need to do are as follows:
+You can delete the commented instructions between the Spack license and the first import statement after reading them.
+The rest of the tasks you need to complete are as follows:
 
 #. Add a description.
 
@@ -329,6 +341,10 @@ The rest of the tasks you need to do are as follows:
 
    Add a list of GitHub accounts of people who want to be notified any time the package is modified. See :ref:`package_maintainers`.
 
+#. Change the ``license`` to the correct license.
+
+   The ``license`` is displayed when users run ``spack info`` so that they can learn more about your package. See :ref:`package_license`.
+
 #. Add ``depends_on()`` calls for the package's dependencies.
 
    ``depends_on`` tells Spack that other packages need to be built and installed before this one. See :ref:`dependencies`.
@@ -337,6 +353,7 @@ The rest of the tasks you need to do are as follows:
 
    Your new package may require specific flags during ``configure``.
    These can be added via ``configure_args``.
+   If no arguments are needed at this time, change the implementation to ``return []``.
    Specifics will differ depending on the package and its build system.
    :ref:`installation_process` is covered in detail later.
 
@@ -2688,6 +2705,8 @@ To add maintainers to a package, simply declare them with the ``maintainers`` di
    maintainers("user1", "user2")
 
 The list of maintainers is additive, and includes all the accounts eventually declared in base classes.
+
+.. _package_license:
 
 -------------------
 License Information

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -337,9 +337,10 @@ This search order allows you to override built-in packages.
 If you have your own ``mpich`` in a repository ``my_custom_repo``, and ``my_custom_repo`` is listed before ``builtin`` in your ``repos.yaml``, Spack will use your version of ``mpich`` by default.
 
 Suppose your effective (merged) ``repos.yaml`` implies the following order:
-1.  ``proto`` (local repo at ``~/my_spack_repos/spack_repo/proto_repo``)
-2.  ``llnl`` (local repo at ``/usr/local/repos/spack_repo/llnl_repo``)
-3.  ``builtin`` (Spack's default packages from `spack/spack-packages`)
+
+1. ``proto`` (local repo at ``~/my_spack_repos/spack_repo/proto_repo``)
+2. ``llnl`` (local repo at ``/usr/local/repos/spack_repo/llnl_repo``)
+3. ``builtin`` (Spack's default packages from ``spack/spack-packages``)
 
 And the packages are:
   +--------------+------------------------------------------------+-----------------------------+

--- a/lib/spack/docs/signing.rst
+++ b/lib/spack/docs/signing.rst
@@ -411,7 +411,7 @@ registered as specific *protected* runners on the spack/spack project. In
 addition to protected runners there are protected branches on the spack/spack
 project. These are the ``develop`` branch, any release branch (i.e. managed with
 the ``releases/v*`` wildcard) and any tag branch (managed with the ``v*``
-wildcard) Finally, Spack's pipeline generation code reserves certain tags to make
+wildcard). Finally, Spack's pipeline generation code reserves certain tags to make
 sure jobs are routed to the correct runners; these tags are ``public``,
 ``protected``, and ``notary``. Understanding how all this works together to
 protect secrets and provide integrity assurances can be a little confusing so

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -134,20 +134,6 @@ So in the spec:
 
 ``dep1`` is a direct dependency of ``root``, while both ``dep2`` and ``dep3`` are direct dependencies of ``transitive``.
 
-.. admonition:: Windows Spec Syntax Caveats
-   :class: note
-   :collapsible:
-
-   Windows has a few idiosyncrasies when it comes to the Spack spec syntax and the use of certain shells.
-   Spack's spec dependency syntax uses the carat (``^``) character; however, this is an escape string in CMD,
-   so it must be escaped with an additional carat (i.e., ``^^``).
-   CMD also will attempt to interpret strings with ``=`` characters in them. Any spec including this symbol
-   must double-quote the string.
-
-   Note: All of these issues are unique to CMD; they can be avoided by using PowerShell.
-
-   For more context on these caveats, see the related issues: `carat <https://github.com/spack/spack/issues/42833>`_ and `equals <https://github.com/spack/spack/issues/43348>`_.
-
 Below are more details about the specifiers that you can add to specs.
 
 .. _version-specifier:
@@ -318,28 +304,6 @@ If the intent is to enable *only* the specified fabrics, then the:
    fabrics:=verbs,ofi
 
 syntax should be used with the ``:=`` operator.
-
-.. admonition:: Alternative ways to deactivate Boolean Variants
-   :class: note
-   :collapsible:
-
-   In certain shells, the ``~`` character expands to the home directory.
-   To avoid these issues, avoid whitespace between the package name and the variant:
-
-   .. code-block:: sh
-
-      mpileaks ~debug   # shell may try to substitute this!
-      mpileaks~debug    # use this instead
-
-   Alternatively, you can use the ``-`` character to disable a variant, but be aware that this requires a space between the package name and the variant:
-
-   .. code-block:: sh
-
-      mpileaks-debug     # wrong: refers to a package named "mpileaks-debug"
-      mpileaks -debug    # right: refers to a package named mpileaks with debug disabled
-
-   As a last resort, ``debug=False`` can also be used to disable a boolean variant.
-
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -718,3 +682,45 @@ We can express conditional constraint by specifying the ``when`` edge attribute:
    spack install hdf5 ^[when=+mpi] mpich@3.1
 
 This tells Spack that hdf5 should depend on ``mpich@3.1`` if it is configured with MPI support.
+
+Specs on the command line
+-------------------------
+
+The characters used in the spec syntax were chosen to work well with most shells.
+However, there are cases where the shell may interpret the spec before Spack gets a chance to parse it, leading to unexpected results.
+Here we document two such cases, and how to avoid them.
+
+Unix shells
+^^^^^^^^^^^
+
+On Unix-like systems, the shell may expand ``~foo`` to the home directory of a user named ``foo``, so Spack won't see it as a :ref:`disabled boolean variant <basic-variants>` ``foo``.
+To work around this without quoting, you can avoid whitespace between the package name and boolean variants:
+
+.. code-block:: spec
+
+   mpileaks ~debug   # shell may expand this to `mpileaks /home/debug`
+   mpileaks~debug    # use this instead
+
+Alternatively, you can use a hyphen ``-`` character to disable a variant, but be aware that this *requires* a space between the package name and the variant:
+
+.. code-block:: spec
+
+   mpileaks-debug     # wrong: refers to a package named "mpileaks-debug"
+   mpileaks -debug    # right: refers to a package named mpileaks with debug disabled
+
+As a last resort, ``debug=False`` can also be used to disable a boolean variant.
+
+Windows CMD
+^^^^^^^^^^^
+
+In Windows CMD, the caret ``^`` is an escape character, and needs itself escaping.
+Similarly, the equals ``=`` character has special meaning in CMD.
+
+To use the caret and equals characters in a spec, you can quote and escape them like this:
+
+.. code-block:: console
+
+   C:\> spack install mpileaks "^^libelf" "foo=bar"
+
+These issues are not present in PowerShell.
+See GitHub issue `#42833 <https://github.com/spack/spack/issues/42833>`_ and `#43348 <https://github.com/spack/spack/issues/43348>`_ for more details.

--- a/lib/spack/docs/windows.rst
+++ b/lib/spack/docs/windows.rst
@@ -195,7 +195,7 @@ at the start of this section. Also note that YAML files use spaces for indentati
 and not tabs, so ensure that this is the case when editing one directly.
 
 
-.. note:: Cygwin
+.. note::
    The use of Cygwin is not officially supported by Spack and is not tested.
    However, Spack will not prevent this, so if choosing to use Spack
    with Cygwin, know that no functionality is guaranteed.
@@ -213,7 +213,7 @@ Spack console via:
 
 If in the previous step, you did not have CMake or Ninja installed, running the command above should install both packages.
 
-.. note:: Spec Syntax Caveats
+.. note::
    Windows has a few idiosyncrasies when it comes to the Spack spec syntax and the use of certain shells
    See the Spack spec syntax doc for more information
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -10,7 +10,7 @@ import spack.paths
 import spack.util.git
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "1.0.1"
+__version__ = "1.0.2.dev0"
 spack_version = __version__
 
 #: The current Package API version implemented by this version of Spack. The Package API defines

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -10,7 +10,7 @@ import spack.paths
 import spack.util.git
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "1.0.2.dev0"
+__version__ = "1.0.2"
 spack_version = __version__
 
 #: The current Package API version implemented by this version of Spack. The Package API defines

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -219,7 +219,16 @@ def config_edit(args):
     the active environment.
     """
     spack_env = os.environ.get(ev.spack_env_var)
-    if spack_env and not args.scope:
+    env_error = ev.environment._active_environment_error
+
+    if env_error and args.scope:
+        # Cannot use scopes beyond the environment itself with a failed environment
+        raise env_error
+    elif env_error:
+        # The rest of the config system wasn't set up fully, but spack.main was allowed
+        # to progress so the user can open the malformed environment file
+        config_file = env_error.filename
+    elif spack_env and not args.scope:
         # Don't use the scope object for envs, as `config edit` can be called
         # for a malformed environment. Use SPACK_ENV to find spack.yaml.
         config_file = ev.manifest_file(spack_env)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -322,8 +322,9 @@ def repo_list(args):
 
         # Print aligned output
         for status, namespace, api, path in repo_info:
+            cpath = color.cescape(path)
             color.cprint(
-                f"{status} {namespace:<{max_namespace_width}} {api:<{max_api_width}} {path}"
+                f"{status} {namespace:<{max_namespace_width}} {api:<{max_api_width}} {cpath}"
             )
 
 

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -55,22 +55,34 @@ def _process_result(result, show, required_format, kwargs):
     opt, _, _ = min(result.answers)
     if ("opt" in show) and (not required_format):
         tty.msg("Best of %d considered solutions." % result.nmodels)
-        tty.msg("Optimization Criteria:")
 
-        maxlen = max(len(s[2]) for s in result.criteria)
-        color.cprint("@*{  Priority  Criterion %sInstalled  ToBuild}" % ((maxlen - 10) * " "))
+        print()
+        maxlen = max(len(s.name) for s in result.criteria)
+        color.cprint("@*{  Priority  Value  Criterion}")
 
-        fmt = "  @K{%%-8d}  %%-%ds%%9s  %%7s" % maxlen
-        for i, (installed_cost, build_cost, name) in enumerate(result.criteria, 1):
-            color.cprint(
-                fmt
-                % (
-                    i,
-                    name,
-                    "-" if build_cost is None else installed_cost,
-                    installed_cost if build_cost is None else build_cost,
-                )
-            )
+        for i, criterion in enumerate(result.criteria, 1):
+            value = f"@K{{{criterion.value:>5}}}"
+            grey_out = True
+            if criterion.value > 0:
+                value = f"@*{{{criterion.value:>5}}}"
+                grey_out = False
+
+            if grey_out:
+                lc = "@K"
+            elif criterion.kind == asp.OptimizationKind.CONCRETE:
+                lc = "@b"
+            elif criterion.kind == asp.OptimizationKind.BUILD:
+                lc = "@g"
+            else:
+                lc = "@y"
+
+            color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
+        print()
+        print()
+        color.cprint("  @*{Legend:}")
+        color.cprint("    @g{Specs to be built}")
+        color.cprint("    @b{Reused specs}")
+        color.cprint("    @y{Other criteria}")
         print()
 
     # dump the solutions as concretized specs

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -184,8 +184,10 @@ class DirectiveMeta(type):
                     ]
                     if kwargs.get("when"):
                         when_constraints.append(spack.spec.Spec(kwargs["when"]))
-                    when_spec = spack.spec.merge_abstract_anonymous_specs(*when_constraints)
 
+                    when_spec = spack.spec.Spec()
+                    for current in when_constraints:
+                        when_spec._constrain_symbolically(current, deps=True)
                     kwargs["when"] = when_spec
 
                 # If any of the arguments are executors returned by a

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -58,6 +58,10 @@ spack_env_view_var = "SPACK_ENV_VIEW"
 #: currently activated environment
 _active_environment: Optional["Environment"] = None
 
+# This is used in spack.main to bypass env failures if the command is `spack config edit`
+# It is used in spack.cmd.config to get the path to a failed env for `spack config edit`
+#: Validation error for a currently activate environment that failed to parse
+_active_environment_error: Optional[spack.config.ConfigFormatError] = None
 
 #: default path where environments are stored in the spack tree
 default_env_path = os.path.join(spack.paths.var_path, "environments")
@@ -572,7 +576,7 @@ def _read_yaml(str_or_file):
         data = syaml.load_config(str_or_file)
     except syaml.SpackYAMLError as e:
         raise SpackEnvironmentConfigError(
-            f"Invalid environment configuration detected: {e.message}"
+            f"Invalid environment configuration detected: {e.message}", e.filename
         )
 
     filename = getattr(str_or_file, "name", None)
@@ -3011,3 +3015,7 @@ class SpackEnvironmentViewError(SpackEnvironmentError):
 
 class SpackEnvironmentConfigError(SpackEnvironmentError):
     """Class for Spack environment-specific configuration errors."""
+
+    def __init__(self, msg, filename):
+        self.filename = filename
+        super().__init__(msg)

--- a/lib/spack/spack/llnl/util/tty/color.py
+++ b/lib/spack/spack/llnl/util/tty/color.py
@@ -210,18 +210,17 @@ def color_when(value):
 
 def _escape(s: str, color: bool, enclose: bool, zsh: bool) -> str:
     """Returns a TTY escape sequence for a color"""
-    if color:
-        if zsh:
-            result = rf"\e[0;{s}m"
-        else:
-            result = f"\033[{s}m"
-
-        if enclose:
-            result = rf"\[{result}\]"
-
-        return result
-    else:
+    if not color:
         return ""
+    elif zsh:
+        return f"\033[0;{s}m"
+
+    result = f"\033[{s}m"
+
+    if enclose:
+        result = rf"\[{result}\]"
+
+    return result
 
 
 def colorize(

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Classes and functions to manage providers of virtual dependencies"""
-from typing import Dict, List, Optional, Set
+from typing import Dict, Iterable, Optional, Set
 
 import spack.error
 import spack.spec
@@ -80,7 +80,7 @@ class ProviderIndex(_IndexBase):
     def __init__(
         self,
         repository: "spack.repo.RepoType",
-        specs: Optional[List["spack.spec.Spec"]] = None,
+        specs: Optional[Iterable["spack.spec.Spec"]] = None,
         restrict: bool = False,
     ):
         """Provider index based on a single mapping of providers.

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1061,6 +1061,7 @@ class Repo:
             config.get("subdirectory", packages_dir_name), root, self.package_api
         )
         self.packages_path = os.path.join(self.root, self.subdirectory)
+        self.build_systems_path = os.path.join(self.root, "build_systems")
 
         check(
             os.path.isdir(self.packages_path),

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2200,7 +2200,7 @@ class SpackSolverSetup:
 
                 when_spec = spec
                 if virtual and spec.name != pkg_name:
-                    when_spec = spack.spec.Spec(f"^[virtuals={pkg_name}] {spec.name}")
+                    when_spec = spack.spec.Spec(f"^[virtuals={pkg_name}] {spec}")
 
                 try:
                     context = ConditionContext()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -199,30 +199,45 @@ build_priority_offset = 200
 fixed_priority_offset = 100
 
 
+class OptimizationKind:
+    """Enum for the optimization KIND of a criteria.
+
+    It's not using enum.Enum since it must be serializable.
+    """
+
+    BUILD = 0
+    CONCRETE = 1
+    OTHER = 2
+
+
+class OptimizationCriteria(NamedTuple):
+    """A named tuple describing an optimization criteria."""
+
+    priority: int
+    value: int
+    name: str
+    kind: OptimizationKind
+
+
 def build_criteria_names(costs, arg_tuples):
     """Construct an ordered mapping from criteria names to costs."""
     # pull optimization criteria names out of the solution
     priorities_names = []
 
-    num_fixed = 0
-    num_high_fixed = 0
     for args in arg_tuples:
         priority, name = args[:2]
         priority = int(priority)
 
-        # add the priority of this opt criterion and its name
-        priorities_names.append((priority, name))
-
-        # if the priority is less than fixed_priority_offset, then it
-        # has an associated build priority -- the same criterion but for
-        # nodes that we have to build.
+        # Add the priority of this opt criterion and its name
         if priority < fixed_priority_offset:
+            # if the priority is less than fixed_priority_offset, then it
+            # has an associated build priority -- the same criterion but for
+            # nodes that we have to build.
+            priorities_names.append((priority, name, OptimizationKind.CONCRETE))
             build_priority = priority + build_priority_offset
-            priorities_names.append((build_priority, name))
-        elif priority >= high_fixed_priority_offset:
-            num_high_fixed += 1
+            priorities_names.append((build_priority, name, OptimizationKind.BUILD))
         else:
-            num_fixed += 1
+            priorities_names.append((priority, name, OptimizationKind.OTHER))
 
     # sort the criteria by priority
     priorities_names = sorted(priorities_names, reverse=True)
@@ -232,33 +247,10 @@ def build_criteria_names(costs, arg_tuples):
     error_criteria = len(costs) - len(priorities_names)
     costs = costs[error_criteria:]
 
-    # split list into three parts: build criteria, fixed criteria, non-build criteria
-    num_criteria = len(priorities_names)
-    num_build = (num_criteria - num_fixed - num_high_fixed) // 2
-
-    build_start_idx = num_high_fixed
-    fixed_start_idx = num_high_fixed + num_build
-    installed_start_idx = num_high_fixed + num_build + num_fixed
-
-    high_fixed = priorities_names[:build_start_idx]
-    build = priorities_names[build_start_idx:fixed_start_idx]
-    fixed = priorities_names[fixed_start_idx:installed_start_idx]
-    installed = priorities_names[installed_start_idx:]
-
-    # mapping from priority to index in cost list
-    indices = dict((p, i) for i, (p, n) in enumerate(priorities_names))
-
-    # make a list that has each name with its build and non-build costs
-    criteria = [(cost, None, name) for cost, (p, name) in zip(costs[:build_start_idx], high_fixed)]
-    criteria += [
-        (cost, None, name)
-        for cost, (p, name) in zip(costs[fixed_start_idx:installed_start_idx], fixed)
+    return [
+        OptimizationCriteria(priority, value, name, status)
+        for (priority, name, status), value in zip(priorities_names, costs)
     ]
-
-    for (i, name), (b, _) in zip(installed, build):
-        criteria.append((costs[indices[i]], costs[indices[b]], name))
-
-    return criteria
 
 
 def specify(spec):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -325,6 +325,32 @@ def extend_flag_list(flag_list, new_flags):
         flag_list.append(flag)
 
 
+def _reorder_flags(flag_list: List[spack.spec.CompilerFlag]) -> List[spack.spec.CompilerFlag]:
+    """Reorder a list of flags to ensure that the order matches that of the flag group."""
+    if not flag_list:
+        return []
+
+    if len({x.flag_group for x in flag_list}) != 1 or len({x.source for x in flag_list}) != 1:
+        raise InternalConcretizerError(
+            "internal solver error: cannot reorder compiler flags for concretized specs. "
+            "Please report a bug at https://github.com/spack/spack/issues"
+        )
+
+    flag_group = flag_list[0].flag_group
+    flag_source = flag_list[0].source
+    flag_propagate = flag_list[0].propagate
+    # Once we have the flag_group, no need to iterate over the flag_list because the
+    # group represents all of them
+    return [
+        spack.spec.CompilerFlag(
+            flag, propagate=flag_propagate, flag_group=flag_group, source=flag_source
+        )
+        for flag, propagate in spack.compilers.flags.tokenize_flags(
+            flag_group, propagate=flag_propagate
+        )
+    ]
+
+
 def check_packages_exist(specs):
     """Ensure all packages mentioned in specs exist."""
     repo = spack.repo.PATH
@@ -4029,14 +4055,25 @@ class SpecBuilder:
         e.g. for `y cflags="-z -a"` "-z" and "-a" should never have any intervening
         flags inserted, and should always appear in that order.
         """
-        cmd_specs = {s.name: s for spec in self._command_line_specs for s in spec.traverse()}
-
         for node, spec in self._specs.items():
             # if bootstrapping, compiler is not in config and has no flags
             flagmap_from_compiler = {
                 flag_type: [x for x in values if x.source == "compiler"]
                 for flag_type, values in spec.compiler_flags.items()
             }
+
+            flagmap_from_cli = {}
+            for flag_type, values in spec.compiler_flags.items():
+                if not values:
+                    continue
+
+                flags = [x for x in values if x.source == "literal"]
+                if not flags:
+                    continue
+
+                # For compiler flags from literal specs, reorder any flags to
+                # the input order from flag.flag_group
+                flagmap_from_cli[flag_type] = _reorder_flags(flags)
 
             for flag_type in spec.compiler_flags.valid_compiler_flags():
                 ordered_flags = []
@@ -4100,9 +4137,8 @@ class SpecBuilder:
                     extend_flag_list(ordered_flags, as_compiler_flags)
 
                 # 3. Now put cmd-line flags last
-                if node.pkg in cmd_specs:
-                    cmd_flags = cmd_specs[node.pkg].compiler_flags.get(flag_type, [])
-                    extend_flag_list(ordered_flags, cmd_flags)
+                if flag_type in flagmap_from_cli:
+                    extend_flag_list(ordered_flags, flagmap_from_cli[flag_type])
 
                 compiler_flags = spec.compiler_flags.get(flag_type, [])
                 msg = f"{set(compiler_flags)} does not equal {set(ordered_flags)}"

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2485,6 +2485,7 @@ class SpackSolverSetup:
         concrete_build_deps: bool = False,
         include_runtimes: bool = False,
         context: Optional[SourceContext] = None,
+        seen: Optional[Set[int]] = None,
     ) -> List[AspFunction]:
         """Return a list of clauses for a spec mandates are true.
 
@@ -2500,6 +2501,7 @@ class SpackSolverSetup:
                 are ommitted from the solve.
             context: tracks what constraint this clause set is generated for (e.g. a
                 `depends_on` constraint in a package.py file)
+            seen: set of ids of specs that have already been processed (for internal use only)
 
         Normally, if called with ``transitive=True``, ``spec_clauses()`` just generates
         hashes for the dependency requirements of concrete specs. If ``expand_hashes``
@@ -2508,6 +2510,8 @@ class SpackSolverSetup:
         for spec ``diff``).
         """
         clauses = []
+        seen = seen if seen is not None else set()
+        seen.add(id(spec))
 
         f: Union[Type[_Head], Type[_Body]] = _Body if body else _Head
 
@@ -2686,13 +2690,14 @@ class SpackSolverSetup:
             # if the spec is abstract, descend into dependencies.
             # if it's concrete, then the hashes above take care of dependency
             # constraints, but expand the hashes if asked for.
-            if not spec.concrete or expand_hashes:
+            if (not spec.concrete or expand_hashes) and id(dep) not in seen:
                 dependency_clauses = self._spec_clauses(
                     dep,
                     body=body,
                     expand_hashes=expand_hashes,
                     concrete_build_deps=concrete_build_deps,
                     context=context,
+                    seen=seen,
                 )
                 ###
                 # Dependency expressed with "^"

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -193,6 +193,13 @@ build_dependency_of_literal_node(LiteralNode, node(X, BuildDependency)) :-
 condition_set(node(min_dupe_id, Root), LiteralNode) :- literal_node(Root, LiteralNode).
 condition_set(LiteralNode, BuildNode) :- build_dependency_of_literal_node(LiteralNode, BuildNode).
 
+% Generate a comprehensible error for cases like 'foo ^bar' where 'bar' is a build dependency
+% of a transitive dependency of 'foo'
+error(1, "{0} is not a direct 'build' or 'test' dependency, or transitive 'link' or 'run' dependency of any root", Literal)
+  :- literal_node(RootPackage, node(X, Literal)),
+     not depends_on(node(min_dupe_id, RootPackage), node(X, Literal)),
+     not unification_set("root", node(X, Literal)).
+
 :- build_dependency_of_literal_node(LiteralNode, BuildNode),
    not attr("depends_on", LiteralNode, BuildNode, "build").
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -624,9 +624,12 @@ error(100, "External {0} cannot satisfy both {1} and {2}", BuildDependency, Lite
      virtual(Virtual).
 
 attr("virtual_node", VirtualNode)  :- virtual_build_requirement(ParentNode, VirtualNode).
-{ build_requirement(ParentNode, ProviderNode) } :-
+build_requirement(ParentNode, ProviderNode)  :-
   virtual_build_requirement(ParentNode, VirtualNode),
-  provider(ProviderNode, VirtualNode).
+  provider(ProviderNode, VirtualNode),
+  not attr("depends_on", ParentNode, ProviderNode, "link"),
+  not attr("depends_on", ParentNode, ProviderNode, "run"),
+  attr("depends_on", ParentNode, ProviderNode, "build").
 
 % From cli we can have literal expressions like:
 %

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1902,7 +1902,7 @@ opt_criterion(110, "number of packages to build (vs. reuse)").
 
 opt_criterion(100, "number of nodes from the same package").
 #minimize { 0@100: #true }.
-#minimize { ID@100,Package : attr("node", node(ID, Package)) }.
+#minimize { ID@100,Package : attr("node", node(ID, Package)), not self_build_requirement(_, node(ID, Package)) }.
 #minimize { ID@100,Package : attr("virtual_node", node(ID, Package)) }.
 #defined optimize_for_reuse/0.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -669,6 +669,10 @@ attr("node_platform_set", node(X, BuildDependency), NodePlatform) :-
   attr("direct_dependency", ParentNode, node_requirement("node_platform_set", BuildDependency, NodePlatform)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
+attr("node_flag_set", node(X, BuildDependency), NodeFlag) :-
+  attr("direct_dependency", ParentNode, node_requirement("node_flag_set", BuildDependency, NodeFlag)),
+  build_requirement(ParentNode, node(X, BuildDependency)).
+
 attr("hash", node(X, BuildDependency), BuildHash) :-
   attr("direct_dependency", ParentNode, node_requirement("hash", BuildDependency, BuildHash)),
   build_requirement(ParentNode, node(X, BuildDependency)).
@@ -1736,6 +1740,12 @@ error(100, "'{0} target={1}' is not compatible with this machine", Package, Targ
 %-----------------------------------------------------------------------------
 
 attr("node_flag", PackageNode, NodeFlag) :- attr("node_flag_set", PackageNode, NodeFlag).
+
+% If we set "foo %bar cflags=A ^fee %bar cflags=B" we want two nodes for "bar"
+error(100, "Cannot set multiple {0} values for {1} from cli", FlagType, Package)
+:- attr("node_flag_set", node(X, Package), node_flag(FlagType, _, FlagGroup1, "literal")),
+   attr("node_flag_set", node(X, Package), node_flag(FlagType, _, FlagGroup2, "literal")),
+   FlagGroup1 < FlagGroup2.
 
 %-----------------------------------------------------------------------------
 % Installed Packages

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -566,8 +566,7 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
 :- attr("direct_dependency", ParentNode, node_requirement("provider_set", BuildDependency, Virtual)),
    concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
-   attr("virtual_on_build_edge", ParentNode, BuildDependency, Virtual),
-   not 1 { pkg_fact(BuildDependency, version_satisfies(Constraint, Version)) : hash_attr(BuildDependencyHash, "version", BuildDependency, Version) } 1.
+   not attr("virtual_on_build_edge", ParentNode, BuildDependency, Virtual).
 
 error(100, "Cannot satisfy the request on {0} to have {1}={2}", BuildDependency, Variant, Value)
 :- attr("direct_dependency", ParentNode, node_requirement("variant_set", BuildDependency, Variant, Value)),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1154,6 +1154,14 @@ error(1, "Cannot use {1} for the {0} virtual, but that is required", Virtual, Pr
   pkg_fact(Package, condition_effect(ConditionID, EffectID)),
   imposed_constraint(EffectID, "node_flag_set", Package, NodeFlag).
 
+{ attr("node_flag", node(ID, Package), NodeFlag) } :-
+  requirement_group_member(ConditionID, Virtual, RequirementID),
+  activate_requirement(node(VirtualID, Virtual), RequirementID),
+  provider(node(ID, Package), VirtualNode),
+  pkg_fact(Virtual, condition_effect(ConditionID, EffectID)),
+  imposed_constraint(EffectID, "node_flag_set", Package, NodeFlag).
+
+
 requirement_weight(node(ID, Package), Group, W) :-
   W = #min {
     Z : requirement_has_weight(Y, Z), condition_holds(Y, node(ID, Package)), requirement_group_member(Y, Package, Group);

--- a/lib/spack/spack/solver/when_possible.lp
+++ b/lib/spack/spack/solver/when_possible.lp
@@ -29,9 +29,9 @@ do_not_impose(EffectID, node(X, Package)) :-
   trigger_and_effect(_, TriggerID, EffectID),
   trigger_node(TriggerID, _, node(X, Package)).
 
-opt_criterion(300, "number of input specs not concretized").
-#minimize{ 0@300: #true }.
-#minimize { 1@300,ID : literal_not_solved(ID) }.
+opt_criterion(320, "number of input specs not concretized").
+#minimize{ 0@320: #true }.
+#minimize { 1@320,ID : literal_not_solved(ID) }.
 
-#heuristic literal_solved(ID) : literal(ID). [1, sign]
-#heuristic literal_solved(ID) : literal(ID). [50, init]
+#heuristic solve_literal(ID) : literal(ID). [1, sign]
+#heuristic solve_literal(ID) : literal(ID). [1000, init]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3150,28 +3150,59 @@ class Spec:
                 f"No such variant {not_existing} for spec: '{spec}'", list(not_existing)
             )
 
-    def constrain(self, other, deps=True):
-        """Intersect self with other in-place. Return True if self changed, False otherwise.
+    def constrain(self, other, deps=True) -> bool:
+        """Constrains self with other, and returns True if self changed, False otherwise.
 
         Args:
             other: constraint to be added to self
-            deps: if False, constrain only the root node, otherwise constrain dependencies
-                as well.
+            deps: if False, constrain only the root node, otherwise constrain dependencies as well
 
         Raises:
              spack.error.UnsatisfiableSpecError: when self cannot be constrained
         """
+        return self._constrain(other, deps=deps, resolve_virtuals=True)
+
+    def _constrain_symbolically(self, other, deps=True) -> bool:
+        """Constrains self with other, and returns True if self changed, False otherwise.
+
+        This function has no notion of virtuals, so it does not need a repository.
+
+        Args:
+            other: constraint to be added to self
+            deps: if False, constrain only the root node, otherwise constrain dependencies as well
+
+        Raises:
+            spack.error.UnsatisfiableSpecError: when self cannot be constrained
+
+        Examples:
+            >>> from spack.spec import Spec, UnsatisfiableDependencySpecError
+            >>> s = Spec("hdf5 ^mpi@4")
+            >>> t = Spec("hdf5 ^mpi=openmpi")
+            >>> try:
+            ...     s.constrain(t)
+            ... except UnsatisfiableDependencySpecError as e:
+            ...     print(e)
+            ...
+            hdf5 ^mpi=openmpi does not satisfy hdf5 ^mpi@4
+            >>> s._constrain_symbolically(t)
+            True
+            >>> s
+            hdf5 ^mpi@4 ^mpi=openmpi
+        """
+        return self._constrain(other, deps=deps, resolve_virtuals=False)
+
+    def _constrain(self, other, deps=True, *, resolve_virtuals: bool):
         # If we are trying to constrain a concrete spec, either the spec
         # already satisfies the constraint (and the method returns False)
         # or it raises an exception
         if self.concrete:
-            if self.satisfies(other):
+            if self._satisfies(other, resolve_virtuals=resolve_virtuals):
                 return False
             else:
                 raise spack.error.UnsatisfiableSpecError(self, other, "constrain a concrete spec")
 
         other = self._autospec(other)
-        if other.concrete and other.satisfies(self):
+        if other.concrete and other._satisfies(self, resolve_virtuals=resolve_virtuals):
             self._dup(other)
             return True
 
@@ -3229,14 +3260,14 @@ class Spec:
             changed = True
 
         if deps:
-            changed |= self._constrain_dependencies(other)
+            changed |= self._constrain_dependencies(other, resolve_virtuals=resolve_virtuals)
 
         if other.concrete and not self.concrete and other.satisfies(self):
             self._finalize_concretization()
 
         return changed
 
-    def _constrain_dependencies(self, other: "Spec") -> bool:
+    def _constrain_dependencies(self, other: "Spec", resolve_virtuals: bool = True) -> bool:
         """Apply constraints of other spec's dependencies to this spec."""
         if not other._dependencies:
             return False
@@ -3244,7 +3275,7 @@ class Spec:
         # TODO: might want more detail than this, e.g. specific deps
         # in violation. if this becomes a priority get rid of this
         # check and be more specific about what's wrong.
-        if not other._intersects_dependencies(self):
+        if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
             raise UnsatisfiableDependencySpecError(other, self)
 
         if any(not d.name for d in other.traverse(root=False)):
@@ -3259,6 +3290,7 @@ class Spec:
                 existing[0].spec.constrain(edge.spec)
                 existing[0].update_deptypes(edge.depflag)
                 existing[0].update_virtuals(edge.virtuals)
+                existing[0].direct |= edge.direct
             else:
                 self.add_dependency_edge(
                     edge.spec,
@@ -3269,23 +3301,11 @@ class Spec:
                 )
         return self != reference_spec
 
-    def common_dependencies(self, other):
-        """Return names of dependencies that self and other have in common."""
-        common = set(s.name for s in self.traverse(root=False))
-        common.intersection_update(s.name for s in other.traverse(root=False))
-        return common
-
     def constrained(self, other, deps=True):
         """Return a constrained copy without modifying this spec."""
         clone = self.copy(deps=deps)
         clone.constrain(other, deps)
         return clone
-
-    def direct_dep_difference(self, other):
-        """Returns dependencies in self that are not in other."""
-        mine = set(dname for dname in self._dependencies)
-        mine.difference_update(dname for dname in other._dependencies)
-        return mine
 
     def _autospec(self, spec_like):
         """
@@ -3308,16 +3328,21 @@ class Spec:
             other: spec to be checked for compatibility
             deps: if True check compatibility of dependency nodes too, if False only check root
         """
+        return self._intersects(other=other, deps=deps, resolve_virtuals=True)
+
+    def _intersects(
+        self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
+    ) -> bool:
         other = self._autospec(other)
 
         if other.concrete and self.concrete:
             return self.dag_hash() == other.dag_hash()
 
         elif self.concrete:
-            return self.satisfies(other)
+            return self._satisfies(other, resolve_virtuals=resolve_virtuals)
 
         elif other.concrete:
-            return other.satisfies(self)
+            return other._satisfies(self, resolve_virtuals=resolve_virtuals)
 
         # From here we know both self and other are not concrete
         self_hash = self.abstract_hash
@@ -3332,6 +3357,9 @@ class Spec:
 
         # If the names are different, we need to consider virtuals
         if self.name != other.name and self.name and other.name:
+            if not resolve_virtuals:
+                return False
+
             self_virtual = spack.repo.PATH.is_virtual(self.name)
             other_virtual = spack.repo.PATH.is_virtual(other.name)
             if self_virtual and other_virtual:
@@ -3384,11 +3412,11 @@ class Spec:
 
         # If we need to descend into dependencies, do it, otherwise we're done.
         if deps:
-            return self._intersects_dependencies(other)
+            return self._intersects_dependencies(other, resolve_virtuals=resolve_virtuals)
 
         return True
 
-    def _intersects_dependencies(self, other):
+    def _intersects_dependencies(self, other, resolve_virtuals: bool = True):
         if not other._dependencies or not self._dependencies:
             # one spec *could* eventually satisfy the other
             return True
@@ -3397,8 +3425,13 @@ class Spec:
         common_dependencies = {x.name for x in self.dependencies()}
         common_dependencies &= {x.name for x in other.dependencies()}
         for name in common_dependencies:
-            if not self[name].intersects(other[name], deps=True):
+            if not self[name]._intersects(
+                other[name], deps=True, resolve_virtuals=resolve_virtuals
+            ):
                 return False
+
+        if not resolve_virtuals:
+            return True
 
         # For virtual dependencies, we need to dig a little deeper.
         self_index = spack.provider_index.ProviderIndex(
@@ -3434,7 +3467,20 @@ class Spec:
 
         Args:
             other: spec to be satisfied
-            deps: if True descend to dependencies, otherwise only check root node
+            deps: if True, descend to dependencies, otherwise only check root node
+        """
+        return self._satisfies(other=other, deps=deps, resolve_virtuals=True)
+
+    def _satisfies(
+        self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
+    ) -> bool:
+        """Return True if all concrete specs matching self also match other, otherwise False.
+
+        Args:
+            other: spec to be satisfied
+            deps: if True, descend to dependencies, otherwise only check root node
+            resolve_virtuals: if True, resolve virtuals in self and other. This requires a
+                repository to be available.
         """
         other = self._autospec(other)
 
@@ -3452,7 +3498,7 @@ class Spec:
                 return False
 
         # If the names are different, we need to consider virtuals
-        if self.name != other.name and self.name and other.name:
+        if self.name != other.name and self.name and other.name and resolve_virtuals:
             # A concrete provider can satisfy a virtual dependency.
             if not spack.repo.PATH.is_virtual(self.name) and spack.repo.PATH.is_virtual(
                 other.name
@@ -3516,19 +3562,22 @@ class Spec:
         for rhs_edge in other.traverse_edges(root=False, cover="edges"):
             # The condition cannot be applied in any case, skip the edge
             test_root = rhs_edge.parent.name in (None, self.name)
-            if test_root and not self.intersects(rhs_edge.when):
+            if test_root and not self._intersects(
+                rhs_edge.when, resolve_virtuals=resolve_virtuals
+            ):
                 continue
 
             if (
                 not test_root
                 and rhs_edge.parent.name in self
-                and not self[rhs_edge.parent.name].intersects(rhs_edge.when)
+                and not self[rhs_edge.parent.name]._intersects(
+                    rhs_edge.when, resolve_virtuals=resolve_virtuals
+                )
             ):
                 continue
 
             # If we are checking for ^mpi we need to verify if there is any edge
-            is_virtual_node = spack.repo.PATH.is_virtual(rhs_edge.spec.name)
-            if is_virtual_node:
+            if resolve_virtuals and spack.repo.PATH.is_virtual(rhs_edge.spec.name):
                 # Don't mutate objects in memory that may be referred elsewhere
                 rhs_edge = rhs_edge.copy()
                 rhs_edge.update_virtuals(virtuals=(rhs_edge.spec.name,))
@@ -3559,11 +3608,17 @@ class Spec:
                     mock_nodes_from_old_specfiles.add(compiler_spec)
                     # This checks that the single node compiler spec satisfies the request
                     # of a direct dependency. The check is not perfect, but based on heuristic.
-                    if not compiler_spec.satisfies(rhs_edge.spec):
+                    if not compiler_spec._satisfies(
+                        rhs_edge.spec, resolve_virtuals=resolve_virtuals
+                    ):
                         return False
 
                 else:
-                    name = rhs_edge.spec.name if not is_virtual_node else None
+                    name = (
+                        None
+                        if resolve_virtuals and spack.repo.PATH.is_virtual(rhs_edge.spec.name)
+                        else rhs_edge.spec.name
+                    )
                     candidate_edges = current_node.edges_to_dependencies(
                         name=name, virtuals=rhs_edge.virtuals or None
                     )
@@ -3573,9 +3628,14 @@ class Spec:
                         lhs_edge.spec
                         for lhs_edge in candidate_edges
                         if ((lhs_edge.depflag & rhs_edge.depflag) ^ rhs_edge.depflag) == 0
-                        and rhs_edge.when.satisfies(lhs_edge.when)
+                        and rhs_edge.when._satisfies(
+                            lhs_edge.when, resolve_virtuals=resolve_virtuals
+                        )
                     ]
-                    if not candidates or not any(x.satisfies(rhs_edge.spec) for x in candidates):
+                    if not candidates or not any(
+                        x._satisfies(rhs_edge.spec, resolve_virtuals=resolve_virtuals)
+                        for x in candidates
+                    ):
                         return False
 
                 continue
@@ -3613,7 +3673,7 @@ class Spec:
                 candidate_edges = [
                     lhs_edge
                     for lhs_edge in lhs_edges[current_dependency_name]
-                    if rhs_edge.when.satisfies(lhs_edge.when)
+                    if rhs_edge.when._satisfies(lhs_edge.when, resolve_virtuals=resolve_virtuals)
                 ]
 
             if not candidate_edges:
@@ -3625,7 +3685,9 @@ class Spec:
                     return False
 
             for lhs_edge in candidate_edges:
-                if lhs_edge.spec.satisfies(rhs_edge.spec, deps=False):
+                if lhs_edge.spec._satisfies(
+                    rhs_edge.spec, deps=False, resolve_virtuals=resolve_virtuals
+                ):
                     break
             else:
                 return False
@@ -4989,35 +5051,6 @@ def parse_with_version_concrete(spec_like: Union[str, Spec]):
     if interpreted_version:
         s.versions = vn.VersionList([interpreted_version])
     return s
-
-
-def merge_abstract_anonymous_specs(*abstract_specs: Spec):
-    """Merge the abstracts specs passed as input and return the result.
-
-    The root specs must be anonymous, and it's duty of the caller to ensure that.
-
-    This function merge the abstract specs based on package names. In particular
-    it doesn't try to resolve virtual dependencies.
-
-    Args:
-        *abstract_specs: abstract specs to be merged
-    """
-    merged_spec = Spec()
-    for current_spec_constraint in abstract_specs:
-        merged_spec.constrain(current_spec_constraint, deps=False)
-
-        for name in merged_spec.common_dependencies(current_spec_constraint):
-            merged_spec[name].constrain(current_spec_constraint[name], deps=False)
-
-        # Update with additional constraints from other spec
-        for name in current_spec_constraint.direct_dep_difference(merged_spec):
-            edge = next(iter(current_spec_constraint.edges_to_dependencies(name)))
-
-            merged_spec._add_dependency(
-                edge.spec.copy(), depflag=edge.depflag, virtuals=edge.virtuals
-            )
-
-    return merged_spec
 
 
 def reconstruct_virtuals_on_edges(spec: Spec) -> None:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2131,131 +2131,6 @@ class Spec:
             visited=visited,
         )
 
-    def _format_edge_attributes(self, dep: DependencySpec, deptypes=True, virtuals=True):
-        deptypes_str = (
-            f"deptypes={','.join(dt.flag_to_tuple(dep.depflag))}"
-            if deptypes and dep.depflag
-            else ""
-        )
-        when_str = f"when='{(dep.when)}'" if dep.when != Spec() else ""
-        virtuals_str = f"virtuals={','.join(dep.virtuals)}" if virtuals and dep.virtuals else ""
-
-        attrs = " ".join(s for s in (when_str, deptypes_str, virtuals_str) if s)
-        if attrs:
-            attrs = f"[{attrs}] "
-
-        return attrs
-
-    def _format_dependencies(
-        self,
-        format_string: str = DEFAULT_FORMAT,
-        include: Optional[Callable[[DependencySpec], bool]] = None,
-        deptypes=True,
-        _force_direct=False,
-    ):
-        """Helper for formatting dependencies on specs.
-
-        Arguments:
-            format_string: format string to use for each dependency
-            include: predicate to select which dependencies to include
-            deptypes: whether to format deptypes
-            _force_direct: if True, print all dependencies as direct dependencies
-                (to be removed when we have this metadata on concrete edges)
-        """
-        include = include or (lambda dep: True)
-        parts = []
-        if self.concrete:
-            direct = self.edges_to_dependencies()
-            transitive: List[DependencySpec] = []
-        else:
-            direct, transitive = lang.stable_partition(
-                self.edges_to_dependencies(), predicate_fn=lambda x: x.direct
-            )
-
-        # helper for direct and transitive loops below
-        def format_edge(edge, sigil, dep_spec=None):
-            dep_spec = dep_spec or edge.spec
-            dep_format = dep_spec.format(format_string)
-
-            edge_attributes = (
-                self._format_edge_attributes(edge, deptypes=deptypes, virtuals=False)
-                if edge.depflag or edge.when != Spec()
-                else ""
-            )
-            virtuals = f"{','.join(edge.virtuals)}=" if edge.virtuals else ""
-            star = _anonymous_star(edge, dep_format)
-
-            return f"{sigil}{edge_attributes}{star}{virtuals}{dep_format}"
-
-        # direct dependencies
-        for edge in sorted(direct, key=lambda x: x.spec.name):
-            if not include(edge):
-                continue
-
-            # replace legacy compiler names
-            old_name = edge.spec.name
-            new_name = spack.aliases.BUILTIN_TO_LEGACY_COMPILER.get(old_name)
-            try:
-                # this is ugly but copies can be expensive
-                if new_name:
-                    edge.spec.name = new_name
-                parts.append(format_edge(edge, "%", edge.spec))
-            finally:
-                edge.spec.name = old_name
-
-        if self.concrete:
-            # Concrete specs should go no further, as the complexity
-            # below is O(paths)
-            return " ".join(parts).strip()
-
-        # transitive dependencies (with any direct dependencies)
-        for edge in sorted(transitive, key=lambda x: x.spec.name):
-            if not include(edge):
-                continue
-            sigil = "%" if _force_direct else "^"  # hack til direct deps represented better
-            parts.append(format_edge(edge, sigil, edge.spec))
-
-            # also recursively add any direct dependencies of transitive dependencies
-            if edge.spec._dependencies:
-                parts.append(
-                    edge.spec._format_dependencies(
-                        format_string=format_string,
-                        include=include,
-                        deptypes=deptypes,
-                        _force_direct=_force_direct,
-                    )
-                )
-
-        return " ".join(parts).strip()
-
-    @property
-    def compilers(self):
-        # TODO: get rid of the space here and make formatting smarter
-        return " " + self._format_dependencies(
-            "{name}{@version}",
-            include=lambda dep: any(lang in dep.virtuals for lang in ("c", "cxx", "fortran")),
-            deptypes=False,
-            _force_direct=True,
-        )
-
-    @property
-    def long_spec(self):
-        """Returns a string of the spec with the dependencies completely enumerated."""
-        if self.concrete:
-            return self.tree(format=DISPLAY_FORMAT)
-        return f"{self.format()} {self._format_dependencies()}".strip()
-
-    @property
-    def short_spec(self):
-        """Returns a version of the spec with the dependencies hashed
-        instead of completely enumerated."""
-        return self.format("{name}{@version}{variants}{ arch=architecture}{/hash:7}")
-
-    @property
-    def cshort_spec(self):
-        """Returns an auto-colorized version of ``self.short_spec``."""
-        return self.cformat("{name}{@version}{variants}{ arch=architecture}{/hash:7}")
-
     @property
     def prefix(self) -> spack.util.prefix.Prefix:
         if not self._concrete:
@@ -4140,6 +4015,16 @@ class Spec:
     def namespace_if_anonymous(self):
         return self.namespace if not self.name else None
 
+    @property
+    def spack_root(self):
+        """Special field for using ``{spack_root}`` in :meth:`format`."""
+        return spack.paths.spack_root
+
+    @property
+    def spack_install(self):
+        """Special field for using ``{spack_install}`` in :meth:`format`."""
+        return spack.store.STORE.layout.root
+
     def format(self, format_string: str = DEFAULT_FORMAT, color: Optional[bool] = False) -> str:
         r"""Prints out attributes of a spec according to a format string.
 
@@ -4336,21 +4221,9 @@ class Spec:
 
         return SPEC_FORMAT_RE.sub(format_attribute, format_string).strip()
 
-    def cformat(self, *args, **kwargs):
-        """Same as format, but color defaults to auto instead of False."""
-        kwargs = kwargs.copy()
-        kwargs.setdefault("color", None)
-        return self.format(*args, **kwargs)
-
-    @property
-    def spack_root(self):
-        """Special field for using ``{spack_root}`` in Spec.format()."""
-        return spack.paths.spack_root
-
-    @property
-    def spack_install(self):
-        """Special field for using ``{spack_install}`` in Spec.format()."""
-        return spack.store.STORE.layout.root
+    def cformat(self, format_string: str = DEFAULT_FORMAT) -> str:
+        """Same as :meth:`format`, but color defaults to auto instead of False."""
+        return self.format(format_string, color=None)
 
     def format_path(
         # self, format_string: str, _path_ctor: Optional[pathlib.PurePath] = None
@@ -4395,26 +4268,166 @@ class Spec:
         ]
         return str(path_ctor(*output_path_components))
 
-    def __str__(self):
-        if self._concrete:
-            return self.format("{name}{@version}{/hash}")
+    def _format_edge_attributes(self, dep: DependencySpec, deptypes=True, virtuals=True):
+        deptypes_str = (
+            f"deptypes={','.join(dt.flag_to_tuple(dep.depflag))}"
+            if deptypes and dep.depflag
+            else ""
+        )
+        when_str = f"when='{(dep.when)}'" if dep.when != Spec() else ""
+        virtuals_str = f"virtuals={','.join(dep.virtuals)}" if virtuals and dep.virtuals else ""
 
-        if not self._dependencies:
-            return self.format()
+        attrs = " ".join(s for s in (when_str, deptypes_str, virtuals_str) if s)
+        if attrs:
+            attrs = f"[{attrs}] "
 
-        return self.long_spec
+        return attrs
+
+    def _format_dependencies(
+        self,
+        format_string: str = DEFAULT_FORMAT,
+        include: Optional[Callable[[DependencySpec], bool]] = None,
+        deptypes: bool = True,
+        color: Optional[bool] = False,
+        _force_direct: bool = False,
+    ):
+        """Helper for formatting dependencies on specs.
+
+        Arguments:
+            format_string: format string to use for each dependency
+            include: predicate to select which dependencies to include
+            deptypes: whether to format deptypes
+            color: colorize if True, don't colorize if False, auto-colorize if None
+            _force_direct: if True, print all dependencies as direct dependencies
+                (to be removed when we have this metadata on concrete edges)
+        """
+        include = include or (lambda dep: True)
+        parts = []
+        if self.concrete:
+            direct = self.edges_to_dependencies()
+            transitive: List[DependencySpec] = []
+        else:
+            direct, transitive = lang.stable_partition(
+                self.edges_to_dependencies(), predicate_fn=lambda x: x.direct
+            )
+
+        # helper for direct and transitive loops below
+        def format_edge(edge: DependencySpec, sigil: str, dep_spec: Optional[Spec] = None) -> str:
+            dep_spec = dep_spec or edge.spec
+            dep_format = dep_spec.format(format_string, color=color)
+
+            edge_attributes = (
+                self._format_edge_attributes(edge, deptypes=deptypes, virtuals=False)
+                if edge.depflag or edge.when != Spec()
+                else ""
+            )
+            virtuals = f"{','.join(edge.virtuals)}=" if edge.virtuals else ""
+            star = _anonymous_star(edge, dep_format)
+
+            return f"{sigil}{edge_attributes}{star}{virtuals}{dep_format}"
+
+        # direct dependencies
+        for edge in sorted(direct, key=lambda x: x.spec.name):
+            if not include(edge):
+                continue
+
+            # replace legacy compiler names
+            old_name = edge.spec.name
+            new_name = spack.aliases.BUILTIN_TO_LEGACY_COMPILER.get(old_name)
+            try:
+                # this is ugly but copies can be expensive
+                if new_name:
+                    edge.spec.name = new_name
+                parts.append(format_edge(edge, "%", edge.spec))
+            finally:
+                edge.spec.name = old_name
+
+        if self.concrete:
+            # Concrete specs should go no further, as the complexity
+            # below is O(paths)
+            return " ".join(parts).strip()
+
+        # transitive dependencies (with any direct dependencies)
+        for edge in sorted(transitive, key=lambda x: x.spec.name):
+            if not include(edge):
+                continue
+            sigil = "%" if _force_direct else "^"  # hack til direct deps represented better
+            parts.append(format_edge(edge, sigil, edge.spec))
+
+            # also recursively add any direct dependencies of transitive dependencies
+            if edge.spec._dependencies:
+                parts.append(
+                    edge.spec._format_dependencies(
+                        format_string=format_string,
+                        include=include,
+                        deptypes=deptypes,
+                        _force_direct=_force_direct,
+                    )
+                )
+
+        return " ".join(parts).strip()
+
+    def _long_spec(self, color: Optional[bool] = False) -> str:
+        """Helper for :attr:`long_spec` and :attr:`clong_spec`."""
+        if self.concrete:
+            return self.tree(format=DISPLAY_FORMAT, color=color)
+        return f"{self.format(color=color)} {self._format_dependencies(color=color)}".strip()
+
+    def _short_spec(self, color: Optional[bool] = False) -> str:
+        """Helper for :attr:`short_spec` and :attr:`cshort_spec`."""
+        return self.format("{name}{@version}{variants}{ arch=architecture}{/hash:7}", color=color)
 
     @property
-    def colored_str(self):
-        root_str = [self.cformat()]
-        sorted_dependencies = sorted(
-            self.traverse(root=False), key=lambda x: (x.name, x.abstract_hash)
+    def compilers(self):
+        # TODO: get rid of the space here and make formatting smarter
+        return " " + self._format_dependencies(
+            "{name}{@version}",
+            include=lambda dep: any(lang in dep.virtuals for lang in ("c", "cxx", "fortran")),
+            deptypes=False,
+            _force_direct=True,
         )
-        sorted_dependencies = [
-            d.cformat("{edge_attributes} " + DISPLAY_FORMAT) for d in sorted_dependencies
-        ]
-        spec_str = " ^".join(root_str + sorted_dependencies)
-        return spec_str.strip()
+
+    @property
+    def long_spec(self):
+        """Long string of the spec, including dependencies."""
+        return self._long_spec(color=False)
+
+    @property
+    def clong_spec(self):
+        """Returns an auto-colorized version of :attr:`long_spec`."""
+        return self._long_spec(color=None)
+
+    @property
+    def short_spec(self):
+        """Short string of the spec, with hash and without dependencies."""
+        return self._short_spec(color=False)
+
+    @property
+    def cshort_spec(self):
+        """Returns an auto-colorized version of :attr:`short_spec`."""
+        return self._short_spec(color=None)
+
+    @property
+    def colored_str(self) -> str:
+        """Auto-colorized string representation of this spec."""
+        return self._str(color=None)
+
+    def _str(self, color: Optional[bool] = False) -> str:
+        """String representation of this spec.
+        Args:
+            color: colorize if True, don't colorize if False, auto-colorize if None
+        """
+        if self._concrete:
+            return self.format("{name}{@version}{/hash}", color=color)
+
+        if not self._dependencies:
+            return self.format(color=color)
+
+        return self._long_spec(color=color)
+
+    def __str__(self) -> str:
+        """String representation of this spec."""
+        return self._str(color=False)
 
     def install_status(self) -> InstallStatus:
         """Helper for tree to print DB install status."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -834,6 +834,10 @@ class CompilerFlag(str):
             for "-g" would indicate ``depends_on``.
     """
 
+    propagate: bool
+    flag_group: str
+    source: str
+
     def __new__(cls, value, **kwargs):
         obj = str.__new__(cls, value)
         obj.propagate = kwargs.pop("propagate", False)

--- a/lib/spack/spack/test/cmd/edit.py
+++ b/lib/spack/spack/test/cmd/edit.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import pathlib
 
+import spack.paths
 import spack.repo
 import spack.util.editor
 from spack.main import SpackCommand
@@ -43,3 +45,23 @@ def test_edit_files(monkeypatch, mock_packages):
     monkeypatch.setattr(spack.util.editor, "editor", editor)
     edit("--build-system", "autotools", "cmake")
     assert called
+
+
+def test_edit_non_default_build_system(monkeypatch, mock_packages, mutable_config):
+    called = False
+
+    def editor(*args: str, **kwargs):
+        nonlocal called
+        called = True
+        from spack_repo.builtin_mock.build_systems import autotools, cmake  # type: ignore
+
+        assert os.path.samefile(args[0], autotools.__file__)
+        assert os.path.samefile(args[1], cmake.__file__)
+
+    monkeypatch.setattr(spack.util.editor, "editor", editor)
+
+    # set up an additional repo
+    extra_repo_dir = pathlib.Path(spack.paths.test_repos_path) / "spack_repo" / "requirements_test"
+    with spack.repo.use_repositories(str(extra_repo_dir), override=False):
+        edit("--build-system", "builtin_mock.autotools", "builtin_mock.cmake")
+        assert called

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3320,14 +3320,22 @@ packages:
     assert s["c"].satisfies("gcc@9.4.0")
 
 
-def test_compiler_can_depend_on_themselves_to_build(config, mock_packages):
+@pytest.mark.parametrize(
+    "spec_str,expected",
+    [
+        ("gcc@14 %gcc@9.4.0", ["gcc@14", "%c,cxx=gcc@9.4.0", "^gcc-runtime@9.4.0"]),
+        # If we don't specify a compiler, we should get the default compiler which is gcc
+        ("gcc@14", ["gcc@14", "%c,cxx=gcc@10", "^gcc-runtime@10"]),
+    ],
+)
+def test_compiler_can_depend_on_themselves_to_build(
+    spec_str, expected, default_mock_concretization
+):
     """Tests that a compiler can depend on "itself" to bootstrap."""
-    s = spack.concretize.concretize_one("gcc@14 %gcc@9.4.0")
-    assert s.satisfies("gcc@14")
-    assert s.satisfies("^gcc-runtime@9.4.0")
-
-    gcc_used_to_build = s.dependencies(name="gcc", virtuals=("c",))
-    assert len(gcc_used_to_build) == 1 and gcc_used_to_build[0].satisfies("gcc@9.4.0")
+    s = default_mock_concretization(spec_str)
+    assert not s.external
+    for c in expected:
+        assert s.satisfies(c)
 
 
 def test_compiler_attribute_is_tolerated_in_externals(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4064,3 +4064,36 @@ def test_caret_in_input_cannot_set_transitive_build_dependencies(default_mock_co
     """
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="transitive 'link' or"):
         _ = default_mock_concretization("multivalue-variant ^gmake")
+
+
+@pytest.mark.regression("51167")
+@pytest.mark.require_provenance
+@pytest.mark.xfail(reason="This is a bug in the solver, related to the 'commit=' variant")
+def test_commit_variant_enters_the_hash(mutable_config, mock_packages, monkeypatch):
+    """Tests that an implicit commit variant, obtained from resolving the commit sha of a branch,
+    enters the hash of the spec.
+    """
+
+    first_call = True
+
+    def _mock_resolve(pkg_self) -> None:
+        if first_call:
+            pkg_self.spec.variants["commit"] = spack.variant.SingleValuedVariant(
+                "commit", f"{'b' * 40}"
+            )
+            return
+
+        pkg_self.spec.variants["commit"] = spack.variant.SingleValuedVariant(
+            "commit", f"{'a' * 40}"
+        )
+
+    monkeypatch.setattr(spack.package_base.PackageBase, "resolve_binary_provenance", _mock_resolve)
+
+    before = spack.concretize.concretize_one("git-ref-package@develop")
+    first_call = False
+    after = spack.concretize.concretize_one("git-ref-package@develop")
+
+    assert before.package.needs_commit(before.version)
+    assert before.satisfies(f"commit={'b' * 40}")
+    assert after.satisfies(f"commit={'a' * 40}")
+    assert before.dag_hash() != after.dag_hash()

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4097,3 +4097,49 @@ def test_commit_variant_enters_the_hash(mutable_config, mock_packages, monkeypat
     assert before.satisfies(f"commit={'b' * 40}")
     assert after.satisfies(f"commit={'a' * 40}")
     assert before.dag_hash() != after.dag_hash()
+
+
+@pytest.mark.regression("51180")
+def test_reuse_with_mixed_compilers(mutable_config, mock_packages):
+    """Tests that potentially reusing a spec with a mixed compiler set, will not interfere
+    with a request on one of the languages for the same package.
+    """
+    packages_yaml = syaml.load_config(
+        """
+packages:
+  gcc:
+    externals:
+    - spec: "gcc@15.1 languages='c,c++,fortran'"
+      prefix: /path1
+      extra_attributes:
+        compilers:
+          c: /path1/bin/gcc
+          cxx: /path1/bin/g++
+          fortran: /path1/bin/gfortran
+  llvm:
+    externals:
+    - spec: "llvm@20 +flang+clang"
+      prefix: /path2
+      extra_attributes:
+        compilers:
+          c: /path2/bin/clang
+          cxx: /path2/bin/clang++
+          fortran: /path2/bin/flang
+"""
+    )
+    mutable_config.set("packages", packages_yaml["packages"])
+
+    s = spack.concretize.concretize_one("openblas %c=gcc %fortran=llvm")
+    reusable_specs = list(s.traverse(root=True))
+
+    root_specs = [Spec("openblas %fortran=gcc")]
+
+    with spack.config.override("concretizer:reuse", True):
+        solver = spack.solver.asp.Solver()
+        setup = spack.solver.asp.SpackSolverSetup()
+        result, _, _ = solver.driver.solve(setup, root_specs, reuse=reusable_specs)
+
+    assert len(result.specs) == 1
+    r = result.specs[0]
+    assert r.satisfies("openblas %fortran=gcc")
+    assert r.dag_hash() != s.dag_hash()

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1884,9 +1884,14 @@ class TestConcretize:
             # version_declared("pkg-b","0.9",1,"package_py").
             # version_declared("pkg-b","1.0",2,"installed").
             # version_declared("pkg-b","0.9",3,"installed").
-            v_weights = [x for x in result.criteria if x[2] == "version badness (non roots)"][0]
-            reused_weights, built_weights, _ = v_weights
-            assert reused_weights > 2 and built_weights == 0
+            weights = {}
+            for x in [x for x in result.criteria if x.name == "version badness (non roots)"]:
+                if x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
+                    weights["reused"] = x.value
+                else:
+                    weights["built"] = x.value
+
+            assert weights["reused"] > 2 and weights["built"] == 0
 
             result_spec = result.specs[0]
             assert result_spec.satisfies("^pkg-b@1.0")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4143,3 +4143,14 @@ packages:
     r = result.specs[0]
     assert r.satisfies("openblas %fortran=gcc")
     assert r.dag_hash() != s.dag_hash()
+
+
+@pytest.mark.regression("51224")
+def test_when_possible_above_all(mutable_config, mock_packages):
+    """Tests that the criterion to solve as many specs as possible is above all other criteria."""
+    specs = [Spec("pkg-a"), Spec("pkg-b")]
+    solver = spack.solver.asp.Solver()
+
+    for result in solver.solve_in_rounds(specs):
+        criteria = sorted(result.criteria, reverse=True)
+        assert criteria[0].name == "number of input specs not concretized"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4047,3 +4047,12 @@ packages:
         s = spack.concretize.concretize_one(spec_str)
         assert s.external
         assert s.prefix == "/path/mpich/gcc"
+
+
+@pytest.mark.regression("51146,51067")
+def test_caret_in_input_cannot_set_transitive_build_dependencies(default_mock_concretization):
+    """Tests that a caret in the input spec does not set transitive build dependencies, and errors
+    with an appropriate message.
+    """
+    with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="transitive 'link' or"):
+        _ = default_mock_concretization("multivalue-variant ^gmake")

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -196,3 +196,19 @@ def test_redistribute_override_when():
     spack.directives._execute_redistribute(cls, source=None, binary=False, when="@1.0")
     assert cls.disable_redistribute[spec_key].binary
     assert cls.disable_redistribute[spec_key].source
+
+
+@pytest.mark.regression("51248")
+def test_direct_dependencies_from_when_context_are_retained(mock_packages):
+    """Tests that direct dependencies from the "when" context manager don't lose the "direct"
+    attribute when turned into directives on the package class.
+    """
+    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
+    # Direct dependency in a "when" single context manager
+    assert spack.spec.Spec("%pkg-b") in pkg_cls.dependencies
+    # Direct dependency in a "when" nested context manager
+    assert spack.spec.Spec("@2 %c=gcc %pkg-c %pkg-b@:4.0") in pkg_cls.dependencies
+    # Nested ^foo followed by %foo
+    assert spack.spec.Spec("%pkg-c") in pkg_cls.dependencies
+    # Nested ^foo followed by ^foo %gcc
+    assert spack.spec.Spec("^pkg-c %gcc") in pkg_cls.dependencies

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2322,6 +2322,11 @@ def test_edge_equality_accounts_for_when_condition():
     assert edge1 != edge2
 
 
+def test_long_spec():
+    """Test that long_spec preserves dependency types and has correct ordering."""
+    assert Spec("foo %m %l ^k %n %j").long_spec == "foo %l %m ^k %j %n"
+
+
 @pytest.mark.parametrize(
     "constraints,expected",
     [

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -148,6 +148,25 @@ contains "usage: spack env deactivate " spack env deactivate no_such_environment
 contains "usage: spack env deactivate " spack env deactivate -h
 contains "usage: spack env deactivate " spack env deactivate --help
 
+title "Testing 'spack config edit'"
+echo "Testing 'spack config edit' with malformed spack.yaml"
+spack env activate --temp
+bad_yaml_env=$(spack location -e)
+mv $bad_yaml_env/spack.yaml $bad_yaml_env/.backup
+echo "bad_yaml" > $bad_yaml_env/spack.yaml
+EDITOR=cat contains "Error: " spack config edit  # error message prints first
+EDITOR=cat contains "bad_yaml" spack config edit  # followed by call to EDITOR
+
+echo "testing 'spack config edit' with non-complying spack.yaml"
+cat > $bad_yaml_env/spack.yaml <<EOF
+spack:
+  foo: bar
+EOF
+EDITOR=cat contains "Error: " spack config edit  # error message prints first
+EDITOR=cat contains "foo: bar" spack config edit  # followed by call to EDITOR
+mv $bad_yaml_env/.backup $bad_yaml_env/spack.yaml
+despacktivate
+
 title 'Testing activate and deactivate together'
 echo "Testing 'spack env activate spack_test_env'"
 succeeds spack env activate spack_test_env

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1500,7 +1500,7 @@ complete -c spack -n '__fish_spack_using_command_pos_remainder 0 edit' -f -a '(_
 complete -c spack -n '__fish_spack_using_command edit' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command edit' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command edit' -s b -l build-system -f -a path
-complete -c spack -n '__fish_spack_using_command edit' -s b -l build-system -d 'edit the build system with the supplied name'
+complete -c spack -n '__fish_spack_using_command edit' -s b -l build-system -d 'edit the build system with the supplied name or fullname'
 complete -c spack -n '__fish_spack_using_command edit' -s c -l command -f -a path
 complete -c spack -n '__fish_spack_using_command edit' -s c -l command -d 'edit the command with the supplied name'
 complete -c spack -n '__fish_spack_using_command edit' -s d -l docs -f -a path
@@ -1510,9 +1510,9 @@ complete -c spack -n '__fish_spack_using_command edit' -s t -l test -d 'edit the
 complete -c spack -n '__fish_spack_using_command edit' -s m -l module -f -a path
 complete -c spack -n '__fish_spack_using_command edit' -s m -l module -d 'edit the main spack module with the supplied name'
 complete -c spack -n '__fish_spack_using_command edit' -s r -l repo -r -f -a repo
-complete -c spack -n '__fish_spack_using_command edit' -s r -l repo -r -d 'path to repo to edit package in'
+complete -c spack -n '__fish_spack_using_command edit' -s r -l repo -r -d 'path to repo to edit package or build system in'
 complete -c spack -n '__fish_spack_using_command edit' -s N -l namespace -r -f -a namespace
-complete -c spack -n '__fish_spack_using_command edit' -s N -l namespace -r -d 'namespace of package to edit'
+complete -c spack -n '__fish_spack_using_command edit' -s N -l namespace -r -d 'namespace of package or build system to edit'
 
 # spack env
 set -g __fish_spack_optspecs_spack_env h/help

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/_7zip_dependent/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/_7zip_dependent/package.py
@@ -1,0 +1,17 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
+class _7zipDependent(AutotoolsPackage):
+    """A dependent of 7zip, that also needs gmake"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("7zip")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/gmake/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/gmake/package.py
@@ -13,6 +13,8 @@ class Gmake(Package):
     homepage = "https://www.gnu.org/software/make"
     url = "https://ftpmirror.gnu.org/make/make-4.4.tar.gz"
 
+    tags = ["build-tools"]
+
     version("4.4", sha256="ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed")
     version("3.0", sha256="ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed")
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/openblas/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/openblas/package.py
@@ -21,6 +21,7 @@ class Openblas(Package):
     variant("shared", default=True, description="Build shared libraries")
 
     depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     # See #20019 for this conflict
     conflicts("%gcc@:4.4", when="@0.2.14:")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
@@ -24,3 +24,22 @@ class WithConstraintMet(Package):
 
     with when("@0.14: ^pkg-b@:4.0"):
         depends_on("pkg-c", when="@:15 ^pkg-b@3.8:")
+
+    # Direct dependency in a "when" context manager
+    with when("%pkg-b"):
+        depends_on("pkg-e")
+
+    # More complex dependency with nested contexts
+    with when("%pkg-c"):
+        with when("@2 %pkg-b@:4.0"):
+            depends_on("pkg-e", when="%c=gcc")
+
+    # Nested ^pkg-c followed by %pkg-c
+    with when("^pkg-c"):
+        with when("%pkg-c"):
+            depends_on("pkg-e")
+
+    # Nested ^pkg-c followed by ^pkg-c %gcc
+    with when("^pkg-c"):
+        with when("^pkg-c %gcc"):
+            depends_on("pkg-e")


### PR DESCRIPTION
Modifications:
- [x] Set version to `v1.0.2.dev0`
- [x] #51110
- [x] #51145
- [x] #51151 (patched to avoid needing #51127)
- [x] #51147 (patched to avoid needing #51127)
- [x] #51088
- [x] #51084
- [x] #51178
- [x] #51176
- [x] #51181 (patched to fix conflict)
- [x] #51172 (patched to fix conflict)
- [x] #51188
- [x] #51201 
- [x] #51182 (needed to apply cleanly 51199)
- [x] #51199
- [x] #51226
- [x] #51258
- [x] #51259 
- [x] #51263
- [x] #51218
- [x] #51270
- [x] #51198
- [x] #51252 (needed to make CI pass)
- [x] #51207 (had conflicts to be solved due to code shuffling)
- [x] #51195 (conflicts due to style changes to docs)
- [x] Set version to `v1.0.2` and update CHANGELOG.md

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
