### PR TITLE
llnl.util.tty: remove custom terminal_size

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import shutil
 import sys
 import textwrap
 from itertools import zip_longest
@@ -11,7 +12,6 @@ import spack.builder
 import spack.deptypes as dt
 import spack.fetch_strategy as fs
 import spack.install_test
-import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.color as color
 import spack.repo
 import spack.spec
@@ -86,7 +86,7 @@ class VariantFormatter:
         self.headers = ("Name [Default]", "When", "Allowed values", "Description")
 
         # Don't let name or possible values be less than max widths
-        _, cols = tty.terminal_size()
+        cols = shutil.get_terminal_size().columns
         max_name = min(self.column_widths[0], 30)
         max_when = min(self.column_widths[1], 30)
         max_vals = min(self.column_widths[2], 20)
@@ -292,7 +292,7 @@ def _fmt_variant_description(variant, width, indent):
 def _fmt_variant(variant, max_name_default_len, indent, when=None, out=None):
     out = out or sys.stdout
 
-    _, cols = tty.terminal_size()
+    cols = shutil.get_terminal_size().columns
 
     name_and_default = _fmt_name_and_default(variant)
     name_default_len = color.clen(name_and_default)

--- a/lib/spack/spack/llnl/util/tty/colify.py
+++ b/lib/spack/spack/llnl/util/tty/colify.py
@@ -7,10 +7,10 @@ Routines for printing columnar output.  See ``colify()`` for more information.
 """
 import io
 import os
+import shutil
 import sys
 from typing import IO, Any, List, Optional
 
-from spack.llnl.util.tty import terminal_size
 from spack.llnl.util.tty.color import cextra, clen
 
 
@@ -138,10 +138,9 @@ def colify(
     env_size = os.environ.get("COLIFY_SIZE")
     if env_size:
         try:
-            r, c = env_size.split("x")
-            console_rows, console_cols = int(r), int(c)
+            console_cols = int(env_size.partition("x")[2])
             tty = True
-        except BaseException:
+        except ValueError:
             pass
 
     # Use only one column if not a tty.
@@ -151,7 +150,7 @@ def colify(
 
     # Specify the number of character columns to use.
     if console_cols is None:
-        console_rows, console_cols = terminal_size()
+        console_cols = shutil.get_terminal_size().columns
     elif not isinstance(console_cols, int):
         raise ValueError("Number of columns must be an int")
 

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import io
+import shutil
 import sys
 from typing import Optional, TextIO, Union
 
-import spack.llnl.util.tty as tty
 from spack.llnl.util.tty.color import cescape, colorize
 from spack.util.ctest_log_parser import BuildError, BuildWarning, CTestLogParser
 
@@ -82,7 +82,7 @@ def make_log_context(log_events, width=None):
     indent = " " * (5 + num_width)
 
     if width is None:
-        _, width = tty.terminal_size()
+        width = shutil.get_terminal_size().columns
     if width <= 0:
         width = sys.maxsize
     wrap_width = width - num_width - 6


### PR DESCRIPTION
Alternative to #51336

Use `shutil.get_terminal_size` in Spack instead of the custom function, which is likely a remnant from when Spack supported Python 2.

Behavior is slightly different (first env vars, then syscall), but `arparse`
uses it, and we use `argparse`, so it would be consistent.

