### PR TITLE
Add test that demonstrates unwanted mixing of compiler flags

### DIFF
--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -471,7 +471,12 @@ class TestConcretize:
 
     @pytest.mark.xfail(reason="asp representation of compilers is merged")
     def test_flag_mixing_env(
-        self, mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mutable_config
+        self,
+        mutable_mock_env_path,
+        tmp_path: pathlib.Path,
+        mock_packages,
+        mutable_config,
+        mutable_database,
     ):
         spack_yaml = tmp_path / ev.manifest_name
         spack_yaml.write_text(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -19,6 +19,7 @@ import spack.concretize
 import spack.config
 import spack.deptypes as dt
 import spack.detection
+import spack.environment as ev
 import spack.error
 import spack.hash_types as ht
 import spack.llnl.util.lang
@@ -467,6 +468,64 @@ class TestConcretize:
             assert bool(x.dependencies(name="gcc", deptype="build")) is expected_gcc
             assert x.satisfies("%clang") is not expected_gcc
             assert x.satisfies("%gcc") is expected_gcc
+
+    @pytest.mark.xfail(reason="asp representation of compilers is merged")
+    def test_flag_mixing_env(
+        self, mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mutable_config
+    ):
+        spack_yaml = tmp_path / ev.manifest_name
+        spack_yaml.write_text(
+            """\
+spack:
+  specs:
+  - dt-diamond-bottom%gcc@9.4.8
+  concretizer:
+    unify: true
+  packages:
+    gcc:
+      externals:
+      - spec: "gcc@9.4.8 languages='c,c++'"
+        prefix: /path
+        extra_attributes:
+          compilers:
+            c: /path/bin/gcc
+            cxx: /path/bin/g++
+          flags:
+            cflags: -A
+"""
+        )
+
+        with ev.Environment(tmp_path) as e:
+            e.concretize()
+            (root1,) = e.roots()
+            PackageInstaller([root1.package], fake=True, explicit=True).install()
+
+        spack_yaml.write_text(
+            """\
+spack:
+  specs:
+  - dt-diamond-bottom%gcc@9.4.8
+  concretizer:
+    unify: true
+  packages:
+    gcc:
+      externals:
+      - spec: "gcc@9.4.8 languages='c,c++'"
+        prefix: /path
+        extra_attributes:
+          compilers:
+            c: /path/bin/gcc
+            cxx: /path/bin/g++
+          flags:
+            cflags: -B
+"""
+        )
+
+        with ev.Environment(tmp_path) as e:
+            e.concretize()
+            (root2,) = e.roots()
+            # This fails right now, -A and -B are merged
+            assert not root2.satisfies("cflags=-A")
 
     def test_compiler_inherited_upwards(self):
         spec = spack.concretize.concretize_one("dt-diamond ^dt-diamond-bottom%clang")


### PR DESCRIPTION
A user was concretizing the same spec in two envs; in each env the only difference was changing compiler flags on the compiler. If they installed one such env, the flags from the first env were merged into the concretized spec of from the second env. This test reproduces that behavior in a test (that xfails).

If the compiler versions in this test are differentiated, then the flags will not be mixed. I think it's a matter of discussion whether compiler identity ought to be based on the flags as well.