### PR TITLE
stale: include unreproducible bugs in the list of stale issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -20,9 +20,11 @@ jobs:
             This issue has been automatically marked as stale because it has not had any activity in the last 6 months.
             It will be closed in 30 days if there is no further activity.
             
+            
             If the issue is waiting for a reply from maintainers, feel free to ping them as a reminder.
             If it is waiting and has no comments yet, feel free to ping `@spack/spack-releasers` or simply leave a comment saying this should not be marked stale.
             This will also reset the issue's stale state.
+            
             
             Thank you for your contributions!
           close-issue-message: >
@@ -37,9 +39,11 @@ jobs:
             This pull request has been automatically marked as stale because it has not had any activity in the last 6 months. 
             It will be closed in 30 days if there is no further activity.
             
+            
             If the pull request is waiting for a reply from reviewers, feel free to ping them as a reminder.
             If it is waiting and has no assigned reviewer, feel free to ping `@spack/spack-releasers` or simply leave a comment saying this should not be marked stale.
             This will reset the pull request's stale state.
+            
             
             To get more eyes on your pull request, you can post a link in the #pull-requests channel of the Spack Slack.
             

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -31,8 +31,8 @@ jobs:
             This issue was closed because it had no activity for 30 days after being marked stale.
             If you feel this is in error, please feel free to reopen this issue.
           stale-issue-label: 'stale'
-          any-of-issue-labels: 'build-error'
-          exempt-issue-labels: 'pinned,bug'
+          any-of-issue-labels: 'build-error,unreproducible'
+          exempt-issue-labels: 'pinned,triage,impact-low,impact-medium,impact-high'
 
           # Pull requests configuration
           stale-pr-message: >


### PR DESCRIPTION
If a bug has been unreproducible for years, and there is no activity, it's likely the issue will just be lost in the huge queue of bugs.

Also, add an additional newline for better rendering of the message
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
