### PR TITLE
docs: improve container image sections

### DIFF
--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -297,7 +297,7 @@ will have the same effect as
 OCI / Docker V2 Registries as Build Cache
 -----------------------------------------
 
-Spack can also use OCI or Docker V2 registries such as Docker Hub, Quay.io, AWS ECR, GitHub Packages, GitLab Container Registry, JFrog Artifactory, and others as build caches.
+Spack can also use OCI or Docker V2 registries such as Docker Hub, Quay.io, Amazon ECR, GitHub Packages, GitLab Container Registry, JFrog Artifactory, and others as build caches.
 This is a convenient way to share binaries using public infrastructure or to cache Spack-built binaries in GitHub Actions and GitLab CI.
 These registries can be used not only to share Spack binaries but also to create and distribute runnable container images.
 
@@ -366,10 +366,10 @@ To authenticate with Docker Hub, you can use your Docker Hub username as the use
 For the password, you need to generate a personal access token (PAT) on the Docker Hub website.
 See `Docker's documentation <https://docs.docker.com/security/access-tokens/>`_ for more information.
 
-AWS ECR
-"""""""
+Amazon ECR
+""""""""""
 
-To authenticate with AWS ECR, you can use the AWS CLI to generate a temporary password.
+To authenticate with Amazon ECR, you can use the AWS CLI to generate a temporary password.
 The username is always ``AWS``.
 
 .. code-block:: console

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -346,7 +346,8 @@ From here, you can use the mirror as any other build cache:
 Authentication with popular Container Registries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Below are instructions for configuring authentication with some popular OCI registries.
+Below are instructions for authenticating with some of the most popular container registries.
+In all cases, you need to generate a (temporary) token to use as the password -- this is not the same as your account password.
 
 GHCR
 """"""
@@ -357,7 +358,7 @@ For the password, you can use either:
 #. A personal access token (PAT) with ``write:packages`` scope.
 #. A GitHub Actions token (``GITHUB_TOKEN``) with ``packages:write`` permission.
 
-See also `GitHub's documentation <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>`_.
+See also `GitHub's documentation <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>`_ and :ref:`github-actions-build-cache` below.
 
 Docker Hub
 """"""""""
@@ -406,6 +407,8 @@ In practice, you won't be able to run these as containers because they don't com
 However, they are still compatible with tools like ``skopeo``, ``podman``, and ``docker`` for pulling and pushing.
 
 See the section :ref:`exporting-images` for more details on how to create container images with Spack.
+
+.. _github-actions-build-cache:
 
 Spack Build Cache for GitHub Actions
 ------------------------------------

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -257,8 +257,6 @@ To reduce the likelihood of this happening, it is highly recommended to add padd
        padded_length: 128
 
 
-.. _binary_caches_oci:
-
 Automatic Push to a Build Cache
 ---------------------------------
 
@@ -294,11 +292,14 @@ will have the same effect as
 
     Packages are automatically pushed to a build cache only if they are built from source.
 
+.. _binary_caches_oci:
+
 OCI / Docker V2 Registries as Build Cache
 -----------------------------------------
 
-Spack can also use OCI or Docker V2 registries such as Docker Hub, Quay.io, GitHub Packages, GitLab Container Registry, JFrog Artifactory, and others as build caches.
+Spack can also use OCI or Docker V2 registries such as Docker Hub, Quay.io, AWS ECR, GitHub Packages, GitLab Container Registry, JFrog Artifactory, and others as build caches.
 This is a convenient way to share binaries using public infrastructure or to cache Spack-built binaries in GitHub Actions and GitLab CI.
+These registries can be used not only to share Spack binaries but also to create and distribute runnable container images.
 
 To get started, configure an OCI mirror using ``oci://`` as the scheme and optionally specify variables that hold the username and password (or personal access token) for the registry:
 
@@ -307,6 +308,17 @@ To get started, configure an OCI mirror using ``oci://`` as the scheme and optio
     $ spack mirror add --oci-username-variable REGISTRY_USER \
                        --oci-password-variable REGISTRY_TOKEN \
                        my_registry oci://example.com/my_image
+
+This registers a mirror in your ``mirrors.yaml`` configuration file that looks as follows:
+
+.. code-block:: yaml
+
+    mirrors:
+      my_registry:
+        url: oci://example.com/my_image
+        access_pair:
+          id_variable: REGISTRY_USER
+          secret_variable: REGISTRY_TOKEN
 
 Spack follows the naming conventions of Docker, with Docker Hub as the default registry.
 To use Docker Hub, you can omit the registry domain:
@@ -329,6 +341,52 @@ From here, you can use the mirror as any other build cache:
    Spack defaults to ``https`` for OCI registries, and does not fall back to ``http`` in case of failure.
    For local registries which use ``http`` instead of ``https``, you can specify ``oci+http://localhost:5000/my_image``.
 
+.. _oci-authentication:
+
+Authentication with popular Container Registries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Below are instructions for configuring authentication with some popular OCI registries.
+
+GHCR
+""""""
+
+To authenticate with GitHub Container Registry (GHCR), you can use your GitHub username as the username.
+For the password, you can use either:
+
+#. A personal access token (PAT) with ``write:packages`` scope.
+#. A GitHub Actions token (``GITHUB_TOKEN``) with ``packages:write`` permission.
+
+See also `GitHub's documentation <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>`_.
+
+Docker Hub
+""""""""""
+
+To authenticate with Docker Hub, you can use your Docker Hub username as the username.
+For the password, you need to generate a personal access token (PAT) on the Docker Hub website.
+See `Docker's documentation <https://docs.docker.com/security/access-tokens/>`_ for more information.
+
+AWS ECR
+"""""""
+
+To authenticate with AWS ECR, you can use the AWS CLI to generate a temporary password.
+The username is always ``AWS``.
+
+.. code-block:: console
+
+    $ export AWS_ECR_PASSWORD=$(aws ecr get-login-password --region <region>)
+    $ spack mirror add \
+          --oci-username AWS \
+          --oci-password-variable AWS_ECR_PASSWORD \
+          my_registry \
+          oci://XXX.dkr.ecr.<region>.amazonaws.com/my/image
+
+See also `AWS's documentation <https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html>`_.
+
+
+Build Cache and Container Images
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 A unique feature of build caches on top of OCI registries is that it's incredibly easy to generate a runnable container image with the binaries installed.
 This is a great way to make applications available to users without requiring them to install Spack -- all you need is Docker, Podman, or any other OCI-compatible container runtime.
 
@@ -347,9 +405,7 @@ If ``--base-image`` is not specified, Spack produces distroless images.
 In practice, you won't be able to run these as containers because they don't come with libc and other system dependencies.
 However, they are still compatible with tools like ``skopeo``, ``podman``, and ``docker`` for pulling and pushing.
 
-.. note::
-    The Docker ``overlayfs2`` storage driver is limited to 128 layers, above which a ``max depth exceeded`` error may be produced when pulling the image.
-    There are `alternative drivers <https://docs.docker.com/storage/storagedriver/>`_.
+See the section :ref:`exporting-images` for more details on how to create container images with Spack.
 
 Spack Build Cache for GitHub Actions
 ------------------------------------
@@ -507,7 +563,7 @@ Binary package manifests live in the ``spec/`` directory, build cache index mani
 Regardless of the type of entity they represent, all manifest files are named with an extension ``.manifest.json``.
 
 Every manifest contains a ``data`` array, each element of which refers to an associated file stored as a content-addressed blob.
-Considering the example spec manifest shown above, the compressed installation archive can be found by picking out the data blob with the appropriate ``mediaType``, which in this case would be ``application/vnd.spack.install.v1.tar+gzip``.
+Considering the example spec manifest shown above, the compressed installation archive can be found by picking out the data blob with the appropriate ``mediaType``, which in this case would be ``application/vnd.spack.install.v2.tar+gzip``.
 The associated file is found by looking in the blobs directory under ``blobs/sha256/fb/`` for the file named with the complete checksum value.
 
 As mentioned above, every entity in a build cache is stored as a content-addressed blob pointed to by a manifest.

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -5,7 +5,7 @@
 
 .. meta::
    :description lang=en:
-      Learn how to create OCI compatible container images, either by copying existing installations or by generating recipes for Docker and Singularity.
+      Learn how to turn Spack packages and Spack environments into OCI-compatible container images, either by exporting existing installations or by generating recipes for Docker and Singularity.
 
 .. _containers:
 
@@ -25,32 +25,32 @@ You can either export software packages already built on your host system as a c
      - :ref:`Container Image Export <exporting-images>`
      - :ref:`Recipe Generation <generating-recipes>`
    * - **Purpose**
-     - Exports existing installations from the host system as a container image.
-     - Runs ``spack install`` to build software from source *inside* the container build process.
+     - Exports existing installations from the host system as a container image
+     - Runs ``spack install`` to build software from source *inside* the container build process
    * - **Spack Command**
      - ``spack buildcache push``
      - ``spack containerize``
    * - **Reproducibility**
-     - Limited: depends on the host system.
-     - High: controlled build environment.
+     - Limited: depends on the host system
+     - High: controlled build environment
    * - **Input**
      - Installed Spack packages or environments
      - A ``spack.yaml`` file
    * - **Speed**
-     - Fast
-     - Slow
+     - Faster: copies existing binaries
+     - Slower: typically builds from source
    * - **Troubleshooting**
-     - Build issues are resolved on the host, where debugging is simpler.
-     - Build issues must be resolved inside the container environment.
-   * - **Required Tools**
-     - None.
-     - Docker, Podman, Singularity, or similar.
+     - Build issues are resolved on the host, where debugging is simpler
+     - Build issues must be resolved inside the container build process
+   * - **Build Tools**
+     - None
+     - Docker, Podman, Singularity, or similar
    * - **Privileges**
-     - None (rootless).
-     - May require elevated privileges (root).
+     - None (rootless)
+     - May require elevated privileges, depending on the container build tool (root)
    * - **Output destination**
-     - OCI-compatible registry.
-     - Local Docker or Singularity image.
+     - OCI-compatible registry
+     - Local Docker or Singularity image
 
 
 .. _exporting-images:
@@ -102,9 +102,9 @@ Spack publishes every individual dependency as a separate image layer, which all
     You can hit this limit when exporting container images from larger environments or packages with many dependencies.
     There are `alternative drivers <https://docs.docker.com/storage/storagedriver/>`_ to work around this limitation.
 
-The ``spack buildcache push`` command serves a **dual purpose**:
+The ``spack buildcache push --base-image ...`` command serves a **dual purpose**:
 
-1. It makes container images available for download with container runtimes like Docker or Podman.
+1. It makes container images available for container runtimes like Docker and Podman.
 2. It makes the *same* binaries available :ref:`as a build cache <binary_caches_oci>` for ``spack install``.
 
 .. _configuring-container-registries:

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -5,75 +5,245 @@
 
 .. meta::
    :description lang=en:
-      Learn how to turn Spack environments into container images, either by copying existing installations or by generating recipes for Docker and Singularity.
+      Learn how to create OCI compatible container images, either by copying existing installations or by generating recipes for Docker and Singularity.
 
 .. _containers:
 
 Container Images
 ================
 
-Spack :ref:`environments` can easily be turned into container images.
-This page outlines two ways in which this can be done:
+Whether you want to share applications with others who do not use Spack, deploy on cloud services that run container images, or move workloads to HPC clusters, containers are an effective way to package and distribute software.
 
-1. By installing the environment on the host system and copying the installations into the container image.
-   This approach does not require any tools like Docker or Singularity to be installed.
-2. By generating a Docker or Singularity recipe that can be used to build the container image.
-   In this approach, Spack builds the software inside the container runtime, not on the host system.
+Spack offers two fundamentally different paradigms for creating container images, each with distinct advantages.
+You can either export software packages already built on your host system as a container image, or you can generate a traditional recipe file (``Dockerfile`` or Singularity Definition File) to build the software from scratch inside the container.
 
-The first approach is easiest if you already have an installed environment, the second approach gives more control over the container image.
+.. list-table:: Comparison of Spack container image creation methods
+   :widths: 15 42 43
+   :header-rows: 1
 
-From Existing Installations
----------------------------
+   * - 
+     - :ref:`Container Image Export <exporting-images>`
+     - :ref:`Recipe Generation <generating-recipes>`
+   * - **Purpose**
+     - Exports existing installations from the host system as a container image.
+     - Runs ``spack install`` to build software from source *inside* the container build process.
+   * - **Spack Command**
+     - ``spack buildcache push``
+     - ``spack containerize``
+   * - **Reproducibility**
+     - Limited: depends on the host system.
+     - High: controlled build environment.
+   * - **Input**
+     - Installed Spack packages or environments
+     - A ``spack.yaml`` file
+   * - **Speed**
+     - Fast
+     - Slow
+   * - **Troubleshooting**
+     - Build issues are resolved on the host, where debugging is simpler.
+     - Build issues must be resolved inside the container environment.
+   * - **Required Tools**
+     - None.
+     - Docker, Podman, Singularity, or similar.
+   * - **Privileges**
+     - None (rootless).
+     - May require elevated privileges (root).
+   * - **Output destination**
+     - OCI-compatible registry.
+     - Local Docker or Singularity image.
 
-If you already have a Spack environment installed on your system, you can share the binaries as an OCI-compatible container image.
-To get started, you just have to configure an OCI registry and run ``spack buildcache push``.
+
+.. _exporting-images:
+
+Exporting Spack installations as Container Images
+-------------------------------------------------
+
+The command
+
+.. code-block:: text
+  
+   spack buildcache push [--base-image BASE_IMAGE] [--tag TAG] mirror [specs...]
+
+creates and pushes a container image to an OCI-compatible container registry, with the ``mirror`` argument specifying a registry (see below).
+
+Think of this command less as "building a container" and more as archiving a working software stack into a portable image.
+
+Container images created this way are **minimal**: they contain only runtime dependencies of the specified specs, the base image, and nothing else.
+Spack itself is *not* included in the resulting image.
+
+The arguments are as follows:
+  
+``--base-image BASE_IMAGE``
+   Specifies the base image to use for the container.
+   This should be a minimal Linux distribution with a libc that is compatible with the host system.
+   For example, if your host system is Ubuntu 22.04, you can use ``ubuntu:22.04``, ``ubuntu:24.04``, or newer: the libc in the container image must be at least the version of the host system, assuming ABI compatibility.
+   It is also perfectly fine to use a completely different Linux distribution as long as the libc is compatible.
+
+``--tag TAG``
+  Specifies a container image tag to use.
+  This tag is used for the image consisting of all specs specified in the command line together.
+
+``mirror`` argument
+  Either the name of a configured OCI registry image (in ``mirrors.yaml``), or a URL specifying the registry and image name.
+
+  * When pushing to remote registries, you will typically :ref:`specify the name of a registry <configuring-container-registries>` from your Spack configuration.
+  * When pushing to a local registry, you can simply specify a URL like ``oci+http://localhost:5000/[image]``, where ``[image]`` is the name of the image to create, and ``oci+http://`` indicates that the registry does not support HTTPS.
+
+``specs...`` arguments
+   is a list of Spack specs to include in the image.
+   These are packages that have already been installed by Spack.
+   When a Spack environment is activated, only the packages in the environment are included in the image.
+   If no specs are given, and a Spack environment is active, all packages in the environment are included.
+
+Spack publishes every individual dependency as a separate image layer, which allows for efficient storage and transfer of images with overlapping dependencies.
+
+.. note::
+    The Docker ``overlayfs2`` storage driver is limited to 128 layers, above which a ``max depth exceeded`` error may be produced when pulling the image.
+    You can hit this limit when exporting container images from larger environments or packages with many dependencies.
+    There are `alternative drivers <https://docs.docker.com/storage/storagedriver/>`_ to work around this limitation.
+
+The ``spack buildcache push`` command serves a **dual purpose**:
+
+1. It makes container images available for download with container runtimes like Docker or Podman.
+2. It makes the *same* binaries available :ref:`as a build cache <binary_caches_oci>` for ``spack install``.
+
+.. _configuring-container-registries:
+
+Container registries
+^^^^^^^^^^^^^^^^^^^^
+
+The ``spack buildcache push`` command exports container images directly to an OCI-compatible container registry, such as Docker Hub, GitHub Container Registry (GHCR), Amazon ECR, Google GCR, Azure ACR, or a private registry.
+
+These services require authentication, which is configured with the ``spack mirror add`` command:
 
 .. code-block:: spec
 
-   # Create and install an environment in the current directory
-   $ spack env create -d .
-   $ spack -e . add pkg-a pkg-b
+   $ spack mirror add \
+         --oci-username-variable REGISTRY_USER \
+         --oci-password-variable REGISTRY_TOKEN \
+         example-registry \
+         oci://example.com/name/image
+
+This registers a mirror named ``example-registry`` in your ``mirrors.yaml`` configuration file that is associated with a container registry and image ``example.com/name/image``.
+The registry can then be referred to by its name, e.g. ``spack buildcache push example-registry ...``.
+
+The ``oci://`` scheme in the URL indicates that this is an OCI-compatible registry with HTTPS support.
+If you only specify ``oci://name/image``, Spack will assume the registry is hosted on Docker Hub.
+
+The ``--oci-username-variable`` and ``--oci-password-variable`` options specify the names of *environment variables* that will be used to authenticate with the registry.
+Spack does not store your credentials in configuration files; it expects you to set the corresponding environment variables in your shell before running the ``spack buildcache push`` command:
+
+.. code-block:: console
+
+   $ REGISTRY_USER=user REGISTRY_TOKEN=token spack buildcache push ...
+
+.. seealso::
+
+   The registry password is typically a *personal access token* (PAT) generated on the registry website or a command line tool.
+   In the section :ref:`oci-authentication` we list specific examples for popular registries.
+
+If you don't have access to a remote registry, or wish to experiment with container images locally, you can run a *local registry* on your machine and let Spack push to it.
+This is as simple as running the `official registry image <https://hub.docker.com/_/registry>`_ in the background:
+
+.. code-block:: console
+
+   $ docker run -d -p 5000:5000 --name registry registry
+
+In this case, it is not necessary to configure a named mirror, you can simply refer to it by URL using ``oci+http://localhost:5000/[image]``, where ``[image]`` is the name of the image to create, and ``oci+http://`` indicates that the registry does not support HTTPS.
+
+.. _local-registry-example:
+
+Example 1: pushing selected specs as container images
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Assume we have ``python@3.13`` and ``cmake@3`` already installed by Spack, and we want to push them as a combined container image ``software_stack:latest`` to a local registry.
+
+First we verify that the specs are indeed installed:
+
+.. code-block:: spec
+
+  $ spack find --long python@3.13 cmake@3
+
+  -- linux-ubuntu24.04-zen2 / %c,cxx=gcc@13.3.0 -------------------
+  scpgv2h cmake@3.31.8  n54tvjw python@3.13.5
+
+Since these are the only installations on our system, we can simply refer to them by their spec strings.
+In case there are multiple installations, we could use ``python/n54tvjw`` and ``cmake/scpgv2h`` to uniquely refer to them by hashes.
+
+We now use ``spack buildcache push`` to publish these packages as a container image with ``ubuntu:24.04`` as a base image:
+
+.. code-block:: console
+
+   $ spack buildcache push \
+         --base-image ubuntu:24.04 \
+         --tag latest \
+         oci+http://localhost:5000/software_stack \
+         python@3.13 cmake@3
+
+They can now be pulled and run with Docker or any other OCI-compatible container runtime:
+
+.. code-block:: console
+
+   $ docker run -it localhost:5000/software_stack:latest
+   root@container-id:/# python3 --version
+   Python 3.13.5
+   root@container-id:/# cmake --version
+   cmake version 3.31.8
+
+.. _installed-environments-as-containers:
+
+Example 2: pushing entire Spack environments as container images
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In this example we show how to export an installed :ref:`Spack environment <environments>` as a container image and push it to a remote registry.
+
+.. code-block:: spec
+
+   # Create and install an environment
+   $ spack env create .
+   $ spack -e . add python@3.13 cmake@3
    $ spack -e . install
 
-   # Configure the registry
-   $ spack -e . mirror add --oci-username-variable REGISTRY_USER \
-                           --oci-password-variable REGISTRY_TOKEN \
-                           container-registry oci://example.com/name/image
+   # Configure a remote registry
+   $ spack -e . mirror add \
+         --oci-username-variable REGISTRY_USER \
+         --oci-password-variable REGISTRY_TOKEN \
+         container-registry \
+         oci://example.com/name/image
 
-   # Push the image (do set REGISTRY_USER and REGISTRY_TOKEN)
-   $ spack -e . buildcache push --update-index --base-image ubuntu:22.04 --tag my_env container-registry
+   # Push the image
+   $ REGISTRY_USER=user REGISTRY_TOKEN=token \
+     spack -e . buildcache push \
+         --update-index \
+         --base-image ubuntu:24.04 \
+         --tag my_env \
+         container-registry
 
 The resulting container image can then be run as follows:
 
 .. code-block:: console
 
    $ docker run -it example.com/name/image:my_env
+   root@container-id:/# python3 --version
+   Python 3.13.5
+   root@container-id:/# cmake --version
+   cmake version 3.31.8
 
-The image generated by Spack consists of the specified base image with each package from the environment as a separate layer on top.
-The image is minimal by construction, it only contains the environment roots and its runtime dependencies.
+The advantage of using a Spack environment is that we do not have to specify the individual specs on the command line when pushing the image.
+With environments, all root specs and their runtime dependencies are included in the container image.
 
-.. note::
+If you do specify specs in ``spack buildcache push`` with an environment active, only those matching specs from the environment are included in the image.
 
-  When using registries like GHCR and Docker Hub, the ``--oci-password`` flag specifies not the password for your account but rather a personal access token that you need to generate separately.
 
-The specified ``--base-image`` should have a libc that is compatible with the host system.
-For example, if your host system is Ubuntu 20.04, you can use ``ubuntu:20.04``, ``ubuntu:22.04``, or newer: the libc in the container image must be at least the version of the host system, assuming ABI compatibility.
-It is also perfectly fine to use a completely different Linux distribution as long as the libc is compatible.
-
-For convenience, Spack also turns the OCI registry into a :ref:`build cache <binary_caches_oci>`, so that future ``spack install`` of the environment will simply pull the binaries from the registry instead of doing source builds.
-The flag ``--update-index`` is needed to make Spack take the build cache into account when concretizing.
-
-.. note::
-
-  When generating container images in CI, the approach above is recommended when CI jobs already run in a sandboxed environment.
-  You can simply use Spack directly in the CI job and push the resulting image to a registry.
-  Subsequent CI jobs should run faster because Spack can install from the same registry instead of rebuilding from sources.
+.. _generating-recipes:
 
 Generating recipes for Docker and Singularity
 ---------------------------------------------
 
-Apart from copying existing installations into container images, Spack can also generate recipes for container images.
+Apart from exporting existing installations into container images, Spack can also generate recipes for container images.
 This is useful if you want to run Spack itself in a sandboxed environment instead of on the host system.
+
+This approach requires you to have a container runtime like Docker or Singularity installed on your system, and can only be used using Spack environments.
 
 Since recipes need a little more boilerplate than:
 
@@ -88,7 +258,7 @@ Customizations include minimizing the size of the image, installing packages in 
 .. _cmd-spack-containerize:
 
 A Quick Introduction
-~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^
 
 Consider having a Spack environment like the following:
 
@@ -178,7 +348,7 @@ The various components involved in the generation of the recipe and their config
 .. _container_spack_images:
 
 Official Container Images for Spack
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Container images with Spack preinstalled are available on `Docker Hub <https://hub.docker.com/u/spack>`_ and `GitHub Container Registry <https://github.com/orgs/spack/packages?repo_name=spack>`_.
 These images are based on popular distributions and are named accordingly (e.g. ``spack/ubuntu-noble`` for Spack on top of ``ubuntu:24.04``).
@@ -252,7 +422,7 @@ These images are available for anyone to use and take care of all the repetitive
 The container recipes generated by Spack use them as default base images for their ``build`` stage, even though options to use custom base images provided by users are available to accommodate complex use cases.
 
 Configuring the Container Recipe
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Any Spack environment can be used for the automatic generation of container recipes.
 Sensible defaults are provided for things like the base image or the version of Spack used in the image.
@@ -292,7 +462,7 @@ If finer tuning is needed, it can be obtained by adding the relevant metadata un
 A detailed description of the options available can be found in the :ref:`container_config_options` section.
 
 Setting Base Images
-~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^
 
 The ``images`` subsection is used to select both the image where Spack builds the software and the image where the built software is installed.
 This attribute can be set in different ways and which one to use depends on the use case at hand.
@@ -515,7 +685,7 @@ Users may need to generate their base images themselves, and it's also their res
 Therefore, we do not recommend its use in cases that can be otherwise covered by the simplified mode shown first.
 
 Singularity Definition Files
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In addition to producing recipes in ``Dockerfile`` format, Spack can produce Singularity Definition Files by just changing the value of the ``format`` attribute:
 
@@ -534,7 +704,7 @@ In addition to producing recipes in ``Dockerfile`` format, Spack can produce Sin
 The minimum version of Singularity required to build a SIF (Singularity Image Format) image from the recipes generated by Spack is ``3.5.3``.
 
 Extending the Jinja2 Templates
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``Dockerfile`` and the Singularity definition file that Spack can generate are based on a few Jinja2 templates that are rendered according to the Spack environment being containerized.
 Even though Spack allows a great deal of customization by just setting appropriate values for the configuration options, sometimes that is not enough.
@@ -663,7 +833,7 @@ The recipe that gets generated contains the two extra instructions that we added
 .. _container_config_options:
 
 Configuration Reference
-~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^
 
 The tables below describe all the configuration options that are currently supported to customize the generation of container recipes:
 
@@ -760,7 +930,7 @@ The tables below describe all the configuration options that are currently suppo
      - No
 
 Best Practices
-~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^
 
 MPI
 """"""


### PR DESCRIPTION
* Explain testing with local registry
* An environment is *not required* for `spack buildcache push --base-image ...`, which the previous version suggested.
* Add a comparison table between `spack buildcache push` and `spack containerize`
* Document authentication with popular container registries
* Fix some typos

Rendered:

https://spack--51327.org.readthedocs.build/en/51327/containers.html
https://spack--51327.org.readthedocs.build/en/51327/binary_caches.html