### PR TITLE
solver: add a `#defined` to `error_messages.lp`

### DIFF
--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -233,6 +233,7 @@ error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
 #defined imposed_constraint/5.
 #defined imposed_constraint/6.
 #defined condition_cause/4.
+#defined condition_nodes/3.
 #defined condition_requirement/3.
 #defined condition_requirement/4.
 #defined condition_requirement/5.


### PR DESCRIPTION
`condition_nodes/3` appears only in the body of rules and may not be among the facts in some edge cases

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
