### PR TITLE
concretizer: allow duplicate py-versioneer by default

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -60,6 +60,7 @@ concretizer:
       py-flit-core: 2
       py-pip: 2
       py-setuptools: 2
+      py-versioneer: 2
       py-wheel: 2
       xcb-proto: 2
       # Compilers


### PR DESCRIPTION
This change allows for duplicates (2) of the build tool `py-versioneer` by default. This build dependency has a habit of having two versions in a DAG often due to dask + something else, e.g., https://github.com/spack/spack/pull/50075, https://github.com/spack/spack/pull/47980, https://github.com/spack/spack/pull/50770.

This MWE environment will fail to concretize without this change:

```
spack:
  specs:
  - 'py-dask@2025:'
  - py-pyogrio
  view: true
```

```
 spack concretize -f -U
==> Error: failed to concretize `py-pyogrio`, `py-xarray@2025:+accel+etc+io+parallel+viz` for the following reasons:
     1. Cannot satisfy 'py-versioneer@0.28'
     2. Cannot satisfy 'py-versioneer@0.28'
        required because py-pyogrio depends on py-versioneer@0.28+toml
          required because py-pyogrio requested explicitly
     3. Cannot satisfy 'py-versioneer@0.29' and 'py-versioneer@0.28'
        required because py-partd depends on py-versioneer@0.29+toml when @1.4.2:
          required because py-dask depends on py-partd@0.3.10: when @2021.3.1:
            required because py-xarray depends on py-dask@2022:+array+dataframe+diagnostics+distributed when @2022.06.0:+parallel
              required because py-xarray@2025:+accel+etc+io+parallel+viz requested explicitly
          required because py-dask depends on py-partd@1.2.0: when @2023.4.0:
          required because py-dask depends on py-partd@1.4.0: when @2024.7.1:
        required because py-pyogrio depends on py-versioneer@0.28+toml
          required because py-pyogrio requested explicitly
     4. Cannot satisfy 'py-versioneer@0.29' and 'py-versioneer@0.28'
        required because py-pyogrio depends on py-versioneer@0.28+toml
          required because py-pyogrio requested explicitly
        required because py-distributed depends on py-versioneer@0.29+toml when @2025.7.0:
          required because py-dask depends on py-distributed@2025.7.0 when @2025.7.0+distributed
            required because py-xarray depends on py-dask@2022:+array+dataframe+diagnostics+distributed when @2022.06.0:+parallel
              required because py-xarray@2025:+accel+etc+io+parallel+viz requested explicitly
     5. Cannot satisfy 'py-versioneer@0.29' and 'py-versioneer@0.28'
        required because py-dask depends on py-versioneer@0.29+toml when @2023.10.1:
          required because py-xarray depends on py-dask@2022:+array+dataframe+diagnostics+distributed when @2022.06.0:+parallel
            required because py-xarray@2025:+accel+etc+io+parallel+viz requested explicitly
        required because py-pyogrio depends on py-versioneer@0.28+toml
          required because py-pyogrio requested explicitly
     6. Cannot satisfy 'py-versioneer@0.28:' and 'py-versioneer@0.28'
        required because py-donfig depends on py-versioneer@0.28:+toml
          required because py-zarr depends on py-donfig@0.8: when @3:
        required because py-pyogrio depends on py-versioneer@0.28+toml
          required because py-pyogrio requested explicitly . You could consider setting `concretizer:unify` to `when_possible` or `false` to allow multiple versions of some packages.
```