### PR TITLE
fix whitespace issues in docstrings, add typehints, fix mypy issues

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -389,11 +389,12 @@ If the package being developed supports out-of-source builds then users can use 
 This is a shortcut to set the ``package_attributes:build_directory`` in the ``packages`` configuration (see :ref:`assigning-package-attributes`).
 The supplied location will become the build-directory for that package in all future builds.
 
-.. warning::
-   Potential pitfalls of setting the build directory
-    Spack does not check for out-of-source build compatibility with the packages and so the onus of making sure the package supports out-of-source builds is on the user.
-    For example, most ``autotool`` and ``makefile`` packages do not support out-of-source builds while all ``CMake`` packages do.
-    Understanding these nuances is up to the software developers and we strongly encourage developers to only redirect the build directory if they understand their package's build-system.
+.. admonition:: Potential pitfalls of setting the build directory
+   :class: warning
+
+   Spack does not check for out-of-source build compatibility with the packages and so the onus of making sure the package supports out-of-source builds is on the user.
+   For example, most ``autotool`` and ``makefile`` packages do not support out-of-source builds while all ``CMake`` packages do.
+   Understanding these nuances is up to the software developers and we strongly encourage developers to only redirect the build directory if they understand their package's build-system.
 
 Loading
 ^^^^^^^

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -259,7 +259,7 @@ Lmod should support hiding implicits in general, while Environment Modules requi
    Further, it makes it easier to get readable module names without collisions, see the section below on :ref:`modules-projections`.
 
    .. code-block:: yaml
-  
+
        modules:
          default:
            tcl:
@@ -314,24 +314,25 @@ For instance, in the snippet below:
 you are instructing Spack to set the environment variable ``BAR=bar`` for every module, unless the associated spec satisfies the abstract dependency ``^mpi`` in which case ``BAR=baz``, and the directory containing the respective MPI executables is prepended to the ``PATH`` variable.
 In addition in any spec that satisfies ``zlib`` the value ``foo`` will be prepended to ``LD_LIBRARY_PATH`` and in any spec that satisfies ``zlib%gcc@4.8`` the variable ``FOOBAR`` will be unset.
 
-.. note::
-   Order does matter
-     The modifications associated with the ``all`` keyword are always evaluated first, no matter where they appear in the configuration file.
-     All the other changes to environment variables for matching specs are evaluated from top to bottom.
+.. admonition:: Note: order does matter
+   :class: note
+
+   The modifications associated with the ``all`` keyword are always evaluated first, no matter where they appear in the configuration file.
+   All the other changes to environment variables for matching specs are evaluated from top to bottom.
 
 .. warning::
 
-     As general advice, it's often better to set as few unnecessary variables as possible.
-     For example, the following seemingly innocent and potentially useful configuration
+   As general advice, it's often better to set as few unnecessary variables as possible.
+   For example, the following seemingly innocent and potentially useful configuration
 
-     .. code-block:: yaml
+   .. code-block:: yaml
 
-        all:
-          environment:
-            set:
-              "{name}_ROOT": "{prefix}"
+      all:
+        environment:
+          set:
+            "{name}_ROOT": "{prefix}"
 
-     sets ``BINUTILS_ROOT`` to its prefix in modules for ``binutils``, which happens to break the ``gcc`` compiler: it uses this variable as its default search path for certain object files and libraries, and by merely setting it, everything fails to link.
+   sets ``BINUTILS_ROOT`` to its prefix in modules for ``binutils``, which happens to break the ``gcc`` compiler: it uses this variable as its default search path for certain object files and libraries, and by merely setting it, everything fails to link.
 
 Exclude or include specific module files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -404,12 +405,12 @@ This uses the projections format covered in :ref:`view_projections`.
 
 .. code-block:: yaml
 
-  modules:
-    default:
-      tcl:
-        projections:
-          all: "{name}/{version}-{compiler.name}-{compiler.version}-module"
-          ^mpi: "{name}/{version}-{^mpi.name}-{^mpi.version}-{compiler.name}-{compiler.version}-module"
+   modules:
+     default:
+       tcl:
+         projections:
+           all: "{name}/{version}-{compiler.name}-{compiler.version}-module"
+           ^mpi: "{name}/{version}-{^mpi.name}-{^mpi.version}-{compiler.name}-{compiler.version}-module"
 
 will create module files that are nested in directories by package name, contain the version and compiler name and version, and have the word ``module`` before the hash for all specs that do not depend on mpi, and will have the same information plus the MPI implementation name and version for all packages that depend on mpi.
 
@@ -418,6 +419,7 @@ When specifying module names by projection for Lmod modules, we recommend NOT in
 
 
 .. note::
+
    Tcl and Lua modules also allow for explicit conflicts between module files.
 
    .. code-block:: yaml
@@ -440,38 +442,41 @@ When specifying module names by projection for Lmod modules, we recommend NOT in
    For Lmod and Environment Modules versions prior to 4.2, it is important to express the conflict on both module files conflicting with each other.
 
 
-.. note::
-   Lmod hierarchical module files
-     When ``lmod`` is activated Spack will generate a set of hierarchical lua module files that are understood by Lmod.
-     The hierarchy always contains the ``Core`` and ``Compiler`` layers, but can be extended to include any virtual packages present in Spack.
-     A case that could be useful in practice is for instance:
+.. admonition:: Note: Lmod hierarchical module files
+   :class: note
 
-     .. code-block:: yaml
+   When ``lmod`` is activated Spack will generate a set of hierarchical lua module files that are understood by Lmod.
+   The hierarchy always contains the ``Core`` and ``Compiler`` layers, but can be extended to include any virtual packages present in Spack.
+   A case that could be useful in practice is for instance:
 
-       modules:
-         default:
-           enable:
-           - lmod
-           lmod:
-             core_compilers:
-             - "gcc@4.8"
-             core_specs:
-             - "python"
-             hierarchy:
-             - "mpi"
-             - "lapack"
+   .. code-block:: yaml
 
-     that will generate a hierarchy in which the ``lapack`` and ``mpi`` layer can be switched independently.
-     This allows a site to build the same libraries or applications against different implementations of ``mpi`` and ``lapack``, and let Lmod switch safely from one to the other.
+      modules:
+        default:
+          enable:
+          - lmod
+          lmod:
+            core_compilers:
+            - "gcc@4.8"
+            core_specs:
+            - "python"
+            hierarchy:
+            - "mpi"
+            - "lapack"
 
-     All packages built with a compiler in ``core_compilers`` and all packages that satisfy a spec in ``core_specs`` will be put in the ``Core`` hierarchy of the lua modules.
+   that will generate a hierarchy in which the ``lapack`` and ``mpi`` layer can be switched independently.
+   This allows a site to build the same libraries or applications against different implementations of ``mpi`` and ``lapack``, and let Lmod switch safely from one to the other.
 
-.. warning::
-  Consistency of Core packages
+   All packages built with a compiler in ``core_compilers`` and all packages that satisfy a spec in ``core_specs`` will be put in the ``Core`` hierarchy of the lua modules.
+
+.. admonition:: Warning: consistency of core packages
+   :class: warning
+
    The user is responsible for maintaining consistency among core packages, as ``core_specs`` bypasses the hierarchy that allows Lmod to safely switch between coherent software stacks.
 
-.. warning::
-  Deep hierarchies and ``lmod spider``
+.. admonition:: Warning: deep hierarchies
+   :class: warning
+
    For hierarchies that are deeper than three layers ``lmod spider`` may have some issues.
    See `this discussion on the Lmod project <https://github.com/TACC/Lmod/issues/114>`_.
 
@@ -487,14 +492,14 @@ This allows users to make general overrides to the default inspections and custo
 
 .. code-block:: yaml
 
-  modules:
-    prefix_inspections:
-      ./bin:
-      - PATH
-      ./man:
-      - MANPATH
-      ./:
-      - CMAKE_PREFIX_PATH
+   modules:
+     prefix_inspections:
+       ./bin:
+       - PATH
+       ./man:
+       - MANPATH
+       ./:
+       - CMAKE_PREFIX_PATH
 
 Prefix inspections are only applied if the relative path inside the installation prefix exists.
 In this case, for a Spack package ``foo`` installed to ``/spack/prefix/foo``, if ``foo`` installs executables to ``bin`` but no manpages in ``man``, the generated module file for ``foo`` would update ``PATH`` to contain ``/spack/prefix/foo/bin`` and ``CMAKE_PREFIX_PATH`` to contain ``/spack/prefix/foo``, but would not update ``MANPATH``.
@@ -568,18 +573,19 @@ If you wish to configure default modules with Spack, add a ``defaults`` key to y
 
 .. code-block:: yaml
 
-  modules:
-    my-module-set:
-      tcl:
-        defaults:
-        - gcc@10.2.1
-        - hdf5@1.2.10+mpi+hl%gcc
+   modules:
+     my-module-set:
+       tcl:
+         defaults:
+         - gcc@10.2.1
+         - hdf5@1.2.10+mpi+hl%gcc
 
 These defaults may be arbitrarily specific.
 For any package that satisfies a default, Spack will generate the module file in the appropriate path, and will generate a default symlink to the module file as well.
 
 .. warning::
-  If Spack is configured to generate multiple default packages in the same directory, the last modulefile to be generated will be the default module.
+
+   If Spack is configured to generate multiple default packages in the same directory, the last modulefile to be generated will be the default module.
 
 .. _maintaining-module-files:
 
@@ -614,7 +620,8 @@ If instead what you need is just to delete a few module files, then the right su
 .. command-output:: spack module tcl rm --help
 
 .. note::
-  We care about your module files!
+
+   We care about your module files!
    Every modification done on modules that are already existing will ask for a confirmation by default.
    If the command is used in a script it is possible though to pass the ``-y`` argument, that will skip this safety measure.
 
@@ -658,13 +665,13 @@ Scripts to load modules recursively may be made with the command:
 
 .. code-block:: console
 
-    $ spack module tcl loads --dependencies <spec>
+   $ spack module tcl loads --dependencies <spec>
 
 An equivalent alternative using `process substitution <http://tldp.org/LDP/abs/html/process-sub.html>`_ is:
 
 .. code-block:: console
 
-    $ source <( spack module tcl loads --dependencies <spec> )
+   $ source <( spack module tcl loads --dependencies <spec> )
 
 
 Module Commands for Shell Scripts
@@ -677,37 +684,37 @@ For example:
 
 .. code-block:: console
 
-    $ spack module tcl loads --dependencies py-numpy git
-    # bzip2@1.0.6%gcc@4.9.3=linux-x86_64
-    module load bzip2/1.0.6-gcc-4.9.3-ktnrhkrmbbtlvnagfatrarzjojmkvzsx
-    # ncurses@6.0%gcc@4.9.3=linux-x86_64
-    module load ncurses/6.0-gcc-4.9.3-kaazyneh3bjkfnalunchyqtygoe2mncv
-    # zlib@1.2.8%gcc@4.9.3=linux-x86_64
-    module load zlib/1.2.8-gcc-4.9.3-v3ufwaahjnviyvgjcelo36nywx2ufj7z
-    # sqlite@3.8.5%gcc@4.9.3=linux-x86_64
-    module load sqlite/3.8.5-gcc-4.9.3-a3eediswgd5f3rmto7g3szoew5nhehbr
-    # readline@6.3%gcc@4.9.3=linux-x86_64
-    module load readline/6.3-gcc-4.9.3-se6r3lsycrwxyhreg4lqirp6xixxejh3
-    # python@3.5.1%gcc@4.9.3=linux-x86_64
-    module load python/3.5.1-gcc-4.9.3-5q5rsrtjld4u6jiicuvtnx52m7tfhegi
-    # py-setuptools@20.5%gcc@4.9.3=linux-x86_64
-    module load py-setuptools/20.5-gcc-4.9.3-4qr2suj6p6glepnedmwhl4f62x64wxw2
-    # py-nose@1.3.7%gcc@4.9.3=linux-x86_64
-    module load py-nose/1.3.7-gcc-4.9.3-pwhtjw2dvdvfzjwuuztkzr7b4l6zepli
-    # openblas@0.2.17%gcc@4.9.3+shared=linux-x86_64
-    module load openblas/0.2.17-gcc-4.9.3-pw6rmlom7apfsnjtzfttyayzc7nx5e7y
-    # py-numpy@1.11.0%gcc@4.9.3+blas+lapack=linux-x86_64
-    module load py-numpy/1.11.0-gcc-4.9.3-mulodttw5pcyjufva4htsktwty4qd52r
-    # curl@7.47.1%gcc@4.9.3=linux-x86_64
-    module load curl/7.47.1-gcc-4.9.3-ohz3fwsepm3b462p5lnaquv7op7naqbi
-    # autoconf@2.69%gcc@4.9.3=linux-x86_64
-    module load autoconf/2.69-gcc-4.9.3-bkibjqhgqm5e3o423ogfv2y3o6h2uoq4
-    # cmake@3.5.0%gcc@4.9.3~doc+ncurses+openssl~qt=linux-x86_64
-    module load cmake/3.5.0-gcc-4.9.3-x7xnsklmgwla3ubfgzppamtbqk5rwn7t
-    # expat@2.1.0%gcc@4.9.3=linux-x86_64
-    module load expat/2.1.0-gcc-4.9.3-6pkz2ucnk2e62imwakejjvbv6egncppd
-    # git@2.8.0-rc2%gcc@4.9.3+curl+expat=linux-x86_64
-    module load git/2.8.0-rc2-gcc-4.9.3-3bib4hqtnv5xjjoq5ugt3inblt4xrgkd
+   $ spack module tcl loads --dependencies py-numpy git
+   # bzip2@1.0.6%gcc@4.9.3=linux-x86_64
+   module load bzip2/1.0.6-gcc-4.9.3-ktnrhkrmbbtlvnagfatrarzjojmkvzsx
+   # ncurses@6.0%gcc@4.9.3=linux-x86_64
+   module load ncurses/6.0-gcc-4.9.3-kaazyneh3bjkfnalunchyqtygoe2mncv
+   # zlib@1.2.8%gcc@4.9.3=linux-x86_64
+   module load zlib/1.2.8-gcc-4.9.3-v3ufwaahjnviyvgjcelo36nywx2ufj7z
+   # sqlite@3.8.5%gcc@4.9.3=linux-x86_64
+   module load sqlite/3.8.5-gcc-4.9.3-a3eediswgd5f3rmto7g3szoew5nhehbr
+   # readline@6.3%gcc@4.9.3=linux-x86_64
+   module load readline/6.3-gcc-4.9.3-se6r3lsycrwxyhreg4lqirp6xixxejh3
+   # python@3.5.1%gcc@4.9.3=linux-x86_64
+   module load python/3.5.1-gcc-4.9.3-5q5rsrtjld4u6jiicuvtnx52m7tfhegi
+   # py-setuptools@20.5%gcc@4.9.3=linux-x86_64
+   module load py-setuptools/20.5-gcc-4.9.3-4qr2suj6p6glepnedmwhl4f62x64wxw2
+   # py-nose@1.3.7%gcc@4.9.3=linux-x86_64
+   module load py-nose/1.3.7-gcc-4.9.3-pwhtjw2dvdvfzjwuuztkzr7b4l6zepli
+   # openblas@0.2.17%gcc@4.9.3+shared=linux-x86_64
+   module load openblas/0.2.17-gcc-4.9.3-pw6rmlom7apfsnjtzfttyayzc7nx5e7y
+   # py-numpy@1.11.0%gcc@4.9.3+blas+lapack=linux-x86_64
+   module load py-numpy/1.11.0-gcc-4.9.3-mulodttw5pcyjufva4htsktwty4qd52r
+   # curl@7.47.1%gcc@4.9.3=linux-x86_64
+   module load curl/7.47.1-gcc-4.9.3-ohz3fwsepm3b462p5lnaquv7op7naqbi
+   # autoconf@2.69%gcc@4.9.3=linux-x86_64
+   module load autoconf/2.69-gcc-4.9.3-bkibjqhgqm5e3o423ogfv2y3o6h2uoq4
+   # cmake@3.5.0%gcc@4.9.3~doc+ncurses+openssl~qt=linux-x86_64
+   module load cmake/3.5.0-gcc-4.9.3-x7xnsklmgwla3ubfgzppamtbqk5rwn7t
+   # expat@2.1.0%gcc@4.9.3=linux-x86_64
+   module load expat/2.1.0-gcc-4.9.3-6pkz2ucnk2e62imwakejjvbv6egncppd
+   # git@2.8.0-rc2%gcc@4.9.3+curl+expat=linux-x86_64
+   module load git/2.8.0-rc2-gcc-4.9.3-3bib4hqtnv5xjjoq5ugt3inblt4xrgkd
 
 The script may be further edited by removing unnecessary modules.
 
@@ -722,13 +729,13 @@ For example, consider the following on one system:
 
 .. code-block:: console
 
-    $ module avail
-    linux-SuSE11-x86_64/antlr/2.7.7-gcc-5.3.0-bdpl46y
+   $ module avail
+   linux-SuSE11-x86_64/antlr/2.7.7-gcc-5.3.0-bdpl46y
 
-    $ spack module tcl loads antlr    # WRONG!
-    # antlr@2.7.7%gcc@5.3.0~csharp+cxx~java~python arch=linux-SuSE11-x86_64
-    module load antlr/2.7.7-gcc-5.3.0-bdpl46y
+   $ spack module tcl loads antlr    # WRONG!
+   # antlr@2.7.7%gcc@5.3.0~csharp+cxx~java~python arch=linux-SuSE11-x86_64
+   module load antlr/2.7.7-gcc-5.3.0-bdpl46y
 
-    $ spack module tcl loads --prefix linux-SuSE11-x86_64/ antlr
-    # antlr@2.7.7%gcc@5.3.0~csharp+cxx~java~python arch=linux-SuSE11-x86_64
-    module load linux-SuSE11-x86_64/antlr/2.7.7-gcc-5.3.0-bdpl46y
+   $ spack module tcl loads --prefix linux-SuSE11-x86_64/ antlr
+   # antlr@2.7.7%gcc@5.3.0~csharp+cxx~java~python arch=linux-SuSE11-x86_64
+   module load linux-SuSE11-x86_64/antlr/2.7.7-gcc-5.3.0-bdpl46y

--- a/lib/spack/docs/signing.rst
+++ b/lib/spack/docs/signing.rst
@@ -194,11 +194,12 @@ Secrets Management
 
 As stated above the Root Private Keys (intermediate and reputational) are stripped from the GPG keys and stored outside Spack's infrastructure.
 
-.. warning::
-  **TODO**
-    - Explanation here about where and how access is handled for these keys.
-    - Both Root private keys are protected with strong passwords
-    - Who has access to these and how?
+.. .. admonition:: TODO
+..    :class: warning
+
+..    - Explanation here about where and how access is handled for these keys.
+..    - Both Root private keys are protected with strong passwords
+..    - Who has access to these and how?
 
 Intermediate CI Key
 ^^^^^^^^^^^^^^^^^^^
@@ -276,24 +277,27 @@ These are the ``develop`` branch, any release branch (i.e. managed with the ``re
 Finally, Spack's pipeline generation code reserves certain tags to make sure jobs are routed to the correct runners; these tags are ``public``, ``protected``, and ``notary``.
 Understanding how all this works together to protect secrets and provide integrity assurances can be a little confusing so lets break these down:
 
--  **Protected Branches**- Protected branches in Spack prevent anyone other than Maintainers in GitLab from pushing code.
-   In the case of Spack, the only Maintainer level entity pushing code to protected branches is Spack bot.
-   Protecting branches also marks them in such a way that Protected Runners will only run jobs from those branches
-- **Protected Runners**- Protected Runners only run jobs from protected
-   branches.
-   Because protected runners have access to secrets, it's critical that they not run jobs from untrusted code (i.e. PR branches).
-   If they did, it would be possible for a PR branch to tag a job in such a way that a protected runner executed that job and mounted secrets into a code execution environment that had not been reviewed by Spack maintainers.
-   Note however that in the absence of tagging used to route jobs, public runners *could* run jobs from protected branches.
-   No secrets would be at risk of being breached because non-protected runners do not have access to those secrets; lack of secrets would, however, cause the jobs to fail.
-- **Reserved Tags**- To mitigate the issue of public runners picking up
-   protected jobs Spack uses a small set of "reserved" job tags (Note that these are *job* tags not git tags).
-   These tags are "public", "private", and "notary."
-   The majority of jobs executed in Spack's GitLab instance are executed via a ``generate`` job.
-   The generate job code systematically ensures that no user defined configuration sets these tags.
-   Instead, the ``generate`` job sets these tags based on rules related to the branch where this pipeline originated.
-   If the job is a part of a pipeline on a PR branch it sets the ``public`` tag.
-   If the job is part of a pipeline on a protected branch it sets the ``protected`` tag.
-   Finally if the job is the package signing job and it is running on a pipeline that is part of a protected branch then it sets the ``notary`` tag.
+Protected Branches
+  Protected branches in Spack prevent anyone other than Maintainers in GitLab from pushing code.
+  In the case of Spack, the only Maintainer level entity pushing code to protected branches is Spack bot.
+  Protecting branches also marks them in such a way that Protected Runners will only run jobs from those branches
+
+Protected Runners
+  Protected Runners only run jobs from protected branches.
+  Because protected runners have access to secrets, it's critical that they not run jobs from untrusted code (i.e. PR branches).
+  If they did, it would be possible for a PR branch to tag a job in such a way that a protected runner executed that job and mounted secrets into a code execution environment that had not been reviewed by Spack maintainers.
+  Note however that in the absence of tagging used to route jobs, public runners *could* run jobs from protected branches.
+  No secrets would be at risk of being breached because non-protected runners do not have access to those secrets; lack of secrets would, however, cause the jobs to fail.
+
+Reserved Tags
+  To mitigate the issue of public runners picking up protected jobs Spack uses a small set of "reserved" job tags (Note that these are *job* tags not git tags).
+  These tags are "public", "private", and "notary."
+  The majority of jobs executed in Spack's GitLab instance are executed via a ``generate`` job.
+  The generate job code systematically ensures that no user defined configuration sets these tags.
+  Instead, the ``generate`` job sets these tags based on rules related to the branch where this pipeline originated.
+  If the job is a part of a pipeline on a PR branch it sets the ``public`` tag.
+  If the job is part of a pipeline on a protected branch it sets the ``protected`` tag.
+  Finally if the job is the package signing job and it is running on a pipeline that is part of a protected branch then it sets the ``notary`` tag.
 
 Protected Runners are configured to only run jobs from protected branches.
 Only jobs running in pipelines on protected branches are tagged with ``protected`` or ``notary`` tags.

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -266,7 +266,8 @@ class BinaryCacheIndex:
             spec_list = [
                 s
                 for s in db.query_local(installed=InstallRecordStatus.ANY)
-                if s.external or db.query_local_by_spec_hash(s.dag_hash()).in_buildcache
+                # todo, make it easer to get install records associated with specs
+                if s.external or db._data[s.dag_hash()].in_buildcache
             ]
 
             for indexed_spec in spec_list:
@@ -320,16 +321,14 @@ class BinaryCacheIndex:
 
         Returns:
             An list of objects containing the found specs and mirror url where
-                each can be found, e.g.:
+            each can be found, e.g.::
 
-                .. code-block:: python
-
-                    [
-                        {
-                            "spec": "<concrete-spec>",
-                            "mirror_url": "<mirror-root-url>"
-                        }
-                    ]
+                [
+                    {
+                        "spec": "<concrete-spec>",
+                        "mirror_url": "<mirror-root-url>"
+                    }
+                ]
         """
         return self.find_by_hash(spec.dag_hash(), mirrors_to_check=mirrors_to_check)
 
@@ -2223,7 +2222,7 @@ def get_mirrors_for_spec(spec=None, mirrors_to_check=None, index_only=False):
 
     Return:
         A list of objects, each containing a ``mirror_url`` and ``spec`` key
-            indicating all mirrors where the spec can be found.
+        indicating all mirrors where the spec can be found.
     """
     if spec is None:
         return []
@@ -2254,7 +2253,7 @@ def update_cache_and_get_specs():
     local index cache (essentially a no-op if it has been done already and
     nothing has changed on the configured mirrors.)
 
-    Throws:
+    Raises:
         FetchCacheError
     """
     BINARY_INDEX.update()

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -34,8 +34,9 @@ def spec_for_current_python() -> str:
     minor version (all patches are ABI compatible with the same minor).
 
     See:
-      https://www.python.org/dev/peps/pep-0513/
-      https://stackoverflow.com/a/35801395/771663
+
+    * https://www.python.org/dev/peps/pep-0513/
+    * https://stackoverflow.com/a/35801395/771663
     """
     version_str = ".".join(str(x) for x in sys.version_info[:2])
     return f"python@{version_str}"

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1517,7 +1517,7 @@ def get_package_context(traceback, context=3):
 
 class ChildError(InstallError):
     """Special exception class for wrapping exceptions from child processes
-       in Spack's build environment.
+    in Spack's build environment.
 
     The main features of a ChildError are:
 

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -295,7 +295,8 @@ def migrate(
         specs_to_migrate = [
             s
             for s in db.query_local(installed=InstallRecordStatus.ANY)
-            if not s.external and db.query_local_by_spec_hash(s.dag_hash()).in_buildcache
+            # todo, make it easer to get install records associated with specs
+            if not s.external and db._data[s.dag_hash()].in_buildcache
         ]
 
         # Run the tasks in parallel if possible

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -658,20 +658,20 @@ def require_active_env(cmd_name):
     )
 
 
-def find_environment(args):
+def find_environment(args: argparse.Namespace) -> Optional[ev.Environment]:
     """Find active environment from args or environment variable.
 
     Check for an environment in this order:
-        1. via ``spack -e ENV`` or ``spack -D DIR`` (arguments)
-        2. via a path in the spack.environment.spack_env_var environment variable.
+
+    1. via ``spack -e ENV`` or ``spack -D DIR`` (arguments)
+    2. via a path in the spack.environment.spack_env_var environment variable.
 
     If an environment is found, read it in.  If not, return None.
 
     Arguments:
-        args (argparse.Namespace): argparse namespace with command arguments
+        args: argparse namespace with command arguments
 
-    Returns:
-        (spack.environment.Environment): a found environment, or ``None``
+    Returns: a found environment, or ``None``
     """
 
     # treat env as a name

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -174,7 +174,7 @@ def checksum(parser, args):
         sys.exit(0)
 
     # convert dict into package.py version statements
-    version_lines = get_version_lines(version_hashes, url_dict)
+    version_lines = get_version_lines(version_hashes)
     print()
     print(version_lines)
     print()

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 import urllib.parse
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import spack.llnl.util.tty as tty
 import spack.repo
@@ -909,23 +909,22 @@ def get_name(name, url):
     return result
 
 
-def get_url(url):
+def get_url(url: Optional[str]) -> str:
     """Get the URL to use.
 
     Use a default URL if none is provided.
 
     Args:
-        url (str): ``url`` argument to ``spack create``
+        url: ``url`` argument to ``spack create``
 
-    Returns:
-        str: The URL of the package
+    Returns: The URL of the package
     """
 
     # Use the user-supplied URL or a default URL if none is present.
     return url or "https://www.example.com/example-1.2.3.tar.gz"
 
 
-def get_versions(args, name):
+def get_versions(args: argparse.Namespace, name: str) -> Tuple[str, BuildSystemAndLanguageGuesser]:
     """Returns a list of versions and hashes for a package.
 
     Also returns a BuildSystemAndLanguageGuesser object.
@@ -933,11 +932,10 @@ def get_versions(args, name):
     Returns default values if no URL is provided.
 
     Args:
-        args (argparse.Namespace): The arguments given to ``spack create``
-        name (str): The name of the package
+        args: The arguments given to ``spack create``
+        name: The name of the package
 
-    Returns:
-        tuple: versions and hashes, and a BuildSystemAndLanguageGuesser object
+    Returns: Tuple of versions and hashes, and a BuildSystemAndLanguageGuesser object
     """
 
     # Default version with hash
@@ -984,7 +982,7 @@ def get_versions(args, name):
             url_dict, name, first_stage_function=guesser, keep_stage=args.keep_stage
         )
 
-        versions = get_version_lines(version_hashes, url_dict)
+        versions = get_version_lines(version_hashes)
     else:
         versions = unhashed_versions
 
@@ -1028,17 +1026,16 @@ def get_build_system(
     return selected_template
 
 
-def get_repository(args, name):
+def get_repository(args: argparse.Namespace, name: str) -> spack.repo.Repo:
     """Returns a Repo object that will allow us to determine the path where
     the new package file should be created.
 
     Args:
-        args (argparse.Namespace): The arguments given to ``spack create``
-        name (str): The name of the package to create
+        args: The arguments given to ``spack create``
+        name: The name of the package to create
 
     Returns:
-        spack.repo.Repo: A Repo object capable of determining the path to the
-            package file
+        A Repo object capable of determining the path to the package file
     """
     spec = Spec(name)
     # Figure out namespace for spec
@@ -1061,7 +1058,9 @@ def get_repository(args, name):
         if spec.namespace:
             repo = spack.repo.PATH.get_repo(spec.namespace)
         else:
-            repo = spack.repo.PATH.first_repo()
+            _repo = spack.repo.PATH.first_repo()
+            assert _repo is not None, "No package repository found"
+            repo = _repo
 
     # Set the namespace on the spec if it's not there already
     if not spec.namespace:

--- a/lib/spack/spack/cmd/mark.py
+++ b/lib/spack/spack/cmd/mark.py
@@ -4,8 +4,10 @@
 
 import argparse
 import sys
+from typing import List, Union
 
 import spack.cmd
+import spack.spec
 import spack.store
 from spack.cmd.common import arguments
 from spack.llnl.util import tty
@@ -51,16 +53,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
 
 
-def find_matching_specs(specs, allow_multiple_matches=False):
-    """Returns a list of specs matching the not necessarily
-       concretized specs given from cli
+def find_matching_specs(
+    specs: List[Union[str, spack.spec.Spec]], allow_multiple_matches: bool = False
+) -> List[spack.spec.Spec]:
+    """Returns a list of specs matching the not necessarily concretized specs given from cli
 
     Args:
-        specs (list): list of specs to be matched against installed packages
-        allow_multiple_matches (bool): if True multiple matches are admitted
-
-    Return:
-        list of specs
+        specs: list of specs to be matched against installed packages
+        allow_multiple_matches: if True multiple matches are admitted
     """
     # List of specs that match expressions given via command line
     specs_from_cli = []

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -83,17 +83,13 @@ def find_matching_specs(
     allow_multiple_matches: bool = False,
     origin=None,
 ) -> List[spack.spec.Spec]:
-    """Returns a list of specs matching the not necessarily
-       concretized specs given from cli
+    """Returns a list of specs matching the not necessarily concretized specs given from cli
 
     Args:
         env: optional active environment
         specs: list of specs to be matched against installed packages
         allow_multiple_matches: if True multiple matches are admitted
         origin: origin of the spec
-
-    Return:
-        list: list of specs
     """
     # constrain uninstall resolution to current environment if one is active
     hashes = env.all_hashes() if env else None

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -825,8 +825,7 @@ def included_path(entry: Union[str, dict]) -> IncludePath:
     Args:
         entry: include configuration entry
 
-    Returns: converted entry, where an empty ``when`` means the path is
-        not conditionally included
+    Returns: converted entry, where an empty ``when`` means the path is not conditionally included
     """
     if isinstance(entry, str):
         return IncludePath(path=entry, sha256="", when="", optional=False)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -724,10 +724,9 @@ class Database:
         """Get a spec for hash, and whether it's installed upstream.
 
         Return:
-            (tuple): (bool, optional InstallRecord): bool tells us whether
-                the record is from an upstream. Its InstallRecord is also
-                returned if available (the record must be checked to know
-                whether the hash is installed).
+            Tuple of bool and optional InstallRecord. The bool tells us whether the record is from
+            an upstream. Its InstallRecord is also returned if available (the record must be
+            checked to know whether the hash is installed).
 
         If the record is available locally, this function will always have
         a preference for returning that, even if it is not installed locally
@@ -744,12 +743,11 @@ class Database:
                 return True, db._data[hash_key]
         return False, None
 
-    def query_local_by_spec_hash(self, hash_key):
+    def query_local_by_spec_hash(self, hash_key: str) -> Optional[InstallRecord]:
         """Get a spec by hash in the local database
 
         Return:
-            (InstallRecord or None): InstallRecord when installed
-                locally, otherwise None."""
+            InstallRecord when installed locally, otherwise None."""
         with self.read_transaction():
             return self._data.get(hash_key, None)
 

--- a/lib/spack/spack/deptypes.py
+++ b/lib/spack/spack/deptypes.py
@@ -51,12 +51,15 @@ def compatible(flag1: DepFlag, flag2: DepFlag) -> bool:
     non-build dependency. This separates our two process spaces, build time and run time.
 
     These dependency combinations are allowed:
-        single dep on name: [b], [l], [r], [bl], [br], [blr]
-        two deps on name: [b, l], [b, r], [b, lr]
+
+    * single dep on name: ``[b]``, ``[l]``, ``[r]``, ``[bl]``, ``[br]``, ``[blr]``
+    * two deps on name: ``[b, l]``, ``[b, r]``, ``[b, lr]``
 
     but none of these make any sense:
-        two build deps: [b, b], [b, br], [b, bl], [b, blr]
-        any two deps that both have an l or an r, i.e. [l, l], [r, r], [l, r], [bl, l], [bl, r]"""
+
+    * two build deps: ``[b, b]``, ``[b, br]``, ``[b, bl]``, ``[b, blr]``
+    * any two deps that both have an ``l`` or an ``r``, i.e. ``[l, l]``, ``[r, r]``, ``[l, r]``,
+      ``[bl, l]``, ``[bl, r]``"""
     # Cannot have overlapping build types to two different dependencies
     if flag1 & flag2:
         return False

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -22,16 +22,16 @@ contents have.  Lockfiles are JSON-formatted and their top-level sections are:
    * ``specfile-version``: an integer representing the spec format version (since
      ``v0.17``)
 2. ``spack`` (object): optional, this identifies information about Spack
-    used to concretize the environment:
+   used to concretize the environment:
 
-    * ``type``: required, identifies form Spack version took (e.g., ``git``, ``release``)
-    * ``commit``: the commit if the version is from git
-    * ``version``: the Spack version
+   * ``type``: required, identifies form Spack version took (e.g., ``git``, ``release``)
+   * ``commit``: the commit if the version is from git
+   * ``version``: the Spack version
 3. ``roots`` (list): an ordered list of records representing the roots of the Spack
-    environment. Each has two fields:
+   environment. Each has two fields:
 
-    * ``hash``: a Spack spec hash uniquely identifying the concrete root spec
-    * ``spec``: a string representation of the abstract spec that was concretized
+   * ``hash``: a Spack spec hash uniquely identifying the concrete root spec
+   * ``spec``: a string representation of the abstract spec that was concretized
 4. ``concrete_specs``: a dictionary containing the specs in the environment.
 5. ``include_concrete`` (dictionary): an optional dictionary that includes the roots
    and concrete specs from the included environments, keyed by the path to that

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1295,12 +1295,12 @@ class Environment:
         """Remove this environment from Spack entirely."""
         shutil.rmtree(self.path)
 
-    def add(self, user_spec, list_name=user_speclist_name):
+    def add(self, user_spec, list_name=user_speclist_name) -> bool:
         """Add a single user_spec (non-concretized) to the Environment
 
         Returns:
-            (bool): True if the spec was added, False if it was already
-                present and did not need to be added
+            True if the spec was added, False if it was already present and did not need to be
+            added
 
         """
         spec = Spec(user_spec)
@@ -1319,7 +1319,7 @@ class Environment:
         list_to_change = self.spec_lists[list_name]
         existing = str(spec) in list_to_change.yaml_list
         if not existing:
-            list_to_change.add(str(spec))
+            list_to_change.add(spec)
             if list_name == user_speclist_name:
                 self.manifest.add_user_spec(str(user_spec))
             else:

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -89,13 +89,12 @@ def get_escaped_text_output(filename: str) -> List[str]:
     return [re.escape(ln) for ln in expected.split("\n")]
 
 
-def get_test_stage_dir():
+def get_test_stage_dir() -> str:
     """Retrieves the ``config:test_stage`` path to the configured test stage
     root directory
 
     Returns:
-        str: absolute path to the configured test stage root or, if none,
-            the default test stage path
+        absolute path to the configured test stage root or, if none, the default test stage path
     """
     return spack.util.path.canonicalize_path(
         spack.config.get("config:test_stage", spack.paths.default_test_path)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1212,8 +1212,8 @@ def check_db(spec: "spack.spec.Spec") -> Tuple[Optional[spack.database.InstallRe
         spec: spec whose database install status is being checked
 
     Return:
-        Tuple of optional database record, and a boolean installed_in_db
-            that's ``True`` iff the spec is considered installed
+        Tuple of optional database record, and a boolean installed_in_db that's ``True`` iff the
+        spec is considered installed
     """
     try:
         rec = spack.store.STORE.db.get_record(spec)

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -107,7 +107,7 @@ def attr_setdefault(obj, name, value):
     return getattr(obj, name)
 
 
-def union_dicts(*dicts):
+def union_dicts(*dicts: Mapping[Any, Any]) -> Dict[Any, Any]:
     """Use update() to combine all dicts into one.
 
     This builds a new dictionary, into which we ``update()`` each element
@@ -115,13 +115,12 @@ def union_dicts(*dicts):
     items from earlier dictionaries.
 
     Args:
-        dicts (list): list of dictionaries
+        dicts: list of dictionaries
 
-    Return: (dict): a merged dictionary containing combined keys and
-        values from ``dicts``.
+    Returns: a merged dictionary containing combined keys and values from ``dicts``.
 
     """
-    result = {}
+    result: Dict[Any, Any] = {}
     for d in dicts:
         result.update(d)
     return result
@@ -541,17 +540,15 @@ def dedupe(sequence, key=None):
             seen.add(x_key)
 
 
-def pretty_date(time, now=None):
+def pretty_date(time: Union[datetime, int], now: Optional[datetime] = None) -> str:
     """Convert a datetime or timestamp to a pretty, relative date.
 
     Args:
-        time (datetime.datetime or int): date to print prettily
-        now (datetime.datetime): datetime for 'now', i.e. the date the pretty date
-            is relative to (default is datetime.now())
+        time: date to print prettily
+        now: the date the pretty date is relative to (default is ``datetime.now()``)
 
     Returns:
-        (str): pretty string like 'an hour ago', 'Yesterday',
-            '3 months ago', 'just now', etc.
+        pretty string like "an hour ago", "Yesterday", "3 months ago", "just now", etc.
 
     Adapted from https://stackoverflow.com/questions/1551382.
 
@@ -576,51 +573,49 @@ def pretty_date(time, now=None):
         if second_diff < 10:
             return "just now"
         if second_diff < 60:
-            return str(second_diff) + " seconds ago"
+            return f"{second_diff} seconds ago"
         if second_diff < 120:
             return "a minute ago"
         if second_diff < 3600:
-            return str(second_diff // 60) + " minutes ago"
+            return f"{second_diff // 60} minutes ago"
         if second_diff < 7200:
             return "an hour ago"
         if second_diff < 86400:
-            return str(second_diff // 3600) + " hours ago"
+            return f"{second_diff // 3600} hours ago"
     if day_diff == 1:
         return "yesterday"
     if day_diff < 7:
-        return str(day_diff) + " days ago"
+        return f"{day_diff} days ago"
     if day_diff < 28:
         weeks = day_diff // 7
         if weeks == 1:
             return "a week ago"
         else:
-            return str(day_diff // 7) + " weeks ago"
+            return f"{day_diff // 7} weeks ago"
     if day_diff < 365:
         months = day_diff // 30
         if months == 1:
             return "a month ago"
         elif months == 12:
             months -= 1
-        return str(months) + " months ago"
+        return f"{months} months ago"
 
-    diff = day_diff // 365
-    if diff == 1:
+    year_diff = day_diff // 365
+    if year_diff == 1:
         return "a year ago"
-    else:
-        return str(diff) + " years ago"
+    return f"{year_diff} years ago"
 
 
-def pretty_string_to_date(date_str, now=None):
+def pretty_string_to_date(date_str: str, now: Optional[datetime] = None) -> datetime:
     """Parses a string representing a date and returns a datetime object.
 
     Args:
-        date_str (str): string representing a date. This string might be
+        date_str: string representing a date. This string might be
             in different format (like ``YYYY``, ``YYYY-MM``, ``YYYY-MM-DD``,
             ``YYYY-MM-DD HH:MM``, ``YYYY-MM-DD HH:MM:SS``)
             or be a *pretty date* (like ``yesterday`` or ``two months ago``)
 
-    Returns:
-        (datetime.datetime): datetime object corresponding to ``date_str``
+    Returns: datetime object corresponding to ``date_str``
     """
 
     pattern = {}
@@ -667,8 +662,7 @@ def pretty_string_to_date(date_str, now=None):
         if bool(regexp.match(date_str)):
             return parser(date_str)
 
-    msg = 'date "{0}" does not match any valid format'.format(date_str)
-    raise ValueError(msg)
+    raise ValueError(f'date "{date_str}" does not match any valid format')
 
 
 def pretty_seconds_formatter(seconds):

--- a/lib/spack/spack/llnl/util/link_tree.py
+++ b/lib/spack/spack/llnl/util/link_tree.py
@@ -456,25 +456,27 @@ class LinkTree:
                     os.remove(marker)
 
     def merge(
-        self, dest_root, ignore_conflicts=False, ignore=None, link=fs.symlink, relative=False
+        self,
+        dest_root,
+        ignore_conflicts: bool = False,
+        ignore: Optional[Callable[[str], bool]] = None,
+        link: Callable = fs.symlink,
+        relative: bool = False,
     ):
-        """Link all files in src into dest, creating directories
-           if necessary.
+        """Link all files in src into dest, creating directories if necessary.
 
-        Keyword Args:
+        Arguments:
 
-        ignore_conflicts (bool): if True, do not break when the target exists;
-            return a list of files that could not be linked
+            ignore_conflicts: if True, do not break when the target exists; return a list of files
+                that could not be linked
 
-        ignore (callable): callable that returns True if a file is to be
-            ignored in the merge (by default ignore nothing)
+            ignore: callable that returns True if a file is to be ignored in the merge (by default
+                ignore nothing)
 
-        link (callable): function to create links with
-            (defaults to spack.llnl.util.filesystem.symlink)
+            link: function to create links with (defaults to
+                ``spack.llnl.util.filesystem.symlink``)
 
-        relative (bool): create all symlinks relative to the target
-            (default False)
-
+            relative: create all symlinks relative to the target (default False)
         """
         if ignore is None:
             ignore = lambda x: False

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -314,9 +314,10 @@ class Mirror:
             Dictionary from credential type string to value
 
             Credential Type Map:
-                access_token -> str
-                access_pair  -> tuple(str,str)
-                profile      -> str
+
+            * ``access_token``: ``str``
+            * ``access_pair``: ``Tuple[str, str]``
+            * ``profile``: ``str``
         """
         creddict: Dict[str, Any] = {}
         access_token = self.get_access_token(direction)

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -101,12 +101,12 @@ def create(path, specs, skip_unstable_versions=False):
             they do not have a stable archive checksum (as determined by
             ``fetch_strategy.stable_target``)
 
-    Return Value:
-        Returns a tuple of lists: (present, mirrored, error)
+    Returns:
+        A tuple of lists, each containing specs
 
-        * present:  Package specs that were already present.
+        * present: Package specs that were already present.
         * mirrored: Package specs that were successfully mirrored.
-        * error:    Package specs that failed to mirror due to some error.
+        * error: Package specs that failed to mirror due to some error.
     """
     # automatically spec-ify anything in the specs array.
     specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1804,9 +1804,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """Create a hash based on the artifacts and patches used to build this package.
 
         This includes:
-            * source artifacts (tarballs, repositories) used to build;
-            * content hashes (``sha256``'s) of all patches applied by Spack; and
-            * canonicalized contents the ``package.py`` recipe used to build.
+
+        * source artifacts (tarballs, repositories) used to build;
+        * content hashes (``sha256``'s) of all patches applied by Spack; and
+        * canonicalized contents the ``package.py`` recipe used to build.
 
         This hash is only included in Spack's DAG hash for concrete specs, but if it
         happens to be called on a package with an abstract spec, only applicable (i.e.,

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -460,12 +460,11 @@ class Indexer(metaclass=abc.ABCMeta):
     def _create(self):
         """Create an empty index and return it."""
 
-    def needs_update(self, pkg):
+    def needs_update(self, pkg) -> bool:
         """Whether an update is needed when the package file hasn't changed.
 
         Returns:
-            (bool): ``True`` if this package needs its index
-                updated, ``False`` otherwise.
+            ``True`` iff this package needs its index updated.
 
         We already automatically update indexes when package files
         change, but other files (like patches) may change underneath the
@@ -1011,13 +1010,13 @@ class Repo:
 
     It contains the following keys:
 
-    ``namespace``:
+    ``namespace``
         A Python namespace where the repository's packages should live.
 
-    ``subdirectory``:
+    ``subdirectory``
         An optional subdirectory name where packages are placed
 
-    ``api``:
+    ``api``
         A string of the form vX.Y that indicates the Package API version. The default is ``v1.0``.
         For the repo to be compatible with the current version of Spack, the version must be
         greater than or equal to :py:data:`spack.min_package_api_version` and less than or equal to
@@ -1151,9 +1150,10 @@ class Repo:
         package names and Python module names, so there is no guessing.
 
         For Packge API v1.x we support the following one-to-many mappings:
-            num3proxy -> 3proxy
-            foo_bar -> foo_bar, foo-bar
-            foo_bar_baz -> foo_bar_baz, foo-bar-baz, foo_bar-baz, foo-bar_baz
+
+        * ``num3proxy`` -> ``3proxy``
+        * ``foo_bar`` -> ``foo_bar``, ``foo-bar``
+        * ``foo_bar_baz`` -> ``foo_bar_baz``, ``foo-bar-baz``, ``foo_bar-baz``, ``foo-bar_baz``
         """
         if self.package_api >= (2, 0):
             if nm.pkg_dir_to_pkg_name(import_name, package_api=self.package_api) in self:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -276,18 +276,20 @@ def parse_virtual_assignment(context: TokenContext) -> Tuple[str]:
     """Look at subvalues and, if present, extract virtual and a push a substitute token.
 
     This handles things like:
-        * ^c=gcc
-        * ^c,cxx=gcc
-        * %[when=+bar] c=gcc
-        * %[when=+bar] c,cxx=gcc
+
+    * ``^c=gcc``
+    * ``^c,cxx=gcc``
+    * ``%[when=+bar] c=gcc``
+    * ``%[when=+bar] c,cxx=gcc``
 
     Virtual assignment can happen anywhere a dependency node can appear. It is
-    shorthand for %[virtuals=c,cxx] gcc.
+    shorthand for ``%[virtuals=c,cxx] gcc``.
 
-    The virtuals=substitute key value pair appears in the subvalues of DEPENDENCY
-    and END_EDGE_PROPERTIES tokens. We extract the virutals and create a token from
-    the substitute, which is then pushed back on the parser stream so that the head
-    of the stream can be parsed like a regular node.
+    The ``virtuals=substitute`` key value pair appears in the subvalues of
+    :attr:`~spack.spec_parser.SpecTokens.DEPENDENCY` and
+    :attr:`~spack.spec_parser.SpecTokens.END_EDGE_PROPERTIES` tokens. We extract the virtuals and
+    create a token from the substitute, which is then pushed back on the parser stream so that the
+    head of the stream can be parsed like a regular node.
 
     Returns:
         the virtuals assigned, or None if there aren't any
@@ -343,7 +345,7 @@ class SpecParser:
             initial_spec: object where to parse the spec. If None a new one
                 will be created.
 
-        Return
+        Return:
             The spec that was parsed
         """
         if not self.ctx.next_token:
@@ -487,7 +489,7 @@ class SpecNodeParser:
             initial_spec: object to be constructed
             root: True if we're parsing a root, False if dependency after ^ or %
 
-        Return
+        Return:
             The object passed as argument
         """
         parser_warnings: List[str] = []
@@ -607,7 +609,7 @@ class FileParser:
         Args:
             initial_spec: object where to parse the spec
 
-        Return
+        Return:
             The initial_spec passed as argument, once constructed
         """
         file = pathlib.Path(self.ctx.current_token.value)
@@ -730,9 +732,10 @@ def strip_quotes_and_unescape(string: str) -> str:
 def quote_if_needed(value: str) -> str:
     """Add quotes around the value if it requires quotes.
 
-    This will add quotes around the value unless it matches ``NO_QUOTES_NEEDED``.
+    This will add quotes around the value unless it matches :data:`NO_QUOTES_NEEDED`.
 
     This adds:
+
     * single quotes by default
     * double quotes around any value that contains single quotes
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -20,7 +20,7 @@ import os
 import pathlib
 import re
 import uuid
-from typing import Any, Callable, Dict, Generator, List, Optional, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import spack.config
 import spack.database
@@ -36,17 +36,16 @@ from spack.llnl.util import tty
 DEFAULT_INSTALL_TREE_ROOT = os.path.join(spack.paths.opt_path, "spack")
 
 
-def parse_install_tree(config_dict):
+def parse_install_tree(config_dict: dict) -> Tuple[str, str, Dict[str, str]]:
     """Parse config settings and return values relevant to the store object.
 
     Arguments:
-        config_dict (dict): dictionary of config values, as returned from
-            ``spack.config.get("config")``
+        config_dict: dictionary of config values, as returned from ``spack.config.get("config")``
 
     Returns:
-        (tuple): triple of the install tree root, the unpadded install tree
-            root (before padding was applied), and the projections for the
-            install tree
+        triple of the install tree root, the unpadded install tree
+        root (before padding was applied), and the projections for the
+        install tree
 
     Encapsulate backwards compatibility capabilities for install_tree
     and deprecated values that are now parsed as part of install_tree.
@@ -67,7 +66,7 @@ def parse_install_tree(config_dict):
 
     install_tree = config_dict.get("install_tree", {})
 
-    padded_length = False
+    padded_length: Union[bool, int] = False
     if isinstance(install_tree, str):
         tty.warn("Using deprecated format for configuring install_tree")
         unpadded_root = install_tree

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -69,6 +69,7 @@ def test_reindex_with_deprecated_packages(
     new_libelf = db.query_local_by_spec_hash(
         db.query_local("libelf@0.8.13", installed=True)[0].dag_hash()
     )
+    assert old_libelf is not None and new_libelf is not None
     assert old_libelf.deprecated_for == new_libelf.spec.dag_hash()
     assert new_libelf.deprecated_for is None
     assert new_libelf.ref_count == 1

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -231,7 +231,7 @@ def test_uploading_with_base_image_in_docker_image_manifest_v2_format(
         (rootfs / "bin").mkdir(parents=True)
         (rootfs / "bin" / "sh").write_text("hello world")
         tarball = tmp_path / "base.tar.gz"
-        with gzip_compressed_tarfile(tarball) as (tar, tar_gz_checksum, tar_checksum):
+        with gzip_compressed_tarfile(str(tarball)) as (tar, tar_gz_checksum, tar_checksum):
             tar.add(rootfs, arcname=".")
         tar_gz_digest = Digest.from_sha256(tar_gz_checksum.hexdigest())
         tar_digest = Digest.from_sha256(tar_checksum.hexdigest())

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -32,7 +32,7 @@ import io
 import os
 import pathlib
 import re
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 import spack.error
 import spack.llnl.url
@@ -48,7 +48,7 @@ from spack.llnl.util.tty.color import cescape, colorize
 #
 
 
-def strip_name_suffixes(path, version):
+def strip_name_suffixes(path: str, version: Union[str, spack.version.StandardVersion]) -> str:
     """Most tarballs contain a package name followed by a version number.
     However, some also contain extraneous information in-between the name
     and version:
@@ -67,8 +67,8 @@ def strip_name_suffixes(path, version):
     * ``jpeg``
 
     Args:
-        path (str): The filename or URL for the package
-        version (str): The version detected for this URL
+        path: The filename or URL for the package
+        version: The version detected for this URL
 
     Returns:
         str: The ``path`` with any extraneous suffixes removed
@@ -120,19 +120,20 @@ def strip_name_suffixes(path, version):
     return path
 
 
-def parse_version_offset(path):
+def parse_version_offset(path: str) -> Tuple[str, int, int, int, str]:
     """Try to extract a version string from a filename or URL.
 
     Args:
         path (str): The filename or URL for the package
 
     Returns:
-        tuple: A tuple containing:
-            version of the package,
-            first index of version,
-            length of version string,
-            the index of the matching regex,
-            the matching regex
+        A tuple containing
+
+        * version of the package
+        * first index of version
+        * length of version string
+        * the index of the matching regex
+        * the matching regex
 
     Raises:
         UndetectableVersionError: If the URL does not match any regexes
@@ -304,20 +305,23 @@ def parse_version(path: str) -> spack.version.StandardVersion:
     return spack.version.StandardVersion.from_string(version)
 
 
-def parse_name_offset(path, v=None):
+def parse_name_offset(
+    path: str, v: Optional[Union[str, spack.version.StandardVersion]] = None
+) -> Tuple[str, int, int, int, str]:
     """Try to determine the name of a package from its filename or URL.
 
     Args:
-        path (str): The filename or URL for the package
-        v (str): The version of the package
+        path: The filename or URL for the package
+        v: The version of the package
 
     Returns:
-        tuple: A tuple containing:
-            name of the package,
-            first index of name,
-            length of name,
-            the index of the matching regex,
-            the matching regex
+        A tuple containing
+
+        * name of the package
+        * first index of name
+        * length of name
+        * the index of the matching regex
+        * the matching regex
 
     Raises:
         UndetectableNameError: If the URL does not match any regexes
@@ -433,12 +437,12 @@ def parse_name(path, ver=None):
     return name
 
 
-def parse_name_and_version(path):
+def parse_name_and_version(path: str) -> Tuple[str, spack.version.StandardVersion]:
     """Try to determine the name of a package and extract its version
     from its filename or URL.
 
     Args:
-        path (str): The filename or URL for the package
+        path: The filename or URL for the package
 
     Returns:
         tuple: a tuple containing the package (name, version)
@@ -545,11 +549,11 @@ def color_url(path, **kwargs):
     """Color the parts of the url according to Spack's parsing.
 
     Colors are:
-       | Cyan: The version found by :func:`parse_version_offset`.
-       | Red:  The name found by :func:`parse_name_offset`.
 
-       | Green:   Instances of version string from :func:`substitute_version`.
-       | Magenta: Instances of the name (protected from substitution).
+    * Cyan: The version found by :func:`parse_version_offset`.
+    * Red: The name found by :func:`parse_name_offset`.
+    * Green: Instances of version string from :func:`substitute_version`.
+    * Magenta: Instances of the name (protected from substitution).
 
     Args:
         path (str): The filename or URL for the package

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1231,9 +1231,12 @@ def compression_writer(output_path: str, compression: str, checksum_algo: str):
     options for ``compression`` are ``"gzip"`` or ``"none"``, ``checksum_algo`` is used to pick
     the checksum algorithm used by the :class:`~spack.util.archive.ChecksumWriter`.
 
-    Yields a tuple containing:
-        io.IOBase: writer that can compress (or not) as it writes
-        ChecksumWriter: provides checksum and length of written data
+    Yields:
+        A tuple containing
+
+        * An :class:`io.BufferedIOBase` writer that can compress (or not) as it writes
+        * A :class:`~spack.util.archive.ChecksumWriter` that provides checksum and length of
+          written data
     """
     with open(output_path, "wb") as writer, ChecksumWriter(
         fileobj=writer, algorithm=hash_fun_for_algo(checksum_algo)

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -16,17 +16,16 @@ from spack.context import Context
 spack_loaded_hashes_var = "SPACK_LOADED_HASHES"
 
 
-def prefix_inspections(platform):
+def prefix_inspections(platform: str) -> dict:
     """Get list of prefix inspections for platform
 
     Arguments:
-        platform (str): the name of the platform to consider. The platform
-            determines what environment variables Spack will use for some
-            inspections.
+        platform: the name of the platform to consider. The platform determines what environment
+            variables Spack will use for some inspections.
 
     Returns:
-        A dictionary mapping subdirectory names to lists of environment
-            variables to modify with that directory if it exists.
+        A dictionary mapping subdirectory names to lists of environment variables to modify with
+        that directory if it exists.
     """
     inspections = spack.config.get("modules:prefix_inspections")
     if isinstance(inspections, dict):

--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -9,7 +9,7 @@ import pathlib
 import tarfile
 from contextlib import closing, contextmanager
 from gzip import GzipFile
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, Generator, List, Tuple
 
 from spack.llnl.util import tty
 from spack.llnl.util.filesystem import readlink
@@ -97,15 +97,19 @@ class ChecksumWriter(io.BufferedIOBase):
 
 
 @contextmanager
-def gzip_compressed_tarfile(path):
+def gzip_compressed_tarfile(
+    path: str,
+) -> Generator[Tuple[tarfile.TarFile, ChecksumWriter, ChecksumWriter], None, None]:
     """Create a reproducible, gzip compressed tarfile, and keep track of shasums of both the
     compressed and uncompressed tarfile. Reproduciblity is achived by normalizing the gzip header
     (no file name and zero mtime).
 
-    Yields a tuple of the following:
-        tarfile.TarFile: tarfile object
-        ChecksumWriter: checksum of the gzip compressed tarfile
-        ChecksumWriter: checksum of the uncompressed tarfile
+    Yields:
+        A tuple of three elements
+
+        * :class:`tarfile.TarFile`: tarfile object
+        * :class:`ChecksumWriter`: checksum of the gzip compressed tarfile
+        * :class:`ChecksumWriter`: checksum of the uncompressed tarfile
     """
     # Create gzip compressed tarball of the install prefix
     # 1) Use explicit empty filename and mtime 0 for gzip header reproducibility.

--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -76,7 +76,7 @@ import sys
 import threading
 import time
 from contextlib import contextmanager
-from typing import Optional, TextIO, Union
+from typing import List, Optional, TextIO, Tuple, Union
 
 _error_matches = [
     "^FAIL: ",
@@ -385,7 +385,9 @@ class CTestLogParser:
                 print("%16.2f        %s" % (self.timings[index][i] * 1e6, stringify(elt)))
             index += 1
 
-    def parse(self, stream: Union[str, TextIO], context: int = 6, jobs: Optional[int] = None):
+    def parse(
+        self, stream: Union[str, TextIO], context: int = 6, jobs: Optional[int] = None
+    ) -> Tuple[List[BuildError], List[BuildWarning]]:
         """Parse a log file by searching each line for errors and warnings.
 
         Args:
@@ -393,8 +395,7 @@ class CTestLogParser:
             context: lines of context to extract around each log event
 
         Returns:
-            (tuple): two lists containing ``BuildError`` and
-                ``BuildWarning`` objects.
+            two lists containing :class:`BuildError` and :class:`BuildWarning` objects.
         """
         if isinstance(stream, str):
             with open(stream) as f:

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -64,8 +64,8 @@ def editor(*args: str, exec_fn: Callable[[str, List[str]], int] = os.execv) -> b
 
     This will try to execute the following, in order:
 
-    1. $VISUAL <args>    # the "visual" editor (per POSIX)
-    2. $EDITOR <args>    # the regular editor (per POSIX)
+    1. ``$VISUAL <args>``: the "visual" editor (per POSIX)
+    2. ``$EDITOR <args>``: the regular editor (per POSIX)
     3. some default editor (see ``_default_editors``) with <args>
 
     If an environment variable isn't defined, it is skipped.  If it
@@ -76,7 +76,6 @@ def editor(*args: str, exec_fn: Callable[[str, List[str]], int] = os.execv) -> b
     Arguments:
         args: args to pass to editor
 
-    Optional Arguments:
         exec_fn: invoke this function to run; use ``spack.util.editor.executable`` if you
             want something that returns, instead of the default ``os.execv()``.
     """

--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -2,20 +2,16 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from typing import Optional
 
-
-def get_version_lines(version_hashes_dict: dict, url_dict: Optional[dict] = None) -> str:
+def get_version_lines(version_hashes_dict: dict) -> str:
     """
     Renders out a set of versions like those found in a package's
     package.py file for a given set of versions and hashes.
 
     Args:
-        version_hashes_dict (dict): A dictionary of the form: version -> checksum.
-        url_dict (dict): A dictionary of the form: version -> URL.
+        version_hashes_dict: A dictionary of the form: version -> checksum.
 
-    Returns:
-        (str): Rendered version lines.
+    Returns: Rendered version lines.
     """
     version_lines = []
 

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -11,6 +11,7 @@ import os
 import sys
 import urllib.parse
 import urllib.response
+from typing import List
 from urllib.error import URLError
 from urllib.request import BaseHandler
 
@@ -96,25 +97,23 @@ class GCSBucket:
             return self.bucket.blob(blob_path)
         return None
 
-    def get_all_blobs(self, recursive=True, relative=True):
+    def get_all_blobs(self, recursive: bool = True, relative: bool = True) -> List[str]:
         """Get a list of all blobs
-        Returns a list of all blobs within this bucket.
+
+        Returns: a list of all blobs within this bucket.
 
         Args:
-            relative: If true (default), print blob paths
-                         relative to 'build_cache' directory.
-                      If false, print absolute blob paths (useful for
-                         destruction of bucket)
+            relative: If true (default), print blob paths relative to 'build_cache' directory.
+                If false, print absolute blob paths (useful for destruction of bucket)
         """
         tty.debug("Getting GCS blobs... Recurse {0} -- Rel: {1}".format(recursive, relative))
 
-        converter = str
-        if relative:
-            converter = self._relative_blob_name
+        converter = self._relative_blob_name if relative else str
+
+        blob_list: List[str] = []
 
         if self.exists():
             all_blobs = self.bucket.list_blobs(prefix=self.prefix)
-            blob_list = []
 
             base_dirs = len(self.prefix.split("/")) + 1
 
@@ -126,7 +125,7 @@ class GCSBucket:
                 else:
                     blob_list.append(converter(blob.name))
 
-            return blob_list
+        return blob_list
 
     def _relative_blob_name(self, blob_name):
         return os.path.relpath(blob_name, self.prefix)

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -602,8 +602,8 @@ def _a_single_value_or_a_combination(single_value: str, *values: str) -> Disjoin
 
 def any_combination_of(*values: str) -> DisjointSetsOfValues:
     """Multi-valued variant that allows either any combination of the specified values, or none
-     at all (using ``variant=none``). The literal value ``none`` is used as sentinel for the empty
-     set, since in the spec DSL we have to always specify a value for a variant.
+    at all (using ``variant=none``). The literal value ``none`` is used as sentinel for the empty
+    set, since in the spec DSL we have to always specify a value for a variant.
 
     It is up to the package implementation to handle the value ``none`` specially, if at all.
 

--- a/lib/spack/spack/version/__init__.py
+++ b/lib/spack/spack/version/__init__.py
@@ -3,15 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """
-This module implements Version and version-ish objects.  These are:
+This module implements Version and version-ish objects. These are:
 
-StandardVersion: A single version of a package.
-ClosedOpenRange: A range of versions of a package.
-VersionList: A ordered list of Version and VersionRange elements.
-
-The set of Version and ClosedOpenRange is totally ordered wiht <
-defined as Version(x) < VersionRange(Version(y), Version(x))
-if Version(x) <= Version(y).
+* :class:`~spack.version.version_types.StandardVersion`: A single version of a package.
+* :class:`~spack.version.version_types.ClosedOpenRange`: A range of versions of a package.
+* :class:`~spack.version.version_types.VersionList`: A ordered list of Version and VersionRange
+  elements.
 """
 
 from .common import (

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -431,8 +431,7 @@ class StandardVersion(ConcreteVersion):
         Version("1_2_3b")
 
         Returns:
-            Version: The version with separator characters replaced by
-                underscores
+            Version: The version with separator characters replaced by underscores
         """
         return type(self).from_string(self.string.replace(".", "_").replace("-", "_"))
 


### PR DESCRIPTION
1. Fix various cases where

   ```
   Returns:
     this is some text
          and this is how it continues
   ```

   rendered as definition lists in the docs.
2. Add dozens of typehints while at it and fix the corresponding mypy issues.
3. Change a couple of `.. note::` to `.. admonition:: <title>` if they were meant to have a title.

Best reviewed with "ignore whitespace" for actual code changes.

```
$ git diff HEAD~1 --stat | tail -n1
 44 files changed, 483 insertions(+), 469 deletions(-)

$ git diff HEAD~1 --stat -w | tail -n1
 41 files changed, 338 insertions(+), 324 deletions(-)
```