### PR TITLE
solver: update heuristic priorities for virtuals and compilers

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1146,11 +1146,16 @@ class PyclingoDriver:
             timer.start("solve")
             time_limit = spack.config.CONFIG.get("concretizer:timeout", -1)
             error_on_timeout = spack.config.CONFIG.get("concretizer:error_on_timeout", True)
-            # Spack uses 0 to set no time limit, clingo API uses -1
-            if time_limit == 0:
-                time_limit = -1
             with self.control.solve(**solve_kwargs, async_=True) as handle:
-                finished = handle.wait(time_limit)
+                # We need the loop below to be able to Ctrl-C out of the solve
+                finished, remaining = handle.wait(0), time_limit
+                while not finished:
+                    if time_limit > 0:
+                        remaining -= 1
+                        if remaining < 0:
+                            break
+                    finished = handle.wait(1.0)
+
                 if not finished:
                     specs_str = ", ".join(
                         spack.llnl.util.lang.elide_list([str(s) for s in specs], 4)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -119,6 +119,7 @@ def default_clingo_control():
     control.configuration.configuration = "tweety"
     control.configuration.solver.heuristic = "Domain"
     control.configuration.solver.opt_strategy = "usc,one,1"
+    control.configuration.solve.parallel_mode = "2"
     return control
 
 

--- a/lib/spack/spack/solver/heuristic.lp
+++ b/lib/spack/spack/solver/heuristic.lp
@@ -6,26 +6,24 @@
 % Heuristic to speed-up solves
 %=============================================================================
 
-#heuristic node_compiler(ParentNode, CompilerNode). [1200, init]
-#heuristic node_compiler(ParentNode, CompilerNode). [  6, factor]
-#heuristic node_compiler(ParentNode, CompilerNode). [ -1, sign]
-#heuristic node_compiler(ParentNode, CompilerNode) : attr("depends_on", ParentNode, CompilerNode, "build"), provider_weight(CompilerNode, Language, 0), language(Language). [1@2, sign]
-
-#heuristic attr("virtual_node", node(X, Virtual)). [600, init]
+#heuristic attr("virtual_node", node(X, Virtual)). [1000, init]
 #heuristic attr("virtual_node", node(X, Virtual)). [-1, sign]
 #heuristic attr("virtual_node", node(0, Virtual)) : node_depends_on_virtual(PackageNode, Virtual). [1@2, sign]
-#heuristic attr("virtual_node", node(0, "c")).     [1@3, sign]
-#heuristic attr("virtual_node", node(0, "cxx")).   [1@3, sign]
+#heuristic attr("virtual_node", node(0, "c")).       [1@3, sign]
+#heuristic attr("virtual_node", node(0, "cxx")).     [1@3, sign]
+#heuristic attr("virtual_node", node(0, "libc")).    [1@3, sign]
 
-#heuristic unification_set(SetID, Node). [400, init]
-#heuristic unification_set(SetID, Node). [  4, factor]
-#heuristic unification_set(SetID, Node). [  -1, sign]
-#heuristic unification_set("root", node(0, "libc")). [  1@2, sign]
+#heuristic node_compiler(ParentNode, CompilerNode, Language). [200, init]
+#heuristic node_compiler(ParentNode, CompilerNode, Language). [ -1, sign]
+#heuristic node_compiler(ParentNode, CompilerNode, Language) : attr("depends_on", ParentNode, CompilerNode, "build"), provider_weight(CompilerNode, Language, 0), language(Language). [1@2, sign]
 
-#heuristic attr("node", PackageNode). [300, init]
+#heuristic attr("node", PackageNode). [100, init]
 #heuristic attr("node", PackageNode). [  4, factor]
 #heuristic attr("node", PackageNode). [ -1, sign]
 #heuristic attr("node", node(0, Dependency)) : attr("dependency_holds", ParentNode, Dependency, Type), not virtual(Dependency). [1@2, sign]
+#heuristic attr("node", node(0, Provider)) : provider_weight_from_config("c", Provider, 0).       [ 1@3, sign]
+#heuristic attr("node", node(0, Provider)) : provider_weight_from_config("cxx", Provider, 0).     [ 1@3, sign]
+#heuristic attr("node", node(0, Provider)) : provider_weight_from_config("fortran", Provider, 0). [ 1@3, sign]
 
 #heuristic attr("depends_on", ParentNode, ChildNode, Type). [100, init]
 #heuristic attr("depends_on", ParentNode, ChildNode, Type). [4,  factor]
@@ -35,16 +33,13 @@
 
 #heuristic attr("version", node(PackageID, Package), Version). [30, init]
 #heuristic attr("version", node(PackageID, Package), Version). [-1, sign]
-#heuristic attr("version", node(PackageID, Package), Version) : pkg_fact(Package, version_declared(Version, 0)), attr("node", node(PackageID, Package)). [ 1@2, sign]
 
 #heuristic version_weight(node(PackageID, Package), Weight).                                          [30, init]
 #heuristic version_weight(node(PackageID, Package), Weight).                                          [-1  , sign]
-#heuristic version_weight(node(PackageID, Package), 0     ) : attr("node", node(PackageID, Package)). [ 1@2, sign]
 
 % Use default variants
-#heuristic attr("variant_value", PackageNode, Variant, Value). [30, init]
+#heuristic attr("variant_value", PackageNode, Variant, Value). [50, init]
 #heuristic attr("variant_value", PackageNode, Variant, Value). [-1, sign]
-#heuristic attr("variant_value", PackageNode, Variant, Value) : variant_default_value(PackageNode, Variant, Value), attr("node", PackageNode). [1@2, sign]
 
 % Use default targets
 #heuristic attr("node_target", node(PackageID, Package), Target). [-1, sign]

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -897,14 +897,13 @@ def test_default_requirements_semantic(packages_yaml, concretize_scope, mock_pac
             ["libs=static", "libs=foo"],
         ),
         (
-            # (TODO): revisit this case when we'll have exact value semantic for mv variants
             """
         packages:
           all:
             require: "libs=static"
     """,
             "multivalue-variant",
-            ["libs=static", "libs=shared"],
+            ["libs=static"],
             [],
         ),
         (


### PR DESCRIPTION
New heuristics:
1. Prioritize decisions on which virtual nodes are in the DAG
2. Deprioritize decisions on which compilers are in the DAG
3. Don't guess unification sets, let clingo construct them based on other decisions

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
