### PR TITLE
docs: spec str order issues & yaml style

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -514,12 +514,12 @@ Every time these modifications are allowed, they are specified as a dictionary, 
 
    environment:
      set:
-       LICENSE_FILE: '/path/to/license'
+       LICENSE_FILE: "/path/to/license"
      unset:
      - CPATH
      - LIBRARY_PATH
      append_path:
-       PATH: '/new/bin/dir'
+       PATH: "/new/bin/dir"
 
 The possible actions that are permitted are ``set``, ``unset``, ``append_path``, ``prepend_path``, and finally ``remove_path``.
 They all require a dictionary of variable names mapped to the values used for the modification, with the exception of ``unset``, which requires just a list of variable names.

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -713,7 +713,7 @@ Avoid double-installing CUDA by adding, e.g.:
    packages:
      cuda:
        externals:
-       - spec: "cuda@9.0.176%gcc@5.4.0 arch=linux-ubuntu16-x86_64"
+       - spec: "cuda@9.0.176 arch=linux-ubuntu16-x86_64 %gcc@5.4.0"
          prefix: /usr/local/cuda
        buildable: False
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -919,7 +919,7 @@ The ``default`` view descriptor name is special: when you ``spack env activate``
 View descriptors must contain the root of the view, and optionally projections, ``select`` and ``exclude`` lists and link information via ``link`` and ``link_type``.
 
 As a more advanced example, in the following manifest file snippet we define a view named ``mpis``, rooted at ``/path/to/view`` in which all projections use the package name, version, and compiler name to determine the path for a given package.
-This view selects all packages that depend on MPI, and excludes those built with the GCC compiler at version 18.5.
+This view selects all packages that depend on MPI, and excludes those built with the GCC compiler at version 8.5.
 The root specs with their (transitive) link and run type dependencies will be put in the view due to the  ``link: all`` option, and the files in the view will be symlinks to the Spack install directories.
 
 .. code-block:: yaml
@@ -930,7 +930,7 @@ The root specs with their (transitive) link and run type dependencies will be pu
        mpis:
          root: /path/to/view
          select: [^mpi]
-         exclude: ['%gcc@18.5']
+         exclude: ["%gcc@8.5"]
          projections:
            all: '{name}/{version}-{compiler.name}'
          link: all

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -707,7 +707,7 @@ The following two environment manifests are identical:
      specs:
        - matrix:
            - [zlib, libelf, libdwarf]
-           - ['%gcc@7.1.0', '%gcc@4.9.3']
+           - ["%gcc@7.1.0", "%gcc@4.9.3"]
          exclude:
            - libdwarf%gcc@4.9.3
        - cmake
@@ -735,7 +735,7 @@ As an example, the following two manifest files are identical.
    spack:
      definitions:
        - first: [libelf, libdwarf]
-       - compilers: ['%gcc', '%intel']
+       - compilers: ["%gcc", "%intel"]
        - second:
            - $first
            - matrix:
@@ -766,15 +766,15 @@ Additionally, the ``-l`` option to the ``spack add`` command allows one to add t
 The ``when`` directive can be used to conditionally add specs to a named list.
 The ``when`` directive takes a string of Python code referring to a restricted set of variables, and evaluates to a boolean.
 The specs listed are appended to the named list if the ``when`` string evaluates to ``True``.
-In the following snippet, the named list ``compilers`` is ``['%gcc', '%clang', '%intel']`` on ``x86_64`` systems and ``['%gcc', '%clang']`` on all other systems.
+In the following snippet, the named list ``compilers`` is ``["%gcc", "%clang", "%intel"]`` on ``x86_64`` systems and ``["%gcc", "%clang"]`` on all other systems.
 
 .. code-block:: yaml
 
    spack:
      definitions:
-       - compilers: ['%gcc', '%clang']
-       - when: arch.satisfies('target=x86_64:')
-         compilers: ['%intel']
+       - compilers: ["%gcc", "%clang"]
+       - when: arch.satisfies("target=x86_64:")
+         compilers: ["%intel"]
 
 .. note::
 
@@ -932,7 +932,7 @@ The root specs with their (transitive) link and run type dependencies will be pu
          select: [^mpi]
          exclude: ["%gcc@8.5"]
          projections:
-           all: '{name}/{version}-{compiler.name}'
+           all: "{name}/{version}-{compiler.name}"
          link: all
          link_type: symlink
 

--- a/lib/spack/docs/features.rst
+++ b/lib/spack/docs/features.rst
@@ -30,19 +30,19 @@ Users can specify the version, compile-time options, and target architecture, al
 .. code-block:: spec
 
    # Install a particular version by appending @
-   $ spack install hdf5@1.14.6
+   $ spack install hdf5@1.14
 
    # Add special compile-time options by name
-   $ spack install hdf5@1.14.6 api=v110
+   $ spack install hdf5@1.14 api=v110
 
    # Add special boolean compile-time options with +
-   $ spack install hdf5@1.14.6 +hl
+   $ spack install hdf5@1.14 +hl
 
    # Add compiler flags using the conventional names
-   $ spack install hdf5@1.14.6 cflags="-O3 -floop-block"
+   $ spack install hdf5@1.14 cflags="-O3 -floop-block"
 
    # Target a specific micro-architecture
-   $ spack install hdf5@1.14.6 target=icelake
+   $ spack install hdf5@1.14 target=icelake
 
 Users can specify as many or as few options as they care about.
 Spack will fill in the unspecified values with sensible defaults.
@@ -55,18 +55,18 @@ Users can specify both *direct* dependencies of a package, using the ``%`` sigil
 
 .. code-block:: spec
 
-   # Install hdf5 using gcc@15.1.0 as a compiler (direct dependency of hdf5)
-   $ spack install hdf5@1.14.6 %gcc@15.1.0
+   # Install hdf5 using gcc@15 as a compiler (direct dependency of hdf5)
+   $ spack install hdf5@1.14 %gcc@15
 
    # Install hdf5 using hwloc with CUDA enabled (transitive dependency)
-   $ spack install hdf5@1.14.6 ^hwloc+cuda
+   $ spack install hdf5@1.14 ^hwloc+cuda
 
 The expression on the command line can be as simple or as complicated as the user needs:
 
 .. code-block:: spec
 
    # Install hdf5 compiled with gcc@15, linked to mpich compiled with gcc@14
-   $ spack install hdf5@1.14.6 %gcc@15 ^mpich %gcc@14
+   $ spack install hdf5@1.14 %gcc@15 ^mpich %gcc@14
 
 Non-destructive installs
 ------------------------

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -288,21 +288,21 @@ For instance, in the snippet below:
          all:
            environment:
              set:
-               BAR: 'bar'
+               BAR: "bar"
          # This anonymous spec selects any package that
          # depends on mpi. The double colon at the
          # end clears the set of rules that matched so far.
          ^mpi::
            environment:
              prepend_path:
-               PATH: '{^mpi.prefix}/bin'
+               PATH: "{^mpi.prefix}/bin"
              set:
-               BAR: 'baz'
+               BAR: "baz"
          # Selects any zlib package
          zlib:
            environment:
              prepend_path:
-               LD_LIBRARY_PATH: 'foo'
+               LD_LIBRARY_PATH: "foo"
          # Selects zlib compiled with gcc@4.8
          zlib%gcc@4.8:
            environment:
@@ -344,8 +344,8 @@ If you write a configuration file like:
    modules:
      default:
        tcl:
-         include: ['gcc', 'llvm']  # include will have precedence over exclude
-         exclude: ['%gcc@4.4.7']   # Assuming gcc@4.4.7 is the system compiler
+         include: ["gcc", "llvm"]  # include will have precedence over exclude
+         exclude: ["%gcc@4.4.7"]   # Assuming gcc@4.4.7 is the system compiler
 
 you will prevent the generation of module files for any package that is compiled with ``gcc@4.4.7``, with the only exception of any ``gcc`` or any ``llvm`` installation.
 
@@ -390,8 +390,8 @@ For instance, the following config options,
        tcl:
          all:
            suffixes:
-             ^python@3: 'python{^python.version.up_to_2}'
-             ^openblas: 'openblas'
+             ^python@3: "python{^python.version.up_to_2}"
+             ^openblas: "openblas"
 
 will add a ``python3.12`` to module names of packages compiled with Python 3.12, and similarly for all specs depending on ``python@3``.
 This is useful to know which version of Python a set of Python extensions is associated with.
@@ -406,8 +406,8 @@ This uses the projections format covered in :ref:`view_projections`.
     default:
       tcl:
         projections:
-          all: '{name}/{version}-{compiler.name}-{compiler.version}-module'
-          ^mpi: '{name}/{version}-{^mpi.name}-{^mpi.version}-{compiler.name}-{compiler.version}-module'
+          all: "{name}/{version}-{compiler.name}-{compiler.version}-module"
+          ^mpi: "{name}/{version}-{^mpi.name}-{^mpi.version}-{compiler.name}-{compiler.version}-module"
 
 will create module files that are nested in directories by package name, contain the version and compiler name and version, and have the word ``module`` before the hash for all specs that do not depend on mpi, and will have the same information plus the MPI implementation name and version for all packages that depend on mpi.
 
@@ -426,11 +426,11 @@ When specifying module names by projection for Lmod modules, we recommend NOT in
             - tcl
           tcl:
             projections:
-              all: '{name}/{version}-{compiler.name}-{compiler.version}'
+              all: "{name}/{version}-{compiler.name}-{compiler.version}"
             all:
               conflict:
-                - '{name}'
-                - 'intel/14.0.1'
+                - "{name}"
+                - "intel/14.0.1"
 
    will create module files that will conflict with ``intel/14.0.1`` and with the base directory of the same module, effectively preventing the possibility to load two or more versions of the same software at the same time.
    The tokens that are available for use in this directive are those understood by the :meth:`~spack.spec.Spec.format` method.
@@ -452,12 +452,12 @@ When specifying module names by projection for Lmod modules, we recommend NOT in
              - lmod
            lmod:
              core_compilers:
-               - 'gcc@4.8'
+               - "gcc@4.8"
              core_specs:
-               - 'python'
+               - "python"
              hierarchy:
-               - 'mpi'
-               - 'lapack'
+               - "mpi"
+               - "lapack"
 
      that will generate a hierarchy in which the ``lapack`` and ``mpi`` layer can be switched independently.
      This allows a site to build the same libraries or applications against different implementations of ``mpi`` and ``lapack``, and let Lmod switch safely from one to the other.
@@ -532,7 +532,7 @@ If the ``use_view`` value is set in the config, then the prefix inspections for 
        my_view:
          projections:
            root: /path/to/my/view
-           all:  '{name}-{hash}'
+           all:  "{name}-{hash}"
 
 The ``spack`` key is relevant to :ref:`environment <environments>` configuration, and the view key is discussed in detail in the section on :ref:`Configuring environment views <configuring_environment_views>`.
 With this configuration the generated module for package ``foo`` would set ``PATH`` to include ``/path/to/my/view/foo-<hash>/bin`` instead of ``/spack/prefix/foo/bin``.
@@ -553,7 +553,7 @@ If you want to prevent modifications to some environment variables, you can do s
          all:
            filter:
              # Exclude changes to any of these variables
-             exclude_env_vars: ['CPATH', 'LIBRARY_PATH']
+             exclude_env_vars: ["CPATH", "LIBRARY_PATH"]
 
 The configuration above will generate module files that will not contain modifications to either ``CPATH`` or ``LIBRARY_PATH``.
 

--- a/lib/spack/docs/package_fundamentals.rst
+++ b/lib/spack/docs/package_fundamentals.rst
@@ -754,7 +754,7 @@ Here is how you would filter to show just versions:
     -  python 2.7.8
     +  python 3.8.11
 
-And you can add as many attributes as you'd like with multiple `--attribute` arguments (for lots of attributes, you can use ``-a`` for short).
+And you can add as many attributes as you'd like with multiple ``--attribute`` arguments (for lots of attributes, you can use ``-a`` for short).
 Finally, if you want to view the data as JSON (and possibly pipe into an output file), just add ``--json``:
 
 

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -379,7 +379,7 @@ You can also set default requirements for all packages under ``all`` like this:
 
    packages:
      all:
-       require: '%[when=%c]c=clang %[when=%cxx]cxx=clang'
+       require: "%[when=%c]c=clang %[when=%cxx]cxx=clang"
 
 which means every spec will be required to use ``clang`` as the compiler for C and C++ code.
 
@@ -419,12 +419,12 @@ For example, with a configuration like this:
    packages:
      all:
        require:
-       - 'build_type=Debug'
-       - '%[when=%c]c=clang %[when=%cxx]cxx=clang'
+       - "build_type=Debug"
+       - "%[when=%c]c=clang %[when=%cxx]cxx=clang"
      cmake:
        require:
-       - 'build_type=Debug'
-       - '%c,cxx=gcc'
+       - "build_type=Debug"
+       - "%c,cxx=gcc"
 
 Spack requires ``cmake`` to use ``gcc`` and all other nodes (including ``cmake`` dependencies) to use ``clang``.
 If enforcing ``build_type=Debug`` is needed also on ``cmake``, it must be repeated in the specific ``cmake`` requirements.
@@ -440,7 +440,7 @@ This can be useful for fixing which virtual provider you want to use:
 
    packages:
      mpi:
-       require: 'mvapich2 %c,cxx,fortran=gcc'
+       require: "mvapich2 %c,cxx,fortran=gcc"
 
 With the configuration above the only allowed ``mpi`` provider is ``mvapich2`` built with ``gcc``/``g++``/``gfortran``.
 
@@ -451,9 +451,9 @@ For instance with a configuration like:
 
    packages:
      mpi:
-       require: 'mvapich2 %c,cxx,fortran=gcc'
+       require: "mvapich2 %c,cxx,fortran=gcc"
      mvapich2:
-       require: '~cuda'
+       require: "~cuda"
 
 you will use ``mvapich2~cuda %c,cxx,fortran=gcc`` as an ``mpi`` provider.
 
@@ -469,9 +469,9 @@ If the semantic of requirements is too strong, you can also express "strong pref
    packages:
      all:
        prefer:
-       - '%c,cxx=clang'
+       - "%c,cxx=clang"
        conflict:
-       - '+shared'
+       - "+shared"
 
 The ``prefer`` and ``conflict`` sections can be used whenever a ``require`` section is allowed.
 The argument is always a list of constraints, and each constraint can be either a simple string, or a more complex object:
@@ -481,9 +481,9 @@ The argument is always a list of constraints, and each constraint can be either 
    packages:
      all:
        conflict:
-       - spec: '%c,cxx=clang'
-         when: 'target=x86_64_v3'
-         message: 'reason why clang cannot be used'
+       - spec: "%c,cxx=clang"
+         when: "target=x86_64_v3"
+         message: "reason why clang cannot be used"
 
 The ``spec`` attribute is mandatory, while both ``when`` and ``message`` are optional.
 
@@ -498,7 +498,7 @@ The ``spec`` attribute is mandatory, while both ``when`` and ``message`` are opt
       packages:
         all:
           require:
-          - one_of: ['%clang', '@:']
+          - one_of: ["%clang", "@:"]
 
    Since only one of the requirements must hold, and ``@:`` is always true, the rule above is equivalent to a conflict.
    For "strong preferences" the same construction works, with the ``any_of`` policy instead of the ``one_of`` policy.

--- a/lib/spack/docs/packaging_guide_advanced.rst
+++ b/lib/spack/docs/packaging_guide_advanced.rst
@@ -425,7 +425,7 @@ Detection tests insisting on ``PATH`` inspections are listed under the ``paths``
          echo "InstalledDir: /usr/bin"
      platforms: ["linux", "darwin"]
      results:
-     - spec: 'llvm@3.9.1 +clang~lld~lldb'
+     - spec: "llvm@3.9.1 +clang~lld~lldb"
 
 If the ``platforms`` attribute is present, tests are run only if the current host matches one of the listed platforms.
 Each test is performed by first creating a temporary directory structure as specified in the corresponding ``layout`` and by then running package detection and checking that the outcome matches the expected ``results``.

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2851,7 +2851,7 @@ The resulting spec objects for its dependencies shows the result of the above at
    # The core headers and libraries of the foo package
 
    >>> spec["foo"]
-   foo@1.0%gcc@11.3.1+bar+baz arch=linux-fedora35-haswell
+   foo@1.0/ca3rczp5omy7dfzoqw4p7oc2yh3u7lt6
    >>> spec["foo"].prefix
    "/opt/spack/linux-fedora35-haswell/gcc-11.3.1/foo-1.0-ca3rczp5omy7dfzoqw4p7oc2yh3u7lt6"
 
@@ -2885,7 +2885,7 @@ The resulting spec objects for its dependencies shows the result of the above at
 
    # bar resolves to the foo package
    >>> spec["bar"]
-   foo@1.0%gcc@11.3.1+bar+baz arch=linux-fedora35-haswell
+   foo@1.0/ca3rczp5omy7dfzoqw4p7oc2yh3u7lt6
    >>> spec["bar"].prefix
    "/opt/spack/linux-fedora35-haswell/gcc-11.3.1/foo-1.0-ca3rczp5omy7dfzoqw4p7oc2yh3u7lt6"
 
@@ -2920,7 +2920,7 @@ The resulting spec objects for its dependencies shows the result of the above at
 
    # baz resolves to the foo package
    >>> spec["baz"]
-   foo@1.0%gcc@11.3.1+bar+baz arch=linux-fedora35-haswell
+   foo@1.0/ca3rczp5omy7dfzoqw4p7oc2yh3u7lt6
    >>> spec["baz"].prefix
    "/opt/spack/linux-fedora35-haswell/gcc-11.3.1/foo-1.0-ca3rczp5omy7dfzoqw4p7oc2yh3u7lt6"
 

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -107,7 +107,7 @@ And here's the Spack environment built by the pipeline represented as a ``spack.
        - zlib
        - bzip2 ~debug
      - compiler:
-       - '%gcc'
+       - "%gcc"
 
      specs:
      - matrix:
@@ -337,10 +337,10 @@ Following is an example of this section added to a ``spack.yaml``:
      ci:
        pipeline-gen:
        - noop-job:
-           tags: ['custom', 'tag']
+           tags: ["custom", "tag"]
            image:
-             name: 'some.image.registry/custom-image:latest'
-             entrypoint: ['/bin/bash']
+             name: "some.image.registry/custom-image:latest"
+             entrypoint: ["/bin/bash"]
            script::
              - echo "Custom message in a custom script"
 
@@ -520,18 +520,18 @@ Here's an example of what bootstrapping some compilers might look like:
    spack:
      definitions:
      - compiler-pkgs:
-       - 'llvm+clang@6.0.1 os=centos7'
-       - 'gcc@6.5.0 os=centos7'
-       - 'llvm+clang@6.0.1 os=ubuntu18.04'
-       - 'gcc@6.5.0 os=ubuntu18.04'
+       - "llvm+clang@6.0.1 os=centos7"
+       - "gcc@6.5.0 os=centos7"
+       - "llvm+clang@6.0.1 os=ubuntu18.04"
+       - "gcc@6.5.0 os=ubuntu18.04"
      - pkgs:
        - readline@7.0
      - compilers:
-       - '%gcc@5.5.0'
-       - '%gcc@6.5.0'
-       - '%gcc@7.3.0'
-       - '%clang@6.0.0'
-       - '%clang@6.0.1'
+       - "%gcc@5.5.0"
+       - "%gcc@6.5.0"
+       - "%gcc@7.3.0"
+       - "%clang@6.0.0"
+       - "%clang@6.0.1"
      - oses:
        - os=ubuntu18.04
        - os=centos7
@@ -541,8 +541,8 @@ Here's an example of what bootstrapping some compilers might look like:
        - [$compilers]
        - [$oses]
        exclude:
-         - '%gcc@7.3.0 os=centos7'
-         - '%gcc@5.5.0 os=ubuntu18.04'
+         - "%gcc@7.3.0 os=centos7"
+         - "%gcc@5.5.0 os=ubuntu18.04"
      ci:
        bootstrap:
          - name: compiler-pkgs

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -398,7 +398,7 @@ Giving a command such as the following:
 
 .. code-block:: spec
 
-   $ spack install zlib%gcc@14.2.0 target=icelake
+   $ spack install zlib target=icelake %gcc@14
 
 will produce compilation lines similar to:
 
@@ -414,7 +414,7 @@ If Spack determines that the requested compiler cannot optimize for the requeste
 
 .. code-block:: spec
 
-   $ spack install zlib%gcc@5.5.0 target=icelake
+   $ spack install zlib target=icelake %gcc@5
    ==> Error: cannot produce optimized binary for micro-architecture "icelake" with gcc@5.5.0 [supported compiler versions are 8:]
 
 Conversely, if an older compiler is selected for a newer microarchitecture, Spack will optimize for the best match instead of failing:


### PR DESCRIPTION
* Fix a few example specs in the docs that have an incorrect order under Spack v1.0 parsing rules: `%gcc target=foo` instead of `target=foo %gcc`, etc.
* Use double quotes for yaml consistently
* Fix an instance of single -> double backticks

