### PR TITLE
zsh: fix regression in spack env activate --prompt

### DIFF
--- a/lib/spack/spack/llnl/util/tty/color.py
+++ b/lib/spack/spack/llnl/util/tty/color.py
@@ -210,18 +210,17 @@ def color_when(value):
 
 def _escape(s: str, color: bool, enclose: bool, zsh: bool) -> str:
     """Returns a TTY escape sequence for a color"""
-    if color:
-        if zsh:
-            result = rf"\e[0;{s}m"
-        else:
-            result = f"\033[{s}m"
-
-        if enclose:
-            result = rf"\[{result}\]"
-
-        return result
-    else:
+    if not color:
         return ""
+    elif zsh:
+        return f"\033[0;{s}m"
+
+    result = f"\033[{s}m"
+
+    if enclose:
+        result = rf"\[{result}\]"
+
+    return result
 
 
 def colorize(


### PR DESCRIPTION
The `spack.llnl.util.tty.color._escape` function started to output the
literal characters `\` and `e` instead of the escape character.

That leads to:

```
\e[0;0;92m[default]\e[0;0m √ spack %
```

instead of

```
[default] √ spack %
```

on macOS's default shell.

(I wonder how this went unnoticed since it regressed in April 2024 🤔 #43712)