### PR TITLE
Retain the "direct" attribute of deps in "when" context manager

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5011,7 +5011,7 @@ def merge_abstract_anonymous_specs(*abstract_specs: Spec):
             edge = next(iter(current_spec_constraint.edges_to_dependencies(name)))
 
             merged_spec._add_dependency(
-                edge.spec.copy(), depflag=edge.depflag, virtuals=edge.virtuals
+                edge.spec.copy(), depflag=edge.depflag, virtuals=edge.virtuals, direct=edge.direct
             )
 
     return merged_spec

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -196,3 +196,15 @@ def test_redistribute_override_when():
     spack.directives._execute_redistribute(cls, source=None, binary=False, when="@1.0")
     assert cls.disable_redistribute[spec_key].binary
     assert cls.disable_redistribute[spec_key].source
+
+
+@pytest.mark.regression("51248")
+def test_direct_dependencies_from_when_context_are_retained(mock_packages):
+    """Tests that direct dependencies from the "when" context manager don't lose the "direct"
+    attribute when turned into directives on the package class.
+    """
+    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
+    # Direct dependency in a "when" single context manager
+    assert spack.spec.Spec("%pkg-b") in pkg_cls.dependencies
+    # Direct dependency in a "when" nested context manager
+    assert spack.spec.Spec("@2 %c=gcc %pkg-c %pkg-b@:4.0") in pkg_cls.dependencies

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
@@ -24,3 +24,12 @@ class WithConstraintMet(Package):
 
     with when("@0.14: ^pkg-b@:4.0"):
         depends_on("pkg-c", when="@:15 ^pkg-b@3.8:")
+
+    # Direct dependency in a "when" context manager
+    with when("%pkg-b"):
+        depends_on("pkg-e")
+
+    # More complex dependency with nested contexts
+    with when("%pkg-c"):
+        with when("@2 %pkg-b@:4.0"):
+            depends_on("pkg-e", when="%c=gcc")


### PR DESCRIPTION
refers #51248

The value of the "direct" attribute of dependencies is currently lost in "when" context managers. This PR fixes the issue and adds unit tests to prevent regressions

Currently, we can't use plain `Spec.constrain` in directives, since that function triggers lookup of the repository being constructed to resolve virtual dependencies. I'll check if that logic can be simplified in a following PR, and keep this one just for the bug fix.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
