### PR TITLE
Inconsistent build-env behavior between "env activate" "-e"

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -989,6 +989,8 @@ def _main(argv=None):
             env_format_error = e
 
     def add_environment_scope(priority):
+        #TODO ammend python environment here? to enable env mod to apply to child processes
+        # while still allowing child processes to take precedent in further  mods
         if env_format_error:
             # Allow command to continue without env in case it is `spack config edit`
             # All other cases will raise in `finish_parse_and_run`

--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -4,20 +4,55 @@
 import pathlib
 import pickle
 import sys
+import os
 
 import pytest
+import spack.environment as ev
+import spack.llnl.util.filesystem as fs
 
 import spack.error
 from spack.llnl.util.filesystem import working_dir
 from spack.main import SpackCommand
 
 build_env = SpackCommand("build-env")
+add = SpackCommand("add")
+env = SpackCommand("env")
+config = SpackCommand("config")
+concretize = SpackCommand("concretize")
+install = SpackCommand("install")
 
 
 @pytest.mark.parametrize("pkg", [("pkg-c",), ("pkg-c", "--")])
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")
 def test_it_just_runs(pkg):
     build_env(*pkg)
+
+    
+@pytest.mark.usefixtures("config", "mock_packages", "working_env")
+def test_env_mods_with_global_arg_e(monkeypatch, tmp_path):
+    with fs.working_dir(str(tmp_path)):
+        env("remove", "test", "-y")
+        env("create", "test")
+        test_env = ev.read("test")
+        with test_env:
+            config("add", "env_vars:unset:['PE_ENV']")
+            add("gmake")
+            install()
+
+        with spack.util.environment.set_env(PE_ENV="PE_ENV_TEST"):
+            #confirm the env variable is set
+            output = os.environ.get("PE_ENV")
+            assert "PE_ENV_TEST" in output
+
+            #is it present in build-env -e ...
+            output=build_env("gmake", global_args=["-e", str(tmp_path)])
+            assert "PE_ENV_TEST" not in output
+                
+            #does env activate remove it?
+            output = env("activate", "--sh", "test")
+            assert "PE_ENV_TEST" not in output
+            assert "export PE_ENV=''" in output
+
 
 
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This is to address #51047.  The issue is that there is inconsistent behavior with 'build-env' depending on how an environment is activated.  For example with:

```
# This is a Spack Environment file.
#
# It describes a set of packages to be installed, along with
# configuration settings.
spack:
  # add package specs to the `specs` list
  specs:
  - gmake%gcc@8.5.0
  view: true
  concretizer:
    unify: true
  packages:
    gcc:
      externals:
      - spec: gcc@8.5.0 languages:='c,c++'
        prefix: /usr
        extra_attributes:
          compilers:
            c: /usr/bin/gcc
            cxx: /usr/bin/g++
  env_vars:
    unset:
    - PE_ENV
```
wtih env activate we get the environment modifications to our shell and the expected result:
```
$ export PE_ENV=CRAY
$ spack env activate .
$ spack build-env gmake echo PE_ENV=${PE_ENV}
PE_ENV=
```
however when we use global arg e the changes are not being propagated correctly:
```
$ export PE_ENV=CRAY
$ spack -e . build-env gmake echo PE_ENV=${PE_ENV}
PE_ENV=CRAY
```

