### PR TITLE
Make `spack solve --show=asp` work with clingo app

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1089,8 +1089,11 @@ class PyclingoDriver:
             control_files.append("splices.lp")
 
         timer.start("setup")
-        asp_problem = setup.setup(specs, reuse=reuse, allow_deprecated=allow_deprecated)
-        if output.out is not None:
+        output_is_set = output.out is not None
+        asp_problem = setup.setup(
+            specs, reuse=reuse, allow_deprecated=allow_deprecated, output_for_cli=output_is_set
+        )
+        if output_is_set:
             output.out.write(asp_problem)
         if output.setup_only:
             return Result(specs), None, None
@@ -3036,6 +3039,7 @@ class SpackSolverSetup:
         *,
         reuse: Optional[List[spack.spec.Spec]] = None,
         allow_deprecated: bool = False,
+        output_for_cli: bool = False,
     ) -> str:
         """Generate an ASP program with relevant constraints for specs.
 
@@ -3196,11 +3200,11 @@ class SpackSolverSetup:
         self.define_target_constraints()
 
         self.gen.h1("Internal errors")
-        self.internal_errors()
+        self.internal_errors(output_for_cli=output_for_cli)
 
         return self.gen.value()
 
-    def internal_errors(self):
+    def internal_errors(self, *, output_for_cli: bool):
         parent_dir = os.path.dirname(__file__)
 
         def visit(node):
@@ -3213,7 +3217,9 @@ class SpackSolverSetup:
                                 arg = ast_sym(ast_sym(term.atom).arguments[0])
                                 symbol = AspFunction(name)(arg.string)
                                 self.assumptions.append((parse_term(str(symbol)), True))
-                                self.gen.asp_problem.append(f"{{ {symbol} }}.\n")
+                                self.gen.asp_problem.append(
+                                    f"{symbol}.\n" if output_for_cli else f"{{ {symbol} }}.\n"
+                                )
 
         path = os.path.join(parent_dir, "concretize.lp")
         parse_files([path], visit)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1091,7 +1091,10 @@ class PyclingoDriver:
         timer.start("setup")
         output_is_set = output.out is not None
         asp_problem = setup.setup(
-            specs, reuse=reuse, allow_deprecated=allow_deprecated, output_for_cli=output_is_set
+            specs,
+            reuse=reuse,
+            allow_deprecated=allow_deprecated,
+            _use_unsat_cores=not output_is_set,
         )
         if output_is_set:
             output.out.write(asp_problem)
@@ -3039,7 +3042,7 @@ class SpackSolverSetup:
         *,
         reuse: Optional[List[spack.spec.Spec]] = None,
         allow_deprecated: bool = False,
-        output_for_cli: bool = False,
+        _use_unsat_cores: bool = True,
     ) -> str:
         """Generate an ASP program with relevant constraints for specs.
 
@@ -3051,6 +3054,7 @@ class SpackSolverSetup:
             specs: list of Specs to solve
             reuse: list of concrete specs that can be reused
             allow_deprecated: if True adds deprecated versions into the solve
+            _use_unsat_cores: if True, use unsat cores for internal errors
         """
         reuse = reuse or []
         check_packages_exist(specs)
@@ -3200,11 +3204,11 @@ class SpackSolverSetup:
         self.define_target_constraints()
 
         self.gen.h1("Internal errors")
-        self.internal_errors(output_for_cli=output_for_cli)
+        self.internal_errors(_use_unsat_cores=_use_unsat_cores)
 
         return self.gen.value()
 
-    def internal_errors(self, *, output_for_cli: bool):
+    def internal_errors(self, *, _use_unsat_cores: bool):
         parent_dir = os.path.dirname(__file__)
 
         def visit(node):
@@ -3216,10 +3220,11 @@ class SpackSolverSetup:
                             if name == "internal_error":
                                 arg = ast_sym(ast_sym(term.atom).arguments[0])
                                 symbol = AspFunction(name)(arg.string)
-                                self.assumptions.append((parse_term(str(symbol)), True))
-                                self.gen.asp_problem.append(
-                                    f"{symbol}.\n" if output_for_cli else f"{{ {symbol} }}.\n"
-                                )
+                                if _use_unsat_cores:
+                                    self.assumptions.append((parse_term(str(symbol)), True))
+                                    self.gen.asp_problem.append(f"{{ {symbol} }}.\n")
+                                else:
+                                    self.gen.asp_problem.append(f"{symbol}.\n")
 
         path = os.path.join(parent_dir, "concretize.lp")
         parse_files([path], visit)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3363,7 +3363,7 @@ def test_concretization_cache_roundtrip(
     # Basically just a quick and dirty memoization
     solver_setup = spack.solver.asp.SpackSolverSetup.setup
 
-    def _setup(self, specs, *, reuse=None, allow_deprecated=False):
+    def _setup(self, specs, *, reuse=None, allow_deprecated=False, output_for_cli=False):
         if not getattr(_setup, "cache_setup", None):
             cache_setup = solver_setup(self, specs, reuse=reuse, allow_deprecated=allow_deprecated)
             setattr(_setup, "cache_setup", cache_setup)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3363,7 +3363,7 @@ def test_concretization_cache_roundtrip(
     # Basically just a quick and dirty memoization
     solver_setup = spack.solver.asp.SpackSolverSetup.setup
 
-    def _setup(self, specs, *, reuse=None, allow_deprecated=False, output_for_cli=False):
+    def _setup(self, specs, *, reuse=None, allow_deprecated=False, _use_unsat_cores=True):
         if not getattr(_setup, "cache_setup", None):
             cache_setup = solver_setup(self, specs, reuse=reuse, allow_deprecated=allow_deprecated)
             setattr(_setup, "cache_setup", cache_setup)


### PR DESCRIPTION
Before, changes in Spack core were required since "assumptions" and "unsat cores" cannot be used from the app.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
