### PR TITLE
patch: refactor to avoid circularity with repo

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1722,7 +1722,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                         patch_path = patch.path
 
                     spack.patch.apply_patch(
-                        self.stage, patch_path, patch.level, patch.working_dir, patch.reverse
+                        self.stage.source_path,
+                        patch_path,
+                        patch.level,
+                        patch.working_dir,
+                        patch.reverse,
                     )
 
                 tty.msg(f"Applied patch {patch.path_or_url}")

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -45,6 +45,7 @@ import spack.llnl.path
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
+import spack.patch
 import spack.paths
 import spack.provider_index
 import spack.tag
@@ -60,7 +61,6 @@ from spack.llnl.util.filesystem import working_dir
 
 if TYPE_CHECKING:
     import spack.package_base
-    import spack.patch
     import spack.spec
 
 PKG_MODULE_PREFIX_V1 = "spack.pkg."
@@ -497,7 +497,7 @@ class Indexer(metaclass=abc.ABCMeta):
 class TagIndexer(Indexer):
     """Lifecycle methods for a TagIndex on a Repo."""
 
-    def _create(self) -> "spack.tag.TagIndex":
+    def _create(self) -> spack.tag.TagIndex:
         return spack.tag.TagIndex()
 
     def read(self, stream):
@@ -536,10 +536,8 @@ class ProviderIndexer(Indexer):
 class PatchIndexer(Indexer):
     """Lifecycle methods for patch cache."""
 
-    def _create(self) -> "spack.patch.PatchCache":
-        from spack.patch import PatchCache
-
-        return PatchCache(repository=self.repository)
+    def _create(self) -> spack.patch.PatchCache:
+        return spack.patch.PatchCache(repository=self.repository)
 
     def needs_update(self):
         # TODO: patches can change under a package and we should handle
@@ -549,9 +547,7 @@ class PatchIndexer(Indexer):
         return False
 
     def read(self, stream):
-        from spack.patch import PatchCache
-
-        self.index = PatchCache.from_json(stream, repository=self.repository)
+        self.index = spack.patch.PatchCache.from_json(stream, repository=self.repository)
 
     def write(self, stream):
         self.index.to_json(stream)
@@ -669,8 +665,8 @@ class RepoPath:
         self.repos: List[Repo] = []
         self.by_namespace = nm.NamespaceTrie()
         self._provider_index: Optional[spack.provider_index.ProviderIndex] = None
-        self._patch_index: Optional["spack.patch.PatchCache"] = None
-        self._tag_index: Optional["spack.tag.TagIndex"] = None
+        self._patch_index: Optional[spack.patch.PatchCache] = None
+        self._tag_index: Optional[spack.tag.TagIndex] = None
 
         for repo in repos:
             self.put_last(repo)
@@ -808,7 +804,7 @@ class RepoPath:
         return self._provider_index
 
     @property
-    def tag_index(self) -> "spack.tag.TagIndex":
+    def tag_index(self) -> spack.tag.TagIndex:
         """Merged TagIndex from all Repos in the RepoPath."""
         if self._tag_index is None:
             self._tag_index = spack.tag.TagIndex()
@@ -817,7 +813,7 @@ class RepoPath:
         return self._tag_index
 
     @property
-    def patch_index(self) -> "spack.patch.PatchCache":
+    def patch_index(self) -> spack.patch.PatchCache:
         """Merged PatchIndex from all Repos in the RepoPath."""
         if self._patch_index is None:
             from spack.patch import PatchCache
@@ -1291,12 +1287,12 @@ class Repo:
         return self.index["providers"]
 
     @property
-    def tag_index(self) -> "spack.tag.TagIndex":
+    def tag_index(self) -> spack.tag.TagIndex:
         """Index of tags and which packages they're defined on."""
         return self.index["tags"]
 
     @property
-    def patch_index(self) -> "spack.patch.PatchCache":
+    def patch_index(self) -> spack.patch.PatchCache:
         """Index of patches and packages they're defined on."""
         return self.index["patches"]
 

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -127,7 +127,11 @@ third line
             patch_stage.fetch()
             patch_stage.expand_archive()
             spack.patch.apply_patch(
-                stage, patch_stage.single_file, patch.level, patch.working_dir, patch.reverse
+                stage.source_path,
+                patch_stage.single_file,
+                patch.level,
+                patch.working_dir,
+                patch.reverse,
             )
 
         with working_dir(stage.source_path):
@@ -143,7 +147,11 @@ third line
             patch_stage.fetch()
             patch_stage.expand_archive()
             spack.patch.apply_patch(
-                stage, patch_stage.single_file, patch.level, patch.working_dir, patch.reverse
+                stage.source_path,
+                patch_stage.single_file,
+                patch.level,
+                patch.working_dir,
+                patch.reverse,
             )
 
         with working_dir(stage.source_path):
@@ -437,7 +445,7 @@ def test_patch_no_file():
     patch = spack.patch.Patch(fp, "nonexistent_file", 0, "")
     patch.path = "test"
     with pytest.raises(spack.error.NoSuchPatchError, match="No such patch:"):
-        spack.patch.apply_patch(Stage("https://example.com/foo.patch"), patch.path)
+        spack.patch.apply_patch(Stage("https://example.com/foo.patch").source_path, patch.path)
 
 
 def test_patch_no_sha256():
@@ -482,11 +490,11 @@ def test_sha256_setter(mock_packages, mock_patch_stage, config):
 def test_invalid_from_dict(mock_packages, config):
     dictionary = {}
     with pytest.raises(ValueError, match="Invalid patch dictionary:"):
-        spack.patch.from_dict(dictionary)
+        spack.patch.from_dict(dictionary, mock_packages)
 
     dictionary = {"owner": "patch"}
     with pytest.raises(ValueError, match="Invalid patch dictionary:"):
-        spack.patch.from_dict(dictionary)
+        spack.patch.from_dict(dictionary, mock_packages)
 
     dictionary = {
         "owner": "patch",
@@ -497,4 +505,4 @@ def test_invalid_from_dict(mock_packages, config):
         "sha256": bar_sha256,
     }
     with pytest.raises(spack.fetch_strategy.ChecksumError, match="sha256 checksum failed for"):
-        spack.patch.from_dict(dictionary)
+        spack.patch.from_dict(dictionary, mock_packages)


### PR DESCRIPTION
Use dependency injection of `spack.repo` classes in `spack.patch`

> The overall number of problematic import statements decreased by 1 from 24 to 23.