### PR TITLE
oci: when --tag is used print full image name last

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1085,6 +1085,8 @@ class OCIUploader(Uploader):
             self._base_images, self._checksums, tagged_image, self.tmpdir, None, None, *roots
         )
 
+        tty.info(f"Tagged {tagged_image}")
+
 
 class URLUploader(Uploader):
     def __init__(


### PR DESCRIPTION
If the user runs

```
spack buildcache push \
    --base-image ubuntu:24.04 \
    --tag latest \
    oci+http://localhost:5000/image \
    /somehash
```

ensure that the last line is

```
==> Tagged localhost:5000/image:latest
```

so that can be directly copied and run with `docker run -it --rm localhost:5000/image:latest`.

(You can try this with `docker run -p 5000:5000 registry` in a separate terminal, or with `-d` in the background)

I believe this used to be printed as part of uploading a manifest, but that was dropped in a refactor that made pushing parallel.