### PR TITLE
docs: fix --flag rendered as –flag, fix more quote -> backticks

### DIFF
--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -1285,7 +1285,7 @@ All it takes is some lines like this:
    env["F77"] = spec["mpi"].mpif77
    env["FC"] = spec["mpi"].mpifc
 
-Or, if you pass CC, CXX, etc. directly to your build with, e.g., `--with-cc=<path>`, you'll want to substitute `spec["mpi"].mpicc` in there instead, e.g.:
+Or, if you pass CC, CXX, etc. directly to your build with, e.g., ``--with-cc=<path>``, you'll want to substitute ``spec["mpi"].mpicc`` in there instead, e.g.:
 
 .. code-block:: python
 

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -861,7 +861,7 @@ def setup_spack_repro_version(repro_dir, checkout_commit, merge_commit=None):
 
 
 def reproduce_ci_job(url, work_dir, autostart, gpg_url, runtime, use_local_head):
-    """Given a url to gitlab artifacts.zip from a failed 'spack ci rebuild' job,
+    """Given a url to gitlab artifacts.zip from a failed ``spack ci rebuild`` job,
     attempt to setup an environment in which the failure can be reproduced
     locally.  This entails the following:
 

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -95,7 +95,7 @@ def get_change_revisions(path: str) -> Tuple[Optional[str], Optional[str]]:
 def filter_added_checksums(
     checksums: Iterable[str], path: str, from_ref: str = "HEAD~1", to_ref: str = "HEAD"
 ) -> List[str]:
-    """Get a list of the version checksums added between ``from_ref`` and ```to_ref``.
+    """Get a list of the version checksums added between ``from_ref`` and ``to_ref``.
 
     Args:
        checksums: an iterable of checksums to look for in the diff

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -740,7 +740,7 @@ def group_arguments(
         max_group_size: max number of elements in any group (default 500)
         prefix_length: length of any additional arguments (including spaces) to be passed before
             the groups from args; default is 0 characters
-        max_group_length: max length of characters that if a group of args is joined by " "
+        max_group_length: max length of characters that if a group of args is joined by ``" "``
             On unix, ths defaults to SC_ARG_MAX from sysconf. On Windows the default is
             the max usable for CreateProcess (32,768 chars)
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -807,15 +807,15 @@ def migrate_fn(args):
     will attempt to verify the signatures on specs, and then re-sign them before
     migration, using whatever keys are already installed in your key ring.  You can
     migrate a mirror of unsigned binaries (or convert a mirror of signed binaries
-    to unsigned) by providing the --unsigned argument.
+    to unsigned) by providing the ``--unsigned`` argument.
 
     By default spack will leave the original mirror contents (in the old layout) in
     place after migration. You can have spack remove the old contents by providing
-    the --delete-existing argument.  Because migrating a mostly-already-migrated
+    the ``--delete-existing``` argument.  Because migrating a mostly-already-migrated
     mirror should be fast, consider a workflow where you perform a default migration,
     (i.e. preserve the existing layout rather than deleting it) then evaluate the
     state of the migrated mirror by attempting to install from it, and finally
-    running the migration again with --delete-existing."""
+    running the migration again with ``--delete-existing``."""
     target_mirror = args.mirror
     unsigned = args.unsigned
     assert isinstance(target_mirror, spack.mirrors.mirror.Mirror)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -811,7 +811,7 @@ def migrate_fn(args):
 
     By default spack will leave the original mirror contents (in the old layout) in
     place after migration. You can have spack remove the old contents by providing
-    the ``--delete-existing``` argument.  Because migrating a mostly-already-migrated
+    the ``--delete-existing`` argument.  Because migrating a mostly-already-migrated
     mirror should be fast, consider a workflow where you perform a default migration,
     (i.e. preserve the existing layout rather than deleting it) then evaluate the
     state of the migrated mirror by attempting to install from it, and finally

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -31,7 +31,7 @@ formatters: Dict[str, Callable[[Namespace, IO], None]] = {}
 
 
 #: standard arguments for updating completion scripts
-#: we iterate through these when called with --update-completion
+#: we iterate through these when called with ``--update-completion``
 update_completion_args: Dict[str, Dict[str, Any]] = {
     "bash": {
         "aliases": True,

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -38,7 +38,7 @@ def grouper(iterable, n, fillvalue=None):
 exclude_paths = [os.path.relpath(spack.paths.vendor_path, spack.paths.prefix)]
 
 #: Order in which tools should be run. flake8 is last so that it can
-#: double-check the results of other tools (if, e.g., --fix was provided)
+#: double-check the results of other tools (if, e.g., ``--fix`` was provided)
 #: The list maps an executable name to a method to ensure the tool is
 #: bootstrapped or present in the environment.
 tool_names = ["import", "isort", "black", "flake8", "mypy"]
@@ -488,7 +488,7 @@ def run_import_check(import_check_cmd, file_list, args):
 
 
 def validate_toolset(arg_value):
-    """Validate --tool and --skip arguments (sets of optionally comma-separated tools)."""
+    """Validate ``--tool`` and ``--skip`` arguments (sets of optionally comma-separated tools)."""
     tools = set(",".join(arg_value).split(","))  # allow args like 'isort,flake8'
     for tool in tools:
         if tool not in tool_names:

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -209,7 +209,7 @@ def get_uninstall_list(args, specs: List[spack.spec.Spec], env: Optional[ev.Envi
     """Returns unordered uninstall_list and remove_list: these may overlap (some things
     may be both uninstalled and removed from the current environment).
 
-    It is assumed we are in an environment if --remove is specified (this
+    It is assumed we are in an environment if ``--remove`` is specified (this
     method raises an exception otherwise)."""
     if args.remove and not env:
         raise ValueError("Can only use --remove when in an environment")

--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -550,7 +550,7 @@ def remove_prefix(pkg_name):
 
 
 def remove_separators(version):
-    """Remove separator characters ('.', '_', and '-') from a version.
+    """Remove separator characters (``.``, ``_``, and ``-``) from a version.
 
     A version like 1.2.3 may be displayed as 1_2_3 in the URL.
     Make sure 1.2.3, 1-2-3, 1_2_3, and 123 are considered equal.

--- a/lib/spack/spack/compilers/flags.py
+++ b/lib/spack/spack/compilers/flags.py
@@ -7,8 +7,8 @@ from typing import List, Tuple
 def tokenize_flags(flags_values: str, propagate: bool = False) -> List[Tuple[str, bool]]:
     """Given a compiler flag specification as a string, this returns a list
     where the entries are the flags. For compiler options which set values
-    using the syntax "-flag value", this function groups flags and their
-    values together. Any token not preceded by a "-" is considered the
+    using the syntax ``-flag value``, this function groups flags and their
+    values together. Any token not preceded by a ``-`` is considered the
     value of a prior flag."""
     tokens = flags_values.split()
     if not tokens:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -688,7 +688,7 @@ class Configuration:
         """Get a config section or a single value from one.
 
         Accepts a path syntax that allows us to grab nested config map
-        entries.  Getting the 'config' section would look like::
+        entries.  Getting the ``config`` section would look like::
 
             spack.config.get("config")
 

--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -35,7 +35,7 @@ def build_info(image, spack_version):
 
     Args:
         image (str): image to be used at run-time. Should be of the form
-            <image_name>:<image_tag> e.g. "ubuntu:18.04"
+            <image_name>:<image_tag> e.g. ``"ubuntu:18.04"``
         spack_version (str): version of Spack that we want to use to build
 
     Returns:
@@ -57,10 +57,10 @@ def os_package_manager_for(image):
 
     Args:
         image (str): image to be used at run-time. Should be of the form
-            <image_name>:<image_tag> e.g. "ubuntu:18.04"
+            <image_name>:<image_tag> e.g. ``"ubuntu:18.04"``
 
     Returns:
-        Name of the package manager, e.g. "apt" or "yum"
+        Name of the package manager, e.g. ``"apt"`` or ``"yum"``
     """
     name = data()["images"][image]["os_package_manager"]
     return name

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1663,10 +1663,10 @@ class Environment:
         """Updates the path of the default view.
 
         If the argument passed as input is False the default view is deleted, if present. The
-        manifest will have an entry "view: false".
+        manifest will have an entry ``view: false``.
 
         If the argument passed as input is True a default view is created, if not already present.
-        The manifest will have an entry "view: true". If a default view is already declared, it
+        The manifest will have an entry ``view: true``. If a default view is already declared, it
         will be left untouched.
 
         If the argument passed as input is a path a default view pointing to that path is created,

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -11,7 +11,7 @@ import spack.llnl.util.tty as tty
 #: this is module-scoped because it needs to be set very early
 debug = 0
 
-#: whether to show a backtrace when an error is printed, enabled with --backtrace.
+#: whether to show a backtrace when an error is printed, enabled with ``--backtrace``.
 SHOW_BACKTRACE = False
 
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -17,7 +17,7 @@ in order to build it.  They need to define the following methods:
 * reset()
     Restore original state of downloaded code.  Used by clean commands.
     This may just remove the expanded source and re-expand an archive,
-    or it may run something like git reset --hard.
+    or it may run something like git reset ``--hard``.
 * archive()
     Archive a source directory, e.g. for creating a mirror.
 """

--- a/lib/spack/spack/llnl/path.py
+++ b/lib/spack/spack/llnl/path.py
@@ -19,13 +19,13 @@ class Path:
 def format_os_path(path: str, mode: int = Path.unix) -> str:
     """Formats the input path to use consistent, platform specific separators.
 
-    Absolute paths are converted between drive letters and a prepended '/' as per platform
+    Absolute paths are converted between drive letters and a prepended ``/`` as per platform
     requirement.
 
     Parameters:
         path: the path to be normalized, must be a string or expose the replace method.
         mode: the path file separator style to normalize the passed path to.
-            Default is unix style, i.e. '/'
+            Default is unix style, i.e. ``/``
     """
     if not path:
         return path

--- a/lib/spack/spack/llnl/string.py
+++ b/lib/spack/spack/llnl/string.py
@@ -28,14 +28,14 @@ def comma_list(sequence: List[str], article: str = "") -> str:
 
 def comma_or(sequence: List[str]) -> str:
     """Return a string with all the elements of the input joined by comma, but the last
-    one (which is joined by 'or').
+    one (which is joined by ``"or"``).
     """
     return comma_list(sequence, "or")
 
 
 def comma_and(sequence: List[str]) -> str:
     """Return a string with all the elements of the input joined by comma, but the last
-    one (which is joined by 'and').
+    one (which is joined by ``"and"``).
     """
     return comma_list(sequence, "and")
 

--- a/lib/spack/spack/llnl/url.py
+++ b/lib/spack/spack/llnl/url.py
@@ -134,7 +134,7 @@ SOURCEFORGE_RE = re.compile(r"(.*(?:sourceforge\.net|sf\.net)/.*)(/download)$")
 
 
 def split_url_on_sourceforge_suffix(url: str) -> Tuple[str, ...]:
-    """If the input is a sourceforge URL, returns base URL and "/download" suffix. Otherwise,
+    """If the input is a sourceforge URL, returns base URL and ``/download`` suffix. Otherwise,
     returns the input URL and an empty string.
     """
     match = SOURCEFORGE_RE.search(url)
@@ -371,7 +371,7 @@ def strip_version_suffixes(path_or_url: str) -> str:
 def expand_contracted_extension(extension: str) -> str:
     """Returns the expanded version of a known contracted extension.
 
-    This function maps extensions like ".tgz" to ".tar.gz". On unknown extensions,
+    This function maps extensions like ``.tgz`` to ``.tar.gz``. On unknown extensions,
     return the input unmodified.
     """
     extension = extension.strip(".")
@@ -408,7 +408,7 @@ def compression_ext_from_compressed_archive(extension: str) -> Optional[str]:
 
 def strip_compression_extension(path_or_url: str, ext: Optional[str] = None) -> str:
     """Strips the compression extension from the input, and returns it. For instance,
-    "foo.tgz" becomes "foo.tar".
+    ``"foo.tgz"`` becomes ``"foo.tar"``.
 
     If no extension is given, try a default list of extensions.
 

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -1275,16 +1275,16 @@ def traverse_tree(
 
     When called on dest, this yields::
 
-        ('root',         'dest')
-        ('root/a',       'dest/a')
-        ('root/a/file1', 'dest/a/file1')
-        ('root/a/file2', 'dest/a/file2')
-        ('root/b',       'dest/b')
-        ('root/b/file3', 'dest/b/file3')
+        ("root",         "dest")
+        ("root/a",       "dest/a")
+        ("root/a/file1", "dest/a/file1")
+        ("root/a/file2", "dest/a/file2")
+        ("root/b",       "dest/b")
+        ("root/b/file3", "dest/b/file3")
 
     Keyword Arguments:
         order (str): Whether to do pre- or post-order traversal. Accepted
-            values are 'pre' and 'post'
+            values are ``"pre"`` and ``"post"``
         ignore (typing.Callable): function indicating which files to ignore. This will also
             ignore symlinks if they point to an ignored file (regardless of whether the symlink
             is explicitly ignored); note this only supports one layer of indirection (i.e. if

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -882,7 +882,7 @@ def uniq(sequence):
 
 def elide_list(line_list: List[str], max_num: int = 10) -> List[str]:
     """Takes a long list and limits it to a smaller number of elements,
-    replacing intervening elements with '...'.  For example::
+    replacing intervening elements with ``"..."``.  For example::
 
         elide_list(["1", "2", "3", "4", "5", "6"], 4)
 

--- a/lib/spack/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/spack/llnl/util/tty/__init__.py
@@ -99,7 +99,7 @@ def output_filter(filter_fn):
 
 
 class SuppressOutput:
-    """Class for disabling output in a scope using 'with' keyword"""
+    """Class for disabling output in a scope using ``with`` keyword"""
 
     def __init__(self, msg_enabled=True, warn_enabled=True, error_enabled=True):
         self._msg_enabled_initial = _msg_enabled
@@ -127,7 +127,7 @@ def set_stacktrace(flag):
 
 
 def process_stacktrace(countback):
-    """Gives file and line frame 'countback' frames from the bottom"""
+    """Gives file and line frame ``countback`` frames from the bottom"""
     st = traceback.extract_stack()
     # Not all entries may be spack files, we have to remove those that aren't.
     file_list = []
@@ -286,7 +286,7 @@ def hline(label=None, **kwargs):
     """Draw a labeled horizontal line.
 
     Keyword Arguments:
-        char (str): Char to draw the line with.  Default '-'
+        char (str): Char to draw the line with.  Default ``-``
         max_width (int): Maximum width of the line.  Default is 64 chars.
     """
     char = kwargs.pop("char", "-")

--- a/lib/spack/spack/llnl/util/tty/color.py
+++ b/lib/spack/spack/llnl/util/tty/color.py
@@ -6,57 +6,57 @@
 This file implements an expression syntax, similar to ``printf``, for adding
 ANSI colors to text.
 
-See ``colorize()``, ``cwrite()``, and ``cprint()`` for routines that can
+See :func:`colorize`, :func:`cwrite`, and :func:`cprint` for routines that can
 generate colored output.
 
-``colorize`` will take a string and replace all color expressions with
+:func:`colorize` will take a string and replace all color expressions with
 ANSI control codes.  If the ``isatty`` keyword arg is set to False, then
 the color expressions will be converted to null strings, and the
 returned string will have no color.
 
-``cwrite`` and ``cprint`` are equivalent to ``write()`` and ``print()``
+:func:`cwrite` and :func:`cprint` are equivalent to ``write()`` and ``print()``
 calls in python, but they colorize their output.  If the ``stream`` argument is
 not supplied, they write to ``sys.stdout``.
 
 Here are some example color expressions:
 
-==========  ============================================================
-Expression  Meaning
-==========  ============================================================
-@r          Turn on red coloring
-@R          Turn on bright red coloring
-@*{foo}     Bold foo, but don't change text color
-@_{bar}     Underline bar, but don't change text color
-@*b         Turn on bold, blue text
-@_B         Turn on bright blue text with an underline
-@.          Revert to plain formatting
-@*g{green}  Print out 'green' in bold, green text, then reset to plain.
-@*ggreen@.  Print out 'green' in bold, green text, then reset to plain.
-==========  ============================================================
+==============  ============================================================
+Expression      Meaning
+==============  ============================================================
+``@r``          Turn on red coloring
+``@R``          Turn on bright red coloring
+``@*{foo}``     Bold foo, but don't change text color
+``@_{bar}``     Underline bar, but don't change text color
+``@*b``         Turn on bold, blue text
+``@_B``         Turn on bright blue text with an underline
+``@.``          Revert to plain formatting
+``@*g{green}``  Print out 'green' in bold, green text, then reset to plain.
+``@*ggreen@.``  Print out 'green' in bold, green text, then reset to plain.
+==============  ============================================================
 
 The syntax consists of:
 
-==========  =================================================
-color-expr  '@' [style] color-code '{' text '}' | '@.' | '@@'
-style       '*' | '_'
-color-code  [krgybmcwKRGYBMCW]
-text        .*
-==========  =================================================
+==========  =====================================================
+color-expr  ``'@' [style] color-code '{' text '}' | '@.' | '@@'``
+style       ``'*' | '_'``
+color-code  ``[krgybmcwKRGYBMCW]``
+text        ``.*``
+==========  =====================================================
 
-'@' indicates the start of a color expression.  It can be followed
-by an optional * or _ that indicates whether the font should be bold or
-underlined.  If * or _ is not provided, the text will be plain.  Then
-an optional color code is supplied.  This can be [krgybmcw] or [KRGYBMCW],
-where the letters map to  black(k), red(r), green(g), yellow(y), blue(b),
-magenta(m), cyan(c), and white(w).  Lowercase letters denote normal ANSI
+``@`` indicates the start of a color expression.  It can be followed
+by an optional ``*`` or ``_`` that indicates whether the font should be bold or
+underlined.  If ``*`` or ``_`` is not provided, the text will be plain.  Then
+an optional color code is supplied.  This can be ``[krgybmcw]`` or ``[KRGYBMCW]``,
+where the letters map to  ``black(k)``, ``red(r)``, ``green(g)``, ``yellow(y)``, ``blue(b)``,
+``magenta(m)``, ``cyan(c)``, and ``white(w)``.  Lowercase letters denote normal ANSI
 colors and capital letters denote bright ANSI colors.
 
-Finally, the color expression can be followed by text enclosed in {}.  If
+Finally, the color expression can be followed by text enclosed in ``{}``.  If
 braces are present, only the text in braces is colored.  If the braces are
 NOT present, then just the control codes to enable the color will be output.
-The console can be reset later to plain text with '@.'.
+The console can be reset later to plain text with ``@.``.
 
-To output an @, use '@@'.  To output a } inside braces, use '}}'.
+To output an ``@``, use ``@@``.  To output a ``}`` inside braces, use ``}}``.
 """
 import os
 import re
@@ -191,9 +191,9 @@ def get_color_when():
 def set_color_when(when):
     """Set when color should be applied.  Options are:
 
-    * True or 'always': always print color
-    * False or 'never': never print color
-    * None or 'auto': only print color if sys.stdout is a tty.
+    * True or ``"always"``: always print color
+    * False or ``"never"``: never print color
+    * None or ``"auto"``: only print color if sys.stdout is a tty.
     """
     global _force_color
     _force_color = _color_when_value(when)

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -138,7 +138,7 @@ class keyboard_input(preserve_terminal_settings):
     the stream immediately, and they are not printed to the
     terminal. Typically, standard input is line-buffered, which means
     keypresses won't be sent until the user hits return. In this mode, a
-    user can hit, e.g., 'v', and it will be read on the other end of the
+    user can hit, e.g., ``v``, and it will be read on the other end of the
     pipe immediately but not printed.
 
     The handler takes care to ensure that terminal changes only take
@@ -415,7 +415,7 @@ class nixlog:
     process and the daemon.  The daemon writes our output to both the
     file and to stdout (if echoing).  The parent process can communicate
     with the daemon to tell it when and when not to echo; this is what
-    force_echo does.  You can also enable/disable echoing by typing 'v'.
+    force_echo does.  You can also enable/disable echoing by typing ``v``.
 
     We try to use OS-level file descriptors to do the redirection, but if
     stdout or stderr has been set to some Python-level file object, we
@@ -732,7 +732,7 @@ class winlog:
     Similar to nixlog, with underlying
     functionality ported to support Windows.
 
-    Does not support the use of 'v' toggling as nixlog does.
+    Does not support the use of ``v`` toggling as nixlog does.
     """
 
     def __init__(self, file_like=None, echo=False, debug=0, buffer=False, filter_fn=None):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -883,7 +883,7 @@ def add_command_line_scopes(
     command_line_scopes: List[Any],  # str or _ENV but mypy can't type sentinels
     add_environment: Callable[[ConfigScopePriority], None],
 ) -> None:
-    """Add additional scopes from the --config-scope argument, either envs or dirs.
+    """Add additional scopes from the ``--config-scope`` argument, either envs or dirs.
 
     Args:
         cfg: configuration instance

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -133,7 +133,7 @@ def dependencies(spec: spack.spec.Spec, request: str = "all") -> List[spack.spec
 
     Args:
         spec: spec to be analyzed
-        request: one of "none", "run", "direct", "all"
+        request: one of ``"none"``, ``"run"``, ``"direct"``, ``"all"``
 
     Returns:
         list of requested dependencies
@@ -203,7 +203,7 @@ def root_path(name, module_set_name):
     """Returns the root folder for module file installation.
 
     Args:
-        name: name of the module system to be used (e.g. 'tcl')
+        name: name of the module system to be used (``"tcl"`` or ``"lmod"``)
         module_set_name: name of the set of module configs to use
 
     Returns:
@@ -1025,19 +1025,19 @@ class ModuleNotFoundError(ModulesError):
 
 
 class DefaultTemplateNotDefined(AttributeError, ModulesError):
-    """Raised if the attribute 'default_template' has not been specified
+    """Raised if the attribute ``default_template`` has not been specified
     in the derived classes.
     """
 
 
 class HideCmdFormatNotDefined(AttributeError, ModulesError):
-    """Raised if the attribute 'hide_cmd_format' has not been specified
+    """Raised if the attribute ``hide_cmd_format`` has not been specified
     in the derived classes.
     """
 
 
 class ModulercHeaderNotDefined(AttributeError, ModulesError):
-    """Raised if the attribute 'modulerc_header' has not been specified
+    """Raised if the attribute ``modulerc_header`` has not been specified
     in the derived classes.
     """
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -154,7 +154,7 @@ class LmodConfiguration(BaseConfiguration):
     @lang.memoized
     def hierarchy_tokens(self):
         """Returns the list of tokens that are part of the modulefile
-        hierarchy. 'compiler' is always present.
+        hierarchy. ``compiler`` is always present.
         """
         tokens = configuration(self.name).get("hierarchy", [])
 
@@ -180,7 +180,7 @@ class LmodConfiguration(BaseConfiguration):
     def requires(self):
         """Returns a dictionary mapping all the requirements of this spec to the actual provider.
 
-        The 'compiler' key is always present among the requirements.
+        The ``compiler`` key is always present among the requirements.
         """
         # If it's a core_spec, lie and say it requires a core compiler
         if (
@@ -502,12 +502,12 @@ class LmodModulefileWriter(BaseModuleFileWriter):
 
 
 class CoreCompilersNotFoundError(spack.error.SpackError, KeyError):
-    """Error raised if the key 'core_compilers' has not been specified
+    """Error raised if the key ``core_compilers`` has not been specified
     in the configuration file.
     """
 
 
 class NonVirtualInHierarchyError(spack.error.SpackError, TypeError):
     """Error raised if non-virtual specs are used as hierarchy tokens in
-    the lmod section of 'modules.yaml'.
+    the lmod section of ``modules.yaml``.
     """

--- a/lib/spack/spack/schema/container.py
+++ b/lib/spack/spack/schema/container.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""Schema for the 'container' subsection of Spack environments."""
+"""Schema for the ``container`` subsection of Spack environments."""
 from typing import Any, Dict
 
 _stages_from_dockerhub = {

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1880,7 +1880,7 @@ class SpackSolverSetup:
             self.gen.newline()
 
     def package_dependencies_rules(self, pkg):
-        """Translate 'depends_on' directives into ASP logic."""
+        """Translate ``depends_on`` directives into ASP logic."""
         for cond, deps_by_name in sorted(pkg.dependencies.items()):
             for _, dep in sorted(deps_by_name.items()):
                 depflag = dep.depflag

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -14,7 +14,7 @@ The syntax looks like this:
     $ spack install mpileaks ^openmpi @1.2:1.4 +debug %intel @12.1 target=zen
                     0        1        2        3      4      5     6
 
-The first part of this is the command, 'spack install'.  The rest of the
+The first part of this is the command, ``spack install``.  The rest of the
 line is a spec for a particular installation of the mpileaks package.
 
 0. The package to install

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -43,10 +43,10 @@ Here is the EBNF grammar for a spec::
     vid           = [a-zA-Z0-9_][a-zA-Z_0-9-.]*
     id            = [a-zA-Z0-9_][a-zA-Z_0-9-]*
 
-Identifiers using the <name>=<value> command, such as architectures and
+Identifiers using the ``<name>=<value>`` command, such as architectures and
 compiler flags, require a space before the name.
 
-There is one context-sensitive part: ids in versions may contain '.', while
+There is one context-sensitive part: ids in versions may contain ``.``, while
 other ids may not.
 
 There is one ambiguity: since ``-`` is allowed in an id, you need to put

--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -103,7 +103,7 @@ class Checker:
     with.  e.g., if the digest is 32 hex characters long this will
     use md5.
 
-    Example: know your tarball should hash to 'abc123'.  You want
+    Example: know your tarball should hash to ``abc123``.  You want
     to check files against this.  You would use this class like so::
 
        hexdigest = 'abc123'

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -93,7 +93,7 @@ def prune_duplicate_paths(paths: List[Path]) -> List[Path]:
 
 def get_path(name: str) -> List[Path]:
     """Given the name of an environment variable containing multiple
-    paths separated by 'os.pathsep', returns a list of the paths.
+    paths separated by :data:`os.pathsep`, returns a list of the paths.
     """
     path = os.environ.get(name, "").strip()
     if path:
@@ -102,8 +102,8 @@ def get_path(name: str) -> List[Path]:
 
 
 def env_flag(name: str) -> bool:
-    """Given the name of an environment variable, returns True if it is set to
-    'true' or to '1', False otherwise.
+    """Given the name of an environment variable, returns True if the lowercase value is set to
+    ``true`` or to ``1``, False otherwise.
     """
     if name in os.environ:
         value = os.environ[name].lower()
@@ -112,7 +112,7 @@ def env_flag(name: str) -> bool:
 
 
 def path_set(var_name: str, directories: List[Path]):
-    """Sets the variable passed as input to the ``os.pathsep`` joined list of directories."""
+    """Sets the variable passed as input to the :data:`os.pathsep` joined list of directories."""
     path_str = os.pathsep.join(str(dir) for dir in directories)
     os.environ[var_name] = path_str
 
@@ -603,7 +603,7 @@ class EnvironmentModifications:
         Args:
             name: name of the environment variable
             elements: ordered list paths
-            separator: separator for the paths (default: os.pathsep)
+            separator: separator for the paths (default: :data:`os.pathsep`)
         """
         elements = [_validate_path_value(name, x) for x in elements]
         item = SetPath(name, elements, separator=separator, trace=self._trace())
@@ -617,7 +617,7 @@ class EnvironmentModifications:
         Args:
             name: name of the environment variable
             path: path to be appended
-            separator: separator for the paths (default: os.pathsep)
+            separator: separator for the paths (default: :data:`os.pathsep`)
         """
         path = _validate_path_value(name, path)
         item = AppendPath(name, path, separator=separator, trace=self._trace())
@@ -631,7 +631,7 @@ class EnvironmentModifications:
         Args:
             name: name of the environment variable
             path: path to be prepended
-            separator: separator for the paths (default: os.pathsep)
+            separator: separator for the paths (default: :data:`os.pathsep`)
         """
         path = _validate_path_value(name, path)
         item = PrependPath(name, path, separator=separator, trace=self._trace())
@@ -645,7 +645,7 @@ class EnvironmentModifications:
         Args:
             name: name of the environment variable
             path: path to be removed
-            separator: separator for the paths (default: os.pathsep)
+            separator: separator for the paths (default: :data:`os.pathsep`)
         """
         path = _validate_path_value(name, path)
         item = RemoveFirstPath(name, path, separator=separator, trace=self._trace())
@@ -659,7 +659,7 @@ class EnvironmentModifications:
         Args:
             name: name of the environment variable
             path: path to be removed
-            separator: separator for the paths (default: os.pathsep)
+            separator: separator for the paths (default: :data:`os.pathsep`)
         """
         path = _validate_path_value(name, path)
         item = RemoveLastPath(name, path, separator=separator, trace=self._trace())
@@ -673,7 +673,7 @@ class EnvironmentModifications:
         Args:
             name: name of the environment variable
             path: path to be removed
-            separator: separator for the paths (default: os.pathsep)
+            separator: separator for the paths (default: :data:`os.pathsep`)
         """
         path = _validate_path_value(name, path)
         item = RemovePath(name, path, separator=separator, trace=self._trace())
@@ -685,7 +685,7 @@ class EnvironmentModifications:
 
         Args:
             name: name of the environment variable
-            separator: separator for the paths (default: os.pathsep)
+            separator: separator for the paths (default: :data:`os.pathsep`)
         """
         item = DeprioritizeSystemPaths(name, separator=separator, trace=self._trace())
         self.env_modifications.append(item)
@@ -696,7 +696,7 @@ class EnvironmentModifications:
 
         Args:
             name: name of the environment variable
-            separator: separator for the paths (default: os.pathsep)
+            separator: separator for the paths (default: :data:`os.pathsep`)
         """
         item = PruneDuplicatePaths(name, separator=separator, trace=self._trace())
         self.env_modifications.append(item)

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -64,7 +64,7 @@ def make_log_context(log_events, width=None):
         str: context from the build log with errors highlighted
 
     Parses the log file for lines containing errors, and prints them out
-    with line numbers and context.  Errors are highlighted with '>>' and
+    with line numbers and context.  Errors are highlighted with ``>>`` and
     with red highlighting (if color is enabled).
 
     Events are sorted by line number before they are displayed.

--- a/lib/spack/spack/util/naming.py
+++ b/lib/spack/spack/util/naming.py
@@ -71,12 +71,12 @@ def pkg_name_to_class_name(pkg_name: str):
 
     Not all package names are valid Python identifiers:
 
-    * They can contain '-', but cannot start with '-'.
-    * They can start with numbers, e.g. "3proxy".
+    * They can contain ``-``, but cannot start with ``-``.
+    * They can start with numbers, e.g. ``3proxy``.
 
-    This function converts from the package name to the class convention by removing _ and - and
-    converting surrounding lowercase text to CapWords.  If package name starts with a number, the
-    class name returned will be prepended with '_' to make a valid Python identifier.
+    This function converts from the package name to the class convention by removing ``_`` and
+    ``-``, and converting surrounding lowercase text to CapWords. If package name starts with a
+    number, the class name returned will be prepended with ``_`` to make a valid Python identifier.
     """
     class_name = re.sub(r"[-_]+", "-", pkg_name)
     class_name = string.capwords(class_name, "-")

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -410,6 +410,7 @@ class StandardVersion(ConcreteVersion):
         """The dotted representation of the version.
 
         Example:
+
         >>> version = Version('1-2-3b')
         >>> version.dotted
         Version('1.2.3b')
@@ -424,9 +425,10 @@ class StandardVersion(ConcreteVersion):
         """The underscored representation of the version.
 
         Example:
-        >>> version = Version('1.2.3b')
+
+        >>> version = Version("1.2.3b")
         >>> version.underscored
-        Version('1_2_3b')
+        Version("1_2_3b")
 
         Returns:
             Version: The version with separator characters replaced by
@@ -439,9 +441,10 @@ class StandardVersion(ConcreteVersion):
         """The dashed representation of the version.
 
         Example:
-        >>> version = Version('1.2.3b')
+
+        >>> version = Version("1.2.3b")
         >>> version.dashed
-        Version('1-2-3b')
+        Version("1-2-3b")
 
         Returns:
             Version: The version with separator characters replaced by dashes
@@ -453,9 +456,10 @@ class StandardVersion(ConcreteVersion):
         """The joined representation of the version.
 
         Example:
-        >>> version = Version('1.2.3b')
+
+        >>> version = Version("1.2.3b")
         >>> version.joined
-        Version('123b')
+        Version("123b")
 
         Returns:
             Version: The version with separator characters removed
@@ -468,21 +472,22 @@ class StandardVersion(ConcreteVersion):
         """The version up to the specified component.
 
         Examples:
-        >>> version = Version('1.23-4b')
+
+        >>> version = Version("1.23-4b")
         >>> version.up_to(1)
-        Version('1')
+        Version("1")
         >>> version.up_to(2)
-        Version('1.23')
+        Version("1.23")
         >>> version.up_to(3)
-        Version('1.23-4')
+        Version("1.23-4")
         >>> version.up_to(4)
-        Version('1.23-4b')
+        Version("1.23-4b")
         >>> version.up_to(-1)
-        Version('1.23-4')
+        Version("1.23-4")
         >>> version.up_to(-2)
-        Version('1.23')
+        Version("1.23")
         >>> version.up_to(-3)
-        Version('1')
+        Version("1")
 
         Returns:
             Version: The first index components of the version
@@ -517,7 +522,7 @@ class GitVersion(ConcreteVersion):
 
     There are two distinct categories of git versions:
 
-    1) GitVersions instantiated with an associated reference version (e.g. 'git.foo=1.2')
+    1) GitVersions instantiated with an associated reference version (e.g. ``git.foo=1.2``)
     2) GitVersions requiring commit lookups
 
     Git ref versions that are not paired with a known version are handled separately from


### PR DESCRIPTION
* Fix a few cases where `--flag` was rendered as `–flag` in the docs, which readers can't copy/past in the terminal
* Use literal code blocks in a few cases where quotes were used
