### PR TITLE
spec.py: ensure Spec.name is str

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -1224,7 +1224,7 @@ def _named_specs_in_when_arguments(pkgs, error_cls):
 
         def _refers_to_pkg(when):
             when_spec = spack.spec.Spec(when)
-            return when_spec.name is None or when_spec.name == pkg_name
+            return not when_spec.name or when_spec.name == pkg_name
 
         def _error_items(when_dict):
             for when, elts in when_dict.items():

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1226,7 +1226,7 @@ class Repo:
         # actually exists, because we have to load it anyway, and that ends up
         # checking for existence. We avoid constructing FastPackageChecker,
         # which will stat all packages.
-        if spec.name is None:
+        if not spec.name:
             raise UnknownPackageError(None, self)
 
         if spec.namespace and spec.namespace != self.namespace:

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -74,7 +74,7 @@ class RuntimePropertyRecorder:
         assert self.current_package == "*", msg
 
         when_spec = spack.spec.Spec(when)
-        assert when_spec.name is None, "only anonymous when specs are accepted"
+        assert not when_spec.name, "only anonymous when specs are accepted"
 
         dependency_spec = spack.spec.Spec(dependency_str)
         if dependency_spec.versions != spack.version.any_version:
@@ -181,7 +181,7 @@ class RuntimePropertyRecorder:
         assert self.current_package == "*", msg
 
         when_spec = spack.spec.Spec(when)
-        assert when_spec.name is None, "only anonymous when specs are accepted"
+        assert not when_spec.name, "only anonymous when specs are accepted"
 
         when_substitutions = {}
         for s in when_spec.traverse(root=False):

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -188,7 +188,6 @@ def test_buildcache_autopush(tmp_path: pathlib.Path, install_mockery, mock_fetch
     # Install and generate build cache index
     PackageInstaller([s.package], fake=True, explicit=True).install()
 
-    assert s.name is not None
     manifest_file = URLBuildcacheEntry.get_manifest_filename(s)
     specs_dirs = os.path.join(
         *URLBuildcacheEntry.get_relative_path_components(BuildcacheComponent.SPEC), s.name
@@ -337,7 +336,6 @@ def test_buildcache_create_install(
         layout_version=spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
     )
     cache_entry = cache_class(mirror_url, spec, allow_unsigned=True)
-    assert spec.name is not None
     manifest_path = os.path.join(
         str(tmp_path),
         *cache_class.get_relative_path_components(BuildcacheComponent.SPEC),


### PR DESCRIPTION
Currently type inference considers `Spec.name` of type `type(None)`, because that's how it is initialized.

That leads to mypy issues where concrete specs are used, and runtime assertions to convince mypy that `name` is in fact a string.

Most pragmatic right now is to use empty string for abstract specs. Also resolves the ambiguity between `None` and `""` as valid options