### PR TITLE
test\cmd\pkg: Ensure getgrep handles not found

### DIFF
--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -168,7 +168,8 @@ def pkg_hash(args):
 def get_grep(required=False):
     """Get a grep command to use with ``spack pkg grep``."""
     grep = exe.which(os.environ.get("SPACK_GREP") or "grep", required=required)
-    grep.ignore_quotes = True  # allow `spack pkg grep '"quoted string"'` without warning
+    if grep:
+        grep.ignore_quotes = True  # allow `spack pkg grep '"quoted string"'` without warning
     return grep
 
 


### PR DESCRIPTION
Adds a check to whether grep check returns none before assigning attributes to returned object

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
