### PR TITLE
spack config get --json

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -61,6 +61,7 @@ import spack.schema.toolchains
 import spack.schema.upstreams
 import spack.schema.view
 import spack.util.remote_file_cache as rfc_util
+import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 from spack.llnl.util import filesystem, lang, tty
 from spack.util.cpus import cpus_available
@@ -758,12 +759,19 @@ class Configuration:
         """Iterate over scopes in this configuration."""
         yield from self.scopes.values()
 
-    def print_section(self, section: str, blame: bool = False, *, scope=None) -> None:
+    def print_section(
+        self, section: str, yaml: bool = True, blame: bool = False, *, scope: Optional[str] = None
+    ) -> None:
         """Print a configuration to stdout."""
         try:
             data = syaml.syaml_dict()
             data[section] = self.get_config(section, scope=scope)
-            syaml.dump_config(data, stream=sys.stdout, default_flow_style=False, blame=blame)
+            if yaml or blame:
+                syaml.dump_config(data, stream=sys.stdout, default_flow_style=False, blame=blame)
+            else:
+                sjson.dump(data, sys.stdout)
+                sys.stdout.write("\n")
+
         except (syaml.SpackYAMLError, OSError) as e:
             raise spack.error.ConfigError(f"cannot read '{section}' configuration") from e
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -762,7 +762,14 @@ class Configuration:
     def print_section(
         self, section: str, yaml: bool = True, blame: bool = False, *, scope: Optional[str] = None
     ) -> None:
-        """Print a configuration to stdout."""
+        """Print a configuration to stdout.
+
+        Arguments:
+            section: The configuration section to print.
+            yaml: If True, output in YAML format, otherwise JSON (ignored when blame is True).
+            blame: Whether to include source locations for each entry.
+            scope: The configuration scope to use.
+        """
         try:
             data = syaml.syaml_dict()
             data[section] = self.get_config(section, scope=scope)

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import functools
+import json
 import os
 import pathlib
 import re
@@ -94,6 +95,22 @@ def test_config_scopes_path_section():
 
 def test_get_config_scope(mock_low_high_config):
     assert config("get", "compilers").strip() == "compilers: {}"
+
+
+def test_get_config_roundtrip(mutable_config):
+    """Test that ``spack config get [--json] <section>`` roundtrips correctly."""
+    json_roundtrip = json.loads(config("get", "--json", "config"))
+    yaml_roundtrip = syaml.load(config("get", "config"))
+    assert json_roundtrip["config"] == yaml_roundtrip["config"] == mutable_config.get("config")
+
+
+def test_get_all_config_roundtrip(mutable_config):
+    """Test that ``spack config get [--json]`` roundtrips correctly."""
+    json_roundtrip = json.loads(config("get", "--json"))
+    yaml_roundtrip = syaml.load(config("get"))
+    assert json_roundtrip == yaml_roundtrip
+    for section in spack.config.SECTION_SCHEMAS:
+        assert json_roundtrip["spack"][section] == mutable_config.get(section)
 
 
 def test_get_config_scope_merged(mock_low_high_config):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -839,7 +839,7 @@ _spack_config() {
 _spack_config_get() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help --json"
     else
         _config_sections
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1227,10 +1227,12 @@ complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_bui
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
-set -g __fish_spack_optspecs_spack_config_get h/help
+set -g __fish_spack_optspecs_spack_config_get h/help json
 complete -c spack -n '__fish_spack_using_command_pos 0 config get' -f -a 'bootstrap cdash ci compilers concretizer config definitions develop env_vars include mirrors modules packages repos toolchains upstreams view'
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command config get' -l json -f -a json
+complete -c spack -n '__fish_spack_using_command config get' -l json -d 'output configuration as JSON'
 
 # spack config blame
 set -g __fish_spack_optspecs_spack_config_blame h/help


### PR DESCRIPTION
Add `spack config get --json` for convenience, so JSON tooling can be used.

For example:

```
$ spack config get --json config | jq '.config.ccache'
true
```

or

```
$ spack config get --json | jq '.spack | keys'
[
  "bootstrap",
  "cdash",
  "ci",
  "compilers",
  "concretizer",
  "config",
  "definitions",
  "develop",
  "env_vars",
  "include",
  "mirrors",
  "modules",
  "packages",
  "repos",
  "toolchains",
  "upstreams",
  "view"
]
```