### PR TITLE
schema: fix issues with regexes

### DIFF
--- a/lib/spack/spack/schema/bootstrap.py
+++ b/lib/spack/spack/schema/bootstrap.py
@@ -19,7 +19,7 @@ properties: Dict[str, Any] = {
             "enable": {"type": "boolean"},
             "root": {"type": "string"},
             "sources": {"type": "array", "items": _source_schema},
-            "trusted": {"type": "object", "patternProperties": {r"\w[\w-]*": {"type": "boolean"}}},
+            "trusted": {"type": "object", "additionalProperties": {"type": "boolean"}},
         },
     }
 }

--- a/lib/spack/spack/schema/cdash.py
+++ b/lib/spack/spack/schema/cdash.py
@@ -15,7 +15,7 @@ properties: Dict[str, Any] = {
         "additionalProperties": False,
         # "required": ["build-group", "url", "project", "site"],
         "required": ["build-group"],
-        "patternProperties": {
+        "properties": {
             r"build-group": {"type": "string"},
             r"url": {"type": "string"},
             r"project": {"type": "string"},

--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -42,7 +42,7 @@ attributes_schema = {
         "tags": {"type": "array", "items": {"type": "string"}},
         "variables": {
             "type": "object",
-            "patternProperties": {r"[\w\d\-_\.]+": {"type": ["string", "number"]}},
+            "patternProperties": {r"^[\w\d\-_\.]+$": {"type": ["string", "number"]}},
         },
         "before_script": script_schema,
         "script": script_schema,

--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -42,7 +42,7 @@ attributes_schema = {
         "tags": {"type": "array", "items": {"type": "string"}},
         "variables": {
             "type": "object",
-            "patternProperties": {r"^[\w\d\-_\.]+$": {"type": ["string", "number"]}},
+            "patternProperties": {r"^[\w\-\.]+$": {"type": ["string", "number"]}},
         },
         "before_script": script_schema,
         "script": script_schema,

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -88,10 +88,12 @@ properties: Dict[str, Any] = {
             "allow_sgid": {"type": "boolean"},
             "install_status": {"type": "boolean"},
             "binary_index_root": {"type": "string"},
-            "url_fetch_method": {"type": "string", "pattern": r"^urllib$|^curl( .*)*"},
+            "url_fetch_method": {
+                "anyOf": [{"enum": ["urllib", "curl"]}, {"type": "string", "pattern": r"^curl "}]
+            },
             "additional_external_search_paths": {"type": "array", "items": {"type": "string"}},
             "binary_index_ttl": {"type": "integer", "minimum": 0},
-            "aliases": {"type": "object", "patternProperties": {r"\w[\w-]*": {"type": "string"}}},
+            "aliases": {"type": "object", "additionalProperties": {"type": "string"}},
         },
     }
 }

--- a/lib/spack/spack/schema/cray_manifest.py
+++ b/lib/spack/spack/schema/cray_manifest.py
@@ -91,19 +91,14 @@ properties: Dict[str, Any] = {
                 },
                 "dependencies": {
                     "type": "object",
-                    "patternProperties": {
-                        "\\w[\\w-]*": {
-                            "type": "object",
-                            "required": ["hash"],
-                            "additionalProperties": False,
-                            "properties": {
-                                "hash": {"type": "string", "minLength": 1},
-                                "type": {
-                                    "type": "array",
-                                    "items": {"type": "string", "minLength": 1},
-                                },
-                            },
-                        }
+                    "additionalProperties": {
+                        "type": "object",
+                        "required": ["hash"],
+                        "additionalProperties": False,
+                        "properties": {
+                            "hash": {"type": "string", "minLength": 1},
+                            "type": {"type": "array", "items": {"type": "string", "minLength": 1}},
+                        },
                     },
                 },
                 "prefix": {"type": "string", "minLength": 1},

--- a/lib/spack/spack/schema/database_index.py
+++ b/lib/spack/spack/schema/database_index.py
@@ -20,7 +20,7 @@ properties: Dict[str, Any] = {
             "installs": {
                 "type": "object",
                 "patternProperties": {
-                    r"^[\w\d]{32}$": {
+                    r"^[a-z0-9]{32}$": {
                         "type": "object",
                         "properties": {
                             "spec": spack.schema.spec.spec_node,

--- a/lib/spack/spack/schema/develop.py
+++ b/lib/spack/spack/schema/develop.py
@@ -7,14 +7,11 @@ properties: Dict[str, Any] = {
     "develop": {
         "type": "object",
         "default": {},
-        "additionalProperties": False,
-        "patternProperties": {
-            r"\w[\w-]*": {
-                "type": "object",
-                "additionalProperties": False,
-                "required": ["spec"],
-                "properties": {"spec": {"type": "string"}, "path": {"type": "string"}},
-            }
+        "additionalProperties": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["spec"],
+            "properties": {"spec": {"type": "string"}, "path": {"type": "string"}},
         },
     }
 }

--- a/lib/spack/spack/schema/environment.py
+++ b/lib/spack/spack/schema/environment.py
@@ -15,7 +15,7 @@ array_of_strings_or_num = {
 
 dictionary_of_strings_or_num = {
     "type": "object",
-    "patternProperties": {r"\w[\w-]*": {"anyOf": [{"type": "string"}, {"type": "number"}]}},
+    "additionalProperties": {"anyOf": [{"type": "string"}, {"type": "number"}]},
 }
 
 definition: Dict[str, Any] = {

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -58,8 +58,7 @@ properties: Dict[str, Any] = {
     "mirrors": {
         "type": "object",
         "default": {},
-        "additionalProperties": False,
-        "patternProperties": {r"\w[\w-]*": {"anyOf": [{"type": "string"}, mirror_entry]}},
+        "additionalProperties": {"anyOf": [{"type": "string"}, mirror_entry]},
     }
 }
 

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -15,8 +15,6 @@ import spack.schema.projections
 #: Definitions for parts of module schema
 array_of_strings = {"type": "array", "default": [], "items": {"type": "string"}}
 
-dictionary_of_strings = {"type": "object", "patternProperties": {r"\w[\w-]*": {"type": "string"}}}
-
 dependency_selection = {"type": "string", "enum": ["none", "run", "direct", "all"]}
 
 module_file_configuration = {
@@ -103,11 +101,8 @@ module_config_properties = {
     "tcl": tcl_configuration,
     "prefix_inspections": {
         "type": "object",
-        "additionalProperties": False,
-        "patternProperties": {
-            # prefix-relative path to be inspected for existence
-            r"^[\w-]*": array_of_strings
-        },
+        # prefix-relative path to be inspected for existence
+        "additionalProperties": array_of_strings,
     },
 }
 
@@ -119,11 +114,8 @@ properties: Dict[str, Any] = {
         "properties": {
             "prefix_inspections": {
                 "type": "object",
-                "additionalProperties": False,
-                "patternProperties": {
-                    # prefix-relative path to be inspected for existence
-                    r"^[\w-]*": array_of_strings
-                },
+                # prefix-relative path to be inspected for existence
+                "additionalProperties": array_of_strings,
             }
         },
         "additionalProperties": {

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -88,7 +88,7 @@ permissions = {
 package_attributes = {
     "type": "object",
     "additionalProperties": False,
-    "patternProperties": {r"\w+": {}},
+    "patternProperties": {r"^[^\d\W]\w*$": {}},
 }
 
 REQUIREMENT_URL = "https://spack.readthedocs.io/en/latest/packages_yaml.html#package-requirements"
@@ -126,13 +126,10 @@ properties: Dict[str, Any] = {
                     "providers": {
                         "type": "object",
                         "default": {},
-                        "additionalProperties": False,
-                        "patternProperties": {
-                            r"\w[\w-]*": {
-                                "type": "array",
-                                "default": [],
-                                "items": {"type": "string"},
-                            }
+                        "additionalProperties": {
+                            "type": "array",
+                            "default": [],
+                            "items": {"type": "string"},
                         },
                     },
                     "variants": variants,
@@ -182,7 +179,7 @@ properties: Dict[str, Any] = {
                                 "properties": {
                                     "compilers": {
                                         "type": "object",
-                                        "patternProperties": {r"(^\w[\w-]*)": {"type": "string"}},
+                                        "patternProperties": {r"^\w": {"type": "string"}},
                                     },
                                     "environment": spack.schema.environment.definition,
                                     "extra_rpaths": extra_rpaths,

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -88,7 +88,7 @@ permissions = {
 package_attributes = {
     "type": "object",
     "additionalProperties": False,
-    "patternProperties": {r"^[^\d\W]\w*$": {}},
+    "patternProperties": {r"^[a-zA-Z_]\w*$": {}},
 }
 
 REQUIREMENT_URL = "https://spack.readthedocs.io/en/latest/packages_yaml.html#package-requirements"

--- a/lib/spack/spack/schema/projections.py
+++ b/lib/spack/spack/schema/projections.py
@@ -11,7 +11,12 @@ from typing import Any, Dict
 
 #: Properties for inclusion in other schemas
 properties: Dict[str, Any] = {
-    "projections": {"type": "object", "patternProperties": {r"all|\w[\w-]*": {"type": "string"}}}
+    "projections": {
+        "type": "object",
+        "properties": {"all": {"type": "string"}},
+        "additionalKeysAreSpecs": True,
+        "additionalProperties": {"type": "string"},
+    }
 }
 
 

--- a/lib/spack/spack/schema/upstreams.py
+++ b/lib/spack/spack/schema/upstreams.py
@@ -8,19 +8,17 @@ properties: Dict[str, Any] = {
     "upstreams": {
         "type": "object",
         "default": {},
-        "patternProperties": {
-            r"\w[\w-]*": {
-                "type": "object",
-                "default": {},
-                "additionalProperties": False,
-                "properties": {
-                    "install_tree": {"type": "string"},
-                    "modules": {
-                        "type": "object",
-                        "properties": {"tcl": {"type": "string"}, "lmod": {"type": "string"}},
-                    },
+        "additionalProperties": {
+            "type": "object",
+            "default": {},
+            "additionalProperties": False,
+            "properties": {
+                "install_tree": {"type": "string"},
+                "modules": {
+                    "type": "object",
+                    "properties": {"tcl": {"type": "string"}, "lmod": {"type": "string"}},
                 },
-            }
+            },
         },
     }
 }

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -22,19 +22,17 @@ properties: Dict[str, Any] = {
             {"type": "string"},
             {
                 "type": "object",
-                "patternProperties": {
-                    r"\w+": {
-                        "required": ["root"],
-                        "additionalProperties": False,
-                        "properties": {
-                            "root": {"type": "string"},
-                            "link": {"type": "string", "pattern": "(roots|all|run)"},
-                            "link_type": {"type": "string"},
-                            "select": {"type": "array", "items": {"type": "string"}},
-                            "exclude": {"type": "array", "items": {"type": "string"}},
-                            "projections": projections_scheme,
-                        },
-                    }
+                "additionalProperties": {
+                    "required": ["root"],
+                    "additionalProperties": False,
+                    "properties": {
+                        "root": {"type": "string"},
+                        "link": {"enum": ["roots", "all", "run"]},
+                        "link_type": {"type": "string"},
+                        "select": {"type": "array", "items": {"type": "string"}},
+                        "exclude": {"type": "array", "items": {"type": "string"}},
+                        "projections": projections_scheme,
+                    },
                 },
             },
         ]


### PR DESCRIPTION
In various cases, people tried to express "valid identifier" as
`\w[\w-]*` but glanced over the fact that it needs `^...$`. So, most of
the `patternProperties` we've used were simply wrong.

Then, a second issue is that some of these patterns were actually wrong
for their use case, such as matching specs in projections, where
`\w[\w-]+` was used, which would not match `^zlib` when wrapping it in
`^...$`. Our docs however advertise that in examples.

To me the simplest solution is to just allow all keys with
`additionalProperties`.
