### PR TITLE
docs: environments basics section

### DIFF
--- a/lib/spack/docs/environments_basics.rst
+++ b/lib/spack/docs/environments_basics.rst
@@ -6,8 +6,6 @@
    :description lang=en:
       Learn how to use Spack environments to manage reproducible software stacks on a local machine.
 
-.. _spack-environments-basic-usage:
-
 Spack Environments
 ==================
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -187,7 +187,7 @@ To undo these modifications, you can:
 .. admonition:: Environments and views
    :class: tip
 
-   :ref:`Spack Environments <spack-environments-basic-usage>` are a better way to install and load a set of packages that are frequently used together.
+   :doc:`Spack Environments <environments_basics>` are a better way to install and load a set of packages that are frequently used together.
    The discussion of this topic goes beyond this ``Getting Started`` guide, and we refer to :ref:`environments` for more information.
 
 Next steps
@@ -199,7 +199,7 @@ There are further resources in the documentation that cover both basic and advan
 Basic Usage
    1. :ref:`basic-usage`
    2. :ref:`compiler-config`
-   3. :ref:`spack-environments-basic-usage`
+   3. :doc:`environments_basics`
 
 Advanced Topics
    1. :ref:`toolchains`

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -54,7 +54,7 @@ If you're new to Spack and want to start using it, see :doc:`getting_started`, o
 
    package_fundamentals
    configuring_compilers
-   replace_conda_homebrew
+   environments_basics
    frequently_asked_questions
    getting_help
 

--- a/lib/spack/docs/replace_conda_homebrew.rst
+++ b/lib/spack/docs/replace_conda_homebrew.rst
@@ -4,50 +4,70 @@
 
 .. meta::
    :description lang=en:
-      Learn how to use Spack environments to manage single-user installations, similar to Homebrew and Conda.
+      Learn how to use Spack environments to manage reproducible software stacks on a local machine.
 
 .. _spack-environments-basic-usage:
 
 Spack Environments
 ==================
 
-Spack is an incredibly powerful package manager, designed for supercomputers where users have diverse installation needs.
-But Spack can also be used to handle simple single-user installations on your laptop.
-Most macOS users are already familiar with package managers like Homebrew and Conda, where all installed packages are symlinked to a single central location like ``/usr/local``.
-In this section, we will show you how to emulate the behavior of Homebrew/Conda using :ref:`Spack environments <environments>`!
+Spack is a powerful package manager designed for the complex software needs of supercomputers.
+These same robust features for managing versions and dependencies also make it an excellent tool for local development on a laptop or workstation.
 
-Creating a New Environment
---------------------------
+If you are used to tools like Conda, Homebrew or pip for managing local command-line tools and development projects, you will find Spack environments to be a powerful and flexible alternative.
+Spack environments allow you to create self-contained, reproducible software collections, a concept similar to Conda environments and Python's virtual environments.
 
-First, let's create a new environment.
-We'll assume that Spack is already set up correctly, and that you've already sourced the setup script for your shell.
-To create and activate a new environment, simply run:
+Unlike other package managers, Spack environments do not contain copies of the software themselves.
+Instead, they reference installations in the Spack store, which is a central location where Spack keeps all installed packages.
+This means that multiple environments can share the same package installations, saving disk space and reducing duplication.
+
+In this section, we will walk through creating a simple environment to manage a personal software stack.
+
+Creating and Activating an Environment
+--------------------------------------
+
+First, let's create and activate a new environment.
+This places you "inside" the environment, so all subsequent Spack commands apply to it by default.
 
 .. code-block:: console
 
    $ spack env create myenv
+   ==> Created environment myenv in /path/to/spack/var/spack/environments/myenv
+   $ spack env activate myenv
 
-Here, *myenv* can be anything you want to name your environment.
-Next, we can add a list of packages we would like to install into our environment.
-Let's say we want a newer version of Bash than the one that comes with macOS, and we want a few Python libraries.
-We can run:
+Here, *myenv* is the name of our new environment.
 
-.. code-block:: spec
-
-   $ spack -e myenv add bash@5 python py-numpy py-scipy py-matplotlib
-
-Each package can be added individually, or together like we did above.
-Notice that we're explicitly asking for Bash 5 here.
-You can use any spec you would normally use on the command line with other Spack commands.
-If you run the following command:
+You can verify you are in the environment using:
 
 .. code-block:: console
 
-   $ spack -e myenv config edit
+   $ spack env status
+   ==> In environment myenv
 
-you'll see what your ``spack.yaml`` looks like:
+Adding Specs to the Environment
+-------------------------------
+
+Now that our environment is active, we can add the packages we want to install.
+Let's say we want a newer version of curl and a few Python libraries.
+
+.. code-block:: spec
+
+   $ spack add curl@8 python py-numpy py-scipy py-matplotlib
+
+You can add packages one at a time or all at once.
+Notice that we didn't need to specify the environment name, as Spack knows we are working inside ``myenv``.
+These packages are now added to the environment's manifest file, ``spack.yaml``.
+
+You can view the manifest at any time by running:
+
+.. code-block:: console
+
+   $ spack config edit
+
+This will open your ``spack.yaml``, which should look like this:
 
 .. code-block:: yaml
+   :caption: Example ``spack.yaml`` for our environment
 
    # This is a Spack Environment file.
    #
@@ -56,7 +76,7 @@ you'll see what your ``spack.yaml`` looks like:
    spack:
      # add package specs to the `specs` list
      specs:
-     - bash@5
+     - curl@8
      - python
      - py-numpy
      - py-scipy
@@ -65,118 +85,110 @@ you'll see what your ``spack.yaml`` looks like:
      concretizer:
        unify: true
 
-Configuring View Location
--------------------------
+The ``view: true`` setting tells Spack to create a single directory where all executables, libraries, etc., are symlinked together, similar to a traditional Unix prefix.
+By default, this view is located inside the environment directory.
 
-Spack symlinks all installations to ``${SPACK_ROOT}/var/spack/environments/myenv/.spack-env/view``, which is the default when ``view: true``.
-You can change this to any directory you want by editing the ``spack.yaml`` manifest file, or by using the following command:
+Installing the Software
+-----------------------
 
-.. code-block:: console
-
-   $ spack -e myenv env view enable <path>
-
-In order to access files in these locations, you need to update ``PATH`` and other environment variables to point to them.
-Activating the Spack environment does this automatically once the software is installed:
+With our specs defined, the next step is to have Spack solve the dependency graph.
+This is called "concretization."
 
 .. code-block:: console
 
-   $ spack env activate -p myenv
+   $ spack concretize
+   ==> Concretized ...
+    ...
 
-For now, let's deactivate the environment and proceed with installing the software:
+Spack will find a consistent set of versions and dependencies for the packages you requested.
+Once this is done, you can install everything with a single command:
+
+.. code-block:: console
+
+   $ spack install
+
+Spack will now download, build, and install all the necessary packages.
+After the installation is complete, the environment's view is automatically updated.
+Because the environment is active, your ``PATH`` and other variables are already configured.
+
+You can verify the installation:
+
+.. code-block:: console
+
+   $ which python3
+   /path/to/spack/var/spack/environments/myenv/.spack-env/view/bin/python3
+
+When you are finished working in the environment, you can deactivate it:
 
 .. code-block:: console
 
    $ spack env deactivate
 
-
-Installing the Software
+Keeping Up With Updates
 -----------------------
 
-Once the manifest file is properly defined, you may want to update the ``builtin`` package repository using this command:
+Over time, you may want to update the packages in your environment to their latest versions.
+Spack makes this easy.
+
+First, update Spack's package repository to make the latest package versions available:
 
 .. code-block:: console
 
    $ spack repo update
 
-Then you can proceed concretizing the environment:
-
-.. code-block:: console
-
-   $ spack -e myenv concretize
-
-This will tell you which packages, if any, are already installed, and alert you to any conflicting specs.
-
-To actually install these packages and symlink them to your ``view:`` directory, simply run:
-
-.. code-block:: console
-
-   $ spack -e myenv install
-   $ spack env activate myenv
-
-Now, when you type ``which python3``, it should find the one you just installed.
-
-.. admonition:: Add the new shell to the list of valid login shells
-   :class: tip
-
-   In order to change the default shell to our newer Bash installation, we first need to add it to this list of acceptable shells.
-   Run:
-
-   .. code-block:: console
-
-      $ sudo vim /etc/shells
-
-   and add the absolute path to your bash executable.
-   Then run:
-
-   .. code-block:: console
-
-      $ chsh -s /path/to/bash
-
-   Now, when you log out and log back in, ``echo $SHELL`` should point to the newer version of Bash.
-
-
-Keeping Up With Updates
------------------------
-
-Let's say you upgraded to a new version of macOS, or a new version of Python was released, and you want to rebuild your entire software stack.
-To do this, simply run the following commands:
+Then, activate the environment, re-concretize and reinstall.
 
 .. code-block:: console
 
    $ spack env activate myenv
-   $ spack concretize --fresh --force
+   $ spack concretize --fresh-roots --force
    $ spack install
 
-The ``--fresh`` flag tells Spack to use the latest version of every package, where possible, instead of trying to reuse installed packages as much as possible.
-
-The ``--force`` flag in addition tells Spack to overwrite its previous concretization decisions, allowing you to choose a new version of Python.
-If any of the new packages like Bash are already installed, ``spack install`` won't re-install them, it will keep the symlinks in place.
+The ``--fresh-roots`` flag tells the concretizer to prefer the latest available package versions you've added explicitly to the environment, while allowing existing dependencies to remain unchanged if possible.
+Alternatively, you can use the ``--fresh`` flag to prefer the latest versions of all packages including dependencies, but that might lead to longer install times and more changes.
+The ``--force`` flag allows it to overwrite the previously solved dependencies.
+The ``install`` command is smart and will only build packages that are not already installed for the new configuration.
 
 Cleaning Up Old Packages
 ------------------------
 
-If we want to clean up old, out-of-date packages from our environment after an upgrade, here's how to upgrade our entire software stack and tidy up the old versions:
+After an update, you may have old, unused packages taking up space.
+You can safely remove any package that is no longer part of an environment's dependency tree.
 
 .. code-block:: console
 
-   $ spack env activate myenv
-   $ spack concretize --fresh --force
-   $ spack install
    $ spack gc --except-any-environment
 
-The final step, ``spack gc --except-any-environment``, runs Spack's garbage collector and removes any packages that are no longer needed by any managed Spack environment -- which will clean up those old versions that got replaced during the upgrade.
+This runs Spack's garbage collector, which will find and uninstall any package versions that are no longer referenced by *any* of your environments.
 
 Removing the Environment
 ------------------------
 
-If you need to remove ``myenv`` completely, the procedure is simple.
-Just run:
+If you no longer need an environment, you can completely remove it.
+
+First, ensure the environment is not active:
 
 .. code-block:: console
 
-   $ spack env activate myenv
-   $ spack uninstall --all
-   $ spack env deactivate myenv
+    $ spack env deactivate
+
+Then, remove the environment.
+
+.. code-block:: console
+
    $ spack env rm myenv
 
-This will uninstall all packages in your environment, remove the symlinks, and finally remove the environment.
+This removes the environment's directory and its view, but the packages that were installed for it remain in the Spack store.
+To actually remove the installations from the Spack store and free up disk space, you can run the garbage collector again.
+
+.. code-block:: console
+
+   $ spack gc --except-any-environment
+
+This command will safely uninstall any packages that are no longer referenced by any of your remaining environments.
+
+Next steps
+----------
+
+Spack has many other features for managing software environments.
+See :doc:`environments` for more advanced usage.


### PR DESCRIPTION
* The section mixes `spack env activate/deactivate` with `spack -e <env>`, which can be confusing to newcomers, as the page does not explain _why_ one or the other should be used. (The actual reason for those -e flags is to "not affect the build environment upon spack install" -- but for a basic usage guide that's just too complicated)
* The somewhat arbitrarily placed `spack repo update` suggestion has moved to "Keeping up with updates"
* Recommend `--fresh-roots` over `--fresh`
* Do not position Spack as an "emulator" of conda/brew, rather merely refer to features of those package managers readers may be familiar with
* Remove a "tip" on how to replace your system's shell... that's out of place and not something I would ever recommend.
* Remove mention of conda/brew from the page title, and instead call it `environments_basics.html`.

Note: after merging, a redirect `replace_conda_homebrew.html -> environments_basics.html` has to be configured in rtd.