### PR TITLE
spack checksum: scrape also tags not just releases for github

### DIFF
--- a/lib/spack/spack/llnl/url.py
+++ b/lib/spack/spack/llnl/url.py
@@ -54,6 +54,7 @@ def find_list_urls(url: str) -> Set[str]:
         # GitHub
         # e.g. https://github.com/llnl/callpath/archive/v1.0.1.tar.gz
         (r"(.*github\.com/[^/]+/[^/]+)", lambda m: m.group(1) + "/releases"),
+        (r"(.*github\.com/[^/]+/[^/]+)", lambda m: m.group(1) + "/tags"),
         # GitLab API endpoint
         # e.g. https://gitlab.dkrz.de/api/v4/projects/k202009%2Flibaec/repository/archive.tar.gz?sha=v1.0.2
         (


### PR DESCRIPTION
DISCLAIMER: not sure it is the right way of solving this, feel free to suggests alternative solution and/or close this without merging it.

On GitHub some packages mark some git tags as "proper releases", and `spack checksum` is able to scrape this page looking for new versions (e.g. https://github.com/pika-org/pika/releases is a good example).

Some other packages uses git tags for versioning, but they don't mark them as "github releases", so if you look in https://github.com/NVIDIA/nccl-tests/releases there is nothing, but https://github.com/NVIDIA/nccl-tests/tags shows them. In this case, `spack checksum` is not useful at all.

I agree that not all tags might be proper releases for all packages on github, but since `checksum` offers an interactive interface, it might be beneficial to have listed them anyway so that `spack checksum` can be used.