### PR TITLE
solver: improve timeout handling and add Ctrl-C interrupt safety

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -15,6 +15,7 @@ import pprint
 import random
 import re
 import sys
+import time
 import typing
 import warnings
 from contextlib import contextmanager
@@ -1144,13 +1145,19 @@ class PyclingoDriver:
                 solve_kwargs["on_unsat"] = cores.append
 
             timer.start("solve")
+            start_time = time.monotonic()
+            # A timeout of 0 or less means no timeout
             time_limit = spack.config.CONFIG.get("concretizer:timeout", -1)
             error_on_timeout = spack.config.CONFIG.get("concretizer:error_on_timeout", True)
-            # Spack uses 0 to set no time limit, clingo API uses -1
-            if time_limit == 0:
-                time_limit = -1
             with self.control.solve(**solve_kwargs, async_=True) as handle:
-                finished = handle.wait(time_limit)
+                # We need the loop below to be able to Ctrl-C out of the solve
+                finished = handle.wait(0)
+                while not finished:
+                    elapsed_time = time.monotonic() - start_time
+                    if 0 < time_limit < elapsed_time:
+                        break
+                    finished = handle.wait(1.0)
+
                 if not finished:
                     specs_str = ", ".join(
                         spack.llnl.util.lang.elide_list([str(s) for s in specs], 4)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1150,7 +1150,10 @@ class PyclingoDriver:
             time_limit = spack.config.CONFIG.get("concretizer:timeout", -1)
             error_on_timeout = spack.config.CONFIG.get("concretizer:error_on_timeout", True)
             with self.control.solve(**solve_kwargs, async_=True) as handle:
-                # We need the loop below to be able to Ctrl-C out of the solve
+                # pyclingo's `SolveHandle` blocks the calling thread for the duration of each `.wait()` call.
+                # Python also requires that signal handlers (like SIGINT for ^C) must be handled in the main thread,
+                # so any `KeyboardInterrupt` is postponed until after the `.wait()` call exits the control of pyclingo.
+                # Polling repeatedly ensures the user won't have to wait long for a response to their ^C.
                 finished = handle.wait(0)
                 while not finished:
                     elapsed_time = time.monotonic() - start_time

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1146,21 +1146,22 @@ class PyclingoDriver:
 
             timer.start("solve")
             starting_point = time.monotonic()
-            # A timeout of 0 or less means no timeout
-            time_limit = spack.config.CONFIG.get("concretizer:timeout", -1)
+            # A timeout of 0 means no timeout
+            time_limit = spack.config.CONFIG.get("concretizer:timeout", 0)
             error_on_timeout = spack.config.CONFIG.get("concretizer:error_on_timeout", True)
             with self.control.solve(**solve_kwargs, async_=True) as handle:
+                # Allow handling of interrupts every second.
+                #
                 # pyclingo's `SolveHandle` blocks the calling thread for the duration of each
-                # `.wait()` call. Python also requires that signal handlers (like SIGINT for ^C)
-                # must be handled in the main thread, so any `KeyboardInterrupt` is postponed
-                # until after the `.wait()` call exits the control of pyclingo. Polling repeatedly
-                # ensures the user won't have to wait long for a response to their ^C.
-                finished = handle.wait(0)
+                # `.wait()` call. Python also requires that signal handlers must be handled in
+                # the main thread, so any `KeyboardInterrupt` is postponed until after the
+                # `.wait()` call exits the control of pyclingo.
+                finished = False
                 while not finished:
-                    elapsed_time = time.monotonic() - starting_point
-                    if 0 < time_limit < elapsed_time:
-                        break
                     finished = handle.wait(1.0)
+                    elapsed_time = time.monotonic() - starting_point
+                    if time_limit != 0 and elapsed_time > time_limit:
+                        break
 
                 if not finished:
                     specs_str = ", ".join(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1145,7 +1145,7 @@ class PyclingoDriver:
                 solve_kwargs["on_unsat"] = cores.append
 
             timer.start("solve")
-            start_time = time.monotonic()
+            starting_point = time.monotonic()
             # A timeout of 0 or less means no timeout
             time_limit = spack.config.CONFIG.get("concretizer:timeout", -1)
             error_on_timeout = spack.config.CONFIG.get("concretizer:error_on_timeout", True)
@@ -1157,7 +1157,7 @@ class PyclingoDriver:
                 # ensures the user won't have to wait long for a response to their ^C.
                 finished = handle.wait(0)
                 while not finished:
-                    elapsed_time = time.monotonic() - start_time
+                    elapsed_time = time.monotonic() - starting_point
                     if 0 < time_limit < elapsed_time:
                         break
                     finished = handle.wait(1.0)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1150,10 +1150,11 @@ class PyclingoDriver:
             time_limit = spack.config.CONFIG.get("concretizer:timeout", -1)
             error_on_timeout = spack.config.CONFIG.get("concretizer:error_on_timeout", True)
             with self.control.solve(**solve_kwargs, async_=True) as handle:
-                # pyclingo's `SolveHandle` blocks the calling thread for the duration of each `.wait()` call.
-                # Python also requires that signal handlers (like SIGINT for ^C) must be handled in the main thread,
-                # so any `KeyboardInterrupt` is postponed until after the `.wait()` call exits the control of pyclingo.
-                # Polling repeatedly ensures the user won't have to wait long for a response to their ^C.
+                # pyclingo's `SolveHandle` blocks the calling thread for the duration of each
+                # `.wait()` call. Python also requires that signal handlers (like SIGINT for ^C)
+                # must be handled in the main thread, so any `KeyboardInterrupt` is postponed
+                # until after the `.wait()` call exits the control of pyclingo. Polling repeatedly
+                # ensures the user won't have to wait long for a response to their ^C.
                 finished = handle.wait(0)
                 while not finished:
                     elapsed_time = time.monotonic() - start_time


### PR DESCRIPTION
This allows using <kbd>Ctrl+C</kbd> to stop Spack even in the middle of concretization.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
