### PR TITLE
docs: add xrefs from command index

### DIFF
--- a/lib/spack/docs/advanced_topics.rst
+++ b/lib/spack/docs/advanced_topics.rst
@@ -6,7 +6,7 @@
    :description lang=en:
       Explore advanced topics in Spack, including auditing packages and configuration, and verifying installations.
 
-.. _audit-packages-and-configuration:
+.. _cmd-spack-audit:
 
 Auditing Packages and Configuration
 ===================================
@@ -31,7 +31,7 @@ If issues are found, they are reported to stdout:
        the variant 'adios' does not exist
        in spack_repo/builtin/packages/lammps/package.py
 
-.. _verify-installations:
+.. _cmd-spack-verify:
 
 Verifying Installations
 =======================

--- a/lib/spack/docs/bootstrapping.rst
+++ b/lib/spack/docs/bootstrapping.rst
@@ -7,6 +7,9 @@
       Learn how Spack's bootstrapping feature automatically fetches and installs essential build tools when they are not available on the host system.
 
 .. _bootstrapping:
+.. _cmd-spack-bootstrap:
+.. _cmd-spack-bootstrap-status:
+.. _cmd-spack-bootstrap-now:
 
 Bootstrapping
 =============
@@ -64,6 +67,8 @@ Users can also bootstrap all Spack's dependencies in a single command, which is 
    ==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.3/build_cache/linux-centos7-x86_64/gcc-10.2.1/patchelf-0.15.0/linux-centos7-x86_64-gcc-10.2.1-patchelf-0.15.0-htk62k7efo2z22kh6kmhaselru7bfkuc.spack
    ==> Installing "patchelf@0.15.0%gcc@10.2.1 ldflags="-static-libstdc++ -static-libgcc"  arch=linux-centos7-x86_64" from a buildcache
 
+.. _cmd-spack-bootstrap-root:
+
 The Bootstrapping Store
 -----------------------
 
@@ -101,6 +106,11 @@ If needed, you can remove all the software in the current bootstrapping store wi
    % spack -b find
    ==> Showing internal bootstrap store at "/Users/spack/.spack/bootstrap/store"
    ==> 0 installed packages
+
+.. _cmd-spack-bootstrap-list:
+.. _cmd-spack-bootstrap-disable:
+.. _cmd-spack-bootstrap-enable:
+.. _cmd-spack-bootstrap-reset:
 
 Enabling and Disabling Bootstrapping Methods
 --------------------------------------------
@@ -141,6 +151,9 @@ You can also reset the bootstrapping configuration to Spack's defaults:
    ==> Bootstrapping configuration is being reset to Spack's defaults. Current configuration will be lost.
    Do you want to continue? [Y/n]
    %
+
+.. _cmd-spack-bootstrap-mirror:
+.. _cmd-spack-bootstrap-add:
 
 Creating a Mirror for Air-Gapped Systems
 ----------------------------------------

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -84,6 +84,8 @@ Since recipes need a little more boilerplate than:
 Spack provides a command to generate customizable recipes for container images.
 Customizations include minimizing the size of the image, installing packages in the base image using the system package manager, and setting up a proper entrypoint to run the image.
 
+.. _cmd-spack-containerize:
+
 A Quick Introduction
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -512,8 +512,7 @@ or a file:
 just like you would with the normal Python command.
 
 
-.. _cmd-spack-url:
-
+.. _cmd-spack-blame:
 
 ``spack blame``
 ^^^^^^^^^^^^^^^
@@ -556,6 +555,8 @@ Finally, to get a JSON export of the data, add ``--json``:
     $ spack blame --json python
 
 
+.. _cmd-spack-url:
+
 ``spack url``
 ^^^^^^^^^^^^^
 
@@ -567,6 +568,9 @@ By determining the version from the URL, Spack can replace it with other version
 
 The regular expressions in ``parse_name_offset`` and ``parse_version_offset`` are used to extract the name and version, but they are not perfect.
 In order to debug Spack's URL parsing support, the ``spack url`` command can be used.
+
+
+.. _cmd-spack-url-parse:
 
 ``spack url parse``
 """""""""""""""""""
@@ -582,12 +586,18 @@ This particular package may require a ``list_url`` or ``url_for_version`` functi
 This command also accepts a ``--spider`` flag.
 If provided, Spack searches for other versions of the package and prints the matching URLs.
 
+
+.. _cmd-spack-url-list:
+
 ``spack url list``
 """"""""""""""""""
 
 This command lists every URL in every package in Spack.
 If given the ``--color`` and ``--extrapolation`` flags, it also colors the part of the string that it detected to be the name and version.
 The ``--incorrect-name`` and ``--incorrect-version`` flags can be used to print URLs that were not being parsed correctly.
+
+
+.. _cmd-spack-url-summary:
 
 ``spack url summary``
 """""""""""""""""""""

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -51,6 +51,8 @@ Using Environments
 
 Here we follow a typical use case of creating, concretizing, installing and loading an environment.
 
+.. _cmd-spack-env-create:
+
 Creating a managed Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -120,6 +122,9 @@ The name of an environment can be a nested path to help organize environments vi
 
 This will create a managed environment under ``$environments_root/projectA/configA/myenv``.
 Changing ``environment_root`` can therefore also be used to make a whole group of nested environments available.
+
+.. _cmd-spack-env-activate:
+.. _cmd-spack-env-deactivate:
 
 Activating an Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -254,6 +259,8 @@ All explicitly installed packages will be listed as roots of the environment.
 All of the Spack commands that act on the list of installed specs are environment-aware in this way, including ``install``, ``uninstall``, ``find``, ``extensions``, etc.
 In the :ref:`environment-configuration` section we will discuss environment-aware commands further.
 
+.. _cmd-spack-add:
+
 Adding Abstract Specs
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -281,7 +288,7 @@ or
 
    $ spack -e myenv add python
 
-.. _environments_concretization:
+.. _cmd-spack-concretize:
 
 Concretizing
 ^^^^^^^^^^^^
@@ -349,7 +356,7 @@ Otherwise, ``spack install`` will concretize the environment before installing t
       [myenv]$ spack install & spack install & spack install & spack install
 
    Another option is to generate a ``Makefile`` and run ``make -j<N>`` to control the number of parallel install processes.
-   See :ref:`env-generate-depfile` for details.
+   See :ref:`cmd-spack-env-depfile` for details.
 
 
 As it installs, ``spack install`` creates symbolic links in the ``logs/`` directory in the environment, allowing for easy inspection of build logs related to that environment.
@@ -360,7 +367,7 @@ For root specs provided to ``spack install`` on the command line, ``--no-add`` i
 In other words, if there is an unambiguous match in the active concrete environment for a root spec provided to ``spack install`` on the command line, Spack does not require you to specify the ``--no-add`` option to prevent the spec from being added again.
 At the same time, a spec that already exists in the environment, but only as a dependency, will be added to the environment as a root spec without the ``--no-add`` option.
 
-.. _develop-specs:
+.. _cmd-spack-develop:
 
 Developing Packages in a Spack Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -906,6 +913,8 @@ Another short way to configure a view is to specify just where to put it:
 
 Views can also be disabled by setting ``view: false``.
 
+.. _cmd-spack-env-view:
+
 Advanced view configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1030,7 +1039,7 @@ For this reason, it is not recommended to use non-default projections with the d
 The ``spack env deactivate`` command will remove the active view of the Spack environment from the user's environment variables.
 
 
-.. _env-generate-depfile:
+.. _cmd-spack-env-depfile:
 
 
 Generating Depfiles from Environments

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -203,5 +203,5 @@ Basic Usage
 
 Advanced Topics
    1. :ref:`toolchains`
-   2. :ref:`audit-packages-and-configuration`
-   3. :ref:`verify-installations`
+   2. :ref:`cmd-spack-audit`
+   3. :ref:`cmd-spack-verify`

--- a/lib/spack/docs/package_fundamentals.rst
+++ b/lib/spack/docs/package_fundamentals.rst
@@ -237,7 +237,7 @@ but you risk breaking other installed packages.
 In general, it is safer to remove dependent packages *before* removing their dependencies or to use the ``--dependents`` option.
 
 
-.. _nondownloadable:
+.. _cmd-spack-gc:
 
 Garbage collection
 ^^^^^^^^^^^^^^^^^^
@@ -277,6 +277,8 @@ It keeps only the packages that were explicitly installed by a user, along with 
 All other packages, such as build-only dependencies or orphaned packages, are identified as "garbage" and removed.
 
 You can check :ref:`cmd-spack-find-metadata` to see how to query for explicitly installed packages or :ref:`dependency-types` for a more thorough treatment of dependency types.
+
+.. _cmd-spack-mark:
 
 Marking packages explicit or implicit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -362,6 +364,8 @@ If there is no new version for either of the packages, ``spack install`` will si
 When using this workflow for installations that contain more packages, care must be taken to either only mark selected packages or issue ``spack install`` for all packages that should be kept.
 
 You can check :ref:`cmd-spack-find-metadata` to see how to query for explicitly or implicitly installed packages.
+
+.. _nondownloadable:
 
 Non-Downloadable Tarballs
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -645,6 +649,7 @@ You can use this with tools like `jq <https://jqlang.org/>`_ to quickly create J
       "hash": "zvaa4lhlhilypw5quj3akyd3apbq5gap"
     }
 
+.. _cmd-spack-diff:
 
 ``spack diff``
 ^^^^^^^^^^^^^^
@@ -782,6 +787,7 @@ Spack has three different ways to solve this problem, which fit different use ca
 
 
 .. _cmd-spack-load:
+.. _cmd-spack-unload:
 
 ``spack load / unload``
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -1414,6 +1414,8 @@ The ``--keep-prefix`` option allows you to keep the install prefix regardless of
 
    $ spack install --keep-prefix <spec>
 
+.. _cmd-spack-graph:
+
 Understanding the DAG
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -637,7 +637,7 @@ In order, they are
 
 If Spack is unable to determine what the commit should be during concretization a warning will be issued.
 Users may also specify which commit SHA they want with the spec since it is simply a variant.
-In this case, or in the case of develop specs (see :ref:`develop-specs`), Spack will skip attempts to assign the commit SHA automatically.
+In this case, or in the case of develop specs (see :ref:`cmd-spack-develop`), Spack will skip attempts to assign the commit SHA automatically.
 
 .. note::
 

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -359,6 +359,7 @@ If you need fine-grained control over which packages use which targets (or over 
 
 
 .. _support-for-microarchitectures:
+.. _cmd-spack-arch:
 
 Support for specific microarchitectures
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add missing `.. _cmd-spack-<cmd>` anchors to environments section, so that the
command reference guide automatically adds "More Documentation" links to them.

