### PR TITLE
Windows GHA: move to `windows-2025`

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -169,7 +169,7 @@ jobs:
 
   windows:
     if: github.repository == 'spack/spack'
-    runs-on: "windows-latest"
+    runs-on: "windows-2025"
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -233,7 +233,7 @@ jobs:
       run:
         shell:
           powershell Invoke-Expression -Command "./share/spack/qa/windows_test_setup.ps1"; {0}
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:


### PR DESCRIPTION
In 1 week,  the GHA image `windows-latest` will be `windows-2025` instead of `windows-2022`. 
This PR switches the GHA pipelines that utilize the `windows-latest` image to explicitly use `windows-2025` to gauge impact to our CI pipelines and to determine whether we can let GH switch the image on us or whether we need to pin `windows-2022` while I address any regressions.

See: https://github.com/actions/runner-images/issues/12677 for more context on the switchover