### PR TITLE
when: deal with `%` vs. `^` correctly

### DIFF
--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -184,8 +184,10 @@ class DirectiveMeta(type):
                     ]
                     if kwargs.get("when"):
                         when_constraints.append(spack.spec.Spec(kwargs["when"]))
-                    when_spec = spack.spec.merge_abstract_anonymous_specs(*when_constraints)
 
+                    when_spec = spack.spec.Spec()
+                    for current in when_constraints:
+                        when_spec.constrain(current, deps=True, resolve_virtuals=False)
                     kwargs["when"] = when_spec
 
                 # If any of the arguments are executors returned by a

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -187,7 +187,7 @@ class DirectiveMeta(type):
 
                     when_spec = spack.spec.Spec()
                     for current in when_constraints:
-                        when_spec._constrain(current, deps=True, resolve_virtuals=False)
+                        when_spec._constrain_symbolically(current, deps=True)
                     kwargs["when"] = when_spec
 
                 # If any of the arguments are executors returned by a

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -187,7 +187,7 @@ class DirectiveMeta(type):
 
                     when_spec = spack.spec.Spec()
                     for current in when_constraints:
-                        when_spec.constrain(current, deps=True, resolve_virtuals=False)
+                        when_spec._constrain(current, deps=True, resolve_virtuals=False)
                     kwargs["when"] = when_spec
 
                 # If any of the arguments are executors returned by a

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Classes and functions to manage providers of virtual dependencies"""
-from typing import Dict, List, Optional, Set
+from typing import Dict, Iterable, Optional, Set
 
 import spack.error
 import spack.spec
@@ -80,7 +80,7 @@ class ProviderIndex(_IndexBase):
     def __init__(
         self,
         repository: "spack.repo.RepoType",
-        specs: Optional[List["spack.spec.Spec"]] = None,
+        specs: Optional[Iterable["spack.spec.Spec"]] = None,
         restrict: bool = False,
     ):
         """Provider index based on a single mapping of providers.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2999,7 +2999,7 @@ class Spec:
             )
 
     def constrain(self, other, deps=True) -> bool:
-        """Intersect self with other in-place. Return True if self changed, False otherwise.
+        """Constrains self with other, and returns True if self changed, False otherwise.
 
         Args:
             other: constraint to be added to self
@@ -3009,6 +3009,35 @@ class Spec:
              spack.error.UnsatisfiableSpecError: when self cannot be constrained
         """
         return self._constrain(other, deps=deps, resolve_virtuals=True)
+
+    def _constrain_symbolically(self, other, deps=True) -> bool:
+        """Constrains self with other, and returns True if self changed, False otherwise.
+
+        This function has no notion of virtuals, so it does not need a repository.
+
+        Args:
+            other: constraint to be added to self
+            deps: if False, constrain only the root node, otherwise constrain dependencies as well
+
+        Raises:
+             spack.error.UnsatisfiableSpecError: when self cannot be constrained
+
+        Examples:
+            >>> from spack.spec import Spec, UnsatisfiableDependencySpecError
+            >>> s = Spec("hdf5 ^mpi@4")
+            >>> t = Spec("hdf5 ^mpi=openmpi")
+            >>> try:
+            ...     s.constrain(t)
+            ... except UnsatisfiableDependencySpecError as e:
+            ...     print(e)
+            ...
+            hdf5 ^mpi=openmpi does not satisfy hdf5 ^mpi@4
+            >>> s._constrain_symbolically(t)
+            True
+            >>> s
+            hdf5 ^mpi@4 ^mpi=openmpi
+        """
+        return self._constrain(other, deps=deps, resolve_virtuals=False)
 
     def _constrain(self, other, deps=True, *, resolve_virtuals: bool):
         # If we are trying to constrain a concrete spec, either the spec

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5011,7 +5011,7 @@ def merge_abstract_anonymous_specs(*abstract_specs: Spec):
             edge = next(iter(current_spec_constraint.edges_to_dependencies(name)))
 
             merged_spec._add_dependency(
-                edge.spec.copy(), depflag=edge.depflag, virtuals=edge.virtuals
+                edge.spec.copy(), depflag=edge.depflag, virtuals=edge.virtuals, direct=edge.direct
             )
 
     return merged_spec

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2998,13 +2998,14 @@ class Spec:
                 f"No such variant {not_existing} for spec: '{spec}'", list(not_existing)
             )
 
-    def constrain(self, other, deps=True):
+    def constrain(self, other, deps=True, resolve_virtuals: bool = True):
         """Intersect self with other in-place. Return True if self changed, False otherwise.
 
         Args:
             other: constraint to be added to self
-            deps: if False, constrain only the root node, otherwise constrain dependencies
-                as well.
+            deps: if False, constrain only the root node, otherwise constrain dependencies as well
+            resolve_virtuals: if True, resolve virtuals in self and other. This requires a
+                repository to be available.
 
         Raises:
              spack.error.UnsatisfiableSpecError: when self cannot be constrained
@@ -3013,13 +3014,13 @@ class Spec:
         # already satisfies the constraint (and the method returns False)
         # or it raises an exception
         if self.concrete:
-            if self.satisfies(other):
+            if self.satisfies(other, resolve_virtuals=resolve_virtuals):
                 return False
             else:
                 raise spack.error.UnsatisfiableSpecError(self, other, "constrain a concrete spec")
 
         other = self._autospec(other)
-        if other.concrete and other.satisfies(self):
+        if other.concrete and other.satisfies(self, resolve_virtuals=resolve_virtuals):
             self._dup(other)
             return True
 
@@ -3077,14 +3078,14 @@ class Spec:
             changed = True
 
         if deps:
-            changed |= self._constrain_dependencies(other)
+            changed |= self._constrain_dependencies(other, resolve_virtuals=resolve_virtuals)
 
         if other.concrete and not self.concrete and other.satisfies(self):
             self._finalize_concretization()
 
         return changed
 
-    def _constrain_dependencies(self, other: "Spec") -> bool:
+    def _constrain_dependencies(self, other: "Spec", resolve_virtuals: bool = True) -> bool:
         """Apply constraints of other spec's dependencies to this spec."""
         if not other._dependencies:
             return False
@@ -3092,7 +3093,7 @@ class Spec:
         # TODO: might want more detail than this, e.g. specific deps
         # in violation. if this becomes a priority get rid of this
         # check and be more specific about what's wrong.
-        if not other._intersects_dependencies(self):
+        if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
             raise UnsatisfiableDependencySpecError(other, self)
 
         if any(not d.name for d in other.traverse(root=False)):
@@ -3107,6 +3108,7 @@ class Spec:
                 existing[0].spec.constrain(edge.spec)
                 existing[0].update_deptypes(edge.depflag)
                 existing[0].update_virtuals(edge.virtuals)
+                existing[0].direct |= edge.direct
             else:
                 self.add_dependency_edge(
                     edge.spec,
@@ -3117,23 +3119,11 @@ class Spec:
                 )
         return self != reference_spec
 
-    def common_dependencies(self, other):
-        """Return names of dependencies that self and other have in common."""
-        common = set(s.name for s in self.traverse(root=False))
-        common.intersection_update(s.name for s in other.traverse(root=False))
-        return common
-
     def constrained(self, other, deps=True):
         """Return a constrained copy without modifying this spec."""
         clone = self.copy(deps=deps)
         clone.constrain(other, deps)
         return clone
-
-    def direct_dep_difference(self, other):
-        """Returns dependencies in self that are not in other."""
-        mine = set(dname for dname in self._dependencies)
-        mine.difference_update(dname for dname in other._dependencies)
-        return mine
 
     def _autospec(self, spec_like):
         """
@@ -3145,7 +3135,9 @@ class Spec:
             return spec_like
         return Spec(spec_like)
 
-    def intersects(self, other: Union[str, "Spec"], deps: bool = True) -> bool:
+    def intersects(
+        self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
+    ) -> bool:
         """Return True if there exists at least one concrete spec that matches both
         self and other, otherwise False.
 
@@ -3155,6 +3147,8 @@ class Spec:
         Args:
             other: spec to be checked for compatibility
             deps: if True check compatibility of dependency nodes too, if False only check root
+            resolve_virtuals: if True, resolve virtuals in self and other. This requires a
+                repository to be available.
         """
         other = self._autospec(other)
 
@@ -3162,10 +3156,10 @@ class Spec:
             return self.dag_hash() == other.dag_hash()
 
         elif self.concrete:
-            return self.satisfies(other)
+            return self.satisfies(other, resolve_virtuals=resolve_virtuals)
 
         elif other.concrete:
-            return other.satisfies(self)
+            return other.satisfies(self, resolve_virtuals=resolve_virtuals)
 
         # From here we know both self and other are not concrete
         self_hash = self.abstract_hash
@@ -3180,6 +3174,9 @@ class Spec:
 
         # If the names are different, we need to consider virtuals
         if self.name != other.name and self.name and other.name:
+            if not resolve_virtuals:
+                return False
+
             self_virtual = spack.repo.PATH.is_virtual(self.name)
             other_virtual = spack.repo.PATH.is_virtual(other.name)
             if self_virtual and other_virtual:
@@ -3232,11 +3229,11 @@ class Spec:
 
         # If we need to descend into dependencies, do it, otherwise we're done.
         if deps:
-            return self._intersects_dependencies(other)
+            return self._intersects_dependencies(other, resolve_virtuals=resolve_virtuals)
 
         return True
 
-    def _intersects_dependencies(self, other):
+    def _intersects_dependencies(self, other, resolve_virtuals: bool = True):
         if not other._dependencies or not self._dependencies:
             # one spec *could* eventually satisfy the other
             return True
@@ -3245,8 +3242,13 @@ class Spec:
         common_dependencies = {x.name for x in self.dependencies()}
         common_dependencies &= {x.name for x in other.dependencies()}
         for name in common_dependencies:
-            if not self[name].intersects(other[name], deps=True):
+            if not self[name].intersects(
+                other[name], deps=True, resolve_virtuals=resolve_virtuals
+            ):
                 return False
+
+        if not resolve_virtuals:
+            return True
 
         # For virtual dependencies, we need to dig a little deeper.
         self_index = spack.provider_index.ProviderIndex(
@@ -3277,12 +3279,16 @@ class Spec:
 
         return True
 
-    def satisfies(self, other: Union[str, "Spec"], deps: bool = True) -> bool:
+    def satisfies(
+        self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
+    ) -> bool:
         """Return True if all concrete specs matching self also match other, otherwise False.
 
         Args:
             other: spec to be satisfied
-            deps: if True descend to dependencies, otherwise only check root node
+            deps: if True, descend to dependencies, otherwise only check root node
+            resolve_virtuals: if True, resolve virtuals in self and other. This requires a
+                repository to be available.
         """
         other = self._autospec(other)
 
@@ -3300,7 +3306,7 @@ class Spec:
                 return False
 
         # If the names are different, we need to consider virtuals
-        if self.name != other.name and self.name and other.name:
+        if self.name != other.name and self.name and other.name and resolve_virtuals:
             # A concrete provider can satisfy a virtual dependency.
             if not spack.repo.PATH.is_virtual(self.name) and spack.repo.PATH.is_virtual(
                 other.name
@@ -3364,19 +3370,20 @@ class Spec:
         for rhs_edge in other.traverse_edges(root=False, cover="edges"):
             # The condition cannot be applied in any case, skip the edge
             test_root = rhs_edge.parent.name in (None, self.name)
-            if test_root and not self.intersects(rhs_edge.when):
+            if test_root and not self.intersects(rhs_edge.when, resolve_virtuals=resolve_virtuals):
                 continue
 
             if (
                 not test_root
                 and rhs_edge.parent.name in self
-                and not self[rhs_edge.parent.name].intersects(rhs_edge.when)
+                and not self[rhs_edge.parent.name].intersects(
+                    rhs_edge.when, resolve_virtuals=resolve_virtuals
+                )
             ):
                 continue
 
             # If we are checking for ^mpi we need to verify if there is any edge
-            is_virtual_node = spack.repo.PATH.is_virtual(rhs_edge.spec.name)
-            if is_virtual_node:
+            if resolve_virtuals and spack.repo.PATH.is_virtual(rhs_edge.spec.name):
                 # Don't mutate objects in memory that may be referred elsewhere
                 rhs_edge = rhs_edge.copy()
                 rhs_edge.update_virtuals(virtuals=(rhs_edge.spec.name,))
@@ -3407,11 +3414,17 @@ class Spec:
                     mock_nodes_from_old_specfiles.add(compiler_spec)
                     # This checks that the single node compiler spec satisfies the request
                     # of a direct dependency. The check is not perfect, but based on heuristic.
-                    if not compiler_spec.satisfies(rhs_edge.spec):
+                    if not compiler_spec.satisfies(
+                        rhs_edge.spec, resolve_virtuals=resolve_virtuals
+                    ):
                         return False
 
                 else:
-                    name = rhs_edge.spec.name if not is_virtual_node else None
+                    name = (
+                        None
+                        if resolve_virtuals and spack.repo.PATH.is_virtual(rhs_edge.spec.name)
+                        else rhs_edge.spec.name
+                    )
                     candidate_edges = current_node.edges_to_dependencies(
                         name=name, virtuals=rhs_edge.virtuals or None
                     )
@@ -3421,9 +3434,14 @@ class Spec:
                         lhs_edge.spec
                         for lhs_edge in candidate_edges
                         if ((lhs_edge.depflag & rhs_edge.depflag) ^ rhs_edge.depflag) == 0
-                        and rhs_edge.when.satisfies(lhs_edge.when)
+                        and rhs_edge.when.satisfies(
+                            lhs_edge.when, resolve_virtuals=resolve_virtuals
+                        )
                     ]
-                    if not candidates or not any(x.satisfies(rhs_edge.spec) for x in candidates):
+                    if not candidates or not any(
+                        x.satisfies(rhs_edge.spec, resolve_virtuals=resolve_virtuals)
+                        for x in candidates
+                    ):
                         return False
 
                 continue
@@ -3461,7 +3479,7 @@ class Spec:
                 candidate_edges = [
                     lhs_edge
                     for lhs_edge in lhs_edges[current_dependency_name]
-                    if rhs_edge.when.satisfies(lhs_edge.when)
+                    if rhs_edge.when.satisfies(lhs_edge.when, resolve_virtuals=resolve_virtuals)
                 ]
 
             if not candidate_edges:
@@ -3473,7 +3491,9 @@ class Spec:
                     return False
 
             for lhs_edge in candidate_edges:
-                if lhs_edge.spec.satisfies(rhs_edge.spec, deps=False):
+                if lhs_edge.spec.satisfies(
+                    rhs_edge.spec, deps=False, resolve_virtuals=resolve_virtuals
+                ):
                     break
             else:
                 return False
@@ -4986,35 +5006,6 @@ def parse_with_version_concrete(spec_like: Union[str, Spec]):
     if interpreted_version:
         s.versions = vn.VersionList([interpreted_version])
     return s
-
-
-def merge_abstract_anonymous_specs(*abstract_specs: Spec):
-    """Merge the abstracts specs passed as input and return the result.
-
-    The root specs must be anonymous, and it's duty of the caller to ensure that.
-
-    This function merge the abstract specs based on package names. In particular
-    it doesn't try to resolve virtual dependencies.
-
-    Args:
-        *abstract_specs: abstract specs to be merged
-    """
-    merged_spec = Spec()
-    for current_spec_constraint in abstract_specs:
-        merged_spec.constrain(current_spec_constraint, deps=False)
-
-        for name in merged_spec.common_dependencies(current_spec_constraint):
-            merged_spec[name].constrain(current_spec_constraint[name], deps=False)
-
-        # Update with additional constraints from other spec
-        for name in current_spec_constraint.direct_dep_difference(merged_spec):
-            edge = next(iter(current_spec_constraint.edges_to_dependencies(name)))
-
-            merged_spec._add_dependency(
-                edge.spec.copy(), depflag=edge.depflag, virtuals=edge.virtuals, direct=edge.direct
-            )
-
-    return merged_spec
 
 
 def reconstruct_virtuals_on_edges(spec: Spec) -> None:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3020,7 +3020,7 @@ class Spec:
             deps: if False, constrain only the root node, otherwise constrain dependencies as well
 
         Raises:
-             spack.error.UnsatisfiableSpecError: when self cannot be constrained
+            spack.error.UnsatisfiableSpecError: when self cannot be constrained
 
         Examples:
             >>> from spack.spec import Spec, UnsatisfiableDependencySpecError

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2998,29 +2998,30 @@ class Spec:
                 f"No such variant {not_existing} for spec: '{spec}'", list(not_existing)
             )
 
-    def constrain(self, other, deps=True, resolve_virtuals: bool = True):
+    def constrain(self, other, deps=True) -> bool:
         """Intersect self with other in-place. Return True if self changed, False otherwise.
 
         Args:
             other: constraint to be added to self
             deps: if False, constrain only the root node, otherwise constrain dependencies as well
-            resolve_virtuals: if True, resolve virtuals in self and other. This requires a
-                repository to be available.
 
         Raises:
              spack.error.UnsatisfiableSpecError: when self cannot be constrained
         """
+        return self._constrain(other, deps=deps, resolve_virtuals=True)
+
+    def _constrain(self, other, deps=True, *, resolve_virtuals: bool):
         # If we are trying to constrain a concrete spec, either the spec
         # already satisfies the constraint (and the method returns False)
         # or it raises an exception
         if self.concrete:
-            if self.satisfies(other, resolve_virtuals=resolve_virtuals):
+            if self._satisfies(other, resolve_virtuals=resolve_virtuals):
                 return False
             else:
                 raise spack.error.UnsatisfiableSpecError(self, other, "constrain a concrete spec")
 
         other = self._autospec(other)
-        if other.concrete and other.satisfies(self, resolve_virtuals=resolve_virtuals):
+        if other.concrete and other._satisfies(self, resolve_virtuals=resolve_virtuals):
             self._dup(other)
             return True
 
@@ -3135,9 +3136,7 @@ class Spec:
             return spec_like
         return Spec(spec_like)
 
-    def intersects(
-        self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
-    ) -> bool:
+    def intersects(self, other: Union[str, "Spec"], deps: bool = True) -> bool:
         """Return True if there exists at least one concrete spec that matches both
         self and other, otherwise False.
 
@@ -3147,19 +3146,22 @@ class Spec:
         Args:
             other: spec to be checked for compatibility
             deps: if True check compatibility of dependency nodes too, if False only check root
-            resolve_virtuals: if True, resolve virtuals in self and other. This requires a
-                repository to be available.
         """
+        return self._intersects(other=other, deps=deps, resolve_virtuals=True)
+
+    def _intersects(
+        self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
+    ) -> bool:
         other = self._autospec(other)
 
         if other.concrete and self.concrete:
             return self.dag_hash() == other.dag_hash()
 
         elif self.concrete:
-            return self.satisfies(other, resolve_virtuals=resolve_virtuals)
+            return self._satisfies(other, resolve_virtuals=resolve_virtuals)
 
         elif other.concrete:
-            return other.satisfies(self, resolve_virtuals=resolve_virtuals)
+            return other._satisfies(self, resolve_virtuals=resolve_virtuals)
 
         # From here we know both self and other are not concrete
         self_hash = self.abstract_hash
@@ -3242,7 +3244,7 @@ class Spec:
         common_dependencies = {x.name for x in self.dependencies()}
         common_dependencies &= {x.name for x in other.dependencies()}
         for name in common_dependencies:
-            if not self[name].intersects(
+            if not self[name]._intersects(
                 other[name], deps=True, resolve_virtuals=resolve_virtuals
             ):
                 return False
@@ -3279,7 +3281,16 @@ class Spec:
 
         return True
 
-    def satisfies(
+    def satisfies(self, other: Union[str, "Spec"], deps: bool = True) -> bool:
+        """Return True if all concrete specs matching self also match other, otherwise False.
+
+        Args:
+            other: spec to be satisfied
+            deps: if True, descend to dependencies, otherwise only check root node
+        """
+        return self._satisfies(other=other, deps=deps, resolve_virtuals=True)
+
+    def _satisfies(
         self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
     ) -> bool:
         """Return True if all concrete specs matching self also match other, otherwise False.
@@ -3370,13 +3381,15 @@ class Spec:
         for rhs_edge in other.traverse_edges(root=False, cover="edges"):
             # The condition cannot be applied in any case, skip the edge
             test_root = rhs_edge.parent.name in (None, self.name)
-            if test_root and not self.intersects(rhs_edge.when, resolve_virtuals=resolve_virtuals):
+            if test_root and not self._intersects(
+                rhs_edge.when, resolve_virtuals=resolve_virtuals
+            ):
                 continue
 
             if (
                 not test_root
                 and rhs_edge.parent.name in self
-                and not self[rhs_edge.parent.name].intersects(
+                and not self[rhs_edge.parent.name]._intersects(
                     rhs_edge.when, resolve_virtuals=resolve_virtuals
                 )
             ):
@@ -3414,7 +3427,7 @@ class Spec:
                     mock_nodes_from_old_specfiles.add(compiler_spec)
                     # This checks that the single node compiler spec satisfies the request
                     # of a direct dependency. The check is not perfect, but based on heuristic.
-                    if not compiler_spec.satisfies(
+                    if not compiler_spec._satisfies(
                         rhs_edge.spec, resolve_virtuals=resolve_virtuals
                     ):
                         return False
@@ -3434,12 +3447,12 @@ class Spec:
                         lhs_edge.spec
                         for lhs_edge in candidate_edges
                         if ((lhs_edge.depflag & rhs_edge.depflag) ^ rhs_edge.depflag) == 0
-                        and rhs_edge.when.satisfies(
+                        and rhs_edge.when._satisfies(
                             lhs_edge.when, resolve_virtuals=resolve_virtuals
                         )
                     ]
                     if not candidates or not any(
-                        x.satisfies(rhs_edge.spec, resolve_virtuals=resolve_virtuals)
+                        x._satisfies(rhs_edge.spec, resolve_virtuals=resolve_virtuals)
                         for x in candidates
                     ):
                         return False
@@ -3479,7 +3492,7 @@ class Spec:
                 candidate_edges = [
                     lhs_edge
                     for lhs_edge in lhs_edges[current_dependency_name]
-                    if rhs_edge.when.satisfies(lhs_edge.when, resolve_virtuals=resolve_virtuals)
+                    if rhs_edge.when._satisfies(lhs_edge.when, resolve_virtuals=resolve_virtuals)
                 ]
 
             if not candidate_edges:
@@ -3491,7 +3504,7 @@ class Spec:
                     return False
 
             for lhs_edge in candidate_edges:
-                if lhs_edge.spec.satisfies(
+                if lhs_edge.spec._satisfies(
                     rhs_edge.spec, deps=False, resolve_virtuals=resolve_virtuals
                 ):
                     break

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -208,3 +208,7 @@ def test_direct_dependencies_from_when_context_are_retained(mock_packages):
     assert spack.spec.Spec("%pkg-b") in pkg_cls.dependencies
     # Direct dependency in a "when" nested context manager
     assert spack.spec.Spec("@2 %c=gcc %pkg-c %pkg-b@:4.0") in pkg_cls.dependencies
+    # Nested ^foo followed by %foo
+    assert spack.spec.Spec("%pkg-c") in pkg_cls.dependencies
+    # Nested ^foo followed by ^foo %gcc
+    assert spack.spec.Spec("^pkg-c %gcc") in pkg_cls.dependencies

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -196,3 +196,15 @@ def test_redistribute_override_when():
     spack.directives._execute_redistribute(cls, source=None, binary=False, when="@1.0")
     assert cls.disable_redistribute[spec_key].binary
     assert cls.disable_redistribute[spec_key].source
+
+
+@pytest.mark.regression("51248")
+def test_direct_dependencies_from_when_context_are_retained(mock_packages):
+    """Tests that direct dependencies from the "when" context manager don't lose the "direct"
+    attribute when turned into directives on the package class.
+    """
+    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
+    # Direct dependency in a "when" single context manager
+    assert spack.spec.Spec("%pkg-b") in pkg_cls.dependencies
+    # Direct dependency in a "when" nested context manager
+    assert spack.spec.Spec("@2 %c=gcc %pkg-c %pkg-b@:4.0") in pkg_cls.dependencies

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2344,9 +2344,9 @@ def test_long_spec():
         (["^foo", "%bar %foo"], "%bar%foo"),
     ],
 )
-def test_constrain_without_resolving_virtuals(constraints, expected):
-    """Tests the semantics of constraining a spec, when we don't resolve virtuals."""
+def test_constrain_symbolically(constraints, expected):
+    """Tests the semantics of constraining a spec when we don't resolve virtuals."""
     merged = Spec()
     for c in constraints:
-        merged._constrain(c, resolve_virtuals=False)
+        merged._constrain_symbolically(c)
     assert merged == Spec(expected)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2348,5 +2348,5 @@ def test_constrain_without_resolving_virtuals(constraints, expected):
     """Tests the semantics of constraining a spec, when we don't resolve virtuals."""
     merged = Spec()
     for c in constraints:
-        merged.constrain(c, resolve_virtuals=False)
+        merged._constrain(c, resolve_virtuals=False)
     assert merged == Spec(expected)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2350,3 +2350,8 @@ def test_constrain_symbolically(constraints, expected):
     for c in constraints:
         merged._constrain_symbolically(c)
     assert merged == Spec(expected)
+
+    reverse_order = Spec()
+    for c in reversed(constraints):
+        reverse_order._constrain_symbolically(c)
+    assert reverse_order == Spec(expected)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1708,25 +1708,6 @@ def test_spec_dict_hashless_dep():
 
 
 @pytest.mark.parametrize(
-    "specs,expected",
-    [
-        # Anonymous specs without dependencies
-        (["+baz", "+bar"], "+baz+bar"),
-        (["@2.0:", "@:5.1", "+bar"], "@2.0:5.1 +bar"),
-        # Anonymous specs with dependencies
-        (["^mpich@3.2", "^mpich@:4.0+foo"], "^mpich@3.2 +foo"),
-        # Mix a real package with a virtual one. This test
-        # should fail if we start using the repository
-        (["^mpich@3.2", "^mpi+foo"], "^mpich@3.2 ^mpi+foo"),
-    ],
-)
-def test_merge_abstract_anonymous_specs(specs, expected):
-    specs = [Spec(x) for x in specs]
-    result = spack.spec.merge_abstract_anonymous_specs(*specs)
-    assert result == Spec(expected)
-
-
-@pytest.mark.parametrize(
     "anonymous,named,expected",
     [
         ("+plumed", "gromacs", "gromacs+plumed"),
@@ -2344,3 +2325,28 @@ def test_edge_equality_accounts_for_when_condition():
 def test_long_spec():
     """Test that long_spec preserves dependency types and has correct ordering."""
     assert Spec("foo %m %l ^k %n %j").long_spec == "foo %l %m ^k %j %n"
+
+
+@pytest.mark.parametrize(
+    "constraints,expected",
+    [
+        # Anonymous specs without dependencies
+        (["+baz", "+bar"], "+baz+bar"),
+        (["@2.0:", "@:5.1", "+bar"], "@2.0:5.1 +bar"),
+        # Anonymous specs with dependencies
+        (["^mpich@3.2", "^mpich@:4.0+foo"], "^mpich@3.2 +foo"),
+        # Mix a real package with a virtual one. This test
+        # should fail if we start using the repository
+        (["^mpich@3.2", "^mpi+foo"], "^mpich@3.2 ^mpi+foo"),
+        # Non direct dependencies + direct dependencies
+        (["^mpich", "%mpich"], "%mpich"),
+        (["^foo", "^bar %foo"], "^foo ^bar%foo"),
+        (["^foo", "%bar %foo"], "%bar%foo"),
+    ],
+)
+def test_constrain_without_resolving_virtuals(constraints, expected):
+    """Tests the semantics of constraining a spec, when we don't resolve virtuals."""
+    merged = Spec()
+    for c in constraints:
+        merged.constrain(c, resolve_virtuals=False)
+    assert merged == Spec(expected)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
@@ -39,7 +39,7 @@ class WithConstraintMet(Package):
         with when("%pkg-c"):
             depends_on("pkg-e")
 
-    # Nested ^pkg-c followed by %pkg-c
+    # Nested ^pkg-c followed by ^pkg-c %gcc
     with when("^pkg-c"):
         with when("^pkg-c %gcc"):
             depends_on("pkg-e")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
@@ -24,3 +24,12 @@ class WithConstraintMet(Package):
 
     with when("@0.14: ^pkg-b@:4.0"):
         depends_on("pkg-c", when="@:15 ^pkg-b@3.8:")
+
+    # Direct dependency in a "when" context manager
+    with when("%pkg-b"):
+        depends_on("pkg-e")
+
+    # More complex dependency with nested contexts
+    with when("%pkg-c"):
+        with when("@2 %pkg-b@:4.0"):
+            depends_on("pkg-e", when="%c=gcc")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/with_constraint_met/package.py
@@ -33,3 +33,13 @@ class WithConstraintMet(Package):
     with when("%pkg-c"):
         with when("@2 %pkg-b@:4.0"):
             depends_on("pkg-e", when="%c=gcc")
+
+    # Nested ^pkg-c followed by %pkg-c
+    with when("^pkg-c"):
+        with when("%pkg-c"):
+            depends_on("pkg-e")
+
+    # Nested ^pkg-c followed by %pkg-c
+    with when("^pkg-c"):
+        with when("^pkg-c %gcc"):
+            depends_on("pkg-e")


### PR DESCRIPTION
builds on #51256 

#51256 solves the most common bug in the `when` context manager, i.e. the case of a single `%` used in a constraint spec, but doesn't do anything for other, less common, cases where `%` is treated incorrectly. 

Here we fix those cases too, by removing the ad-hoc `merge_abstract_anonymous_specs` function, and using `Spec.constrain` instead.  To do so we had to:
1. Implement `Spec.satisfies`, `Spec.constrain`, and `Spec.intersects` in terms a private function with an additional argument, i.e.  `resolve_virtuals`.
1. Use `Spec._constrain` with `resolve_virtuals=False` in the context of evaluating directives

The PR is separate from #51256 because it involves code changes that touch functions that are widely use, which may be a source of bugs, so we may want to avoid backporting this.

Other changes:
- `Spec.common_dependencies`, `Spec.direct_dep_difference` have been removed since they are unused, and are pretty much internal API. They can be deprecated, if that seems better.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
