### PR TITLE
spec: change default string representation of arch components

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -330,7 +330,11 @@ def ensure_single_spec_or_die(spec, matching_specs):
     if len(matching_specs) <= 1:
         return
 
-    format_string = "{name}{@version}{ arch=architecture} {%compiler.name}{@compiler.version}"
+    format_string = (
+        "{name}{@version}"
+        "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
+        "{%compiler.name}{@compiler.version}"
+    )
     args = ["%s matches multiple packages." % spec, "Matching packages:"]
     args += [
         colorize("  @K{%s} " % s.dag_hash(7)) + s.cformat(format_string) for s in matching_specs

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -384,7 +384,9 @@ def modules_cmd(parser, args, module_type, callbacks=callbacks):
         for s in specs:
             spec_fmt = (
                 "{hash:7} {name}{@version}{compiler_flags}{variants}"
-                "{arch=architecture} {%compiler}"
+                "{ platform=architecture.platform}{ os=architecture.os}"
+                "{ target=architecture.target}"
+                "{%compiler}"
             )
             msg += "\t" + s.cformat(spec_fmt) + "\n"
         tty.die(msg, "In this context exactly *one* match is needed.")

--- a/lib/spack/spack/environment/depfile.py
+++ b/lib/spack/spack/environment/depfile.py
@@ -165,7 +165,11 @@ class MakefileModel:
                 item.target.safe_name(),
                 " ".join(self._install_target(s.safe_name()) for s in item.prereqs),
                 item.target.spec_hash(),
-                item.target.unsafe_format("{name}{@version}{variants}{ arch=architecture}"),
+                item.target.unsafe_format(
+                    "{name}{@version}{variants}"
+                    "{ platform=architecture.platform}{ os=architecture.os}"
+                    "{ target=architecture.target}"
+                ),
                 item.buildcache_flag,
             )
             for item in adjacency_list

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -164,13 +164,17 @@ HASH_COLOR = "@K"  #: color for highlighting package hashes
 #:     Spec(Spec("string").format()) == Spec("string)"
 DEFAULT_FORMAT = (
     "{name}{@versions}{compiler_flags}"
-    "{variants}{ namespace=namespace_if_anonymous}{ arch=architecture}{/abstract_hash}"
+    "{variants}{ namespace=namespace_if_anonymous}"
+    "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
+    "{/abstract_hash}"
 )
 
 #: Display format, which eliminates extra `@=` in the output, for readability.
 DISPLAY_FORMAT = (
     "{name}{@version}{compiler_flags}"
-    "{variants}{ namespace=namespace_if_anonymous}{ arch=architecture}{/abstract_hash}"
+    "{variants}{ namespace=namespace_if_anonymous}"
+    "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
+    "{/abstract_hash}"
     "{compilers}"
 )
 
@@ -4287,7 +4291,12 @@ class Spec:
 
     def _short_spec(self, color: Optional[bool] = False) -> str:
         """Helper for :attr:`short_spec` and :attr:`cshort_spec`."""
-        return self.format("{name}{@version}{variants}{ arch=architecture}{/hash:7}", color=color)
+        return self.format(
+            "{name}{@version}{variants}"
+            "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
+            "{/hash:7}",
+            color=color,
+        )
 
     @property
     def compilers(self):
@@ -5534,7 +5543,11 @@ class UnconstrainableDependencySpecError(spack.error.SpecError):
 
 class AmbiguousHashError(spack.error.SpecError):
     def __init__(self, msg, *specs):
-        spec_fmt = "{namespace}.{name}{@version}{variants}{ arch=architecture}{/hash:7}"
+        spec_fmt = (
+            "{namespace}.{name}{@version}{variants}"
+            "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
+            "{/hash:7}"
+        )
         specs_str = "\n  " + "\n  ".join(spec.format(spec_fmt) for spec in specs)
         super().__init__(msg + specs_str)
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -92,7 +92,7 @@ def specfile_for(default_mock_concretization):
         (
             "platform=test",
             [Token(SpecTokens.KEY_VALUE_PAIR, value="platform=test")],
-            "arch=test-None-None",
+            "platform=test",
         ),
         # Multiple tokens anonymous specs
         (
@@ -392,27 +392,27 @@ def specfile_for(default_mock_concretization):
         (
             r"os=fe",  # Various translations associated with the architecture
             [Token(SpecTokens.KEY_VALUE_PAIR, value="os=fe")],
-            "arch=test-debian6-None",
+            "platform=test os=debian6",
         ),
         (
             r"os=default_os",
             [Token(SpecTokens.KEY_VALUE_PAIR, value="os=default_os")],
-            "arch=test-debian6-None",
+            "platform=test os=debian6",
         ),
         (
             r"target=be",
             [Token(SpecTokens.KEY_VALUE_PAIR, value="target=be")],
-            f"arch=test-None-{spack.platforms.test.Test.default}",
+            f"platform=test target={spack.platforms.test.Test.default}",
         ),
         (
             r"target=default_target",
             [Token(SpecTokens.KEY_VALUE_PAIR, value="target=default_target")],
-            f"arch=test-None-{spack.platforms.test.Test.default}",
+            f"platform=test target={spack.platforms.test.Test.default}",
         ),
         (
             r"platform=linux",
             [Token(SpecTokens.KEY_VALUE_PAIR, value="platform=linux")],
-            r"arch=linux-None-None",
+            r"platform=linux",
         ),
         # Version hash pair
         (
@@ -495,7 +495,7 @@ def specfile_for(default_mock_concretization):
         (
             r"target=:broadwell,icelake",
             [Token(SpecTokens.KEY_VALUE_PAIR, value="target=:broadwell,icelake")],
-            r"arch=None-None-:broadwell,icelake",
+            r"target=:broadwell,icelake",
         ),
         # Hash pair version followed by a variant
         (
@@ -635,7 +635,7 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.VERSION, value="@10.4.0:10,11.3.0:"),
                 Token(SpecTokens.KEY_VALUE_PAIR, value="target=aarch64:"),
             ],
-            "@10.4.0:10,11.3.0: arch=None-None-aarch64:",
+            "@10.4.0:10,11.3.0: target=aarch64:",
         ),
         (
             "@:0.4 % nvhpc",
@@ -883,7 +883,7 @@ def specfile_for(default_mock_concretization):
                 Token(SpecTokens.KEY_VALUE_PAIR, "languages:=c,c++"),
                 Token(SpecTokens.KEY_VALUE_PAIR, "target=x86_64"),
             ],
-            "mvapich %gcc languages:='c,c++' arch=None-None-x86_64",
+            "mvapich %gcc languages:='c,c++' target=x86_64",
         ),
         # Test conditional dependencies
         (


### PR DESCRIPTION
Currently missing architecture components are displayed as `None` e.g. `arch=None-None-x86_64`.

This is sub-optimal, considering that:

* We discussed dropping `target=` and `os=` in the future, on specific nodes

* We might want to start detecting the architecture of (some?) externals, see https://github.com/spack/spack/issues/51227

This PR changes the default representation to display only the components that are actually present in the spec being considered.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
