### PR TITLE
Buildcache Views

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -52,10 +52,6 @@ jobs:
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
       with:
         python-version: '3.13'
-    - name: Install Requirements
-      run: |
-        sudo apt update
-        sudo apt install -y zig-dev
     - name: Install Python packages
       run: |
         pip install -r .github/workflows/requirements/style/requirements.txt

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -52,6 +52,10 @@ jobs:
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
       with:
         python-version: '3.13'
+    - name: Install Requirements
+      run: |
+        sudo apt update
+        sudo apt install -y zig-dev
     - name: Install Python packages
       run: |
         pip install -r .github/workflows/requirements/style/requirements.txt

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -137,9 +137,70 @@ For example, to combine all of the commands above to add the E4S build cache and
 The ``--install`` and ``--trust`` flags install keys to the keyring and trust all downloaded keys.
 
 
+Build Cache Index Views
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Introduced in Spack v1.1
+
+Build caches can quickly become large and inefficient to search as binaries are added over time.
+A common work around to this problem is to break the build cache into stacks that target specific applications or workflows.
+This allows for curation of binaries as smaller collections of packages that push a their own mirrors that each maintain a smaller search area.
+However, this approach comes with the tradeoff of requiring much larger storage and computational footprints due to duplication of common dependencies between stacks.
+Splitting build caches can also reduce direct fetch hits by reducing the breadth of binaries availabe in a single mirror.
+
+
+To better address the issues with large search areas, build cache index views (or just "views" in this section) were introduced.
+A view is a named index which provides a curated view into a larger buildcache.
+This allows build cache maintainers to provide the same granularity of build caches split by stacks without having to pay for the extra storage and compute required for the duplicated dependencies.
+
+Views can be created or updated using an active environment, environment lockfile(s), specfile(s), or specifying a spec hash(es) indexed in the local database.
+
+View indices are stored similarly to the top level build cache index, but use an additional prefix of the view name ``<build cache prefix>/v3/manifests/index/my-stack-view/index.manifest.json``.
+
+.. _cmd-spack-buildcache-create-view:
+
+``spack buildcache create-view``
+""""""""""""""""""""""""""""""""
+
+Here is an example of creating a view using from an active environent.
+
+.. code-block:: console
+
+   $ spack env activate my-stack
+   $ spack install
+   $ spack buildcache push my-mirror
+   $ spack buildcache create-view --name my-stack my-mirror
+
+
+.. _cmd-spack-buildcache-update-view:
+
+``spack buildcache update-view``
+""""""""""""""""""""""""""""""""
+
+Updating the existing view using appending as the stack moves forward.
+To prevent accidently overwriting an existing view it is required to specify how a view should be handled by update.
+The two options for handling updates are ``--force`` and ``--append``.
+Using the force option will replace the index as if the previous one did not exist.
+The append option will first read the existing index, and then add the specs specified the command.
+
+.. code-block:: console
+
+   $ spack buildcache push my-mirror
+   $ spack buildcache update-view --append --name my-stack my-mirror
+
+
+.. warning::
+
+   Using the ``--append`` option with build cache index views is a non-synchonous operation.
+   In the case where multiple writers are appending to the same view, the result will only include the state of the last to write.
+   When using ``--append`` for build cache workflows it is up to the user to correctly serialize the update operations.
+
+
+
 List of Popular Build Caches
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* `Spack Public Build Cache <https://spack.io/>`_: `build cache <https://cache.spack.io/>`_
 * `Extreme-scale Scientific Software Stack (E4S) <https://e4s-project.github.io/>`_: `build cache <https://oaciss.uoregon.edu/e4s/inventory.html>`_
 
 

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -165,7 +165,7 @@ View indices are stored similarly to the top level build cache index, but use an
 .. _cmd-spack-buildcache-create-view:
 
 Creating a Build Cache Index View
-""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""
 
 Here is an example of creating a view using an active environent.
 
@@ -186,7 +186,7 @@ If a list of environments is passed while inside of an active environment, the a
 .. _cmd-spack-buildcache-update-view:
 
 Updating a Build Cache Index View
-""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""
 
 To prevent accidently overwriting an existing view, it is required to specify how a view should be updated.
 It is possible to use one of two options for updating a view index: ``--force`` or ``--append``.

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -140,29 +140,31 @@ The ``--install`` and ``--trust`` flags install keys to the keyring and trust al
 Build Cache Index Views
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Introduced in Spack v1.1
+Introduced in Spack v1.2. The addition of this feature does not increment the build cache version.
+
+.. note::
+   Build cache index views are not supported in OCI build caches.
 
 Build caches can quickly become large and inefficient to search as binaries are added over time.
 A common work around to this problem is to break the build cache into stacks that target specific applications or workflows.
-This allows for curation of binaries as smaller collections of packages that push a their own mirrors that each maintain a smaller search area.
+This allows for curation of binaries as smaller collections of packages that push to their own mirrors that each maintain a smaller search area.
 However, this approach comes with the tradeoff of requiring much larger storage and computational footprints due to duplication of common dependencies between stacks.
 Splitting build caches can also reduce direct fetch hits by reducing the breadth of binaries availabe in a single mirror.
 
-
 To better address the issues with large search areas, build cache index views (or just "views" in this section) were introduced.
-A view is a named index which provides a curated view into a larger buildcache.
+A view is a named index which provides a curated view into a larger build cache.
 This allows build cache maintainers to provide the same granularity of build caches split by stacks without having to pay for the extra storage and compute required for the duplicated dependencies.
 
-Views can be created or updated using an active environment, environment lockfile(s), specfile(s), or specifying a spec hash(es) indexed in the local database.
+Views can be created or updated using an active environment, environment lockfile(s), specfile(s), or by specifying one or more spec hashes indexed in the local database.
 
-View indices are stored similarly to the top level build cache index, but use an additional prefix of the view name ``<build cache prefix>/v3/manifests/index/my-stack-view/index.manifest.json``.
+View indices are stored similarly to the top level build cache index, but use an additional prefix of the view name ``<build cache prefix>/v3/manifests/index/my-stack/index.manifest.json``.
 
 .. _cmd-spack-buildcache-create-view:
 
 ``spack buildcache create-view``
 """"""""""""""""""""""""""""""""
 
-Here is an example of creating a view using from an active environent.
+Here is an example of creating a view using an active environent.
 
 .. code-block:: console
 
@@ -177,11 +179,10 @@ Here is an example of creating a view using from an active environent.
 ``spack buildcache update-view``
 """"""""""""""""""""""""""""""""
 
-Updating the existing view using appending as the stack moves forward.
-To prevent accidently overwriting an existing view it is required to specify how a view should be handled by update.
+To prevent accidently overwriting an existing view, it is required to specify how a view should be updated.
 The two options for handling updates are ``--force`` and ``--append``.
 Using the force option will replace the index as if the previous one did not exist.
-The append option will first read the existing index, and then add the specs specified the command.
+The append option will first read the existing index, and then add the new specs to it.
 
 .. code-block:: console
 
@@ -191,7 +192,7 @@ The append option will first read the existing index, and then add the specs spe
 
 .. warning::
 
-   Using the ``--append`` option with build cache index views is a non-synchonous operation.
+   Using the ``--append`` option with build cache index views is a non-atomic operation.
    In the case where multiple writers are appending to the same view, the result will only include the state of the last to write.
    When using ``--append`` for build cache workflows it is up to the user to correctly serialize the update operations.
 
@@ -200,8 +201,8 @@ The append option will first read the existing index, and then add the specs spe
 List of Popular Build Caches
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* `Spack Public Build Cache <https://spack.io/>`_: `build cache <https://cache.spack.io/>`_
-* `Extreme-scale Scientific Software Stack (E4S) <https://e4s-project.github.io/>`_: `build cache <https://oaciss.uoregon.edu/e4s/inventory.html>`_
+* `Spack Public Build Cache <https://spack.io/>`_: `spack build cache <https://cache.spack.io/>`_
+* `Extreme-scale Scientific Software Stack (E4S) <https://e4s-project.github.io/>`_: `e4s build cache <https://oaciss.uoregon.edu/e4s/inventory.html>`_
 
 
 Creating and Trusting GPG keys

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -157,13 +157,14 @@ To better address the issues with large search areas, build cache index views (o
 A view is a named index which provides a curated view into a larger build cache.
 This allows build cache maintainers to provide the same granularity of build caches split by stacks without having to pay for the extra storage and compute required for the duplicated dependencies.
 
-Views can be created or updated using an active environment, environment lockfile(s), specfile(s), or by specifying one or more spec hashes indexed in the local database.
+Views can be created or updated using an active environment, or a list of environment names or paths.
+The ``spack buildcache`` commands for views are alias of the command ``spack buildcache update-index``.
 
 View indices are stored similarly to the top level build cache index, but use an additional prefix of the view name ``<build cache prefix>/v3/manifests/index/my-stack/index.manifest.json``.
 
 .. _cmd-spack-buildcache-create-view:
 
-``spack buildcache create-view``
+Creating a Build Cache Index View
 """"""""""""""""""""""""""""""""
 
 Here is an example of creating a view using an active environent.
@@ -173,28 +174,29 @@ Here is an example of creating a view using an active environent.
    $ spack env activate my-stack
    $ spack install
    $ spack buildcache push my-mirror
-   $ spack buildcache create-view --name my-view my-mirror
+   $ spack buildcache update-index --name my-view my-mirror
 
 It is also possible to create a view from a list of one or more environments by passing the environment names or paths.
+If a list of environments is passed while inside of an active environment, the active environment is ignored and only the passed environments are considered.
 
 .. code-block:: console
 
-   $ spack buildcache create-view --name my-view my-mirror my-stack # other environments...
+   $ spack buildcache update-index --name my-view my-mirror my-stack /path/to/environment/my-other-stack
 
 .. _cmd-spack-buildcache-update-view:
 
-``spack buildcache update-view``
+Updating a Build Cache Index View
 """"""""""""""""""""""""""""""""
 
 To prevent accidently overwriting an existing view, it is required to specify how a view should be updated.
-The two options for handling updates are ``--force`` and ``--append``.
-Using the force option will replace the index as if the previous one did not exist.
-The append option will first read the existing index, and then add the new specs to it.
+It is possible to use one of two options for updating a view index: ``--force`` or ``--append``.
+Using the ``--force`` option will replace the index as if the previous one did not exist.
+The ``--append`` option will first read the existing index, and then add the new specs to it.
 
 .. code-block:: console
 
    $ spack buildcache push my-mirror
-   $ spack buildcache update-view --append --name my-view my-mirror my-stack
+   $ spack buildcache update-index --append --name my-view my-mirror my-stack
 
 
 .. warning::

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -140,7 +140,9 @@ The ``--install`` and ``--trust`` flags install keys to the keyring and trust al
 Build Cache Index Views
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Introduced in Spack v1.2. The addition of this feature does not increment the build cache version.
+.. note::
+    Introduced in Spack v1.2.
+    The addition of this feature does not increment the build cache version (v3).
 
 .. note::
    Build cache index views are not supported in OCI build caches.

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -173,8 +173,13 @@ Here is an example of creating a view using an active environent.
    $ spack env activate my-stack
    $ spack install
    $ spack buildcache push my-mirror
-   $ spack buildcache create-view --name my-stack my-mirror
+   $ spack buildcache create-view --name my-view my-mirror
 
+It is also possible to create a view from a list of one or more environments by passing the environment names or paths.
+
+.. code-block:: console
+
+   $ spack buildcache create-view --name my-view my-mirror my-stack # other environments...
 
 .. _cmd-spack-buildcache-update-view:
 
@@ -189,7 +194,7 @@ The append option will first read the existing index, and then add the new specs
 .. code-block:: console
 
    $ spack buildcache push my-mirror
-   $ spack buildcache update-view --append --name my-stack my-mirror
+   $ spack buildcache update-view --append --name my-view my-mirror my-stack
 
 
 .. warning::

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -372,6 +372,7 @@ class BinaryCacheIndex:
                         all_methods_failed = False
                 else:
                     # May need to fetch the index and update the local caches
+                    needs_regen = False
                     try:
                         needs_regen = self._fetch_and_cache_index(
                             urlAndVersion, cache_entry=cache_entry
@@ -379,9 +380,12 @@ class BinaryCacheIndex:
                         self._last_fetch_times[urlAndVersion] = (now, True)
                         all_methods_failed = False
                     except FetchIndexError as e:
-                        needs_regen = False
                         fetch_errors.append(e)
                         self._last_fetch_times[urlAndVersion] = (now, False)
+                    except BuildcacheIndexNotExists:
+                        self._last_fetch_times[urlAndVersion] = (now, False)
+                        all_methods_failed = False
+
                     # The need to regenerate implies a need to clear as well.
                     spec_cache_clear_needed |= needs_regen
                     spec_cache_regenerate_needed |= needs_regen
@@ -413,14 +417,18 @@ class BinaryCacheIndex:
                 continue
 
             # Need to fetch the index and update the local caches
+            needs_regen = False
             try:
                 needs_regen = self._fetch_and_cache_index(urlAndVersion)
                 self._last_fetch_times[urlAndVersion] = (now, True)
                 all_methods_failed = False
             except FetchIndexError as e:
                 fetch_errors.append(e)
-                needs_regen = False
                 self._last_fetch_times[urlAndVersion] = (now, False)
+            except BuildcacheIndexNotExists:
+                self._last_fetch_times[urlAndVersion] = (now, False)
+                all_methods_failed = False
+
             # Generally speaking, a new mirror wouldn't imply the need to
             # clear the spec cache, so leave it as is.
             if needs_regen:
@@ -464,8 +472,9 @@ class BinaryCacheIndex:
 
         if scheme != "oci":
             cache_class = get_url_buildcache_class(layout_version=layout_version)
-            if not web_util.url_exists(cache_class.get_index_url(mirror_url, mirror_view)):
-                raise FetchIndexError("Index not found in cache")
+            index_url = cache_class.get_index_url(mirror_url, mirror_view)
+            if not web_util.url_exists(index_url):
+                raise BuildcacheIndexNotExists(f"Index not found in cache {index_url}")
 
         fetcher: IndexFetcher = get_index_fetcher(scheme, url_and_version, cache_entry)
         result = fetcher.conditional_fetch()
@@ -2541,6 +2550,10 @@ class FetchIndexError(Exception):
 
 class BuildcacheIndexError(spack.error.SpackError):
     """Raised when a buildcache cannot be read for any reason"""
+
+
+class BuildcacheIndexNotExists(Exception):
+    """Buildcache does not contain an index"""
 
 
 FetchIndexResult = collections.namedtuple("FetchIndexResult", "etag hash data fresh")

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -92,7 +92,7 @@ from .url_buildcache import (
     BuildcacheManifest,
     InvalidMetadataFile,
     ListMirrorSpecsError,
-    MirrorURLAndVersion,
+    MirrorMetadata,
     URLBuildcacheEntry,
     get_entries_from_cache,
     get_url_buildcache_class,
@@ -179,12 +179,12 @@ class BinaryCacheIndex:
 
         # mapping from mirror urls to the time.time() of the last index fetch and a bool indicating
         # whether the fetch succeeded or not.
-        self._last_fetch_times: Dict[MirrorURLAndVersion, Tuple[float, bool]] = {}
+        self._last_fetch_times: Dict[MirrorMetadata, Tuple[float, bool]] = {}
 
         #: Dictionary mapping DAG hashes of specs to Spec objects
         self._known_specs: Dict[str, spack.spec.Spec] = {}
         #: Dictionary mapping DAG hashes of specs to a list of mirrors where they can be found
-        self._mirrors_for_spec: Dict[str, Set[MirrorURLAndVersion]] = defaultdict(set)
+        self._mirrors_for_spec: Dict[str, Set[MirrorMetadata]] = defaultdict(set)
 
     def _init_local_index_cache(self):
         if not self._index_file_cache_initialized:
@@ -224,11 +224,11 @@ class BinaryCacheIndex:
             cached_index_hash = cache_entry["index_hash"]
             if cached_index_hash not in self._specs_already_associated:
                 self._associate_built_specs_with_mirror(
-                    cached_index_path, MirrorURLAndVersion.from_string(url_and_version)
+                    cached_index_path, MirrorMetadata.from_string(url_and_version)
                 )
                 self._specs_already_associated.add(cached_index_hash)
 
-    def _associate_built_specs_with_mirror(self, cache_key, url_and_version: MirrorURLAndVersion):
+    def _associate_built_specs_with_mirror(self, cache_key, url_and_version: MirrorMetadata):
         with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
             db = BuildCacheDatabase(tmpdir)
 
@@ -264,8 +264,8 @@ class BinaryCacheIndex:
         """Returns a list of all concrete specs known to be available in a binary cache."""
         return list(self._known_specs.values())
 
-    def find_built_spec(self, spec: spack.spec.Spec) -> List[MirrorURLAndVersion]:
-        """Returns a list of MirrorURLAndVersion objects indicating which mirrors have the given
+    def find_built_spec(self, spec: spack.spec.Spec) -> List[MirrorMetadata]:
+        """Returns a list of MirrorMetadata objects indicating which mirrors have the given
         concrete spec.
 
         This method does not trigger reading anything from remote mirrors, but rather just checks
@@ -278,7 +278,7 @@ class BinaryCacheIndex:
         """
         return self.find_by_hash(spec.dag_hash())
 
-    def find_by_hash(self, dag_hash: str) -> List[MirrorURLAndVersion]:
+    def find_by_hash(self, dag_hash: str) -> List[MirrorMetadata]:
         """Same as find_built_spec but uses the hash of a spec.
 
         Args:
@@ -286,7 +286,7 @@ class BinaryCacheIndex:
         """
         return list(self._mirrors_for_spec.get(dag_hash, []))
 
-    def update_spec(self, spec: spack.spec.Spec, found_list: List[MirrorURLAndVersion]) -> None:
+    def update_spec(self, spec: spack.spec.Spec, found_list: List[MirrorMetadata]) -> None:
         """Update the cache with a new list of mirrors for a given spec."""
         spec_dag_hash = spec.dag_hash()
 
@@ -309,7 +309,7 @@ class BinaryCacheIndex:
         on disk under ``_index_cache_root``)."""
         self._init_local_index_cache()
         configured_mirrors = [
-            MirrorURLAndVersion(m.fetch_url, layout_version, m.fetch_view)
+            MirrorMetadata(m.fetch_url, layout_version, m.fetch_view)
             for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
             for layout_version in m.supported_layout_versions
         ]
@@ -346,7 +346,7 @@ class BinaryCacheIndex:
         now = time.time()
 
         for local_index_cache_key in self._local_index_cache:
-            urlAndVersion = MirrorURLAndVersion.from_string(local_index_cache_key)
+            urlAndVersion = MirrorMetadata.from_string(local_index_cache_key)
             cached_mirror_url = urlAndVersion.url
             cache_entry = self._local_index_cache[local_index_cache_key]
             cached_index_path = cache_entry["index_path"]
@@ -445,7 +445,7 @@ class BinaryCacheIndex:
         if spec_cache_regenerate_needed:
             self.regenerate_spec_cache(clear_existing=spec_cache_clear_needed)
 
-    def _fetch_and_cache_index(self, url_and_version: MirrorURLAndVersion, cache_entry={}):
+    def _fetch_and_cache_index(self, url_and_version: MirrorMetadata, cache_entry={}):
         """Fetch a buildcache index file from a remote mirror and cache it.
 
         If we already have a cached index from this mirror, then we first
@@ -1682,7 +1682,7 @@ def try_fetch(url_to_fetch):
 def download_tarball(
     spec: spack.spec.Spec,
     unsigned: Optional[bool] = False,
-    mirrors_for_spec: Optional[List[MirrorURLAndVersion]] = None,
+    mirrors_for_spec: Optional[List[MirrorMetadata]] = None,
 ) -> Optional[spack.stage.Stage]:
     """Download binary tarball for given package
 
@@ -1714,7 +1714,7 @@ def download_tarball(
     # mirror for the spec twice though.
     try_first = mirrors_for_spec or []
     try_next = [
-        MirrorURLAndVersion(mirror.fetch_url, layout, mirror.fetch_view)
+        MirrorMetadata(mirror.fetch_url, layout, mirror.fetch_view)
         for mirror in configured_mirrors
         for layout in mirror.supported_layout_versions
     ]
@@ -1722,7 +1722,7 @@ def download_tarball(
 
     # TODO: turn `mirrors_for_spec` into a list of Mirror instances, instead of doing that here.
     def fetch_url_to_mirror(
-        url_and_version: MirrorURLAndVersion,
+        url_and_version: MirrorMetadata,
     ) -> Tuple[spack.mirrors.mirror.Mirror, int]:
         url = url_and_version.url
         layout_version = url_and_version.version
@@ -2157,9 +2157,9 @@ def install_single_spec(spec, unsigned=False, force=False):
         install_root_node(node, unsigned=unsigned, force=force)
 
 
-def try_direct_fetch(spec: spack.spec.Spec) -> List[MirrorURLAndVersion]:
+def try_direct_fetch(spec: spack.spec.Spec) -> List[MirrorMetadata]:
     """Try to find the spec directly on the configured mirrors"""
-    found_specs: List[MirrorURLAndVersion] = []
+    found_specs: List[MirrorMetadata] = []
     binary_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True).values()
 
     for mirror in binary_mirrors:
@@ -2184,16 +2184,12 @@ def try_direct_fetch(spec: spack.spec.Spec) -> List[MirrorURLAndVersion]:
             fetched_spec = spack.spec.Spec.from_dict(spec_dict)
             fetched_spec._mark_concrete()
 
-            found_specs.append(
-                MirrorURLAndVersion(mirror.fetch_url, layout_version, mirror.fetch_view)
-            )
+            found_specs.append(MirrorMetadata(mirror.fetch_url, layout_version, mirror.fetch_view))
 
     return found_specs
 
 
-def get_mirrors_for_spec(
-    spec: spack.spec.Spec, index_only: bool = False
-) -> List[MirrorURLAndVersion]:
+def get_mirrors_for_spec(spec: spack.spec.Spec, index_only: bool = False) -> List[MirrorMetadata]:
     """
     Check if concrete spec exists on mirrors and return a list indicating the mirrors on which it
     can be found
@@ -2708,7 +2704,7 @@ class EtagIndexFetcherV2(IndexFetcher):
 
 
 class OCIIndexFetcher(IndexFetcher):
-    def __init__(self, url_and_version: MirrorURLAndVersion, local_hash, urlopen=None) -> None:
+    def __init__(self, url_and_version: MirrorMetadata, local_hash, urlopen=None) -> None:
         self.local_hash = local_hash
         self.ref = spack.oci.image.ImageReference.from_url(url_and_version.url)
         self.urlopen = urlopen or spack.oci.opener.urlopen
@@ -2763,7 +2759,7 @@ class OCIIndexFetcher(IndexFetcher):
 class DefaultIndexFetcher(IndexFetcher):
     """Fetcher for buildcache index, cache invalidation via manifest contents"""
 
-    def __init__(self, url_and_version: MirrorURLAndVersion, local_hash, urlopen=web_util.urlopen):
+    def __init__(self, url_and_version: MirrorMetadata, local_hash, urlopen=web_util.urlopen):
         self.url = url_and_version.url
         self.view = url_and_version.view
         self.layout_version = url_and_version.version
@@ -2822,7 +2818,7 @@ class EtagIndexFetcher(IndexFetcher):
     4. If it needs to actually read the manifest, it does not need to do any checks of the url
     scheme to determine whether an etag should be included in the return value."""
 
-    def __init__(self, url_and_version: MirrorURLAndVersion, etag, urlopen=web_util.urlopen):
+    def __init__(self, url_and_version: MirrorMetadata, etag, urlopen=web_util.urlopen):
         self.url = url_and_version.url
         self.view = url_and_version.view
         self.layout_version = url_and_version.version
@@ -2865,7 +2861,7 @@ class EtagIndexFetcher(IndexFetcher):
 
 
 def get_index_fetcher(
-    scheme: str, url_and_version: MirrorURLAndVersion, cache_entry: Dict[str, str]
+    scheme: str, url_and_version: MirrorMetadata, cache_entry: Dict[str, str]
 ) -> IndexFetcher:
     if scheme == "oci":
         # TODO: Actually etag and OCI are not mutually exclusive...

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -456,6 +456,7 @@ class BinaryCacheIndex:
             FetchIndexError
         """
         mirror_url = url_and_version.url
+        mirror_view = url_and_version.view
         layout_version = url_and_version.version
 
         # TODO: get rid of this request, handle 404 better
@@ -463,8 +464,8 @@ class BinaryCacheIndex:
 
         if scheme != "oci":
             cache_class = get_url_buildcache_class(layout_version=layout_version)
-            if not web_util.url_exists(cache_class.get_index_url(mirror_url)):
-                return False
+            if not web_util.url_exists(cache_class.get_index_url(mirror_url, mirror_view)):
+                raise FetchIndexError("Index not found in cache")
 
         fetcher: IndexFetcher = get_index_fetcher(scheme, url_and_version, cache_entry)
         result = fetcher.conditional_fetch()
@@ -474,7 +475,7 @@ class BinaryCacheIndex:
             return False
 
         # Persist new index.json
-        url_hash = compute_hash(f"{mirror_url}/v{layout_version}")
+        url_hash = compute_hash(str(url_and_version))
         cache_key = "{}_{}.json".format(url_hash[:10], result.hash[:10])
         self._index_file_cache.init_entry(cache_key)
         with self._index_file_cache.write_transaction(cache_key) as (old, new):
@@ -636,7 +637,7 @@ def select_signing_key() -> str:
     return keys[0]
 
 
-def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str):
+def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str, name: str = ""):
     """Generate the index, compute its hash, and push the files to the mirror"""
     index_json_path = os.path.join(temp_dir, spack.database.INDEX_JSON_FILE)
     with open(index_json_path, "w", encoding="utf-8") as f:
@@ -644,7 +645,11 @@ def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str):
 
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
     cache_class.push_local_file_as_blob(
-        index_json_path, cache_prefix, "index", BuildcacheComponent.INDEX, compression="none"
+        index_json_path,
+        cache_prefix,
+        url_util.join(name, "index") if name else "index",
+        BuildcacheComponent.INDEX,
+        compression="none",
     )
     cache_class.maybe_push_layout_json(cache_prefix)
 
@@ -652,6 +657,8 @@ def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str):
 def _read_specs_and_push_index(
     file_list: List[str],
     read_method: Callable[[str], URLBuildcacheEntry],
+    name: str,
+    filter_fn: Callable[[str], bool],
     cache_prefix: str,
     db: BuildCacheDatabase,
     temp_dir: str,
@@ -667,6 +674,16 @@ def _read_specs_and_push_index(
         temp_dir: Location to write index.json and hash for pushing
     """
     for file in file_list:
+        # All supported versions of build caches put the hash as the last
+        # parameter before the extension
+        try:
+            x = file.split("/")[-1].split("-")[-1].split(".")[0]
+        except IndexError:
+            raise GenerateIndexError(f"Malformed metadata file name detected {file}")
+
+        if not filter_fn(x):
+            continue
+
         cache_entry: Optional[URLBuildcacheEntry] = None
         try:
             cache_entry = read_method(file)
@@ -681,10 +698,16 @@ def _read_specs_and_push_index(
         db.add(fetched_spec)
         db.mark(fetched_spec, "in_buildcache", True)
 
-    _push_index(db, temp_dir, cache_prefix)
+    _push_index(db, temp_dir, cache_prefix, name)
 
 
-def _url_generate_package_index(url: str, tmpdir: str):
+def _url_generate_package_index(
+    url: str,
+    tmpdir: str,
+    db: Optional[BuildCacheDatabase] = None,
+    name: str = "",
+    filter_fn: Callable[[str], bool] = lambda x: True,
+):
     """Create or replace the build cache index on the given mirror.  The
     buildcache index contains an entry for each binary package under the
     cache_prefix.
@@ -706,11 +729,14 @@ def _url_generate_package_index(url: str, tmpdir: str):
 
         tty.debug(f"Retrieving spec descriptor files from {url} to build index")
 
-        db = BuildCacheDatabase(tmpdir)
-        db._write()
+        if not db:
+            db = BuildCacheDatabase(tmpdir)
+            db._write()
 
         try:
-            _read_specs_and_push_index(file_list, read_fn, url, db, str(db.database_directory))
+            _read_specs_and_push_index(
+                file_list, read_fn, name, filter_fn, url, db, str(db.database_directory)
+            )
         except Exception as e:
             raise GenerateIndexError(
                 f"Encountered problem pushing package index to {url}: {e}"
@@ -1679,7 +1705,7 @@ def download_tarball(
     # mirror for the spec twice though.
     try_first = mirrors_for_spec or []
     try_next = [
-        MirrorURLAndVersion(mirror.fetch_url, layout)
+        MirrorURLAndVersion(mirror.fetch_url, layout, mirror.fetch_view)
         for mirror in configured_mirrors
         for layout in SUPPORTED_LAYOUT_VERSIONS
     ]
@@ -2135,6 +2161,12 @@ def try_direct_fetch(spec: spack.spec.Spec) -> List[MirrorURLAndVersion]:
             # TODO: OCI-support
             if spack.oci.image.is_oci_url(mirror.fetch_url):
                 continue
+
+            if not mirror.supported_version(binary_layout_version=layout_version):
+                # Check if the features of this mirror are supported by the layout version
+                # ie. only v3 mirrors have view support
+                continue
+
             # layout_version could eventually come from the mirror config
             cache_class = get_url_buildcache_class(layout_version=layout_version)
             cache_entry = cache_class(mirror.fetch_url, spec)
@@ -2151,7 +2183,7 @@ def try_direct_fetch(spec: spack.spec.Spec) -> List[MirrorURLAndVersion]:
             fetched_spec = spack.spec.Spec.from_dict(spec_dict)
             fetched_spec._mark_concrete()
 
-            found_specs.append(MirrorURLAndVersion(mirror.fetch_url, layout_version))
+            found_specs.append(MirrorURLAndVersion(mirror.fetch_url, layout_version, mirror.fetch_view))
 
     return found_specs
 
@@ -2726,6 +2758,7 @@ class DefaultIndexFetcher(IndexFetcher):
 
     def __init__(self, url_and_version: MirrorURLAndVersion, local_hash, urlopen=web_util.urlopen):
         self.url = url_and_version.url
+        self.view = url_and_version.view
         self.layout_version = url_and_version.version
         self.local_hash = local_hash
         self.urlopen = urlopen
@@ -2733,7 +2766,7 @@ class DefaultIndexFetcher(IndexFetcher):
 
     def conditional_fetch(self) -> FetchIndexResult:
         cache_class = get_url_buildcache_class(layout_version=self.layout_version)
-        url_index_manifest = cache_class.get_index_url(self.url)
+        url_index_manifest = cache_class.get_index_url(self.url, self.view)
 
         try:
             response = self.urlopen(
@@ -2784,6 +2817,7 @@ class EtagIndexFetcher(IndexFetcher):
 
     def __init__(self, url_and_version: MirrorURLAndVersion, etag, urlopen=web_util.urlopen):
         self.url = url_and_version.url
+        self.view = url_and_version.view
         self.layout_version = url_and_version.version
         self.etag = etag
         self.urlopen = urlopen
@@ -2791,7 +2825,7 @@ class EtagIndexFetcher(IndexFetcher):
     def conditional_fetch(self) -> FetchIndexResult:
         # Do a conditional fetch of the index manifest (i.e. using If-None-Match header)
         cache_class = get_url_buildcache_class(layout_version=self.layout_version)
-        manifest_url = cache_class.get_index_url(self.url)
+        manifest_url = cache_class.get_index_url(self.url, self.view)
         headers = {"User-Agent": web_util.SPACK_USER_AGENT, "If-None-Match": f'"{self.etag}"'}
 
         try:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -85,7 +85,6 @@ from spack.util.executable import which
 from .enums import InstallRecordStatus
 from .url_buildcache import (
     CURRENT_BUILD_CACHE_LAYOUT_VERSION,
-    SUPPORTED_LAYOUT_VERSIONS,
     BlobRecord,
     BuildcacheComponent,
     BuildcacheEntryError,
@@ -313,12 +312,8 @@ class BinaryCacheIndex:
         self._init_local_index_cache()
         configured_mirrors = [
             MirrorURLAndVersion(m.fetch_url, layout_version, m.fetch_view)
-            for layout_version in SUPPORTED_LAYOUT_VERSIONS
             for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
-            # TODO: OCI does not have a versioned layout. Get rid of this once we no longer support
-            # URL layout v2.
-            if not spack.oci.image.is_oci_url(m.fetch_url)
-            or layout_version == SUPPORTED_LAYOUT_VERSIONS[0]
+            for layout_version in m.supported_layout_versions
         ]
         items_to_remove = []
         spec_cache_clear_needed = False
@@ -1723,7 +1718,7 @@ def download_tarball(
     try_next = [
         MirrorURLAndVersion(mirror.fetch_url, layout, mirror.fetch_view)
         for mirror in configured_mirrors
-        for layout in SUPPORTED_LAYOUT_VERSIONS
+        for layout in mirror.supported_layout_versions
     ]
     urls_and_versions = try_first + [uv for uv in try_next if uv not in try_first]
 
@@ -1749,9 +1744,6 @@ def download_tarball(
 
         # TODO: refactor this to some "nice" place.
         if spack.oci.image.is_oci_url(fetch_url):
-            # TODO: OCI does not have a concept of layout versions, get rid of this notion.
-            if layout_version != SUPPORTED_LAYOUT_VERSIONS[0]:
-                continue
             ref = ImageReference.from_url(fetch_url).with_tag(_oci_default_tag(spec))
 
             # Fetch the manifest
@@ -2172,17 +2164,12 @@ def try_direct_fetch(spec: spack.spec.Spec) -> List[MirrorURLAndVersion]:
     found_specs: List[MirrorURLAndVersion] = []
     binary_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True).values()
 
-    for layout_version in SUPPORTED_LAYOUT_VERSIONS:
-        for mirror in binary_mirrors:
-            # TODO: OCI-support
-            if spack.oci.image.is_oci_url(mirror.fetch_url):
-                continue
+    for mirror in binary_mirrors:
+        # TODO: OCI-support
+        if spack.oci.image.is_oci_url(mirror.fetch_url):
+            continue
 
-            if not mirror.supported_version(binary_layout_version=layout_version):
-                # Check if the features of this mirror are supported by the layout version
-                # ie. only v3 mirrors have view support
-                continue
-
+        for layout_version in mirror.supported_layout_versions:
             # layout_version could eventually come from the mirror config
             cache_class = get_url_buildcache_class(layout_version=layout_version)
             cache_entry = cache_class(mirror.fetch_url, spec)
@@ -2262,12 +2249,12 @@ def get_keys(
         tty.die("Please add a spack mirror to allow " + "download of build caches.")
 
     for mirror in mirror_collection.values():
-        for layout_version in SUPPORTED_LAYOUT_VERSIONS:
-            fetch_url = mirror.fetch_url
-            # TODO: oci:// does not support signing.
-            if spack.oci.image.is_oci_url(fetch_url):
-                continue
+        if not mirror.signed:
+            # Don't bother fetching keys for unsigned mirrors
+            continue
 
+        for layout_version in mirror.supported_layout_versions:
+            fetch_url = mirror.fetch_url
             if layout_version == 2:
                 _get_keys_v2(fetch_url, install, trust, force)
             else:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -218,17 +218,17 @@ class BinaryCacheIndex:
             self._mirrors_for_spec = defaultdict(set)
             self._known_specs = {}
 
-        for url_and_version in self._local_index_cache:
-            cache_entry = self._local_index_cache[url_and_version]
+        for mirror_metadata in self._local_index_cache:
+            cache_entry = self._local_index_cache[mirror_metadata]
             cached_index_path = cache_entry["index_path"]
             cached_index_hash = cache_entry["index_hash"]
             if cached_index_hash not in self._specs_already_associated:
                 self._associate_built_specs_with_mirror(
-                    cached_index_path, MirrorMetadata.from_string(url_and_version)
+                    cached_index_path, MirrorMetadata.from_string(mirror_metadata)
                 )
                 self._specs_already_associated.add(cached_index_hash)
 
-    def _associate_built_specs_with_mirror(self, cache_key, url_and_version: MirrorMetadata):
+    def _associate_built_specs_with_mirror(self, cache_key, mirror_metadata: MirrorMetadata):
         with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
             db = BuildCacheDatabase(tmpdir)
 
@@ -240,7 +240,7 @@ class BinaryCacheIndex:
             except spack.database.InvalidDatabaseVersionError as e:
                 tty.warn(
                     "you need a newer Spack version to read the buildcache index for the "
-                    f"following v{url_and_version.version} mirror: '{url_and_version.url}'. "
+                    f"following v{mirror_metadata.version} mirror: '{mirror_metadata.url}'. "
                     f"{e.database_version_message}"
                 )
                 return
@@ -256,7 +256,7 @@ class BinaryCacheIndex:
                 dag_hash = spec.dag_hash()
                 mirrors = self._mirrors_for_spec[dag_hash]
 
-                mirrors.add(url_and_version.strip_view())
+                mirrors.add(mirror_metadata.strip_view())
                 if dag_hash not in self._known_specs:
                     self._known_specs[dag_hash] = spec
 
@@ -445,14 +445,14 @@ class BinaryCacheIndex:
         if spec_cache_regenerate_needed:
             self.regenerate_spec_cache(clear_existing=spec_cache_clear_needed)
 
-    def _fetch_and_cache_index(self, url_and_version: MirrorMetadata, cache_entry={}):
+    def _fetch_and_cache_index(self, mirror_metadata: MirrorMetadata, cache_entry={}):
         """Fetch a buildcache index file from a remote mirror and cache it.
 
         If we already have a cached index from this mirror, then we first
         check if the hash has changed, and we avoid fetching it if not.
 
         Args:
-            url_and_version: Contains mirror base url and target binary cache layout version
+            mirror_metadata: Contains mirror base url and target binary cache layout version
             cache_entry (dict): Old cache metadata with keys ``index_hash``, ``index_path``,
                 ``etag``
 
@@ -463,9 +463,9 @@ class BinaryCacheIndex:
             FetchIndexError
             BuildcacheIndexNotExists
         """
-        mirror_url = url_and_version.url
-        mirror_view = url_and_version.view
-        layout_version = url_and_version.version
+        mirror_url = mirror_metadata.url
+        mirror_view = mirror_metadata.view
+        layout_version = mirror_metadata.version
 
         # TODO: get rid of this request, handle 404 better
         scheme = urllib.parse.urlparse(mirror_url).scheme
@@ -476,7 +476,7 @@ class BinaryCacheIndex:
             if not web_util.url_exists(index_url):
                 raise BuildcacheIndexNotExists(f"Index not found in cache {index_url}")
 
-        fetcher: IndexFetcher = get_index_fetcher(scheme, url_and_version, cache_entry)
+        fetcher: IndexFetcher = get_index_fetcher(scheme, mirror_metadata, cache_entry)
         result = fetcher.conditional_fetch()
 
         # Nothing to do
@@ -484,13 +484,13 @@ class BinaryCacheIndex:
             return False
 
         # Persist new index.json
-        url_hash = compute_hash(str(url_and_version))
+        url_hash = compute_hash(str(mirror_metadata))
         cache_key = "{}_{}.json".format(url_hash[:10], result.hash[:10])
         self._index_file_cache.init_entry(cache_key)
         with self._index_file_cache.write_transaction(cache_key) as (old, new):
             new.write(result.data)
 
-        self._local_index_cache[str(url_and_version)] = {
+        self._local_index_cache[str(mirror_metadata)] = {
             "index_hash": result.hash,
             "index_path": cache_key,
             "etag": result.etag,
@@ -1722,16 +1722,16 @@ def download_tarball(
 
     # TODO: turn `mirrors_for_spec` into a list of Mirror instances, instead of doing that here.
     def fetch_url_to_mirror(
-        url_and_version: MirrorMetadata,
+        mirror_metadata: MirrorMetadata,
     ) -> Tuple[spack.mirrors.mirror.Mirror, int]:
-        url = url_and_version.url
-        layout_version = url_and_version.version
+        url = mirror_metadata.url
+        layout_version = mirror_metadata.version
         for mirror in configured_mirrors:
             if mirror.fetch_url == url:
                 return mirror, layout_version
         return spack.mirrors.mirror.Mirror(url), layout_version
 
-    mirrors = [fetch_url_to_mirror(url_and_version) for url_and_version in urls_and_versions]
+    mirrors = [fetch_url_to_mirror(mirror_metadata) for mirror_metadata in urls_and_versions]
 
     for mirror, layout_version in mirrors:
         # Override mirror's default if
@@ -2704,9 +2704,9 @@ class EtagIndexFetcherV2(IndexFetcher):
 
 
 class OCIIndexFetcher(IndexFetcher):
-    def __init__(self, url_and_version: MirrorMetadata, local_hash, urlopen=None) -> None:
+    def __init__(self, mirror_metadata: MirrorMetadata, local_hash, urlopen=None) -> None:
         self.local_hash = local_hash
-        self.ref = spack.oci.image.ImageReference.from_url(url_and_version.url)
+        self.ref = spack.oci.image.ImageReference.from_url(mirror_metadata.url)
         self.urlopen = urlopen or spack.oci.opener.urlopen
 
     def conditional_fetch(self) -> FetchIndexResult:
@@ -2759,10 +2759,10 @@ class OCIIndexFetcher(IndexFetcher):
 class DefaultIndexFetcher(IndexFetcher):
     """Fetcher for buildcache index, cache invalidation via manifest contents"""
 
-    def __init__(self, url_and_version: MirrorMetadata, local_hash, urlopen=web_util.urlopen):
-        self.url = url_and_version.url
-        self.view = url_and_version.view
-        self.layout_version = url_and_version.version
+    def __init__(self, mirror_metadata: MirrorMetadata, local_hash, urlopen=web_util.urlopen):
+        self.url = mirror_metadata.url
+        self.view = mirror_metadata.view
+        self.layout_version = mirror_metadata.version
         self.local_hash = local_hash
         self.urlopen = urlopen
         self.headers = {"User-Agent": web_util.SPACK_USER_AGENT}
@@ -2818,10 +2818,10 @@ class EtagIndexFetcher(IndexFetcher):
     4. If it needs to actually read the manifest, it does not need to do any checks of the url
     scheme to determine whether an etag should be included in the return value."""
 
-    def __init__(self, url_and_version: MirrorMetadata, etag, urlopen=web_util.urlopen):
-        self.url = url_and_version.url
-        self.view = url_and_version.view
-        self.layout_version = url_and_version.version
+    def __init__(self, mirror_metadata: MirrorMetadata, etag, urlopen=web_util.urlopen):
+        self.url = mirror_metadata.url
+        self.view = mirror_metadata.view
+        self.layout_version = mirror_metadata.version
         self.etag = etag
         self.urlopen = urlopen
 
@@ -2861,25 +2861,25 @@ class EtagIndexFetcher(IndexFetcher):
 
 
 def get_index_fetcher(
-    scheme: str, url_and_version: MirrorMetadata, cache_entry: Dict[str, str]
+    scheme: str, mirror_metadata: MirrorMetadata, cache_entry: Dict[str, str]
 ) -> IndexFetcher:
     if scheme == "oci":
         # TODO: Actually etag and OCI are not mutually exclusive...
-        return OCIIndexFetcher(url_and_version, cache_entry.get("index_hash", None))
+        return OCIIndexFetcher(mirror_metadata, cache_entry.get("index_hash", None))
     elif cache_entry.get("etag"):
-        if url_and_version.version < 3:
-            return EtagIndexFetcherV2(url_and_version.url, cache_entry["etag"])
+        if mirror_metadata.version < 3:
+            return EtagIndexFetcherV2(mirror_metadata.url, cache_entry["etag"])
         else:
-            return EtagIndexFetcher(url_and_version, cache_entry["etag"])
+            return EtagIndexFetcher(mirror_metadata, cache_entry["etag"])
 
     else:
-        if url_and_version.version < 3:
+        if mirror_metadata.version < 3:
             return DefaultIndexFetcherV2(
-                url_and_version.url, local_hash=cache_entry.get("index_hash", None)
+                mirror_metadata.url, local_hash=cache_entry.get("index_hash", None)
             )
         else:
             return DefaultIndexFetcher(
-                url_and_version, local_hash=cache_entry.get("index_hash", None)
+                mirror_metadata, local_hash=cache_entry.get("index_hash", None)
             )
 
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -25,6 +25,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import warnings
+from collections import defaultdict
 from contextlib import closing
 from typing import IO, Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
@@ -183,7 +184,7 @@ class BinaryCacheIndex:
         #: Dictionary mapping DAG hashes of specs to Spec objects
         self._known_specs: Dict[str, spack.spec.Spec] = {}
         #: Dictionary mapping DAG hashes of specs to a list of mirrors where they can be found
-        self._mirrors_for_spec: Dict[str, List[MirrorURLAndVersion]] = {}
+        self._mirrors_for_spec: Dict[str, Set[MirrorURLAndVersion]] = defaultdict(set)
 
     def _init_local_index_cache(self):
         if not self._index_file_cache_initialized:
@@ -214,7 +215,7 @@ class BinaryCacheIndex:
 
         if clear_existing:
             self._specs_already_associated = set()
-            self._mirrors_for_spec = {}
+            self._mirrors_for_spec = defaultdict(set)
             self._known_specs = {}
 
         for url_and_version in self._local_index_cache:
@@ -253,13 +254,11 @@ class BinaryCacheIndex:
 
             for spec in spec_list:
                 dag_hash = spec.dag_hash()
-                mirrors = self._mirrors_for_spec.get(dag_hash)
+                mirrors = self._mirrors_for_spec[dag_hash]
 
-                if mirrors is None:
-                    self._mirrors_for_spec[dag_hash] = [url_and_version]
+                mirrors.add(url_and_version.strip_view())
+                if dag_hash not in self._known_specs:
                     self._known_specs[dag_hash] = spec
-                elif url_and_version not in mirrors:
-                    mirrors.append(url_and_version)
 
     def get_all_built_specs(self) -> List[spack.spec.Spec]:
         """Returns a list of all concrete specs known to be available in a binary cache."""
@@ -285,20 +284,19 @@ class BinaryCacheIndex:
         Args:
             dag_hash: hash of the spec to search
         """
-        return self._mirrors_for_spec.get(dag_hash, [])
+        return list(self._mirrors_for_spec.get(dag_hash, []))
 
     def update_spec(self, spec: spack.spec.Spec, found_list: List[MirrorURLAndVersion]) -> None:
         """Update the cache with a new list of mirrors for a given spec."""
         spec_dag_hash = spec.dag_hash()
 
         if spec_dag_hash not in self._mirrors_for_spec:
-            self._mirrors_for_spec[spec_dag_hash] = found_list
+            self._mirrors_for_spec[spec_dag_hash] = set(found_list)
             self._known_specs[spec_dag_hash] = spec
         else:
             current_list = self._mirrors_for_spec[spec_dag_hash]
             for new_entry in found_list:
-                if new_entry not in current_list:
-                    current_list.append(new_entry)
+                current_list.add(new_entry.strip_view())
 
     def update(self, with_cooldown: bool = False) -> None:
         """Make sure local cache of buildcache index files is up to date.

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -312,7 +312,7 @@ class BinaryCacheIndex:
         on disk under ``_index_cache_root``)."""
         self._init_local_index_cache()
         configured_mirrors = [
-            MirrorURLAndVersion(m.fetch_url, layout_version)
+            MirrorURLAndVersion(m.fetch_url, layout_version, m.fetch_view)
             for layout_version in SUPPORTED_LAYOUT_VERSIONS
             for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
             # TODO: OCI does not have a versioned layout. Get rid of this once we no longer support
@@ -382,8 +382,11 @@ class BinaryCacheIndex:
                     except FetchIndexError as e:
                         fetch_errors.append(e)
                         self._last_fetch_times[urlAndVersion] = (now, False)
-                    except BuildcacheIndexNotExists:
+                    except BuildcacheIndexNotExists as e:
+                        fetch_errors.append(e)
                         self._last_fetch_times[urlAndVersion] = (now, False)
+                        # Binary caches are not required to have an index, don't raise
+                        # if it doesn't exist.
                         all_methods_failed = False
 
                     # The need to regenerate implies a need to clear as well.
@@ -425,8 +428,11 @@ class BinaryCacheIndex:
             except FetchIndexError as e:
                 fetch_errors.append(e)
                 self._last_fetch_times[urlAndVersion] = (now, False)
-            except BuildcacheIndexNotExists:
+            except BuildcacheIndexNotExists as e:
+                fetch_errors.append(e)
                 self._last_fetch_times[urlAndVersion] = (now, False)
+                # Binary caches are not required to have an index, don't raise
+                # if it doesn't exist.
                 all_methods_failed = False
 
             # Generally speaking, a new mirror wouldn't imply the need to
@@ -462,6 +468,7 @@ class BinaryCacheIndex:
 
         Throws:
             FetchIndexError
+            BuildcacheIndexNotExists
         """
         mirror_url = url_and_version.url
         mirror_view = url_and_version.view

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -342,7 +342,7 @@ class BinaryCacheIndex:
         # Otherwise the concrete spec cache should not need to be updated at
         # all.
 
-        fetch_errors = []
+        fetch_errors: List[Exception] = []
         all_methods_failed = True
         ttl = spack.config.get("config:binary_index_ttl", 600)
         now = time.time()
@@ -2186,7 +2186,9 @@ def try_direct_fetch(spec: spack.spec.Spec) -> List[MirrorURLAndVersion]:
             fetched_spec = spack.spec.Spec.from_dict(spec_dict)
             fetched_spec._mark_concrete()
 
-            found_specs.append(MirrorURLAndVersion(mirror.fetch_url, layout_version, mirror.fetch_view))
+            found_specs.append(
+                MirrorURLAndVersion(mirror.fetch_url, layout_version, mirror.fetch_view)
+            )
 
     return found_specs
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -4,7 +4,7 @@
 import argparse
 import glob
 import json
-import re
+import os
 import sys
 import tempfile
 from typing import List, Optional, Tuple
@@ -838,29 +838,28 @@ def update_index_fn(args):
 def read_concrete_hashes(source: str) -> List[str]:
     """Read all of the concrete hashes from a given source"""
 
-    if re.match(r"^/[^ ]{32}$", source):
-        return [source[1:]]
-    else:
-        # This could be a lock file or a spec file
-        try:
+    # Try to read input as a spec
+    try:
+        concrete_specs = spack.cmd.parse_specs(source, concretize=True)
+        return [spec.dag_hash() for spec in concrete_specs]
+    except Exception:
+        pass
+
+    # Try to read input as a lockfile
+    try:
+        if not os.path.exists(source):
+            raise FileNotFoundError(f"Expected lockfile: {source}")
+
+        with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
+            # Touch a dummy manifest file
+            with open(os.path.join(tmpdir, "spack.yaml"), "w", encoding="utf-8") as fd:
+                fd.write("spack: {}")
+            env = spack.environment.Environment(tmpdir)
             with open(source, "r", encoding="utf-8") as fd:
-                data = json.loads(fd.read())
-
-            if "spec" in data:
-                # This is a spec file, return the hashes of all of the nodes
-                tty.debug(f"Reading {source} as specfile")
-                return [n["hash"] for n in data["spec"]["nodes"]]
-            elif "concrete_specs" in data:
-                # This is a lock file
-                tty.debug(f"Reading {source} as lockfile")
-                return [h for h in data["concrete_specs"]]
-            else:
-                raise spack.error.SpackError(f"Recognized fields not found: {data}")
-
-        except Exception as e:
-            raise spack.error.SpackError(
-                f"Could not determine spec source type of {source}"
-            ) from e
+                env._read_lockfile(fd)
+            return list(env.specs_by_hash.keys())
+    except Exception as e:
+        raise spack.error.SpackError(f"Could not determine spec source type of {source}") from e
 
 
 def update_view_fn(args):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -295,10 +295,12 @@ def setup_parser(subparser: argparse.ArgumentParser):
     check_index.add_argument(
         "--verify",
         nargs="+",
-        action="append",
         choices=["exists", "manifests", "blobs", "all"],
-        default=[["exists"]],
+        default=["exists"],
         help="List of items to verify along along with the index.",
+    )
+    check_index.add_argument(
+        "--name", "-n", action="store", help="Name of the view index to check"
     )
     check_index.add_argument(
         "--output", "-o", action="store", help="File to write check details to"
@@ -950,6 +952,8 @@ def check_index_fn(args):
     mirror = args.mirror
     verify = set(args.verify)
 
+    checking_view_index = (args.name or mirror.fetch_view) is not None
+
     if "all" in verify:
         verify.update(["exists", "manifests", "blobs"])
 
@@ -963,13 +967,19 @@ def check_index_fn(args):
     mirror_metadata = spack.binary_distribution.MirrorMetadata(
         mirror.fetch_url,
         spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION,
-        mirror.fetch_view,
+        args.name or mirror.fetch_view,
     )
     index_exists = True
+    missing_index_blob = False
     try:
         BINARY_INDEX._fetch_and_cache_index(mirror_metadata)
     except spack.binary_distribution.BuildcacheIndexNotExists:
         index_exists = False
+    except spack.binary_distribution.FetchIndexError:
+        # Here the index manifest exists, but the index blob did not
+        # We can still run some of the other validations here, so let's try
+        index_exists = False
+        missing_index_blob = True
 
     missing_specs = []
     unindexed_specs = []
@@ -984,7 +994,7 @@ def check_index_fn(args):
             manifest_files, read_fn = get_entries_from_cache(
                 mirror.fetch_url, tmpdir, BuildcacheComponent.SPEC
             )
-        if "manifests" in verify:
+        if "manifests" in verify and index_exists:
             # Read the index file
             db = spack.binary_distribution.BuildCacheDatabase(tmpdir)
             cache_entry = BINARY_INDEX._local_index_cache[str(mirror_metadata)]
@@ -1002,9 +1012,13 @@ def check_index_fn(args):
             )
 
         for spec_manifest in manifest_files:
+
             # Spec manifests have a naming format
             # <name>-<version>-<hash>.spec.manifest.json
             spec_hash = spec_manifest.rsplit("-", 1)[1].split(".", 1)[0]
+            if checking_view_index and spec_hash not in index_hash_list:
+                continue
+
             cache_hash_list.append(spec_hash)
             if spec_hash not in index_hash_list:
                 unindexed_specs.append(spec_hash)
@@ -1032,9 +1046,17 @@ def check_index_fn(args):
         if mirror.fetch_view:
             summary_msg += f"@{mirror.fetch_view}"
         summary_msg += "\n"
+        if missing_index_blob:
+            tty.warn("The index blob is missing")
 
     if "manifests" in verify:
-        summary_msg += f"\tUnindexed specs: {len(unindexed_specs)}\n"
+        if checking_view_index:
+            count = "n/a"
+        else:
+            count = len(unindexed_specs)
+        summary_msg += f"\tUnindexed specs: {count}\n"
+
+    if "manifests" in verify:
         summary_msg += f"\tMissing specs: {len(missing_specs)}\n"
 
     if "blobs" in verify:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -923,9 +923,10 @@ def update_view_fn(args):
 
         if args.append:
             # Load the current state of the view index from the cache into the database
-            cache_index = BINARY_INDEX._local_index_cache[str(url_and_version)]
-            cache_key = cache_index["index_path"]
-            db._read_from_file(BINARY_INDEX._index_file_cache.cache_path(cache_key))
+            cache_index = BINARY_INDEX._local_index_cache.get(str(url_and_version))
+            if cache_index:
+                cache_key = cache_index["index_path"]
+                db._read_from_file(BINARY_INDEX._index_file_cache.cache_path(cache_key))
 
         spack.binary_distribution._url_generate_package_index(url, tmpdir, db, name, filter_fn)
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -290,7 +290,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
 
     sync.set_defaults(func=sync_fn)
 
-    # Update buildcache index without copying any additional packages
+    # Check the validity of a buildcache
     check_index = subparsers.add_parser("check-index", help=check_index_fn.__doc__)
     check_index.add_argument(
         "--verify",
@@ -299,6 +299,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
         choices=["exists", "manifests", "blobs", "all"],
         default=[["exists"]],
         help="List of items to verify along along with the index.",
+    )
+    check_index.add_argument(
+        "--output", "-o", action="store", help="File to write check details to"
     )
     check_index.add_argument(
         "mirror", type=arguments.mirror_name_or_url, help="mirror name, path, or URL"
@@ -963,7 +966,7 @@ def update_view(
 
 
 def check_index_fn(args):
-    """Check if a build cache index is valid"""
+    """Check if a build cache index, manifests, and blobs are consistent"""
     mirror = args.mirror
     verify = set()
     for v in args.verify:
@@ -1058,6 +1061,18 @@ def check_index_fn(args):
 
     if "blobs" in verify:
         summary_msg += f"\tMissing blobs: {len(missing_blobs)}\n"
+
+    if args.output:
+        os.makedirs(os.path.dirname(args.output), exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as fd:
+            json.dump(
+                {
+                    "exists": index_exists,
+                    "manifests": {"missing": missing_specs, "unindexed": unindexed_specs},
+                    "blobs": {"missing": missing_blobs},
+                },
+                fd,
+            )
 
     tty.info(summary_msg)
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -343,6 +343,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         action="store_true",
         help="if provided, key index will be updated as well as package index",
     )
+    arguments.add_common_arguments(update_index, ["yes_to_all"])
     update_index.set_defaults(func=update_index_fn)
 
     # Migrate a buildcache from layout_version 2 to version 3
@@ -859,6 +860,7 @@ def update_view(
     *sources: str,
     name: Optional[str] = None,
     update_keys: bool = False,
+    yes_to_all: bool = False,
 ):
     """update a buildcache view index"""
     # OCI images do not support views.
@@ -868,11 +870,12 @@ def update_view(
     except ValueError:
         pass
 
-    if update_mode == ViewUpdateMode.APPEND:
+    if update_mode == ViewUpdateMode.APPEND and not yes_to_all:
         tty.warn(
             "Appending to a view index does not guarantee idempotent write when contending "
             "with multiple writers. This feature is meant to be used by a single process."
         )
+        tty.get_yes_or_no("Do you want to proceed?", default=False)
 
     # Otherwise, assume a normal mirror.
     url = mirror.push_url
@@ -886,7 +889,11 @@ def update_view(
         )
 
     name = name or mirror.push_view
-    assert name
+    if not name:
+        tty.die(
+            "Attempting to update a view but could not determine the view name.\n"
+            "    Either pass --name <view name> or configure the view name in mirrors.yaml"
+        )
 
     mirror_metadata = spack.binary_distribution.MirrorMetadata(
         url, spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION, name
@@ -913,8 +920,7 @@ def update_view(
             hashes.extend(env.all_hashes())
     else:
         # Get hashes in the current active environment
-        env = spack.cmd.require_active_env(cmd_name="buildcache update-view")
-        hashes = env.all_hashes()
+        hashes = spack.cmd.require_active_env(cmd_name="buildcache update-view").all_hashes()
 
     if not hashes:
         tty.warn("No specs found for view, creating an empty index")
@@ -1064,7 +1070,12 @@ def update_index_fn(args):
             update_mode = ViewUpdateMode.APPEND
 
         return update_view(
-            args.mirror, update_mode, *args.sources, name=args.name, update_keys=args.keys
+            args.mirror,
+            update_mode,
+            *args.sources,
+            name=args.name,
+            update_keys=args.keys,
+            yes_to_all=args.yes_to_all,
         )
     else:
         return update_index(args.mirror, update_keys=args.keys)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -42,6 +42,7 @@ from ..url_buildcache import (
     BuildcacheEntryError,
     URLBuildcacheEntry,
     check_mirror_for_layout,
+    get_entries_from_cache,
     get_url_buildcache_class,
 )
 
@@ -288,6 +289,21 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     sync.set_defaults(func=sync_fn)
+
+    # Update buildcache index without copying any additional packages
+    check_index = subparsers.add_parser("check-index", help=check_index_fn.__doc__)
+    check_index.add_argument(
+        "--verify",
+        nargs="+",
+        action="append",
+        choices=["exists", "manifests", "blobs", "all"],
+        default=[["exists"]],
+        help="List of items to verify along along with the index.",
+    )
+    check_index.add_argument(
+        "mirror", type=arguments.mirror_name_or_url, help="mirror name, path, or URL"
+    )
+    check_index.set_defaults(func=check_index_fn)
 
     # Update buildcache index without copying any additional packages
     update_index = subparsers.add_parser(
@@ -944,6 +960,106 @@ def update_view(
 
     if update_keys:
         mirror_update_keys(mirror)
+
+
+def check_index_fn(args):
+    """Check if a build cache index is valid"""
+    mirror = args.mirror
+    verify = set()
+    for v in args.verify:
+        verify.update(v)
+
+    if "all" in verify:
+        verify.update(["exists", "manifests", "blobs"])
+
+    try:
+        spack.oci.oci.image_from_mirror(mirror)
+        raise spack.error.SpackError("OCI build caches do not support index views")
+    except ValueError:
+        pass
+
+    # Check if the index exists, and cache it locally for next operations
+    url_and_version = spack.binary_distribution.MirrorMetadata(
+        mirror.fetch_url,
+        spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION,
+        mirror.fetch_view,
+    )
+    index_exists = True
+    try:
+        BINARY_INDEX._fetch_and_cache_index(url_and_version)
+    except spack.binary_distribution.BuildcacheIndexNotExists:
+        index_exists = False
+
+    missing_specs = []
+    unindexed_specs = []
+    missing_blobs = {}
+    cache_hash_list = []
+    index_hash_list = []
+    # List the manifests and verify
+    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
+        # Get listing of spec manifests in mirror
+        manifest_files = []
+        if "manifests" in verify or "blobs" in verify:
+            manifest_files, read_fn = get_entries_from_cache(
+                mirror.fetch_url, tmpdir, BuildcacheComponent.SPEC
+            )
+        if "manifests" in verify:
+            # Read the index file
+            db = spack.binary_distribution.BuildCacheDatabase(tmpdir)
+            cache_entry = BINARY_INDEX._local_index_cache[str(url_and_version)]
+            cache_key = cache_entry["index_path"]
+            cache_path = BINARY_INDEX._index_file_cache.cache_path(cache_key)
+            with BINARY_INDEX._index_file_cache.read_transaction(cache_key):
+                db._read_from_file(cache_path)
+
+            index_hash_list = set(
+                [
+                    s.dag_hash()
+                    for s in db.query_local(installed=InstallRecordStatus.ANY)
+                    if db._data[s.dag_hash()].in_buildcache
+                ]
+            )
+
+        for spec_manifest in manifest_files:
+            # Spec manifests have a naming format
+            # <name>-<version>-<hash>.spec.manifest.json
+            spec_hash = spec_manifest.rsplit("-", 1)[1].split(".", 1)[0]
+            cache_hash_list.append(spec_hash)
+            if spec_hash not in index_hash_list:
+                unindexed_specs.append(spec_hash)
+
+            if "blobs" in verify:
+                entry = read_fn(spec_manifest)
+                entry.read_manifest()
+                for record in entry.manifest.data:
+                    if not entry.check_blob_exists(record):
+                        blobs = missing_blobs.get(spec_hash, [])
+                        blobs.append(record)
+                        missing_blobs[spec_hash] = blobs
+
+    for h in index_hash_list:
+        if h not in cache_hash_list:
+            missing_specs.append(h)
+
+    # Print summary
+    summary_msg = "Build cache check:\n\t"
+    if "exists" in verify:
+        if index_exists:
+            summary_msg = f"Index exists in mirror: {mirror.name}"
+        else:
+            summary_msg = f"Index does not exist in mirror: {mirror.name}"
+        if mirror.fetch_view:
+            summary_msg += f"@{mirror.fetch_view}"
+        summary_msg += "\n"
+
+    if "manifests" in verify:
+        summary_msg += f"\tUnindexed specs: {len(unindexed_specs)}\n"
+        summary_msg += f"\tMissing specs: {len(missing_specs)}\n"
+
+    if "blobs" in verify:
+        summary_msg += f"\tMissing blobs: {len(missing_blobs)}\n"
+
+    tty.info(summary_msg)
 
 
 def update_index_fn(args):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -296,6 +296,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         action="store_true",
         help="if provided, key index will be updated as well as package index",
     )
+    update_index.set_defaults(func=update_index_fn)
     update_view = subparsers.add_parser(
         "update-view", aliases=["create-view"], help=update_view_fn.__doc__
     )
@@ -894,7 +895,7 @@ def update_view_fn(args):
     index_exists = True
     try:
         BINARY_INDEX._fetch_and_cache_index(url_and_version)
-    except spack.binary_distribution.FetchIndexError:
+    except spack.binary_distribution.BuildcacheIndexNotExists:
         index_exists = False
 
     if index_exists and (not args.force and not args.append):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -4,6 +4,7 @@
 import argparse
 import glob
 import json
+import re
 import sys
 import tempfile
 from typing import List, Optional, Tuple
@@ -25,6 +26,7 @@ import spack.store
 import spack.util.parallel
 import spack.util.web as web_util
 from spack import traverse
+from spack.binary_distribution import BINARY_INDEX
 from spack.cmd import display_specs
 from spack.cmd.common import arguments
 from spack.llnl.string import plural
@@ -294,7 +296,35 @@ def setup_parser(subparser: argparse.ArgumentParser):
         action="store_true",
         help="if provided, key index will be updated as well as package index",
     )
-    update_index.set_defaults(func=update_index_fn)
+    update_view = subparsers.add_parser(
+        "update-view", aliases=["create-view"], help=update_view_fn.__doc__
+    )
+    update_view.add_argument(
+        "mirror", type=arguments.mirror_name_or_url, help="destination mirror name, path, or URL"
+    )
+    update_view.add_argument(
+        "sources",
+        nargs=argparse.REMAINDER,
+        help="one or more of the specified source type to use for generating the view index",
+    )
+    update_view.add_argument(
+        "--name", "-n", action="store", help="Name of the view index to update"
+    )
+    update_view.add_argument(
+        "--append",
+        "-a",
+        action="store_true",
+        help="Append the listed specs to the current view index if it already exists. "
+        "This operation does not guarentee atomic write and should be run with care.",
+    )
+    update_view.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="If an view index already exists, overwrite it and "
+        "suppress warnings (this is the default for non-view indices)",
+    )
+    update_view.set_defaults(func=update_view_fn)
 
     # Migrate a buildcache from layout_version 2 to version 3
     migrate = subparsers.add_parser("migrate", help=migrate_fn.__doc__)
@@ -802,6 +832,102 @@ def update_index(mirror: spack.mirrors.mirror.Mirror, update_keys=False):
 def update_index_fn(args):
     """update a buildcache index"""
     return update_index(args.mirror, update_keys=args.keys)
+
+
+def read_concrete_hashes(source: str) -> List[str]:
+    """Read all of the concrete hashes from a given source"""
+
+    if re.match(r"^/[^ ]{32}$", source):
+        return [source[1:]]
+    else:
+        # This could be a lock file or a spec file
+        try:
+            with open(source, "r", encoding="utf-8") as fd:
+                data = json.loads(fd.read())
+
+            if "spec" in data:
+                # This is a spec file, return the hashes of all of the nodes
+                tty.debug(f"Reading {source} as specfile")
+                return [n["hash"] for n in data["spec"]["nodes"]]
+            elif "concrete_specs" in data:
+                # This is a lock file
+                tty.debug(f"Reading {source} as lockfile")
+                return [h for h in data["concrete_specs"]]
+            else:
+                raise spack.error.SpackError(f"Recognized fields not found: {data}")
+
+        except Exception as e:
+            raise spack.error.SpackError(
+                f"Could not determine spec source type of {source}"
+            ) from e
+
+
+def update_view_fn(args):
+    """update a buildcache view index"""
+    mirror = args.mirror
+    # OCI images do not support views.
+    try:
+        spack.oci.oci.image_from_mirror(mirror)
+        raise spack.error.SpackError("OCI build caches do not support index views")
+    except ValueError:
+        pass
+
+    if args.append:
+        tty.warn(
+            "Appending to a view index does not guarantee idempotent write when contending "
+            "with multiple writers. This feature is meant to be used by a single process."
+        )
+
+    # Otherwise, assume a normal mirror.
+    url = mirror.push_url
+
+    name = args.name or mirror.push_view
+
+    assert name
+
+    url_and_version = spack.binary_distribution.MirrorURLAndVersion(
+        url, spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION, name
+    )
+
+    # Check if the index already exists, if it does make sure there is a copy in the
+    # local cache.
+    index_exists = True
+    try:
+        BINARY_INDEX._fetch_and_cache_index(url_and_version)
+    except spack.binary_distribution.FetchIndexError:
+        index_exists = False
+
+    if index_exists and (not args.force and not args.append):
+        raise spack.error.SpackError(
+            "Index already exists. To overwrite or update pass --force or --append respectively"
+        )
+
+    hashes = []
+    if args.sources:
+        for source in args.sources:
+            hashes.extend(read_concrete_hashes(source))
+    else:
+        # Get hashes in the current active environment
+        env = spack.cmd.require_active_env(cmd_name="buildcache update-view")
+        hashes = env.all_hashes()
+
+    if not hashes:
+        tty.warn("No specs found for view, creating an empty index")
+
+    filter_fn = lambda x: x in hashes
+
+    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
+        # Initialize a database
+        db = spack.binary_distribution.BuildCacheDatabase(tmpdir)
+        db._write()
+
+        if args.append:
+            # Load the current state of the view index from the cache into the database
+            cache_index = BINARY_INDEX._local_index_cache[str(url_and_version)]
+            cache_key = cache_index["index_path"]
+            db._read_from_file(BINARY_INDEX._index_file_cache.cache_path(cache_key))
+
+        spack.binary_distribution._url_generate_package_index(url, tmpdir, db, name, filter_fn)
 
 
 def migrate_fn(args):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -870,12 +870,6 @@ def update_view(
 ):
     """update a buildcache view index"""
     # OCI images do not support views.
-    print(f"mirror: {mirror.name}")
-    print(f"mode: {update_mode}")
-    print(f"name: {name}")
-    for source in sources:
-        print(f"source: {source}")
-
     try:
         spack.oci.oci.image_from_mirror(mirror)
         raise spack.error.SpackError("OCI build caches do not support index views")
@@ -902,7 +896,7 @@ def update_view(
     name = name or mirror.push_view
     assert name
 
-    url_and_version = spack.binary_distribution.MirrorURLAndVersion(
+    url_and_version = spack.binary_distribution.MirrorMetadata(
         url, spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION, name
     )
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -324,14 +324,17 @@ def setup_parser(subparser: argparse.ArgumentParser):
     update_index_view_args.add_argument(
         "--name", "-n", action="store", help="Name of the view index to update"
     )
-    update_index_view_args.add_argument(
+    update_index_view_mode_args = update_index_view_args.add_mutually_exclusive_group(
+        required=False
+    )
+    update_index_view_mode_args.add_argument(
         "--append",
         "-a",
         action="store_true",
         help="Append the listed specs to the current view index if it already exists. "
         "This operation does not guarentee atomic write and should be run with care.",
     )
-    update_index_view_args.add_argument(
+    update_index_view_mode_args.add_argument(
         "--force",
         "-f",
         action="store_true",

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -1036,9 +1036,4 @@ def prune_fn(args):
 
 
 def buildcache(parser, args):
-    try:
-        # update-index supports unkwown_args for view extension
-        return args.func(args)
-    except Exception:
-        pass
     return args.func(args)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -338,7 +338,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         "--force",
         "-f",
         action="store_true",
-        help="If an view index already exists, overwrite it and "
+        help="If a view index already exists, overwrite it and "
         "suppress warnings (this is the default for non-view indices)",
     )
     update_index.add_argument(

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -857,7 +857,7 @@ def read_concrete_hashes(source: str) -> List[str]:
     """Read all of the concrete hashes from a given source"""
     try:
         env = ev.environment_from_name_or_dir(source)
-        return list(env.all_hashes())
+        return env.all_hashes()
     except ev.SpackEnvironmentError as e:
         raise spack.error.SpackError(f"Failed to read specs from source: {source}") from e
 
@@ -897,7 +897,7 @@ def update_view(
     name = name or mirror.push_view
     assert name
 
-    url_and_version = spack.binary_distribution.MirrorMetadata(
+    mirror_metadata = spack.binary_distribution.MirrorMetadata(
         url, spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION, name
     )
 
@@ -905,7 +905,7 @@ def update_view(
     # local cache.
     index_exists = True
     try:
-        BINARY_INDEX._fetch_and_cache_index(url_and_version)
+        BINARY_INDEX._fetch_and_cache_index(mirror_metadata)
     except spack.binary_distribution.BuildcacheIndexNotExists:
         index_exists = False
 
@@ -936,7 +936,7 @@ def update_view(
 
         if update_mode == ViewUpdateMode.APPEND:
             # Load the current state of the view index from the cache into the database
-            cache_index = BINARY_INDEX._local_index_cache.get(str(url_and_version))
+            cache_index = BINARY_INDEX._local_index_cache.get(str(mirror_metadata))
             if cache_index:
                 cache_key = cache_index["index_path"]
                 db._read_from_file(BINARY_INDEX._index_file_cache.cache_path(cache_key))
@@ -950,9 +950,7 @@ def update_view(
 def check_index_fn(args):
     """Check if a build cache index, manifests, and blobs are consistent"""
     mirror = args.mirror
-    verify = set()
-    for v in args.verify:
-        verify.update(v)
+    verify = set(args.verify)
 
     if "all" in verify:
         verify.update(["exists", "manifests", "blobs"])
@@ -964,14 +962,14 @@ def check_index_fn(args):
         pass
 
     # Check if the index exists, and cache it locally for next operations
-    url_and_version = spack.binary_distribution.MirrorMetadata(
+    mirror_metadata = spack.binary_distribution.MirrorMetadata(
         mirror.fetch_url,
         spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION,
         mirror.fetch_view,
     )
     index_exists = True
     try:
-        BINARY_INDEX._fetch_and_cache_index(url_and_version)
+        BINARY_INDEX._fetch_and_cache_index(mirror_metadata)
     except spack.binary_distribution.BuildcacheIndexNotExists:
         index_exists = False
 
@@ -991,7 +989,7 @@ def check_index_fn(args):
         if "manifests" in verify:
             # Read the index file
             db = spack.binary_distribution.BuildCacheDatabase(tmpdir)
-            cache_entry = BINARY_INDEX._local_index_cache[str(url_and_version)]
+            cache_entry = BINARY_INDEX._local_index_cache[str(mirror_metadata)]
             cache_key = cache_entry["index_path"]
             cache_path = BINARY_INDEX._index_file_cache.cache_path(cache_key)
             with BINARY_INDEX._index_file_cache.read_transaction(cache_key):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -317,7 +317,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
     update_index_view_args = update_index.add_argument_group("view arguments")
     update_index_view_args.add_argument(
-        "sources", nargs="*", help="Sources to use for updating the index"
+        "sources", nargs="*", help="List of environments names or paths"
     )
     update_index_view_args.add_argument(
         "--name", "-n", action="store", help="Name of the view index to update"
@@ -855,29 +855,11 @@ def mirror_update_keys(mirror: spack.mirrors.mirror.Mirror):
 
 def read_concrete_hashes(source: str) -> List[str]:
     """Read all of the concrete hashes from a given source"""
-
-    # Try to read input as a spec
     try:
-        concrete_specs = spack.cmd.parse_specs(source, concretize=True)
-        return [spec.dag_hash() for spec in concrete_specs]
-    except Exception:
-        pass
-
-    # Try to read input as a lockfile
-    try:
-        if not os.path.exists(source):
-            raise FileNotFoundError(f"Expected lockfile: {source}")
-
-        with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
-            # Touch a dummy manifest file
-            with open(os.path.join(tmpdir, "spack.yaml"), "w", encoding="utf-8") as fd:
-                fd.write("spack: {}")
-            env = spack.environment.Environment(tmpdir)
-            with open(source, "r", encoding="utf-8") as fd:
-                env._read_lockfile(fd)
-            return list(env.specs_by_hash.keys())
-    except Exception as e:
-        raise spack.error.SpackError(f"Could not determine spec source type of {source}") from e
+        env = ev.environment_from_name_or_dir(source)
+        return list(env.all_hashes())
+    except ev.SpackEnvironmentError as e:
+        raise spack.error.SpackError(f"Failed to read specs from source: {source}") from e
 
 
 def update_view(
@@ -935,7 +917,7 @@ def update_view(
     hashes = []
     if sources:
         for source in sources:
-            print(f"Source... {source}")
+            tty.debug(f"reading specs from source: {source}")
             hashes.extend(read_concrete_hashes(source))
     else:
         # Get hashes in the current active environment

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -853,15 +853,6 @@ def mirror_update_keys(mirror: spack.mirrors.mirror.Mirror):
         tty.warn(f"did not update the key index: {e}")
 
 
-def read_concrete_hashes(source: str) -> List[str]:
-    """Read all of the concrete hashes from a given source"""
-    try:
-        env = ev.environment_from_name_or_dir(source)
-        return env.all_hashes()
-    except ev.SpackEnvironmentError as e:
-        raise spack.error.SpackError(f"Failed to read specs from source: {source}") from e
-
-
 def update_view(
     mirror: spack.mirrors.mirror.Mirror,
     update_mode: ViewUpdateMode,
@@ -918,7 +909,8 @@ def update_view(
     if sources:
         for source in sources:
             tty.debug(f"reading specs from source: {source}")
-            hashes.extend(read_concrete_hashes(source))
+            env = ev.environment_from_name_or_dir(source)
+            hashes.extend(env.all_hashes())
     else:
         # Get hashes in the current active environment
         env = spack.cmd.require_active_env(cmd_name="buildcache update-view")

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import argparse
+import enum
 import glob
 import json
 import os
@@ -47,6 +48,12 @@ from ..url_buildcache import (
 description = "create, download and install binary packages"
 section = "packaging"
 level = "long"
+
+
+class ViewMode(enum.Enum):
+    CREATE = enum.auto()
+    OVERWRITE = enum.auto()
+    APPEND = enum.auto()
 
 
 def setup_parser(subparser: argparse.ArgumentParser):
@@ -289,6 +296,27 @@ def setup_parser(subparser: argparse.ArgumentParser):
     update_index.add_argument(
         "mirror", type=arguments.mirror_name_or_url, help="destination mirror name, path, or URL"
     )
+    update_index_view_args = update_index.add_argument_group("view arguments")
+    update_index_view_args.add_argument(
+        "sources", nargs="*", help="Sources to use for updating the index"
+    )
+    update_index_view_args.add_argument(
+        "--name", "-n", action="store", help="Name of the view index to update"
+    )
+    update_index_view_args.add_argument(
+        "--append",
+        "-a",
+        action="store_true",
+        help="Append the listed specs to the current view index if it already exists. "
+        "This operation does not guarentee atomic write and should be run with care.",
+    )
+    update_index_view_args.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="If an view index already exists, overwrite it and "
+        "suppress warnings (this is the default for non-view indices)",
+    )
     update_index.add_argument(
         "-k",
         "--keys",
@@ -297,35 +325,6 @@ def setup_parser(subparser: argparse.ArgumentParser):
         help="if provided, key index will be updated as well as package index",
     )
     update_index.set_defaults(func=update_index_fn)
-    update_view = subparsers.add_parser(
-        "update-view", aliases=["create-view"], help=update_view_fn.__doc__
-    )
-    update_view.add_argument(
-        "mirror", type=arguments.mirror_name_or_url, help="destination mirror name, path, or URL"
-    )
-    update_view.add_argument(
-        "sources",
-        nargs=argparse.REMAINDER,
-        help="one or more of the specified source type to use for generating the view index",
-    )
-    update_view.add_argument(
-        "--name", "-n", action="store", help="Name of the view index to update"
-    )
-    update_view.add_argument(
-        "--append",
-        "-a",
-        action="store_true",
-        help="Append the listed specs to the current view index if it already exists. "
-        "This operation does not guarentee atomic write and should be run with care.",
-    )
-    update_view.add_argument(
-        "--force",
-        "-f",
-        action="store_true",
-        help="If an view index already exists, overwrite it and "
-        "suppress warnings (this is the default for non-view indices)",
-    )
-    update_view.set_defaults(func=update_view_fn)
 
     # Migrate a buildcache from layout_version 2 to version 3
     migrate = subparsers.add_parser("migrate", help=migrate_fn.__doc__)
@@ -821,18 +820,18 @@ def update_index(mirror: spack.mirrors.mirror.Mirror, update_keys=False):
         spack.binary_distribution._url_generate_package_index(url, tmpdir)
 
     if update_keys:
-        try:
-            with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
-                spack.binary_distribution.generate_key_index(url, tmpdir)
-        except spack.binary_distribution.CannotListKeys as e:
-            # Do not error out if listing keys went wrong. This usually means that the _gpg path
-            # does not exist. TODO: distinguish between this and other errors.
-            tty.warn(f"did not update the key index: {e}")
+        mirror_update_keys(mirror)
 
 
-def update_index_fn(args):
-    """update a buildcache index"""
-    return update_index(args.mirror, update_keys=args.keys)
+def mirror_update_keys(mirror: spack.mirrors.mirror.Mirror):
+    url = mirror.push_url
+    try:
+        with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
+            spack.binary_distribution.generate_key_index(url, tmpdir)
+    except spack.binary_distribution.CannotListKeys as e:
+        # Do not error out if listing keys went wrong. This usually means that the _gpg path
+        # does not exist. TODO: distinguish between this and other errors.
+        tty.warn(f"did not update the key index: {e}")
 
 
 def read_concrete_hashes(source: str) -> List[str]:
@@ -862,17 +861,28 @@ def read_concrete_hashes(source: str) -> List[str]:
         raise spack.error.SpackError(f"Could not determine spec source type of {source}") from e
 
 
-def update_view_fn(args):
+def update_view(
+    mirror: spack.mirrors.mirror.Mirror,
+    update_mode: int,
+    *sources: str,
+    name: Optional[str] = None,
+    update_keys: bool = False,
+):
     """update a buildcache view index"""
-    mirror = args.mirror
     # OCI images do not support views.
+    print(f"mirror: {mirror.name}")
+    print(f"mode: {update_mode}")
+    print(f"name: {name}")
+    for source in sources:
+        print(f"source: {source}")
+
     try:
         spack.oci.oci.image_from_mirror(mirror)
         raise spack.error.SpackError("OCI build caches do not support index views")
     except ValueError:
         pass
 
-    if args.append:
+    if update_mode == ViewMode.APPEND:
         tty.warn(
             "Appending to a view index does not guarantee idempotent write when contending "
             "with multiple writers. This feature is meant to be used by a single process."
@@ -881,8 +891,15 @@ def update_view_fn(args):
     # Otherwise, assume a normal mirror.
     url = mirror.push_url
 
-    name = args.name or mirror.push_view
+    if (name and mirror.push_view) and not name == mirror.push_view:
+        tty.warn(
+            (
+                f"Updating index view with name ({name}), which is different than "
+                f"the configured name ({mirror.push_view}) for the mirror {mirror.name}"
+            )
+        )
 
+    name = name or mirror.push_view
     assert name
 
     url_and_version = spack.binary_distribution.MirrorURLAndVersion(
@@ -897,14 +914,15 @@ def update_view_fn(args):
     except spack.binary_distribution.BuildcacheIndexNotExists:
         index_exists = False
 
-    if index_exists and (not args.force and not args.append):
+    if index_exists and update_mode == ViewMode.CREATE:
         raise spack.error.SpackError(
             "Index already exists. To overwrite or update pass --force or --append respectively"
         )
 
     hashes = []
-    if args.sources:
-        for source in args.sources:
+    if sources:
+        for source in sources:
+            print(f"Source... {source}")
             hashes.extend(read_concrete_hashes(source))
     else:
         # Get hashes in the current active environment
@@ -921,7 +939,7 @@ def update_view_fn(args):
         db = spack.binary_distribution.BuildCacheDatabase(tmpdir)
         db._write()
 
-        if args.append:
+        if update_mode == ViewMode.APPEND:
             # Load the current state of the view index from the cache into the database
             cache_index = BINARY_INDEX._local_index_cache.get(str(url_and_version))
             if cache_index:
@@ -929,6 +947,30 @@ def update_view_fn(args):
                 db._read_from_file(BINARY_INDEX._index_file_cache.cache_path(cache_key))
 
         spack.binary_distribution._url_generate_package_index(url, tmpdir, db, name, filter_fn)
+
+    if update_keys:
+        mirror_update_keys(mirror)
+
+
+def update_index_fn(args):
+    """update a buildcache index or index view if extra arguments are provided."""
+
+    update_view_index = (
+        args.append or args.force or args.name or args.sources or args.mirror.push_view
+    )
+
+    if update_view_index:
+        update_mode = ViewMode.CREATE
+        if args.force:
+            update_mode = ViewMode.OVERWRITE
+        elif args.append:
+            update_mode = ViewMode.APPEND
+
+        return update_view(
+            args.mirror, update_mode, *args.sources, name=args.name, update_keys=args.keys
+        )
+    else:
+        return update_index(args.mirror, update_keys=args.keys)
 
 
 def migrate_fn(args):
@@ -994,4 +1036,9 @@ def prune_fn(args):
 
 
 def buildcache(parser, args):
+    try:
+        # update-index supports unkwown_args for view extension
+        return args.func(args)
+    except Exception:
+        pass
     return args.func(args)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -50,7 +50,7 @@ section = "packaging"
 level = "long"
 
 
-class ViewMode(enum.Enum):
+class ViewUpdateMode(enum.Enum):
     CREATE = enum.auto()
     OVERWRITE = enum.auto()
     APPEND = enum.auto()
@@ -863,7 +863,7 @@ def read_concrete_hashes(source: str) -> List[str]:
 
 def update_view(
     mirror: spack.mirrors.mirror.Mirror,
-    update_mode: int,
+    update_mode: ViewUpdateMode,
     *sources: str,
     name: Optional[str] = None,
     update_keys: bool = False,
@@ -882,7 +882,7 @@ def update_view(
     except ValueError:
         pass
 
-    if update_mode == ViewMode.APPEND:
+    if update_mode == ViewUpdateMode.APPEND:
         tty.warn(
             "Appending to a view index does not guarantee idempotent write when contending "
             "with multiple writers. This feature is meant to be used by a single process."
@@ -914,7 +914,7 @@ def update_view(
     except spack.binary_distribution.BuildcacheIndexNotExists:
         index_exists = False
 
-    if index_exists and update_mode == ViewMode.CREATE:
+    if index_exists and update_mode == ViewUpdateMode.CREATE:
         raise spack.error.SpackError(
             "Index already exists. To overwrite or update pass --force or --append respectively"
         )
@@ -939,7 +939,7 @@ def update_view(
         db = spack.binary_distribution.BuildCacheDatabase(tmpdir)
         db._write()
 
-        if update_mode == ViewMode.APPEND:
+        if update_mode == ViewUpdateMode.APPEND:
             # Load the current state of the view index from the cache into the database
             cache_index = BINARY_INDEX._local_index_cache.get(str(url_and_version))
             if cache_index:
@@ -960,11 +960,11 @@ def update_index_fn(args):
     )
 
     if update_view_index:
-        update_mode = ViewMode.CREATE
+        update_mode = ViewUpdateMode.CREATE
         if args.force:
-            update_mode = ViewMode.OVERWRITE
+            update_mode = ViewUpdateMode.OVERWRITE
         elif args.append:
-            update_mode = ViewMode.APPEND
+            update_mode = ViewUpdateMode.APPEND
 
         return update_view(
             args.mirror, update_mode, *args.sources, name=args.name, update_keys=args.keys

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -143,6 +143,13 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=None,
         dest="signed",
     )
+    add_parser.add_argument(
+        "--name",
+        "-n",
+        action="store",
+        dest="view_name",
+        help="Name of the index view for a binary mirror",
+    )
     arguments.add_connection_args(add_parser, False)
     # Remove
     remove_parser = sp.add_parser("remove", aliases=["rm"], help=mirror_remove.__doc__)
@@ -306,6 +313,7 @@ def mirror_add(args):
         or args.s3_access_token_variable
         or args.s3_profile
         or args.s3_endpoint_url
+        or args.view_name
         or args.type
         or args.oci_username
         or args.oci_username_variable
@@ -344,6 +352,9 @@ def mirror_add(args):
             connection["autopush"] = args.autopush
         if args.signed is not None:
             connection["signed"] = args.signed
+        if args.view_name:
+            connection["view"] = args.view_name
+
         mirror = spack.mirrors.mirror.Mirror(connection, name=args.name)
     else:
         mirror = spack.mirrors.mirror.Mirror(args.url, name=args.name)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -439,7 +439,7 @@ class URLFetchStrategy(FetchStrategy):
 
         try:
             response = web_util.urlopen(request)
-            tty.msg(f"Fetching {url}")
+            tty.verbose(f"Fetching {url}")
             progress = FetchProgress.from_headers(response.headers, enabled=sys.stdout.isatty())
             with open(save_file, "wb") as f:
                 while True:
@@ -472,7 +472,7 @@ class URLFetchStrategy(FetchStrategy):
         if self.stage.save_filename:
             save_file = self.stage.save_filename
             partial_file = self.stage.save_filename + ".part"
-        tty.msg(f"Fetching {url}")
+        tty.verbose(f"Fetching {url}")
         if partial_file:
             save_args = [
                 "-C",
@@ -659,7 +659,7 @@ class OCIRegistryFetchStrategy(URLFetchStrategy):
 
         try:
             response = self._urlopen(self.url)
-            tty.msg(f"Fetching {self.url}")
+            tty.verbose(f"Fetching {self.url}")
             with open(file, "wb") as f:
                 shutil.copyfileobj(response, f)
         except OSError as e:

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -4,7 +4,7 @@
 import operator
 import os
 import urllib.parse
-from typing import Any, Dict, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import spack.config
 import spack.llnl.util.tty as tty
@@ -13,9 +13,13 @@ import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 from spack.error import MirrorError
+from spack.oci.image import is_oci_url
 
 #: What schemes do we support
 supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oci", "oci+http")
+
+#: The layout version spack can current install
+SUPPORTED_LAYOUT_VERSIONS = (3, 2)
 
 
 def _url_or_path_to_url(url_or_path: str) -> str:
@@ -111,6 +115,11 @@ class Mirror:
 
     @property
     def signed(self) -> bool:
+        # TODO: OCI support signing
+        # Only checking for fetch, push is handled by OCI implementation
+        if is_oci_url(self.fetch_url):
+            return False
+
         return isinstance(self._data, str) or self._data.get("signed", True)
 
     @property
@@ -168,14 +177,24 @@ class Mirror:
             msg += "\n    ".join(errors)
             raise MirrorError(msg)
 
-    def supported_version(self, binary_layout_version: int):
-        """Determine if the mirrors configuration is supported by a binary mirror layout version"""
+    @property
+    def supported_layout_versions(self) -> List[int]:
+        """List all of the supported layouts a mirror can fetch from"""
         # Only check the fetch configuration, the push configuration is whatever the latest
         # mirror version is which should support all configurable features.
-        if binary_layout_version == 2:
-            return self.get_view("fetch") is not None
 
-        return True
+        # All configured mirrors support the latest version
+        supported_versions = [SUPPORTED_LAYOUT_VERSIONS[0]]
+        has_view = self.fetch_view is not None
+
+        # Check if the mirror supports older layout versions
+        # OCI - Only return the newest version, the layout version is a dummy version since OCI
+        #       has its own layout.
+        # Views - Only versions >=3 support the views feature
+        if not is_oci_url(self.fetch_url) and not has_view:
+            supported_versions.extend(SUPPORTED_LAYOUT_VERSIONS[1:])
+
+        return supported_versions
 
     def _update_connection_dict(self, current_data: dict, new_data: dict, top_level: bool):
         # Only allow one to exist in the config

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -129,6 +129,16 @@ class Mirror:
         """Get the valid, canonicalized fetch URL"""
         return self.get_url("push")
 
+    @property
+    def fetch_view(self):
+        """Get the valid, canonicalized fetch URL"""
+        return self.get_view("fetch")
+
+    @property
+    def push_view(self):
+        """Get the valid, canonicalized fetch URL"""
+        return self.get_view("push")
+
     def ensure_mirror_usable(self, direction: str = "push"):
         access_pair = self._get_value("access_pair", direction)
         access_token_variable = self._get_value("access_token_variable", direction)
@@ -157,6 +167,15 @@ class Mirror:
             msg = f"invalid {direction} configuration for mirror {self.name}: "
             msg += "\n    ".join(errors)
             raise MirrorError(msg)
+
+    def supported_version(self, binary_layout_version: int):
+        """Determine if the mirrors configuration is supported by a binary mirror layout version"""
+        # Only check the fetch configuration, the push configuration is whatever the latest
+        # mirror version is which should support all configurable features.
+        if binary_layout_version == 2:
+            return self.get_view("fetch") is not None
+
+        return True
 
     def _update_connection_dict(self, current_data: dict, new_data: dict, top_level: bool):
         # Only allow one to exist in the config
@@ -303,6 +322,9 @@ class Mirror:
             raise ValueError(f"Mirror {self.name} has no URL configured")
 
         return _url_or_path_to_url(url)
+
+    def get_view(self, direction: str):
+        return self._get_value("view", direction)
 
     def get_credentials(self, direction: str) -> Dict[str, Any]:
         """Get the mirror credentials from the mirror config

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -216,7 +216,7 @@ class Tee:
 
 
 def install_from_buildcache(
-    mirrors: List[spack.url_buildcache.MirrorURLAndVersion],
+    mirrors: List[spack.url_buildcache.MirrorMetadata],
     spec: spack.spec.Spec,
     unsigned: Optional[bool],
     state_stream: io.TextIOWrapper,
@@ -327,7 +327,7 @@ class PrefixPivoter:
 def worker_function(
     spec: spack.spec.Spec,
     explicit: bool,
-    mirrors: List[spack.url_buildcache.MirrorURLAndVersion],
+    mirrors: List[spack.url_buildcache.MirrorMetadata],
     unsigned: Optional[bool],
     install_policy: InstallPolicy,
     dirty: bool,
@@ -415,7 +415,7 @@ def worker_function(
 def _install(
     spec: spack.spec.Spec,
     explicit: bool,
-    mirrors: List[spack.url_buildcache.MirrorURLAndVersion],
+    mirrors: List[spack.url_buildcache.MirrorMetadata],
     unsigned: Optional[bool],
     install_policy: InstallPolicy,
     dirty: bool,
@@ -569,7 +569,7 @@ class JobServer:
 def start_build(
     spec: spack.spec.Spec,
     explicit: bool,
-    mirrors: List[spack.url_buildcache.MirrorURLAndVersion],
+    mirrors: List[spack.url_buildcache.MirrorMetadata],
     unsigned: Optional[bool],
     install_policy: InstallPolicy,
     dirty: bool,

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -16,6 +16,7 @@ connection = {
         "description": "URL pointing to the mirror directory, can be local filesystem "
         "(file://) or remote server (http://, https://, s3://, oci://)",
     },
+    "view": {"type": "string"},
     "access_pair": {
         "type": "object",
         "description": "Authentication credentials for accessing private mirrors with ID and "

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1205,7 +1205,7 @@ def test_etag_fetching_304():
         assert False, "Unexpected request {}".format(url)
 
     fetcher = spack.binary_distribution.EtagIndexFetcher(
-        spack.binary_distribution.MirrorURLAndVersion(
+        spack.binary_distribution.MirrorMetadata(
             "https://www.example.com", spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
         ),
         etag="112a8bbc1b3f7f185621c1ee335f0502",
@@ -1232,7 +1232,7 @@ def test_etag_fetching_200(mock_index):
         assert False, "Unexpected request {}".format(url)
 
     fetcher = spack.binary_distribution.EtagIndexFetcher(
-        spack.binary_distribution.MirrorURLAndVersion(
+        spack.binary_distribution.MirrorMetadata(
             "https://www.example.com", spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
         ),
         etag="112a8bbc1b3f7f185621c1ee335f0502",
@@ -1260,7 +1260,7 @@ def test_etag_fetching_404():
         )
 
     fetcher = spack.binary_distribution.EtagIndexFetcher(
-        spack.binary_distribution.MirrorURLAndVersion(
+        spack.binary_distribution.MirrorMetadata(
             "https://www.example.com", spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
         ),
         etag="112a8bbc1b3f7f185621c1ee335f0502",
@@ -1286,7 +1286,7 @@ def test_default_index_fetch_200(mock_index):
         assert False, "Unexpected request {}".format(url)
 
     fetcher = spack.binary_distribution.DefaultIndexFetcher(
-        spack.binary_distribution.MirrorURLAndVersion(
+        spack.binary_distribution.MirrorMetadata(
             "https://www.example.com", spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
         ),
         local_hash="outdated",
@@ -1315,7 +1315,7 @@ def test_default_index_404():
         )
 
     fetcher = spack.binary_distribution.DefaultIndexFetcher(
-        spack.binary_distribution.MirrorURLAndVersion(
+        spack.binary_distribution.MirrorMetadata(
             "https://www.example.com", spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
         ),
         local_hash=None,
@@ -1342,7 +1342,7 @@ def test_default_index_not_modified(mock_index):
         assert False, "Unexpected request {}".format(url)
 
     fetcher = spack.binary_distribution.DefaultIndexFetcher(
-        spack.binary_distribution.MirrorURLAndVersion(
+        spack.binary_distribution.MirrorMetadata(
             "https://www.example.com", spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
         ),
         local_hash=mock_index.index_hash,
@@ -1392,9 +1392,9 @@ def test_get_entries_from_cache_nested_mirrors(monkeypatch, tmp_path: pathlib.Pa
 
 
 def test_url_and_version():
-    url_and_version = spack.binary_distribution.MirrorURLAndVersion("https://dummy.io/__v3", 3)
+    url_and_version = spack.binary_distribution.MirrorMetadata("https://dummy.io/__v3", 3)
     as_str = str(url_and_version)
-    from_str = spack.binary_distribution.MirrorURLAndVersion.from_string(as_str)
+    from_str = spack.binary_distribution.MirrorMetadata.from_string(as_str)
 
     # Verify values
     assert url_and_version.url == "https://dummy.io/__v3"
@@ -1405,16 +1405,16 @@ def test_url_and_version():
     assert url_and_version == from_str
     assert as_str == str(from_str)
 
-    with pytest.raises(spack.url_buildcache.MirrorURLAndVersionError, match="Malformed string"):
-        spack.binary_distribution.MirrorURLAndVersion.from_string("https://dummy.io/__v3@@4")
+    with pytest.raises(spack.url_buildcache.MirrorMetadataError, match="Malformed string"):
+        spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3@@4")
 
 
 def test_url_and_version_with_view():
-    url_and_version = spack.binary_distribution.MirrorURLAndVersion(
+    url_and_version = spack.binary_distribution.MirrorMetadata(
         "https://dummy.io/__v3__@aview", 3, "aview"
     )
     as_str = str(url_and_version)
-    from_str = spack.binary_distribution.MirrorURLAndVersion.from_string(as_str)
+    from_str = spack.binary_distribution.MirrorMetadata.from_string(as_str)
 
     # Verify round trip
     assert url_and_version.url == "https://dummy.io/__v3__@aview"
@@ -1423,7 +1423,5 @@ def test_url_and_version_with_view():
     assert url_and_version == from_str
     assert as_str == str(from_str)
 
-    with pytest.raises(spack.url_buildcache.MirrorURLAndVersionError, match="Malformed string"):
-        spack.binary_distribution.MirrorURLAndVersion.from_string(
-            "https://dummy.io/__v3%asdf__@aview"
-        )
+    with pytest.raises(spack.url_buildcache.MirrorMetadataError, match="Malformed string"):
+        spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3%asdf__@aview")

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1391,36 +1391,36 @@ def test_get_entries_from_cache_nested_mirrors(monkeypatch, tmp_path: pathlib.Pa
     assert len(spec_manifests_nested) == 1
 
 
-def test_url_and_version():
-    url_and_version = spack.binary_distribution.MirrorMetadata("https://dummy.io/__v3", 3)
-    as_str = str(url_and_version)
+def test_mirror_metadata():
+    mirror_metadata = spack.binary_distribution.MirrorMetadata("https://dummy.io/__v3", 3)
+    as_str = str(mirror_metadata)
     from_str = spack.binary_distribution.MirrorMetadata.from_string(as_str)
 
     # Verify values
-    assert url_and_version.url == "https://dummy.io/__v3"
-    assert url_and_version.version == 3
-    assert url_and_version.view is None
+    assert mirror_metadata.url == "https://dummy.io/__v3"
+    assert mirror_metadata.version == 3
+    assert mirror_metadata.view is None
 
     # Verify round trip
-    assert url_and_version == from_str
+    assert mirror_metadata == from_str
     assert as_str == str(from_str)
 
     with pytest.raises(spack.url_buildcache.MirrorMetadataError, match="Malformed string"):
         spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3@@4")
 
 
-def test_url_and_version_with_view():
-    url_and_version = spack.binary_distribution.MirrorMetadata(
+def test_mirror_metadata_with_view():
+    mirror_metadata = spack.binary_distribution.MirrorMetadata(
         "https://dummy.io/__v3__@aview", 3, "aview"
     )
-    as_str = str(url_and_version)
+    as_str = str(mirror_metadata)
     from_str = spack.binary_distribution.MirrorMetadata.from_string(as_str)
 
     # Verify round trip
-    assert url_and_version.url == "https://dummy.io/__v3__@aview"
-    assert url_and_version.version == 3
-    assert url_and_version.view == "aview"
-    assert url_and_version == from_str
+    assert mirror_metadata.url == "https://dummy.io/__v3__@aview"
+    assert mirror_metadata.version == 3
+    assert mirror_metadata.view == "aview"
+    assert mirror_metadata == from_str
     assert as_str == str(from_str)
 
     with pytest.raises(spack.url_buildcache.MirrorMetadataError, match="Malformed string"):

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -28,6 +28,7 @@ import spack.oci.image
 import spack.spec
 import spack.stage
 import spack.store
+import spack.url_buildcache
 import spack.util.gpg
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
@@ -1362,3 +1363,41 @@ def test_get_entries_from_cache_nested_mirrors(monkeypatch, tmp_path: pathlib.Pa
     # Expected specs in nested mirror
     #   - zlib
     assert len(spec_manifests_nested) == 1
+
+
+def test_url_and_version():
+    url_and_version = spack.binary_distribution.MirrorURLAndVersion("https://dummy.io/__v3", 3)
+    as_str = str(url_and_version)
+    from_str = spack.binary_distribution.MirrorURLAndVersion.from_string(as_str)
+
+    # Verify values
+    assert url_and_version.url == "https://dummy.io/__v3"
+    assert url_and_version.version == 3
+    assert url_and_version.view is None
+
+    # Verify round trip
+    assert url_and_version == from_str
+    assert as_str == str(from_str)
+
+    with pytest.raises(spack.url_buildcache.MirrorURLAndVersionError, match="Malformed string"):
+        spack.binary_distribution.MirrorURLAndVersion.from_string("https://dummy.io/__v3@@4")
+
+
+def test_url_and_version_with_view():
+    url_and_version = spack.binary_distribution.MirrorURLAndVersion(
+        "https://dummy.io/__v3__@aview", 3, "aview"
+    )
+    as_str = str(url_and_version)
+    from_str = spack.binary_distribution.MirrorURLAndVersion.from_string(as_str)
+
+    # Verify round trip
+    assert url_and_version.url == "https://dummy.io/__v3__@aview"
+    assert url_and_version.version == 3
+    assert url_and_version.view == "aview"
+    assert url_and_version == from_str
+    assert as_str == str(from_str)
+
+    with pytest.raises(spack.url_buildcache.MirrorURLAndVersionError, match="Malformed string"):
+        spack.binary_distribution.MirrorURLAndVersion.from_string(
+            "https://dummy.io/__v3%asdf__@aview"
+        )

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -295,6 +295,38 @@ def test_use_bin_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
 
 
 @pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
+def test_use_bin_index_active_env_with_view(
+    monkeypatch, tmp_path: pathlib.Path, mutable_config, mutable_mock_env_path
+):
+    """Check use of binary cache index: perform an operation that
+    instantiates it, and a second operation that reconstructs it.
+    """
+    monkeypatch.setattr(
+        spack.binary_distribution, "BINARY_INDEX", spack.binary_distribution.BinaryCacheIndex()
+    )
+
+    # Create a mirror, configure us to point at it, install a spec, and
+    # put it in the mirror
+    mirror_dir = tmp_path / "mirror_dir"
+    mirror_url = url_util.path_to_file_url(str(mirror_dir))
+    spack.config.set("mirrors", {"test": {"url": mirror_url, "view": "test"}})
+    s = spack.concretize.concretize_one("libdwarf")
+
+    # Create an environment and install specs for the view
+    ev.create("testenv")
+    with ev.read("testenv"):
+        install_cmd("--add", "--fake", "--no-cache", s.name)
+        buildcache_cmd("push", "-u", "test", s.name)
+        buildcache_cmd("update-index", "test", "testenv")
+
+    # Now the test
+    buildcache_cmd("list", "-al")
+    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex()
+    cache_list = buildcache_cmd("list", "-al")
+    assert "libdwarf" in cache_list
+
+
+@pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
 def test_use_bin_index_with_view(
     monkeypatch, tmp_path: pathlib.Path, mutable_config, mutable_mock_env_path
 ):

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -310,7 +310,7 @@ def test_use_bin_index_with_view(monkeypatch, tmp_path: pathlib.Path, mutable_co
     s = spack.concretize.concretize_one("libdwarf")
     install_cmd("--fake", "--no-cache", s.name)
     buildcache_cmd("push", "-u", "test", s.name)
-    buildcache_cmd("create-view", "test", s.format("{/hash}"))
+    buildcache_cmd("update-index", "test", s.format("{/hash}"))
 
     # Now the test
     buildcache_cmd("list", "-al")

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -21,6 +21,7 @@ import pytest
 import spack.binary_distribution
 import spack.concretize
 import spack.config
+import spack.environment as ev
 import spack.hooks.sbang as sbang
 import spack.main
 import spack.mirrors.mirror
@@ -294,7 +295,9 @@ def test_use_bin_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
 
 
 @pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
-def test_use_bin_index_with_view(monkeypatch, tmp_path: pathlib.Path, mutable_config):
+def test_use_bin_index_with_view(
+    monkeypatch, tmp_path: pathlib.Path, mutable_config, mutable_mock_env_path
+):
     """Check use of binary cache index: perform an operation that
     instantiates it, and a second operation that reconstructs it.
     """
@@ -308,9 +311,14 @@ def test_use_bin_index_with_view(monkeypatch, tmp_path: pathlib.Path, mutable_co
     mirror_url = url_util.path_to_file_url(str(mirror_dir))
     spack.config.set("mirrors", {"test": {"url": mirror_url, "view": "test"}})
     s = spack.concretize.concretize_one("libdwarf")
-    install_cmd("--fake", "--no-cache", s.name)
-    buildcache_cmd("push", "-u", "test", s.name)
-    buildcache_cmd("update-index", "test", s.format("{/hash}"))
+
+    # Create an environment and install specs for the view
+    ev.create("testenv")
+    with ev.read("testenv"):
+        install_cmd("--add", "--fake", "--no-cache", s.name)
+        buildcache_cmd("push", "-u", "test", s.name)
+
+    buildcache_cmd("update-index", "test", "testenv")
 
     # Now the test
     buildcache_cmd("list", "-al")

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -317,7 +317,7 @@ def test_use_bin_index_active_env_with_view(
     with ev.read("testenv"):
         install_cmd("--add", "--fake", "--no-cache", s.name)
         buildcache_cmd("push", "-u", "test", s.name)
-        buildcache_cmd("update-index", "test", "testenv")
+        buildcache_cmd("update-index", "test")
 
     # Now the test
     buildcache_cmd("list", "-al")

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -293,6 +293,32 @@ def test_use_bin_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
     assert "libdwarf" in cache_list
 
 
+@pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
+def test_use_bin_index_with_view(monkeypatch, tmp_path: pathlib.Path, mutable_config):
+    """Check use of binary cache index: perform an operation that
+    instantiates it, and a second operation that reconstructs it.
+    """
+    monkeypatch.setattr(
+        spack.binary_distribution, "BINARY_INDEX", spack.binary_distribution.BinaryCacheIndex()
+    )
+
+    # Create a mirror, configure us to point at it, install a spec, and
+    # put it in the mirror
+    mirror_dir = tmp_path / "mirror_dir"
+    mirror_url = url_util.path_to_file_url(str(mirror_dir))
+    spack.config.set("mirrors", {"test": {"url": mirror_url, "view": "test"}})
+    s = spack.concretize.concretize_one("libdwarf")
+    install_cmd("--fake", "--no-cache", s.name)
+    buildcache_cmd("push", "-u", "test", s.name)
+    buildcache_cmd("create-view", "test", s.format("{/hash}"))
+
+    # Now the test
+    buildcache_cmd("list", "-al")
+    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex()
+    cache_list = buildcache_cmd("list", "-al")
+    assert "libdwarf" in cache_list
+
+
 def test_generate_key_index_failure(monkeypatch, tmp_path: pathlib.Path):
     def list_url(url, recursive=False):
         if "fails-listing" in url:

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import contextlib
 import errno
 import json
 import os
@@ -28,6 +27,7 @@ import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.installer import PackageInstaller
 from spack.llnl.util.filesystem import copy_tree, find, getuid
+from spack.llnl.util.lang import nullcontext
 from spack.paths import test_path
 from spack.url_buildcache import (
     BuildcacheComponent,
@@ -977,44 +977,37 @@ def test_buildcache_prune_new_specs_race_condition(
     assert web_util.url_exists(manifest_url)
 
 
-def spec_env_name(spec: spack.spec.Spec) -> str:
-    return f"specenv-{spec.dag_hash()}"
-
-
-@contextlib.contextmanager
-def spec_env(spec: spack.spec.Spec):
+def create_env_from_concrete_spec(spec: spack.spec.Spec):
     """Build cache index view source is current active environment"""
     # Create a unique environment for this spec only
-    env_name = spec_env_name(spec)
+    env_name = f"specenv-{spec.dag_hash()}"
     if not ev.exists(env_name):
         env("create", "--without-view", env_name)
 
-    with ev.environment_from_name_or_dir(env_name):
+    e = ev.environment_from_name_or_dir(env_name)
+    with e:
         add(f"{spec.name}/{spec.dag_hash()}")
         # This should handle updating the environment to mark all packges as installed
         install()
-        # Empty list since we want to use the active environment
-        yield []
+    return e
 
 
-@contextlib.contextmanager
-def spec_env_path(spec: spack.spec.Spec):
+def args_for_active_env(spec: spack.spec.Spec):
+    """Build cache index view source is an active environment"""
+    env = create_env_from_concrete_spec(spec)
+    return [env, []]
+
+
+def args_for_env_by_path(spec: spack.spec.Spec):
     """Build cache index view source is an environment path"""
-    # Create the environment, reuse they logic from spec_env
-    env_name = spec_env_name(spec)
-    with spec_env(spec):
-        pass
-    yield [ev.environment_dir_from_name(env_name, exists_ok=True)]
+    env = create_env_from_concrete_spec(spec)
+    return [nullcontext(), [env.path]]
 
 
-@contextlib.contextmanager
-def spec_env_by_name(spec: spack.spec.Spec):
-    """Build cache index view source is an managed environment name"""
-    # Create the environment, reuse they logic from spec_env
-    env_name = spec_env_name(spec)
-    with spec_env(spec):
-        pass
-    yield [env_name]
+def args_for_env_by_name(spec: spack.spec.Spec):
+    """Build cache index view source is a managed environment name"""
+    env = create_env_from_concrete_spec(spec)
+    return [nullcontext(), [env.name]]
 
 
 def read_specs_in_index(mirror_directory, view):
@@ -1086,9 +1079,11 @@ def test_buildcache_create_view_empty(
     assert not hashes_in_view
 
 
-@pytest.mark.parametrize("source", (spec_env, spec_env_path, spec_env_by_name))
+@pytest.mark.parametrize(
+    "source_args", (args_for_active_env, args_for_env_by_path, args_for_env_by_name)
+)
 def test_buildcache_create_view(
-    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source_args
 ):
     mirror_directory = str(tmp_path)
     mirror("add", "--unsigned", "my-mirror", mirror_directory)
@@ -1106,15 +1101,14 @@ def test_buildcache_create_view(
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Create a view using a parametrized source that contains one of the mpileaks
-    with source(mpileaks_specs[0]) as source_args:
-        command_args = ["update-index", "--name", "test_view", "my-mirror"]
-        if source_args:
-            command_args.extend(source_args)
+    context, extra_args = source_args(mpileaks_specs[0])
+    with context:
+        command_args = ["update-index", "--name", "test_view", "my-mirror"] + extra_args
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
     # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
-    assert not (hashes_in_view - mpileaks_0_hashes)
+    assert hashes_in_view == mpileaks_0_hashes
 
     # Test fail to overwrite without force
     expect = "Index already exists. To overwrite or update pass --force or --append respectively"
@@ -1130,12 +1124,14 @@ def test_buildcache_create_view(
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
     # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
-    assert not (hashes_in_view - mpileaks_0_hashes)
+    assert hashes_in_view == mpileaks_0_hashes
 
 
-@pytest.mark.parametrize("source", (spec_env, spec_env_path, spec_env_by_name))
+@pytest.mark.parametrize(
+    "source_args", (args_for_active_env, args_for_env_by_path, args_for_env_by_name)
+)
 def test_buildcache_create_view_append(
-    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source_args
 ):
     mirror_directory = str(tmp_path)
     mirror("add", "--unsigned", "my-mirror", mirror_directory)
@@ -1154,32 +1150,46 @@ def test_buildcache_create_view_append(
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Test append to empty index view
-    with source(mpileaks_specs[0]) as source_args:
-        command_args = ["update-index", "-y", "--append", "--name", "test_view", "my-mirror"]
-        if source_args:
-            command_args.extend(source_args)
+    context, extra_args = source_args(mpileaks_specs[0])
+    with context:
+        command_args = [
+            "update-index",
+            "-y",
+            "--append",
+            "--name",
+            "test_view",
+            "my-mirror",
+        ] + extra_args
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
     # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
-    assert not (hashes_in_view - mpileaks_0_hashes)
+    assert hashes_in_view == mpileaks_0_hashes
 
     # Test append to existing index view
-    with source(mpileaks_specs[1]) as source_args:
-        command_args = ["update-index", "-y", "--append", "--name", "test_view", "my-mirror"]
-        if source_args:
-            command_args.extend(source_args)
+    context, extra_args = source_args(mpileaks_specs[1])
+    with context:
+        command_args = [
+            "update-index",
+            "-y",
+            "--append",
+            "--name",
+            "test_view",
+            "my-mirror",
+        ] + extra_args
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
     # Assert all of the hashes for mpileaks_0_hashes and mpileaks_1_hashes exist in the view,
     # and no other hashes
-    assert not (hashes_in_view - (mpileaks_0_hashes | mpileaks_1_hashes))
+    assert hashes_in_view == (mpileaks_0_hashes | mpileaks_1_hashes)
 
 
-@pytest.mark.parametrize("source", (spec_env, spec_env_path, spec_env_by_name))
+@pytest.mark.parametrize(
+    "source_args", (args_for_active_env, args_for_env_by_path, args_for_env_by_name)
+)
 def test_buildcache_create_view_overwrite(
-    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source_args
 ):
     mirror_directory = str(tmp_path)
     mirror("add", "--unsigned", "my-mirror", mirror_directory)
@@ -1198,26 +1208,24 @@ def test_buildcache_create_view_overwrite(
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Create a view using a parametrized source that contains one of the mpileaks
-    with source(mpileaks_specs[0]) as source_args:
-        command_args = ["update-index", "--name", "test_view", "my-mirror"]
-        if source_args:
-            command_args.extend(source_args)
+    context, extra_args = source_args(mpileaks_specs[0])
+    with context:
+        command_args = ["update-index", "--name", "test_view", "my-mirror"] + extra_args
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
     # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
-    assert not (hashes_in_view - mpileaks_0_hashes)
+    assert hashes_in_view == mpileaks_0_hashes
 
     # Override a view with force
-    with source(mpileaks_specs[1]) as source_args:
-        command_args = ["update-index", "--force", "--name", "test_view", "my-mirror"]
-        if source_args:
-            command_args.extend(source_args)
+    context, extra_args = source_args(mpileaks_specs[1])
+    with context:
+        command_args = ["update-index", "--force", "--name", "test_view", "my-mirror"] + extra_args
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
     # Assert all of the hashes for mpileaks_1_hashes exist in the view, and no other hashes
-    assert not (hashes_in_view - mpileaks_1_hashes)
+    assert hashes_in_view == mpileaks_1_hashes
 
 
 def test_buildcache_create_view_non_active_env(
@@ -1239,16 +1247,19 @@ def test_buildcache_create_view_non_active_env(
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Create a view from an environment name that is different from the current active environment
-    with spec_env_by_name(mpileaks_specs[0]) as source_args:
-        with spec_env(mpileaks_specs[1]) as _:
-            command_args = ["update-index", "--name", "test_view", "my-mirror"]
-            if source_args:
-                command_args.extend(source_args)
-            buildcache(*command_args)
+    _, extra_args = args_for_env_by_name(
+        mpileaks_specs[0]
+    )  # Get args for env by name using mpileaks[0]
+    context, _ = args_for_active_env(
+        mpileaks_specs[1]
+    )  # Get the context for an active env using mpileaks[1]
+    with context:
+        command_args = ["update-index", "--name", "test_view", "my-mirror"] + extra_args
+        buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
     # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
-    assert not (hashes_in_view - mpileaks_0_hashes)
+    assert hashes_in_view == mpileaks_0_hashes
 
 
 @pytest.mark.parametrize("view", (None, "test_view"))
@@ -1265,9 +1276,10 @@ def test_buildcache_check_index_full(
     for s in mpileaks_specs:
         buildcache("push", "my-mirror", s.format("{/hash}"))
 
-    # Activate environment containing mpileaks[0]
-    with spec_env(mpileaks_specs[0]):
-        buildcache("update-index", "my-mirror")
+    # Update index using and active environment containing mpileaks[0]
+    context, extra_args = args_for_active_env(mpileaks_specs[0])
+    with context:
+        buildcache("update-index", "my-mirror", *extra_args)
 
     out = buildcache("check-index", "--verify", "exists", "manifests", "blobs", "--", "my-mirror")
     # Everything thing be good here

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1026,7 +1026,7 @@ def test_buildcache_create_view_failure(tmp_path, mutable_config, mutable_mock_e
         buildcache(*command_args)
 
     # spec sources should raise an exception
-    expect = "Failed to read specs from source: DEADBEEF"
+    expect = "no such environment 'DEADBEEF'"
     with pytest.raises(spack.error.SpackError, match=expect):
         command_args = ["update-index", "--name", "test_view", "my-mirror", "DEADBEEF"]
         buildcache(*command_args)
@@ -1141,7 +1141,7 @@ def test_buildcache_create_view_append(
 
     # Test append to empty index view
     with source(mpileaks_specs[0], tmp_path / "source_stage") as source_args:
-        command_args = ["update-index", "--append", "--name", "test_view", "my-mirror"]
+        command_args = ["update-index", "-y", "--append", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
@@ -1152,7 +1152,7 @@ def test_buildcache_create_view_append(
 
     # Test append to existing index view
     with source(mpileaks_specs[1], tmp_path / "source_stage") as source_args:
-        command_args = ["update-index", "--append", "--name", "test_view", "my-mirror"]
+        command_args = ["update-index", "-y", "--append", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -30,7 +30,6 @@ from spack.installer import PackageInstaller
 from spack.llnl.util.filesystem import copy_tree, find, getuid
 from spack.paths import test_path
 from spack.url_buildcache import (
-    SUPPORTED_LAYOUT_VERSIONS,
     BuildcacheComponent,
     URLBuildcacheEntry,
     URLBuildcacheEntryV2,
@@ -1027,7 +1026,7 @@ def spec_lockfile(spec: spack.spec.Spec, prefix: str):
 
 def read_specs_in_index(mirror_directory, view):
     url_and_version = spack.binary_distribution.MirrorURLAndVersion(
-        f"file://{mirror_directory}", SUPPORTED_LAYOUT_VERSIONS[0], view
+        f"file://{mirror_directory}", spack.mirrors.mirror.SUPPORTED_LAYOUT_VERSIONS[0], view
     )
     fetcher = spack.binary_distribution.DefaultIndexFetcher(url_and_version, None)
     result = fetcher.conditional_fetch()
@@ -1090,6 +1089,56 @@ def test_buildcache_create_view_empty(
 
 
 @pytest.mark.parametrize("sources", ("hash", "specfile", "env", "lockfile"))
+def test_buildcache_create_view(
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, sources
+):
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # Push all of the mpileaks packages to the cache
+    mpileaks_specs = mutable_database.query_local("mpileaks")
+    for s in mpileaks_specs:
+        buildcache("push", "--update-index", "my-mirror", s.format("{/hash}"))
+
+    # Grab all of the hashes for each mpileaks spec
+    mpileaks_0_hashes = [s.dag_hash() for s in mpileaks_specs[0].traverse()]
+    mpileaks_1_hashes = [s.dag_hash() for s in mpileaks_specs[1].traverse()]
+
+    # Make sure the view doesn't exist yet
+    with pytest.raises(spack.binary_distribution.FetchIndexError):
+        hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+
+    # Create a view using a parametrized source that contains one of the mpileaks
+    with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
+        command_args = ["create-view", "--name", "test_view", "my-mirror"]
+        if source_args:
+            command_args.extend(source_args)
+        buildcache(*command_args)
+
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    for h in mpileaks_0_hashes:
+        assert h in hashes_in_view
+
+    # Test fail to overwrite without force
+    expect = "Index already exists. To overwrite or update pass --force or --append respectively"
+    with pytest.raises(spack.error.SpackError, match=expect):
+        command_args = [
+            "update-view",
+            "--name",
+            "test_view",
+            "my-mirror",
+            mpileaks_specs[2].format("{/hash}"),
+        ]
+        buildcache(*command_args)
+
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    for h in mpileaks_0_hashes:
+        assert h in hashes_in_view
+    for h in mpileaks_1_hashes:
+        assert h not in hashes_in_view or h in mpileaks_0_hashes
+
+
+@pytest.mark.parametrize("sources", ("hash", "specfile", "env", "lockfile"))
 def test_buildcache_create_view_append(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path, sources
 ):
@@ -1133,7 +1182,7 @@ def test_buildcache_create_view_append(
 
 
 @pytest.mark.parametrize("sources", ("hash", "specfile", "env", "lockfile"))
-def test_buildcache_create_view(
+def test_buildcache_create_view_overwrite(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path, sources
 ):
     mirror_directory = str(tmp_path)
@@ -1147,7 +1196,6 @@ def test_buildcache_create_view(
     # Grab all of the hashes for each mpileaks spec
     mpileaks_0_hashes = [s.dag_hash() for s in mpileaks_specs[0].traverse()]
     mpileaks_1_hashes = [s.dag_hash() for s in mpileaks_specs[1].traverse()]
-    mpileaks_2_hashes = [s.dag_hash() for s in mpileaks_specs[2].traverse()]
 
     # Make sure the view doesn't exist yet
     with pytest.raises(spack.binary_distribution.FetchIndexError):
@@ -1164,24 +1212,6 @@ def test_buildcache_create_view(
     for h in mpileaks_0_hashes:
         assert h in hashes_in_view
 
-    # Test fail to overwrite without force
-    expect = "Index already exists. To overwrite or update pass --force or --append respectively"
-    with pytest.raises(spack.error.SpackError, match=expect):
-        command_args = [
-            "update-view",
-            "--name",
-            "test_view",
-            "my-mirror",
-            mpileaks_specs[2].format("{/hash}"),
-        ]
-        buildcache(*command_args)
-
-    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_0_hashes:
-        assert h in hashes_in_view
-    for h in mpileaks_2_hashes:
-        assert h not in hashes_in_view or h in mpileaks_0_hashes
-
     # Override a view with force
     with globals()[f"spec_{sources}"](mpileaks_specs[1], tmp_path / "source_stage") as source_args:
         command_args = ["create-view", "--force", "--name", "test_view", "my-mirror"]
@@ -1194,4 +1224,3 @@ def test_buildcache_create_view(
         assert h in hashes_in_view
     for h in mpileaks_0_hashes:
         assert h not in hashes_in_view or h in mpileaks_1_hashes
-

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import contextlib
 import errno
 import json
 import os
@@ -29,6 +30,7 @@ from spack.installer import PackageInstaller
 from spack.llnl.util.filesystem import copy_tree, find, getuid
 from spack.paths import test_path
 from spack.url_buildcache import (
+    SUPPORTED_LAYOUT_VERSIONS,
     BuildcacheComponent,
     URLBuildcacheEntry,
     URLBuildcacheEntryV2,
@@ -90,7 +92,7 @@ def tests_buildcache_create_env(
     """ "Ensure that buildcache create creates output files from env"""
     pkg = "trivial-install-test-package"
 
-    env("create", "test")
+    env("create", "--without-view", "test")
     with ev.read("test"):
         add(pkg)
         install()
@@ -241,7 +243,7 @@ def test_buildcache_sync(
     install("--fake", s.name)
     buildcache("push", "-u", "-f", src_mirror_url, s.name)
 
-    env("create", "test")
+    env("create", "--without-view", "test")
     with ev.read("test"):
         add(in_env_pkg)
         install()
@@ -976,3 +978,187 @@ def test_buildcache_prune_new_specs_race_condition(
     assert web_util.url_exists(manifest_url)
     buildcache("prune", "my-mirror", "--keeplist", str(keeplist_file))
     assert web_util.url_exists(manifest_url)
+
+
+@contextlib.contextmanager
+def spec_hash(spec: spack.spec.Spec, prefix: str):
+    spec_hashes = [spec.format("{/hash}")]
+    for dep_spec in spec.traverse():
+        spec_hashes.append(dep_spec.format("{/hash}"))
+    yield spec_hashes
+
+
+@contextlib.contextmanager
+def spec_specfile(spec: spack.spec.Spec, prefix: pathlib.Path):
+    # Hash in name with format /{hash}/ tests for bad matching of single hash
+    os.makedirs(str(prefix / spec.format("{hash}")))
+    specfile = prefix / spec.format("{hash}") / "spec.json"
+    with open(specfile, "w", encoding="utf-8") as fd:
+        json.dump(spec.to_dict(), fd)
+    yield [str(specfile)]
+
+
+def spec_env_name(spec: spack.spec.Spec) -> str:
+    return f"specenv-{spec.dag_hash()}"
+
+
+@contextlib.contextmanager
+def spec_env(spec: spack.spec.Spec, prefix: str):
+    # Create a unique environment for this spec only
+    env_name = spec_env_name(spec)
+    if not ev.exists(env_name):
+        env("create", "--without-view", env_name)
+
+    with ev.environment_from_name_or_dir(env_name):
+        add(f"{spec.name}/{spec.dag_hash()}")
+        # This should handle concretization and updating the environment
+        # to mark all packges as installed
+        install()
+        yield []
+
+
+@contextlib.contextmanager
+def spec_lockfile(spec: spack.spec.Spec, prefix: str):
+    env_name = spec_env_name(spec)
+    with spec_env(spec, prefix):
+        pass
+    yield [os.path.join(ev.environment_dir_from_name(env_name, exists_ok=True), "spack.lock")]
+
+
+def read_specs_in_index(mirror_directory, view):
+    url_and_version = spack.binary_distribution.MirrorURLAndVersion(
+        f"file://{mirror_directory}", SUPPORTED_LAYOUT_VERSIONS[0], view
+    )
+    fetcher = spack.binary_distribution.DefaultIndexFetcher(url_and_version, None)
+    result = fetcher.conditional_fetch()
+    db_dict = json.loads(result.data)
+    return [h for h in db_dict["database"]["installs"]]
+
+
+def test_buildcache_create_view_failure(tmp_path, mutable_config, mutable_mock_env_path):
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # No spec sources should raise an exception
+    with pytest.raises(spack.main.SpackCommandError):
+        command_args = ["create-view", "--name", "test_view", "my-mirror"]
+        buildcache(*command_args)
+
+    # spec sources should raise an exception
+    expect = "Could not determine spec source type of DEADBEEF"
+    with pytest.raises(spack.error.SpackError, match=expect):
+        command_args = ["create-view", "--name", "test_view", "my-mirror", "DEADBEEF"]
+        buildcache(*command_args)
+
+    invalid_field_json = tmp_path / "invalid_field_json.json"
+    invalid_field_json.write_text('{"DEADBEEF": []}')
+    with pytest.raises(spack.error.SpackError, match=str(invalid_field_json)):
+        command_args = ["create-view", "--name", "test_view", "my-mirror", str(invalid_field_json)]
+        buildcache(*command_args)
+
+
+def test_buildcache_create_view_empty(
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path
+
+    # Push a spec to the cache
+    mpileaks_specs = mutable_database.query_local("mpileaks")
+    buildcache("push", "--update-index", "my-mirror", mpileaks_specs[0].format("{/hash}"))
+
+    # Make sure the view doesn't exist yet
+    with pytest.raises(spack.binary_distribution.FetchIndexError):
+        hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+
+    # Write a minimal lockfile (this is not validated/read by an enviornment)
+    empty_lockfile = tmp_path / "emptylock" / "spack.lock"
+    empty_lockfile.parent.mkdir()
+    empty_lockfile.write_text('{"concrete_specs": []}', encoding="utf-8")
+    # Create a view with now specs
+    command_args = [
+        "create-view",
+        "--force",
+        "--name",
+        "test_view",
+        "my-mirror",
+        str(empty_lockfile),
+    ]
+    out = buildcache(*command_args)
+    assert "No specs found for view, creating an empty index" in out
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    assert not hashes_in_view
+
+
+@pytest.mark.parametrize("sources", ("hash", "specfile", "env", "lockfile"))
+def test_buildcache_create_view(
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, sources
+):
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # Push all of the mpileaks packages to the cache
+    mpileaks_specs = mutable_database.query_local("mpileaks")
+    for s in mpileaks_specs:
+        buildcache("push", "--update-index", "my-mirror", s.format("{/hash}"))
+
+    # Grab all of the hashes for each mpileaks spec
+    mpileaks_0_hashes = [s.dag_hash() for s in mpileaks_specs[0].traverse()]
+    mpileaks_1_hashes = [s.dag_hash() for s in mpileaks_specs[1].traverse()]
+    mpileaks_2_hashes = [s.dag_hash() for s in mpileaks_specs[2].traverse()]
+
+    # Make sure the view doesn't exist yet
+    with pytest.raises(spack.binary_distribution.FetchIndexError):
+        hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+
+    # Create a view using a parametrized source that contains one of the mpileaks
+    with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
+        command_args = ["create-view", "--force", "--name", "test_view", "my-mirror"]
+        if source_args:
+            command_args.extend(source_args)
+        buildcache(*command_args)
+
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    for h in mpileaks_0_hashes:
+        assert h in hashes_in_view
+
+    # Test failure due to existing index
+
+    # Test append
+    with globals()[f"spec_{sources}"](mpileaks_specs[1], tmp_path / "source_stage") as source_args:
+        command_args = ["update-view", "--append", "--name", "test_view", "my-mirror"]
+        if source_args:
+            command_args.extend(source_args)
+        buildcache(*command_args)
+
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    for h in mpileaks_0_hashes + mpileaks_1_hashes:
+        assert h in hashes_in_view
+
+    # Test fail to overwrite
+    expect = "Index already exists. To overwrite or update pass --force or --append respectively"
+    with pytest.raises(spack.error.SpackError, match=expect):
+        command_args = [
+            "update-view",
+            "--name",
+            "test_view",
+            "my-mirror",
+            mpileaks_specs[2].format("{/hash}"),
+        ]
+        buildcache(*command_args)
+
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    for h in mpileaks_0_hashes + mpileaks_1_hashes:
+        assert h in hashes_in_view
+
+    # Test fail to overwrite
+    with globals()[f"spec_{sources}"](mpileaks_specs[2], tmp_path / "source_stage") as source_args:
+        command_args = ["update-view", "--force", "--name", "test_view", "my-mirror"]
+        if source_args:
+            command_args.extend(source_args)
+        buildcache(*command_args)
+
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    for h in mpileaks_2_hashes:
+        assert h in hashes_in_view
+
+    for h in mpileaks_0_hashes + mpileaks_1_hashes:
+        if h not in mpileaks_2_hashes:
+            assert h not in hashes_in_view

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1064,6 +1064,9 @@ def test_buildcache_create_view_failure(tmp_path, mutable_config, mutable_mock_e
 
 def test_buildcache_create_view_empty(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path
+):
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
 
     # Push a spec to the cache
     mpileaks_specs = mutable_database.query_local("mpileaks")

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -979,24 +979,6 @@ def test_buildcache_prune_new_specs_race_condition(
     assert web_util.url_exists(manifest_url)
 
 
-@contextlib.contextmanager
-def spec_hash(spec: spack.spec.Spec, prefix: str):
-    spec_hashes = [spec.format("{/hash}")]
-    for dep_spec in spec.traverse():
-        spec_hashes.append(dep_spec.format("{/hash}"))
-    yield spec_hashes
-
-
-@contextlib.contextmanager
-def spec_specfile(spec: spack.spec.Spec, prefix: pathlib.Path):
-    # Hash in name with format /{hash}/ tests for bad matching of single hash
-    os.makedirs(str(prefix / spec.format("{hash}")))
-    specfile = prefix / spec.format("{hash}") / "spec.json"
-    with open(specfile, "w", encoding="utf-8") as fd:
-        json.dump(spec.to_dict(), fd)
-    yield [str(specfile)]
-
-
 def spec_env_name(spec: spack.spec.Spec) -> str:
     return f"specenv-{spec.dag_hash()}"
 
@@ -1021,7 +1003,7 @@ def spec_lockfile(spec: spack.spec.Spec, prefix: str):
     env_name = spec_env_name(spec)
     with spec_env(spec, prefix):
         pass
-    yield [os.path.join(ev.environment_dir_from_name(env_name, exists_ok=True), "spack.lock")]
+    yield [ev.environment_dir_from_name(env_name, exists_ok=True)]
 
 
 def read_specs_in_index(mirror_directory, view):
@@ -1044,21 +1026,9 @@ def test_buildcache_create_view_failure(tmp_path, mutable_config, mutable_mock_e
         buildcache(*command_args)
 
     # spec sources should raise an exception
-    expect = "Could not determine spec source type of DEADBEEF"
+    expect = "Failed to read specs from source: DEADBEEF"
     with pytest.raises(spack.error.SpackError, match=expect):
         command_args = ["update-index", "--name", "test_view", "my-mirror", "DEADBEEF"]
-        buildcache(*command_args)
-
-    invalid_field_json = tmp_path / "invalid_field_json.json"
-    invalid_field_json.write_text('{"DEADBEEF": []}')
-    with pytest.raises(spack.error.SpackError, match=str(invalid_field_json)):
-        command_args = [
-            "update-index",
-            "--name",
-            "test_view",
-            "my-mirror",
-            str(invalid_field_json),
-        ]
         buildcache(*command_args)
 
 
@@ -1077,8 +1047,10 @@ def test_buildcache_create_view_empty(
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Write a minimal lockfile (this is not validated/read by an enviornment)
+    empty_manifest = tmp_path / "emptylock" / "spack.yaml"
+    empty_manifest.parent.mkdir(exist_ok=False)
+    empty_manifest.write_text("spack: {}", encoding="utf-8")
     empty_lockfile = tmp_path / "emptylock" / "spack.lock"
-    empty_lockfile.parent.mkdir()
     empty_lockfile.write_text(
         '{"_meta": {"lockfile-version": 1}, "roots": [], "concrete_specs": {}}', encoding="utf-8"
     )
@@ -1089,7 +1061,7 @@ def test_buildcache_create_view_empty(
         "--name",
         "test_view",
         "my-mirror",
-        str(empty_lockfile),
+        str(empty_lockfile.parent),
     ]
     out = buildcache(*command_args)
     assert "No specs found for view, creating an empty index" in out
@@ -1097,7 +1069,7 @@ def test_buildcache_create_view_empty(
     assert not hashes_in_view
 
 
-@pytest.mark.parametrize("source", (spec_hash, spec_specfile, spec_env, spec_lockfile))
+@pytest.mark.parametrize("source", (spec_env, spec_lockfile))
 def test_buildcache_create_view(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
 ):
@@ -1147,7 +1119,7 @@ def test_buildcache_create_view(
         assert h not in hashes_in_view or h in mpileaks_0_hashes
 
 
-@pytest.mark.parametrize("source", (spec_hash, spec_specfile, spec_env, spec_lockfile))
+@pytest.mark.parametrize("source", (spec_env, spec_lockfile))
 def test_buildcache_create_view_append(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
 ):
@@ -1190,7 +1162,7 @@ def test_buildcache_create_view_append(
         assert h in hashes_in_view
 
 
-@pytest.mark.parametrize("source", (spec_hash, spec_specfile, spec_env, spec_lockfile))
+@pytest.mark.parametrize("source", (spec_env, spec_lockfile))
 def test_buildcache_create_view_overwrite(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
 ):

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -86,7 +86,7 @@ def test_buildcache_list_allarch(database, mock_get_specs_multiarch):
 
 
 def tests_buildcache_create_env(
-    install_mockery, mock_fetch, monkeypatch, tmp_path: pathlib.Path, mutable_mock_env_path
+    install_mockery, mock_fetch, tmp_path: pathlib.Path, mutable_mock_env_path
 ):
     """ "Ensure that buildcache create creates output files from env"""
     pkg = "trivial-install-test-package"
@@ -119,7 +119,7 @@ def test_buildcache_create_fails_on_noargs(tmp_path: pathlib.Path):
 
 @pytest.mark.skipif(getuid() == 0, reason="user is root")
 def test_buildcache_create_fail_on_perm_denied(
-    install_mockery, mock_fetch, monkeypatch, tmp_path: pathlib.Path
+    install_mockery, mock_fetch, tmp_path: pathlib.Path
 ):
     """Ensure that buildcache create fails on permission denied error."""
     install("trivial-install-test-package")
@@ -320,7 +320,6 @@ def test_buildcache_create_install(
     mock_packages,
     mock_fetch,
     mock_stage,
-    monkeypatch,
     tmp_path: pathlib.Path,
 ):
     """ "Ensure that buildcache create creates output files"""
@@ -604,7 +603,6 @@ def test_install_v2_layout(
     mutable_mock_env_path,
     install_mockery,
     mock_gnupghome,
-    monkeypatch,
 ):
     """Ensure we can still install from signed and unsigned v2 buildcache"""
     test_mirror_path = v2_buildcache_layout(signing)
@@ -661,7 +659,7 @@ def test_basic_migrate_unsigned(v2_buildcache_layout, mutable_config):
     assert not os.path.exists(build_cache_path)
 
 
-def test_basic_migrate_signed(v2_buildcache_layout, monkeypatch, mock_gnupghome, mutable_config):
+def test_basic_migrate_signed(v2_buildcache_layout, mock_gnupghome, mutable_config):
     """Test a signed migration requires a signing key, requires the public
     key originally used to sign the pkgs, fails and prints reasonable messages
     if those requirements are unmet, and eventually succeeds when they are met."""
@@ -984,7 +982,8 @@ def spec_env_name(spec: spack.spec.Spec) -> str:
 
 
 @contextlib.contextmanager
-def spec_env(spec: spack.spec.Spec, prefix: str):
+def spec_env(spec: spack.spec.Spec):
+    """Build cache index view source is current active environment"""
     # Create a unique environment for this spec only
     env_name = spec_env_name(spec)
     if not ev.exists(env_name):
@@ -992,28 +991,45 @@ def spec_env(spec: spack.spec.Spec, prefix: str):
 
     with ev.environment_from_name_or_dir(env_name):
         add(f"{spec.name}/{spec.dag_hash()}")
-        # This should handle concretization and updating the environment
-        # to mark all packges as installed
+        # This should handle updating the environment to mark all packges as installed
         install()
+        # Empty list since we want to use the active environment
         yield []
 
 
 @contextlib.contextmanager
-def spec_lockfile(spec: spack.spec.Spec, prefix: str):
+def spec_env_path(spec: spack.spec.Spec):
+    """Build cache index view source is an environment path"""
+    # Create the environment, reuse they logic from spec_env
     env_name = spec_env_name(spec)
-    with spec_env(spec, prefix):
+    with spec_env(spec):
         pass
     yield [ev.environment_dir_from_name(env_name, exists_ok=True)]
 
 
+@contextlib.contextmanager
+def spec_env_by_name(spec: spack.spec.Spec):
+    """Build cache index view source is an managed environment name"""
+    # Create the environment, reuse they logic from spec_env
+    env_name = spec_env_name(spec)
+    with spec_env(spec):
+        pass
+    yield [env_name]
+
+
 def read_specs_in_index(mirror_directory, view):
+    """Read specs hashes from a build cache index (ie. a database file)
+
+    This assumes the layout of the database holds the spec hashes under:
+        database -> installs -> hashes...
+    """
     mirror_metadata = spack.binary_distribution.MirrorMetadata(
         f"file://{mirror_directory}", spack.mirrors.mirror.SUPPORTED_LAYOUT_VERSIONS[0], view
     )
     fetcher = spack.binary_distribution.DefaultIndexFetcher(mirror_metadata, None)
     result = fetcher.conditional_fetch()
     db_dict = json.loads(result.data)
-    return [h for h in db_dict["database"]["installs"]]
+    return set([h for h in db_dict["database"]["installs"]])
 
 
 def test_buildcache_create_view_failure(tmp_path, mutable_config, mutable_mock_env_path):
@@ -1040,7 +1056,7 @@ def test_buildcache_create_view_empty(
 
     # Push a spec to the cache
     mpileaks_specs = mutable_database.query_local("mpileaks")
-    buildcache("push", "--update-index", "my-mirror", mpileaks_specs[0].format("{/hash}"))
+    buildcache("push", "my-mirror", mpileaks_specs[0].format("{/hash}"))
 
     # Make sure the view doesn't exist yet
     with pytest.raises(spack.binary_distribution.FetchIndexError):
@@ -1066,10 +1082,11 @@ def test_buildcache_create_view_empty(
     out = buildcache(*command_args)
     assert "No specs found for view, creating an empty index" in out
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    # Assert there are no hashes in the view
     assert not hashes_in_view
 
 
-@pytest.mark.parametrize("source", (spec_env, spec_lockfile))
+@pytest.mark.parametrize("source", (spec_env, spec_env_path, spec_env_by_name))
 def test_buildcache_create_view(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
 ):
@@ -1079,26 +1096,25 @@ def test_buildcache_create_view(
     # Push all of the mpileaks packages to the cache
     mpileaks_specs = mutable_database.query_local("mpileaks")
     for s in mpileaks_specs:
-        buildcache("push", "--update-index", "my-mirror", s.format("{/hash}"))
+        buildcache("push", "my-mirror", s.format("{/hash}"))
 
     # Grab all of the hashes for each mpileaks spec
-    mpileaks_0_hashes = [s.dag_hash() for s in mpileaks_specs[0].traverse()]
-    mpileaks_1_hashes = [s.dag_hash() for s in mpileaks_specs[1].traverse()]
+    mpileaks_0_hashes = set([s.dag_hash() for s in mpileaks_specs[0].traverse()])
 
     # Make sure the view doesn't exist yet
     with pytest.raises(spack.binary_distribution.FetchIndexError):
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Create a view using a parametrized source that contains one of the mpileaks
-    with source(mpileaks_specs[0], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[0]) as source_args:
         command_args = ["update-index", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_0_hashes:
-        assert h in hashes_in_view
+    # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
+    assert not (hashes_in_view - mpileaks_0_hashes)
 
     # Test fail to overwrite without force
     expect = "Index already exists. To overwrite or update pass --force or --append respectively"
@@ -1113,13 +1129,11 @@ def test_buildcache_create_view(
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_0_hashes:
-        assert h in hashes_in_view
-    for h in mpileaks_1_hashes:
-        assert h not in hashes_in_view or h in mpileaks_0_hashes
+    # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
+    assert not (hashes_in_view - mpileaks_0_hashes)
 
 
-@pytest.mark.parametrize("source", (spec_env, spec_lockfile))
+@pytest.mark.parametrize("source", (spec_env, spec_env_path, spec_env_by_name))
 def test_buildcache_create_view_append(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
 ):
@@ -1129,40 +1143,41 @@ def test_buildcache_create_view_append(
     # Push all of the mpileaks packages to the cache
     mpileaks_specs = mutable_database.query_local("mpileaks")
     for s in mpileaks_specs:
-        buildcache("push", "--update-index", "my-mirror", s.format("{/hash}"))
+        buildcache("push", "my-mirror", s.format("{/hash}"))
 
     # Grab all of the hashes for each mpileaks spec
-    mpileaks_0_hashes = [s.dag_hash() for s in mpileaks_specs[0].traverse()]
-    mpileaks_1_hashes = [s.dag_hash() for s in mpileaks_specs[1].traverse()]
+    mpileaks_0_hashes = set([s.dag_hash() for s in mpileaks_specs[0].traverse()])
+    mpileaks_1_hashes = set([s.dag_hash() for s in mpileaks_specs[1].traverse()])
 
     # Make sure the view doesn't exist yet
     with pytest.raises(spack.binary_distribution.FetchIndexError):
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Test append to empty index view
-    with source(mpileaks_specs[0], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[0]) as source_args:
         command_args = ["update-index", "-y", "--append", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_0_hashes:
-        assert h in hashes_in_view
+    # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
+    assert not (hashes_in_view - mpileaks_0_hashes)
 
     # Test append to existing index view
-    with source(mpileaks_specs[1], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[1]) as source_args:
         command_args = ["update-index", "-y", "--append", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_0_hashes + mpileaks_1_hashes:
-        assert h in hashes_in_view
+    # Assert all of the hashes for mpileaks_0_hashes and mpileaks_1_hashes exist in the view,
+    # and no other hashes
+    assert not (hashes_in_view - (mpileaks_0_hashes | mpileaks_1_hashes))
 
 
-@pytest.mark.parametrize("source", (spec_env, spec_lockfile))
+@pytest.mark.parametrize("source", (spec_env, spec_env_path, spec_env_by_name))
 def test_buildcache_create_view_overwrite(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
 ):
@@ -1172,36 +1187,122 @@ def test_buildcache_create_view_overwrite(
     # Push all of the mpileaks packages to the cache
     mpileaks_specs = mutable_database.query_local("mpileaks")
     for s in mpileaks_specs:
-        buildcache("push", "--update-index", "my-mirror", s.format("{/hash}"))
+        buildcache("push", "my-mirror", s.format("{/hash}"))
 
     # Grab all of the hashes for each mpileaks spec
-    mpileaks_0_hashes = [s.dag_hash() for s in mpileaks_specs[0].traverse()]
-    mpileaks_1_hashes = [s.dag_hash() for s in mpileaks_specs[1].traverse()]
+    mpileaks_0_hashes = set([s.dag_hash() for s in mpileaks_specs[0].traverse()])
+    mpileaks_1_hashes = set([s.dag_hash() for s in mpileaks_specs[1].traverse()])
 
     # Make sure the view doesn't exist yet
     with pytest.raises(spack.binary_distribution.FetchIndexError):
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Create a view using a parametrized source that contains one of the mpileaks
-    with source(mpileaks_specs[0], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[0]) as source_args:
         command_args = ["update-index", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_0_hashes:
-        assert h in hashes_in_view
+    # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
+    assert not (hashes_in_view - mpileaks_0_hashes)
 
     # Override a view with force
-    with source(mpileaks_specs[1], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[1]) as source_args:
         command_args = ["update-index", "--force", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_1_hashes:
-        assert h in hashes_in_view
-    for h in mpileaks_0_hashes:
-        assert h not in hashes_in_view or h in mpileaks_1_hashes
+    # Assert all of the hashes for mpileaks_1_hashes exist in the view, and no other hashes
+    assert not (hashes_in_view - mpileaks_1_hashes)
+
+
+def test_buildcache_create_view_non_active_env(
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path
+):
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # Push all of the mpileaks packages to the cache
+    mpileaks_specs = mutable_database.query_local("mpileaks")
+    for s in mpileaks_specs:
+        buildcache("push", "my-mirror", s.format("{/hash}"))
+
+    # Grab all of the hashes for each mpileaks spec
+    mpileaks_0_hashes = set([s.dag_hash() for s in mpileaks_specs[0].traverse()])
+
+    # Make sure the view doesn't exist yet
+    with pytest.raises(spack.binary_distribution.FetchIndexError):
+        hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+
+    # Create a view from an environment name that is different from the current active environment
+    with spec_env_by_name(mpileaks_specs[0]) as source_args:
+        with spec_env(mpileaks_specs[1]) as _:
+            command_args = ["update-index", "--name", "test_view", "my-mirror"]
+            if source_args:
+                command_args.extend(source_args)
+            buildcache(*command_args)
+
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    # Assert all of the hashes for mpileaks_0_hashes exist in the view, and no other hashes
+    assert not (hashes_in_view - mpileaks_0_hashes)
+
+
+@pytest.mark.parametrize("view", (None, "test_view"))
+@pytest.mark.disable_clean_stage_check
+def test_buildcache_check_index_full(
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, view
+):
+    view_args = ["--name", view] if view is not None else []
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", *view_args, "my-mirror", mirror_directory)
+
+    # Push all of the mpileaks packages to the cache
+    mpileaks_specs = mutable_database.query_local("mpileaks")
+    for s in mpileaks_specs:
+        buildcache("push", "my-mirror", s.format("{/hash}"))
+
+    # Activate environment containing mpileaks[0]
+    with spec_env(mpileaks_specs[0]):
+        buildcache("update-index", "my-mirror")
+
+    out = buildcache("check-index", "--verify", "exists", "manifests", "blobs", "--", "my-mirror")
+    # Everything thing be good here
+    assert "Index exists in mirror: my-mirror"
+    assert "Missing specs: 0"
+    assert "Missing blobs: 0"
+    if view:
+        assert "Unindexed specs: n/a" in out
+    else:
+        assert "Unindexed specs: 0" in out
+
+    # Remove the index blob
+    # This creates index not for both view and non-view indices
+    # For non-view indices this is also a missing blob
+    index_name = "index.manifest.json"
+    if view:
+        index_name = os.path.join(view, index_name)
+    blob_path = tmp_path / "blobs" / "sha256"
+    with open(tmp_path / "v3" / "manifests" / "index" / index_name, "r", encoding="utf-8") as fd:
+        manifest = json.load(fd)
+        print(manifest)
+        digest = manifest["data"][0]["checksum"]
+        blob_path = blob_path / digest[:2] / digest
+
+    # Delete the index manifest
+    os.remove(blob_path)
+
+    out = buildcache("check-index", "--verify", "exists", "manifests", "blobs", "--", "my-mirror")
+    # Everything thing be good here
+    assert "Index does not exist in mirror: my-mirror"
+    assert "Missing specs: 0"
+    if view:
+        assert "Unindexed specs: n/a" in out
+        assert "Missing blobs: 0"
+    else:
+        assert "The index blob is missing" in out
+        assert "Unindexed specs: 15" in out
+        assert "Missing blobs: 1"

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1097,9 +1097,9 @@ def test_buildcache_create_view_empty(
     assert not hashes_in_view
 
 
-@pytest.mark.parametrize("sources", ("hash", "specfile", "env", "lockfile"))
+@pytest.mark.parametrize("source", (spec_hash, spec_specfile, spec_env, spec_lockfile))
 def test_buildcache_create_view(
-    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, sources
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
 ):
     mirror_directory = str(tmp_path)
     mirror("add", "--unsigned", "my-mirror", mirror_directory)
@@ -1118,7 +1118,7 @@ def test_buildcache_create_view(
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Create a view using a parametrized source that contains one of the mpileaks
-    with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[0], tmp_path / "source_stage") as source_args:
         command_args = ["update-index", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
@@ -1147,9 +1147,9 @@ def test_buildcache_create_view(
         assert h not in hashes_in_view or h in mpileaks_0_hashes
 
 
-@pytest.mark.parametrize("sources", ("hash", "specfile", "env", "lockfile"))
+@pytest.mark.parametrize("source", (spec_hash, spec_specfile, spec_env, spec_lockfile))
 def test_buildcache_create_view_append(
-    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, sources
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
 ):
     mirror_directory = str(tmp_path)
     mirror("add", "--unsigned", "my-mirror", mirror_directory)
@@ -1168,7 +1168,7 @@ def test_buildcache_create_view_append(
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Test append to empty index view
-    with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[0], tmp_path / "source_stage") as source_args:
         command_args = ["update-index", "--append", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
@@ -1179,7 +1179,7 @@ def test_buildcache_create_view_append(
         assert h in hashes_in_view
 
     # Test append to existing index view
-    with globals()[f"spec_{sources}"](mpileaks_specs[1], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[1], tmp_path / "source_stage") as source_args:
         command_args = ["update-index", "--append", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
@@ -1190,9 +1190,9 @@ def test_buildcache_create_view_append(
         assert h in hashes_in_view
 
 
-@pytest.mark.parametrize("sources", ("hash", "specfile", "env", "lockfile"))
+@pytest.mark.parametrize("source", (spec_hash, spec_specfile, spec_env, spec_lockfile))
 def test_buildcache_create_view_overwrite(
-    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, sources
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, source
 ):
     mirror_directory = str(tmp_path)
     mirror("add", "--unsigned", "my-mirror", mirror_directory)
@@ -1211,7 +1211,7 @@ def test_buildcache_create_view_overwrite(
         hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
 
     # Create a view using a parametrized source that contains one of the mpileaks
-    with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[0], tmp_path / "source_stage") as source_args:
         command_args = ["update-index", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
@@ -1222,7 +1222,7 @@ def test_buildcache_create_view_overwrite(
         assert h in hashes_in_view
 
     # Override a view with force
-    with globals()[f"spec_{sources}"](mpileaks_specs[1], tmp_path / "source_stage") as source_args:
+    with source(mpileaks_specs[1], tmp_path / "source_stage") as source_args:
         command_args = ["update-index", "--force", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1025,7 +1025,7 @@ def spec_lockfile(spec: spack.spec.Spec, prefix: str):
 
 
 def read_specs_in_index(mirror_directory, view):
-    url_and_version = spack.binary_distribution.MirrorURLAndVersion(
+    url_and_version = spack.binary_distribution.MirrorMetadata(
         f"file://{mirror_directory}", spack.mirrors.mirror.SUPPORTED_LAYOUT_VERSIONS[0], view
     )
     fetcher = spack.binary_distribution.DefaultIndexFetcher(url_and_version, None)

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1082,7 +1082,7 @@ def test_buildcache_create_view_empty(
     empty_lockfile.write_text(
         '{"_meta": {"lockfile-version": 1}, "roots": [], "concrete_specs": {}}', encoding="utf-8"
     )
-    # Create a view with now specs
+    # Create a view with no specs
     command_args = [
         "update-index",
         "--force",

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1071,7 +1071,9 @@ def test_buildcache_create_view_empty(
     # Write a minimal lockfile (this is not validated/read by an enviornment)
     empty_lockfile = tmp_path / "emptylock" / "spack.lock"
     empty_lockfile.parent.mkdir()
-    empty_lockfile.write_text('{"concrete_specs": []}', encoding="utf-8")
+    empty_lockfile.write_text(
+        '{"_meta": {"lockfile-version": 1}, "roots": [], "concrete_specs": {}}', encoding="utf-8"
+    )
     # Create a view with now specs
     command_args = [
         "create-view",

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1090,6 +1090,49 @@ def test_buildcache_create_view_empty(
 
 
 @pytest.mark.parametrize("sources", ("hash", "specfile", "env", "lockfile"))
+def test_buildcache_create_view_append(
+    tmp_path, mutable_config, mutable_database, mutable_mock_env_path, sources
+):
+    mirror_directory = str(tmp_path)
+    mirror("add", "--unsigned", "my-mirror", mirror_directory)
+
+    # Push all of the mpileaks packages to the cache
+    mpileaks_specs = mutable_database.query_local("mpileaks")
+    for s in mpileaks_specs:
+        buildcache("push", "--update-index", "my-mirror", s.format("{/hash}"))
+
+    # Grab all of the hashes for each mpileaks spec
+    mpileaks_0_hashes = [s.dag_hash() for s in mpileaks_specs[0].traverse()]
+    mpileaks_1_hashes = [s.dag_hash() for s in mpileaks_specs[1].traverse()]
+
+    # Make sure the view doesn't exist yet
+    with pytest.raises(spack.binary_distribution.FetchIndexError):
+        hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+
+    # Test append to empty index view
+    with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
+        command_args = ["update-view", "--append", "--name", "test_view", "my-mirror"]
+        if source_args:
+            command_args.extend(source_args)
+        buildcache(*command_args)
+
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    for h in mpileaks_0_hashes:
+        assert h in hashes_in_view
+
+    # Test append to existing index view
+    with globals()[f"spec_{sources}"](mpileaks_specs[1], tmp_path / "source_stage") as source_args:
+        command_args = ["update-view", "--append", "--name", "test_view", "my-mirror"]
+        if source_args:
+            command_args.extend(source_args)
+        buildcache(*command_args)
+
+    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
+    for h in mpileaks_0_hashes + mpileaks_1_hashes:
+        assert h in hashes_in_view
+
+
+@pytest.mark.parametrize("sources", ("hash", "specfile", "env", "lockfile"))
 def test_buildcache_create_view(
     tmp_path, mutable_config, mutable_database, mutable_mock_env_path, sources
 ):
@@ -1112,7 +1155,7 @@ def test_buildcache_create_view(
 
     # Create a view using a parametrized source that contains one of the mpileaks
     with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
-        command_args = ["create-view", "--force", "--name", "test_view", "my-mirror"]
+        command_args = ["create-view", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
@@ -1121,20 +1164,7 @@ def test_buildcache_create_view(
     for h in mpileaks_0_hashes:
         assert h in hashes_in_view
 
-    # Test failure due to existing index
-
-    # Test append
-    with globals()[f"spec_{sources}"](mpileaks_specs[1], tmp_path / "source_stage") as source_args:
-        command_args = ["update-view", "--append", "--name", "test_view", "my-mirror"]
-        if source_args:
-            command_args.extend(source_args)
-        buildcache(*command_args)
-
-    hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_0_hashes + mpileaks_1_hashes:
-        assert h in hashes_in_view
-
-    # Test fail to overwrite
+    # Test fail to overwrite without force
     expect = "Index already exists. To overwrite or update pass --force or --append respectively"
     with pytest.raises(spack.error.SpackError, match=expect):
         command_args = [
@@ -1147,20 +1177,21 @@ def test_buildcache_create_view(
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_0_hashes + mpileaks_1_hashes:
+    for h in mpileaks_0_hashes:
         assert h in hashes_in_view
+    for h in mpileaks_2_hashes:
+        assert h not in hashes_in_view or h in mpileaks_0_hashes
 
-    # Test fail to overwrite
-    with globals()[f"spec_{sources}"](mpileaks_specs[2], tmp_path / "source_stage") as source_args:
-        command_args = ["update-view", "--force", "--name", "test_view", "my-mirror"]
+    # Override a view with force
+    with globals()[f"spec_{sources}"](mpileaks_specs[1], tmp_path / "source_stage") as source_args:
+        command_args = ["create-view", "--force", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
 
     hashes_in_view = read_specs_in_index(mirror_directory, "test_view")
-    for h in mpileaks_2_hashes:
+    for h in mpileaks_1_hashes:
         assert h in hashes_in_view
+    for h in mpileaks_0_hashes:
+        assert h not in hashes_in_view or h in mpileaks_1_hashes
 
-    for h in mpileaks_0_hashes + mpileaks_1_hashes:
-        if h not in mpileaks_2_hashes:
-            assert h not in hashes_in_view

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1007,10 +1007,10 @@ def spec_lockfile(spec: spack.spec.Spec, prefix: str):
 
 
 def read_specs_in_index(mirror_directory, view):
-    url_and_version = spack.binary_distribution.MirrorMetadata(
+    mirror_metadata = spack.binary_distribution.MirrorMetadata(
         f"file://{mirror_directory}", spack.mirrors.mirror.SUPPORTED_LAYOUT_VERSIONS[0], view
     )
-    fetcher = spack.binary_distribution.DefaultIndexFetcher(url_and_version, None)
+    fetcher = spack.binary_distribution.DefaultIndexFetcher(mirror_metadata, None)
     result = fetcher.conditional_fetch()
     db_dict = json.loads(result.data)
     return [h for h in db_dict["database"]["installs"]]

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1040,19 +1040,25 @@ def test_buildcache_create_view_failure(tmp_path, mutable_config, mutable_mock_e
 
     # No spec sources should raise an exception
     with pytest.raises(spack.main.SpackCommandError):
-        command_args = ["create-view", "--name", "test_view", "my-mirror"]
+        command_args = ["update-index", "--name", "test_view", "my-mirror"]
         buildcache(*command_args)
 
     # spec sources should raise an exception
     expect = "Could not determine spec source type of DEADBEEF"
     with pytest.raises(spack.error.SpackError, match=expect):
-        command_args = ["create-view", "--name", "test_view", "my-mirror", "DEADBEEF"]
+        command_args = ["update-index", "--name", "test_view", "my-mirror", "DEADBEEF"]
         buildcache(*command_args)
 
     invalid_field_json = tmp_path / "invalid_field_json.json"
     invalid_field_json.write_text('{"DEADBEEF": []}')
     with pytest.raises(spack.error.SpackError, match=str(invalid_field_json)):
-        command_args = ["create-view", "--name", "test_view", "my-mirror", str(invalid_field_json)]
+        command_args = [
+            "update-index",
+            "--name",
+            "test_view",
+            "my-mirror",
+            str(invalid_field_json),
+        ]
         buildcache(*command_args)
 
 
@@ -1075,7 +1081,7 @@ def test_buildcache_create_view_empty(
     )
     # Create a view with now specs
     command_args = [
-        "create-view",
+        "update-index",
         "--force",
         "--name",
         "test_view",
@@ -1110,7 +1116,7 @@ def test_buildcache_create_view(
 
     # Create a view using a parametrized source that contains one of the mpileaks
     with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
-        command_args = ["create-view", "--name", "test_view", "my-mirror"]
+        command_args = ["update-index", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
@@ -1123,7 +1129,7 @@ def test_buildcache_create_view(
     expect = "Index already exists. To overwrite or update pass --force or --append respectively"
     with pytest.raises(spack.error.SpackError, match=expect):
         command_args = [
-            "update-view",
+            "update-index",
             "--name",
             "test_view",
             "my-mirror",
@@ -1160,7 +1166,7 @@ def test_buildcache_create_view_append(
 
     # Test append to empty index view
     with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
-        command_args = ["update-view", "--append", "--name", "test_view", "my-mirror"]
+        command_args = ["update-index", "--append", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
@@ -1171,7 +1177,7 @@ def test_buildcache_create_view_append(
 
     # Test append to existing index view
     with globals()[f"spec_{sources}"](mpileaks_specs[1], tmp_path / "source_stage") as source_args:
-        command_args = ["update-view", "--append", "--name", "test_view", "my-mirror"]
+        command_args = ["update-index", "--append", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
@@ -1203,7 +1209,7 @@ def test_buildcache_create_view_overwrite(
 
     # Create a view using a parametrized source that contains one of the mpileaks
     with globals()[f"spec_{sources}"](mpileaks_specs[0], tmp_path / "source_stage") as source_args:
-        command_args = ["create-view", "--name", "test_view", "my-mirror"]
+        command_args = ["update-index", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)
@@ -1214,7 +1220,7 @@ def test_buildcache_create_view_overwrite(
 
     # Override a view with force
     with globals()[f"spec_{sources}"](mpileaks_specs[1], tmp_path / "source_stage") as source_args:
-        command_args = ["create-view", "--force", "--name", "test_view", "my-mirror"]
+        command_args = ["update-index", "--force", "--name", "test_view", "my-mirror"]
         if source_args:
             command_args.extend(source_args)
         buildcache(*command_args)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -875,8 +875,8 @@ spack:
 
             # Validate resulting buildcache (database) index
             layout_version = spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
-            url_and_version = spack.binary_distribution.MirrorMetadata(mirror_url, layout_version)
-            index_fetcher = spack.binary_distribution.DefaultIndexFetcher(url_and_version, None)
+            mirror_metadata = spack.binary_distribution.MirrorMetadata(mirror_url, layout_version)
+            index_fetcher = spack.binary_distribution.DefaultIndexFetcher(mirror_metadata, None)
             result = index_fetcher.conditional_fetch()
             spack.vendor.jsonschema.validate(json.loads(result.data), db_idx_schema)
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -875,9 +875,7 @@ spack:
 
             # Validate resulting buildcache (database) index
             layout_version = spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
-            url_and_version = spack.binary_distribution.MirrorURLAndVersion(
-                mirror_url, layout_version
-            )
+            url_and_version = spack.binary_distribution.MirrorMetadata(mirror_url, layout_version)
             index_fetcher = spack.binary_distribution.DefaultIndexFetcher(url_and_version, None)
             result = index_fetcher.conditional_fetch()
             spack.vendor.jsonschema.validate(json.loads(result.data), db_idx_schema)

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1388,6 +1388,9 @@ class MirrorURLAndVersion:
         url, version, view = m.groups()
         return cls(url, int(version), view)
 
+    def strip_view(self) -> "MirrorURLAndVersion":
+        return MirrorURLAndVersion(self.url, self.version)
+
 
 class InvalidMetadataFile(spack.error.SpackError):
     """Raised when spack encounters a spec file it cannot understand or process"""

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -42,9 +42,6 @@ from spack.util.executable import which
 #: Version 3: Introduces content-addressable tarballs
 CURRENT_BUILD_CACHE_LAYOUT_VERSION = 3
 
-#: The layout version spack can current install
-SUPPORTED_LAYOUT_VERSIONS = (3, 2)
-
 #: The name of the default buildcache index manifest file
 INDEX_MANIFEST_FILE = "index.manifest.json"
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1371,7 +1371,7 @@ class MirrorURLAndVersion:
     def __str__(self):
         s = f"{self.url}__v{self.version}"
         if self.view:
-            s += f"__@{self.view}"
+            s += f"__{self.view}"
         return s
 
     def __eq__(self, other):
@@ -1384,11 +1384,11 @@ class MirrorURLAndVersion:
 
     @classmethod
     def from_string(cls, s: str):
-        m = re.match(r"^(.*)__v([0-9]+)(__@(.*))?$", s)
+        m = re.match(r"^(.*)__v([0-9]+)(?:__(.*))?$", s)
         if not m:
             raise MirrorURLAndVersionError(f"Malformed string {s}")
 
-        url, version, _, view = m.groups()
+        url, version, view = m.groups()
         return cls(url, int(version), view)
 
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1358,7 +1358,7 @@ class MirrorURLAndVersion:
     track of downloaded/processed buildcache index files from remote mirrors
     in some layout version."""
 
-    __slots__ = ("url", "version")
+    __slots__ = ("url", "version", "view")
 
     def __init__(self, url: str, version: int, view: Optional[str] = None):
         self.url = url

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -259,11 +259,11 @@ class URLBuildcacheEntry:
         return rematch.group(1)
 
     @classmethod
-    def get_index_url(cls, mirror_url: str):
+    def get_index_url(cls, mirror_url: str, view: Optional[str] = None):
         return url_util.join(
             mirror_url,
             *cls.get_relative_path_components(BuildcacheComponent.INDEX),
-            cls.BUILDCACHE_INDEX_FILE,
+            url_util.join(view or "", cls.BUILDCACHE_INDEX_FILE),
         )
 
     @classmethod
@@ -571,6 +571,7 @@ class URLBuildcacheEntry:
         # write the manifest to a temporary location
         manifest_file_name = f"{manifest_name}.manifest.json"
         manifest_path = os.path.join(tmpdir, manifest_file_name)
+        os.makedirs(os.path.dirname(manifest_path), exist_ok=True)
         with open(manifest_path, "w", encoding="utf-8") as f:
             json.dump(manifest.to_dict(), f, indent=0, separators=(",", ":"))
             # Note: when using gpg clear sign, we need to avoid long lines (19995
@@ -1362,56 +1363,58 @@ class MirrorURLAndVersion:
 
     __slots__ = ("url", "version")
 
-    def __init__(self, url: str, version: int):
+    def __init__(self, url: str, version: int, view: Optional[str] = None):
         self.url = url
         self.version = version
+        self.view = view
 
     def __str__(self):
-        return f"{self.url}__v{self.version}"
+        s = f"{self.url}__v{self.version}"
+        if self.view:
+            s += f"__@{self.view}"
+        return s
 
     def __eq__(self, other):
         if not isinstance(other, MirrorURLAndVersion):
             return NotImplemented
-        return self.url == other.url and self.version == other.version
+        return self.url == other.url and self.version == other.version and self.view == other.view
 
     def __hash__(self):
-        return hash((self.url, self.version))
+        return hash((self.url, self.version, self.view))
 
     @classmethod
     def from_string(cls, s: str):
-        parts = s.split("__v")
-        return cls(parts[0], int(parts[1]))
+        m = re.match(r"^(.*)__v([0-9]+)(__@(.*))?$", s)
+        if not m:
+            raise MirrorURLAndVersionError(f"Malformed string {s}")
+
+        url, version, _, view = m.groups()
+        return cls(url, int(version), view)
 
 
 class InvalidMetadataFile(spack.error.SpackError):
     """Raised when spack encounters a spec file it cannot understand or process"""
 
-    pass
-
 
 class BuildcacheEntryError(spack.error.SpackError):
     """Raised for problems finding or accessing binary cache entry on mirror"""
-
-    pass
 
 
 class NoSuchBlobException(spack.error.SpackError):
     """Raised when manifest does have some requested type of requested type"""
 
-    pass
-
 
 class NoVerifyException(BuildcacheEntryError):
     """Raised if file fails signature verification"""
-
-    pass
 
 
 class UnknownBuildcacheLayoutError(BuildcacheEntryError):
     """Raised when unrecognized buildcache layout version is encountered"""
 
-    pass
-
 
 class ListMirrorSpecsError(spack.error.SpackError):
     """Raised when unable to retrieve list of specs from the mirror"""
+
+
+class MirrorURLAndVersionError(spack.error.SpackError):
+    """Raised when unable to interpret a MirrorURLAndVersion string"""

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1351,7 +1351,7 @@ def try_verify(specfile_path):
     return True
 
 
-class MirrorURLAndVersion:
+class MirrorMetadata:
     """Simple class to hold a mirror url and a buildcache layout version
 
     This class is used by BinaryCacheIndex to produce a key used to keep
@@ -1372,7 +1372,7 @@ class MirrorURLAndVersion:
         return s
 
     def __eq__(self, other):
-        if not isinstance(other, MirrorURLAndVersion):
+        if not isinstance(other, MirrorMetadata):
             return NotImplemented
         return self.url == other.url and self.version == other.version and self.view == other.view
 
@@ -1383,13 +1383,13 @@ class MirrorURLAndVersion:
     def from_string(cls, s: str):
         m = re.match(r"^(.*)__v([0-9]+)(?:__(.*))?$", s)
         if not m:
-            raise MirrorURLAndVersionError(f"Malformed string {s}")
+            raise MirrorMetadataError(f"Malformed string {s}")
 
         url, version, view = m.groups()
         return cls(url, int(version), view)
 
-    def strip_view(self) -> "MirrorURLAndVersion":
-        return MirrorURLAndVersion(self.url, self.version)
+    def strip_view(self) -> "MirrorMetadata":
+        return MirrorMetadata(self.url, self.version)
 
 
 class InvalidMetadataFile(spack.error.SpackError):
@@ -1416,5 +1416,5 @@ class ListMirrorSpecsError(spack.error.SpackError):
     """Raised when unable to retrieve list of specs from the mirror"""
 
 
-class MirrorURLAndVersionError(spack.error.SpackError):
-    """Raised when unable to interpret a MirrorURLAndVersion string"""
+class MirrorMetadataError(spack.error.SpackError):
+    """Raised when unable to interpret a MirrorMetadata string"""

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -563,7 +563,7 @@ _spack_buildcache() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="push create install list keys check download prune save-specfile sync update-index rebuild-index migrate"
+        SPACK_COMPREPLY="push create install list keys check download prune save-specfile sync update-index rebuild-index update-view create-view migrate"
     fi
 }
 
@@ -655,6 +655,24 @@ _spack_buildcache_rebuild_index() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help -k --keys"
+    else
+        _mirrors
+    fi
+}
+
+_spack_buildcache_update_view() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f"
+    else
+        _mirrors
+    fi
+}
+
+_spack_buildcache_create_view() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -563,7 +563,7 @@ _spack_buildcache() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="push create install list keys check download prune save-specfile sync update-index rebuild-index update-view create-view migrate"
+        SPACK_COMPREPLY="push create install list keys check download prune save-specfile sync update-index rebuild-index migrate"
     fi
 }
 
@@ -645,7 +645,7 @@ _spack_buildcache_sync() {
 _spack_buildcache_update_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -k --keys"
+        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys"
     else
         _mirrors
     fi
@@ -654,25 +654,7 @@ _spack_buildcache_update_index() {
 _spack_buildcache_rebuild_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -k --keys"
-    else
-        _mirrors
-    fi
-}
-
-_spack_buildcache_update_view() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f"
-    else
-        _mirrors
-    fi
-}
-
-_spack_buildcache_create_view() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f"
+        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -645,7 +645,7 @@ _spack_buildcache_sync() {
 _spack_buildcache_check_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --verify"
+        SPACK_COMPREPLY="-h --help --verify --output -o"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -645,7 +645,7 @@ _spack_buildcache_sync() {
 _spack_buildcache_check_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --verify --output -o"
+        SPACK_COMPREPLY="-h --help --verify --name -n --output -o"
     else
         _mirrors
     fi
@@ -1486,7 +1486,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
+        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --name -n --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -654,7 +654,7 @@ _spack_buildcache_check_index() {
 _spack_buildcache_update_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys"
+        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys -y --yes-to-all"
     else
         _mirrors
     fi
@@ -663,7 +663,7 @@ _spack_buildcache_update_index() {
 _spack_buildcache_rebuild_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys"
+        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys -y --yes-to-all"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -563,7 +563,7 @@ _spack_buildcache() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="push create install list keys check download prune save-specfile sync update-index rebuild-index migrate"
+        SPACK_COMPREPLY="push create install list keys check download prune save-specfile sync check-index update-index rebuild-index migrate"
     fi
 }
 
@@ -639,6 +639,15 @@ _spack_buildcache_sync() {
         SPACK_COMPREPLY="-h --help --manifest-glob"
     else
         SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_buildcache_check_index() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --verify"
+    else
+        _mirrors
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -701,6 +701,8 @@ complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a save-sp
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a sync -d 'sync binaries (and associated metadata) from one mirror to another'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a update-index -d 'update a buildcache index'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a rebuild-index -d 'update a buildcache index'
+complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a update-view -d 'update a buildcache view index'
+complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a create-view -d 'update a buildcache view index'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a migrate -d 'perform in-place binary mirror migration (2 to 3)'
 complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -d 'show this help message and exit'
@@ -875,6 +877,30 @@ complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h 
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
+
+# spack buildcache update-view
+set -g __fish_spack_optspecs_spack_buildcache_update_view h/help n/name= a/append f/force
+
+complete -c spack -n '__fish_spack_using_command buildcache update-view' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command buildcache update-view' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command buildcache update-view' -l name -s n -r -f -a name
+complete -c spack -n '__fish_spack_using_command buildcache update-view' -l name -s n -r -d 'Name of the view index to update'
+complete -c spack -n '__fish_spack_using_command buildcache update-view' -l append -s a -f -a append
+complete -c spack -n '__fish_spack_using_command buildcache update-view' -l append -s a -d 'Append the listed specs to the current view index if it already exists. This operation does not guarentee atomic write and should be run with care.'
+complete -c spack -n '__fish_spack_using_command buildcache update-view' -l force -s f -f -a force
+complete -c spack -n '__fish_spack_using_command buildcache update-view' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
+
+# spack buildcache create-view
+set -g __fish_spack_optspecs_spack_buildcache_create_view h/help n/name= a/append f/force
+
+complete -c spack -n '__fish_spack_using_command buildcache create-view' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command buildcache create-view' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command buildcache create-view' -l name -s n -r -f -a name
+complete -c spack -n '__fish_spack_using_command buildcache create-view' -l name -s n -r -d 'Name of the view index to update'
+complete -c spack -n '__fish_spack_using_command buildcache create-view' -l append -s a -f -a append
+complete -c spack -n '__fish_spack_using_command buildcache create-view' -l append -s a -d 'Append the listed specs to the current view index if it already exists. This operation does not guarentee atomic write and should be run with care.'
+complete -c spack -n '__fish_spack_using_command buildcache create-view' -l force -s f -f -a force
+complete -c spack -n '__fish_spack_using_command buildcache create-view' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 
 # spack buildcache migrate
 set -g __fish_spack_optspecs_spack_buildcache_migrate h/help u/unsigned d/delete-existing y/yes-to-all

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -699,10 +699,8 @@ complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a downloa
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a prune -d 'prune buildcache entries from the mirror'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a save-specfile -d 'get full spec for dependencies and write them to files in the specified output directory'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a sync -d 'sync binaries (and associated metadata) from one mirror to another'
-complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a update-index -d 'update a buildcache index'
-complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a rebuild-index -d 'update a buildcache index'
-complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a update-view -d 'update a buildcache view index'
-complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a create-view -d 'update a buildcache view index'
+complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a update-index -d 'update a buildcache index or index view if extra arguments are provided.'
+complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a rebuild-index -d 'update a buildcache index or index view if extra arguments are provided.'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a migrate -d 'perform in-place binary mirror migration (2 to 3)'
 complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -d 'show this help message and exit'
@@ -863,44 +861,32 @@ complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-gl
 complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-glob -r -d 'a quoted glob pattern identifying CI rebuild manifest files'
 
 # spack buildcache update-index
-set -g __fish_spack_optspecs_spack_buildcache_update_index h/help k/keys
+set -g __fish_spack_optspecs_spack_buildcache_update_index h/help n/name= a/append f/force k/keys
 
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l name -s n -r -f -a name
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l name -s n -r -d 'Name of the view index to update'
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l append -s a -f -a append
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l append -s a -d 'Append the listed specs to the current view index if it already exists. This operation does not guarentee atomic write and should be run with care.'
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l force -s f -f -a force
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
 
 # spack buildcache rebuild-index
-set -g __fish_spack_optspecs_spack_buildcache_rebuild_index h/help k/keys
+set -g __fish_spack_optspecs_spack_buildcache_rebuild_index h/help n/name= a/append f/force k/keys
 
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l name -s n -r -f -a name
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l name -s n -r -d 'Name of the view index to update'
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l append -s a -f -a append
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l append -s a -d 'Append the listed specs to the current view index if it already exists. This operation does not guarentee atomic write and should be run with care.'
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l force -s f -f -a force
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
-
-# spack buildcache update-view
-set -g __fish_spack_optspecs_spack_buildcache_update_view h/help n/name= a/append f/force
-
-complete -c spack -n '__fish_spack_using_command buildcache update-view' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command buildcache update-view' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command buildcache update-view' -l name -s n -r -f -a name
-complete -c spack -n '__fish_spack_using_command buildcache update-view' -l name -s n -r -d 'Name of the view index to update'
-complete -c spack -n '__fish_spack_using_command buildcache update-view' -l append -s a -f -a append
-complete -c spack -n '__fish_spack_using_command buildcache update-view' -l append -s a -d 'Append the listed specs to the current view index if it already exists. This operation does not guarentee atomic write and should be run with care.'
-complete -c spack -n '__fish_spack_using_command buildcache update-view' -l force -s f -f -a force
-complete -c spack -n '__fish_spack_using_command buildcache update-view' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
-
-# spack buildcache create-view
-set -g __fish_spack_optspecs_spack_buildcache_create_view h/help n/name= a/append f/force
-
-complete -c spack -n '__fish_spack_using_command buildcache create-view' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command buildcache create-view' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command buildcache create-view' -l name -s n -r -f -a name
-complete -c spack -n '__fish_spack_using_command buildcache create-view' -l name -s n -r -d 'Name of the view index to update'
-complete -c spack -n '__fish_spack_using_command buildcache create-view' -l append -s a -f -a append
-complete -c spack -n '__fish_spack_using_command buildcache create-view' -l append -s a -d 'Append the listed specs to the current view index if it already exists. This operation does not guarentee atomic write and should be run with care.'
-complete -c spack -n '__fish_spack_using_command buildcache create-view' -l force -s f -f -a force
-complete -c spack -n '__fish_spack_using_command buildcache create-view' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 
 # spack buildcache migrate
 set -g __fish_spack_optspecs_spack_buildcache_migrate h/help u/unsigned d/delete-existing y/yes-to-all

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -883,7 +883,7 @@ complete -c spack -n '__fish_spack_using_command buildcache update-index' -l nam
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -l append -s a -f -a append
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -l append -s a -d 'Append the listed specs to the current view index if it already exists. This operation does not guarentee atomic write and should be run with care.'
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -l force -s f -f -a force
-complete -c spack -n '__fish_spack_using_command buildcache update-index' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -l force -s f -d 'If a view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s y -l yes-to-all -f -a yes_to_all
@@ -899,7 +899,7 @@ complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l na
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l append -s a -f -a append
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l append -s a -d 'Append the listed specs to the current view index if it already exists. This operation does not guarentee atomic write and should be run with care.'
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l force -s f -f -a force
-complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l force -s f -d 'If a view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s y -l yes-to-all -f -a yes_to_all

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -872,7 +872,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check-index' -l outp
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -l output -s o -r -d 'File to write check details to'
 
 # spack buildcache update-index
-set -g __fish_spack_optspecs_spack_buildcache_update_index h/help n/name= a/append f/force k/keys
+set -g __fish_spack_optspecs_spack_buildcache_update_index h/help n/name= a/append f/force k/keys y/yes-to-all
 
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s h -l help -d 'show this help message and exit'
@@ -884,9 +884,11 @@ complete -c spack -n '__fish_spack_using_command buildcache update-index' -l for
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack buildcache rebuild-index
-set -g __fish_spack_optspecs_spack_buildcache_rebuild_index h/help n/name= a/append f/force k/keys
+set -g __fish_spack_optspecs_spack_buildcache_rebuild_index h/help n/name= a/append f/force k/keys y/yes-to-all
 
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h -l help -d 'show this help message and exit'
@@ -898,6 +900,8 @@ complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l fo
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l force -s f -d 'If an view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack buildcache migrate
 set -g __fish_spack_optspecs_spack_buildcache_migrate h/help u/unsigned d/delete-existing y/yes-to-all

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -699,7 +699,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a downloa
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a prune -d 'prune buildcache entries from the mirror'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a save-specfile -d 'get full spec for dependencies and write them to files in the specified output directory'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a sync -d 'sync binaries (and associated metadata) from one mirror to another'
-complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a check-index -d 'Check if a build cache index is valid'
+complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a check-index -d 'Check if a build cache index, manifests, and blobs are consistent'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a update-index -d 'update a buildcache index or index view if extra arguments are provided.'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a rebuild-index -d 'update a buildcache index or index view if extra arguments are provided.'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a migrate -d 'perform in-place binary mirror migration (2 to 3)'
@@ -862,12 +862,14 @@ complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-gl
 complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-glob -r -d 'a quoted glob pattern identifying CI rebuild manifest files'
 
 # spack buildcache check-index
-set -g __fish_spack_optspecs_spack_buildcache_check_index h/help verify=
+set -g __fish_spack_optspecs_spack_buildcache_check_index h/help verify= o/output=
 
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -l verify -r -f -a 'exists manifests blobs all'
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -l verify -r -d 'List of items to verify along along with the index.'
+complete -c spack -n '__fish_spack_using_command buildcache check-index' -l output -s o -r -f -a output
+complete -c spack -n '__fish_spack_using_command buildcache check-index' -l output -s o -r -d 'File to write check details to'
 
 # spack buildcache update-index
 set -g __fish_spack_optspecs_spack_buildcache_update_index h/help n/name= a/append f/force k/keys

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -862,12 +862,14 @@ complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-gl
 complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-glob -r -d 'a quoted glob pattern identifying CI rebuild manifest files'
 
 # spack buildcache check-index
-set -g __fish_spack_optspecs_spack_buildcache_check_index h/help verify= o/output=
+set -g __fish_spack_optspecs_spack_buildcache_check_index h/help verify= n/name= o/output=
 
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -l verify -r -f -a 'exists manifests blobs all'
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -l verify -r -d 'List of items to verify along along with the index.'
+complete -c spack -n '__fish_spack_using_command buildcache check-index' -l name -s n -r -f -a name
+complete -c spack -n '__fish_spack_using_command buildcache check-index' -l name -s n -r -d 'Name of the view index to check'
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -l output -s o -r -f -a output
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -l output -s o -r -d 'File to write check details to'
 
@@ -2396,7 +2398,7 @@ complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -
 complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -r -d 'find mirror to destroy by url'
 
 # spack mirror add
-set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
+set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed n/name= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
@@ -2410,6 +2412,8 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror add' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror add' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror add' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
+complete -c spack -n '__fish_spack_using_command mirror add' -l name -s n -r -f -a view_name
+complete -c spack -n '__fish_spack_using_command mirror add' -l name -s n -r -d 'Name of the index view for a binary mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -699,6 +699,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a downloa
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a prune -d 'prune buildcache entries from the mirror'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a save-specfile -d 'get full spec for dependencies and write them to files in the specified output directory'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a sync -d 'sync binaries (and associated metadata) from one mirror to another'
+complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a check-index -d 'Check if a build cache index is valid'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a update-index -d 'update a buildcache index or index view if extra arguments are provided.'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a rebuild-index -d 'update a buildcache index or index view if extra arguments are provided.'
 complete -c spack -n '__fish_spack_using_command_pos 0 buildcache' -f -a migrate -d 'perform in-place binary mirror migration (2 to 3)'
@@ -859,6 +860,14 @@ complete -c spack -n '__fish_spack_using_command buildcache sync' -s h -l help -
 complete -c spack -n '__fish_spack_using_command buildcache sync' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-glob -r -f -a manifest_glob
 complete -c spack -n '__fish_spack_using_command buildcache sync' -l manifest-glob -r -d 'a quoted glob pattern identifying CI rebuild manifest files'
+
+# spack buildcache check-index
+set -g __fish_spack_optspecs_spack_buildcache_check_index h/help verify=
+
+complete -c spack -n '__fish_spack_using_command buildcache check-index' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command buildcache check-index' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command buildcache check-index' -l verify -r -f -a 'exists manifests blobs all'
+complete -c spack -n '__fish_spack_using_command buildcache check-index' -l verify -r -d 'List of items to verify along along with the index.'
 
 # spack buildcache update-index
 set -g __fish_spack_optspecs_spack_buildcache_update_index h/help n/name= a/append f/force k/keys


### PR DESCRIPTION
Enable generating index files for build caches containing a subset of specs.

The primary motivation for this change is described in this [discussion](https://github.com/spack/spack/discussions/45629).

This feature is enabled by #48713 which allow concurrent writing of duplicate specs using the build cache layout v3. While likely possible to implement, views are currently not made available for OCI caches.

Build cache views allow for stack/distribution curation to happen using the same unified base cache, while generating "view" indices containing only the packages for each specific distribution. This reduces the total footprint required to provide curated build caches.

For the Spack build caches, each curated stack (ie. HEP/Data-Vis SDK/Radiuss/E4S/etc.) has been required to maintain it's own build cache, and then "promote" binaries from each build cache to a top level cache. This resulted in duplication not only between stacks, but also with the top level cache.

This problem was further exacerbated with snapshot mirrors for develop and releases. These represented full copies of of all binaries concretized in a pipeline. Under the new layout, snapshot storage cost will be reduced from terabytes to megabytes. This will make it possible to persist snapshots longer and/or provide more frequent snapshots (ie. nightly/semi-weekly).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
