### PR TITLE
docs: add opengraph tags

### DIFF
--- a/lib/spack/docs/_common/og.rst
+++ b/lib/spack/docs/_common/og.rst
@@ -1,0 +1,11 @@
+.. Copyright Spack Project Developers. See COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. meta::
+   :og:image:
+      https://spack.readthedocs.io/en/latest/_static/spack-logo.png
+   :og:image:width:
+      1200
+   :og:image:height:
+      630

--- a/lib/spack/docs/advanced_topics.rst
+++ b/lib/spack/docs/advanced_topics.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Explore advanced topics in Spack, including auditing packages and configuration, and verifying installations.
+   :og:description:
+      Explore advanced topics in Spack, including auditing packages and configuration, and verifying installations.
+   :og:title:
+      Advanced Topics in Spack: Auditing and Verification
 
 .. _cmd-spack-audit:
 

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Discover how to create, use, and manage build caches in Spack to share pre-built binary packages and speed up installations.
+   :og:description:
+      Discover how to create, use, and manage build caches in Spack to share pre-built binary packages and speed up installations.
+   :og:title:
+      Managing Build Caches in Spack for Faster Installations
 
 .. _binary_caches:
 

--- a/lib/spack/docs/bootstrapping.rst
+++ b/lib/spack/docs/bootstrapping.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how Spack's bootstrapping feature automatically fetches and installs essential build tools when they are not available on the host system.
+   :og:description:
+      Learn how Spack's bootstrapping feature automatically fetches and installs essential build tools when they are not available on the host system.
+   :og:title:
+      Automated Build Tool Bootstrapping with Spack
 
 .. _bootstrapping:
 .. _cmd-spack-bootstrap:

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Understand how to control the build process in Spack by customizing package-specific build settings and environment variables.
+   :og:description:
+      Understand how to control the build process in Spack by customizing package-specific build settings and environment variables.
+   :og:title:
+      Customizing Build Settings and Environment in Spack
 
 .. _concretizer-options:
 

--- a/lib/spack/docs/build_systems.rst
+++ b/lib/spack/docs/build_systems.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       An overview of the build systems supported by Spack, with links to detailed documentation for each system.
+   :og:description:
+      An overview of the build systems supported by Spack, with links to detailed documentation for each system.
+   :og:title:
+      A Comprehensive Overview of Build Systems in Spack
 
 .. _build-systems:
 

--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       An overview of the Autotools build system in Spack for packages that use GNU Autotools.
+   :og:description:
+      An overview of the Autotools build system in Spack for packages that use GNU Autotools.
+   :og:title:
+      Using the Autotools Build System in Spack
 
 .. _autotoolspackage:
 

--- a/lib/spack/docs/build_systems/bundlepackage.rst
+++ b/lib/spack/docs/build_systems/bundlepackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Discover how to create meta-packages known as "bundles" in Spack to group multiple packages together for a single installation.
+   :og:description:
+      Discover how to create meta-packages known as "bundles" in Spack to group multiple packages together for a single installation.
+   :og:title:
+      Creating and Using Bundle Packages in Spack
 
 .. _bundlepackage:
 

--- a/lib/spack/docs/build_systems/cachedcmakepackage.rst
+++ b/lib/spack/docs/build_systems/cachedcmakepackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn about the CachedCMakePackage build system in Spack for CMake-based projects.
+   :og:description:
+      Learn about the CachedCMakePackage build system in Spack for CMake-based projects.
+   :og:title:
+      Using the CachedCMakePackage Build System in Spack
 
 .. _cachedcmakepackage:
 

--- a/lib/spack/docs/build_systems/cmakepackage.rst
+++ b/lib/spack/docs/build_systems/cmakepackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to package software that uses the CMake build system with Spack, covering common practices and customization options for CMake-based packages.
+   :og:description:
+      Learn how to package software that uses the CMake build system with Spack, covering common practices and customization options for CMake-based packages.
+   :og:title:
+      Packaging CMake-Based Software with Spack
 
 .. _cmakepackage:
 

--- a/lib/spack/docs/build_systems/cudapackage.rst
+++ b/lib/spack/docs/build_systems/cudapackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to packaging CUDA applications with Spack, including helpers for managing CUDA dependencies and architecture-specific builds.
+   :og:description:
+      A guide to packaging CUDA applications with Spack, including helpers for managing CUDA dependencies and architecture-specific builds.
+   :og:title:
+      Packaging CUDA Applications with Spack
 
 .. _cudapackage:
 

--- a/lib/spack/docs/build_systems/custompackage.rst
+++ b/lib/spack/docs/build_systems/custompackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to creating custom build systems in Spack for packaging software with its own build scripts or adding support for new build systems.
+   :og:description:
+      A guide to creating custom build systems in Spack for packaging software with its own build scripts or adding support for new build systems.
+   :og:title:
+      Creating Custom Build Systems in Spack
 
 .. _custompackage:
 

--- a/lib/spack/docs/build_systems/inteloneapipackage.rst
+++ b/lib/spack/docs/build_systems/inteloneapipackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to using the Intel oneAPI packages in Spack, including how to build with icx, use the oneAPI Spack environment, and configure externally installed oneAPI tools.
+   :og:description:
+      A guide to using the Intel oneAPI packages in Spack, including how to build with icx, use the oneAPI Spack environment, and configure externally installed oneAPI tools.
+   :og:title:
+      Using Intel oneAPI Packages in Spack
 
 .. _inteloneapipackage:
 

--- a/lib/spack/docs/build_systems/luapackage.rst
+++ b/lib/spack/docs/build_systems/luapackage.rst
@@ -3,9 +3,15 @@
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn about the Lua build system in Spack for packages using rockspec files.
+   :og:description:
+      Learn about the Lua build system in Spack for packages using rockspec files.
+   :og:title:
+      Using the Lua Build System in Spack
 
 .. _luapackage:
 

--- a/lib/spack/docs/build_systems/makefilepackage.rst
+++ b/lib/spack/docs/build_systems/makefilepackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to using the Makefile build system in Spack for packages that use plain Makefiles.
+   :og:description:
+      A guide to using the Makefile build system in Spack for packages that use plain Makefiles.
+   :og:title:
+      Using the Makefile Build System in Spack
 
 .. _makefilepackage:
 

--- a/lib/spack/docs/build_systems/mavenpackage.rst
+++ b/lib/spack/docs/build_systems/mavenpackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn about the Maven build system in Spack for building and managing Java-based projects.
+   :og:description:
+      Learn about the Maven build system in Spack for building and managing Java-based projects.
+   :og:title:
+      Using the Maven Build System in Spack
 
 .. _mavenpackage:
 

--- a/lib/spack/docs/build_systems/mesonpackage.rst
+++ b/lib/spack/docs/build_systems/mesonpackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to use the Meson build system in Spack for projects that use Meson for their build process.
+   :og:description:
+      Learn how to use the Meson build system in Spack for projects that use Meson for their build process.
+   :og:title:
+      Using the Meson Build System in Spack
 
 .. _mesonpackage:
 

--- a/lib/spack/docs/build_systems/octavepackage.rst
+++ b/lib/spack/docs/build_systems/octavepackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn about the Octave build system in Spack for installing Octave packages.
+   :og:description:
+      Learn about the Octave build system in Spack for installing Octave packages.
+   :og:title:
+      Using the Octave Build System in Spack
 
 .. _octavepackage:
 

--- a/lib/spack/docs/build_systems/perlpackage.rst
+++ b/lib/spack/docs/build_systems/perlpackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to packaging Perl modules with Spack, covering when to add a package and build system integration.
+   :og:description:
+      A guide to packaging Perl modules with Spack, covering when to add a package and build system integration.
+   :og:title:
+      Packaging Perl Modules with Spack
 
 .. _perlpackage:
 

--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to packaging Python libraries with Spack, covering PyPI downloads, dependency management, and build system integration.
+   :og:description:
+      A guide to packaging Python libraries with Spack, covering PyPI downloads, dependency management, and build system integration.
+   :og:title:
+      Packaging Python Libraries with Spack
 
 .. _pythonpackage:
 

--- a/lib/spack/docs/build_systems/qmakepackage.rst
+++ b/lib/spack/docs/build_systems/qmakepackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn about the QMake build system in Spack, a script generator for Qt-based projects.
+   :og:description:
+      Learn about the QMake build system in Spack, a script generator for Qt-based projects.
+   :og:title:
+      Using the QMake Build System in Spack
 
 .. _qmakepackage:
 

--- a/lib/spack/docs/build_systems/racketpackage.rst
+++ b/lib/spack/docs/build_systems/racketpackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn about the Racket build system in Spack for installing Racket packages and modules.
+   :og:description:
+      Learn about the Racket build system in Spack for installing Racket packages and modules.
+   :og:title:
+      Using the Racket Build System in Spack
 
 .. _racketpackage:
 

--- a/lib/spack/docs/build_systems/rocmpackage.rst
+++ b/lib/spack/docs/build_systems/rocmpackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn about the ROCmPackage helper in Spack, which provides standard variants, dependencies, and conflicts for building packages that target AMD GPUs.
+   :og:description:
+      Learn about the ROCmPackage helper in Spack, which provides standard variants, dependencies, and conflicts for building packages that target AMD GPUs.
+   :og:title:
+      Building ROCm Packages with Spack
 
 .. _rocmpackage:
 

--- a/lib/spack/docs/build_systems/rpackage.rst
+++ b/lib/spack/docs/build_systems/rpackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to packaging R libraries and applications with Spack, including support for CRAN, Bioconductor, and GitHub sources.
+   :og:description:
+      A guide to packaging R libraries and applications with Spack, including support for CRAN, Bioconductor, and GitHub sources.
+   :og:title:
+      Packaging R Libraries and Applications with Spack
 
 .. _rpackage:
 

--- a/lib/spack/docs/build_systems/rubypackage.rst
+++ b/lib/spack/docs/build_systems/rubypackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Discover the Ruby build system in Spack for installing Ruby gems, with support for gemspec, Rakefile, and pre-packaged .gem files.
+   :og:description:
+      Discover the Ruby build system in Spack for installing Ruby gems, with support for gemspec, Rakefile, and pre-packaged .gem files.
+   :og:title:
+      Using the Ruby Build System in Spack
 
 .. _rubypackage:
 

--- a/lib/spack/docs/build_systems/sconspackage.rst
+++ b/lib/spack/docs/build_systems/sconspackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn about the SCons build system in Spack, a Python-based tool that handles building and linking without relying on Makefiles.
+   :og:description:
+      Learn about the SCons build system in Spack, a Python-based tool that handles building and linking without relying on Makefiles.
+   :og:title:
+      Using the SCons Build System in Spack
 
 .. _sconspackage:
 

--- a/lib/spack/docs/build_systems/sippackage.rst
+++ b/lib/spack/docs/build_systems/sippackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to using the SIP build system in Spack for creating Python bindings for C and C++ libraries.
+   :og:description:
+      A guide to using the SIP build system in Spack for creating Python bindings for C and C++ libraries.
+   :og:title:
+      Using the SIP Build System in Spack
 
 .. _sippackage:
 

--- a/lib/spack/docs/build_systems/sourceforgepackage.rst
+++ b/lib/spack/docs/build_systems/sourceforgepackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Discover how to use the SourceforgePackage mixin in Spack to automatically generate download URLs for packages hosted on SourceForge.
+   :og:description:
+      Discover how to use the SourceforgePackage mixin in Spack to automatically generate download URLs for packages hosted on SourceForge.
+   :og:title:
+      Using the SourceforgePackage Mixin in Spack
 
 .. _sourceforgepackage:
 

--- a/lib/spack/docs/build_systems/wafpackage.rst
+++ b/lib/spack/docs/build_systems/wafpackage.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Explore the Waf build system in Spack, a Python-based tool for configuring and building software projects without Makefiles.
+   :og:description:
+      Explore the Waf build system in Spack, a Python-based tool for configuring and building software projects without Makefiles.
+   :og:title:
+      Using the Waf Build System in Spack
 
 .. _wafpackage:
 

--- a/lib/spack/docs/chain.rst
+++ b/lib/spack/docs/chain.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to chain Spack installations by pointing one Spack instance to another to use its installed packages.
+   :og:description:
+      Learn how to chain Spack installations by pointing one Spack instance to another to use its installed packages.
+   :og:title:
+      Chaining Spack Installations for Shared Packages
 
 Chaining Spack Installations (upstreams.yaml)
 =============================================

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -4,9 +4,15 @@
 
 .. _config-yaml:
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A detailed guide to the config.yaml file in Spack, which allows you to set core configuration options like installation paths, build parallelism, and trusted sources.
+   :og:description:
+      A detailed guide to the config.yaml file in Spack, which allows you to set core configuration options like installation paths, build parallelism, and trusted sources.
+   :og:title:
+      Configuring Spack with the config.yaml File
 
 Spack Settings (config.yaml)
 ============================

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to configure Spack using its flexible YAML-based system. This guide covers the different configuration scopes and provides links to detailed documentation for each configuration file, helping you customize Spack to your specific needs.
+   :og:description:
+      Learn how to configure Spack using its flexible YAML-based system. This guide covers the different configuration scopes and provides links to detailed documentation for each configuration file, helping you customize Spack to your specific needs.
+   :og:title:
+      Customizing Spack with YAML Configuration Files
 
 .. _configuration:
 

--- a/lib/spack/docs/configuring_compilers.rst
+++ b/lib/spack/docs/configuring_compilers.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Discover how to configure compilers in Spack, whether by specifying them as externals, or by installing them with Spack.
+   :og:description:
+      Discover how to configure compilers in Spack, whether by specifying them as externals, or by installing them with Spack.
+   :og:title:
+      Configuring Compilers in Spack
 
 .. _compiler-config:
 

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to turn Spack environments into container images, either by copying existing installations or by generating recipes for Docker and Singularity.
+   :og:description:
+      Learn how to turn Spack environments into container images, either by copying existing installations or by generating recipes for Docker and Singularity.
+   :og:title:
+      Creating Container Images with Spack
 
 .. _containers:
 

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide for developers and administrators on contributing new packages, features, or bug fixes to Spack, covering Git workflows, pull requests, and continuous integration testing.
+   :og:description:
+      A guide for developers and administrators on contributing new packages, features, or bug fixes to Spack, covering Git workflows, pull requests, and continuous integration testing.
+   :og:title:
+      Contributing to the Spack Project
 
 .. _contribution-guide:
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A comprehensive guide for developers working on Spack itself, covering the directory structure, code organization, and key concepts like specs and packages.
+   :og:description:
+      A comprehensive guide for developers working on Spack itself, covering the directory structure, code organization, and key concepts like specs and packages.
+   :og:title:
+      A Developer's Guide to the Spack Internals
 
 .. _developer_guide:
 

--- a/lib/spack/docs/env_vars_yaml.rst
+++ b/lib/spack/docs/env_vars_yaml.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to modify shell environment variables within a Spack environment using the env_vars.yaml file.
+   :og:description:
+      Learn how to modify shell environment variables within a Spack environment using the env_vars.yaml file.
+   :og:title:
+      Managing Environment Variables in Spack
 
 .. _env-vars-yaml:
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to use Spack environments to manage reproducible software stacks, making it easy to share and recreate specific sets of packages and their dependencies.
+   :og:description:
+      Learn how to use Spack environments to manage reproducible software stacks, making it easy to share and recreate specific sets of packages and their dependencies.
+   :og:title:
+      Managing Reproducible Software Stacks with Spack
 
 .. _environments:
 

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Discover how to extend Spack's core functionality by creating custom commands and plugins.
+   :og:description:
+      Discover how to extend Spack's core functionality by creating custom commands and plugins.
+   :og:title:
+      Extending Spack with Custom Commands and Plugins
 
 Custom Extensions
 =================

--- a/lib/spack/docs/features.rst
+++ b/lib/spack/docs/features.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       An overview of the key features that distinguish Spack from other package managers, including simple installation, custom configurations, and non-destructive installs.
+   :og:description:
+      An overview of the key features that distinguish Spack from other package managers, including simple installation, custom configurations, and non-destructive installs.
+   :og:title:
+      An Overview of Spack's Key Features
 
 Feature Overview
 ================

--- a/lib/spack/docs/frequently_asked_questions.rst
+++ b/lib/spack/docs/frequently_asked_questions.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Answers to common Spack questions, including version and variant selection, package preferences, compiler configuration, and concretizer behavior, with practical YAML and command-line examples.
+   :og:description:
+      Answers to common Spack questions, including version and variant selection, package preferences, compiler configuration, and concretizer behavior, with practical YAML and command-line examples.
+   :og:title:
+      Frequently Asked Questions about Spack
 
 Frequently Asked Questions
 ==========================

--- a/lib/spack/docs/getting_help.rst
+++ b/lib/spack/docs/getting_help.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Find out how to get help with Spack, including using the spack help command.
+   :og:description:
+      Find out how to get help with Spack, including using the spack help command.
+   :og:title:
+      Getting Help with Spack
 
 Getting Help
 ============

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A beginner's guide to Spack, walking you through the initial setup, basic commands, and core concepts to get you started with managing software.
+   :og:description:
+      A beginner's guide to Spack, walking you through the initial setup, basic commands, and core concepts to get you started with managing software.
+   :og:title:
+      Getting Started with Spack: A Beginner's Guide
 
 .. _getting_started:
 

--- a/lib/spack/docs/gpu_configuration.rst
+++ b/lib/spack/docs/gpu_configuration.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to configuring Spack to use external GPU support, including ROCm and CUDA installations, as well as the OpenGL API.
+   :og:description:
+      A guide to configuring Spack to use external GPU support, including ROCm and CUDA installations, as well as the OpenGL API.
+   :og:title:
+      Configuring Spack for GPU Support
 
 Using External GPU Support
 ==========================

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to use include directives to modularize your Spack YAML configuration files for better organization and reusability.
+   :og:description:
+      Learn how to use include directives to modularize your Spack YAML configuration files for better organization and reusability.
+   :og:title:
+      Modularizing Spack Configuration with Includes
 
 .. _include-yaml:
 

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -7,9 +7,15 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Documentation of Spack, a flexible package manager for high-performance computing, designed to support multiple versions and configurations of software on a wide variety of platforms.
+   :og:description:
+      Documentation of Spack, a flexible package manager for high-performance computing, designed to support multiple versions and configurations of software on a wide variety of platforms.
+   :og:title:
+      Spack: A Flexible Package Manager for HPC
 
 Spack
 ===================

--- a/lib/spack/docs/installing_prerequisites.rst
+++ b/lib/spack/docs/installing_prerequisites.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Find instructions on how to install the necessary prerequisites for Spack on various operating systems, including Linux and macOS.
+   :og:description:
+      Find instructions on how to install the necessary prerequisites for Spack on various operating systems, including Linux and macOS.
+   :og:title:
+      Installing Prerequisites for Spack
 
 .. _verify-spack-prerequisites:
 

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Discover how to set up and manage mirrors in Spack to provide a local repository of tarballs for offline package fetching.
+   :og:description:
+      Discover how to set up and manage mirrors in Spack to provide a local repository of tarballs for offline package fetching.
+   :og:title:
+      Setting Up and Managing Mirrors in Spack
 
 .. _mirrors:
 

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to configure and customize module file generation in Spack for Environment Modules and Lmod.
+   :og:description:
+      Learn how to configure and customize module file generation in Spack for Environment Modules and Lmod.
+   :og:title:
+      Configuring Module File Generation in Spack
 
 .. _modules:
 

--- a/lib/spack/docs/package_api.rst
+++ b/lib/spack/docs/package_api.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       An overview of the Spack Package API, a stable interface for package authors to interact with the Spack framework.
+   :og:description:
+      An overview of the Spack Package API, a stable interface for package authors to interact with the Spack framework.
+   :og:title:
+      An Overview of the Spack Package API
 
 Spack Package API v2.2
 ======================

--- a/lib/spack/docs/package_fundamentals.rst
+++ b/lib/spack/docs/package_fundamentals.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn the fundamental Spack commands for managing software packages, including how to find, inspect, install, and remove them.
+   :og:description:
+      Learn the fundamental Spack commands for managing software packages, including how to find, inspect, install, and remove them.
+   :og:title:
+      Fundamental Spack Commands for Package Management
 
 .. _basic-usage:
 

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to customizing package settings in Spack using the packages.yaml file, including configuring compilers, specifying external packages, package requirements, and permissions.
+   :og:description:
+      A guide to customizing package settings in Spack using the packages.yaml file, including configuring compilers, specifying external packages, package requirements, and permissions.
+   :og:title:
+      Customizing Package Settings in Spack
 
 .. _packages-config:
 

--- a/lib/spack/docs/packaging_guide_advanced.rst
+++ b/lib/spack/docs/packaging_guide_advanced.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Advanced topics in Spack packaging, covering packages with multiple build systems, making packages discoverable with spack external find, and specifying ABI compatibility.
+   :og:description:
+      Advanced topics in Spack packaging, covering packages with multiple build systems, making packages discoverable with spack external find, and specifying ABI compatibility.
+   :og:title:
+      Advanced Topics in Spack Packaging
 
 .. list-table::
    :widths: 25 25 25 25

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to customizing the build process in Spack, covering installation procedures, build systems, and how to control the build with spec objects and environment variables.
+   :og:description:
+      A guide to customizing the build process in Spack, covering installation procedures, build systems, and how to control the build with spec objects and environment variables.
+   :og:title:
+      Customizing the Build Process in Spack
 
 .. list-table::
    :widths: 25 25 25 25

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide for developers and administrators on how to package software for Spack, covering the structure of a package, creating and editing packages, and defining dependencies and variants.
+   :og:description:
+      A guide for developers and administrators on how to package software for Spack, covering the structure of a package, creating and editing packages, and defining dependencies and variants.
+   :og:title:
+      A Guide to Packaging Software for Spack
 
 .. list-table::
    :widths: 25 25 25 25

--- a/lib/spack/docs/packaging_guide_testing.rst
+++ b/lib/spack/docs/packaging_guide_testing.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to adding tests to Spack packages to ensure correct installation and functionality.
+   :og:description:
+      A guide to adding tests to Spack packages to ensure correct installation and functionality.
+   :og:title:
+      Adding Tests to Spack Packages
 
 .. list-table::
    :widths: 25 25 25 25

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to generate and run automated build pipelines in Spack for CI instances, enabling the building and deployment of binaries and reporting to CDash.
+   :og:description:
+      Learn how to generate and run automated build pipelines in Spack for CI instances, enabling the building and deployment of binaries and reporting to CDash.
+   :og:title:
+      Generating Automated Build Pipelines in Spack
 
 .. _pipelines:
 

--- a/lib/spack/docs/replace_conda_homebrew.rst
+++ b/lib/spack/docs/replace_conda_homebrew.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to use Spack environments to manage single-user installations, similar to Homebrew and Conda.
+   :og:description:
+      Learn how to use Spack environments to manage single-user installations, similar to Homebrew and Conda.
+   :og:title:
+      Using Spack Environments for Single-User Installations
 
 .. _spack-environments-basic-usage:
 

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Learn how to set up and manage package repositories in Spack, enabling you to maintain custom packages and override built-in ones.
+   :og:description:
+      Learn how to set up and manage package repositories in Spack, enabling you to maintain custom packages and override built-in ones.
+   :og:title:
+      Managing Package Repositories in Spack
 
 .. _repositories:
 

--- a/lib/spack/docs/signing.rst
+++ b/lib/spack/docs/signing.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Understand the Spack package signing process, which ensures data integrity for official packages from automated CI pipelines through cryptographic signing.
+   :og:description:
+      Understand the Spack package signing process, which ensures data integrity for official packages from automated CI pipelines through cryptographic signing.
+   :og:title:
+      Understanding the Spack Package Signing Process
 
 
 .. _signing:

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A detailed guide to the Spack spec syntax for describing package constraints, including versions, variants, and dependencies.
+   :og:description:
+      A detailed guide to the Spack spec syntax for describing package constraints, including versions, variants, and dependencies.
+   :og:title:
+      A Detailed Guide to the Spack Spec Syntax
 
 .. _sec-specs:
 

--- a/lib/spack/docs/toolchains_yaml.rst
+++ b/lib/spack/docs/toolchains_yaml.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       Define named compiler sets (toolchains) in Spack to easily and consistently apply compiler choices for C, C++, and Fortran across different packages.
+   :og:description:
+      Define named compiler sets (toolchains) in Spack to easily and consistently apply compiler choices for C, C++, and Fortran across different packages.
+   :og:title:
+      Defining Compiler Toolchains in Spack
 
 .. _toolchains:
 

--- a/lib/spack/docs/windows.rst
+++ b/lib/spack/docs/windows.rst
@@ -2,9 +2,15 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. include:: /_common/og.rst
+
 .. meta::
    :description lang=en:
       A guide to setting up and using Spack on Windows, including installing prerequisites and configuring the environment.
+   :og:description:
+      A guide to setting up and using Spack on Windows, including installing prerequisites and configuring the environment.
+   :og:title:
+      Setting Up and Using Spack on Windows
 
 .. _windows_support:
 


### PR DESCRIPTION
Add various https://ogp.me/ tags, so that title, description, and image are
included when sharing links to Spack documentation (e.g. on Slack, social
media, etc).

Edit: the Slack link preview actually looks worse :(
