### PR TITLE
docs: "last updated on" from git history

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,9 @@ build:
     - graphviz
   tools:
     python: "3.11"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true  # get accurate "Last updated on" info
 
 sphinx:
   configuration: lib/spack/docs/conf.py

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -54,9 +54,17 @@ sys.path[0:0] = [
     os.path.abspath(".spack/spack-packages/repos"),
 ]
 
-subprocess.call(["spack", "list"], stdout=subprocess.DEVNULL)
+# Init the package repo with all git history, so "Last updated on" is accurate.
+subprocess.call(["spack", "repo", "update"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+if os.path.exists(".spack/spack-packages/.git/shallow"):
+    subprocess.call(
+        ["git", "fetch", "--unshallow"],
+        cwd=".spack/spack-packages",
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 
-# Generate a command index if an update is needed -- this also clones the package repository.
+# Generate a command index if an update is needed
 subprocess.call(
     [
         "spack",
@@ -264,6 +272,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
     "sphinxcontrib.programoutput",
+    "sphinx_last_updated_by_git",
 ]
 
 copybutton_exclude = ".linenos, .gp, .go"

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,6 +1,7 @@
 sphinx==8.2.3
 sphinxcontrib-programoutput==0.18
 sphinx-copybutton==0.5.2
+sphinx-last-updated-by-git==0.3.8
 # fork of furo with a few changes that are not merged upstream
 git+https://github.com/haampie/furo.git@c1d161cb9e04b481ec3331db981aacfa132ecaa6#egg=furo
 python-levenshtein==0.27.1


### PR DESCRIPTION
Currently "Last updated on" is always the date of the build, not the date of the last file modification.

This extension fixes that. It also seems to keep track of dependencies of rst files, so even generated files have an accurate timestamp.

