### PR TITLE
solver: avoid duplicate libc in packages.yaml

### DIFF
--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -299,5 +299,8 @@ def _external_config_with_implicit_externals(configuration):
         if libc and libc not in seen:
             seen.add(libc)
             entry = {"spec": f"{libc}", "prefix": libc.external_path}
-            packages_yaml.setdefault(libc.name, {}).setdefault("externals", []).append(entry)
+            existing_entries = packages_yaml.setdefault(libc.name, {}).setdefault("externals", [])
+            if entry in existing_entries:
+                continue
+            existing_entries.append(entry)
     return packages_yaml


### PR DESCRIPTION
Since `packages.yaml` is a global variable, we need to check whether the entry was already added in a previous call. This causes the existence of multiple "equivalent" solutions in `clingo`, which would all map to the same concrete spec.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
