### PR TITLE
solver: mutate deepcopied packages config

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -639,6 +639,10 @@ class Configuration:
         """
         return self._get_config_memoized(section, scope=scope, _merged_scope=_merged_scope)
 
+    def deepcopy_as_builtin(self, section: str, scope: Optional[str] = None) -> Dict[str, Any]:
+        """Get a deep copy of a section with native Python types, excluding YAML metadata."""
+        return syaml.deepcopy_as_builtin(self.get_config(section, scope=scope))
+
     @lang.memoized
     def _get_config_memoized(
         self, section: str, scope: Optional[str], _merged_scope: Optional[str]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -87,7 +87,7 @@ from .core import (
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector, SpecFilter
-from .runtimes import RuntimePropertyRecorder, _external_config_with_implicit_externals
+from .runtimes import RuntimePropertyRecorder, external_config_with_implicit_externals
 from .versions import DeclaredVersion, Provenance, concretization_version_order
 
 GitOrStandardVersion = Union[spack.version.GitVersion, spack.version.StandardVersion]
@@ -2207,7 +2207,7 @@ class SpackSolverSetup:
                     )
                 )
 
-        packages_yaml = _external_config_with_implicit_externals(spack.config.CONFIG)
+        packages_yaml = external_config_with_implicit_externals(spack.config.CONFIG)
         for pkg_name, data in packages_yaml.items():
             if pkg_name == "all":
                 continue
@@ -3666,7 +3666,7 @@ class SpecBuilder:
 
     def external_spec_selected(self, node, idx):
         """This means that the external spec and index idx has been selected for this package."""
-        packages_yaml = _external_config_with_implicit_externals(spack.config.CONFIG)
+        packages_yaml = external_config_with_implicit_externals(spack.config.CONFIG)
         spec_info = packages_yaml[node.pkg]["externals"][int(idx)]
         self._specs[node].external_path = spec_info.get("prefix", None)
         self._specs[node].external_modules = spack.spec.Spec._format_module_list(

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -12,7 +12,7 @@ import spack.repo
 import spack.spec
 import spack.store
 
-from .runtimes import _external_config_with_implicit_externals
+from .runtimes import external_config_with_implicit_externals
 
 
 class SpecFilter:
@@ -58,7 +58,7 @@ class SpecFilter:
     @staticmethod
     def from_store(configuration, *, include, exclude) -> "SpecFilter":
         """Constructs a filter that takes the specs from the current store."""
-        packages = _external_config_with_implicit_externals(configuration)
+        packages = external_config_with_implicit_externals(configuration)
         is_reusable = functools.partial(_is_reusable, packages=packages, local=True)
         factory = functools.partial(_specs_from_store, configuration=configuration)
         return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
@@ -66,7 +66,7 @@ class SpecFilter:
     @staticmethod
     def from_buildcache(configuration, *, include, exclude) -> "SpecFilter":
         """Constructs a filter that takes the specs from the configured buildcaches."""
-        packages = _external_config_with_implicit_externals(configuration)
+        packages = external_config_with_implicit_externals(configuration)
         is_reusable = functools.partial(_is_reusable, packages=packages, local=False)
         return SpecFilter(
             factory=_specs_from_mirror, is_usable=is_reusable, include=include, exclude=exclude
@@ -74,7 +74,7 @@ class SpecFilter:
 
     @staticmethod
     def from_environment(configuration, *, include, exclude, env) -> "SpecFilter":
-        packages = _external_config_with_implicit_externals(configuration)
+        packages = external_config_with_implicit_externals(configuration)
         is_reusable = functools.partial(_is_reusable, packages=packages, local=True)
         factory = functools.partial(_specs_from_environment, env=env)
         return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
@@ -88,7 +88,7 @@ class SpecFilter:
         env: spack.environment.Environment,
         included_concrete: str,
     ) -> "SpecFilter":
-        packages = _external_config_with_implicit_externals(configuration)
+        packages = external_config_with_implicit_externals(configuration)
         is_reusable = functools.partial(_is_reusable, packages=packages, local=True)
         factory = functools.partial(
             _specs_from_environment_included_concrete, env=env, included_concrete=included_concrete

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1402,3 +1402,19 @@ def test_config_include_similar_name(tmp_path: pathlib.Path):
     assert len(config.matching_scopes("^test$")) == 1
     assert len(config.matching_scopes("^test:a/config$")) == 1
     assert len(config.matching_scopes("^test:b/config$")) == 1
+
+
+def test_deepcopy_as_builtin(env_yaml):
+    cfg = spack.config.create_from(
+        spack.config.SingleFileScope("env", env_yaml, spack.schema.env.schema, yaml_path=["spack"])
+    )
+    config_copy = cfg.deepcopy_as_builtin("config")
+    assert config_copy == cfg.get_config("config")
+    assert type(config_copy) is dict
+    assert type(config_copy["verify_ssl"]) is bool
+
+    packages_copy = cfg.deepcopy_as_builtin("packages")
+    assert type(packages_copy) is dict
+    assert type(packages_copy["all"]) is dict
+    assert type(packages_copy["all"]["compiler"]) is list
+    assert type(packages_copy["all"]["compiler"][0]) is str

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -63,6 +63,25 @@ def syaml_type(obj):
     return obj
 
 
+def deepcopy_as_builtin(obj: Any) -> Any:
+    """Deep copy a YAML object as built-in types (dict, list, str, int, ...)."""
+    if isinstance(obj, str):
+        return str(obj)
+    elif isinstance(obj, dict):
+        return {deepcopy_as_builtin(k): deepcopy_as_builtin(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [deepcopy_as_builtin(x) for x in obj]
+    elif isinstance(obj, bool):
+        return bool(obj)
+    elif isinstance(obj, int):
+        return int(obj)
+    elif isinstance(obj, float):
+        return float(obj)
+    elif obj is None:
+        return obj
+    raise ValueError(f"cannot convert {type(obj)} to built-in type")
+
+
 def markable(obj):
     """Whether an object can be marked."""
     return type(obj) in markable_types


### PR DESCRIPTION
closes #51350.

Fixes a bug where shallow-copied packages.yaml config was mutated as part of the solve, causing duplicate entries for glibc in the solver, leading to a multiple unique solutions ultimately mapping to the same concrete spec. This just means that the solver has to spend more time proving optimality.

* Add `spack.util.spack_yaml.deepcopy_as_builtin` which takes ruamel.yaml objects and spits out a deep copy using native types `dict`, `list`, `int`, `float`, `bool` and `type(None)`.
* Add `spack.config.Configuration.deepcopy_as_builtin`, which is like `get_config`, except it is a deep copy with native types.
* Use this in `spack.solver.runtimes.external_config_with_implicit_externals` (which was renamed from `_*`).

I think in the future the solver can just call `deepcopy_as_builtin` and work with ordinary dicts, instead of all these inefficient subtypes of strings etc produced by ruamel.yaml.