### PR TITLE
spack style: change criteria for determining whether file is a package

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -58,7 +58,7 @@ def is_package(f):
     packages, since we allow ``from spack.package import *`` and poking globals
     into packages.
     """
-    return f.startswith("var/spack/") and f.endswith("package.py")
+    return "spack_repo" in f and f.endswith("package.py")
 
 
 #: decorator for adding tools to the list


### PR DESCRIPTION
This method is probably mostly vestigial, but could still be relevant if someone configures spack to download the spack repo to an internal location. In any case, it's not correct anymore.