### PR TITLE
solver: simplify sorting logic for function tuples in ASP solver

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3543,6 +3543,9 @@ def possible_compilers(*, configuration) -> Tuple[Set["spack.spec.Spec"], Set["s
     return result, rejected
 
 
+FunctionTupleT = Tuple[str, Tuple[Union[str, NodeArgument], ...]]
+
+
 class SpecBuilder:
     """Class with actions to rebuild a spec from ASP results."""
 
@@ -3592,6 +3595,7 @@ class SpecBuilder:
         # Pass in as arguments reusable specs and plug them in
         # from this dictionary during reconstruction
         self._hash_lookup = hash_lookup or ConcreteSpecsByHash()
+        self.function_tuples: List[FunctionTupleT] = []
 
     def hash(self, node, h):
         if node not in self._specs:
@@ -3817,7 +3821,7 @@ class SpecBuilder:
         )
         self._splices.setdefault(parent_spec, []).append(splice)
 
-    def build_specs(self, function_tuples):
+    def build_specs(self, function_tuples: List[FunctionTupleT]) -> List[spack.spec.Spec]:
 
         attr_key = {
             # hash attributes are handled first, since they imply entire concrete specs
@@ -3830,7 +3834,8 @@ class SpecBuilder:
         }
 
         # Sort functions so that directives building objects are called in the right order
-        self.function_tuples = sorted(function_tuples, key=lambda x: attr_key.get(x[0], 0))
+        function_tuples.sort(key=lambda x: attr_key.get(x[0], 0))
+        self.function_tuples = function_tuples
         self._specs = {}
         for name, args in self.function_tuples:
             if SpecBuilder.ignored_attributes.match(name):
@@ -3855,6 +3860,12 @@ class SpecBuilder:
             # predicates on virtual packages.
             if name != "error":
                 node = args[0]
+                if not isinstance(node, NodeArgument):
+                    raise InternalConcretizerError(
+                        f"internal solver error: expected a node, but got a {type(args[0])}. "
+                        "Please report a bug at https://github.com/spack/spack/issues"
+                    )
+
                 pkg = node.pkg
                 if spack.repo.PATH.is_virtual(pkg):
                     continue
@@ -3863,7 +3874,7 @@ class SpecBuilder:
                 # do not bother calling actions on it except for node_flag_source,
                 # since node_flag_source is tracking information not in the spec itself
                 # we also need to keep track of splicing information.
-                spec = self._specs.get(args[0])
+                spec = self._specs.get(node)
                 if spec and spec.concrete:
                     do_not_ignore_attrs = ["node_flag_source", "splice_at_hash"]
                     if name not in do_not_ignore_attrs:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3858,11 +3858,10 @@ class SpecBuilder:
             # predicates on virtual packages.
             if name != "error":
                 node = args[0]
-                if not isinstance(node, NodeArgument):
-                    raise InternalConcretizerError(
-                        f"internal solver error: expected a node, but got a {type(args[0])}. "
-                        "Please report a bug at https://github.com/spack/spack/issues"
-                    )
+                assert isinstance(node, NodeArgument), (
+                    f"internal solver error: expected a node, but got a {type(args[0])}. "
+                    "Please report a bug at https://github.com/spack/spack/issues"
+                )
 
                 pkg = node.pkg
                 if spack.repo.PATH.is_virtual(pkg):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3595,7 +3595,6 @@ class SpecBuilder:
         # Pass in as arguments reusable specs and plug them in
         # from this dictionary during reconstruction
         self._hash_lookup = hash_lookup or ConcreteSpecsByHash()
-        self._function_tuples: List[FunctionTupleT] = []
 
     def hash(self, node, h):
         if node not in self._specs:
@@ -3835,9 +3834,8 @@ class SpecBuilder:
 
         # Sort functions so that directives building objects are called in the right order
         function_tuples.sort(key=lambda x: attr_key.get(x[0], 0))
-        self._function_tuples = function_tuples
         self._specs = {}
-        for name, args in self._function_tuples:
+        for name, args in function_tuples:
             if SpecBuilder.ignored_attributes.match(name):
                 continue
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3595,7 +3595,7 @@ class SpecBuilder:
         # Pass in as arguments reusable specs and plug them in
         # from this dictionary during reconstruction
         self._hash_lookup = hash_lookup or ConcreteSpecsByHash()
-        self.function_tuples: List[FunctionTupleT] = []
+        self._function_tuples: List[FunctionTupleT] = []
 
     def hash(self, node, h):
         if node not in self._specs:
@@ -3835,9 +3835,9 @@ class SpecBuilder:
 
         # Sort functions so that directives building objects are called in the right order
         function_tuples.sort(key=lambda x: attr_key.get(x[0], 0))
-        self.function_tuples = function_tuples
+        self._function_tuples = function_tuples
         self._specs = {}
-        for name, args in self.function_tuples:
+        for name, args in self._function_tuples:
             if SpecBuilder.ignored_attributes.match(name):
                 continue
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3817,34 +3817,20 @@ class SpecBuilder:
         )
         self._splices.setdefault(parent_spec, []).append(splice)
 
-    @staticmethod
-    def sort_fn(function_tuple) -> Tuple[int, int]:
-        """Ensure attributes are evaluated in the correct order.
-
-        hash attributes are handled first, since they imply entire concrete specs
-        node attributes are handled next, since they instantiate nodes
-        external_spec_selected attributes are handled last, so that external extensions can find
-        the concrete specs on which they depend because all nodes are fully constructed before we
-        consider which ones are external.
-        """
-        name = function_tuple[0]
-        if name == "hash":
-            return (-5, 0)
-        elif name == "node":
-            return (-4, 0)
-        elif name == "node_flag":
-            return (-2, 0)
-        elif name == "external_spec_selected":
-            return (0, 0)  # note out of order so this goes last
-        elif name == "virtual_on_edge":
-            return (1, 0)
-        else:
-            return (-1, 0)
-
     def build_specs(self, function_tuples):
-        # Functions don't seem to be in particular order in output. Sort them here so that
-        # directives that build objects, like node, are called in the right order.
-        self.function_tuples = sorted(set(function_tuples), key=self.sort_fn)
+
+        attr_key = {
+            # hash attributes are handled first, since they imply entire concrete specs
+            "hash": -5,
+            # node attributes are handled next, since they instantiate nodes
+            "node": -4,
+            # evaluated last, so all nodes are fully constructed
+            "external_spec_selected": 1,
+            "virtual_on_edge": 2,
+        }
+
+        # Sort functions so that directives building objects are called in the right order
+        self.function_tuples = sorted(function_tuples, key=lambda x: attr_key.get(x[0], 0))
         self._specs = {}
         for name, args in self.function_tuples:
             if SpecBuilder.ignored_attributes.match(name):


### PR DESCRIPTION
Replaces the static `sort_fn` method with a dictionary-based lookup for attribute priorities.

Notes:
- The custom priority for `node_flag` has been removed, since I don't see a clear reason for it. 
- `function_tuples` are not turned into a set before being sorted, since they come from clingo's answer set which should not contain duplicate

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
