### PR TITLE
tag.py: refactor

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -500,15 +500,15 @@ class TagIndexer(Indexer):
     def _create(self) -> "spack.tag.TagIndex":
         from spack.tag import TagIndex
 
-        return TagIndex(self.repository)
+        return TagIndex()
 
     def read(self, stream):
         from spack.tag import TagIndex
 
-        self.index = TagIndex.from_json(stream, self.repository)
+        self.index = TagIndex.from_json(stream)
 
     def update(self, pkg_fullname):
-        self.index.update_package(pkg_fullname.split(".")[-1])
+        self.index.update_package(pkg_fullname.split(".")[-1], self.repository)
 
     def write(self, stream):
         self.index.to_json(stream)
@@ -817,7 +817,7 @@ class RepoPath:
         if self._tag_index is None:
             from spack.tag import TagIndex
 
-            self._tag_index = TagIndex(repository=self)
+            self._tag_index = TagIndex()
             for repo in reversed(self.repos):
                 self._tag_index.merge(repo.tag_index)
         return self._tag_index

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -47,6 +47,7 @@ import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.paths
 import spack.provider_index
+import spack.tag
 import spack.util.executable
 import spack.util.file_cache
 import spack.util.git
@@ -61,7 +62,6 @@ if TYPE_CHECKING:
     import spack.package_base
     import spack.patch
     import spack.spec
-    import spack.tag
 
 PKG_MODULE_PREFIX_V1 = "spack.pkg."
 PKG_MODULE_PREFIX_V2 = "spack_repo."
@@ -498,14 +498,10 @@ class TagIndexer(Indexer):
     """Lifecycle methods for a TagIndex on a Repo."""
 
     def _create(self) -> "spack.tag.TagIndex":
-        from spack.tag import TagIndex
-
-        return TagIndex()
+        return spack.tag.TagIndex()
 
     def read(self, stream):
-        from spack.tag import TagIndex
-
-        self.index = TagIndex.from_json(stream)
+        self.index = spack.tag.TagIndex.from_json(stream)
 
     def update(self, pkg_fullname):
         self.index.update_package(pkg_fullname.split(".")[-1], self.repository)
@@ -815,9 +811,7 @@ class RepoPath:
     def tag_index(self) -> "spack.tag.TagIndex":
         """Merged TagIndex from all Repos in the RepoPath."""
         if self._tag_index is None:
-            from spack.tag import TagIndex
-
-            self._tag_index = TagIndex()
+            self._tag_index = spack.tag.TagIndex()
             for repo in reversed(self.repos):
                 self._tag_index.merge(repo.tag_index)
         return self._tag_index

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1366,7 +1366,8 @@ class Repo:
 
     def packages_with_tags(self, *tags: str) -> Set[str]:
         v = set(self.all_package_names())
-        v.intersection_update(*(self.tag_index[tag.lower()] for tag in tags))
+        for tag in tags:
+            v.intersection_update(self.tag_index.get_packages(tag.lower()))
         return v
 
     def all_package_classes(self) -> Generator[Type["spack.package_base.PackageBase"], None, None]:

--- a/lib/spack/spack/tag.py
+++ b/lib/spack/spack/tag.py
@@ -16,15 +16,14 @@ RepoType = Union["spack.repo.Repo", "spack.repo.RepoPath"]
 class TagIndex:
     """Maps tags to list of package names."""
 
-    def __init__(self, repository: RepoType) -> None:
+    def __init__(self) -> None:
         self.tags: Dict[str, List[str]] = {}
-        self.repository = repository
 
     def to_json(self, stream) -> None:
         sjson.dump({"tags": self.tags}, stream)
 
     @staticmethod
-    def from_json(stream, repository: RepoType) -> "TagIndex":
+    def from_json(stream) -> "TagIndex":
         d = sjson.load(stream)
 
         if not isinstance(d, dict):
@@ -33,11 +32,9 @@ class TagIndex:
         if "tags" not in d:
             raise TagIndexError("TagIndex data does not start with 'tags'")
 
-        r = TagIndex(repository=repository)
-
+        r = TagIndex()
         for tag, packages in d["tags"].items():
             r.tags[tag] = packages
-
         return r
 
     def get_packages(self, tag: str) -> List[str]:
@@ -56,13 +53,13 @@ class TagIndex:
             else:
                 self.tags[tag] = sorted({*self.tags[tag], *pkgs})
 
-    def update_package(self, pkg_name: str) -> None:
+    def update_package(self, pkg_name: str, repo: RepoType) -> None:
         """Updates a package in the tag index.
 
         Args:
             pkg_name: name of the package to be updated
         """
-        pkg_cls = self.repository.get_pkg_class(pkg_name)
+        pkg_cls = repo.get_pkg_class(pkg_name)
 
         # Remove the package from the list of packages, if present
         for pkg_list in self.tags.values():

--- a/lib/spack/spack/tag.py
+++ b/lib/spack/spack/tag.py
@@ -2,15 +2,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Classes and functions to manage package tags"""
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import TYPE_CHECKING, Dict, List
 
 import spack.error
 import spack.util.spack_json as sjson
 
 if TYPE_CHECKING:
     import spack.repo
-
-RepoType = Union["spack.repo.Repo", "spack.repo.RepoPath"]
 
 
 class TagIndex:
@@ -53,7 +51,7 @@ class TagIndex:
             else:
                 self.tags[tag] = sorted({*self.tags[tag], *pkgs})
 
-    def update_package(self, pkg_name: str, repo: RepoType) -> None:
+    def update_package(self, pkg_name: str, repo: "spack.repo.Repo") -> None:
         """Updates a package in the tag index.
 
         Args:

--- a/lib/spack/spack/tag.py
+++ b/lib/spack/spack/tag.py
@@ -2,64 +2,29 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Classes and functions to manage package tags"""
-import collections
-import copy
-from collections.abc import Mapping
+from typing import TYPE_CHECKING, Dict, List, Union
 
 import spack.error
-import spack.repo
 import spack.util.spack_json as sjson
 
+if TYPE_CHECKING:
+    import spack.repo
 
-def _get_installed_package_names():
-    """Returns names of packages installed in the active environment."""
-    import spack.environment
-
-    specs = spack.environment.installed_specs()
-    return [spec.name for spec in specs]
+RepoType = Union["spack.repo.Repo", "spack.repo.RepoPath"]
 
 
-def packages_with_tags(tags, installed, skip_empty):
-    """
-    Returns a dict, indexed by tag, containing lists of names of packages
-    containing the tag or, if no tags, for all available tags.
+class TagIndex:
+    """Maps tags to list of package names."""
 
-    Arguments:
-        tags (list or None): list of tags of interest or None for all
-        installed (bool): True if want names of packages that are installed;
-            otherwise, False if want all packages with the tag
-        skip_empty (bool): True if exclude tags with no associated packages;
-            otherwise, False if want entries for all tags even when no such
-            tagged packages
-    """
-    tag_pkgs = collections.defaultdict(lambda: list)
-    spec_names = _get_installed_package_names() if installed else []
-    keys = spack.repo.PATH.tag_index if tags is None else tags
-    for tag in keys:
-        packages = [
-            name for name in spack.repo.PATH.tag_index[tag] if not installed or name in spec_names
-        ]
-        if packages or not skip_empty:
-            tag_pkgs[tag] = packages
-    return tag_pkgs
-
-
-class TagIndex(Mapping):
-    """Maps tags to list of packages."""
-
-    def __init__(self, repository):
-        self._tag_dict = collections.defaultdict(list)
+    def __init__(self, repository: RepoType) -> None:
+        self.tags: Dict[str, List[str]] = {}
         self.repository = repository
 
-    @property
-    def tags(self):
-        return self._tag_dict
-
-    def to_json(self, stream):
-        sjson.dump({"tags": self._tag_dict}, stream)
+    def to_json(self, stream) -> None:
+        sjson.dump({"tags": self.tags}, stream)
 
     @staticmethod
-    def from_json(stream, repository):
+    def from_json(stream, repository: RepoType) -> "TagIndex":
         d = sjson.load(stream)
 
         if not isinstance(d, dict):
@@ -71,62 +36,46 @@ class TagIndex(Mapping):
         r = TagIndex(repository=repository)
 
         for tag, packages in d["tags"].items():
-            r[tag].extend(packages)
+            r.tags[tag] = packages
 
         return r
 
-    def __getitem__(self, item):
-        return self._tag_dict[item]
-
-    def __iter__(self):
-        return iter(self._tag_dict)
-
-    def __len__(self):
-        return len(self._tag_dict)
-
-    def copy(self):
-        """Return a deep copy of this index."""
-        clone = TagIndex(repository=self.repository)
-        clone._tag_dict = copy.deepcopy(self._tag_dict)
-        return clone
-
-    def get_packages(self, tag):
+    def get_packages(self, tag: str) -> List[str]:
         """Returns all packages associated with the tag."""
-        return self.tags[tag] if tag in self.tags else []
+        return self.tags.get(tag, [])
 
-    def merge(self, other):
+    def merge(self, other: "TagIndex") -> None:
         """Merge another tag index into this one.
 
         Args:
-            other (TagIndex): tag index to be merged
+            other: tag index to be merged
         """
-        other = other.copy()  # defensive copy.
-
-        for tag in other.tags:
+        for tag, pkgs in other.tags.items():
             if tag not in self.tags:
-                self.tags[tag] = other.tags[tag]
-                continue
+                self.tags[tag] = pkgs.copy()
+            else:
+                self.tags[tag] = sorted({*self.tags[tag], *pkgs})
 
-            spkgs, opkgs = self.tags[tag], other.tags[tag]
-            self.tags[tag] = sorted(list(set(spkgs + opkgs)))
-
-    def update_package(self, pkg_name):
+    def update_package(self, pkg_name: str) -> None:
         """Updates a package in the tag index.
 
         Args:
-            pkg_name (str): name of the package to be removed from the index
+            pkg_name: name of the package to be updated
         """
         pkg_cls = self.repository.get_pkg_class(pkg_name)
 
         # Remove the package from the list of packages, if present
-        for pkg_list in self._tag_dict.values():
+        for pkg_list in self.tags.values():
             if pkg_name in pkg_list:
                 pkg_list.remove(pkg_name)
 
         # Add it again under the appropriate tags
         for tag in getattr(pkg_cls, "tags", []):
             tag = tag.lower()
-            self._tag_dict[tag].append(pkg_cls.name)
+            if tag not in self.tags:
+                self.tags[tag] = [pkg_cls.name]
+            else:
+                self.tags[tag].append(pkg_cls.name)
 
 
 class TagIndexError(spack.error.SpackError):

--- a/lib/spack/spack/test/cmd/tags.py
+++ b/lib/spack/spack/test/cmd/tags.py
@@ -6,6 +6,7 @@ import spack.concretize
 import spack.main
 import spack.repo
 from spack.installer import PackageInstaller
+from spack.tag import TagIndex
 
 tags = spack.main.SpackCommand("tags")
 
@@ -38,10 +39,7 @@ def test_tags_all_mock_tag_packages(mock_packages):
 
 
 def test_tags_no_tags(monkeypatch):
-    class tag_path:
-        tag_index = dict()
-
-    monkeypatch.setattr(spack.repo, "PATH", tag_path)
+    monkeypatch.setattr(spack.repo.PATH, "tag_index", TagIndex())
     out = tags()
     assert "No tagged" in out
 

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -6,6 +6,7 @@ import io
 
 import pytest
 
+import spack.cmd.tags
 import spack.repo
 import spack.tag
 from spack.main import SpackCommand
@@ -38,16 +39,9 @@ more_tags_json = """
     """
 
 
-def test_tag_copy(mock_packages):
-    index = spack.tag.TagIndex.from_json(io.StringIO(tags_json), repository=mock_packages)
-    new_index = index.copy()
-
-    assert index.tags == new_index.tags
-
-
 def test_tag_get_all_available(mock_packages):
     for skip in [False, True]:
-        all_pkgs = spack.tag.packages_with_tags(None, False, skip)
+        all_pkgs = spack.cmd.tags.packages_with_tags(["tag1", "tag2", "tag3"], False, skip)
         assert sorted(all_pkgs["tag1"]) == ["mpich", "mpich2"]
         assert all_pkgs["tag2"] == ["mpich"]
         assert all_pkgs["tag3"] == ["mpich2"]
@@ -73,11 +67,11 @@ def ensure_tags_results_equal(results, expected):
 )
 def test_tag_get_available(tags, expected, mock_packages):
     # Ensure results for all tags
-    all_tag_pkgs = spack.tag.packages_with_tags(tags, False, False)
+    all_tag_pkgs = spack.cmd.tags.packages_with_tags(tags, False, False)
     ensure_tags_results_equal(all_tag_pkgs, expected)
 
     # Ensure results for tags expecting results since skipping otherwise
-    only_pkgs = spack.tag.packages_with_tags(tags, False, True)
+    only_pkgs = spack.cmd.tags.packages_with_tags(tags, False, True)
     if expected[tags[0]]:
         ensure_tags_results_equal(only_pkgs, expected)
     else:
@@ -88,7 +82,7 @@ def test_tag_get_installed_packages(mock_packages, mock_archive, mock_fetch, ins
     install("--fake", "mpich")
 
     for skip in [False, True]:
-        all_pkgs = spack.tag.packages_with_tags(None, True, skip)
+        all_pkgs = spack.cmd.tags.packages_with_tags(["tag1", "tag2", "tag3"], True, skip)
         assert sorted(all_pkgs["tag1"]) == ["mpich"]
         assert all_pkgs["tag2"] == ["mpich"]
         assert skip or all_pkgs["tag3"] == []
@@ -105,14 +99,14 @@ def test_tag_index_round_trip(mock_packages):
     istream = io.StringIO(ostream.getvalue())
     new_index = spack.tag.TagIndex.from_json(istream, repository=mock_packages)
 
-    assert mock_index == new_index
+    assert mock_index.tags == new_index.tags
 
 
 def test_tag_equal(mock_packages):
     first_index = spack.tag.TagIndex.from_json(io.StringIO(tags_json), repository=mock_packages)
     second_index = spack.tag.TagIndex.from_json(io.StringIO(tags_json), repository=mock_packages)
 
-    assert first_index == second_index
+    assert first_index.tags == second_index.tags
 
 
 def test_tag_merge(mock_packages):

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -97,23 +97,21 @@ def test_tag_index_round_trip(mock_packages):
     mock_index.to_json(ostream)
 
     istream = io.StringIO(ostream.getvalue())
-    new_index = spack.tag.TagIndex.from_json(istream, repository=mock_packages)
+    new_index = spack.tag.TagIndex.from_json(istream)
 
     assert mock_index.tags == new_index.tags
 
 
 def test_tag_equal(mock_packages):
-    first_index = spack.tag.TagIndex.from_json(io.StringIO(tags_json), repository=mock_packages)
-    second_index = spack.tag.TagIndex.from_json(io.StringIO(tags_json), repository=mock_packages)
+    first_index = spack.tag.TagIndex.from_json(io.StringIO(tags_json))
+    second_index = spack.tag.TagIndex.from_json(io.StringIO(tags_json))
 
     assert first_index.tags == second_index.tags
 
 
 def test_tag_merge(mock_packages):
-    first_index = spack.tag.TagIndex.from_json(io.StringIO(tags_json), repository=mock_packages)
-    second_index = spack.tag.TagIndex.from_json(
-        io.StringIO(more_tags_json), repository=mock_packages
-    )
+    first_index = spack.tag.TagIndex.from_json(io.StringIO(tags_json))
+    second_index = spack.tag.TagIndex.from_json(io.StringIO(more_tags_json))
 
     assert first_index != second_index
 
@@ -134,21 +132,21 @@ def test_tag_merge(mock_packages):
 def test_tag_not_dict(mock_packages):
     list_json = "[]"
     with pytest.raises(spack.tag.TagIndexError) as e:
-        spack.tag.TagIndex.from_json(io.StringIO(list_json), repository=mock_packages)
+        spack.tag.TagIndex.from_json(io.StringIO(list_json))
         assert "not a dict" in str(e)
 
 
 def test_tag_no_tags(mock_packages):
     pkg_json = '{"packages": []}'
     with pytest.raises(spack.tag.TagIndexError) as e:
-        spack.tag.TagIndex.from_json(io.StringIO(pkg_json), repository=mock_packages)
+        spack.tag.TagIndex.from_json(io.StringIO(pkg_json))
         assert "does not start with" in str(e)
 
 
 def test_tag_update_package(mock_packages):
     mock_index = mock_packages.tag_index
-    index = spack.tag.TagIndex(repository=mock_packages)
+    index = spack.tag.TagIndex()
     for name in spack.repo.all_package_names():
-        index.update_package(name)
+        index.update_package(name, repo=mock_packages)
 
     ensure_tags_results_equal(mock_index.tags, index.tags)


### PR DESCRIPTION
* Fix circular import issue with `spack.environment` by moving to call site
* Fix circular import with `spack.repo` and remove inline import of `spack.tag`
* Simplify constructor of `TagIndex` to make testing independent of a repo
* Drop `Mapping` and `def tags` as they offer 3 APIs for the same: `self._tag_dict`, `self.tags`, `self` are all the same mapping.
* Do not use `collections.defaultdict` since that could cause storing empty lists if a certain tag without packages associated is queried before calling `to_json`.
* Sprinkle typehints

> The overall number of problematic import statements decreased by 1 from 25 to 24.
