### PR TITLE
Remove `D` virtual

### DIFF
--- a/etc/spack/defaults/base/packages.yaml
+++ b/etc/spack/defaults/base/packages.yaml
@@ -21,9 +21,6 @@ packages:
       blas: [openblas, amdblis]
       c: [gcc, llvm, intel-oneapi-compilers]
       cxx: [gcc, llvm, intel-oneapi-compilers]
-      # D is replaced by d-lang
-      D: [ldc]
-      d-lang: [ldc]
       daal: [intel-oneapi-daal]
       elf: [elfutils]
       fftw-api: [fftw, amdfftw]

--- a/etc/spack/defaults/base/packages.yaml
+++ b/etc/spack/defaults/base/packages.yaml
@@ -21,7 +21,9 @@ packages:
       blas: [openblas, amdblis]
       c: [gcc, llvm, intel-oneapi-compilers]
       cxx: [gcc, llvm, intel-oneapi-compilers]
+      # D is replaced by d-lang
       D: [ldc]
+      d-lang: [ldc]
       daal: [intel-oneapi-daal]
       elf: [elfutils]
       fftw-api: [fftw, amdfftw]


### PR DESCRIPTION
`D` is not a valid package name, so I don't see why it should be used as a
virtual name. And `d` is probably too short, so use `d-lang`?

edit: decided to just remove `D` from config, since it's unused in `builtin`, other than being provided by two packages.

Ref: https://github.com/spack/spack-packages/pull/1318