### PR TITLE
repositories.rst: make it possible to link to git repos

### DIFF
--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -101,6 +101,7 @@ You can point Spack to a repository on your local filesystem:
 
 .. code-block:: yaml
    :caption: ``~/.spack/repos.yaml``
+   :name: code-example-local-repo
 
    repos:
      my_local_packages: /path/to/my_repository_root
@@ -138,6 +139,7 @@ For example, to use ``~/custom_packages_clone`` for ``my_remote_repo``:
 
 .. code-block:: yaml
    :caption: ``~/.spack/repos.yaml``
+   :name: code-example-location
 
    repos:
      my_remote_repo:
@@ -149,6 +151,7 @@ Spack can make the configuration changes for you using ``spack repo set --destin
 
 .. code-block:: yaml
    :caption: ``~/.spack/repos.yaml``
+   :name: code-example-builtin
 
    repos:
      builtin:
@@ -161,6 +164,7 @@ Repos can be pinned to a git branch, tag, or commit.
 
 .. code-block:: yaml
    :caption: ``~/.spack/repos.yaml``
+   :name: code-example-branch
 
    repos:
      builtin:
@@ -206,6 +210,7 @@ The ``spack-repo-index.yaml`` in the root of ``https://example.com/my_org/my_pkg
 
 .. code-block:: yaml
    :caption: ``my_pkgs.git/spack-repo-index.yaml``
+   :name: code-example-repo-index
 
    repo_index:
      paths:
@@ -216,6 +221,7 @@ If ``my_pkgs.git`` is configured in ``repos.yaml`` as follows:
 
 .. code-block:: yaml
    :caption: ``~/.spack/repos.yaml``
+   :name: code-example-git-repo
 
    repos:
      example_mono_repo: https://example.com/my_org/my_pkgs.git
@@ -229,6 +235,7 @@ For example, if you only want the computer science packages:
 
 .. code-block:: yaml
    :caption: ``~/.spack/repos.yaml``
+   :name: code-example-specific-repo
 
    repos:
      example_mono_repo:
@@ -261,6 +268,7 @@ For example, the built-in repository (from ``spack/spack-packages``) has its nam
 
 .. code-block:: yaml
    :caption: ``repo.yaml`` of ``spack/spack-packages``
+   :name: code-example-repo-yaml
 
    repo:
      namespace: builtin
@@ -538,6 +546,7 @@ This updates your user-level ``repos.yaml``, adding or modifying the ``destinati
 
 .. code-block:: yaml
    :caption: ``~/.spack/repos.yaml`` after ``spack repo set``
+   :name: code-example-specific-destination
 
    repos:
      builtin:

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -46,9 +46,9 @@ An individual Spack package repository is a directory structured as follows:
 
   .. code-block:: yaml
 
-    repo:
-      namespace: myrepo
-      api: v2.0
+     repo:
+       namespace: myrepo
+       api: v2.0
 
   It defines primarily:
 
@@ -114,8 +114,8 @@ Spack can clone and use repositories directly from Git URLs:
 
 .. code-block:: yaml
 
-  repos:
-    my_remote_repo: https://github.com/myorg/spack-custom-pkgs.git
+   repos:
+     my_remote_repo: https://github.com/myorg/spack-custom-pkgs.git
 
 Automatic Cloning
 """""""""""""""""
@@ -247,9 +247,9 @@ The default configuration in ``$spack/etc/spack/defaults/repos.yaml`` looks some
 
 .. code-block:: yaml
 
-  repos:
-    builtin:
-      git: https://github.com/spack/spack-packages.git
+   repos:
+     builtin:
+       git: https://github.com/spack/spack-packages.git
 
 .. _namespaces:
 
@@ -260,11 +260,11 @@ Every repository in Spack has an associated **namespace** defined in the ``names
 For example, the built-in repository (from ``spack/spack-packages``) has its namespace defined as ``builtin``:
 
 .. code-block:: yaml
+   :caption: ``repo.yaml`` of ``spack/spack-packages``
 
-  # In spack/spack-packages repository's repo.yaml
-  repo:
-    namespace: builtin
-    api: v2.0 # Or newer
+   repo:
+     namespace: builtin
+     api: v2.0 # Or newer
 
 Spack records the repository namespace of each installed package.
 For example, if you install the ``mpich`` package from the ``builtin`` repo, Spack records its fully qualified name as ``builtin.mpich``.
@@ -318,19 +318,19 @@ If you've installed both, ``spack find`` alone might be ambiguous:
 
 .. code-block:: console
 
-  $ spack find
-  ==> 2 installed packages.
-  -- linux-rhel6-x86_64 / gcc@4.4.7 -------------
-  mpich@3.2  mpich@3.2
+   $ spack find
+   ==> 2 installed packages.
+   -- linux-rhel6-x86_64 / gcc@4.4.7 -------------
+   mpich@3.2  mpich@3.2
 
 Using ``spack find -N`` displays packages with their namespaces:
 
 .. code-block:: console
 
-  $ spack find -N
-  ==> 2 installed packages.
-  -- linux-rhel6-x86_64 / gcc@4.4.7 -------------
-  builtin.mpich@3.2  llnl.comp.mpich@3.2
+   $ spack find -N
+   ==> 2 installed packages.
+   -- linux-rhel6-x86_64 / gcc@4.4.7 -------------
+   builtin.mpich@3.2  llnl.comp.mpich@3.2
 
 Now you can distinguish them.
 Packages differing only by namespace will have different hashes:
@@ -418,11 +418,11 @@ This command shows all repositories Spack currently knows about, including their
 
 .. code-block:: console
 
-  $ spack repo list
-  [+] my_local           v2.0    /path/to/spack_repo/my_local_packages
-  [+] comp_sci_packages  v2.0    ~/.spack/package_repos/<hash 1>/spack_pkgs/spack_repo/comp_sci_packages
-  [+] physics_packages   v2.0    ~/.spack/package_repos/<hash 1>/spack_pkgs/spack_repo/physics_packages  # From the same git repo
-  [+] builtin            v2.0    ~/.spack/package_repos/<hash 2>/repos/spack_repo/builtin
+   $ spack repo list
+   [+] my_local           v2.0    /path/to/spack_repo/my_local_packages
+   [+] comp_sci_packages  v2.0    ~/.spack/package_repos/<hash 1>/spack_pkgs/spack_repo/comp_sci_packages
+   [+] physics_packages   v2.0    ~/.spack/package_repos/<hash 1>/spack_pkgs/spack_repo/physics_packages  # From the same git repo
+   [+] builtin            v2.0    ~/.spack/package_repos/<hash 2>/repos/spack_repo/builtin
 
 Spack shows a green ``[+]`` next to each repository that is available for use.
 It shows a red ``[-]`` to indicate that package repositories cannot be used due to an error (e.g., unsupported API version, missing ``repo.yaml``, etc.).
@@ -450,10 +450,10 @@ To create the directory structure for a new, empty local repository:
 
 .. code-block:: console
 
-  $ spack repo create ~/my_spack_projects myorg.projectx
-  ==> Created repo with namespace 'myorg.projectx'.
-  ==> To register it with spack, run this command:
-    spack repo add ~/my_spack_projects/spack_repo/myorg/projectx
+   $ spack repo create ~/my_spack_projects myorg.projectx
+   ==> Created repo with namespace 'myorg.projectx'.
+   ==> To register it with spack, run this command:
+     spack repo add ~/my_spack_projects/spack_repo/myorg/projectx
 
 This command creates the following structure:
 
@@ -508,15 +508,15 @@ By configuration name (e.g., ``projectx`` from the add example):
 
 .. code-block:: console
 
-  $ spack repo remove projectx
-  ==> Removed repository 'projectx'.
+   $ spack repo remove projectx
+   ==> Removed repository 'projectx'.
 
 By path (for a local repo):
 
 .. code-block:: console
 
-  $ spack repo remove ~/my_spack_projects/spack_repo/myorg/projectx
-  ==> Removed repository '/home/user/my_spack_projects/spack_repo/myorg/projectx'.
+   $ spack repo remove ~/my_spack_projects/spack_repo/myorg/projectx
+   ==> Removed repository '/home/user/my_spack_projects/spack_repo/myorg/projectx'.
 
 This command removes the corresponding entry from your ``repos.yaml`` configuration.
 It does *not* delete the local repository files or any cloned Git repositories.
@@ -531,18 +531,18 @@ The ``<config_name>`` is the key used in your ``repos.yaml`` file for that Git r
 
 .. code-block:: console
 
-  $ spack repo set --destination /my/custom/path/for/spack-packages builtin
-  ==> Updated repo 'builtin'
+   $ spack repo set --destination /my/custom/path/for/spack-packages builtin
+   ==> Updated repo 'builtin'
 
 This updates your user-level ``repos.yaml``, adding or modifying the ``destination:`` key for the specified repository configuration name.
 
 .. code-block:: yaml
+   :caption: ``~/.spack/repos.yaml`` after ``spack repo set``
 
-  # ~/.spack/repos.yaml after the command
-  repos:
-    builtin:
-      destination: /my/custom/path/for/spack-packages
-      # The 'git:' URL is typically inherited from Spack's default configuration for 'builtin'
+   repos:
+     builtin:
+       destination: /my/custom/path/for/spack-packages
+       # The 'git:' URL is typically inherited from Spack's default configuration for 'builtin'
 
 Spack will then use ``/my/custom/path/for/spack-packages`` for the ``builtin`` repository.
 If the directory doesn't exist, Spack will clone into it.

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -100,10 +100,10 @@ Local Repositories (Path-based)
 You can point Spack to a repository on your local filesystem:
 
 .. code-block:: yaml
+   :caption: ``~/.spack/repos.yaml``
 
-  # Example: ~/.spack/repos.yaml
-  repos:
-    my_local_packages: /path/to/my_repository_root
+   repos:
+     my_local_packages: /path/to/my_repository_root
 
 Here, ``/path/to/my_repository_root`` should be the directory containing that repository's ``repo.yaml`` and ``packages/`` subdirectory.
 
@@ -117,7 +117,9 @@ Spack can clone and use repositories directly from Git URLs:
   repos:
     my_remote_repo: https://github.com/myorg/spack-custom-pkgs.git
 
-**Automatic Cloning.**
+Automatic Cloning
+"""""""""""""""""
+
 When Spack first encounters a Git-based repository configuration, it automatically clones it.
 By default, these repositories are cloned into a subdirectory within ``~/.spack/package_repos/``, named with a hash of the repository URL.
 
@@ -125,7 +127,9 @@ To change directories to the package repository, you can use ``spack cd --repo [
 To find where a repository is cloned, you can use ``spack location --repo [name]`` or ``spack repo list``.
 The ``name`` argument is optional; if omitted, Spack will use the first package repository in configuration order.
 
-**Customizing Clone Location.**
+Customizing Clone Location
+""""""""""""""""""""""""""
+
 The default clone location (``~/.spack/package_repos/<hashed_name>``) might not be convenient for package maintainers who want to make changes to packages.
 You can specify a custom local directory for Spack to clone a Git repository into, or to use if the repository is already cloned there.
 This is done using the ``destination`` key in ``repos.yaml`` or via the ``spack repo set --destination`` command (see :ref:`cmd-spack-repo-set-destination`).
@@ -133,29 +137,31 @@ This is done using the ``destination`` key in ``repos.yaml`` or via the ``spack 
 For example, to use ``~/custom_packages_clone`` for ``my_remote_repo``:
 
 .. code-block:: yaml
+   :caption: ``~/.spack/repos.yaml``
 
-  # ~/.spack/repos.yaml
-  repos:
-    my_remote_repo:
-      git: https://github.com/myorg/spack-custom-pkgs.git
-      destination: ~/custom_packages_clone
+   repos:
+     my_remote_repo:
+       git: https://github.com/myorg/spack-custom-pkgs.git
+       destination: ~/custom_packages_clone
 
 If the ``git`` URL is defined in a lower-precedence configuration (like Spack's defaults for ``builtin``), you only need to specify the ``destination`` in your user-level ``repos.yaml``.
 Spack can make the configuration changes for you using ``spack repo set --destination ~/spack-packages builtin``, or you can directly edit your ``repos.yaml`` file:
 
 .. code-block:: yaml
+   :caption: ``~/.spack/repos.yaml``
 
-  # ~/.spack/repos.yaml
-  repos:
-    builtin:
-      destination: ~/spack-packages
+   repos:
+     builtin:
+       destination: ~/spack-packages
 
-**Updating and pinning.**
+Updating and pinning
+""""""""""""""""""""
+
 Repos can be pinned to a git branch, tag, or commit.
 
 .. code-block:: yaml
+   :caption: ``~/.spack/repos.yaml``
 
-   # ~/.spack/repos.yaml
    repos:
      builtin:
        branch: releases/v2025.07
@@ -166,7 +172,9 @@ The ``spack repo update`` command will update the repo on disk to match the curr
 If the repo is pinned to a commit or tag, it will ensure the repo on disk reflects that commit or tag.
 If the repo is pinned to a branch or unpinned, ``spack repo update`` will pull the most recent state of the branch (the default branch if unpinned).
 
-**Git repositories need a package repo index.**
+Git repositories need a package repo index
+""""""""""""""""""""""""""""""""""""""""""
+
 A single Git repository can contain one or more Spack package repositories.
 To enable Spack to discover these, the root of the Git repository should contain a ``spack-repo-index.yaml`` file.
 This file lists the relative paths to package repository roots within the git repo.
@@ -197,20 +205,20 @@ For example, assume a Git repository at ``https://example.com/my_org/my_pkgs.git
 The ``spack-repo-index.yaml`` in the root of ``https://example.com/my_org/my_pkgs.git`` should look like this:
 
 .. code-block:: yaml
+   :caption: ``my_pkgs.git/spack-repo-index.yaml``
 
-  # my_pkgs.git/spack-repo-index.yaml
-  repo_index:
-    paths:
-    - spack_pkgs/spack_repo/my_org/comp_sci_packages
-    - spack_pkgs/spack_repo/my_org/physics_packages
+   repo_index:
+     paths:
+     - spack_pkgs/spack_repo/my_org/comp_sci_packages
+     - spack_pkgs/spack_repo/my_org/physics_packages
 
 If ``my_pkgs.git`` is configured in ``repos.yaml`` as follows:
 
 .. code-block:: yaml
+   :caption: ``~/.spack/repos.yaml``
 
-  # ~/.spack/repos.yaml
-  repos:
-    example_mono_repo: https://example.com/my_org/my_pkgs.git
+   repos:
+     example_mono_repo: https://example.com/my_org/my_pkgs.git
 
 Spack will clone ``my_pkgs.git`` and look for ``spack-repo-index.yaml``.
 It will then register two separate repositories based on the paths found (e.g., ``<clone_dir>/spack_pkgs/spack_repo/my_org/comp_sci_packages`` and ``<clone_dir>/spack_pkgs/spack_repo/my_org/physics_packages``), each with its own namespace defined in its respective ``repo.yaml`` file.
@@ -220,8 +228,8 @@ If you want only one of the package repositories from a Git mono-repo, you can o
 For example, if you only want the computer science packages:
 
 .. code-block:: yaml
+   :caption: ``~/.spack/repos.yaml``
 
-   # ~/.spack/repos.yaml
    repos:
      example_mono_repo:
        git: https://example.com/my_org/my_pkgs.git


### PR DESCRIPTION
current it's just paragraphs, so can't link to a particular subsection.