### PR TITLE
schema: set top-level `type`

### DIFF
--- a/lib/spack/spack/schema/include.py
+++ b/lib/spack/spack/schema/include.py
@@ -37,5 +37,7 @@ properties: Dict[str, Any] = {
 schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Spack include configuration file schema",
+    "type": "object",
+    "additionalProperties": False,
     "properties": properties,
 }

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -45,5 +45,7 @@ properties: Dict[str, Any] = {
 schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Spack view configuration file schema",
+    "type": "object",
+    "additionalProperties": False,
     "properties": properties,
 }


### PR DESCRIPTION
Add two missing instances of top-level `"type": "object"` for top-level config
