### PR TITLE
solver: adjust optimization weights for "when possible"

### DIFF
--- a/lib/spack/spack/solver/when_possible.lp
+++ b/lib/spack/spack/solver/when_possible.lp
@@ -29,9 +29,9 @@ do_not_impose(EffectID, node(X, Package)) :-
   trigger_and_effect(_, TriggerID, EffectID),
   trigger_node(TriggerID, _, node(X, Package)).
 
-opt_criterion(300, "number of input specs not concretized").
-#minimize{ 0@300: #true }.
-#minimize { 1@300,ID : literal_not_solved(ID) }.
+opt_criterion(320, "number of input specs not concretized").
+#minimize{ 0@320: #true }.
+#minimize { 1@320,ID : literal_not_solved(ID) }.
 
-#heuristic literal_solved(ID) : literal(ID). [1, sign]
-#heuristic literal_solved(ID) : literal(ID). [50, init]
+#heuristic solve_literal(ID) : literal(ID). [1, sign]
+#heuristic solve_literal(ID) : literal(ID). [1000, init]

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4153,3 +4153,14 @@ packages:
     r = result.specs[0]
     assert r.satisfies("openblas %fortran=gcc")
     assert r.dag_hash() != s.dag_hash()
+
+
+@pytest.mark.regression("51224")
+def test_when_possible_above_all(mutable_config, mock_packages):
+    """Tests that the criterion to solve as many specs as possible is above all other criteria."""
+    specs = [Spec("pkg-a"), Spec("pkg-b")]
+    solver = spack.solver.asp.Solver()
+
+    for result in solver.solve_in_rounds(specs):
+        criteria = sorted(result.criteria, reverse=True)
+        assert criteria[0].name == "number of input specs not concretized"


### PR DESCRIPTION
fixes #51224

In this way trying to solve more input specs is at higher priority than trying to satisfy strong preferences or requirements.

This was an unwanted side effect of #44373

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
