### PR TITLE
break all circular imports

### DIFF
--- a/.github/workflows/import-check.yaml
+++ b/.github/workflows/import-check.yaml
@@ -40,11 +40,14 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: haampie/circular-import-fighter
-        ref: dff7a5051010cbbc49306ac94c3d3b45de6eb1e8
+        ref: 0bd80774e5dc58180c2d2ea8cff8aa5b9b6502da
         path: circular-import-fighter
     - name: Install dependencies
       working-directory: circular-import-fighter
       run: make -j dependencies
-    - name: Circular import check
+    - name: Circular import check (without inline imports)
       working-directory: circular-import-fighter
       run: make -j compare "SPACK_ROOT=../old ../new"
+    - name: Circular import check (with inline imports)
+      working-directory: circular-import-fighter
+      run: make clean-graph && make -j compare "SPACK_ROOT=../old ../new" IMPORTS_FLAGS=--inline

--- a/.github/workflows/import-check.yaml
+++ b/.github/workflows/import-check.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: haampie/circular-import-fighter
-        ref: 0bd80774e5dc58180c2d2ea8cff8aa5b9b6502da
+        ref: f1c56367833f3c82f6a85dc58595b2cd7995ad48
         path: circular-import-fighter
     - name: Install dependencies
       working-directory: circular-import-fighter

--- a/.github/workflows/import-check.yaml
+++ b/.github/workflows/import-check.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: haampie/circular-import-fighter
-        ref: 6645c9d4e81ac278f4b3970f221dbead699204fe
+        ref: dff7a5051010cbbc49306ac94c3d3b45de6eb1e8
         path: circular-import-fighter
     - name: Install dependencies
       working-directory: circular-import-fighter

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -360,17 +360,6 @@ nitpick_ignore = [
     # Spack classes that are private and we don't want to expose
     ("py:class", "spack.provider_index._IndexBase"),
     ("py:class", "spack.repo._PrependFileLoader"),
-    ("py:class", "spack_repo.builtin.build_systems._checks.BuilderWithDefaults"),
-    # Spack classes that intersphinx is unable to resolve
-    ("py:class", "spack.version.StandardVersion"),
-    ("py:class", "spack.spec.DependencySpec"),
-    ("py:class", "spack.spec.ArchSpec"),
-    ("py:class", "spack.spec.InstallStatus"),
-    ("py:class", "spack.spec.SpecfileReaderBase"),
-    ("py:class", "spack.filesystem_view.SimpleFilesystemView"),
-    ("py:class", "spack.traverse.EdgeAndDepth"),
-    ("py:class", "spack.vendor.archspec.cpu.microarchitecture.Microarchitecture"),
-    ("py:class", "spack.compiler.CompilerCache"),
     # TypeVar that is not handled correctly
     ("py:class", "spack.llnl.util.lang.T"),
     ("py:class", "spack.llnl.util.lang.KT"),

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -360,6 +360,17 @@ nitpick_ignore = [
     # Spack classes that are private and we don't want to expose
     ("py:class", "spack.provider_index._IndexBase"),
     ("py:class", "spack.repo._PrependFileLoader"),
+    ("py:class", "spack_repo.builtin.build_systems._checks.BuilderWithDefaults"),
+    # Spack classes that intersphinx is unable to resolve
+    ("py:class", "spack.version.StandardVersion"),
+    ("py:class", "spack.spec.DependencySpec"),
+    ("py:class", "spack.spec.ArchSpec"),
+    ("py:class", "spack.spec.InstallStatus"),
+    ("py:class", "spack.spec.SpecfileReaderBase"),
+    ("py:class", "spack.filesystem_view.SimpleFilesystemView"),
+    ("py:class", "spack.traverse.EdgeAndDepth"),
+    ("py:class", "spack.vendor.archspec.cpu.microarchitecture.Microarchitecture"),
+    ("py:class", "spack.compiler.CompilerCache"),
     # TypeVar that is not handled correctly
     ("py:class", "spack.llnl.util.lang.T"),
     ("py:class", "spack.llnl.util.lang.KT"),

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -13,7 +13,7 @@ from collections import Counter
 from typing import Generator, List, Optional, Sequence, Union
 
 import spack.concretize
-import spack.config  # breaks a cycle.
+import spack.config
 import spack.environment as ev
 import spack.error
 import spack.extensions

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -219,3 +219,11 @@ class NoChecksumException(SpackError):
 
 class CompilerError(SpackError):
     """Raised if something goes wrong when probing or querying a compiler."""
+
+
+class SpecFilenameError(SpecError):
+    """Raised when a spec file name is invalid."""
+
+
+class NoSuchSpecFileError(SpecFilenameError):
+    """Raised when a spec file doesn't exist."""

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -30,17 +30,14 @@ import re
 import shutil
 import sys
 import time
-import urllib.error
 import urllib.parse
 import urllib.request
-import urllib.response
 from pathlib import PurePath
 from typing import Callable, List, Mapping, Optional
 
 import spack.config
 import spack.error
 import spack.llnl.url
-import spack.llnl.util
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.oci.opener
@@ -50,7 +47,6 @@ import spack.util.git
 import spack.util.url as url_util
 import spack.util.web as web_util
 import spack.version
-import spack.version.git_ref_lookup
 from spack.llnl.string import comma_and, quote
 from spack.llnl.util.filesystem import get_single_file, mkdirp, symlink, temp_cwd, working_dir
 from spack.util.compression import decompressor_for
@@ -1720,7 +1716,9 @@ def for_package_version(pkg, version=None):
             )
         # Populate the version with comparisons to other commits
         if isinstance(version, spack.version.GitVersion):
-            version.attach_lookup(spack.version.git_ref_lookup.GitRefLookup(pkg.name))
+            from spack.version.git_ref_lookup import GitRefLookup
+
+            version.attach_lookup(GitRefLookup(pkg.name))
 
         # For GitVersion, we have no way to determine whether a ref is a branch or tag
         # Fortunately, we handle branches and tags identically, except tags are

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -22,6 +22,7 @@ import types
 import uuid
 import warnings
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -44,11 +45,8 @@ import spack.llnl.path
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
-import spack.patch
 import spack.paths
 import spack.provider_index
-import spack.spec
-import spack.tag
 import spack.util.executable
 import spack.util.file_cache
 import spack.util.git
@@ -58,6 +56,12 @@ import spack.util.naming as nm
 import spack.util.path
 import spack.util.spack_yaml as syaml
 from spack.llnl.util.filesystem import working_dir
+
+if TYPE_CHECKING:
+    import spack.package_base
+    import spack.patch
+    import spack.spec
+    import spack.tag
 
 PKG_MODULE_PREFIX_V1 = "spack.pkg."
 PKG_MODULE_PREFIX_V2 = "spack_repo."
@@ -309,8 +313,10 @@ def autospec(function):
 
     @functools.wraps(function)
     def converter(self, spec_like, *args, **kwargs):
-        if not isinstance(spec_like, spack.spec.Spec):
-            spec_like = spack.spec.Spec(spec_like)
+        from spack.spec import Spec
+
+        if not isinstance(spec_like, Spec):
+            spec_like = Spec(spec_like)
         return function(self, spec_like, *args, **kwargs)
 
     return converter
@@ -492,11 +498,15 @@ class Indexer(metaclass=abc.ABCMeta):
 class TagIndexer(Indexer):
     """Lifecycle methods for a TagIndex on a Repo."""
 
-    def _create(self):
-        return spack.tag.TagIndex(self.repository)
+    def _create(self) -> "spack.tag.TagIndex":
+        from spack.tag import TagIndex
+
+        return TagIndex(self.repository)
 
     def read(self, stream):
-        self.index = spack.tag.TagIndex.from_json(stream, self.repository)
+        from spack.tag import TagIndex
+
+        self.index = TagIndex.from_json(stream, self.repository)
 
     def update(self, pkg_fullname):
         self.index.update_package(pkg_fullname.split(".")[-1])
@@ -508,7 +518,7 @@ class TagIndexer(Indexer):
 class ProviderIndexer(Indexer):
     """Lifecycle methods for virtual package providers."""
 
-    def _create(self):
+    def _create(self) -> "spack.provider_index.ProviderIndex":
         return spack.provider_index.ProviderIndex(repository=self.repository)
 
     def read(self, stream):
@@ -531,8 +541,10 @@ class ProviderIndexer(Indexer):
 class PatchIndexer(Indexer):
     """Lifecycle methods for patch cache."""
 
-    def _create(self):
-        return spack.patch.PatchCache(repository=self.repository)
+    def _create(self) -> "spack.patch.PatchCache":
+        from spack.patch import PatchCache
+
+        return PatchCache(repository=self.repository)
 
     def needs_update(self):
         # TODO: patches can change under a package and we should handle
@@ -542,7 +554,9 @@ class PatchIndexer(Indexer):
         return False
 
     def read(self, stream):
-        self.index = spack.patch.PatchCache.from_json(stream, repository=self.repository)
+        from spack.patch import PatchCache
+
+        self.index = PatchCache.from_json(stream, repository=self.repository)
 
     def write(self, stream):
         self.index.to_json(stream)
@@ -615,9 +629,9 @@ class RepoIndex:
         """Determine which packages need an update, and update indexes."""
 
         # Filename of the provider index cache (we assume they're all json)
-        cache_filename = (
-            f"{name}/{self.namespace}-specfile_v{spack.spec.SPECFILE_FORMAT_VERSION}-index.json"
-        )
+        from spack.spec import SPECFILE_FORMAT_VERSION
+
+        cache_filename = f"{name}/{self.namespace}-specfile_v{SPECFILE_FORMAT_VERSION}-index.json"
 
         # Compute which packages needs to be updated in the cache
         index_mtime = self.cache.mtime(cache_filename)
@@ -660,8 +674,8 @@ class RepoPath:
         self.repos: List[Repo] = []
         self.by_namespace = nm.NamespaceTrie()
         self._provider_index: Optional[spack.provider_index.ProviderIndex] = None
-        self._patch_index: Optional[spack.patch.PatchCache] = None
-        self._tag_index: Optional[spack.tag.TagIndex] = None
+        self._patch_index: Optional["spack.patch.PatchCache"] = None
+        self._tag_index: Optional["spack.tag.TagIndex"] = None
 
         for repo in repos:
             self.put_last(repo)
@@ -799,19 +813,23 @@ class RepoPath:
         return self._provider_index
 
     @property
-    def tag_index(self) -> spack.tag.TagIndex:
+    def tag_index(self) -> "spack.tag.TagIndex":
         """Merged TagIndex from all Repos in the RepoPath."""
         if self._tag_index is None:
-            self._tag_index = spack.tag.TagIndex(repository=self)
+            from spack.tag import TagIndex
+
+            self._tag_index = TagIndex(repository=self)
             for repo in reversed(self.repos):
                 self._tag_index.merge(repo.tag_index)
         return self._tag_index
 
     @property
-    def patch_index(self) -> spack.patch.PatchCache:
+    def patch_index(self) -> "spack.patch.PatchCache":
         """Merged PatchIndex from all Repos in the RepoPath."""
         if self._patch_index is None:
-            self._patch_index = spack.patch.PatchCache(repository=self)
+            from spack.patch import PatchCache
+
+            self._patch_index = PatchCache(repository=self)
             for repo in reversed(self.repos):
                 self._patch_index.update(repo.patch_index)
         return self._patch_index
@@ -831,10 +849,12 @@ class RepoPath:
     def extensions_for(
         self, extendee_spec: "spack.spec.Spec"
     ) -> List["spack.package_base.PackageBase"]:
+        from spack.spec import Spec
+
         return [
-            pkg_cls(spack.spec.Spec(pkg_cls.name))
+            pkg_cls(Spec(pkg_cls.name))
             for pkg_cls in self.all_package_classes()
-            if pkg_cls(spack.spec.Spec(pkg_cls.name)).extends(extendee_spec)
+            if pkg_cls(Spec(pkg_cls.name)).extends(extendee_spec)
         ]
 
     def last_mtime(self):
@@ -845,7 +865,9 @@ class RepoPath:
         """Given a spec, get the repository for its package."""
         # We don't @_autospec this function b/c it's called very frequently
         # and we want to avoid parsing str's into Specs unnecessarily.
-        if isinstance(spec, spack.spec.Spec):
+        from spack.spec import Spec
+
+        if isinstance(spec, Spec):
             namespace = spec.namespace
             name = spec.name
         else:
@@ -874,8 +896,10 @@ class RepoPath:
 
     def get(self, spec: "spack.spec.Spec") -> "spack.package_base.PackageBase":
         """Returns the package associated with the supplied spec."""
+        from spack.spec import Spec
+
         msg = "RepoPath.get can only be called on concrete specs"
-        assert isinstance(spec, spack.spec.Spec) and spec.concrete, msg
+        assert isinstance(spec, Spec) and spec.concrete, msg
         return self.repo_for_pkg(spec).get(spec)
 
     def python_paths(self) -> List[str]:
@@ -1200,8 +1224,10 @@ class Repo:
 
     def get(self, spec: "spack.spec.Spec") -> "spack.package_base.PackageBase":
         """Returns the package associated with the supplied spec."""
+        from spack.spec import Spec
+
         msg = "Repo.get can only be called on concrete specs"
-        assert isinstance(spec, spack.spec.Spec) and spec.concrete, msg
+        assert isinstance(spec, Spec) and spec.concrete, msg
         # NOTE: we only check whether the package is None here, not whether it
         # actually exists, because we have to load it anyway, and that ends up
         # checking for existence. We avoid constructing FastPackageChecker,
@@ -1271,12 +1297,12 @@ class Repo:
         return self.index["providers"]
 
     @property
-    def tag_index(self) -> spack.tag.TagIndex:
+    def tag_index(self) -> "spack.tag.TagIndex":
         """Index of tags and which packages they're defined on."""
         return self.index["tags"]
 
     @property
-    def patch_index(self) -> spack.patch.PatchCache:
+    def patch_index(self) -> "spack.patch.PatchCache":
         """Index of patches and packages they're defined on."""
         return self.index["patches"]
 
@@ -1291,7 +1317,9 @@ class Repo:
     def extensions_for(
         self, extendee_spec: "spack.spec.Spec"
     ) -> List["spack.package_base.PackageBase"]:
-        result = [pkg_cls(spack.spec.Spec(pkg_cls.name)) for pkg_cls in self.all_package_classes()]
+        from spack.spec import Spec
+
+        result = [pkg_cls(Spec(pkg_cls.name)) for pkg_cls in self.all_package_classes()]
         return [x for x in result if x.extends(extendee_spec)]
 
     def dirname_for_package_name(self, pkg_name: str) -> str:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -62,18 +62,20 @@ import re
 import sys
 import traceback
 import warnings
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple, Union
 
 import spack.config
 import spack.deptypes
 import spack.error
 import spack.paths
-import spack.spec
 import spack.util.spack_yaml
 import spack.version
 from spack.aliases import LEGACY_COMPILER_TO_BUILTIN
 from spack.llnl.util.tty import color
 from spack.tokenize import Token, TokenBase, Tokenizer
+
+if TYPE_CHECKING:
+    import spack.spec
 
 #: Valid name for specs and variants. Here we are not using
 #: the previous ``w[\w.-]*`` since that would match most
@@ -356,7 +358,10 @@ class SpecParser:
             except spack.error.SpecError as e:
                 raise SpecParsingError(str(e), self.ctx.current_token, self.literal_str) from e
 
-        initial_spec = initial_spec or spack.spec.Spec()
+        if not initial_spec:
+            from spack.spec import Spec
+
+            initial_spec = Spec()
         root_spec, parser_warnings = SpecNodeParser(self.ctx, self.literal_str).parse(initial_spec)
         current_spec = root_spec
         while True:
@@ -443,7 +448,9 @@ class SpecParser:
             toolchain = parse_one_or_raise(toolchain_config)
             self._ensure_all_direct_edges(toolchain)
         else:
-            toolchain = spack.spec.Spec()
+            from spack.spec import Spec
+
+            toolchain = Spec()
             for entry in toolchain_config:
                 toolchain_part = parse_one_or_raise(entry["spec"])
                 when = entry.get("when", "")
@@ -494,7 +501,9 @@ class SpecNodeParser:
         last_compiler = None
 
         if initial_spec is None:
-            initial_spec = spack.spec.Spec()
+            from spack.spec import Spec
+
+            initial_spec = Spec()
 
         if not self.ctx.next_token or self.ctx.expect(SpecTokens.DEPENDENCY):
             return initial_spec, parser_warnings
@@ -613,13 +622,15 @@ class FileParser:
         file = pathlib.Path(self.ctx.current_token.value)
 
         if not file.exists():
-            raise spack.spec.NoSuchSpecFileError(f"No such spec file: '{file}'")
+            raise spack.error.NoSuchSpecFileError(f"No such spec file: '{file}'")
+
+        from spack.spec import Spec
 
         with file.open("r", encoding="utf-8") as stream:
             if str(file).endswith(".json"):
-                spec_from_file = spack.spec.Spec.from_json(stream)
+                spec_from_file = Spec.from_json(stream)
             else:
-                spec_from_file = spack.spec.Spec.from_yaml(stream)
+                spec_from_file = Spec.from_yaml(stream)
         initial_spec._dup(spec_from_file)
         return initial_spec
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -13,6 +13,7 @@ import spack.binary_distribution
 import spack.cmd
 import spack.concretize
 import spack.config
+import spack.error
 import spack.llnl.util.filesystem as fs
 import spack.platforms.test
 import spack.repo
@@ -1470,55 +1471,57 @@ def test_error_conditions(text, match_string):
     [
         # Specfile related errors
         pytest.param(
-            "/bogus/path/libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS
+            "/bogus/path/libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS
         ),
-        pytest.param("../../libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS),
-        pytest.param("./libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS),
+        pytest.param(
+            "../../libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS
+        ),
+        pytest.param("./libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS),
         pytest.param(
             "libfoo ^/bogus/path/libdwarf.yaml",
-            spack.spec.NoSuchSpecFileError,
+            spack.error.NoSuchSpecFileError,
             marks=SKIP_ON_WINDOWS,
         ),
         pytest.param(
-            "libfoo ^../../libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS
+            "libfoo ^../../libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS
         ),
         pytest.param(
-            "libfoo ^./libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS
+            "libfoo ^./libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_WINDOWS
         ),
         pytest.param(
             "/bogus/path/libdwarf.yamlfoobar",
-            spack.spec.NoSuchSpecFileError,
+            spack.error.NoSuchSpecFileError,
             marks=SKIP_ON_WINDOWS,
         ),
         pytest.param(
             "libdwarf^/bogus/path/libelf.yamlfoobar ^/path/to/bogus.yaml",
-            spack.spec.NoSuchSpecFileError,
+            spack.error.NoSuchSpecFileError,
             marks=SKIP_ON_WINDOWS,
         ),
         pytest.param(
-            "c:\\bogus\\path\\libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_UNIX
+            "c:\\bogus\\path\\libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_UNIX
         ),
-        pytest.param("..\\..\\libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_UNIX),
-        pytest.param(".\\libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_UNIX),
+        pytest.param("..\\..\\libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_UNIX),
+        pytest.param(".\\libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_UNIX),
         pytest.param(
             "libfoo ^c:\\bogus\\path\\libdwarf.yaml",
-            spack.spec.NoSuchSpecFileError,
+            spack.error.NoSuchSpecFileError,
             marks=SKIP_ON_UNIX,
         ),
         pytest.param(
-            "libfoo ^..\\..\\libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_UNIX
+            "libfoo ^..\\..\\libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_UNIX
         ),
         pytest.param(
-            "libfoo ^.\\libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=SKIP_ON_UNIX
+            "libfoo ^.\\libdwarf.yaml", spack.error.NoSuchSpecFileError, marks=SKIP_ON_UNIX
         ),
         pytest.param(
             "c:\\bogus\\path\\libdwarf.yamlfoobar",
-            spack.spec.SpecFilenameError,
+            spack.error.SpecFilenameError,
             marks=SKIP_ON_UNIX,
         ),
         pytest.param(
             "libdwarf^c:\\bogus\\path\\libelf.yamlfoobar ^c:\\path\\to\\bogus.yaml",
-            spack.spec.SpecFilenameError,
+            spack.error.SpecFilenameError,
             marks=SKIP_ON_UNIX,
         ),
     ],

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -4,6 +4,7 @@
 
 from collections import defaultdict, deque
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Iterable,
@@ -20,7 +21,9 @@ from typing import (
 from spack.vendor.typing_extensions import Literal
 
 import spack.deptypes as dt
-import spack.spec
+
+if TYPE_CHECKING:
+    import spack.spec
 
 # Export only the high-level API.
 __all__ = ["traverse_edges", "traverse_nodes", "traverse_tree"]
@@ -227,10 +230,10 @@ def get_visitor_from_args(
 
 def with_artificial_edges(specs):
     """Initialize a deque of edges from an artificial root node to the root specs."""
+    from spack.spec import DependencySpec
+
     return deque(
-        EdgeAndDepth(
-            edge=spack.spec.DependencySpec(parent=None, spec=s, depflag=0, virtuals=()), depth=0
-        )
+        EdgeAndDepth(edge=DependencySpec(parent=None, spec=s, depflag=0, virtuals=()), depth=0)
         for s in specs
     )
 

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -10,13 +10,27 @@ import enum
 import functools
 import inspect
 import itertools
-from typing import Any, Callable, Collection, Iterable, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Collection,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import spack.error
 import spack.llnl.util.lang as lang
 import spack.llnl.util.tty.color
-import spack.spec
 import spack.spec_parser
+
+if TYPE_CHECKING:
+    import spack.package_base
+    import spack.spec
 
 #: These are variant names used by Spack internally; packages can't use them
 RESERVED_NAMES = {


### PR DESCRIPTION
1. Apply the *minimal* diff turning module scope imports into inline imports, in order to break *all* circular imports among modules in Spack.
2. Use conditional imports under `if TYPE_CHECKING:` to improve mypy coverage
3. Bump the import-check GitHub action, with the following improvements:
   a. It reports problematic and regressions to imports *with and without inline imports* separately. In this PR we go from 10 to 0 problematic imports not considering inline imports
   b. It does not include top-level imports conditional under `if TYPE_CHECKING`

As a result, every module in Spack should now be importable directly without fear of circular import errors, and mypy coverage should be improved. This also helps future refactors.

---

The minimal set of module scope imports was found by computing the feedback arc set of the graph induced by Python modules as nodes and their top-level non-TYPECHECKING import statements as edges. See https://github.com/haampie/circular-import-fighter/blob/master/imports.py for how they are obtained.