### PR TITLE
Update reading terminal size from ioctl for Python 3.14

### DIFF
--- a/lib/spack/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/spack/llnl/util/tty/__init__.py
@@ -333,7 +333,8 @@ def terminal_size() -> Tuple[int, int]:
 
         def ioctl_gwinsz(fd):
             try:
-                rc = struct.unpack("hh", fcntl.ioctl(fd, termios.TIOCGWINSZ, "1234"))
+                buf = fcntl.ioctl(fd, termios.TIOCGWINSZ, "12345678")
+                rc = struct.unpack("hh", buf[0:4])
                 return rc if is_valid_size(rc[0], rc[1]) else None
             except (OSError, ValueError):
                 return None


### PR DESCRIPTION
On python 3.14, this causes a segfault.

```python
fcntl.ioctl(fd, termios.TIOCGWINSZ, "1234")
```

It's not clear why, but `TIOCGWINSZ` now requires a buffer of at least 7 bytes. I've tested this against Fedora 43 (Rawhide), 42, and 41 as well as Ubuntu 25.04 and 25.10. All five are using the same version of the kernel (6.8.0-79), but only Fedora 43 is using python 3.140.rc2 which is where I see the segfault. The rest are using 3.13.7. I haven't done a full root-cause analysis, but I believe this strongly suggests it's an issue with Python 3.14. I checked the release docs, but didn't see any explicit mention of modifications to the `fcntl` module.

The proposed change works correctly on all five OSes.

---

```
$ spack/bin/spack --version
1.1.0.dev0 (a487f1c4edf7f577019921a41a4330b29a0ebd9e)

$ python3 --version
Python 3.14.0rc2

$ head -2 /etc/os-release
NAME="Fedora Linux"
VERSION="43 (Container Image Prerelease)"
```