### PR TITLE
package api: fix git_sparse_paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@ Deprecated the implicit attributes:
 - `Builder.legacy_attributes`
 - `Builder.legacy_long_methods`
 
+## Package API v2.3
+- `spack.package.version` directive: added `git_sparse_paths` parameter.
+
 ## Package API v2.2
 Added to `spack.package`:
 - `BuilderWithDefaults`

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -163,7 +163,9 @@ def version(
     tag: Optional[str] = None,
     branch: Optional[str] = None,
     get_full_repo: Optional[bool] = None,
-    git_sparse_paths: Optional[bool] = None,
+    git_sparse_paths: Optional[
+        Union[List[str], Callable[[spack.package_base.PackageBase], List[str]]]
+    ] = None,
     submodules: Union[SubmoduleCallback, Optional[bool]] = None,
     submodules_delete: Optional[bool] = None,
     # other version control
@@ -179,6 +181,10 @@ def version(
 
         version("2.1", sha256="...")
         version("2.0", sha256="...", preferred=True)
+
+    .. versionchanged:: v2.3
+
+       The ``git_sparse_paths`` parameter was added.
     """
     kwargs = {
         key: value

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -748,9 +748,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: TestSuite instance used to manage stand-alone tests for 1+ specs.
     test_suite: Optional[Any] = None
 
-    #: A list of sub-directories to checkout with a git sparse checkout.  Added in version 2.3.
-    git_sparse_paths: List[str] = []
-
     def __init__(self, spec: spack.spec.Spec) -> None:
         # this determines how the package should be built.
         self.spec = spec

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -370,14 +370,14 @@ def test_package_version_can_have_sparse_checkout_properties(
 ):
     spec = Spec("git-sparsepaths-version")
     pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
-    assert hasattr(pkg_cls, "git_sparse_paths")
-    assert pkg_cls.git_sparse_paths == []
 
-    version = "1.0"
-    fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), version)
+    fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), version="1.0")
     assert isinstance(fetcher, spack.fetch_strategy.GitFetchStrategy)
-    assert hasattr(fetcher, "git_sparse_paths")
     assert fetcher.git_sparse_paths == ["foo", "bar"]
+
+    fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), version="0.9")
+    assert isinstance(fetcher, spack.fetch_strategy.GitFetchStrategy)
+    assert fetcher.git_sparse_paths is None
 
 
 def test_package_can_depend_on_commit_of_dependency(mock_packages, config):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparsepaths_version/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparsepaths_version/package.py
@@ -14,3 +14,4 @@ class GitSparsepathsVersion(Package):
     git = "https://a/really.com/big/repo.git"
 
     version("1.0", tag="v1.0", git_sparse_paths=["foo", "bar"])
+    version("0.9", tag="v0.9")


### PR DESCRIPTION
* `PackageBase.git_sparse_paths` was _not_ added in v2.3, it's an optional attribute supported since Spack v1.0
* `spack.package.version`'s `git_sparse_paths` argument was added in v2.3
* Fix the incorrect function signature of `spack.package.version`