### PR TITLE
git provenance: minimally invasive access to mirrors for abstract specs

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1088,7 +1088,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         sha = None
 
         # construct a package instance to get fetch/staging together
-        # TODO need to refactor mirror/stage/package relationship to remove pkg construction here
         pkg_instance = cls(spec.copy())
 
         try:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1055,6 +1055,17 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         return False
 
     @classmethod
+    def commit_from_src_mirror(cls, spec) -> Optional[str]:
+        # commit = check_local_cache(spec)
+        # if commit:
+        #    return commit
+        # for m in other_source_mirrors:
+        #     add_src_if_spec_in_mirror(m, spec)
+        # commit = check_local_cache(spec)
+        # return commit
+        pass
+
+    @classmethod
     def _resolve_git_provenance(cls, spec) -> None:
         # early return cases, don't overwrite user intention
         # commit pre-assigned or develop specs don't need commits changed
@@ -1088,6 +1099,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         sha = None
 
         # construct a package instance to get fetch/staging together
+        # TODO we really need to detangle package class, fetcher, stage, and mirrors
         pkg_instance = cls(spec.copy())
 
         try:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1055,17 +1055,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         return False
 
     @classmethod
-    def commit_from_src_mirror(cls, spec) -> Optional[str]:
-        # commit = check_local_cache(spec)
-        # if commit:
-        #    return commit
-        # for m in other_source_mirrors:
-        #     add_src_if_spec_in_mirror(m, spec)
-        # commit = check_local_cache(spec)
-        # return commit
-        pass
-
-    @classmethod
     def _resolve_git_provenance(cls, spec) -> None:
         # early return cases, don't overwrite user intention
         # commit pre-assigned or develop specs don't need commits changed
@@ -1099,7 +1088,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         sha = None
 
         # construct a package instance to get fetch/staging together
-        # TODO we really need to detangle package class, fetcher, stage, and mirrors
+        # TODO need to refactor mirror/stage/package relationship to remove pkg construction here
         pkg_instance = cls(spec.copy())
 
         try:

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -58,8 +58,12 @@ stage_prefix = "spack-stage-"
 
 def compute_stage_name(spec):
     """Determine stage name given a spec"""
-    default_stage_structure = stage_prefix + "{name}-{version}-{hash}"
-    stage_name_structure = spack.config.get("config:stage_name", default=default_stage_structure)
+    spec_stage_structure = stage_prefix
+    if spec.concrete:
+        spec_stage_structure += "{name}-{version}-{hash}"
+    else:
+        spec_stage_structure += "{name}-{version}"
+    stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
     return spec.format_path(format_string=stage_name_structure)
 
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -63,8 +63,8 @@ def compute_stage_name(spec):
         spec_stage_structure += "{name}-{version}-{hash}"
     else:
         spec_stage_structure += "{name}-{version}"
-    # TODO (psakiev, scheibelp) Technically a user could still reintroduce a hash via config:stage_name
-    # This is a fix for how to handle staging an abstact spec (see #51305)
+    # TODO (psakiev, scheibelp) Technically a user could still reintroduce a hash via 
+    # config:stage_name. This is a fix for how to handle staging an abstact spec (see #51305)
     stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
     return spec.format_path(format_string=stage_name_structure)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -63,6 +63,8 @@ def compute_stage_name(spec):
         spec_stage_structure += "{name}-{version}-{hash}"
     else:
         spec_stage_structure += "{name}-{version}"
+    # TODO (psakiev, scheibelp) Technically a user could still reintroduce a hash via config:stage_name
+    # This is a fix for how to handle staging an abstact spec (see #51305)
     stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
     return spec.format_path(format_string=stage_name_structure)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -63,7 +63,7 @@ def compute_stage_name(spec):
         spec_stage_structure += "{name}-{version}-{hash}"
     else:
         spec_stage_structure += "{name}-{version}"
-    # TODO (psakiev, scheibelp) Technically a user could still reintroduce a hash via 
+    # TODO (psakiev, scheibelp) Technically a user could still reintroduce a hash via
     # config:stage_name. This is a fix for how to handle staging an abstact spec (see #51305)
     stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
     return spec.format_path(format_string=stage_name_structure)


### PR DESCRIPTION
This is a temporary solution to #51280. Ideally we should just construct a fetcher and query the mirrors, but the source of the performance loss is hash  computation which could be avoided. 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
