### PR TITLE
docs: fix PDF build and enable in RtD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,8 @@ build:
   os: "ubuntu-22.04"
   apt_packages:
     - graphviz
+    - imagemagick
+    - libmagickwand-dev
   tools:
     python: "3.11"
   jobs:
@@ -13,6 +15,10 @@ build:
 sphinx:
   configuration: lib/spack/docs/conf.py
   fail_on_warning: true
+
+formats:
+  - pdf
+  - epub
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,8 +4,7 @@ build:
   os: "ubuntu-22.04"
   apt_packages:
     - graphviz
-    - imagemagick
-    - libmagickwand-dev
+    - inkscape
   tools:
     python: "3.11"
   jobs:
@@ -18,7 +17,6 @@ sphinx:
 
 formats:
   - pdf
-  - epub
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,7 @@ build:
   apt_packages:
     - graphviz
     - inkscape
+    - xindy
   tools:
     python: "3.11"
   jobs:

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -266,15 +266,15 @@ needs_sphinx = "3.4"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.graphviz",
-    "sphinx.ext.imgconverter",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
-    "sphinxcontrib.programoutput",
     "sphinx_last_updated_by_git",
     "sphinx_sitemap",
+    "sphinxcontrib.inkscapeconverter",
+    "sphinxcontrib.programoutput",
 ]
 
 copybutton_exclude = ".linenos, .gp, .go"

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -266,6 +266,7 @@ needs_sphinx = "3.4"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.graphviz",
+    "sphinx.ext.imgconverter",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
@@ -496,6 +497,8 @@ sitemap_url_scheme = "{link}"
 sitemap_excludes = ["search.html", "_modules/*"]
 
 # -- Options for LaTeX output --------------------------------------------------
+
+latex_engine = "lualatex"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx==8.2.3
 sphinxcontrib-programoutput==0.18
+sphinxcontrib-svg2pdfconverter==1.3.0
 sphinx-copybutton==0.5.2
 sphinx-last-updated-by-git==0.3.8
 sphinx-sitemap==2.8.0


### PR DESCRIPTION
Closes #50963
Closes #23124

This fixes the LaTeX build. Without this it would compile with error as there are SVG images in the documentation.