### PR TITLE
Enable gitlab ci

### DIFF
--- a/.ci/gitlab-ci.yml
+++ b/.ci/gitlab-ci.yml
@@ -20,7 +20,7 @@ dotenv:
   image: ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18
   tags: [ spack, service ]
   script:
-    - export REPO_DESTINATION=${CI_PROJECT_DIR}/etc/spack-packages
+    - export REPO_DESTINATION=etc/spack-packages
     - *clone_packages
     - repo_commit=$(git -C ${REPO_DESTINATION} rev-parse FETCH_HEAD)
     # When running CI from spack/spack all packages are untouched

--- a/.ci/gitlab-ci.yml
+++ b/.ci/gitlab-ci.yml
@@ -1,0 +1,48 @@
+# Gitlab configuraiton for spack/spack
+
+stages:
+  - packages
+
+variables:
+  SPACK_PACKAGES_CHECKOUT_VERSION: refs/pull/342/head
+
+.clone_packages: &clone_packages
+  - mkdir -p ${REPO_DESTINATION}
+  - cd ${REPO_DESTINATION}
+  - git init
+  - git remote add origin https://github.com/spack/spack-packages.git
+  - git fetch --depth 1 origin ${SPACK_PACKAGES_CHECKOUT_VERSION}
+  - git checkout FETCH_HEAD
+  - cd -
+
+dotenv:
+  stage: .pre
+  image: ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18
+  tags: [ spack, service ]
+  script:
+    - export REPO_DESTINATION=${CI_PROJECT_DIR}/etc/spack-packages
+    - *clone_packages
+    - repo_commit=$(git -C ${REPO_DESTINATION} rev-parse FETCH_HEAD)
+    # When running CI from spack/spack all packages are untouched
+    # so skip pruning untouched. Deferred pipelines _should_ handle
+    # most of the cases where this type of pruning would need to be
+    # applied.
+    - echo "SPACK_CHECKOUT_VERSION=${repo_commit}" >> ${CI_PROJECT_DIR}/env
+    - echo "SPACK_CHECKOUT_REPO=spack/spack-packages" >> ${CI_PROJECT_DIR}/env
+    - cat ${CI_PROJECT_DIR}/env
+    - python3 ${CI_PROJECT_DIR}/.ci/gitlab/forward_dotenv_variables.py
+        ${CI_PROJECT_DIR}/env
+        ${REPO_DESTINATION}/.ci/gitlab/.gitlab-ci.yml
+
+  artifacts:
+    paths:
+      - etc/spack-packages/.ci/gitlab/.gitlab-ci.yml
+
+spack-packages:
+  stage: packages
+  trigger:
+    strategy: depend
+    include:
+      - artifact: etc/spack-packages/.ci/gitlab/.gitlab-ci.yml
+        job: dotenv
+

--- a/.ci/gitlab/forward_dotenv_variables.py
+++ b/.ci/gitlab/forward_dotenv_variables.py
@@ -1,0 +1,36 @@
+import sys
+from typing import Dict
+
+import yaml
+
+
+def read_dotenv(file_name: str) -> Dict[str, str]:
+    result = []
+    with open(file_name, "r", encoding="utf-8") as fd:
+        for field in fd:
+            if field.strip()[0] == "#":
+                continue
+
+            data = field.strip("\n").split("=", 1)
+            try:
+                result.append((data[0], data[1]))
+            except IndexError:
+                print(f"Skipping bad value: {field}")
+
+    return dict(result)
+
+
+if __name__ == "__main__":
+    dotenv = read_dotenv(sys.argv[1])
+    if not dotenv:
+        exit(0)
+
+    with open(sys.argv[2], "r", encoding="utf-8") as fd:
+        conf = yaml.load(fd, Loader=yaml.Loader)
+
+    if "variables" not in conf:
+        conf["variables"] = {}
+    conf["variables"].update(dotenv)
+
+    with open(sys.argv[2], "w", encoding="utf-8") as fd:
+        yaml.dump(conf, fd, Dumper=yaml.Dumper)

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -518,16 +518,19 @@ def generate_pipeline(env: ev.Environment, args) -> None:
         # packagen name not in that list.
         unaffected_pruner = get_unaffected_pruners(env, options.untouched_pruning_dependent_depth)
         if unaffected_pruner:
+            tty.info("Enabling Unaffected Pruner")
             pruning_filters.append(unaffected_pruner)
 
     # Possibly prune specs that are already built on some configured mirror
     if options.prune_up_to_date:
+        tty.info("Enabling Up-to-date Pruner")
         pruning_filters.append(
             create_already_built_pruner(check_index_only=options.check_index_only)
         )
 
     # Possibly prune specs that are external
     if options.prune_external:
+        tty.info("Enabling Externals Pruner")
         pruning_filters.append(create_external_pruner())
 
     # Do all the pruning

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -28,7 +28,6 @@ import spack.mirrors.mirror
 import spack.schema
 import spack.spec
 import spack.util.compression as compression
-import spack.util.spack_yaml as syaml
 import spack.util.web as web_util
 from spack import traverse
 from spack.llnl.util.lang import memoized
@@ -142,34 +141,6 @@ def ensure_expected_target_path(path: str) -> str:
     if path:
         return path.replace("\\", "/")
     return path
-
-
-def update_env_scopes(
-    env: ev.Environment,
-    cli_scopes: List[str],
-    output_file: str,
-    transform_windows_paths: bool = False,
-) -> None:
-    """Add any config scopes from cli_scopes which aren't already included in the
-    environment, by reading the yaml, adding the missing includes, and writing the
-    updated yaml back to the same location.
-    """
-    with open(env.manifest_path, "r", encoding="utf-8") as env_fd:
-        env_yaml_root = syaml.load(env_fd)
-
-    # Add config scopes to environment
-    env_includes = env_yaml_root["spack"].get("include", [])
-    include_scopes: List[str] = []
-    for scope in cli_scopes:
-        if scope not in include_scopes and scope not in env_includes:
-            include_scopes.insert(0, scope)
-    env_includes.extend(include_scopes)
-    env_yaml_root["spack"]["include"] = [
-        ensure_expected_target_path(i) if transform_windows_paths else i for i in env_includes
-    ]
-
-    with open(output_file, "w", encoding="utf-8") as fd:
-        syaml.dump_config(env_yaml_root, fd, default_flow_style=False)
 
 
 def write_pipeline_manifest(specs, src_prefix, dest_prefix, output_file):

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -140,9 +140,7 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             )
 
         # If there are no includes, just copy
-        if "include" not in data["spack"]:
-            shutil.copyfileobj(fin, fout)
-        else:
+        if "include" in data["spack"]:
             includes = data["spack"]["include"]
             # If there are includes in the config, then we need to fix the relative paths
             # to be relative from the concrete env dir used by downstream pipelines
@@ -171,7 +169,7 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             data["spack"]["include"] = fixed_includes
 
             os.makedirs(concrete_env_dir, exist_ok=True)
-            syaml.dump(data, fout)
+        syaml.dump(data, fout)
 
     shutil.copyfile(options.env.lock_path, os.path.join(concrete_env_dir, "spack.lock"))
 

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -10,7 +10,7 @@ import spack.vendor.ruamel.yaml
 
 import spack
 import spack.binary_distribution
-import spack.config as cfg
+import spack.config
 import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
 import spack.schema

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -26,7 +26,6 @@ from .common import (
     SpackCIError,
     ensure_expected_target_path,
     unpack_script,
-    update_env_scopes,
     write_pipeline_manifest,
 )
 from .generator_registry import generator
@@ -129,29 +128,57 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
     # concrete environment directory, along with the spack.lock file.
     if not os.path.exists(concrete_env_dir):
         os.makedirs(concrete_env_dir)
-    shutil.copyfile(options.env.manifest_path, os.path.join(concrete_env_dir, "spack.yaml"))
-    shutil.copyfile(options.env.lock_path, os.path.join(concrete_env_dir, "spack.lock"))
 
-    update_env_scopes(
-        options.env,
-        [
-            os.path.relpath(s.path, concrete_env_dir)
-            for s in cfg.scopes().values()
-            if not s.writable
-            and isinstance(s, (cfg.DirectoryConfigScope))
-            and os.path.exists(s.path)
-        ],
-        os.path.join(concrete_env_dir, "spack.yaml"),
-        # Here transforming windows paths is only required in the special case
-        # of copy_only_pipelines, a unique scenario where the generate job and
-        # child pipelines are run on different platforms. To make this compatible
-        # w/ Windows, we cannot write Windows style path separators that will be
-        # consumed on by the Posix copy job runner.
-        #
-        # TODO (johnwparent): Refactor config + cli read/write to deal only in
-        # posix style paths
-        transform_windows_paths=(options.pipeline_type == PipelineType.COPY_ONLY),
-    )
+    # Copy the manifest and handle relative included paths
+    with open(options.env.manifest_path, "r") as fin, open(
+        os.path.join(concrete_env_dir, "spack.yaml"), "w"
+    ) as fout:
+        data = syaml.load(fin)
+        if "spack" not in data:
+            raise spack.config.ConfigSectionError(
+                'Missing top level "spack" section in environment'
+            )
+
+        # If there are no includes, just copy
+        if "include" not in data["spack"]:
+            shutil.copyfileobj(fin, fout)
+        else:
+            includes = data["spack"]["include"]
+            # If there are includes in the config, then we need to fix the relative paths
+            # to be relative from the concrete env dir used by downstream pipelines
+            env_root_path = os.path.dirname(os.path.abspath(options.env.manifest_path))
+            fixed_includes = []
+            for inc in includes:
+                if isinstance(inc, dict):
+                    inc_path = inc["path"]
+                else:
+                    inc_path = inc
+
+                print(f"checking_include: {inc_path}")
+                if os.path.isabs(inc_path):
+                    fixed_includes.append(inc)
+                    continue
+
+                inc_abs_path = os.path.normpath(os.path.join(env_root_path, inc_path))
+                inc_path = os.path.relpath(inc_abs_path, start=concrete_env_dir)
+
+                print(f"abs: {inc_abs_path}")
+                print(f"fixed rel: {inc_path}")
+                if isinstance(inc, dict):
+                    inc["path"] = inc_path
+                else:
+                    inc = inc_path
+
+                fixed_includes.append(inc)
+
+            print(fixed_includes)
+
+            data["spack"]["include"] = fixed_includes
+
+            os.makedirs(concrete_env_dir, exist_ok=True)
+            syaml.dump(data, fout)
+
+    shutil.copyfile(options.env.lock_path, os.path.join(concrete_env_dir, "spack.lock"))
 
     job_log_dir = os.path.join(pipeline_artifacts_dir, "logs")
     job_repro_dir = os.path.join(pipeline_artifacts_dir, "reproduction")

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -130,8 +130,8 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
         os.makedirs(concrete_env_dir)
 
     # Copy the manifest and handle relative included paths
-    with open(options.env.manifest_path, "r") as fin, open(
-        os.path.join(concrete_env_dir, "spack.yaml"), "w"
+    with open(options.env.manifest_path, "r", encoding="utf-8") as fin, open(
+        os.path.join(concrete_env_dir, "spack.yaml"), "w", encoding="utf-8"
     ) as fout:
         data = syaml.load(fin)
         if "spack" not in data:
@@ -154,7 +154,6 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
                 else:
                     inc_path = inc
 
-                print(f"checking_include: {inc_path}")
                 if os.path.isabs(inc_path):
                     fixed_includes.append(inc)
                     continue
@@ -162,16 +161,12 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
                 inc_abs_path = os.path.normpath(os.path.join(env_root_path, inc_path))
                 inc_path = os.path.relpath(inc_abs_path, start=concrete_env_dir)
 
-                print(f"abs: {inc_abs_path}")
-                print(f"fixed rel: {inc_path}")
                 if isinstance(inc, dict):
                     inc["path"] = inc_path
                 else:
                     inc = inc_path
 
                 fixed_includes.append(inc)
-
-            print(fixed_includes)
 
             data["spack"]["include"] = fixed_includes
 

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -139,6 +139,12 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
                 'Missing top level "spack" section in environment'
             )
 
+        def _rewrite_include(path, orig_root, new_root):
+            if os.path.isabs(path):
+                return path
+            abs_path = os.path.normpath(os.path.join(orig_root, path))
+            return os.path.relpath(abs_path, start=new_root)
+
         # If there are no includes, just copy
         if "include" in data["spack"]:
             includes = data["spack"]["include"]
@@ -148,21 +154,9 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             fixed_includes = []
             for inc in includes:
                 if isinstance(inc, dict):
-                    inc_path = inc["path"]
+                    inc["path"] = _rewrite_include(inc["path"], env_root_path, concrete_env_dir)
                 else:
-                    inc_path = inc
-
-                if os.path.isabs(inc_path):
-                    fixed_includes.append(inc)
-                    continue
-
-                inc_abs_path = os.path.normpath(os.path.join(env_root_path, inc_path))
-                inc_path = os.path.relpath(inc_abs_path, start=concrete_env_dir)
-
-                if isinstance(inc, dict):
-                    inc["path"] = inc_path
-                else:
-                    inc = inc_path
+                    inc = _rewrite_include(inc, env_root_path, concrete_env_dir)
 
                 fixed_includes.append(inc)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -153,7 +153,11 @@ class ConfigScope:
                 include_paths = [included_path(data) for data in includes["include"]]
                 for path in include_paths:
                     included_scope = include_path_scope(path, self)
-                    if included_scope:
+                    # Do not include duplicate scopes
+                    if any([included_scope.name == scope.name for scope in self._included_scopes]):
+                        tty.warn(f"Ignoring duplicate included scope: {included_scope.name}")
+                        continue
+                    if included_scope and included_scope not in self._included_scopes:
                         self._included_scopes.append(included_scope)
 
         return self._included_scopes

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -153,11 +153,15 @@ class ConfigScope:
                 include_paths = [included_path(data) for data in includes["include"]]
                 for path in include_paths:
                     included_scope = include_path_scope(path, self)
+                    if not included_scope:
+                        continue
+
                     # Do not include duplicate scopes
                     if any([included_scope.name == scope.name for scope in self._included_scopes]):
                         tty.warn(f"Ignoring duplicate included scope: {included_scope.name}")
                         continue
-                    if included_scope and included_scope not in self._included_scopes:
+
+                    if included_scope not in self._included_scopes:
                         self._included_scopes.append(included_scope)
 
         return self._included_scopes

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2681,8 +2681,7 @@ def initialize_environment_dir(
             fs.touchp(abspath)
             shutil.copy(orig_abspath, abspath)
         else:
-            os.makedirs(abspath)
-            shutil.copytree(orig_abspath, abspath, symlinks=True, dirs_exist_ok=True)
+            shutil.copytree(orig_abspath, abspath, symlinks=True)
 
 
 class EnvironmentManifestFile(collections.abc.Mapping):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2677,8 +2677,12 @@ def initialize_environment_dir(
             tty.warn(f"Included file does not exist; will not copy: '{path}'")
             continue
 
-        fs.touchp(abspath)
-        shutil.copy(orig_abspath, abspath)
+        if os.path.isfile(orig_abspath):
+            fs.touchp(abspath)
+            shutil.copy(orig_abspath, abspath)
+        else:
+            os.makedirs(abspath)
+            shutil.copytree(orig_abspath, abspath, symlinks=True, dirs_exist_ok=True)
 
 
 class EnvironmentManifestFile(collections.abc.Mapping):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2681,6 +2681,9 @@ def initialize_environment_dir(
             fs.touchp(abspath)
             shutil.copy(orig_abspath, abspath)
         else:
+            if os.path.exists(abspath):
+                tty.warn(f"Skipping copying duplicate directories: {path}")
+                continue
             shutil.copytree(orig_abspath, abspath, symlinks=True)
 
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1585,7 +1585,8 @@ ci:
         f"""\
 spack:
   config:
-    install_tree: {tmp_path / "opt"}
+    install_tree:
+      root: {tmp_path / "opt"}
   include:
   - {rel_configs_path}
   - path: {rel_configs_path}

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1588,6 +1588,7 @@ spack:
     install_tree: {tmp_path / "opt"}
   include:
   - {rel_configs_path}
+  - path: {rel_configs_path}
   view: false
   specs:
     - dependent-install

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1589,6 +1589,7 @@ spack:
   include:
   - {rel_configs_path}
   - path: {rel_configs_path}
+  - {configs_path}
   view: false
   specs:
     - dependent-install

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -122,8 +122,7 @@ def ci_generate_test(
     def _func(spack_yaml_content, *args, fail_on_error=True):
         spack_yaml = tmp_path / "spack.yaml"
         spack_yaml.write_text(spack_yaml_content)
-
-        env_cmd("create", "test", str(spack_yaml))
+        ev.create("test", init_file=spack_yaml, with_view=False)
         outputfile = tmp_path / ".gitlab-ci.yml"
         with ev.read("test"):
             output = ci_cmd(
@@ -1562,16 +1561,33 @@ def test_docstring_utils():
     )
 
 
-@pytest.mark.skip(reason="Gitlab CI was removed from Spack")
 def test_gitlab_config_scopes(install_mockery, ci_generate_test, tmp_path: pathlib.Path):
-    """Test pipeline generation with real configs included"""
-    configs_path = os.path.join(spack_paths.share_path, "gitlab", "cloud_pipelines", "configs")
-    _, outputfile, _ = ci_generate_test(
+    """Test pipeline generation with included configs"""
+    # Create an included config scope
+    configs_path = tmp_path / "gitlab" / "configs"
+    configs_path.mkdir(parents=True, exist_ok=True)
+    with open(configs_path / "ci.yaml", "w", encoding="utf-8") as fd:
+        fd.write(
+            """
+ci:
+  pipeline-gen:
+  - reindex-job:
+      variables:
+        CI_JOB_SIZE: small
+        KUBERNETES_CPU_REQUEST: 10
+        KUBERNETES_MEMORY_REQUEST: 100
+      tags: ["spack", "service"]
+"""
+        )
+
+    rel_configs_path = configs_path.relative_to(tmp_path)
+    manifest, outputfile, _ = ci_generate_test(
         f"""\
 spack:
   config:
     install_tree: {tmp_path / "opt"}
-  include: [{configs_path}]
+  include:
+  - {rel_configs_path}
   view: false
   specs:
     - dependent-install
@@ -1598,6 +1614,17 @@ spack:
     assert all([t in rebuild_tags for t in ["spack", "service"]])
     expected_vars = ["CI_JOB_SIZE", "KUBERNETES_CPU_REQUEST", "KUBERNETES_MEMORY_REQUEST"]
     assert all([v in rebuild_vars for v in expected_vars])
+
+    # Read the concrete environment and ensure the relative path was updated
+    conc_env_path = tmp_path / "jobs_scratch_dir" / "concrete_environment"
+    conc_env_manifest = conc_env_path / "spack.yaml"
+
+    env_manifest = syaml.load(conc_env_manifest.read_text())
+    assert "include" in env_manifest["spack"]
+    # Ensure the relocated concrete env includes point to the same location
+    rel_conc_path = env_manifest["spack"]["include"][0]
+    abs_conc_path = (conc_env_path / rel_conc_path).absolute().resolve()
+    assert str(abs_conc_path) == os.path.join(ev.as_env_dir("test"), "gitlab", "configs")
 
 
 def test_ci_generate_mirror_config(


### PR DESCRIPTION
In order to enable running the spack-packages CI from spack/spack we need to be able to run the `.ci/gitlab/gitlab-ci.yml` found in spack-packages, and the associated stack environments, a number of changes are required in spack and in spack-packages.

This PR implements the CI configuration and updates to how `ci generate` handles includes using relative paths. In order for these changes to work with spack-packages the PR https://github.com/spack/spack-packages/pull/342 needs to also be merged. This PR makes the spack-packages CI implementation configurable to run from the root of either spack/spack or spack/spack-packages.


Additional related changes.
* fix creating environments from a `spack.yaml` that includes a directory path (still does not support recursive includes)
* fix handling when listing duplicate includes