### PR TITLE
tests: SPACK_ROOT -> spack.paths.spack_root

### DIFF
--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -9,6 +9,7 @@ import pytest
 
 import spack.config
 import spack.llnl.util.tty as tty
+import spack.paths
 import spack.util.path as sup
 
 #: Some lines with lots of placeholders
@@ -140,7 +141,7 @@ def test_path_debug_padded_filter(debug, monkeypatch):
     [
         ("/home/spack/path/to/file.txt", "/home/spack/path/to/file.txt"),
         ("file:///home/another/config.yaml", "/home/another/config.yaml"),
-        ("path/to.txt", os.path.join(os.environ["SPACK_ROOT"], "path", "to.txt")),
+        ("path/to.txt", os.path.join(spack.paths.spack_root, "path", "to.txt")),
         (r"C:\Files (x86)\Windows\10", r"C:\Files (x86)\Windows\10"),
         (r"E:/spack stage", "E:\\spack stage"),
     ],

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -9,6 +9,7 @@ import pytest
 
 import spack.config
 import spack.llnl.util.tty as tty
+import spack.paths
 import spack.util.remote_file_cache as rfc_util
 from spack.llnl.util.filesystem import join_path
 
@@ -35,7 +36,7 @@ def test_rfc_local_path_bad_scheme(path, err):
         ("file:///this/is/a/file/url/include.yaml", "/this/is/a/file/url/include.yaml"),
         (
             "relative/packages.txt",
-            os.path.join(os.environ["SPACK_ROOT"], "relative", "packages.txt"),
+            os.path.join(spack.paths.spack_root, "relative", "packages.txt"),
         ),
         (r"C:\Files (x86)\Windows\10", r"C:\Files (x86)\Windows\10"),
         (r"D:/spack stage", "D:\\spack stage"),


### PR DESCRIPTION
the environment variable `SPACK_ROOT` may not be set, or may be set
incorrectly, it's a shell support "feature", not something set by Spack
during setup. So replace `os.environ["SPACK_ROOT"]` with
`spack.paths.spack_root`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
