### PR TITLE
package api: add 'prefers' directive

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -18,7 +18,7 @@ spack_version = __version__
 #: version is incremented when the package API is extended in a backwards-compatible way. The major
 #: version is incremented upon breaking changes. This version is changed independently from the
 #: Spack version.
-package_api_version = (2, 2)
+package_api_version = (2, 3)
 
 #: The minimum Package API version that this version of Spack is compatible with. This should
 #: always be a tuple of the form ``(major, 0)``, since compatibility with vX.Y implies

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -922,13 +922,18 @@ def prefers(*preferred_specs: str, when: Optional[str] = None, msg: Optional[str
     """Declare that a spec is preferred for a package.
 
     For instance, a package that depends on `llvm` for some functionality but does not require
-    `clang` might declare:
+    ``clang`` might declare:
+
+    code-block:: python
 
         depends_on("llvm", when="+llvm")
         prefers("%llvm~clang", when="+llvm", msg="Prefer smaller, faster llvm build)
 
     This allows the package to prefer the smaller build without failing when another package in the
     solve requires llvm+clang
+
+    ``prefers("foo")`` is equivalent to ``requires("foo", "@:", policy="any_of")`` and is
+    implemented as such.
 
     Args:
         preferred_specs: specs expressing the preferences

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -950,7 +950,7 @@ def _requires(
     requirements: Tuple[spack.spec.Spec, ...],
     policy="one_of",
     when: Optional[str] = None,
-    msg: Optional[str] = None
+    msg: Optional[str] = None,
 ):
     def _execute_requires(pkg: Type[spack.package_base.PackageBase]):
         if policy not in ("one_of", "any_of"):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -942,7 +942,7 @@ def prefers(*preferred_specs: str, when: Optional[str] = None, msg: Optional[str
 
 
 def _requires(
-    requirements: Tuple[spack.spec.Spec],
+    requirements: Tuple[spack.spec.Spec, ...],
     policy="one_of",
     when: Optional[str] = None,
     msg: Optional[str] = None

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -46,6 +46,7 @@ from spack.directives import (
     license,
     maintainers,
     patch,
+    prefers,
     provides,
     redistribute,
     requires,
@@ -438,6 +439,9 @@ api: Dict[str, Tuple[str, ...]] = {
         "substitute_version_in_url",
         "windows_sfn",
     ),
+    "v2.3": (
+        "prefers",
+    )
 }
 
 # Splatting does not work for static analysis tools.
@@ -607,6 +611,8 @@ __all__ = [
     "static_library_suffix",
     "substitute_version_in_url",
     "windows_sfn",
+    # v2.3
+    "prefers",
 ]
 
 # These are just here for editor support; they may be set when the build env is set up.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -439,9 +439,7 @@ api: Dict[str, Tuple[str, ...]] = {
         "substitute_version_in_url",
         "windows_sfn",
     ),
-    "v2.3": (
-        "prefers",
-    )
+    "v2.3": ("prefers",),
 }
 
 # Splatting does not work for static analysis tools.


### PR DESCRIPTION
Add a `prefers` directive which mimics the behavior relative to the `requires` directive of the `prefer` key in packages config relative to the `require` key.

This requires updating the package API -- do we have a method in place for batching API changing PRs? Do we just bump the API and leave it in an indeterminate state until the next release?

TODO:
[ ] docs
[ ] tests