### PR TITLE
docs: fix :emphasize-lines: after black formatting

### DIFF
--- a/lib/spack/docs/build_systems/cudapackage.rst
+++ b/lib/spack/docs/build_systems/cudapackage.rst
@@ -78,7 +78,7 @@ This helper package can be added to your package by adding it as a base class of
 For example, you can add it to your :ref:`CMakePackage <cmakepackage>`-based package as follows:
 
 .. code-block:: python
-   :emphasize-lines: 1,7-16
+   :emphasize-lines: 1,8-17
 
    class MyCudaPackage(CMakePackage, CudaPackage):
        ...

--- a/lib/spack/docs/build_systems/rocmpackage.rst
+++ b/lib/spack/docs/build_systems/rocmpackage.rst
@@ -62,7 +62,7 @@ This helper package can be added to your package by adding it as a base class of
 For example, you can add it to your :ref:`CMakePackage <cmakepackage>`-based package as follows:
 
 .. code-block:: python
-   :emphasize-lines: 1,3-7,14-25
+   :emphasize-lines: 1,3-6,13-21
 
    class MyRocmPackage(CMakePackage, ROCmPackage):
        ...

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -645,7 +645,7 @@ If a package does not build properly in parallel, you can simply define ``parall
 For example:
 
 .. code-block:: python
-   :emphasize-lines: 3
+   :emphasize-lines: 4
 
    class ExamplePackage(MakefilePackage):
        """Example package that does not build in parallel."""


### PR DESCRIPTION
Follow up to previous pr that ran black on code blocks.

This fixes the highlighted lines
