### PR TITLE
docs: disable values in autodoc

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -340,6 +340,7 @@ gettext_uuid = False
 exclude_patterns = ["_build", "_spack_root", ".spack-env", ".spack", ".venv"]
 
 autodoc_mock_imports = ["llnl"]
+autodoc_default_options = {"no-value": True}
 
 nitpicky = True
 nitpick_ignore = [


### PR DESCRIPTION
Do not document default values, cause they are documented as values as
Sphinx evaluates them, instead of the Python expressions they are
defined as.

An example of where this is currently really bad is
`spack.config.SECTION_SCHEMAS`, which is an enormous, deeply nested
data structure, 45KB long, and actually highlighted, so much bigger in
the docs with about 8K dom nodes.

Another example that was potentially a security issue is where we
re-exported `os.environ` in the package API, and ended up "documenting"
the environment variables inside the read the docs build, which could
leak secrets. This was avoided in `package_api.rst` explicitly with `:no-value:`
already.

Note: this change does not affect the `package_api.html` page.

---

<details>

<summary>Here's a list of all the variables whose values are no longer documented:</summary>

```python
# a/spack.bootstrap.html
config_scope_name
spack.bootstrap.core.IS_WINDOWS
spack.bootstrap.core.METADATA_YAML_FILENAME
# a/spack.ci.html
COPY_ONLY
PROTECTED_BRANCH
PULL_REQUEST
spack_copy_only
spack_protected_branch
spack_pull_request
# a/spack.cmd.html
spack.cmd.bootstrap.LOCAL_MIRROR_DIR
spack.cmd.commands.formatters: Dict[str, Callable[[Namespace, IO], None]]
spack.cmd.commands.update_completion_args: Dict[str, Dict[str, Any]]
base_class_name
body_def
dependencies
package_class_import
base_class_name
body_def
package_class_import
body_def
dependencies
base_class_name
body_def
dependencies
package_class_import
url_def
base_class_name
body_def
package_class_import
spack.cmd.create.CXX_EXT
spack.cmd.create.C_EXT
base_class_name
body_def
package_class_import
spack.cmd.create.FORTRAN_EXT
base_class_name
body_def
package_class_import
base_class_name
body_def
package_class_import
base_class_name
body_def
package_class_import
base_class_name
body_def
package_class_import
base_class_name
body_def
package_class_import
base_class_name
body_def
package_class_import
base_class_name
dependencies
package_class_import
base_class_name
body_def
package_class_import
url_line
dependencies
base_class_name
body_def
dependencies
package_class_import
base_class_name
body_def
dependencies
package_class_import
base_class_name
body_def
package_class_import
base_class_name
body_def
dependencies
package_class_import
base_class_name
body_def
dependencies
package_class_import
url_line
base_class_name
body_def
dependencies
package_class_import
base_class_name
body_def
package_class_import
base_class_name
body_def
package_class_import
base_class_name
body_def
package_class_import
disable
enable
regenerate
spack.cmd.env.subcommand_functions
spack.cmd.env.subcommands: List[Tuple[str, ...]]
GENERAL_MISMATCH
NOT_IN_FIRST_N_LINES
SPDX_MISMATCH
spack.cmd.license.apache2_mit_spdx
spack.cmd.license.license_line_regexes
spack.cmd.license.license_lines
spack.cmd.license.licensed_files_patterns
spack.cmd.solve.show_options
spack.cmd.style.exclude_paths
spack.cmd.style.mypy_ignores
spack.cmd.style.tool_names
spack.cmd.style.tools: Dict[str, tool]
# a/spack.cmd.modules.html
spack.cmd.modules.callbacks
# a/spack.compilers.html
C
CXX
FORTRAN
spack.compilers.config.COMPILER_TAG
name
# a/spack.container.html
context_properties
template_name: str | None
context_properties
template_name: str | None
context_properties
template_name: str | None
# a/spack.detection.html
spack.detection.path.DETECTION_TIMEOUT
# a/spack.environment.html
AUTO
NEVER
ONLY
spack.environment.environment.default_env_path
spack.environment.environment.env_subdir_name
spack.environment.environment.lockfile_format_version
spack.environment.environment.lockfile_name
spack.environment.environment.manifest_name
spack.environment.environment.spack_env_var
spack.environment.environment.spack_env_view_var
spack.environment.environment.valid_environment_name_re
# a/spack.hooks.html
spack.hooks.sbang.spack_shebang_limit
# a/spack.html
spack.min_package_api_version
spack.package_api_version
spack.spack_version_info
spack.audit.CALLBACKS
spack.audit.GROUPS
spack.audit.config_compiler
spack.audit.config_packages
spack.audit.config_repos
spack.audit.external_detection
spack.audit.generic
spack.audit.package_directives
spack.binary_distribution.BINARY_INDEX: BinaryCacheIndex
record_fields: Tuple[str, ...]
BINARY
TEXT
UNKNOWN
spack.binary_distribution.default_index_tag
build_errors
ADDED
BUILDTIME
BUILDTIME_DIRECT
ROOT
RUNTIME
RUNTIME_EXECUTABLE
spack.builder.BUILDER_CLS: Dict[str, Type[Builder]]
build_system: str | None
legacy_attributes: Tuple[str, ...]
legacy_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system: str | None
install_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
spack.caches.FETCH_CACHE: FsCache
spack.caches.MISC_CACHE: FileCache
spack.config.CONFIG: Configuration
spack.config.CONFIGURATION_DEFAULTS_PATH
spack.config.CONFIG_DEFAULTS
element
next_key_pattern
quoted_string
unquoted_string
spack.config.MAX_RECURSIVE_INCLUDES
spack.config.SCOPES_METAVAR
spack.config.SECTION_SCHEMAS: Dict[str, Any]
BUILD
RUN
TEST
spack.cray_manifest.default_path
spack.database.DEFAULT_INSTALL_RECORD_FIELDS
spack.database.DEFAULT_LOCK_CFG: LockConfiguration
record_fields: Tuple[str, ...]
spack.database.INDEX_JSON_FILE
spack.database.NO_LOCK: LockConfiguration
spack.database.NO_TIMEOUT: LockConfiguration
spack.deptypes.ALL: int
spack.deptypes.ALL_FLAGS: Tuple[int, int, int, int]
spack.deptypes.ALL_TYPES: Tuple[Literal['build', 'link', 'run', 'test'], ...]
spack.deptypes.DEFAULT: int
spack.deptypes.DEFAULT_TYPES: Tuple[Literal['build', 'link', 'run', 'test'], ...]
spack.deptypes.NONE: int
spack.directives_meta.directive_names
BUILTIN
COMMAND_LINE
CONFIG_FILES
CUSTOM
ENVIRONMENT
ANY
DEPRECATED
INSTALLED
MISSING
spack.error.SHOW_BACKTRACE
spack.error.debug
url_attr: str | None
optional_attrs: List[str]
url_attr: str | None
spinner
optional_attrs: List[str]
url_attr: str | None
url_attr: str | None
git_version_re
optional_attrs: List[str]
url_attr: str | None
url_attr: str | None
optional_attrs: List[str]
url_attr: str | None
url_attr: str | None
optional_attrs: List[str]
url_attr: str | None
optional_attrs: List[str]
url_attr: str | None
spack.fetch_strategy.all_strategies: List[Type[FetchStrategy]]
spack.hash_types.dag_hash
spack.hash_types.package_hash
FAILED
NO_TESTS
PASSED
SKIPPED
spack.install_test.results_filename
spack.install_test.spack_install_test_log
spack.install_test.test_suite_filename
DEQUEUED
FAILED
INSTALLED
INSTALLING
QUEUED
REMOVED
backup_dir
no_op: bool
process_handle: BuildProcess | None
started: bool
tmpdir
FAILED
MISSING_BUILD_SPEC
NO_OP
SUCCESS
INSTALL
NONE
OVERWRITE
error_result: BaseException | None
no_op: bool
success_result: ExecuteResult | None
spack.main.intro_by_level
spack.main.levels
spack.main.options_by_level
spack.main.required_command_properties
spack.main.section_descriptions
spack.main.section_order
spack.main.stat_names
TAG
extendable: bool
fetch_options: Dict[str, Any]
has_code: bool
homepage: str | None | classproperty[str | None]
license_comment: str
license_files: List[str]
license_required: bool
license_url: str
license_vars: List[str]
list_depth: int
list_url: str | None | classproperty[str | None]
maintainers: List[str]
manual_download: bool
non_bindable_shared_objects: List[str]
parallel: bool
run_tests: bool
sanity_check_is_dir: List[str]
sanity_check_is_file: List[str]
test_requires_compiler: bool
test_suite: Any | None
transitive_rpaths: bool
unresolved_libraries: List[str]
virtual: bool
spack.package_base.detectable_packages
spack.package_base.spack_times_log
spack.paths.bin_path
spack.paths.default_conc_cache_path
spack.paths.default_misc_cache_path
spack.paths.default_monitor_path
spack.paths.default_test_path
spack.paths.default_user_bootstrap_path
spack.paths.package_repos_path
spack.paths.prefix
spack.paths.reports_path
spack.paths.sbang_script
spack.paths.spack_instance_id
spack.paths.spack_root
spack.paths.spack_script
spack.paths.spack_working_dir
spack.paths.system_config_path
spack.paths.user_config_path
spack.paths.user_repos_cache_path
spack.repo.NOT_PROVIDED
spack.repo.PATH: RepoPath
spack.spec_utils.GIT_REF
spack.spec_utils.IDENTIFIER
spack.spec_utils.NO_QUOTES_NEEDED
spack.spec_utils.QUOTED_VALUE
spack.spec_utils.STRIP_QUOTES
BOOL_VARIANT
DAG_HASH
DEPENDENCY
END_EDGE_PROPERTIES
FILENAME
FULLY_QUALIFIED_PACKAGE_NAME
GIT_VERSION
KEY_VALUE_PAIR
PROPAGATED_BOOL_VARIANT
PROPAGATED_KEY_VALUE_PAIR
START_EDGE_PROPERTIES
UNEXPECTED
UNQUALIFIED_PACKAGE_NAME
VERSION
VERSION_HASH_PAIR
WS
spack.spec_utils.VALUE
spack.spec_utils.VIRTUAL_ASSIGNMENT
spack.spec_utils.WINDOWS_FILENAME
requires_patch_success
requires_patch_success
spack.store.DEFAULT_INSTALL_TREE_ROOT
spack.store.STORE: Store
context_properties
BLOB
INDEX
KEY
KEY_INDEX
LAYOUT_JSON
SPEC
TARBALL
spack.url_buildcache.CURRENT_BUILD_CACHE_LAYOUT_VERSION
spack.url_buildcache.INDEX_MANIFEST_FILE
spack.url_buildcache.SUPPORTED_LAYOUT_VERSIONS
BUILDCACHE_INDEX_FILE
BUILDCACHE_INDEX_MEDIATYPE
COMPONENT_PATHS
LAYOUT_VERSION
PUBLIC_KEY_INDEX_MEDIATYPE
PUBLIC_KEY_MEDIATYPE
SPEC_MEDIATYPE
SPEC_URL_REGEX
TARBALL_MEDIATYPE
BUILDCACHE_INDEX_FILE
COMPONENT_PATHS
LAYOUT_VERSION
SPEC_URL_REGEX
spack.user_environment.spack_loaded_hashes_var
spack.variant.RESERVED_NAMES
BOOL
MULTI
SINGLE
slots
spack.verify_libraries.ALLOW_UNRESOLVED
# a/spack.llnl.html
platform_path: int
unix: int
windows: int
# a/spack.llnl.util.html
include_regex
spack.llnl.util.filesystem.library_extensions
error_lvl
spack.llnl.util.lang.done
# a/spack.mirrors.html
spack.mirrors.mirror.supported_url_schemes
# a/spack.modules.html
default_template: str
hide_cmd_format: str
modulerc_header: List[str]
default_template: str
hide_cmd_format: str
modulerc_header: List[str]
default_projections
context_properties
extension: str | None
default_projections
context_properties
extension: str | None
default_template: str
hide_cmd_format: str
modulerc_header: List[str]
context_properties
default_template: str
hide_cmd_format: str
modulerc_header: List[str]
# a/spack.oci.html
spack.oci.oci.all_content_type
spack.oci.oci.index_content_type
spack.oci.oci.manifest_content_type
AUTH_PARAM
AUTH_PARAM_LIST_START
AUTH_PARAM_OR_SCHEME
CHALLENGE
NEXT_IN_LIST
ANY
AUTH_PARAM
COMMA
EOF
EQUALS
SPACE
TOKEN
spack.oci.opener.urlopen: Callable[[...], HTTPResponse]
# a/spack.platforms.html
binary_formats
priority: int | None
priority: int | None
priority: int | None
binary_formats
deprecated_names
priority: int | None
reserved_oss
reserved_targets
default: str
default_os: str
priority: int | None
priority: int | None
binary_formats
priority: int | None
priority: int | None
priority: int | None
default: str
default_os: str
priority: int | None
priority: int | None
# a/spack.schema.html
spack.schema.bootstrap.schema
spack.schema.cdash.properties: Dict[str, Any]
spack.schema.cdash.schema
spack.schema.ci.properties: Dict[str, Any]
spack.schema.ci.schema
spack.schema.compilers.properties: Dict[str, Any]
spack.schema.compilers.schema
spack.schema.concretizer.schema
spack.schema.config.properties: Dict[str, Any]
spack.schema.config.schema
spack.schema.container.container_schema
spack.schema.database_index.schema
spack.schema.definitions.properties: Dict[str, Any]
spack.schema.definitions.schema
spack.schema.develop.schema
spack.schema.env.TOP_LEVEL_KEY
spack.schema.env_vars.schema
spack.schema.include.properties: Dict[str, Any]
spack.schema.include.schema
spack.schema.merged.properties: Dict[str, Any]
spack.schema.merged.schema
spack.schema.mirrors.connection
spack.schema.mirrors.fetch_and_push
spack.schema.mirrors.mirror_entry
spack.schema.mirrors.properties: Dict[str, Any]
spack.schema.mirrors.schema
spack.schema.modules.array_of_strings
spack.schema.modules.schema
spack.schema.packages.properties: Dict[str, Any]
spack.schema.packages.schema
spack.schema.projections.properties: Dict[str, Any]
spack.schema.projections.schema
spack.schema.repos.properties: Dict[str, Any]
spack.schema.repos.schema
spack.schema.spec.properties: Dict[str, Any]
spack.schema.spec.schema
spack.schema.toolchains.properties: Dict[str, Any]
spack.schema.toolchains.schema
spack.schema.upstreams.properties: Dict[str, Any]
spack.schema.upstreams.schema
spack.schema.url_buildcache_manifest.schema
spack.schema.view.properties: Dict[str, Any]
spack.schema.view.schema
# a/spack.solver.html
CONDITIONAL_SPEC
DEPENDS_ON
REQUIRE
spack.solver.asp.DEFAULT_OUTPUT_CONFIGURATION
BUILD
CONCRETE
OTHER
ignored_attributes
spack.solver.asp.build_priority_offset
spack.solver.asp.fixed_priority_offset
spack.solver.asp.high_fixed_priority_offset
spack.solver.core.fn
DEFAULT
PACKAGE
VIRTUAL
DEPENDENCIES
NONE
ROOTS
DEV_SPEC
EXTERNAL
INSTALLED
INSTALLED_GIT_VERSION
PACKAGES_YAML
PACKAGE_PY
PACKAGE_REQUIREMENT
RUNTIME
SPEC
# a/spack.util.html
myfileobj
extension: str
name: str
OFFSET
extension: str
name: str
extension: str
name: str
spack.util.compression.MAX_BYTES_ARCHIVE_HEADER
spack.util.compression.SUPPORTED_FILETYPES: List[FileTypeInterface]
OFFSET
extension: str
name: str
extension: str
name: str
extension: str
name: str
spack.util.crypto.hashes
PT_INTERP
RPATH
CLASS32
CLASS64
DATA2LSB
DATA2MSB
DT_NEEDED
DT_NULL
DT_RPATH
DT_RUNPATH
DT_SONAME
DT_STRTAB
ET_DYN
ET_EXEC
MAGIC
PT_DYNAMIC
PT_INTERP
PT_LOAD
SHT_STRTAB
spack.util.environment.SYSTEM_DIR_CASE_ENTRY
spack.util.gpg.GNUPGHOME
spack.util.gpg.GPG
spack.util.gpg.GPGCONF
spack.util.gpg.SOCKET_DIR
spack.util.libc.GLIBC_PATTERN
spack.util.s3.s3_client_cache: Dict[Tuple[str, str], Any]
spack.util.timer.NULL_TIMER
spack.util.timer.global_timer_name
spack.util.web.SPACK_USER_AGENT
spack.util.web.urlopen
HKEY_CLASSES_ROOT
HKEY_CURRENT_CONFIG
HKEY_CURRENT_USER
HKEY_LOCAL_MACHINE
HKEY_PERFORMANCE_DATA
HKEY_USERS
# a/spack.util.unparse.html
binop
binop_precedence
binop_rassoc
boolop_precedence
boolops
cmpops
unop
unop_precedence
# a/spack.version.html
spack.version.any_version: VersionList
# a/spack_repo.builtin.build_systems.html
autoreconf_extra_args: List[str]
build_system: str | None
build_targets: List[str]
build_time_test_callbacks: List[str]
force_autoreconf
install_libtool_archives
install_targets
install_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
patch_libtool
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
build_system: str | None
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
has_code: bool
FLUX
LSF
SLURM
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system: str | None
install_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
build_system: str | None
build_targets: List[str]
build_time_test_callbacks: List[str]
install_targets
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
find_python_hints
compiler_languages: Sequence[str]
compiler_prefixes: List[str]
compiler_suffixes: List[str]
compiler_version_argument: str | Tuple[str, ...]
compiler_version_regex: str
compiler_wrapper_link_paths: Dict[str, str]
debug_flags: Sequence[str]
implicit_rpath_libs: List[str]
linker_arg: str
openmp_flag: str
opt_flags: Sequence[str]
pic_flag: str
rpath_arg: str | None
tags: Sequence[str]
verbose_flags: str
cuda_arch_values
build_system: str | None
install_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
base_mirrors
gnu_mirror_path: str | None
build_system: str | None
install_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
build_system: str | None
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
list_depth: int
build_system: str | None
build_targets: List[str]
build_time_test_callbacks: List[str]
install_targets
install_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
build_system: str | None
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
build_system: str | None
build_targets: List[str]
build_time_test_callbacks: List[str]
install_targets
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
plat
build_system: str | None
build_targets: List[str]
install_targets: List[str]
phases: Tuple[str, ...]
build_system_class: str
build_system: str | None
build_targets: List[str]
install_targets: List[str]
phases: Tuple[str, ...]
build_system_class: str
build_system: str | None
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
spack_repo.builtin.build_systems.oneapi.INTEL_MATH_LIBRARIES
c
homepage: str | None | classproperty[str | None]
unresolved_libraries: List[str]
build_system: str | None
build_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
build_system_class: str
default_buildsystem: str
install_time_test_callbacks
pypi: str | None
build_system: str | None
install_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_long_methods: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system: str | None
build_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
package_methods: Tuple[str, ...]
bioc: str | None
build_system_class: str
cran: str | None
build_system: str | None
build_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
racket_name: str | None
build_system_class: str
default_buildsystem: str
racket_name: str | None
amdgpu_targets
build_system: str | None
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
build_system: str | None
build_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_long_methods: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
build_directory
build_system: str | None
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
install_time_test_callbacks
sip_module
base_mirrors
sourceforge_mirror_path: str | None
base_mirrors
sourceware_mirror_path: str | None
build_system: str | None
build_time_test_callbacks: List[str]
install_time_test_callbacks: List[str]
package_attributes: Tuple[str, ...]
package_methods: Tuple[str, ...]
phases: Tuple[str, ...]
build_system_class: str
default_buildsystem: str
base_mirrors
xorg_mirror_path: str | None
```

</details>