### PR TITLE
docs: fix code -> code-block directives

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -1068,7 +1068,7 @@ This comes up when you want to install an environment that provides executables 
 
 The example below shows how to accomplish this: the ``env`` target specifies the generated ``spack/env`` target as a prerequisite, meaning that the environment gets installed and is available for use in the ``env`` target.
 
-.. code:: Makefile
+.. code-block:: Makefile
 
    SPACK ?= spack
 
@@ -1143,7 +1143,7 @@ They are respectively the spec hash (excluding leading ``/``), and a human-reada
 Finally, we have an entry point target ``push`` that will update the buildcache index once every package is pushed.
 Note how this target uses the generated ``example/SPACK_PACKAGE_IDS`` variable to define its prerequisites.
 
-.. code:: Makefile
+.. code-block:: Makefile
 
    SPACK ?= spack
    BUILDCACHE_DIR = $(CURDIR)/tarballs

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -577,7 +577,7 @@ This includes ``repro.json``, copies of all of the files in ``concrete_environme
 The ``repro.json`` file is not versioned and is only designed to work with the version that Spack CI was run with.
 An example of what a ``repro.json`` may look like is here.
 
-.. code:: json
+.. code-block:: json
 
   {
     "job_name": "adios2@2.9.2 /feaevuj %gcc@11.4.0 arch=linux-ubuntu20.04-x86_64_v3 E4S ROCm External",


### PR DESCRIPTION
`.. code::` is a [builtin of docutils](https://docutils.sourceforge.io/docs/ref/rst/directives.html#code), whereas `.. code-block::` is defined by Sphinx.

Maybe Sphinx overrides the `.. code::` directive (https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code) but in any case, we're using Sphinx, so let's use Sphinx directives.