### PR TITLE
Add name for macOS release 26

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -142,6 +142,7 @@ class MacOs(OperatingSystem):
             "13": "ventura",
             "14": "sonoma",
             "15": "sequoia",
+            "26": "tahoe",
         }
 
         version = macos_version()


### PR DESCRIPTION
Add "Tahoe" as the standard recognized name for the latest macOS. I think this should be cherry-picked into the release branch?