### PR TITLE
solver: requirements on virtual can influence provider weights

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2043,33 +2043,30 @@ class SpackSolverSetup:
 
             self.gen.newline()
 
-    def virtual_preferences(self, pkg_name, func):
-        """Call func(vspec, provider, i) for each of pkg's provider prefs."""
-        config = spack.config.get("packages")
-        pkg_prefs = config.get(pkg_name, {}).get("providers", {})
-        for vspec, providers in pkg_prefs.items():
-            if vspec not in self.possible_virtuals:
+    def virtual_requirements_and_weights(self):
+        virtual_preferences = spack.config.CONFIG.get("packages:all:providers", {})
+
+        self.gen.h1("Virtual requirements and weights")
+        for virtual_str in sorted(self.possible_virtuals):
+            self.gen.newline()
+            self.gen.h2(f"Virtual: {virtual_str}")
+            self.gen.fact(fn.virtual(virtual_str))
+
+            rules = self.requirement_parser.rules_from_virtual(virtual_str)
+            if not rules and virtual_str not in virtual_preferences:
                 continue
 
-            for i, provider in enumerate(providers):
-                provider_name = spack.spec.Spec(provider).name
-                func(vspec, provider_name, i)
-            self.gen.newline()
-
-    def provider_defaults(self):
-        self.gen.h2("Default virtual providers")
-        self.virtual_preferences(
-            "all", lambda v, p, i: self.gen.fact(fn.default_provider_preference(v, p, i))
-        )
-
-    def provider_requirements(self):
-        self.gen.h2("Requirements on virtual providers")
-        for virtual_str in sorted(self.possible_virtuals):
-            rules = self.requirement_parser.rules_from_virtual(virtual_str)
             if rules:
                 self.emit_facts_from_requirement_rules(rules)
                 self.trigger_rules()
                 self.effect_rules()
+
+            for i, provider in enumerate(virtual_preferences[virtual_str]):
+                provider_name = spack.spec.Spec(provider).name
+                self.gen.fact(fn.provider_weight_from_config(virtual_str, provider_name, i))
+            self.gen.newline()
+
+        self.gen.newline()
 
     def emit_facts_from_requirement_rules(self, rules: List[RequirementRule]):
         """Generate facts to enforce requirements.
@@ -2838,12 +2835,6 @@ class SpackSolverSetup:
         self.default_targets = list(sorted(set(self.default_targets)))
         self.target_preferences()
 
-    def virtual_providers(self):
-        self.gen.h2("Virtual providers")
-        for vspec in sorted(self.possible_virtuals):
-            self.gen.fact(fn.virtual(vspec))
-        self.gen.newline()
-
     def define_version_constraints(self):
         """Define what version_satisfies(...) means in ASP logic."""
 
@@ -3119,9 +3110,7 @@ class SpackSolverSetup:
         self.os_defaults(specs + dev_specs)
         self.target_defaults(specs + dev_specs)
 
-        self.virtual_providers()
-        self.provider_defaults()
-        self.provider_requirements()
+        self.virtual_requirements_and_weights()
         self.external_packages()
 
         # TODO: make a config option for this undocumented feature

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2064,20 +2064,20 @@ class SpackSolverSetup:
 
                 if len(rule.requirements) == 1:
                     required.append(rule.requirements[0].name)
-                    continue
-
-                preferred.extend([x.name for x in rule.requirements if x.name])
+                else:
+                    preferred.extend(x.name for x in rule.requirements if x.name)
 
             current_preferences = required + preferred + virtual_preferences.get(virtual_str, [])
+
+            for i, provider in enumerate(spack.llnl.util.lang.dedupe(current_preferences)):
+                provider_name = spack.spec.Spec(provider).name
+                self.gen.fact(fn.provider_weight_from_config(virtual_str, provider_name, i))
 
             if rules:
                 self.emit_facts_from_requirement_rules(rules)
                 self.trigger_rules()
                 self.effect_rules()
 
-            for i, provider in enumerate(spack.llnl.util.lang.dedupe(current_preferences)):
-                provider_name = spack.spec.Spec(provider).name
-                self.gen.fact(fn.provider_weight_from_config(virtual_str, provider_name, i))
             self.gen.newline()
 
         self.gen.newline()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2058,7 +2058,7 @@ class SpackSolverSetup:
 
             required, preferred = [], []
             for rule in rules:
-                # Account only for unconditional requirements
+                # We don't deal with conditional requirements
                 if rule.condition != spack.spec.Spec():
                     continue
 
@@ -2066,8 +2066,6 @@ class SpackSolverSetup:
                     required.append(rule.requirements[0].name)
                     continue
 
-                # TODO: here we may have edge cases that are difficult to deal with, and won't
-                # TODO: make much sense. Should we report them?
                 preferred.extend([x.name for x in rule.requirements if x.name])
 
             current_preferences = required + preferred + virtual_preferences.get(virtual_str, [])

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -84,7 +84,7 @@ from .core import (
     using_libc_compatibility,
 )
 from .input_analysis import create_counter, create_graph_analyzer
-from .requirements import RequirementKind, RequirementParser, RequirementRule
+from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector, SpecFilter
 from .runtimes import RuntimePropertyRecorder, _external_config_with_implicit_externals
 from .versions import DeclaredVersion, Provenance, concretization_version_order
@@ -2056,31 +2056,33 @@ class SpackSolverSetup:
             if not rules and virtual_str not in virtual_preferences:
                 continue
 
-            required, preferred = [], []
+            required, preferred, removed = [], [], set()
             for rule in rules:
                 # We don't deal with conditional requirements
                 if rule.condition != spack.spec.Spec():
                     continue
 
-                if len(rule.requirements) == 1:
-                    required.append(rule.requirements[0].name)
-                else:
+                if rule.origin == RequirementOrigin.PREFER_YAML:
                     preferred.extend(x.name for x in rule.requirements if x.name)
+                elif rule.origin == RequirementOrigin.REQUIRE_YAML:
+                    required.extend(x.name for x in rule.requirements if x.name)
+                elif rule.origin == RequirementOrigin.CONFLICT_YAML:
+                    conflict_spec = rule.requirements[0]
+                    # For conflicts, we take action only if just a name is used
+                    if spack.spec.Spec(conflict_spec.name).satisfies(conflict_spec):
+                        removed.add(conflict_spec.name)
 
             current_preferences = required + preferred + virtual_preferences.get(virtual_str, [])
-
+            current_preferences = [x for x in current_preferences if x not in removed]
             for i, provider in enumerate(spack.llnl.util.lang.dedupe(current_preferences)):
                 provider_name = spack.spec.Spec(provider).name
                 self.gen.fact(fn.provider_weight_from_config(virtual_str, provider_name, i))
+            self.gen.newline()
 
             if rules:
                 self.emit_facts_from_requirement_rules(rules)
                 self.trigger_rules()
                 self.effect_rules()
-
-            self.gen.newline()
-
-        self.gen.newline()
 
     def emit_facts_from_requirement_rules(self, rules: List[RequirementRule]):
         """Generate facts to enforce requirements.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2056,12 +2056,28 @@ class SpackSolverSetup:
             if not rules and virtual_str not in virtual_preferences:
                 continue
 
+            required, preferred = [], []
+            for rule in rules:
+                # Account only for unconditional requirements
+                if rule.condition != spack.spec.Spec():
+                    continue
+
+                if len(rule.requirements) == 1:
+                    required.append(rule.requirements[0].name)
+                    continue
+
+                # TODO: here we may have edge cases that are difficult to deal with, and won't
+                # TODO: make much sense. Should we report them?
+                preferred.extend([x.name for x in rule.requirements if x.name])
+
+            current_preferences = required + preferred + virtual_preferences.get(virtual_str, [])
+
             if rules:
                 self.emit_facts_from_requirement_rules(rules)
                 self.trigger_rules()
                 self.effect_rules()
 
-            for i, provider in enumerate(virtual_preferences[virtual_str]):
+            for i, provider in enumerate(spack.llnl.util.lang.dedupe(current_preferences)):
                 provider_name = spack.spec.Spec(provider).name
                 self.gen.fact(fn.provider_weight_from_config(virtual_str, provider_name, i))
             self.gen.newline()

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -956,7 +956,7 @@ do_not_impose(EffectID, node(X, Package))
 % Any configured provider has a weight based on index in the preference list
 possible_provider_weight(node(ProviderID, Provider), node(VirtualID, Virtual), Weight, "default")
   :- provider(node(ProviderID, Provider), node(VirtualID, Virtual)),
-     default_provider_preference(Virtual, Provider, Weight).
+     provider_weight_from_config(Virtual, Provider, Weight).
 
 % Any non-configured provider has a default weight of 100
 possible_provider_weight(node(ProviderID, Provider), VirtualNode, 100, "fallback")
@@ -965,7 +965,7 @@ possible_provider_weight(node(ProviderID, Provider), VirtualNode, 100, "fallback
 % do not warn if generated program contains none of these.
 #defined virtual/1.
 #defined buildable_false/1.
-#defined default_provider_preference/3.
+#defined provider_weight_from_config/3.
 
 %-----------------------------------------------------------------------------
 % External semantics

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -24,11 +24,21 @@ class RequirementKind(enum.Enum):
     PACKAGE = enum.auto()
 
 
+class RequirementOrigin(enum.Enum):
+    """Origin of a requirement"""
+
+    REQUIRE_YAML = enum.auto()
+    PREFER_YAML = enum.auto()
+    CONFLICT_YAML = enum.auto()
+    DIRECTIVE = enum.auto()
+
+
 class RequirementRule(NamedTuple):
     """Data class to collect information on a requirement"""
 
     pkg_name: str
     policy: str
+    origin: RequirementOrigin
     requirements: Sequence[spack.spec.Spec]
     condition: spack.spec.Spec
     kind: RequirementKind
@@ -63,6 +73,7 @@ class RequirementParser:
                         kind=RequirementKind.PACKAGE,
                         condition=when_spec,
                         message=message,
+                        origin=RequirementOrigin.DIRECTIVE,
                     )
                 )
         return rules
@@ -105,6 +116,7 @@ class RequirementParser:
                     kind=kind,
                     message=message,
                     condition=condition,
+                    origin=RequirementOrigin.PREFER_YAML,
                 )
             )
         return result
@@ -131,6 +143,7 @@ class RequirementParser:
                     kind=kind,
                     message=message,
                     condition=condition,
+                    origin=RequirementOrigin.CONFLICT_YAML,
                 )
             )
         return result
@@ -209,6 +222,7 @@ class RequirementParser:
                         kind=kind,
                         message=requirement.get("message"),
                         condition=when,
+                        origin=RequirementOrigin.REQUIRE_YAML,
                     )
                 )
         return rules

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1971,6 +1971,42 @@ class TestConcretize:
                     'provider_weight_from_config("mpi","low-priority-mpi",3).',
                 ],
             ),
+            # Configuration with conflicts
+            (
+                """
+    packages:
+      all:
+        providers:
+          mpi: [mpich, low-priority-mpi]
+      mpi:
+        require:
+        - mpich2
+        conflict:
+        - mpich
+    """,
+                [
+                    'provider_weight_from_config("mpi","mpich2",0).',
+                    'provider_weight_from_config("mpi","low-priority-mpi",1).',
+                ],
+            ),
+            (
+                """
+        packages:
+          all:
+            providers:
+              mpi: [mpich, low-priority-mpi]
+          mpi:
+            require:
+            - mpich2
+            conflict:
+            - mpich@1
+        """,
+                [
+                    'provider_weight_from_config("mpi","mpich2",0).',
+                    'provider_weight_from_config("mpi","mpich",1).',
+                    'provider_weight_from_config("mpi","low-priority-mpi",2).',
+                ],
+            ),
         ],
     )
     def test_requirements_and_weights(self, packages_config, expected, mutable_config):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1902,6 +1902,89 @@ class TestConcretize:
             assert result_spec.satisfies("^pkg-b@1.0")
             assert result_spec["pkg-b"].dag_hash() == reusable_specs[1].dag_hash()
 
+    @pytest.mark.regression("51267")
+    @pytest.mark.parametrize(
+        "packages_config,expected",
+        [
+            # Two preferences on different virtuals
+            (
+                """
+    packages:
+      c:
+        prefer:
+        - clang
+      mpi:
+        prefer:
+        - mpich2
+    """,
+                [
+                    'provider_weight_from_config("mpi","mpich2",0).',
+                    'provider_weight_from_config("c","clang",0).',
+                ],
+            ),
+            # A requirement and a preference on the same virtual
+            (
+                """
+    packages:
+      c:
+        require:
+        - gcc
+        prefer:
+        - clang
+    """,
+                [
+                    'provider_weight_from_config("c","gcc",0).',
+                    'provider_weight_from_config("c","clang",1).',
+                ],
+            ),
+            (
+                """
+        packages:
+          c:
+            require:
+            - clang
+            prefer:
+            - gcc
+        """,
+                [
+                    'provider_weight_from_config("c","gcc",1).',
+                    'provider_weight_from_config("c","clang",0).',
+                ],
+            ),
+            # Multiple requirements with priorities
+            (
+                """
+    packages:
+      all:
+        providers:
+          mpi: [low-priority-mpi]
+      mpi:
+        require:
+        - any_of: [mpich2, zmpi]
+        prefer:
+        - mpich
+    """,
+                [
+                    'provider_weight_from_config("mpi","mpich2",0).',
+                    'provider_weight_from_config("mpi","zmpi",1).',
+                    'provider_weight_from_config("mpi","mpich",2).',
+                    'provider_weight_from_config("mpi","low-priority-mpi",3).',
+                ],
+            ),
+        ],
+    )
+    def test_requirements_and_weights(self, packages_config, expected, mutable_config):
+        """Checks that requirements and strong preferences on virtual packages influence the
+        weights for providers, even if "package preferences" are not set consistently.
+        """
+        packages_yaml = syaml.load_config(packages_config)
+        mutable_config.set("packages", packages_yaml["packages"])
+
+        setup = spack.solver.asp.SpackSolverSetup()
+        asp_problem = setup.setup([Spec("mpileaks")], reuse=[], allow_deprecated=False)
+
+        assert all(x in asp_problem for x in expected)
+
     def test_reuse_succeeds_with_config_compatible_os(self):
         root_spec = Spec("pkg-b")
         s = spack.concretize.concretize_one(root_spec)


### PR DESCRIPTION
fixes #51267

Before this change, provider weights were determined just by package preferences. This could cause issues in cases where the preferred, or required, provider is not the "default" provider.

This PR changes the ASP setup to take into account the most common cases of requirements and strong preferences, so that the provider weights are set accordingly.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
