### PR TITLE
packages.yaml: no additional attributes under external entry

### DIFF
--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -191,7 +191,7 @@ properties: Dict[str, Any] = {
                                 },
                             },
                         },
-                        "additionalProperties": True,
+                        "additionalProperties": False,
                         "required": ["spec"],
                     },
                 },


### PR DESCRIPTION
package specific attributes go under `extra_attributes`

Closes #51276.

I guess this should not be backported to v1.0
