### PR TITLE
Bugfix: Only clone spack-packages once when running unit-tests

### DIFF
--- a/etc/spack/defaults/cache_repo/repos.yaml
+++ b/etc/spack/defaults/cache_repo/repos.yaml
@@ -1,0 +1,15 @@
+# -------------------------------------------------------------------------
+# This is the default spack repository configuration. It includes the
+# builtin spack package repository.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/repos.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/repos.yaml
+# -------------------------------------------------------------------------
+repos:
+  builtin:
+    destination: $tempdir/spack/unit_test/

--- a/etc/spack/defaults/include.yaml
+++ b/etc/spack/defaults/include.yaml
@@ -1,4 +1,6 @@
 include:
   - path: "${platform}"
     optional: true
+  - when: '"SPACK_CACHE_REPO" in env'
+    path: cache_repo
   - path: base

--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -245,12 +245,7 @@ def unit_test(parser, args, unknown_args):
             return 1
 
         pytest_args.extend(
-            [
-                "--dist",
-                "loadfile",
-                "--tx",
-                f"{args.numprocesses}*popen//python=spack-tmpconfig spack python",
-            ]
+            ["--dist", "loadfile", "--tx", f"{args.numprocesses}*popen//python=spack python"]
         )
 
     # pytest.ini lives in the root of the spack repository.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -947,6 +947,7 @@ def create_incremental() -> Generator[Configuration, None, None]:
     # This is disabled if user asks for no local configuration.
     if not disable_local_config:
         configuration_paths.append(("system", spack.paths.system_config_path))
+        print("SYST_PATH" + spack.paths.system_config_path)
 
     # Site configuration is per spack instance, for sites or projects
     # No site-level configs should be checked into spack by default.
@@ -959,6 +960,7 @@ def create_incremental() -> Generator[Configuration, None, None]:
     # This is disabled if user asks for no local configuration.
     if not disable_local_config:
         configuration_paths.append(("user", spack.paths.user_config_path))
+        print("USER_PATH" + spack.paths.user_config_path)
 
     # add each scope
     for name, path in configuration_paths:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -930,6 +930,10 @@ def create_incremental() -> Generator[Configuration, None, None]:
         (ConfigScopePriority.BUILTIN, InternalConfigScope("_builtin", CONFIG_DEFAULTS))
     )
 
+    # Must yield the _builtin configuration here in order to avoid recursive
+    # initialization with includes in defaults scope
+    yield cfg
+
     # Builtin paths to configuration files in Spack
     configuration_paths = [
         # Default configuration scope is the lowest-level scope. These are

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -81,6 +81,7 @@ env_subdir_name = ".spack-env"
 
 def env_root_path() -> str:
     """Override default root path if the user specified it"""
+    print("env_root" + str(spack.config.get("config:environment_root")))
     return spack.util.path.canonicalize_path(
         spack.config.get("config:environments_root", default=default_env_path)
     )
@@ -557,6 +558,8 @@ def all_environment_names():
     # operation like list should not try to create a directory.
     if not os.path.exists(env_root_path()):
         return []
+
+    print(f"root path: {env_root_path()}")
 
     env_root = pathlib.Path(env_root_path()).resolve()
 

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -258,7 +258,7 @@ def test_update_completion_arg(shell, tmp_path: pathlib.Path, monkeypatch):
 # Note: this test is never expected to be supported on Windows
 @pytest.mark.not_on_windows("Shell completion script generator fails on windows")
 @pytest.mark.parametrize("shell", ["bash", "fish"])
-def test_updated_completion_scripts(shell, tmp_path: pathlib.Path):
+def test_updated_completion_scripts(no_cached_repo, shell, tmp_path: pathlib.Path):
     """Make sure our shell tab completion scripts remain up-to-date."""
 
     width = 72

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -258,7 +258,7 @@ def test_update_completion_arg(shell, tmp_path: pathlib.Path, monkeypatch):
 # Note: this test is never expected to be supported on Windows
 @pytest.mark.not_on_windows("Shell completion script generator fails on windows")
 @pytest.mark.parametrize("shell", ["bash", "fish"])
-def test_updated_completion_scripts(no_cached_repo, shell, tmp_path: pathlib.Path):
+def test_updated_completion_scripts(shell, tmp_path: pathlib.Path):
     """Make sure our shell tab completion scripts remain up-to-date."""
 
     width = 72

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -382,6 +382,19 @@ def clean_user_environment():
         os.environ[ev.spack_env_var] = spack_env_value
 
 
+os.environ["SPACK_CACHE_REPO"] = "ON"
+
+
+@pytest.fixture
+def no_cached_repo():
+    cache_repo_state = os.environ.get("SPACK_CACHE_REPO")
+    if cache_repo_state:
+        os.environ.pop("SPACK_CACHE_REPO")
+    yield
+    if cache_repo_state:
+        os.environ["SPACK_CACHE_REPO"] = cache_repo_state
+
+
 #
 # Make sure global state of active env does not leak between tests.
 #

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -81,6 +81,14 @@ from spack.util.remote_file_cache import raw_github_gitlab_url
 mirror_cmd = SpackCommand("mirror")
 
 
+@pytest.fixture(scope="function", autouse=True)
+def assert_mock_paths():
+    # Sanity check for the overrides in mock_config_scopes
+    assert os.path.basename(spack.paths.system_config_path) == "sys_conf"
+    assert os.path.basename(spack.paths.user_config_path) == "user_conf"
+    assert os.path.basename(spack.paths.user_cache_path) == "user_cache"
+
+
 def _recursive_chmod(path: Path, mode: int):
     """Recursively change permissions of a directory and all its contents."""
     path.chmod(mode)
@@ -380,19 +388,6 @@ def clean_user_environment():
         yield
     if spack_env_value:
         os.environ[ev.spack_env_var] = spack_env_value
-
-
-os.environ["SPACK_CACHE_REPO"] = "ON"
-
-
-@pytest.fixture
-def no_cached_repo():
-    cache_repo_state = os.environ.get("SPACK_CACHE_REPO")
-    if cache_repo_state:
-        os.environ.pop("SPACK_CACHE_REPO")
-    yield
-    if cache_repo_state:
-        os.environ["SPACK_CACHE_REPO"] = cache_repo_state
 
 
 #
@@ -2401,3 +2396,46 @@ def config_two_gccs(mutable_config):
             },
         ],
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _0_mock_global_configuration_scopes():
+    with tempfile.TemporaryDirectory() as tmp:
+        print(f"Mocking config scopes: {tmp}", file=sys.stderr)
+        mock_path = {}
+        mock_path["system_config_path"] = f"{tmp}/sys_conf"
+        mock_path["user_config_path"] = f"{tmp}/user_conf"
+        mock_path["user_cache_path"] = f"{tmp}/user_cache"
+
+        for var in mock_path:
+            os.makedirs(mock_path[var])
+            setattr(spack.paths, var, mock_path[var])
+
+        config_path = os.path.join(mock_path["user_config_path"], "config.yaml")
+        with open(config_path, "w", encoding="utf-8") as fd:
+            fd.write(
+                f"""
+config:
+  install_tree:
+    root: {tmp}/install
+  misc_cache: $$user_cache_path/cache
+  source_cache: $$user_cache_path/source
+  environments_root: {tmp}/envs"
+"""
+            )
+
+        bootstrap_path = os.path.join(mock_path["user_config_path"], "bootstrap.yaml")
+        with open(bootstrap_path, "w", encoding="utf-8") as fd:
+            fd.write(
+                f"""
+bootstrap:
+    root: {mock_path['user_cache_path']}/bootstrap
+"""
+            )
+
+        os.environ["SPACK_SYSTEM_CONFIG_PATH"] = mock_path["system_config_path"]
+        os.environ["SPACK_USER_CACHE_PATH"] = mock_path["user_cache_path"]
+        os.environ["SPACK_USER_CONFIG_PATH"] = mock_path["user_config_path"]
+
+        spack.config.CONFIG = [_ for _ in spack.config.create_incremental()][-1]
+        yield


### PR DESCRIPTION
Point unit-tests at a clone of spack-packages that lives on a common cached location to avoid cloning it for every worker.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
