### PR TITLE
spack.cmd: `doc_first_line`, `doc_dedented` helpers to fix formatting

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -704,7 +704,7 @@ def find_environment(args):
 
 def doc_first_line(function: object) -> Optional[str]:
     """Return the first line of the docstring."""
-    return function.__doc__.split("\n", 1)[0] if function.__doc__ else None
+    return function.__doc__.split("\n", 1)[0].strip() if function.__doc__ else None
 
 
 if sys.version_info >= (3, 13):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import sys
+import textwrap
 from collections import Counter
 from typing import Generator, List, Optional, Sequence, Union
 
@@ -701,9 +702,23 @@ def find_environment(args):
     raise ev.SpackEnvironmentError("no environment in %s" % env)
 
 
-def first_line(docstring):
+def doc_first_line(function: object) -> Optional[str]:
     """Return the first line of the docstring."""
-    return docstring.split("\n")[0]
+    return function.__doc__.split("\n", 1)[0] if function.__doc__ else None
+
+
+if sys.version_info >= (3, 13):
+    # indent of __doc__ is automatically removed in 3.13+
+    # see https://github.com/python/cpython/commit/2566b74b26bcce24199427acea392aed644f4b17
+    def doc_dedented(function: object) -> Optional[str]:
+        """Return the docstring with leading indentation removed."""
+        return function.__doc__
+
+else:
+
+    def doc_dedented(function: object) -> Optional[str]:
+        """Return the docstring with leading indentation removed."""
+        return textwrap.dedent(function.__doc__) if function.__doc__ else None
 
 
 def converted_arg_length(arg: str):

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -32,9 +32,10 @@ import spack.util.gpg as gpg_util
 import spack.util.timer as timer
 import spack.util.url as url_util
 import spack.util.web as web_util
-import spack.version
 from spack.llnl.util import tty
 from spack.version import StandardVersion
+
+from . import doc_dedented, doc_first_line
 
 description = "manage continuous integration pipelines"
 section = "build"
@@ -61,9 +62,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
     # Dynamic generation of the jobs yaml from a spack environment
     generate = subparsers.add_parser(
-        "generate",
-        description=deindent(ci_generate.__doc__),
-        help=spack.cmd.first_line(ci_generate.__doc__),
+        "generate", description=doc_dedented(ci_generate), help=doc_first_line(ci_generate)
     )
     generate.add_argument(
         "--output-file",
@@ -159,17 +158,13 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     # Rebuild the buildcache index associated with the mirror in the
     # active, gitlab-enabled environment.
     index = subparsers.add_parser(
-        "rebuild-index",
-        description=deindent(ci_reindex.__doc__),
-        help=spack.cmd.first_line(ci_reindex.__doc__),
+        "rebuild-index", description=doc_dedented(ci_reindex), help=doc_first_line(ci_reindex)
     )
     index.set_defaults(func=ci_reindex)
 
     # Handle steps of a ci build/rebuild
     rebuild = subparsers.add_parser(
-        "rebuild",
-        description=deindent(ci_rebuild.__doc__),
-        help=spack.cmd.first_line(ci_rebuild.__doc__),
+        "rebuild", description=doc_dedented(ci_rebuild), help=doc_first_line(ci_rebuild)
     )
     rebuild.add_argument(
         "-t",
@@ -196,8 +191,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     # Facilitate reproduction of a failed CI build job
     reproduce = subparsers.add_parser(
         "reproduce-build",
-        description=deindent(ci_reproduce.__doc__),
-        help=spack.cmd.first_line(ci_reproduce.__doc__),
+        description=doc_dedented(ci_reproduce),
+        help=doc_first_line(ci_reproduce),
     )
     reproduce.add_argument(
         "job_url", help="URL of GitLab job web page or artifact", type=_gitlab_artifacts_url
@@ -234,8 +229,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     # Verify checksums inside of ci workflows
     verify_versions = subparsers.add_parser(
         "verify-versions",
-        description=deindent(ci_verify_versions.__doc__),
-        help=spack.cmd.first_line(ci_verify_versions.__doc__),
+        description=doc_dedented(ci_verify_versions),
+        help=doc_first_line(ci_verify_versions),
     )
     verify_versions.add_argument("from_ref", help="git ref from which start looking at changes")
     verify_versions.add_argument("to_ref", help="git ref to end looking at changes")

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -238,7 +238,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 
 def ci_generate(args):
-    """generate jobs file from a CI-aware spack file
+    """\
+    generate jobs file from a CI-aware spack file
 
     if you want to report the results on CDash, you will need to set the SPACK_CDASH_AUTH_TOKEN
     before invoking this command. the value must be the CDash authorization token needed to create
@@ -249,7 +250,8 @@ def ci_generate(args):
 
 
 def ci_reindex(args):
-    """rebuild the buildcache index for the remote mirror
+    """\
+    rebuild the buildcache index for the remote mirror
 
     use the active, gitlab-enabled environment to rebuild the buildcache index for the associated
     mirror
@@ -269,7 +271,8 @@ def ci_reindex(args):
 
 
 def ci_rebuild(args):
-    """rebuild a spec if it is not on the remote mirror
+    """\
+    rebuild a spec if it is not on the remote mirror
 
     check a single spec against the remote mirror, and rebuild it from source if the mirror does
     not contain the hash
@@ -651,7 +654,8 @@ If this project does not have public pipelines, you will need to first:
 
 
 def ci_reproduce(args):
-    """generate instructions for reproducing the spec rebuild job
+    """\
+    generate instructions for reproducing the spec rebuild job
 
     artifacts of the provided gitlab pipeline rebuild job's URL will be used to derive
     instructions for reproducing the build locally
@@ -811,7 +815,8 @@ def validate_git_versions(
 
 
 def ci_verify_versions(args):
-    """validate version checksum & commits between git refs
+    """\
+    validate version checksum & commits between git refs
     This command takes a from_ref and to_ref arguments and
     then parses the git diff between the two to determine which packages
     have been modified verifies the new checksums inside of them.

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -58,7 +58,8 @@ subcommands: List[Tuple[str, ...]] = [
 # env create
 #
 def env_create_setup_parser(subparser):
-    """create a new environment
+    """\
+    create a new environment
 
     create a new environment or, optionally, copy an existing environment
 
@@ -639,7 +640,8 @@ def env_untrack(args):
 # env remove
 #
 def env_remove_setup_parser(subparser):
-    """remove managed environment(s)
+    """\
+    remove managed environment(s)
 
     remove existing environment(s) managed by Spack
 
@@ -669,7 +671,8 @@ def env_remove(args):
 # env rename
 #
 def env_rename_setup_parser(subparser):
-    """rename an existing environment
+    """\
+    rename an existing environment
 
     rename a managed environment or move an independent/directory environment
 
@@ -779,7 +782,8 @@ class ViewAction:
 # env view
 #
 def env_view_setup_parser(subparser):
-    """manage the environment's view
+    """\
+    manage the environment's view
 
     provide the path when enabling a view with a non-default path
     """
@@ -874,7 +878,8 @@ def env_loads(args):
 
 
 def env_update_setup_parser(subparser):
-    """update the environment manifest to the latest schema format
+    """\
+    update the environment manifest to the latest schema format
 
     update the environment to the latest schema format, which may not be
     readable by older versions of spack
@@ -919,7 +924,8 @@ def env_update(args):
 
 
 def env_revert_setup_parser(subparser):
-    """restore the environment manifest to its previous format
+    """\
+    restore the environment manifest to its previous format
 
     revert the environment's manifest to the schema format from its last
     'spack env update'
@@ -966,7 +972,8 @@ def env_revert(args):
 
 
 def env_depfile_setup_parser(subparser):
-    """generate a depfile to exploit parallel builds across specs
+    """\
+    generate a depfile to exploit parallel builds across specs
 
     requires the active environment to be concrete
     """

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -1083,8 +1083,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         subsubparser = sp.add_parser(
             name,
             aliases=aliases,
-            description=setup_parser_cmd.__doc__,
-            help=spack.cmd.first_line(setup_parser_cmd.__doc__),
+            description=spack.cmd.doc_dedented(setup_parser_cmd),
+            help=spack.cmd.doc_first_line(setup_parser_cmd),
         )
         setup_parser_cmd(subsubparser)
 

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -20,6 +20,8 @@ from spack.cmd.common import arguments
 from spack.llnl.util import tty
 from spack.llnl.util.tty import colify
 
+from . import doc_dedented, doc_first_line
+
 description = "run spack's tests for an install"
 section = "admin"
 level = "long"
@@ -30,7 +32,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
     # Run
     run_parser = sp.add_parser(
-        "run", description=test_run.__doc__, help=spack.cmd.first_line(test_run.__doc__)
+        "run", description=doc_dedented(test_run), help=doc_first_line(test_run)
     )
 
     run_parser.add_argument(
@@ -77,7 +79,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
     # List
     list_parser = sp.add_parser(
-        "list", description=test_list.__doc__, help=spack.cmd.first_line(test_list.__doc__)
+        "list", description=doc_dedented(test_list), help=doc_first_line(test_list)
     )
     list_parser.add_argument(
         "-a",
@@ -91,7 +93,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
     # Find
     find_parser = sp.add_parser(
-        "find", description=test_find.__doc__, help=spack.cmd.first_line(test_find.__doc__)
+        "find", description=doc_dedented(test_find), help=doc_first_line(test_find)
     )
     find_parser.add_argument(
         "filter",
@@ -101,7 +103,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
     # Status
     status_parser = sp.add_parser(
-        "status", description=test_status.__doc__, help=spack.cmd.first_line(test_status.__doc__)
+        "status", description=doc_dedented(test_status), help=doc_first_line(test_status)
     )
     status_parser.add_argument(
         "names", nargs=argparse.REMAINDER, help="test suites for which to print status"
@@ -109,9 +111,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
     # Results
     results_parser = sp.add_parser(
-        "results",
-        description=test_results.__doc__,
-        help=spack.cmd.first_line(test_results.__doc__),
+        "results", description=doc_dedented(test_results), help=doc_first_line(test_results)
     )
     results_parser.add_argument(
         "-l", "--logs", action="store_true", help="print the test log for each matching package"
@@ -138,7 +138,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
     # Remove
     remove_parser = sp.add_parser(
-        "remove", description=test_remove.__doc__, help=spack.cmd.first_line(test_remove.__doc__)
+        "remove", description=doc_dedented(test_remove), help=doc_first_line(test_remove)
     )
     arguments.add_common_arguments(remove_parser, ["yes_to_all"])
     remove_parser.add_argument(

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -147,7 +147,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 
 def test_run(args):
-    """run tests for the specified installed packages
+    """\
+    run tests for the specified installed packages
 
     if no specs are listed, run tests for all packages in the current
     environment or all installed packages if there is no active environment
@@ -253,7 +254,8 @@ def test_list(args):
 
 
 def test_find(args):  # TODO: merge with status (noargs)
-    """find tests that are running or have available results
+    """\
+    find tests that are running or have available results
 
     displays aliases for tests that have them, otherwise test suite content hashes
     """
@@ -404,7 +406,8 @@ def test_results(args):
 
 
 def test_remove(args):
-    """remove results from Spack test suite(s) (default all)
+    """\
+    remove results from Spack test suite(s) (default all)
 
     if no test suite is listed, remove results for all suites.
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1549,7 +1549,8 @@ def test_ci_help(subcmd, capsys):
 
 def test_docstring_utils():
     def example_function():
-        """this is the first line
+        """\
+        this is the first line
 
         this is not the first line
         """

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1547,16 +1547,18 @@ def test_ci_help(subcmd, capsys):
     assert usage in out
 
 
-def test_cmd_first_line():
-    """Explicitly test first_line since not picked up in test_ci_help."""
-    first = "This is a test."
-    doc = """{0}
+def test_docstring_utils():
+    def example_function():
+        """this is the first line
 
-    Is there more to be said?""".format(
-        first
+        this is not the first line
+        """
+        pass
+
+    assert spack.cmd.doc_first_line(example_function) == "this is the first line"
+    assert spack.cmd.doc_dedented(example_function) == (
+        "this is the first line\n\nthis is not the first line\n"
     )
-
-    assert spack.cmd.first_line(doc) == first
 
 
 @pytest.mark.skip(reason="Gitlab CI was removed from Spack")


### PR DESCRIPTION
Sometimes we pass `description=func.__doc__` directly to argparse, which
is wrong in Python < 3.13, because it needs to be dedented there.

(See https://github.com/python/cpython/commit/2566b74b26bcce24199427acea392aed644f4b17)

If not dedented, leading indentation is printed verbatim both in

```
spack command --help
```

and renders as a blockquote in online docs due to how rST parses it, see for example here: https://spack.readthedocs.io/en/latest/command_index.html#spack-env-create