### PR TITLE
docs: add compiler config to FAQ, improve configuring compilers in packages.yaml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,46 +17,46 @@ python:
 
 search:
   ranking:
-    spack.html: -10
-    spack.*.html: -10
-    spack_repo.html: -10
-    spack_repo.*.html: -10
     _modules/*: -10
-    command_index.html: -9
-    features.html: 5
-    getting_started.html: 5
-    spec_syntax.html: 5
-    installing_prerequisites.html: 5
-    windows.html: 5
-    package_fundamentals.html: 5
-    configuring_compilers.html: 5
-    replace_conda_homebrew.html: 5
-    frequently_asked_questions.html: 5
-    getting_help.html: 5
+    spack_repo.*.html: -10
+    spack_repo.html: -10
+    spack.*.html: -10
+    spack.html: -10
+    command_index.html: 4
     advanced_topics.html: 5
-    config_yaml.html: 5
-    include_yaml.html: 5
-    packages_yaml.html: 5
-    build_settings.html: 5
-    environments.html: 5
-    env_vars_yaml.html: 5
-    containers.html: 5
-    mirrors.html: 5
-    module_file_support.html: 5
-    repositories.html: 5
     binary_caches.html: 5
     bootstrapping.html: 5
-    chain.html: 5
-    extensions.html: 5
-    pipelines.html: 5
-    signing.html: 5
-    gpu_configuration.html: 5
-    packaging_guide_creation.html: 5
-    packaging_guide_build.html: 5
-    packaging_guide_testing.html: 5
-    packaging_guide_advanced.html: 5
+    build_settings.html: 5
     build_systems.html: 5
     build_systems/*.html: 5
+    chain.html: 5
+    config_yaml.html: 5
+    configuring_compilers.html: 5
+    containers.html: 5
     contribution_guide.html: 5
     developer_guide.html: 5
+    env_vars_yaml.html: 5
+    environments.html: 5
+    extensions.html: 5
+    features.html: 5
+    getting_help.html: 5
+    getting_started.html: 5
+    gpu_configuration.html: 5
+    include_yaml.html: 5
+    installing_prerequisites.html: 5
+    mirrors.html: 5
+    module_file_support.html: 5
     package_api.html: 5
+    package_fundamentals.html: 5
+    packages_yaml.html: 5
+    packaging_guide_advanced.html: 5
+    packaging_guide_build.html: 5
+    packaging_guide_creation.html: 5
+    packaging_guide_testing.html: 5
+    pipelines.html: 5
+    replace_conda_homebrew.html: 5
+    repositories.html: 5
+    signing.html: 5
+    spec_syntax.html: 5
+    windows.html: 5
+    frequently_asked_questions.html: 6

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -122,7 +122,8 @@ Suppose that you need to support simultaneous building of release and developmen
 You could create the following files:
 
 .. code-block:: yaml
-   :caption: ~/myscopes/release/packages.yaml
+   :caption: ``~/myscopes/release/packages.yaml``
+   :name: code-example-release-packages-yaml
 
    packages:
      mypackage:
@@ -133,7 +134,8 @@ You could create the following files:
        prefer: ["@0.8"]
 
 .. code-block:: yaml
-   :caption: ~/myscopes/develop/packages.yaml
+   :caption: ``~/myscopes/develop/packages.yaml``
+   :name: code-example-develop-packages-yaml
 
    packages:
      mypackage:
@@ -154,7 +156,8 @@ For ``pkg-b`` you want a newer Python version and a different MPI implementation
 You can create different configuration scopes for use with ``pkg-a`` and ``pkg-b``:
 
 .. code-block:: yaml
-   :caption: ~/myscopes/pkg-a/packages.yaml
+   :caption: ``~/myscopes/pkg-a/packages.yaml``
+   :name: code-example-pkg-a-packages-yaml
 
    packages:
      python:
@@ -163,7 +166,8 @@ You can create different configuration scopes for use with ``pkg-a`` and ``pkg-b
        require: [openmpi]
 
 .. code-block:: yaml
-   :caption: ~/myscopes/pkg-b/packages.yaml
+   :caption: ``~/myscopes/pkg-b/packages.yaml``
+   :name: code-example-pkg-b-packages-yaml
 
    packages:
      python:
@@ -287,7 +291,8 @@ Let's look at an example of overriding a single key in a Spack configuration fil
 If your configurations look like this:
 
 .. code-block:: yaml
-   :caption: $(prefix)/etc/spack/defaults/config.yaml
+   :caption: ``$(prefix)/etc/spack/defaults/config.yaml``
+   :name: code-example-defaults-config-yaml
 
    config:
      install_tree: $spack/opt/spack
@@ -297,7 +302,8 @@ If your configurations look like this:
 
 
 .. code-block:: yaml
-   :caption: ~/.spack/config.yaml
+   :caption: ``~/.spack/config.yaml``
+   :name: code-example-user-config-yaml
 
    config:
      install_tree: /some/other/directory
@@ -329,7 +335,8 @@ For example:
 
 .. code-block:: yaml
    :emphasize-lines: 1
-   :caption: ~/.spack/config.yaml
+   :caption: ``~/.spack/config.yaml``
+   :name: code-example-append-install-tree
 
    config:
      install_tree-: /my/custom/suffix/
@@ -350,7 +357,8 @@ Similarly, ``+:`` can be used to *prepend* to a path or name:
 
 .. code-block:: yaml
    :emphasize-lines: 1
-   :caption: ~/.spack/config.yaml
+   :caption: ``~/.spack/config.yaml``
+   :name: code-example-prepend-install-tree
 
    config:
      install_tree+: /my/custom/suffix/
@@ -368,7 +376,8 @@ For example:
 
 .. code-block:: yaml
    :emphasize-lines: 1
-   :caption: ~/.spack/config.yaml
+   :caption: ``~/.spack/config.yaml``
+   :name: code-example-override-config-section
 
    config::
      install_tree: /some/other/directory
@@ -389,21 +398,25 @@ Let's revisit the ``config.yaml`` example one more time.
 The ``build_stage`` setting's value is an ordered list of directories:
 
 .. code-block:: yaml
-   :caption: $(prefix)/etc/spack/defaults/config.yaml
+   :caption: ``$(prefix)/etc/spack/defaults/config.yaml``
+   :name: code-example-defaults-build-stage
 
-   build_stage:
-   - $tempdir/$user/spack-stage
-   - ~/.spack/stage
+   config:
+     build_stage:
+     - $tempdir/$user/spack-stage
+     - ~/.spack/stage
 
 
 Suppose the user configuration adds its *own* list of ``build_stage`` paths:
 
 .. code-block:: yaml
-   :caption: ~/.spack/config.yaml
+   :caption: ``~/.spack/config.yaml``
+   :name: code-example-user-build-stage
 
-   build_stage:
-   - /lustre-scratch/$user/spack
-   - ~/mystage
+   config:
+     build_stage:
+     - /lustre-scratch/$user/spack
+     - ~/mystage
 
 
 Spack will first look at the paths in the defaults ``config.yaml``, then the paths in the user's ``~/.spack/config.yaml``.
@@ -428,11 +441,13 @@ So if the user config looked like this:
 
 .. code-block:: yaml
    :emphasize-lines: 1
-   :caption: ~/.spack/config.yaml
+   :caption: ``~/.spack/config.yaml``
+   :name: code-example-override-build-stage
 
-   build_stage::
-   - /lustre-scratch/$user/spack
-   - ~/mystage
+   config:
+     build_stage::
+     - /lustre-scratch/$user/spack
+     - ~/mystage
 
 
 The merged configuration would look like this:

--- a/lib/spack/docs/frequently_asked_questions.rst
+++ b/lib/spack/docs/frequently_asked_questions.rst
@@ -75,36 +75,24 @@ The following set of criteria (from lowest to highest precedence) explains commo
 
 Requirements and constraints restrict the set of possible solutions, while reuse behavior and preferences influence what an optimal solution looks like.
 
-How do I specify or require a compiler?
----------------------------------------
+How do I use a specific compiler?
+---------------------------------
 
-When specifying compilers, you have two main options: either you specify compilers globally for all packages in configuration files, or you specify them on the level of :doc:`individual specs <spec_syntax>`.
+When you have multiple compilers available in :ref:`spack-compiler-list`, and want to build your packages with a specific one, you have the following options:
+
+1. Specify your compiler preferences globally for all packages in configuration files.
+2. Specify them on the level of individual specs, like ``pkg %gcc@15`` or ``pkg %c,cxx=gcc@15``.
+
+We'll explore both options in more detail.
 
 Specific compiler for all packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you want to use a specific compiler for all packages, it's best to use :ref:`requirements in packages.yaml config <setting-requirements-on-virtual-specs>`.
-The following example requires GCC 15 for all languages ``c``, ``cxx``, and ``fortran``:
+If you want to use a specific compiler for all packages, it's best to use :ref:`strong preferences in packages.yaml config <setting-requirements-on-virtual-specs>`.
+The following example prefers GCC 15 for all languages ``c``, ``cxx``, and ``fortran``:
 
 .. code-block:: yaml
-   :caption: Recommended: *require* a specific compiler
-   :name: code-example-require-compiler-per-language
-
-   packages:
-     c:
-       require:
-       - gcc@15
-     cxx:
-       require:
-       - gcc@15
-     fortran:
-       require:
-       - gcc@15
-
-Alternatively, you can use :ref:`strong preferences <package-strong-preferences>` instead of hard requirements, which are more forgiving when certain packages conflict with the requested compiler:
-
-.. code-block:: yaml
-   :caption: Alternative: *prefer* a specific compiler
+   :caption: Recommended: *prefer* a specific compiler
    :name: code-example-prefer-compiler
 
    packages:
@@ -118,9 +106,12 @@ Alternatively, you can use :ref:`strong preferences <package-strong-preferences>
        prefer:
        - gcc@15
 
+You can also replace ``prefer:`` with ``require:`` if you want Spack to produce an error if the preferred compiler cannot be used.
+See also :ref:`the previous FAQ entry <faq-concretizer-precedence>`.
+
 In Spack, the languages ``c``, ``cxx`` and ``fortran`` are :ref:`virtual packages <language-dependencies>`, on which packages depend if they need a compiler for that language.
 Compiler packages provide these language virtuals.
-When you specify these requirements or strong preferences, Spack determines whether the package depends on the language virtuals, and if so, it applies the requested compiler spec.
+When you specify these strong preferences, Spack determines whether the package depends on any of the language virtuals, and if so, it applies the associated compiler spec when possible.
 
 What is **not recommended** is to define ``%gcc`` as a required dependency of all packages:
 
@@ -138,7 +129,7 @@ This is *incorrect*, because some packages do not need a compiler at all (e.g. p
 Specific compiler for individual specs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If different parts of your software stack need to be built with different compilers, it's best to specify compilers as dependencies of the relevant specs (whether on the command line or in Spack environment).
+If different parts of your software stack need to be built with different compilers, it's best to specify compilers as dependencies of the relevant specs (whether on the command line or in Spack environments).
 
 .. code-block:: spec
    :caption: Example of specifying different compilers for different specs

--- a/lib/spack/docs/frequently_asked_questions.rst
+++ b/lib/spack/docs/frequently_asked_questions.rst
@@ -4,7 +4,7 @@
 
 .. meta::
    :description lang=en:
-      Find answers to common questions about Spack, covering topics like version and variant selection, package preferences, and concretizer behavior.
+      Answers to common Spack questions, including version and variant selection, package preferences, compiler configuration, and concretizer behavior, with practical YAML and command-line examples.
 
 Frequently Asked Questions
 ==========================

--- a/lib/spack/docs/frequently_asked_questions.rst
+++ b/lib/spack/docs/frequently_asked_questions.rst
@@ -75,7 +75,90 @@ The following set of criteria (from lowest to highest precedence) explains commo
 
 Requirements and constraints restrict the set of possible solutions, while reuse behavior and preferences influence what an optimal solution looks like.
 
+How do I specify or require a compiler?
+---------------------------------------
+
+When specifying compilers, you have two main options: either you specify compilers globally for all packages in configuration files, or you specify them on the level of :doc:`individual specs <spec_syntax>`.
+
+Specific compiler for all packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want to use a specific compiler for all packages, it's best to use :ref:`requirements in packages.yaml config <setting-requirements-on-virtual-specs>`.
+The following example requires GCC 15 for all languages ``c``, ``cxx``, and ``fortran``:
+
+.. code-block:: yaml
+   :caption: Recommended: *require* a specific compiler
+   :name: code-example-require-compiler-per-language
+
+   packages:
+     c:
+       require:
+       - gcc@15
+     cxx:
+       require:
+       - gcc@15
+     fortran:
+       require:
+       - gcc@15
+
+Alternatively, you can use :ref:`strong preferences <package-strong-preferences>` instead of hard requirements, which are more forgiving when certain packages conflict with the requested compiler:
+
+.. code-block:: yaml
+   :caption: Alternative: *prefer* a specific compiler
+   :name: code-example-prefer-compiler
+
+   packages:
+     c:
+       prefer:
+       - gcc@15
+     cxx:
+       prefer:
+       - gcc@15
+     fortran:
+       prefer:
+       - gcc@15
+
+In Spack, the languages ``c``, ``cxx`` and ``fortran`` are :ref:`virtual packages <language-dependencies>`, on which packages depend if they need a compiler for that language.
+Compiler packages provide these language virtuals.
+When you specify these requirements or strong preferences, Spack determines whether the package depends on the language virtuals, and if so, it applies the requested compiler spec.
+
+What is **not recommended** is to define ``%gcc`` as a required dependency of all packages:
+
+.. code-block:: yaml
+   :caption: Incorrect: requiring a dependency on a compiler for all packages
+   :name: code-example-typical-mistake-require-compiler
+
+   packages:
+     all:
+       require:
+       - "%gcc@15"
+
+This is *incorrect*, because some packages do not need a compiler at all (e.g. pure Python packages).
+
+Specific compiler for individual specs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If different parts of your software stack need to be built with different compilers, it's best to specify compilers as dependencies of the relevant specs (whether on the command line or in Spack environment).
+
+.. code-block:: spec
+   :caption: Example of specifying different compilers for different specs
+   :name: console-example-different-compilers
+
+   $ spack install foo %gcc@15 ^bar %intel-oneapi-compilers
+
+What this means is that ``foo`` will depend on GCC 15, while ``bar`` will depend on ``intel-oneapi-compilers``.
+
+You can also be more specific about what compiler to use for a particular language:
+
+.. code-block:: spec
+   :caption: Example of specifying different compilers for different languages
+   :name: console-example-different-languages
+
+   $ spack install foo %c,cxx=gcc@15 %fortran=intel-oneapi-compilers
+
+These input specs can be simplified using :doc:`toolchains_yaml`.
+See also :ref:`pitfalls-without-toolchains` for common mistakes to avoid.
 
 .. rubric:: Footnotes
 
-.. [#f1] The exact list of criteria can be retrieved with the ``spack solve`` command
+.. [#f1] The exact list of criteria can be retrieved with the :ref:`spack-solve` command.

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -212,7 +212,7 @@ This means that you can also configure system compilers as external packages and
 Spack automatically detects system compilers and configures them in ``packages.yaml`` for you.
 You can also run :ref:`spack-compiler-find` to find and configure new system compilers.
 
-When configuring compilers as external packages, you need to configure a few :ref:`extra attributes <extra-attributes-for-externals>` for them to work properly.
+When configuring compilers as external packages, you need to set a few :ref:`extra attributes <extra-attributes-for-externals>` for them to work properly.
 The ``compilers`` extra attribute field is required to clarify which paths within the compiler prefix are used for which languages:
 
 .. code-block:: yaml

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -428,6 +428,7 @@ For example, with a configuration like this:
 Spack requires ``cmake`` to use ``gcc`` and all other nodes (including ``cmake`` dependencies) to use ``clang``.
 If enforcing ``build_type=Debug`` is needed also on ``cmake``, it must be repeated in the specific ``cmake`` requirements.
 
+.. _setting-requirements-on-virtual-specs:
 
 Setting requirements on virtual specs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -201,6 +201,8 @@ This could be configured as follows:
 
 See :ref:`configuration_environment_variables` for more information on how to configure environment modifications in Spack config files.
 
+.. _configuring-system-compilers-as-external-packages:
+
 Configuring system compilers as external packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -37,7 +37,7 @@ For more details on how this works, see :ref:`configuration-scopes`.
 
 .. _sec-external-packages:
 
-External Packages
+External packages
 -----------------
 
 Spack can be configured to use externally-installed packages rather than building its own packages.
@@ -77,88 +77,29 @@ Each external should specify a ``spec:`` string that should be as well-defined a
 If a package lacks a spec component, such as missing a compiler or package version, then Spack will guess the missing component based on its most-favored packages, and it may guess incorrectly.
 
 
-Extra attributes for external packages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _cmd-spack-external-find:
 
-Sometimes external packages require additional attributes to be used effectively.
-This information can be defined on a per-package basis and stored in the ``extra_attributes`` section of the external package configuration.
-In addition to per-package information, this section can be used to define environment modifications to be performed whenever the package is used.
-For example, if an external package is built without ``rpath`` support, it may require ``LD_LIBRARY_PATH`` settings to find its dependencies.
-This could be configured as follows:
+Automatically find external packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: yaml
-
-   packages:
-     mpich:
-       externals:
-       - spec: mpich@3.3 +hwloc
-         prefix: /path/to/mpich
-         extra_attributes:
-           environment:
-             prepend_path:
-               LD_LIBRARY_PATH: /path/to/hwloc/lib64
-
-See :ref:`configuration_environment_variables` for more information on how to configure environment modifications in Spack config files.
-
-Extra attributes for external compilers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-External package configuration allows several extra attributes for configuring compilers.
-The ``compilers`` extra attribute field is required to clarify which paths within the compiler prefix are used for which languages:
+You can run the :ref:`spack external find <spack-external-find>` command to search for system-provided packages and add them to ``packages.yaml``.
+After running this command your ``packages.yaml`` may include new entries:
 
 .. code-block:: yaml
 
    packages:
-     gcc:
+     cmake:
        externals:
-       - spec: gcc@10.5.0 languages='c,c++,fortran'
+       - spec: cmake@3.17.2
          prefix: /usr
-         extra_attributes:
-           compilers:
-             c: /usr/bin/gcc-10
-             cxx: /usr/bin/g++-10
-             fortran: /usr/bin/gfortran-10
 
-Other fields accepted by compilers under ``extra_attributes`` are ``flags``, ``environment``, ``extra_rpaths``, and ``implicit_rpaths``.
+Generally this is useful for detecting a small set of commonly-used packages; for now this is generally limited to finding build-only dependencies.
+Specific limitations include:
 
-.. code-block:: yaml
-
-   packages:
-     gcc:
-       externals:
-       - spec: gcc@10.5.0 languages='c,c++,fortran'
-         prefix: /usr
-         extra_attributes:
-           compilers:
-             c: /usr/bin/gcc-10
-             cxx: /usr/bin/g++-10
-             fortran: /usr/bin/gfortran-10
-           flags:
-             cflags: -O3
-             fflags: -g -O2
-           environment:
-             set:
-               GCC_ROOT: /usr
-             prepend_path:
-               PATH: /usr/unusual_path_for_ld/bin
-           implicit_rpaths:
-           - /usr/lib/gcc
-           extra_rpaths:
-           - /usr/lib/unusual_gcc_path
-
-The ``flags`` attribute specifies compiler flags to apply to every spec that depends on this compiler.
-The accepted flag types are ``cflags``, ``cxxflags``, ``fflags``, ``cppflags``, ``ldflags``, and ``ldlibs``.
-In the example above, every spec compiled with this compiler will pass the flags ``-g -O2`` to ``/usr/bin/gfortran-10`` and will pass the flag ``-O3`` to ``/usr/bin/gcc-10``.
-
-The ``environment`` attribute specifies user environment modifications to apply before every time the compiler is invoked.
-The available operations are ``set``, ``unset``, ``prepend_path``, ``append_path``, and ``remove_path``.
-In the example above, Spack will set ``GCC_ROOT=/usr`` and set ``PATH=/usr/unusual_path_for_ld/bin:$PATH`` before handing control to the build system that will use this compiler.
-
-The ``extra_rpaths`` and ``implicit_rpaths`` fields specify additional paths to pass as rpaths to the linker when using this compiler.
-The ``implicit_rpaths`` field is filled in automatically by Spack when detecting compilers, and the ``extra_rpaths`` field is available for users to configure necessary rpaths that have not been detected by Spack.
-In addition, paths from ``extra_rpaths`` are added as library search paths for the linker.
-In the example above, both ``/usr/lib/gcc`` and ``/usr/lib/unusual_gcc_path`` would be added as rpaths to the linker, and ``-L/usr/lib/unusual_gcc_path`` would be added as well.
-
+* Packages are not discoverable by default: For a package to be discoverable with ``spack external find``, it needs to add special logic.
+  See :ref:`here <make-package-findable>` for more details.
+* The logic does not search through module files, it can only detect packages with executables defined in ``PATH``; you can help Spack locate externals which use module files by loading any associated modules for packages that you want Spack to know about before running ``spack external find``.
+* Spack does not overwrite existing entries in the package configuration: If there is an external defined for a spec at any configuration scope, then Spack will not add a new external entry (``spack config blame packages`` can help locate all external entries).
 
 Prevent packages from being built from sources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -234,29 +175,96 @@ In cases where the concretizer is configured to reuse specs, and other ``mpi`` p
 This configuration prevents any spec using MPI and originating from stores or buildcaches to be reused, unless it matches the requirements under ``packages:mpi:require``.
 For more information on requirements see :ref:`package-requirements`.
 
-.. _cmd-spack-external-find:
 
-Automatically Find External Packages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _extra-attributes-for-externals:
 
-You can run the :ref:`spack external find <spack-external-find>` command to search for system-provided packages and add them to ``packages.yaml``.
-After running this command your ``packages.yaml`` may include new entries:
+Extra attributes for external packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sometimes external packages require additional attributes to be used effectively.
+This information can be defined on a per-package basis and stored in the ``extra_attributes`` section of the external package configuration.
+In addition to per-package information, this section can be used to define environment modifications to be performed whenever the package is used.
+For example, if an external package is built without ``rpath`` support, it may require ``LD_LIBRARY_PATH`` settings to find its dependencies.
+This could be configured as follows:
 
 .. code-block:: yaml
 
    packages:
-     cmake:
+     mpich:
        externals:
-       - spec: cmake@3.17.2
+       - spec: mpich@3.3 +hwloc
+         prefix: /path/to/mpich
+         extra_attributes:
+           environment:
+             prepend_path:
+               LD_LIBRARY_PATH: /path/to/hwloc/lib64
+
+See :ref:`configuration_environment_variables` for more information on how to configure environment modifications in Spack config files.
+
+Configuring system compilers as external packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In Spack, compilers are treated as packages like any other.
+This means that you can also configure system compilers as external packages and use them in Spack.
+
+Spack automatically detects system compilers and configures them in ``packages.yaml`` for you.
+You can also run :ref:`spack-compiler-find` to find and configure new system compilers.
+
+When configuring compilers as external packages, you need to configure a few :ref:`extra attributes <extra-attributes-for-externals>` for them to work properly.
+The ``compilers`` extra attribute field is required to clarify which paths within the compiler prefix are used for which languages:
+
+.. code-block:: yaml
+
+   packages:
+     gcc:
+       externals:
+       - spec: gcc@10.5.0 languages='c,c++,fortran'
          prefix: /usr
+         extra_attributes:
+           compilers:
+             c: /usr/bin/gcc-10
+             cxx: /usr/bin/g++-10
+             fortran: /usr/bin/gfortran-10
 
-Generally this is useful for detecting a small set of commonly-used packages; for now this is generally limited to finding build-only dependencies.
-Specific limitations include:
+Other fields accepted by compilers under ``extra_attributes`` are ``flags``, ``environment``, ``extra_rpaths``, and ``implicit_rpaths``.
 
-* Packages are not discoverable by default: For a package to be discoverable with ``spack external find``, it needs to add special logic.
-  See :ref:`here <make-package-findable>` for more details.
-* The logic does not search through module files, it can only detect packages with executables defined in ``PATH``; you can help Spack locate externals which use module files by loading any associated modules for packages that you want Spack to know about before running ``spack external find``.
-* Spack does not overwrite existing entries in the package configuration: If there is an external defined for a spec at any configuration scope, then Spack will not add a new external entry (``spack config blame packages`` can help locate all external entries).
+.. code-block:: yaml
+
+   packages:
+     gcc:
+       externals:
+       - spec: gcc@10.5.0 languages='c,c++,fortran'
+         prefix: /usr
+         extra_attributes:
+           compilers:
+             c: /usr/bin/gcc-10
+             cxx: /usr/bin/g++-10
+             fortran: /usr/bin/gfortran-10
+           flags:
+             cflags: -O3
+             fflags: -g -O2
+           environment:
+             set:
+               GCC_ROOT: /usr
+             prepend_path:
+               PATH: /usr/unusual_path_for_ld/bin
+           implicit_rpaths:
+           - /usr/lib/gcc
+           extra_rpaths:
+           - /usr/lib/unusual_gcc_path
+
+The ``flags`` attribute specifies compiler flags to apply to every spec that depends on this compiler.
+The accepted flag types are ``cflags``, ``cxxflags``, ``fflags``, ``cppflags``, ``ldflags``, and ``ldlibs``.
+In the example above, every spec compiled with this compiler will pass the flags ``-g -O2`` to ``/usr/bin/gfortran-10`` and will pass the flag ``-O3`` to ``/usr/bin/gcc-10``.
+
+The ``environment`` attribute specifies user environment modifications to apply before every time the compiler is invoked.
+The available operations are ``set``, ``unset``, ``prepend_path``, ``append_path``, and ``remove_path``.
+In the example above, Spack will set ``GCC_ROOT=/usr`` and set ``PATH=/usr/unusual_path_for_ld/bin:$PATH`` before handing control to the build system that will use this compiler.
+
+The ``extra_rpaths`` and ``implicit_rpaths`` fields specify additional paths to pass as rpaths to the linker when using this compiler.
+The ``implicit_rpaths`` field is filled in automatically by Spack when detecting compilers, and the ``extra_rpaths`` field is available for users to configure necessary rpaths that have not been detected by Spack.
+In addition, paths from ``extra_rpaths`` are added as library search paths for the linker.
+In the example above, both ``/usr/lib/gcc`` and ``/usr/lib/unusual_gcc_path`` would be added as rpaths to the linker, and ``-L/usr/lib/unusual_gcc_path`` would be added as well.
 
 .. _package-requirements:
 
@@ -564,15 +572,15 @@ The ``read`` and ``write`` attributes take one of ``user``, ``group``, and ``wor
 
 .. code-block:: yaml
 
-  packages:
-    all:
-      permissions:
-        write: group
-        group: spack
-    my_app:
-      permissions:
-        read: group
-        group: my_team
+   packages:
+     all:
+       permissions:
+         write: group
+         group: spack
+     my_app:
+       permissions:
+         read: group
+         group: my_team
 
 The permissions settings describe the broadest level of access to installations of the specified packages.
 The execute permissions of the file are set to the same level as read permissions for those files that are executable.
@@ -595,13 +603,13 @@ You can assign class-level attributes in the configuration:
 
 .. code-block:: yaml
 
-  packages:
-    mpileaks:
-      package_attributes:
-        # Override existing attributes
-        url: http://www.somewhereelse.com/mpileaks-1.0.tar.gz
-        # ... or add new ones
-        x: 1
+   packages:
+     mpileaks:
+       package_attributes:
+         # Override existing attributes
+         url: http://www.somewhereelse.com/mpileaks-1.0.tar.gz
+         # ... or add new ones
+         x: 1
 
 Attributes set this way will be accessible to any method executed in the package.py file (e.g. the ``install()`` method).
 Values for these attributes may be any value parseable by yaml.

--- a/lib/spack/docs/toolchains_yaml.rst
+++ b/lib/spack/docs/toolchains_yaml.rst
@@ -25,7 +25,7 @@ Basic usage
 As an example, the following configuration file defines a toolchain named ``llvm_gfortran``:
 
 .. code-block:: yaml
-   :caption: ~/.spack/toolchains.yaml
+   :caption: ``~/.spack/toolchains.yaml``
 
    toolchains:
      llvm_gfortran:
@@ -57,6 +57,8 @@ Toolchains are useful for three reasons:
    Toolchains are used at the level of a single spec.
 
 
+.. _pitfalls-without-toolchains:
+
 Pitfalls without toolchains
 ---------------------------
 
@@ -75,7 +77,7 @@ Different toolchains can be used independently or even in the same spec.
 Consider the following configuration:
 
 .. code-block:: yaml
-   :caption: ~/.spack/toolchains.yaml
+   :caption: ``~/.spack/toolchains.yaml``
 
    toolchains:
      llvm_gfortran:
@@ -115,7 +117,7 @@ A common use case is to define a toolchain that also picks a specific MPI implem
 In the following example, we define a toolchain that uses ``openmpi@5`` as an MPI provider, and ``llvm@19`` as the compiler for C and C++:
 
 .. code-block:: yaml
-   :caption: ~/.spack/toolchains.yaml
+   :caption: ``~/.spack/toolchains.yaml``
 
    toolchains:
      clang_openmpi:


### PR DESCRIPTION
* Document how users should set compilers for all/specific packages in the FAQ
* Make the section about configuring compilers in packages.yaml a bit more discoverable and less technical (title: "Extra attributes for external compilers" -> "Configuring system compilers as external packages" + small introduction and reference to `spack compiler find`).
* Reorder the sections in `external packages` from simple (populating with external find) to more advanced (all the yaml details) instead of the other way around.
* Increment FAQ's search ranking weight so the term `compiler` (which is the current number 1 search query from rtd's analytics) is more likely to direct to it.

While at it:

* Use `:name:` for `code-block` directive to get persistent URLs with `#readable-fragment` instead of `#id0`.
* Fix a few cases where `configuration.rst` did not have the top-level configuration key in YAML code blocks.