### PR TITLE
Ci fail fast

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -177,15 +177,15 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     rebuild_ff_group.add_argument(
         "--no-fail-fast",
         action="store_false",
-        default=False,
+        default=True,
         dest="fail_fast",
-        help="stop stand-alone tests after the first failure",
+        help="continue build/stand-alone tests after the first failure",
     )
     rebuild_ff_group.add_argument(
         "--fail-fast",
         action="store_true",
         dest="fail_fast",
-        help="stop stand-alone tests after the first failure",
+        help="stop build/stand-alone tests after the first failure",
     )
     rebuild.add_argument(
         "--timeout",

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -173,10 +173,18 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=False,
         help="run stand-alone tests after the build",
     )
-    rebuild.add_argument(
+    rebuild_ff_group = rebuild.add_mutually_exclusive_group()
+    rebuild_ff_group.add_argument(
+        "--no-fail-fast",
+        action="store_false",
+        default=False,
+        dest="fail_fast",
+        help="stop stand-alone tests after the first failure",
+    )
+    rebuild_ff_group.add_argument(
         "--fail-fast",
         action="store_true",
-        default=False,
+        dest="fail_fast",
         help="stop stand-alone tests after the first failure",
     )
     rebuild.add_argument(
@@ -475,6 +483,10 @@ def ci_rebuild(args):
     if args.jobs:
         install_args.append(f"-j{args.jobs}")
 
+    fail_fast = bool(os.environ.get("SPACK_CI_FAIL_FAST", str(args.fail_fast)))
+    if fail_fast:
+        install_args.append("--fail-fast")
+
     slash_hash = spack_ci.common.win_quote("/" + job_spec.dag_hash())
 
     # Arguments when installing the root from sources
@@ -553,7 +565,7 @@ def ci_rebuild(args):
                 spack_ci.run_standalone_tests(
                     cdash=cdash_handler,
                     job_spec=job_spec,
-                    fail_fast=args.fail_fast,
+                    fail_fast=fail_fast,
                     log_file=log_file,
                     repro_dir=repro_dir,
                     timeout=args.timeout,

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -714,7 +714,7 @@ _spack_ci_rebuild_index() {
 }
 
 _spack_ci_rebuild() {
-    SPACK_COMPREPLY="-h --help -t --tests --fail-fast --timeout -j --jobs"
+    SPACK_COMPREPLY="-h --help -t --tests --no-fail-fast --fail-fast --timeout -j --jobs"
 }
 
 _spack_ci_reproduce_build() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1004,9 +1004,9 @@ complete -c spack -n '__fish_spack_using_command ci rebuild' -s h -l help -d 'sh
 complete -c spack -n '__fish_spack_using_command ci rebuild' -s t -l tests -f -a tests
 complete -c spack -n '__fish_spack_using_command ci rebuild' -s t -l tests -d 'run stand-alone tests after the build'
 complete -c spack -n '__fish_spack_using_command ci rebuild' -l no-fail-fast -f -a fail_fast
-complete -c spack -n '__fish_spack_using_command ci rebuild' -l no-fail-fast -d 'stop stand-alone tests after the first failure'
+complete -c spack -n '__fish_spack_using_command ci rebuild' -l no-fail-fast -d 'continue build/stand-alone tests after the first failure'
 complete -c spack -n '__fish_spack_using_command ci rebuild' -l fail-fast -f -a fail_fast
-complete -c spack -n '__fish_spack_using_command ci rebuild' -l fail-fast -d 'stop stand-alone tests after the first failure'
+complete -c spack -n '__fish_spack_using_command ci rebuild' -l fail-fast -d 'stop build/stand-alone tests after the first failure'
 complete -c spack -n '__fish_spack_using_command ci rebuild' -l timeout -r -f -a timeout
 complete -c spack -n '__fish_spack_using_command ci rebuild' -l timeout -r -d 'maximum time (in seconds) that tests are allowed to run'
 complete -c spack -n '__fish_spack_using_command ci rebuild' -s j -l jobs -r -f -a jobs

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -998,11 +998,13 @@ complete -c spack -n '__fish_spack_using_command ci rebuild-index' -s h -l help 
 complete -c spack -n '__fish_spack_using_command ci rebuild-index' -s h -l help -d 'show this help message and exit'
 
 # spack ci rebuild
-set -g __fish_spack_optspecs_spack_ci_rebuild h/help t/tests fail-fast timeout= j/jobs=
+set -g __fish_spack_optspecs_spack_ci_rebuild h/help t/tests no-fail-fast fail-fast timeout= j/jobs=
 complete -c spack -n '__fish_spack_using_command ci rebuild' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command ci rebuild' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command ci rebuild' -s t -l tests -f -a tests
 complete -c spack -n '__fish_spack_using_command ci rebuild' -s t -l tests -d 'run stand-alone tests after the build'
+complete -c spack -n '__fish_spack_using_command ci rebuild' -l no-fail-fast -f -a fail_fast
+complete -c spack -n '__fish_spack_using_command ci rebuild' -l no-fail-fast -d 'stop stand-alone tests after the first failure'
 complete -c spack -n '__fish_spack_using_command ci rebuild' -l fail-fast -f -a fail_fast
 complete -c spack -n '__fish_spack_using_command ci rebuild' -l fail-fast -d 'stop stand-alone tests after the first failure'
 complete -c spack -n '__fish_spack_using_command ci rebuild' -l timeout -r -f -a timeout


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Expand `--fail-fast` to apply to install.
Change the default to `--fail-fast` to `True`
Add environment variable to control fail-fast mode `SPACK_CI_FAIL_FAST`