### PR TITLE
Add `:=` to `spack help --spec`

### DIFF
--- a/lib/spack/spack/cmd/help.py
+++ b/lib/spack/spack/cmd/help.py
@@ -44,9 +44,10 @@ spec expression syntax:
 
     variants:
       @B{+variant}                      enable <variant>
-      @r{-variant} or @r{~variant}          disable <variant>
-      @B{variant=value}                 set non-boolean <variant> to <value>
-      @B{variant=value1,value2,value3}  set multi-value <variant> values
+      @r{~variant} or @r{-variant}          disable <variant>
+      @B{variant=value}                 <variant> has <value> (at least)
+      @B{variant=value1,value2,value3}  <variant> has value1, 2, and 3 (at least)
+      @B{variant:=value1,value2}        <variant> has exactly value1 and value2
       @B{++}, @r{--}, @r{~~}, @B{==}                propagate variants to package dependencies
 
     architecture variants:


### PR DESCRIPTION
#49756 introduced `:=` to specify concrete variants, but it wasn't added to `spack spec --help`.  Add it here.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
