### PR TITLE
Minor updates to developer guide

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -686,22 +686,22 @@ Both minor and patch releases are tagged.
 As a convenience, we also tag the latest release as ``releases/latest``, so that users can easily check it out to get the latest stable version.
 See :ref:`updating-latest-release` for more details.
 
-.. note::
+.. admonition:: PEP 440 compliance
+   :class: note
 
-   Older spack releases were merged **back** into develop so that we could do fancy things with tags, but since tarballs and many git checkouts do not have tags, this proved overly complex and confusing.
-
-   We have since converted to using `PEP 440 <https://peps.python.org/pep-0440/>`_ compliant versions.
-   `See here <https://github.com/spack/spack/pull/25267>`_ for details.
+   Spack releases up to ``v0.17`` were merged back into the ``develop`` branch to ensure that release tags would appear among its ancestors.
+   Since ``v0.18`` we opted to have a linear history of the ``develop`` branch, for reasons explained `here <https://github.com/spack/spack/pull/25267>`_.
+   At the same time, we converted to using `PEP 440 <https://peps.python.org/pep-0440/>`_ compliant versions.
 
 Scheduling work for releases
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We schedule work for **minor releases** through `milestones <https://github.com/spack/spack/milestones>`_ and `GitHub Projects <https://github.com/spack/spack/projects>`_, while **patch releases** use `labels <https://github.com/spack/spack/labels>`_.
 
-There is only one milestone open at a time.
+While there can be multiple milestones open at a given time, only one is usually active.
 Its name corresponds to the next major/minor version, for example ``v1.1.0``.
 Important issues and pull requests should be assigned to this milestone by core developers, so that they are not forgotten at the time of release.
-The milestone is closed when the release is made, and a new milestone is created for the next major/minor release.
+The milestone is closed when the release is made, and a new milestone is created for the next major/minor release, if not already there.
 
 Bug reports in GitHub issues are automatically labelled ``bug`` and ``triage``.
 Spack developers assign one of the labels ``impact-low``, ``impact-medium`` or ``impact-high``.
@@ -750,7 +750,7 @@ Assuming all required work from the milestone is completed, the steps to make th
 
 #. Update ``CHANGELOG.md`` with major highlights in bullet form.
 
-   Use proper Markdown formatting, like `this example from v0.15.0 <https://github.com/spack/spack/commit/d4bf70d9882fcfe88507e9cb444331d7dd7ba71c>`_.
+   Use proper Markdown formatting, like `this example from v1.0.0 <https://github.com/spack/spack/commit/b187f8758227abdfc9eb349a48f8b725aa27a162>`_.
 
 #. Push the release branch to GitHub.
 
@@ -816,7 +816,7 @@ When all commits are cherry-picked in the ``backports/vX.Y.Z`` branch, make the 
    2. Update ``CHANGELOG.md`` with a list of the changes.
 
    This is typically a summary of the commits you cherry-picked onto the release branch.
-   See `the changelog from v0.14.1 <https://github.com/spack/spack/commit/ff0abb9838121522321df2a054d18e54b566b44a>`_.
+   See `the changelog from v1.0.2 <https://github.com/spack/spack/commit/734c5db2121b01c373eed6538e452f18887e9e44>`_.
 
 #. Make sure CI passes on the **backports pull request**, including:
 
@@ -889,11 +889,11 @@ Updating `releases/latest`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If the new release is the **highest** Spack release yet, you should also tag it as ``releases/latest``.
-For example, suppose the highest release is currently ``v1.0.3``:
+For example, suppose the highest release is currently ``v1.1.3``:
 
-* If you are releasing ``v1.0.4`` or ``v1.1.0``, then you should tag it with ``releases/latest``, as these are higher than ``v1.0.3``.
+* If you are releasing ``v1.1.4`` or ``v1.2.0``, then you should tag it with ``releases/latest``, as these are higher than ``v1.1.3``.
 
-* If you are making a new release of an **older** minor version of Spack, e.g., ``v1.0.4``, then you should not tag it as ``releases/latest`` (as there are newer major/minor versions).
+* If you are making a new release of an **older** minor version of Spack, e.g., ``v1.0.5``, then you should not tag it as ``releases/latest`` (as there are newer major/minor versions).
 
 To do so, first fetch the latest tag created on GitHub, since you may not have it locally:
 


### PR DESCRIPTION
Modifications:
* Be more precise on PEP440 compliance, and linear history of develop
* Update a few old examples with more recent links
* Fix inconsistency in "Updating `releases/latest`"

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
