### PR TITLE
solver: fix error with flags when a package appears multiple times in the DAG

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -277,6 +277,24 @@ def extend_flag_list(flag_list, new_flags):
         flag_list.append(flag)
 
 
+def _reorder_flags(flag_list: List[spack.spec.CompilerFlag]) -> List[spack.spec.CompilerFlag]:
+    """Reorder a list of flags to ensure that the order matches that of the flag group."""
+    assert flag_list, "expected a non-empty list of flags"
+    assert len({x.flag_group for x in flag_list}) == 1, "expected a single group of flags"
+    assert len({x.source for x in flag_list}) == 1, "expected a single source for the flags"
+    flag_group = flag_list[0].flag_group
+    flag_source = flag_list[0].source
+    flag_propagate = flag_list[0].propagate
+    return [
+        spack.spec.CompilerFlag(
+            flag, propagate=flag_propagate, flag_group=flag_group, source=flag_source
+        )
+        for flag, propagate in spack.compilers.flags.tokenize_flags(
+            flag_group, propagate=flag_propagate
+        )
+    ]
+
+
 def check_packages_exist(specs):
     """Ensure all packages mentioned in specs exist."""
     repo = spack.repo.PATH
@@ -3683,14 +3701,23 @@ class SpecBuilder:
         e.g. for ``y cflags="-z -a"`` ``-z`` and ``-a`` should never have any intervening
         flags inserted, and should always appear in that order.
         """
-        cmd_specs = {s.name: s for spec in self._command_line_specs for s in spec.traverse()}
-
         for node, spec in self._specs.items():
             # if bootstrapping, compiler is not in config and has no flags
             flagmap_from_compiler = {
                 flag_type: [x for x in values if x.source == "compiler"]
                 for flag_type, values in spec.compiler_flags.items()
             }
+
+            flagmap_from_cli = {}
+            for flag_type, values in spec.compiler_flags.items():
+                if not values:
+                    continue
+
+                flags = [x for x in values if x.source == "literal"]
+                if not flags:
+                    continue
+
+                flagmap_from_cli[flag_type] = _reorder_flags(flags)
 
             for flag_type in spec.compiler_flags.valid_compiler_flags():
                 ordered_flags = []
@@ -3754,9 +3781,8 @@ class SpecBuilder:
                     extend_flag_list(ordered_flags, as_compiler_flags)
 
                 # 3. Now put cmd-line flags last
-                if node.pkg in cmd_specs:
-                    cmd_flags = cmd_specs[node.pkg].compiler_flags.get(flag_type, [])
-                    extend_flag_list(ordered_flags, cmd_flags)
+                if flag_type in flagmap_from_cli:
+                    extend_flag_list(ordered_flags, flagmap_from_cli[flag_type])
 
                 compiler_flags = spec.compiler_flags.get(flag_type, [])
                 msg = f"{set(compiler_flags)} does not equal {set(ordered_flags)}"

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -279,9 +279,15 @@ def extend_flag_list(flag_list, new_flags):
 
 def _reorder_flags(flag_list: List[spack.spec.CompilerFlag]) -> List[spack.spec.CompilerFlag]:
     """Reorder a list of flags to ensure that the order matches that of the flag group."""
-    assert flag_list, "expected a non-empty list of flags"
-    assert len({x.flag_group for x in flag_list}) == 1, "expected a single group of flags"
-    assert len({x.source for x in flag_list}) == 1, "expected a single source for the flags"
+    if not flag_list:
+        return []
+
+    if len({x.flag_group for x in flag_list}) != 1 or len({x.source for x in flag_list}) != 1:
+        raise InternalConcretizerError(
+            "internal solver error: cannot reorder compiler flags for concretized specs. "
+            "Please report a bug at https://github.com/spack/spack/issues"
+        )
+
     flag_group = flag_list[0].flag_group
     flag_source = flag_list[0].source
     flag_propagate = flag_list[0].propagate

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -291,6 +291,8 @@ def _reorder_flags(flag_list: List[spack.spec.CompilerFlag]) -> List[spack.spec.
     flag_group = flag_list[0].flag_group
     flag_source = flag_list[0].source
     flag_propagate = flag_list[0].propagate
+    # Once we have the flag_group, no need to iterate over the flag_list because the
+    # group represents all of them
     return [
         spack.spec.CompilerFlag(
             flag, propagate=flag_propagate, flag_group=flag_group, source=flag_source
@@ -3723,6 +3725,8 @@ class SpecBuilder:
                 if not flags:
                     continue
 
+                # For compiler flags from literal specs, reorder any flags to
+                # the input order from flag.flag_group
                 flagmap_from_cli[flag_type] = _reorder_flags(flags)
 
             for flag_type in spec.compiler_flags.valid_compiler_flags():

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -660,6 +660,10 @@ attr("node_platform_set", node(X, BuildDependency), NodePlatform) :-
   attr("direct_dependency", ParentNode, node_requirement("node_platform_set", BuildDependency, NodePlatform)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
+attr("node_flag_set", node(X, BuildDependency), NodeFlag) :-
+  attr("direct_dependency", ParentNode, node_requirement("node_flag_set", BuildDependency, NodeFlag)),
+  build_requirement(ParentNode, node(X, BuildDependency)).
+
 attr("hash", node(X, BuildDependency), BuildHash) :-
   attr("direct_dependency", ParentNode, node_requirement("hash", BuildDependency, BuildHash)),
   build_requirement(ParentNode, node(X, BuildDependency)).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1728,6 +1728,12 @@ error(100, "'{0} target={1}' is not compatible with this machine", Package, Targ
 
 attr("node_flag", PackageNode, NodeFlag) :- attr("node_flag_set", PackageNode, NodeFlag).
 
+% If we set "foo %bar cflags=A ^fee %bar cflags=B" we want two nodes for "bar"
+error(100, "Cannot set multiple {0} values for {1} from cli", FlagType, Package)
+:- attr("node_flag_set", node(X, Package), node_flag(FlagType, _, FlagGroup1, "literal")),
+   attr("node_flag_set", node(X, Package), node_flag(FlagType, _, FlagGroup2, "literal")),
+   FlagGroup1 < FlagGroup2.
+
 %-----------------------------------------------------------------------------
 % Installed Packages
 %-----------------------------------------------------------------------------

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -837,6 +837,10 @@ class CompilerFlag(str):
             for "-g" would indicate ``depends_on``.
     """
 
+    propagate: bool
+    flag_group: str
+    source: str
+
     def __new__(cls, value, **kwargs):
         obj = str.__new__(cls, value)
         obj.propagate = kwargs.pop("propagate", False)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4159,14 +4159,3 @@ def test_when_possible_above_all(mutable_config, mock_packages):
     for result in solver.solve_in_rounds(specs):
         criteria = sorted(result.criteria, reverse=True)
         assert criteria[0].name == "number of input specs not concretized"
-
-
-@pytest.mark.regression("51209")
-def test_flags_and_duplicate_nodes(default_mock_concretization):
-    """Tests that we can concretize a spec with flags on a node that is present with duplicates
-    in the DAG. For instance, a compiler built with a previous version of itself.
-    """
-    s = default_mock_concretization("gcc@14 cflags='-O3'")
-    assert s.satisfies("gcc@14 cflags='-O3'")
-    assert s.satisfies("%gcc@10")
-    assert not s.satisfies("%gcc cflags='-O3'")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4159,3 +4159,14 @@ def test_when_possible_above_all(mutable_config, mock_packages):
     for result in solver.solve_in_rounds(specs):
         criteria = sorted(result.criteria, reverse=True)
         assert criteria[0].name == "number of input specs not concretized"
+
+
+@pytest.mark.regression("51209")
+def test_flags_and_duplicate_nodes(default_mock_concretization):
+    """Tests that we can concretize a spec with flags on a node that is present with duplicates
+    in the DAG. For instance, a compiler built with a previous version of itself.
+    """
+    s = default_mock_concretization("gcc@14 cflags='-O3'")
+    assert s.satisfies("gcc@14 cflags='-O3'")
+    assert s.satisfies("%gcc@10")
+    assert not s.satisfies("%gcc cflags='-O3'")

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -282,10 +282,20 @@ def test_flag_injection_different_compilers(mock_packages, mutable_config):
 
 
 @pytest.mark.regression("51209")
-@pytest.mark.parametrize("spec_str,expected,not_expected", [
-    ("gcc@14 cflags='-O3'", ["gcc@14 cflags='-O3'", "%gcc@10"], ["%gcc cflags='-O3'"]),
-])
-def test_flags_and_duplicate_nodes(spec_str,expected,not_expected,default_mock_concretization):
+@pytest.mark.parametrize(
+    "spec_str,expected,not_expected",
+    [
+        # gcc using flags compiled with another gcc not using flags
+        ("gcc@14 cflags='-O3'", ["gcc@14 cflags='-O3'", "%gcc@10"], ["%gcc cflags='-O3'"]),
+        # Parent and child, imposing different flags on gmake
+        (
+            "7zip-dependent %gmake cflags='-O2' ^7zip %gmake cflags='-g'",
+            ["%gmake cflags='-O2'", "^7zip %gmake cflags='-g'"],
+            ["%gmake cflags='-g'"],
+        ),
+    ],
+)
+def test_flags_and_duplicate_nodes(spec_str, expected, not_expected, default_mock_concretization):
     """Tests that we can concretize a spec with flags on a node that is present with duplicates
     in the DAG. For instance, a compiler built with a previous version of itself.
     """

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -279,3 +279,16 @@ def test_flag_injection_different_compilers(mock_packages, mutable_config):
     s = spack.concretize.concretize_one('mpileaks cflags=="-O2" %gcc ^callpath %llvm')
     assert s.satisfies('cflags="-O2"') and s["c"].name == "gcc"
     assert not s["callpath"].satisfies('cflags="-O2"') and s["callpath"]["c"].name == "llvm"
+
+
+@pytest.mark.regression("51209")
+@pytest.mark.parametrize("spec_str,expected,not_expected", [
+    ("gcc@14 cflags='-O3'", ["gcc@14 cflags='-O3'", "%gcc@10"], ["%gcc cflags='-O3'"]),
+])
+def test_flags_and_duplicate_nodes(spec_str,expected,not_expected,default_mock_concretization):
+    """Tests that we can concretize a spec with flags on a node that is present with duplicates
+    in the DAG. For instance, a compiler built with a previous version of itself.
+    """
+    s = default_mock_concretization(spec_str)
+    assert all(s.satisfies(x) for x in expected)
+    assert all(not s.satisfies(x) for x in not_expected)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/_7zip_dependent/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/_7zip_dependent/package.py
@@ -1,0 +1,17 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+
+class _7zipDependent(AutotoolsPackage):
+    """A dependent of 7zip, that also needs gmake"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("7zip")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/gmake/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/gmake/package.py
@@ -13,6 +13,8 @@ class Gmake(Package):
     homepage = "https://www.gnu.org/software/make"
     url = "https://ftpmirror.gnu.org/make/make-4.4.tar.gz"
 
+    tags = ["build-tools"]
+
     version("4.4", sha256="ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed")
     version("3.0", sha256="ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed")
 


### PR DESCRIPTION
fixes #51209

Compiler flags from the command line are evaluated as part of the ASP problem, so they are already in the output, but:
1. They might have the wrong order, or
2. They might be conflated on a single node, when they come from duplicates of the same package

In this PR we fix those issues, just by reordering the spec from a "literal" source correctly.

**Before the PR**
```console
$ spack -m spec gcc@14 cflags=-O3
==> Error: set() does not equal {'-O3'}
$ spack spec hdf5~mpi %gmake cflags="-O2" ^zlib-ng %gmake cflags="-O3"
==> Error: set() does not equal {'-O3'}
```

**After the PR**
```console
$ spack -m spec gcc@14 cflags=-O3
 -   gcc@14.0 cflags=-O3  build_system=generic languages:='c,c++,fortran' platform=linux os=ubuntu20.04 target=icelake %c,cxx=gcc@10.5.0
 -       ^compiler-wrapper@1.0 build_system=generic platform=linux os=ubuntu20.04 target=icelake 
[e]      ^gcc@10.5.0 build_system=generic languages:='c,c++,fortran' platform=linux os=ubuntu20.04 target=icelake 
 -       ^gcc-runtime@10.5.0 build_system=generic platform=linux os=ubuntu20.04 target=icelake 
[e]      ^glibc@2.31 build_system=autotools platform=linux os=ubuntu20.04 target=icelake 

$ spack spec hdf5~mpi %gmake cflags="-O2" ^zlib-ng %gmake cflags="-O3"
 -   hdf5@1.14.6~cxx~fortran~hl~ipo~java~map~mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0
 -       ^cmake@3.31.8~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release platform=linux os=ubuntu20.04 target=icelake %c,cxx=gcc@10.5.0
 -           ^curl@8.15.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl platform=linux os=ubuntu20.04 target=icelake %c,cxx=gcc@10.5.0
 -               ^nghttp2@1.65.0 build_system=autotools platform=linux os=ubuntu20.04 target=icelake %c,cxx=gcc@10.5.0
 -                   ^diffutils@3.12 build_system=autotools platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0
 -                       ^libiconv@1.18 build_system=autotools libs:=shared,static platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0
 -               ^openssl@3.4.1~docs+shared build_system=generic certs=mozilla platform=linux os=ubuntu20.04 target=icelake %c,cxx=gcc@10.5.0
 -                   ^ca-certificates-mozilla@2025-05-20 build_system=generic platform=linux os=ubuntu20.04 target=icelake 
 -               ^perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0
 -                   ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc platform=linux os=ubuntu20.04 target=icelake %c,cxx=gcc@10.5.0
 -                   ^bzip2@1.0.8~debug~pic+shared build_system=generic platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0
 -                   ^gdbm@1.25 build_system=autotools platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0
 -                       ^readline@8.3 build_system=autotools patches:=21f0a03 platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0
 -           ^ncurses@6.5-20250705~symlinks+termlib abi=none build_system=autotools patches:=7a351bc platform=linux os=ubuntu20.04 target=icelake %c,cxx=gcc@10.5.0
[+]      ^compiler-wrapper@1.0 build_system=generic platform=linux os=ubuntu20.04 target=icelake 
[e]      ^gcc@10.5.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' patches:=2c18531 platform=linux os=ubuntu20.04 target=icelake 
[+]      ^gcc-runtime@10.5.0 build_system=generic platform=linux os=ubuntu20.04 target=icelake 
[e]      ^glibc@2.31 build_system=autotools platform=linux os=ubuntu20.04 target=icelake 
 -       ^gmake@4.4.1 cflags=-O2 ~guile build_system=generic platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0
 -       ^pkgconf@2.5.1 build_system=autotools platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0
 -       ^zlib-ng@2.2.4+compat+new_strategies+opt+pic+shared build_system=autotools platform=linux os=ubuntu20.04 target=icelake %c,cxx=gcc@10.5.0
 -           ^gmake@4.4.1 cflags=-O3 ~guile build_system=generic platform=linux os=ubuntu20.04 target=icelake %c=gcc@10.5.0

```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
