### PR TITLE
schema: remove deprecated options, replace union_dicts with unpacking

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -648,15 +648,13 @@ def add_connection_args(subparser, add_help):
         "--s3-access-key-id",
         help="ID string to use to connect to this S3 mirror",
     )
-    add_argument_string_or_variable(
-        s3_connection_parser,
-        "--s3-access-key-secret",
-        help="secret string to use to connect to this S3 mirror",
+    s3_connection_parser.add_argument(
+        "--s3-access-key-secret-variable",
+        help="environment variable containing secret string to use to connect to this S3 mirror",
     )
-    add_argument_string_or_variable(
-        s3_connection_parser,
-        "--s3-access-token",
-        help="access token to use to connect to this S3 mirror",
+    s3_connection_parser.add_argument(
+        "--s3-access-token-variable",
+        help="environment variable containing access token to use to connect to this S3 mirror",
     )
     s3_connection_parser.add_argument(
         "--s3-profile", help="S3 profile name to use to connect to this S3 mirror", default=None
@@ -673,10 +671,9 @@ def add_connection_args(subparser, add_help):
         deprecate_str=False,
         help="username to use to connect to this OCI mirror",
     )
-    add_argument_string_or_variable(
-        oci_connection_parser,
-        "--oci-password",
-        help="password to use to connect to this OCI mirror",
+    oci_connection_parser.add_argument(
+        "--oci-password-variable",
+        help="environment variable containing password to use to connect to this OCI mirror",
     )
 
 

--- a/lib/spack/spack/container/writers.py
+++ b/lib/spack/spack/container/writers.py
@@ -196,7 +196,7 @@ class PathContext(tengine.Context):
 
         # Ensure that a few paths are where they need to be
         manifest.setdefault("config", syaml.syaml_dict())
-        manifest["config"]["install_tree"] = self.paths.store
+        manifest["config"]["install_tree"] = {"root": self.paths.store}
         manifest["view"] = self.paths.view
         manifest = {"spack": manifest}
 

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -107,25 +107,6 @@ def attr_setdefault(obj, name, value):
     return getattr(obj, name)
 
 
-def union_dicts(*dicts: Mapping[Any, Any]) -> Dict[Any, Any]:
-    """Use update() to combine all dicts into one.
-
-    This builds a new dictionary, into which we ``update()`` each element
-    of ``dicts`` in order.  Items from later dictionaries will override
-    items from earlier dictionaries.
-
-    Args:
-        dicts: list of dictionaries
-
-    Returns: a merged dictionary containing combined keys and values from ``dicts``.
-
-    """
-    result: Dict[Any, Any] = {}
-    for d in dicts:
-        result.update(d)
-    return result
-
-
 def memoized(func):
     """Decorator that caches the results of a function, storing them in
     an attribute of that function.

--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -8,8 +8,6 @@
 """
 from typing import Any, Dict
 
-from spack.llnl.util.lang import union_dicts
-
 # Schema for script fields
 # List of lists and/or strings
 # This is similar to what is allowed in
@@ -124,15 +122,13 @@ pipeline_gen_schema = {
     },
 }
 
-core_shared_properties = union_dicts(
-    {
-        "pipeline-gen": pipeline_gen_schema,
-        "rebuild-index": {"type": "boolean"},
-        "broken-specs-url": {"type": "string"},
-        "broken-tests-packages": {"type": "array", "items": {"type": "string"}},
-        "target": {"type": "string", "enum": ["gitlab"], "default": "gitlab"},
-    }
-)
+core_shared_properties = {
+    "pipeline-gen": pipeline_gen_schema,
+    "rebuild-index": {"type": "boolean"},
+    "broken-specs-url": {"type": "string"},
+    "broken-tests-packages": {"type": "array", "items": {"type": "string"}},
+    "target": {"type": "string", "enum": ["gitlab"], "default": "gitlab"},
+}
 
 #: Properties for inclusion in other schemas
 properties: Dict[str, Any] = {"ci": core_shared_properties}

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -37,22 +37,14 @@ properties: Dict[str, Any] = {
                 ]
             },
             "install_tree": {
-                "anyOf": [
-                    {
-                        "type": "object",
-                        "properties": {
-                            "root": {"type": "string"},
-                            "padded_length": {
-                                "oneOf": [
-                                    {"type": "integer", "minimum": 0},
-                                    {"type": "boolean"},
-                                ]
-                            },
-                            **spack.schema.projections.properties,
-                        },
+                "type": "object",
+                "properties": {
+                    "root": {"type": "string"},
+                    "padded_length": {
+                        "oneOf": [{"type": "integer", "minimum": 0}, {"type": "boolean"}]
                     },
-                    {"type": "string"},  # deprecated
-                ]
+                    **spack.schema.projections.properties,
+                },
             },
             "concretization_cache": {
                 "type": "object",
@@ -64,7 +56,6 @@ properties: Dict[str, Any] = {
                 },
             },
             "install_hash_length": {"type": "integer", "minimum": 1},
-            "install_path_scheme": {"type": "string"},  # deprecated
             "build_stage": {
                 "oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}]
             },
@@ -102,28 +93,6 @@ properties: Dict[str, Any] = {
             "binary_index_ttl": {"type": "integer", "minimum": 0},
             "aliases": {"type": "object", "patternProperties": {r"\w[\w-]*": {"type": "string"}}},
         },
-        "deprecatedProperties": [
-            {
-                "names": ["concretizer"],
-                "message": "Spack supports only clingo as a concretizer from v0.23. "
-                "The config:concretizer config option is ignored.",
-                "error": False,
-            },
-            {
-                "names": ["install_missing_compilers"],
-                "message": "The config:install_missing_compilers option has been deprecated in "
-                "Spack v0.23, and is currently ignored. It will be removed from config in "
-                "Spack v1.0.",
-                "error": False,
-            },
-            {
-                "names": ["install_path_scheme"],
-                "message": "The config:install_path_scheme option was deprecated in Spack v0.16 "
-                "in favor of config:install_tree:projections:all. It will be removed in Spack "
-                "v1.0.",
-                "error": False,
-            },
-        ],
     }
 }
 
@@ -138,54 +107,20 @@ schema = {
 }
 
 
-def update(data):
+def update(data: dict) -> bool:
     """Update the data in place to remove deprecated properties.
 
     Args:
-        data (dict): dictionary to be updated
+        data: dictionary to be updated
 
-    Returns:
-        True if data was changed, False otherwise
+    Returns: True if data was changed, False otherwise
     """
-    # currently deprecated properties are
-    # install_tree: <string>
-    # install_path_scheme: <string>
-    # updated: install_tree: {root: <string>,
-    #                         projections: <projections_dict}
-    # root replaces install_tree, projections replace install_path_scheme
     changed = False
-
     data = data["config"]
-
-    install_tree = data.get("install_tree", None)
-    if isinstance(install_tree, str):
-        # deprecated short-form install tree
-        # add value as `root` in updated install_tree
-        data["install_tree"] = {"root": install_tree}
-        changed = True
-
-    install_path_scheme = data.pop("install_path_scheme", None)
-    if install_path_scheme:
-        projections_data = {"projections": {"all": install_path_scheme}}
-
-        # update projections with install_scheme
-        # whether install_tree was updated or not
-        # we merge the yaml to ensure we don't invalidate other projections
-        update_data = data.get("install_tree", {})
-        update_data = spack.schema.merge_yaml(update_data, projections_data)
-        data["install_tree"] = update_data
-        changed = True
-
-    use_curl = data.pop("use_curl", None)
-    if use_curl is not None:
-        data["url_fetch_method"] = "curl" if use_curl else "urllib"
-        changed = True
-
     shared_linking = data.get("shared_linking", None)
     if isinstance(shared_linking, str):
         # deprecated short-form shared_linking: rpath/runpath
         # add value as `type` in updated shared_linking
         data["shared_linking"] = {"type": shared_linking, "bind": False}
         changed = True
-
     return changed

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -10,7 +10,6 @@ from typing import Any, Dict
 
 import spack.schema
 import spack.schema.projections
-from spack.llnl.util.lang import union_dicts
 
 #: Properties for inclusion in other schemas
 properties: Dict[str, Any] = {
@@ -41,18 +40,16 @@ properties: Dict[str, Any] = {
                 "anyOf": [
                     {
                         "type": "object",
-                        "properties": union_dicts(
-                            {"root": {"type": "string"}},
-                            {
-                                "padded_length": {
-                                    "oneOf": [
-                                        {"type": "integer", "minimum": 0},
-                                        {"type": "boolean"},
-                                    ]
-                                }
+                        "properties": {
+                            "root": {"type": "string"},
+                            "padded_length": {
+                                "oneOf": [
+                                    {"type": "integer", "minimum": 0},
+                                    {"type": "boolean"},
+                                ]
                             },
-                            spack.schema.projections.properties,
-                        ),
+                            **spack.schema.projections.properties,
+                        },
                     },
                     {"type": "string"},  # deprecated
                 ]

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -10,7 +10,6 @@
 from typing import Any, Dict
 
 import spack.schema.merged
-from spack.llnl.util.lang import union_dicts
 
 from .spec_list import spec_list_schema
 
@@ -24,12 +23,13 @@ properties: Dict[str, Any] = {
         "type": "object",
         "default": {},
         "additionalProperties": False,
-        "properties": union_dicts(
+        "properties": {
             # merged configuration scope schemas
-            spack.schema.merged.properties,
+            **spack.schema.merged.properties,
             # extra environment schema properties
-            {"specs": spec_list_schema, "include_concrete": include_concrete},
-        ),
+            "specs": spec_list_schema,
+            "include_concrete": include_concrete,
+        },
     }
 }
 

--- a/lib/spack/spack/schema/merged.py
+++ b/lib/spack/spack/schema/merged.py
@@ -27,29 +27,28 @@ import spack.schema.repos
 import spack.schema.toolchains
 import spack.schema.upstreams
 import spack.schema.view
-from spack.llnl.util.lang import union_dicts
 
 #: Properties for inclusion in other schemas
-properties: Dict[str, Any] = union_dicts(
-    spack.schema.bootstrap.properties,
-    spack.schema.cdash.properties,
-    spack.schema.compilers.properties,
-    spack.schema.concretizer.properties,
-    spack.schema.config.properties,
-    spack.schema.container.properties,
-    spack.schema.ci.properties,
-    spack.schema.definitions.properties,
-    spack.schema.develop.properties,
-    spack.schema.env_vars.properties,
-    spack.schema.include.properties,
-    spack.schema.mirrors.properties,
-    spack.schema.modules.properties,
-    spack.schema.packages.properties,
-    spack.schema.repos.properties,
-    spack.schema.toolchains.properties,
-    spack.schema.upstreams.properties,
-    spack.schema.view.properties,
-)
+properties: Dict[str, Any] = {
+    **spack.schema.bootstrap.properties,
+    **spack.schema.cdash.properties,
+    **spack.schema.compilers.properties,
+    **spack.schema.concretizer.properties,
+    **spack.schema.config.properties,
+    **spack.schema.container.properties,
+    **spack.schema.ci.properties,
+    **spack.schema.definitions.properties,
+    **spack.schema.develop.properties,
+    **spack.schema.env_vars.properties,
+    **spack.schema.include.properties,
+    **spack.schema.mirrors.properties,
+    **spack.schema.modules.properties,
+    **spack.schema.packages.properties,
+    **spack.schema.repos.properties,
+    **spack.schema.toolchains.properties,
+    **spack.schema.upstreams.properties,
+    **spack.schema.view.properties,
+}
 
 #: Full schema with metadata
 schema = {

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -482,12 +482,10 @@ full_padded_string = os.path.join(os.sep + "path", os.sep.join(reps))[:MAX_PADDE
     [
         ([], [None, None, None]),
         ([["config:install_tree:root", os.sep + "path"]], [os.sep + "path", None, None]),
-        ([["config:install_tree", os.sep + "path"]], [os.sep + "path", None, None]),
         (
             [["config:install_tree:projections", {"all": "{name}"}]],
             [None, None, {"all": "{name}"}],
         ),
-        ([["config:install_path_scheme", "{name}"]], [None, None, {"all": "{name}"}]),
     ],
 )
 def test_parse_install_tree(config_settings, expected, mutable_config):
@@ -551,24 +549,12 @@ def test_change_or_add(mutable_config, mock_packages):
             [["config:install_tree:root", "/path/$padding:11"]],
             [os.path.join(os.sep + "path", PAD_STRING[:5]), os.sep + "path", None],
         ),
-        (
-            [["config:install_tree", "/path/${padding:11}"]],
-            [os.path.join(os.sep + "path", PAD_STRING[:5]), os.sep + "path", None],
-        ),
         ([["config:install_tree:padded_length", False]], [None, None, None]),
         (
             [
                 ["config:install_tree:padded_length", True],
                 ["config:install_tree:root", os.sep + "path"],
             ],
-            [full_padded_string, os.sep + "path", None],
-        ),
-        (
-            [["config:install_tree:", os.sep + "path$padding"]],
-            [full_padded_string, os.sep + "path", None],
-        ),
-        (
-            [["config:install_tree:", os.sep + "path" + os.sep + "${padding}"]],
             [full_padded_string, os.sep + "path", None],
         ),
     ],

--- a/lib/spack/spack/test/container/images.py
+++ b/lib/spack/spack/test/container/images.py
@@ -36,7 +36,7 @@ def test_package_info(image):
         ({"modules": {"enable": ["tcl"]}}, 'the subsection "modules" in'),
         ({"concretizer": {"unify": False}}, '"concretizer:unify" is not set to "true"'),
         (
-            {"config": {"install_tree": "/some/dir"}},
+            {"config": {"install_tree": {"root": "/some/dir"}}},
             'the "config:install_tree" attribute has been set',
         ),
         ({"view": "/some/dir"}, 'the "view" attribute has been set'),

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1477,7 +1477,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret --s3-access-key-secret-variable --s3-access-token --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password --oci-password-variable"
+        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
     else
         _mirrors
     fi
@@ -1504,7 +1504,7 @@ _spack_mirror_rm() {
 _spack_mirror_set_url() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --push --fetch --scope --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret --s3-access-key-secret-variable --s3-access-token --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password --oci-password-variable"
+        SPACK_COMPREPLY="-h --help --push --fetch --scope --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
     else
         _mirrors
     fi
@@ -1513,7 +1513,7 @@ _spack_mirror_set_url() {
 _spack_mirror_set() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --push --fetch --type --url --autopush --no-autopush --unsigned --signed --scope --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret --s3-access-key-secret-variable --s3-access-token --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password --oci-password-variable"
+        SPACK_COMPREPLY="-h --help --push --fetch --type --url --autopush --no-autopush --unsigned --signed --scope --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2352,7 +2352,7 @@ complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -
 complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -r -d 'find mirror to destroy by url'
 
 # spack mirror add
-set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret= s3-access-key-secret-variable= s3-access-token= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password= oci-password-variable=
+set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
@@ -2370,12 +2370,8 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id-variable -r -d 'environment variable containing ID string to use to connect to this S3 mirror'
-complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-secret -r -f -a s3_access_key_secret
-complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-secret -r -d 'secret string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-secret-variable -r -f -a s3_access_key_secret_variable
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-secret-variable -r -d 'environment variable containing secret string to use to connect to this S3 mirror'
-complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-token -r -f -a s3_access_token
-complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-token -r -d 'access token to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-token-variable -r -f -a s3_access_token_variable
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-token-variable -r -d 'environment variable containing access token to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-profile -r -f -a s3_profile
@@ -2386,8 +2382,6 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l oci-username -r 
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-username -r -d 'username to use to connect to this OCI mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-username-variable -r -f -a oci_username_variable
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-username-variable -r -d 'environment variable containing username to use to connect to this OCI mirror'
-complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password -r -f -a oci_password
-complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password -r -d 'password to use to connect to this OCI mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password-variable -r -f -a oci_password_variable
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password-variable -r -d 'environment variable containing password to use to connect to this OCI mirror'
 
@@ -2408,7 +2402,7 @@ complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror set-url
-set -g __fish_spack_optspecs_spack_mirror_set_url h/help push fetch scope= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret= s3-access-key-secret-variable= s3-access-token= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password= oci-password-variable=
+set -g __fish_spack_optspecs_spack_mirror_set_url h/help push fetch scope= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror set-url' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror set-url' -s h -l help -d 'show this help message and exit'
@@ -2422,12 +2416,8 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-ke
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id-variable -r -d 'environment variable containing ID string to use to connect to this S3 mirror'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-secret -r -f -a s3_access_key_secret
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-secret -r -d 'secret string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-secret-variable -r -f -a s3_access_key_secret_variable
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-secret-variable -r -d 'environment variable containing secret string to use to connect to this S3 mirror'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-token -r -f -a s3_access_token
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-token -r -d 'access token to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-token-variable -r -f -a s3_access_token_variable
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-token-variable -r -d 'environment variable containing access token to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-profile -r -f -a s3_profile
@@ -2438,13 +2428,11 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-username
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-username -r -d 'username to use to connect to this OCI mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-username-variable -r -f -a oci_username_variable
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-username-variable -r -d 'environment variable containing username to use to connect to this OCI mirror'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password -r -f -a oci_password
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password -r -d 'password to use to connect to this OCI mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password-variable -r -f -a oci_password_variable
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password-variable -r -d 'environment variable containing password to use to connect to this OCI mirror'
 
 # spack mirror set
-set -g __fish_spack_optspecs_spack_mirror_set h/help push fetch type= url= autopush no-autopush unsigned signed scope= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret= s3-access-key-secret-variable= s3-access-token= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password= oci-password-variable=
+set -g __fish_spack_optspecs_spack_mirror_set h/help push fetch type= url= autopush no-autopush unsigned signed scope= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror set' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror set' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror set' -s h -l help -d 'show this help message and exit'
@@ -2470,12 +2458,8 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id-variable -r -d 'environment variable containing ID string to use to connect to this S3 mirror'
-complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-secret -r -f -a s3_access_key_secret
-complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-secret -r -d 'secret string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-secret-variable -r -f -a s3_access_key_secret_variable
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-secret-variable -r -d 'environment variable containing secret string to use to connect to this S3 mirror'
-complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-token -r -f -a s3_access_token
-complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-token -r -d 'access token to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-token-variable -r -f -a s3_access_token_variable
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-token-variable -r -d 'environment variable containing access token to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-profile -r -f -a s3_profile
@@ -2486,8 +2470,6 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l oci-username -r 
 complete -c spack -n '__fish_spack_using_command mirror set' -l oci-username -r -d 'username to use to connect to this OCI mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l oci-username-variable -r -f -a oci_username_variable
 complete -c spack -n '__fish_spack_using_command mirror set' -l oci-username-variable -r -d 'environment variable containing username to use to connect to this OCI mirror'
-complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password -r -f -a oci_password
-complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password -r -d 'password to use to connect to this OCI mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-variable -r -f -a oci_password_variable
 complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-variable -r -d 'environment variable containing password to use to connect to this OCI mirror'
 


### PR DESCRIPTION
* remove deprecated properties from `mirrors.yaml`
* remove deprecated properties from `config.yaml`
* remove the flags `--s3-access-key-secret`, `--s3-access-token`, `--oci-password` from `spack mirror` subcommands, which were deprecated in favor of `--s3-access-key-secret-variable`, `--s3-access-token-variable`, `--oci-password-variable` resp. (I think `--s3-access-token` did not show a deprecation message, but it was intended to be deprecated for security reasons together with the others; otherwise secrets could end up in world readable files).
* use unpacking `{**foo, **bar}` instead of `union_dicts(foo, bar)` (which suffers from type erasure)