### PR TITLE
solver: allow preferences with provider details

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2090,7 +2090,7 @@ class SpackSolverSetup:
 
                 when_spec = spec
                 if virtual and spec.name != pkg_name:
-                    when_spec = spack.spec.Spec(f"^[virtuals={pkg_name}] {spec.name}")
+                    when_spec = spack.spec.Spec(f"^[virtuals={pkg_name}] {spec}")
 
                 try:
                     context = ConditionContext()

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1141,6 +1141,14 @@ error(1, "Cannot use {1} for the {0} virtual, but that is required", Virtual, Pr
   pkg_fact(Package, condition_effect(ConditionID, EffectID)),
   imposed_constraint(EffectID, "node_flag_set", Package, NodeFlag).
 
+{ attr("node_flag", node(ID, Package), NodeFlag) } :-
+  requirement_group_member(ConditionID, Virtual, RequirementID),
+  activate_requirement(node(VirtualID, Virtual), RequirementID),
+  provider(node(ID, Package), VirtualNode),
+  pkg_fact(Virtual, condition_effect(ConditionID, EffectID)),
+  imposed_constraint(EffectID, "node_flag_set", Package, NodeFlag).
+
+
 requirement_weight(node(ID, Package), Group, W) :-
   W = #min {
     Z : requirement_has_weight(Y, Z), condition_holds(Y, node(ID, Package)), requirement_group_member(Y, Package, Group);

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1397,3 +1397,34 @@ packages:
     assert concrete.satisfies("%gcc")
     assert concrete["mpi"].satisfies("mpich@4.3.0")
     assert concrete["mpi"].prefix == str(tmp_path / "gcc")
+
+
+@pytest.mark.regression("51262")
+def test_overriding_preference_with_provider_details(
+    concretize_scope, mock_packages, tmp_path: pathlib.Path
+):
+    """Tests that if we have a preference with provider details, such as a version range,
+    or a variant, we can override it from the command line.
+    """
+    packages_yaml = """
+packages:
+  c:
+    prefer:
+    - gcc@9
+  mpi:
+    prefer:
+    - mpich@3 +debug
+"""
+    update_packages_config(packages_yaml)
+
+    # Override the compiler preference with a different version of gcc
+    concrete = spack.concretize.concretize_one("mpileaks %c=gcc@10")
+    assert concrete.satisfies("%c=gcc@10")
+
+    # Override the mpi preference with a different version of mpich
+    concrete = spack.concretize.concretize_one("mpileaks %mpi=mpich@3 ~debug")
+    assert concrete.satisfies("%mpi=mpich ~debug")
+
+    # Override the mpi preference with a different provider
+    concrete = spack.concretize.concretize_one("mpileaks %mpi=mpich2")
+    assert concrete.satisfies("%mpi=mpich2")

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1421,6 +1421,10 @@ packages:
     concrete = spack.concretize.concretize_one("mpileaks %c=gcc@10")
     assert concrete.satisfies("%c=gcc@10")
 
+    # Same, but without specifying the virtual
+    concrete = spack.concretize.concretize_one("mpileaks %gcc@10")
+    assert concrete.satisfies("%c=gcc@10")
+
     # Override the mpi preference with a different version of mpich
     concrete = spack.concretize.concretize_one("mpileaks %mpi=mpich@3 ~debug")
     assert concrete.satisfies("%mpi=mpich ~debug")

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1400,12 +1400,27 @@ packages:
 
 
 @pytest.mark.regression("51262")
+@pytest.mark.parametrize(
+    "input_constraint",
+    [
+        # Override the compiler preference with a different version of gcc
+        "%c=gcc@10",
+        # Same, but without specifying the virtual
+        "%gcc@10",
+        # Override the mpi preference with a different version of mpich
+        "%mpi=mpich@3 ~debug",
+        # Override the mpi preference with a different provider
+        "%mpi=mpich2",
+    ],
+)
 def test_overriding_preference_with_provider_details(
-    concretize_scope, mock_packages, tmp_path: pathlib.Path
+    input_constraint, concretize_scope, mock_packages, tmp_path: pathlib.Path
 ):
     """Tests that if we have a preference with provider details, such as a version range,
-    or a variant, we can override it from the command line.
+    or a variant, we can override it from the command line, while we can't do the same
+    when we have a requirement.
     """
+    # A preference can be overridden
     packages_yaml = """
 packages:
   c:
@@ -1416,19 +1431,19 @@ packages:
     - mpich@3 +debug
 """
     update_packages_config(packages_yaml)
+    concrete = spack.concretize.concretize_one(f"mpileaks {input_constraint}")
+    assert concrete.satisfies(input_constraint)
 
-    # Override the compiler preference with a different version of gcc
-    concrete = spack.concretize.concretize_one("mpileaks %c=gcc@10")
-    assert concrete.satisfies("%c=gcc@10")
-
-    # Same, but without specifying the virtual
-    concrete = spack.concretize.concretize_one("mpileaks %gcc@10")
-    assert concrete.satisfies("%c=gcc@10")
-
-    # Override the mpi preference with a different version of mpich
-    concrete = spack.concretize.concretize_one("mpileaks %mpi=mpich@3 ~debug")
-    assert concrete.satisfies("%mpi=mpich ~debug")
-
-    # Override the mpi preference with a different provider
-    concrete = spack.concretize.concretize_one("mpileaks %mpi=mpich2")
-    assert concrete.satisfies("%mpi=mpich2")
+    # A requirement cannot
+    packages_yaml = """
+    packages:
+      c:
+        require:
+        - gcc@9
+      mpi:
+        require:
+        - mpich@3 +debug
+    """
+    update_packages_config(packages_yaml)
+    with pytest.raises(UnsatisfiableSpecError):
+        spack.concretize.concretize_one(f"mpileaks {input_constraint}")


### PR DESCRIPTION
fixes #51262

The main issue is a typo, where we use `spec.name` instead of `spec` to construct a condition for the solver.

Fixing that issue uncovered a new bug (a unit test was failing) related to adding flags to providers through a requirements on the virtual. That is also fixed here.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
