### PR TITLE
gha: avoid spack-packages clone

### DIFF
--- a/.github/workflows/bin/format-rst.py
+++ b/.github/workflows/bin/format-rst.py
@@ -60,7 +60,7 @@ DOCUTILS_SETTING = {"report_level": 5, "raw_enabled": False, "file_insertion_ena
 
 
 def _warning(msg: str) -> str:
-    return f"\033[33mwarning:\033[0m {msg}"
+    return f"\033[1;31mwarning:\033[0m {msg}"
 
 
 class Warning:

--- a/.github/workflows/bin/format-rst.py
+++ b/.github/workflows/bin/format-rst.py
@@ -60,7 +60,7 @@ DOCUTILS_SETTING = {"report_level": 5, "raw_enabled": False, "file_insertion_ena
 
 
 def _warning(msg: str) -> str:
-    return f"\033[1;31mwarning:\033[0m {msg}"
+    return f"\033[1;33mwarning:\033[0m {msg}"
 
 
 class Warning:

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -51,13 +51,14 @@ jobs:
     - name: Install Python packages
       run: |
         pip install -r .github/workflows/requirements/style/requirements.txt
+        echo "PYTHONPATH=$PWD/lib/spack" >> $GITHUB_ENV
     - name: Run style tests (code)
       run: |
         bin/spack style --base HEAD^1
         bin/spack license verify
         pylint -j $(nproc) --disable=all --enable=unspecified-encoding --ignore-paths=lib/spack/spack/vendor lib
     - name: Run style tests (docs)
-      run: bin/spack python .github/workflows/bin/format-rst.py $(git ls-files 'lib/spack/docs/*.rst')
+      run: .github/workflows/bin/format-rst.py $(git ls-files 'lib/spack/docs/*.rst')
 
 
   # Check that spack can bootstrap the development environment on Python 3.6 - RHEL8


### PR DESCRIPTION
Apparently `spack python` triggers a clone of `spack-packages` (cause `import
spack_repo.builtin` should be possible), so just use `PYTHONPATH` in this GHA to make `import spack` possible.

