### PR TITLE
Correct the external GPU SW doc

### DIFF
--- a/lib/spack/docs/gpu_configuration.rst
+++ b/lib/spack/docs/gpu_configuration.rst
@@ -34,11 +34,6 @@ The following is an example ``packages.yaml`` that organizes a consistent set of
        externals:
        - spec: hsa-rocr-dev@5.3.0
          prefix: /opt/rocm-5.3.0/
-     llvm-amdgpu:
-       buildable: false
-       externals:
-       - spec: llvm-amdgpu@5.3.0
-         prefix: /opt/rocm-5.3.0/llvm/
      comgr:
        buildable: false
        externals:
@@ -74,9 +69,10 @@ This is in combination with the following compiler definition:
        externals:
        - spec: llvm-amdgpu@=5.3.0
          prefix: /opt/rocm-5.3.0
-         compilers:
-           c: /opt/rocm-5.3.0/bin/amdclang
-           cxx: /opt/rocm-5.3.0/bin/amdclang++
+         extra_attributes:
+	   compilers:
+             c: /opt/rocm-5.3.0/bin/amdclang
+             cxx: /opt/rocm-5.3.0/bin/amdclang++
 
 This includes the following considerations:
 

--- a/lib/spack/docs/gpu_configuration.rst
+++ b/lib/spack/docs/gpu_configuration.rst
@@ -70,7 +70,7 @@ This is in combination with the following compiler definition:
        - spec: llvm-amdgpu@=5.3.0
          prefix: /opt/rocm-5.3.0
          extra_attributes:
-	   compilers:
+           compilers:
              c: /opt/rocm-5.3.0/bin/amdclang
              cxx: /opt/rocm-5.3.0/bin/amdclang++
 


### PR DESCRIPTION
Fix two problems in the the external GPU documentation. 1) The llvm-amdgpu package was listed twice with searate content. If
   both are inserted into a packages.yaml file it ends up creating a
   duplicated key causing spack to stop. Delete the first one which
   doesn't seem to have the right data.
2) The second compiler definition for llvm-amdgpu has broken syntax It
   needs to have extra_attributes before defining the compilers.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
