### PR TITLE
Show progress when Spack is computing caches

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -653,9 +653,15 @@ class RepoIndex:
                 if new_index_mtime != index_mtime:
                     needs_update = self.checker.modified_since(new_index_mtime)
 
-                for pkg_name in needs_update:
+                for counter, pkg_name in enumerate(needs_update):
+                    if sys.stdout.isatty():
+                        progress = int(counter * 100 / len(needs_update))
+                        print(
+                            f"\r\033[KComputing {name} cache [{progress:3d}%]", end="", flush=True
+                        )
                     indexer.update(f"{self.namespace}.{pkg_name}")
-
+                if sys.stdout.isatty():
+                    print("\r\033[K", flush=True, end="")
                 indexer.write(new)
 
         return indexer.index


### PR DESCRIPTION
If stdout is a tty, display the progress when Spack is computing the caches.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
