### PR TITLE
solver: set preferences from input specs using `%%`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## Package API v2.4
+- Added the `%%` sigil to spec syntax, to propagate compiler preferences.
+
 ## Spack v1.0.0
 Deprecated the implicit attributes:
 - `PackageBase.legacy_buildsystem`

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -569,6 +569,20 @@ We can express conditional constraints by specifying the ``when`` edge attribute
 
 This tells Spack that hdf5 should depend on ``mpich@3.1`` if it is configured with MPI support.
 
+Dependency propagation
+^^^^^^^^^^^^^^^^^^^^^^
+
+The dependency specifications on a node, can be propagated using a double percent ``%%`` sigil.
+This is particularly useful when specifying compilers.
+For instance, the following command:
+
+.. code-block:: spec
+
+   $ spack install hdf5+cxx+fortran %%c,cxx=clang %%fortran=gfortran
+
+tells Spack to install ``hdf5`` using Clang as the C and C++ compiler, and GCC as the Fortran compiler.
+It also tells Spack to propagate the same choices, as :ref:`strong preferences <package-strong-preferences>`,  to the runtime sub-DAG of ``hdf5``.
+Build tools are unaffected and can still prefer to use a different compiler.
 
 Specifying Specs by Hash
 ------------------------

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -18,7 +18,7 @@ spack_version = __version__
 #: version is incremented when the package API is extended in a backwards-compatible way. The major
 #: version is incremented upon breaking changes. This version is changed independently from the
 #: Spack version.
-package_api_version = (2, 3)
+package_api_version = (2, 4)
 
 #: The minimum Package API version that this version of Spack is compatible with. This should
 #: always be a tuple of the form ``(major, 0)``, since compatibility with vX.Y implies

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -22,3 +22,11 @@ class ConfigScopePriority(enum.IntEnum):
     ENVIRONMENT = 2
     CUSTOM = 3
     COMMAND_LINE = 4
+
+
+class PropagationPolicy(enum.Enum):
+    """Enum to specify the behavior of a propagated dependency"""
+
+    NONE = enum.auto()
+    PREFERENCE = enum.auto()
+    REQUIREMENT = enum.auto()

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -29,4 +29,3 @@ class PropagationPolicy(enum.Enum):
 
     NONE = enum.auto()
     PREFERENCE = enum.auto()
-    REQUIREMENT = enum.auto()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3016,6 +3016,7 @@ class SpackSolverSetup:
             if node.namespace is not None:
                 self.explicitly_required_namespaces[node.name] = node.namespace
 
+        self.requirement_parser.parse_rules_from_input_specs(specs)
         self.gen.h1("Generic information")
         if using_libc_compatibility():
             for libc in self.libcs:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -246,9 +246,9 @@ def dag_closure_by_deptype(spec: spack.spec.Spec, facts: List[AspFunction]) -> L
     # Compute the "link" transitive closure with `when: root ^[deptypes=link] <this_pkg>`
     if len(edges) == 1:
         edge = edges[0]
-        if not edge.direct and edge.depflag == dt.LINK:
+        if not edge.direct and edge.depflag == dt.LINK | dt.RUN:
             root, leaf = edge.parent.name, edge.spec.name
-            return [fn.attr("closure", root, leaf, "link")]
+            return [fn.attr("closure", root, leaf, "linkrun")]
     return facts
 
 
@@ -2143,7 +2143,8 @@ class SpackSolverSetup:
 
             pkg_name, policy, requirement_grp = rule.pkg_name, rule.policy, rule.requirements
             requirement_weight = 0
-
+            # Propagated preferences have a higher penalty that normal preferences
+            weight_multiplier = 2 if rule.origin == RequirementOrigin.INPUT_SPECS else 1
             # Write explicitly if a requirement is conditional or not
             if rule.condition != spack.spec.Spec():
                 msg = f"activate requirement {requirement_grp_id} if {rule.condition} holds"
@@ -2217,7 +2218,9 @@ class SpackSolverSetup:
                     continue
 
                 self.gen.fact(fn.requirement_group_member(member_id, pkg_name, requirement_grp_id))
-                self.gen.fact(fn.requirement_has_weight(member_id, requirement_weight))
+                self.gen.fact(
+                    fn.requirement_has_weight(member_id, requirement_weight * weight_multiplier)
+                )
                 self.gen.newline()
                 requirement_weight += 1
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -241,6 +241,17 @@ def remove_facts(
     return _remove
 
 
+def dag_closure_by_deptype(spec: spack.spec.Spec, facts: List[AspFunction]) -> List[AspFunction]:
+    edges = spec.edges_to_dependencies()
+    # Compute the "link" transitive closure with `when: root ^[deptypes=link] <this_pkg>`
+    if len(edges) == 1:
+        edge = edges[0]
+        if not edge.direct and edge.depflag == dt.LINK:
+            root, leaf = edge.parent.name, edge.spec.name
+            return [fn.attr("closure", root, leaf, "link")]
+    return facts
+
+
 def libc_is_compatible(lhs: spack.spec.Spec, rhs: spack.spec.Spec) -> bool:
     return (
         lhs.name == rhs.name
@@ -2135,10 +2146,12 @@ class SpackSolverSetup:
 
             # Write explicitly if a requirement is conditional or not
             if rule.condition != spack.spec.Spec():
-                msg = f"condition to activate requirement {requirement_grp_id}"
+                msg = f"activate requirement {requirement_grp_id} if {rule.condition} holds"
+                context = ConditionContext()
+                context.transform_required = dag_closure_by_deptype
                 try:
                     main_condition_id = self.condition(
-                        rule.condition, required_name=pkg_name, msg=msg
+                        rule.condition, required_name=pkg_name, msg=msg, context=context
                     )
                 except Exception as e:
                     if rule.kind != RequirementKind.DEFAULT:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2145,16 +2145,6 @@ opt_criterion(46, "number of compilers used on the same node").
     : compiler_penalty(PackageNode, Penalty), build_priority(PackageNode, Priority)
 }.
 
-% Minimize the ids of the providers, i.e. use as much as
-% possible the first providers
-opt_criterion(45, "number of duplicate virtuals needed").
-#minimize{ 0@245: #true }.
-#minimize{ 0@45: #true }.
-#minimize{
-    Weight@45+Priority,ProviderNode,Virtual
-    : provider(ProviderNode, node(Weight, Virtual)),
-      build_priority(ProviderNode, Priority)
-}.
 
 opt_criterion(40, "preferred compilers").
 #minimize{ 0@240: #true }.
@@ -2260,9 +2250,10 @@ opt_criterion(2, "providers on edges").
 #minimize{ 0@202: #true }.
 #minimize{ 0@2: #true }.
 #minimize{
-    Weight@2,ParentNode,ProviderNode,Virtual
-    : provider_weight(ProviderNode, Virtual, Weight),
+    Weight@2,ParentNode,ProviderNode,node(X, Virtual)
+    : provider_weight(ProviderNode, node(X, Virtual), Weight),
       not attr("root", ProviderNode),
+      language(Virtual),
       depends_on(ParentNode, ProviderNode)
 }.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1144,6 +1144,15 @@ requirement_is_met(GroupID, ConditionID, node(X, Package)) :-
   subcondition(SubconditionID, ConditionID),
   pkg_fact(Package, condition_effect(SubconditionID, EffectID)).
 
+% clingo decided not to impose a condition for a subcondition that holds
+exclude_requirement_weight(ConditionID, Package, GroupID) :-
+  requirement_group_member(ConditionID, Package, GroupID),
+  condition_holds(ConditionID, node(X, Package)),
+  subcondition(SubconditionID, ConditionID),
+  condition_holds(SubconditionID, node(X, Package)),
+  do_not_impose(EffectID, node(X, Package)),
+  pkg_fact(Package, condition_effect(SubconditionID, EffectID)).
+
 % Do not impose requirements, if the conditional requirement is not active
 do_not_impose(EffectID, node(ID, Package)) :-
   trigger_condition_holds(TriggerID, node(ID, Package)),
@@ -1192,10 +1201,12 @@ error(1, "Cannot use {1} for the {0} virtual, but that is required", Virtual, Pr
   pkg_fact(Virtual, condition_effect(ConditionID, EffectID)),
   imposed_constraint(EffectID, "node_flag_set", Package, NodeFlag).
 
-
 requirement_weight(node(ID, Package), Group, W) :-
   W = #min {
-    Z : requirement_has_weight(Y, Z), condition_holds(Y, node(ID, Package)), requirement_group_member(Y, Package, Group);
+    Z : requirement_has_weight(Y, Z),
+        condition_holds(Y, node(ID, Package)),
+        requirement_group_member(Y, Package, Group),
+        not exclude_requirement_weight(Y, Package, Group);
     % We need this to avoid an annoying warning during the solve
     %   concretize.lp:1151:5-11: info: tuple ignored:
     %   #sup@73

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -129,20 +129,33 @@ unification_set(SetID, VirtualNode)
 % to another node by "link" edges, or the nodes connected to another node by "link and
 % "run" edges.
 
-compute_closure(node(ID, Package), "link")  :-
-  condition_requirement(_, "closure", Package, _, "link"),
+compute_closure(node(ID, Package), "linkrun")  :-
+  condition_requirement(_, "closure", Package, _, "linkrun"),
   attr("node", node(ID, Package)).
 
-attr("closure", PackageNode, DependencyNode, "link") :-
+attr("closure", PackageNode, DependencyNode, "linkrun") :-
   attr("depends_on", PackageNode, DependencyNode, "link"),
-  compute_closure(PackageNode, "link").
+  not provider(DependencyNode, node(_, Language)) : language(Language);
+  compute_closure(PackageNode, "linkrun").
 
-attr("closure", PackageNode, DependencyNode, "link") :-
+attr("closure", PackageNode, DependencyNode, "linkrun") :-
+  attr("depends_on", PackageNode, DependencyNode, "run"),
+  not provider(DependencyNode, node(_, Language)) : language(Language);
+  compute_closure(PackageNode, "linkrun").
+
+attr("closure", PackageNode, DependencyNode, "linkrun") :-
   attr("depends_on", ParentNode, DependencyNode, "link"),
-  attr("closure", PackageNode, ParentNode, "link"),
-  compute_closure(PackageNode, "link").
+  not provider(DependencyNode, node(_, Language)) : language(Language);
+  attr("closure", PackageNode, ParentNode, "linkrun"),
+  compute_closure(PackageNode, "linkrun").
 
-related(NodeA, NodeB) :- attr("closure", NodeA, NodeB, "link").
+attr("closure", PackageNode, DependencyNode, "linkrun") :-
+  attr("depends_on", ParentNode, DependencyNode, "run"),
+  not provider(DependencyNode, node(_, Language)) : language(Language);
+  attr("closure", PackageNode, ParentNode, "linkrun"),
+  compute_closure(PackageNode, "linkrun").
+
+related(NodeA, NodeB) :- attr("closure", NodeA, NodeB, "linkrun").
 
 % Do not allow split dependencies, for now. This ensures that we don't construct graphs where e.g.
 % a python extension depends on setuptools@63.4 as a run dependency, but uses e.g. setuptools@68

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -125,6 +125,25 @@ unification_set(SetID, VirtualNode)
   :- provider(PackageNode, VirtualNode),
      unification_set(SetID, PackageNode).
 
+% Compute sub-sets of the nodes, if requested. These can be either the nodes connected
+% to another node by "link" edges, or the nodes connected to another node by "link and
+% "run" edges.
+
+compute_closure(node(ID, Package), "link")  :-
+  condition_requirement(_, "closure", Package, _, "link"),
+  attr("node", node(ID, Package)).
+
+attr("closure", PackageNode, DependencyNode, "link") :-
+  attr("depends_on", PackageNode, DependencyNode, "link"),
+  compute_closure(PackageNode, "link").
+
+attr("closure", PackageNode, DependencyNode, "link") :-
+  attr("depends_on", ParentNode, DependencyNode, "link"),
+  attr("closure", PackageNode, ParentNode, "link"),
+  compute_closure(PackageNode, "link").
+
+related(NodeA, NodeB) :- attr("closure", NodeA, NodeB, "link").
+
 % Do not allow split dependencies, for now. This ensures that we don't construct graphs where e.g.
 % a python extension depends on setuptools@63.4 as a run dependency, but uses e.g. setuptools@68
 % as a build dependency.
@@ -182,6 +201,7 @@ node_attributes_with_custom_rules("virtual_on_edge").
 node_attributes_with_custom_rules("provider_set").
 node_attributes_with_custom_rules("concrete_variant_set").
 node_attributes_with_custom_rules("concrete_variant_request").
+node_attributes_with_custom_rules("closure").
 
 trigger_condition_holds(TriggerID, node(min_dupe_id, Package)) :-
   solve_literal(TriggerID),
@@ -461,6 +481,11 @@ satisfied(trigger(PackageNode), condition_requirement(ID, "depends_on", A1, A2, 
 satisfied(trigger(PackageNode), condition_requirement(ID, "concrete_variant_request", A1, A2, A3)) :-
   trigger_node(ID, PackageNode, _),
   condition_requirement(ID, "concrete_variant_request", A1, A2, A3),
+  condition_nodes(ID, PackageNode, node(X, A1)).
+
+satisfied(trigger(PackageNode), condition_requirement(ID, "closure", A1, A2, A3)) :-
+  attr("closure", node(X, A1), node(_, A2), A3),
+  condition_requirement(ID, "closure", A1, A2, A3),
   condition_nodes(ID, PackageNode, node(X, A1)).
 
 %%%%
@@ -1100,6 +1125,16 @@ activate_requirement(node(ID, Package), X) :-
   requirement_group(Package, X),
   condition_holds(Y, node(ID, Package)),
   requirement_conditional(Package, X, Y).
+
+activate_requirement(node(ID, Package), X) :-
+  package_in_dag(node(ID, Package)),
+  package_in_dag(node(CID, ConditionPackage)),
+  requirement_group(Package, X),
+  pkg_fact(ConditionPackage, condition(Y)),
+  related(node(CID, ConditionPackage), node(ID, Package)),
+  condition_holds(Y, node(CID, ConditionPackage)),
+  requirement_conditional(Package, X, Y),
+  ConditionPackage != Package.
 
 requirement_group_satisfied(node(ID, Package), GroupID) :-
   1 { requirement_is_met(GroupID, ConditionID, node(ID, Package)) } 1,

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -72,6 +72,30 @@ def preference(
     )
 
 
+def conflict(
+    pkg_name: str,
+    constraint: spack.spec.Spec,
+    condition: spack.spec.Spec = spack.spec.Spec(),
+    origin: RequirementOrigin = RequirementOrigin.CONFLICT_YAML,
+    kind: RequirementKind = RequirementKind.PACKAGE,
+    message: Optional[str] = None,
+) -> RequirementRule:
+    """Returns a conflict rule"""
+    # A conflict is defined as:
+    #
+    # require:
+    # - one_of: [spec_str, "@:"]
+    return RequirementRule(
+        pkg_name=pkg_name,
+        policy="one_of",
+        requirements=[constraint, spack.spec.Spec("@:")],
+        kind=kind,
+        condition=condition,
+        origin=origin,
+        message=message,
+    )
+
+
 class RequirementParser:
     """Parses requirements from package.py files and configuration, and returns rules."""
 
@@ -159,21 +183,9 @@ class RequirementParser:
     ) -> List[RequirementRule]:
         result = []
         for item in conflicts:
-            spec, condition, message = self._parse_prefer_conflict_item(item)
+            spec, condition, msg = self._parse_prefer_conflict_item(item)
             result.append(
-                # A conflict is defined as:
-                #
-                # require:
-                # - one_of: [spec_str, "@:"]
-                RequirementRule(
-                    pkg_name=pkg_name,
-                    policy="one_of",
-                    requirements=[spec, spack.spec.Spec("@:")],
-                    kind=kind,
-                    message=message,
-                    condition=condition,
-                    origin=RequirementOrigin.CONFLICT_YAML,
-                )
+                conflict(pkg_name, constraint=spec, condition=condition, kind=kind, message=msg)
             )
         return result
 

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -297,6 +297,7 @@ def _split_edge_on_virtuals(edge: spack.spec.DependencySpec) -> List[spack.spec.
     for v in edge.virtuals:
         t = edge.copy(keep_parent=False, keep_virtuals=False)
         t.update_virtuals(v)
+        t.when = spack.spec.Spec(f"%{v}")
         result.append(spack.spec.Spec(str(t)))
 
     return result

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -127,7 +127,7 @@ class RequirementParser:
             preference(
                 pkg.name,
                 constraint=s,
-                condition=spack.spec.Spec(f"{root_name} ^[deptypes=link]{pkg.name}"),
+                condition=spack.spec.Spec(f"{root_name} ^[deptypes=link,run]{pkg.name}"),
                 origin=RequirementOrigin.INPUT_SPECS,
             )
             for s, root_name in self.preferences_from_input

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
-from typing import List, NamedTuple, Optional, Sequence
+from typing import List, NamedTuple, Optional, Sequence, Tuple
 
 import spack.config
 import spack.error
@@ -103,7 +103,7 @@ class RequirementParser:
         self.config = configuration
         self.runtime_pkgs = spack.repo.PATH.packages_with_tags("runtime")
         self.compiler_pkgs = spack.repo.PATH.packages_with_tags("compiler")
-        self.preferences_from_input: List[spack.spec.Spec] = []
+        self.preferences_from_input: List[Tuple[spack.spec.Spec, str]] = []
 
     def rules(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
         result = []
@@ -114,16 +114,23 @@ class RequirementParser:
         result.extend(self.rules_from_conflict(pkg))
         return result
 
-    def parse_rules_from_input_specs(self, specs: List[spack.spec.Spec]):
+    def parse_rules_from_input_specs(self, specs: Sequence[spack.spec.Spec]):
         self.preferences_from_input.clear()
         for edge in spack.traverse.traverse_edges(specs, root=False):
             if edge.propagation == PropagationPolicy.PREFERENCE:
-                self.preferences_from_input.extend(_split_edge_on_virtuals(edge))
+                for constraint in _split_edge_on_virtuals(edge):
+                    root_name = edge.parent.name
+                    self.preferences_from_input.append((constraint, root_name))
 
     def rules_from_input_specs(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
         return [
-            preference(pkg.name, constraint=s, origin=RequirementOrigin.INPUT_SPECS)
-            for s in self.preferences_from_input
+            preference(
+                pkg.name,
+                constraint=s,
+                condition=spack.spec.Spec(f"{root_name} ^[deptypes=link]{pkg.name}"),
+                origin=RequirementOrigin.INPUT_SPECS,
+            )
+            for s, root_name in self.preferences_from_input
         ]
 
     def rules_from_package_py(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -9,6 +9,8 @@ import spack.error
 import spack.package_base
 import spack.repo
 import spack.spec
+import spack.traverse
+from spack.enums import PropagationPolicy
 from spack.llnl.util import tty
 from spack.util.spack_yaml import get_mark_from_yaml_data
 
@@ -31,6 +33,7 @@ class RequirementOrigin(enum.Enum):
     PREFER_YAML = enum.auto()
     CONFLICT_YAML = enum.auto()
     DIRECTIVE = enum.auto()
+    INPUT_SPECS = enum.auto()
 
 
 class RequirementRule(NamedTuple):
@@ -52,13 +55,37 @@ class RequirementParser:
         self.config = configuration
         self.runtime_pkgs = spack.repo.PATH.packages_with_tags("runtime")
         self.compiler_pkgs = spack.repo.PATH.packages_with_tags("compiler")
+        self.preferences_from_input: List[spack.spec.Spec] = []
 
     def rules(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
         result = []
+        result.extend(self.rules_from_input_specs(pkg))
         result.extend(self.rules_from_package_py(pkg))
         result.extend(self.rules_from_require(pkg))
         result.extend(self.rules_from_prefer(pkg))
         result.extend(self.rules_from_conflict(pkg))
+        return result
+
+    def parse_rules_from_input_specs(self, specs: List[spack.spec.Spec]):
+        self.preferences_from_input.clear()
+        for edge in spack.traverse.traverse_edges(specs, root=False):
+            if edge.propagation == PropagationPolicy.PREFERENCE:
+                self.preferences_from_input.extend(_split_edge_on_virtuals(edge))
+
+    def rules_from_input_specs(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
+        result = []
+        for spec in self.preferences_from_input:
+            result.append(
+                RequirementRule(
+                    pkg_name=pkg.name,
+                    policy="any_of",
+                    requirements=[spec, spack.spec.Spec("@:")],
+                    kind=RequirementKind.PACKAGE,
+                    condition=spack.spec.Spec(),
+                    origin=RequirementOrigin.INPUT_SPECS,
+                    message=None,
+                )
+            )
         return result
 
     def rules_from_package_py(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
@@ -258,6 +285,21 @@ class RequirementParser:
             )
             return True
         return False
+
+
+def _split_edge_on_virtuals(edge: spack.spec.DependencySpec) -> List[spack.spec.Spec]:
+    """Split the edge on virtuals and removes the parent."""
+    if not edge.virtuals:
+        return [spack.spec.Spec(str(edge.copy(keep_parent=False)))]
+
+    result = []
+    # We split on virtuals so that "%%c,cxx=gcc" enforces "%%c=gcc" and "%%cxx=gcc" separately
+    for v in edge.virtuals:
+        t = edge.copy(keep_parent=False, keep_virtuals=False)
+        t.update_virtuals(v)
+        result.append(spack.spec.Spec(str(t)))
+
+    return result
 
 
 def parse_spec_from_yaml_string(string: str, *, named: bool = False) -> spack.spec.Spec:

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -48,6 +48,30 @@ class RequirementRule(NamedTuple):
     message: Optional[str]
 
 
+def preference(
+    pkg_name: str,
+    constraint: spack.spec.Spec,
+    condition: spack.spec.Spec = spack.spec.Spec(),
+    origin: RequirementOrigin = RequirementOrigin.PREFER_YAML,
+    kind: RequirementKind = RequirementKind.PACKAGE,
+    message: Optional[str] = None,
+) -> RequirementRule:
+    """Returns a preference rule"""
+    # A strong preference is defined as:
+    #
+    # require:
+    # - any_of: [spec_str, "@:"]
+    return RequirementRule(
+        pkg_name=pkg_name,
+        policy="any_of",
+        requirements=[constraint, spack.spec.Spec("@:")],
+        kind=kind,
+        condition=condition,
+        origin=origin,
+        message=message,
+    )
+
+
 class RequirementParser:
     """Parses requirements from package.py files and configuration, and returns rules."""
 
@@ -73,20 +97,10 @@ class RequirementParser:
                 self.preferences_from_input.extend(_split_edge_on_virtuals(edge))
 
     def rules_from_input_specs(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
-        result = []
-        for spec in self.preferences_from_input:
-            result.append(
-                RequirementRule(
-                    pkg_name=pkg.name,
-                    policy="any_of",
-                    requirements=[spec, spack.spec.Spec("@:")],
-                    kind=RequirementKind.PACKAGE,
-                    condition=spack.spec.Spec(),
-                    origin=RequirementOrigin.INPUT_SPECS,
-                    message=None,
-                )
-            )
-        return result
+        return [
+            preference(pkg.name, constraint=s, origin=RequirementOrigin.INPUT_SPECS)
+            for s in self.preferences_from_input
+        ]
 
     def rules_from_package_py(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
         rules = []
@@ -130,21 +144,9 @@ class RequirementParser:
     ) -> List[RequirementRule]:
         result = []
         for item in preferences:
-            spec, condition, message = self._parse_prefer_conflict_item(item)
+            spec, condition, msg = self._parse_prefer_conflict_item(item)
             result.append(
-                # A strong preference is defined as:
-                #
-                # require:
-                # - any_of: [spec_str, "@:"]
-                RequirementRule(
-                    pkg_name=pkg_name,
-                    policy="any_of",
-                    requirements=[spec, spack.spec.Spec("@:")],
-                    kind=kind,
-                    message=message,
-                    condition=condition,
-                    origin=RequirementOrigin.PREFER_YAML,
-                )
+                preference(pkg_name, constraint=spec, condition=condition, kind=kind, message=msg)
             )
         return result
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3195,6 +3195,7 @@ class Spec:
                     depflag=edge.depflag,
                     virtuals=edge.virtuals,
                     direct=edge.direct,
+                    propagation=edge.propagation,
                     when=edge.when,
                 )
         return self != reference_spec
@@ -3622,7 +3623,13 @@ class Spec:
 
         return self._patches
 
-    def _dup(self, other: "Spec", deps: Union[bool, dt.DepTypes, dt.DepFlag] = True) -> bool:
+    def _dup(
+        self,
+        other: "Spec",
+        deps: Union[bool, dt.DepTypes, dt.DepFlag] = True,
+        *,
+        propagation: Optional[PropagationPolicy] = None,
+    ) -> bool:
         """Copies "other" into self, by overwriting all attributes.
 
         Args:
@@ -3685,7 +3692,7 @@ class Spec:
             depflag = dt.ALL
             if isinstance(deps, (tuple, list, str)):
                 depflag = dt.canonicalize(deps)
-            self._dup_deps(other, depflag)
+            self._dup_deps(other, depflag, propagation=propagation)
 
         self._prefix = other._prefix
         self._concrete = other._concrete
@@ -3703,7 +3710,9 @@ class Spec:
 
         return changed
 
-    def _dup_deps(self, other, depflag: dt.DepFlag):
+    def _dup_deps(
+        self, other, depflag: dt.DepFlag, propagation: Optional[PropagationPolicy] = None
+    ):
         def spid(spec):
             return id(spec)
 
@@ -3718,11 +3727,12 @@ class Spec:
             if spid(edge.spec) not in new_specs:
                 new_specs[spid(edge.spec)] = edge.spec.copy(deps=False)
 
+            edge_propagation = edge.propagation if propagation is None else propagation
             new_specs[spid(edge.parent)].add_dependency_edge(
                 new_specs[spid(edge.spec)],
                 depflag=edge.depflag,
                 virtuals=edge.virtuals,
-                propagation=edge.propagation,
+                propagation=edge_propagation,
                 direct=edge.direct,
                 when=edge.when,
             )

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -102,7 +102,7 @@ import spack.variant as vt
 import spack.version as vn
 import spack.version.git_ref_lookup
 
-from .enums import InstallRecordStatus
+from .enums import InstallRecordStatus, PropagationPolicy
 
 __all__ = [
     "CompilerSpec",
@@ -734,7 +734,7 @@ class DependencySpec:
         virtuals: virtual packages provided from child to parent node.
     """
 
-    __slots__ = "parent", "spec", "depflag", "virtuals", "direct", "when"
+    __slots__ = "parent", "spec", "depflag", "virtuals", "direct", "when", "propagation"
 
     def __init__(
         self,
@@ -744,6 +744,7 @@ class DependencySpec:
         depflag: dt.DepFlag,
         virtuals: Tuple[str, ...],
         direct: bool = False,
+        propagation: PropagationPolicy = PropagationPolicy.NONE,
         when: Optional["Spec"] = None,
     ):
         self.parent = parent
@@ -751,6 +752,7 @@ class DependencySpec:
         self.depflag = depflag
         self.virtuals = tuple(sorted(set(virtuals)))
         self.direct = direct
+        self.propagation = propagation
         self.when = when or Spec()
 
     def update_deptypes(self, depflag: dt.DepFlag) -> bool:
@@ -781,6 +783,7 @@ class DependencySpec:
             self.spec,
             depflag=self.depflag,
             virtuals=self.virtuals,
+            propagation=self.propagation,
             direct=self.direct,
             when=self.when,
         )
@@ -1832,6 +1835,7 @@ class Spec:
         depflag: dt.DepFlag,
         virtuals: Tuple[str, ...],
         direct: bool = False,
+        propagation: PropagationPolicy = PropagationPolicy.NONE,
         when: Optional["Spec"] = None,
     ):
         """Called by the parser to add another spec as a dependency.
@@ -1840,6 +1844,7 @@ class Spec:
             depflag: dependency type for this edge
             virtuals: virtuals on this edge
             direct: if True denotes a direct dependency (associated with the % sigil)
+            propagation: propagation policy for this edge
             when: optional condition under which dependency holds
         """
         if when is None:
@@ -1847,7 +1852,12 @@ class Spec:
 
         if spec.name not in self._dependencies or not spec.name:
             self.add_dependency_edge(
-                spec, depflag=depflag, virtuals=virtuals, direct=direct, when=when
+                spec,
+                depflag=depflag,
+                virtuals=virtuals,
+                direct=direct,
+                when=when,
+                propagation=propagation,
             )
             return
 
@@ -1895,6 +1905,7 @@ class Spec:
         depflag: dt.DepFlag,
         virtuals: Tuple[str, ...],
         direct: bool = False,
+        propagation: PropagationPolicy = PropagationPolicy.NONE,
         when: Optional["Spec"] = None,
     ):
         """Add a dependency edge to this spec.
@@ -1904,6 +1915,7 @@ class Spec:
             depflag: dependency type for this edge
             virtuals: virtuals provided by this edge
             direct: if True denotes a direct dependency
+            propagation: propagation policy for this edge
             when: if non-None, condition under which dependency holds
         """
         if when is None:
@@ -1950,7 +1962,13 @@ class Spec:
                 return
 
         edge = DependencySpec(
-            self, dependency_spec, depflag=depflag, virtuals=virtuals, direct=direct, when=when
+            self,
+            dependency_spec,
+            depflag=depflag,
+            virtuals=virtuals,
+            direct=direct,
+            propagation=propagation,
+            when=when,
         )
         self._dependencies.add(edge)
         dependency_spec._dependents.add(edge)
@@ -3699,6 +3717,7 @@ class Spec:
                 new_specs[spid(edge.spec)],
                 depflag=edge.depflag,
                 virtuals=edge.virtuals,
+                propagation=edge.propagation,
                 direct=edge.direct,
                 when=edge.when,
             )
@@ -4338,9 +4357,14 @@ class Spec:
             new_name = spack.aliases.BUILTIN_TO_LEGACY_COMPILER.get(old_name)
             try:
                 # this is ugly but copies can be expensive
+                sigil = "%"
                 if new_name:
                     edge.spec.name = new_name
-                parts.append(format_edge(edge, "%", edge.spec))
+
+                if edge.propagation == PropagationPolicy.PREFERENCE:
+                    sigil = "%%"
+
+                parts.append(format_edge(edge, sigil=sigil, dep_spec=edge.spec))
             finally:
                 edge.spec.name = old_name
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -747,6 +747,9 @@ class DependencySpec:
         propagation: PropagationPolicy = PropagationPolicy.NONE,
         when: Optional["Spec"] = None,
     ):
+        if direct is False and propagation != PropagationPolicy.NONE:
+            raise InvalidEdgeError("only direct dependencies can be propagated")
+
         self.parent = parent
         self.spec = spec
         self.depflag = depflag
@@ -796,6 +799,7 @@ class DependencySpec:
         yield self.depflag
         yield self.virtuals
         yield self.direct
+        yield self.propagation
         yield self.when
 
     def __str__(self) -> str:
@@ -808,6 +812,9 @@ class DependencySpec:
 
         if self.when != Spec():
             keywords.append(f"when={self.when}")
+
+        if self.propagation != PropagationPolicy.NONE:
+            keywords.append(f"propagation={self.propagation}")
 
         keywords_str = ", ".join(keywords)
         return f"DependencySpec({self.parent.format()!r}, {self.spec.format()!r}, {keywords_str})"
@@ -5713,3 +5720,7 @@ class InvalidSpecDetected(spack.error.SpecError):
 class SpliceError(spack.error.SpecError):
     """Raised when a splice is not possible due to dependency or provider
     satisfaction mismatch. The resulting splice would be unusable."""
+
+
+class InvalidEdgeError(spack.error.SpecError):
+    """Raised when an edge doesn't pass validation checks."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -776,13 +776,15 @@ class DependencySpec:
         self.virtuals = tuple(sorted(union))
         return True
 
-    def copy(self) -> "DependencySpec":
+    def copy(self, *, keep_virtuals: bool = True, keep_parent: bool = True) -> "DependencySpec":
         """Return a copy of this edge"""
+        parent = self.parent if keep_parent else Spec()
+        virtuals = self.virtuals if keep_virtuals else ()
         return DependencySpec(
-            self.parent,
+            parent,
             self.spec,
             depflag=self.depflag,
-            virtuals=self.virtuals,
+            virtuals=virtuals,
             propagation=self.propagation,
             direct=self.direct,
             when=self.when,
@@ -825,6 +827,9 @@ class DependencySpec:
             when_str = f"when='{self.when}'"
 
         dep_sigil = "%" if self.direct else "^"
+        if self.propagation == PropagationPolicy.PREFERENCE:
+            dep_sigil = "%%"
+
         edge_attrs = [x for x in (virtuals_str, when_str) if x]
 
         if edge_attrs:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -71,6 +71,7 @@ import spack.paths
 import spack.util.spack_yaml
 import spack.version
 from spack.aliases import LEGACY_COMPILER_TO_BUILTIN
+from spack.enums import PropagationPolicy
 from spack.llnl.util.tty import color
 from spack.tokenize import Token, TokenBase, Tokenizer
 
@@ -135,9 +136,9 @@ class SpecTokens(TokenBase):
     """
 
     # Dependency, with optional virtual assignment specifier
-    START_EDGE_PROPERTIES = r"(?:[\^%]\[)"
+    START_EDGE_PROPERTIES = r"(?:(?:\^|\%\%|\%)\[)"
     END_EDGE_PROPERTIES = rf"(?:\](?:\s*{VIRTUAL_ASSIGNMENT})?)"
-    DEPENDENCY = rf"(?:[\^\%](?:\s*{VIRTUAL_ASSIGNMENT})?)"
+    DEPENDENCY = rf"(?:(?:\^|\%\%|\%)(?:\s*{VIRTUAL_ASSIGNMENT})?)"
 
     # Version
     VERSION_HASH_PAIR = rf"(?:@(?:{GIT_VERSION_PATTERN})=(?:{VERSION}))"
@@ -370,10 +371,15 @@ class SpecParser:
             if self.ctx.accept(SpecTokens.START_EDGE_PROPERTIES):
                 is_direct = self.ctx.current_token.value[0] == "%"
 
+                propagation = PropagationPolicy.NONE
+                if is_direct and self.ctx.current_token.value.startswith("%%"):
+                    propagation = PropagationPolicy.PREFERENCE
+
                 edge_properties = EdgeAttributeParser(self.ctx, self.literal_str).parse()
                 edge_properties.setdefault("virtuals", ())
                 edge_properties["direct"] = is_direct
                 edge_properties.setdefault("depflag", 0)
+                edge_properties["propagation"] = propagation
 
                 dependency, warnings = self._parse_node(root_spec)
 
@@ -390,6 +396,11 @@ class SpecParser:
 
             elif self.ctx.accept(SpecTokens.DEPENDENCY):
                 is_direct = self.ctx.current_token.value[0] == "%"
+                propagation = PropagationPolicy.NONE
+
+                if is_direct and self.ctx.current_token.value.startswith("%%"):
+                    propagation = PropagationPolicy.PREFERENCE
+
                 virtuals = parse_virtual_assignment(self.ctx)
 
                 # if no virtual assignment, check for a toolchain - look ahead to find the
@@ -402,7 +413,12 @@ class SpecParser:
                         raise SpecParsingError(str(e), self.ctx.current_token, self.literal_str)
                     continue
 
-                edge_properties = {"direct": is_direct, "virtuals": virtuals, "depflag": 0}
+                edge_properties = {
+                    "direct": is_direct,
+                    "virtuals": virtuals,
+                    "depflag": 0,
+                    "propagation": propagation,
+                }
                 dependency, warnings = self._parse_node(root_spec)
 
                 if is_direct:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -408,7 +408,9 @@ class SpecParser:
                 if not virtuals and is_direct and self.ctx.next_token.value in self.toolchains:
                     assert self.ctx.accept(SpecTokens.UNQUALIFIED_PACKAGE_NAME)
                     try:
-                        self._apply_toolchain(current_spec, self.ctx.current_token.value)
+                        self._apply_toolchain(
+                            current_spec, self.ctx.current_token.value, propagation=propagation
+                        )
                     except spack.error.SpecError as e:
                         raise SpecParsingError(str(e), self.ctx.current_token, self.literal_str)
                     continue
@@ -452,12 +454,17 @@ class SpecParser:
             raise spack.error.SpecError(str(root_spec), "^" + str(dependency))
         return dependency, parser_warnings
 
-    def _apply_toolchain(self, spec: "spack.spec.Spec", name: str) -> None:
+    def _apply_toolchain(
+        self, spec: "spack.spec.Spec", name: str, *, propagation: PropagationPolicy
+    ) -> None:
         if name not in self.parsed_toolchains:
             toolchain = self._parse_toolchain(name)
             self.parsed_toolchains[name] = toolchain
 
         toolchain = self.parsed_toolchains[name]
+        if propagation == PropagationPolicy.PREFERENCE:
+            toolchain = toolchain.copy(propagation=propagation)
+
         spec.constrain(toolchain)
 
     def _parse_toolchain(self, name: str) -> "spack.spec.Spec":

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -31,21 +31,20 @@ def test_immediate_dependents(mock_packages):
 def test_transitive_dependents(mock_packages):
     out = dependents("--transitive", "libelf")
     actual = set(re.split(r"\s+", out.strip()))
-    assert actual == set(
-        [
-            "callpath",
-            "dyninst",
-            "libdwarf",
-            "mixing-parent",
-            "mpileaks",
-            "multivalue-variant",
-            "singlevalue-variant-dependent",
-            "patch-a-dependency",
-            "patch-several-dependencies",
-            "quantum-espresso",
-            "conditionally-patch-dependency",
-        ]
-    )
+    assert actual == {
+        "callpath",
+        "dyninst",
+        "libdwarf",
+        "mixing-parent",
+        "mpileaks",
+        "multivalue-variant",
+        "singlevalue-variant-dependent",
+        "trilinos",
+        "patch-a-dependency",
+        "patch-several-dependencies",
+        "quantum-espresso",
+        "conditionally-patch-dependency",
+    }
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -223,11 +223,13 @@ def installed_environment(
         spack_yaml.write_text(content)
         with fs.working_dir(tmp_path):
             env("create", "test", "./spack.yaml")
-            with ev.read("test"):
-                install("--fake")
+            with ev.read("test") as current_environment:
+                current_environment.concretize()
+                current_environment.install_all(fake=True)
+                current_environment.write(regenerate=True)
 
-            test = ev.read("test")
-            yield test
+            with ev.read("test") as current_environment:
+                yield current_environment
 
     return _installed_environment
 

--- a/lib/spack/spack/test/cmd/extensions.py
+++ b/lib/spack/spack/test/cmd/extensions.py
@@ -32,12 +32,12 @@ def test_extensions(mock_packages, python_database, capsys):
             packages = extensions("-s", "packages", "python")
             installed = extensions("-s", "installed", "python")
         assert "==> python@2.7.11" in output
-        assert "==> 3 extensions" in output
+        assert "==> 4 extensions" in output
         assert "py-extension1" in output
         assert "py-extension2" in output
         assert "python-venv" in output
 
-        assert "==> 3 extensions" in packages
+        assert "==> 4 extensions" in packages
         assert "py-extension1" in packages
         assert "py-extension2" in packages
         assert "python-venv" in packages

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -201,23 +201,22 @@ def test_test_help_cdash(mock_test_stage):
 def test_test_list_all(mock_packages):
     """Confirm `spack test list --all` returns all packages with test methods"""
     pkgs = spack_test("list", "--all").strip().split()
-    assert set(pkgs) == set(
-        [
-            "fail-test-audit",
-            "fail-test-audit-deprecated",
-            "fail-test-audit-docstring",
-            "fail-test-audit-impl",
-            "mpich",
-            "perl-extension",
-            "printing-package",
-            "py-extension1",
-            "py-extension2",
-            "py-test-callback",
-            "simple-standalone-test",
-            "test-error",
-            "test-fail",
-        ]
-    )
+    assert set(pkgs) == {
+        "py-numpy",
+        "fail-test-audit",
+        "fail-test-audit-deprecated",
+        "fail-test-audit-docstring",
+        "fail-test-audit-impl",
+        "mpich",
+        "perl-extension",
+        "printing-package",
+        "py-extension1",
+        "py-extension2",
+        "py-test-callback",
+        "simple-standalone-test",
+        "test-error",
+        "test-fail",
+    }
 
 
 def test_test_list(mock_packages, mock_archive, mock_fetch, install_mockery):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1323,6 +1323,7 @@ spack:
 @pytest.mark.parametrize(
     "spack_yaml",
     [
+        # Use a plain requirement for callpath
         """
 spack:
   specs:
@@ -1335,6 +1336,7 @@ spack:
   concretizer:
     unify: false
 """,
+        # Propagate a toolchain
         """
 spack:
   specs:
@@ -1350,6 +1352,21 @@ spack:
     callpath:
       require:
       - "%c=gcc"
+  concretizer:
+    unify: false
+""",
+        # Override callpath from input spec
+        """
+spack:
+  specs:
+  - mpileaks %%c,cxx=gcc ^callpath %c=gcc
+  - mpileaks %%llvm_toolchain ^callpath %c=gcc
+  toolchains:
+    llvm_toolchain:
+    - spec: "%c=llvm"
+      when: "%c"
+    - spec: "%cxx=llvm"
+      when: "%cxx"
   concretizer:
     unify: false
 """,

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1390,3 +1390,122 @@ def test_dependency_propagation_in_environments(spack_yaml, tmp_path, mutable_co
 
     assert mpileaks_gcc["callpath"].satisfies("%c=gcc")
     assert mpileaks_llvm["callpath"].satisfies("%c=gcc")
+
+
+@pytest.mark.parametrize(
+    "spack_yaml,exception_nodes",
+    [
+        # trilinos and its link/run subdag are compiled with clang, all other nodes use gcc
+        (
+            """
+spack:
+  specs:
+  - trilinos %%c,cxx=clang
+  packages:
+    c:
+      prefer:
+      - gcc
+    cxx:
+      prefer:
+      - gcc
+""",
+            set(),
+        ),
+        # callpath and its link/run subdag are compiled with clang, all other nodes use gcc
+        (
+            """
+spack:
+  specs:
+  - trilinos ^callpath %%c,cxx=clang
+  packages:
+    c:
+      prefer:
+      - gcc
+    cxx:
+      prefer:
+      - gcc
+""",
+            {"trilinos", "mpich", "py-numpy"},
+        ),
+        # trilinos and its link/run subdag, with the exception of mpich, are compiled with clang.
+        # All other nodes use gcc.
+        (
+            """
+spack:
+  specs:
+  - trilinos %%c,cxx=clang ^mpich %c=gcc
+  packages:
+    c:
+      prefer:
+      - gcc
+    cxx:
+      prefer:
+      - gcc
+""",
+            {"mpich"},
+        ),
+        (
+            """
+spack:
+  specs:
+  - trilinos %%c,cxx=clang
+  packages:
+    c:
+      prefer:
+      - gcc
+    cxx:
+      prefer:
+      - gcc
+    mpich:
+      require:
+      - "%c=gcc"
+""",
+            {"mpich"},
+        ),
+    ],
+)
+def test_double_percent_semantics(spack_yaml, exception_nodes, tmp_path, mutable_config):
+    """Tests semantics of %% in environments, when combined with other features.
+
+    The test assumes clang is the propagated compiler, and gcc is the preferred compiler.
+    """
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(spack_yaml)
+    with ev.Environment(tmp_path) as e:
+        e.concretize()
+        trilinos = e.concrete_roots()[0]
+
+    runtime_nodes = [
+        x for x in trilinos.traverse(deptype=("link", "run")) if x.name not in exception_nodes
+    ]
+    remaining_nodes = [x for x in trilinos.traverse() if x not in runtime_nodes]
+
+    for x in runtime_nodes:
+        error_msg = f"\n{x.tree()} does not use clang while expected to"
+        assert x.satisfies("%[when=%c]c=clang %[when=%cxx]cxx=clang"), error_msg
+
+    for x in remaining_nodes:
+        error_msg = f"\n{x.tree()} does not use gcc while expected to"
+        assert x.satisfies("%[when=%c]c=gcc %[when=%cxx]cxx=gcc"), error_msg
+
+
+def test_cannot_use_double_percent_with_require(tmp_path, mutable_config):
+    """Tests that %% cannot be used with a requirement on languages, since they'll conflict."""
+    # trilinos wants to use clang, but we require gcc, so Spack will error
+    spack_yaml = """
+spack:
+  specs:
+  - trilinos %%c,cxx=clang
+  packages:
+    c:
+      require:
+      - gcc
+    cxx:
+      require:
+      - gcc
+"""
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(spack_yaml)
+    with ev.Environment(tmp_path) as e:
+        with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="failed to concretize"):
+            e.concretize()

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1318,3 +1318,35 @@ spack:
         derived_pkga = e.concrete_roots()[0]
 
     assert base_pkga.dag_hash() == derived_pkga.dag_hash()
+
+
+def test_dependency_propagation_in_environments(tmp_path, mutable_config):
+    """Tests that we can enforce compiler preferences using %% in environments."""
+    spack_yaml = """
+spack:
+  specs:
+  - mpileaks %%c,cxx=gcc
+  - mpileaks %%c,cxx=llvm
+  packages:
+    callpath:
+      require:
+      - "%c=gcc"
+  concretizer:
+    unify: false
+"""
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(spack_yaml)
+    with ev.Environment(tmp_path) as e:
+        e.concretize()
+        roots = e.concrete_roots()
+
+    mpileaks_gcc = [s for s in roots if s.satisfies("mpileaks %c=gcc")][0]
+    for c in ("%[when=%c]c=gcc", "%[when=%cxx]cxx=gcc"):
+        assert all(x.satisfies(c) for x in mpileaks_gcc.traverse() if x.name != "callpath")
+
+    mpileaks_llvm = [s for s in roots if s.satisfies("mpileaks %c=llvm")][0]
+    for c in ("%[when=%c]c=llvm", "%[when=%cxx]cxx=llvm"):
+        assert all(x.satisfies(c) for x in mpileaks_llvm.traverse() if x.name != "callpath")
+
+    assert mpileaks_gcc["callpath"].satisfies("%c=gcc")
+    assert mpileaks_llvm["callpath"].satisfies("%c=gcc")

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1320,9 +1320,10 @@ spack:
     assert base_pkga.dag_hash() == derived_pkga.dag_hash()
 
 
-def test_dependency_propagation_in_environments(tmp_path, mutable_config):
-    """Tests that we can enforce compiler preferences using %% in environments."""
-    spack_yaml = """
+@pytest.mark.parametrize(
+    "spack_yaml",
+    [
+        """
 spack:
   specs:
   - mpileaks %%c,cxx=gcc
@@ -1333,7 +1334,29 @@ spack:
       - "%c=gcc"
   concretizer:
     unify: false
-"""
+""",
+        """
+spack:
+  specs:
+  - mpileaks %%c,cxx=gcc
+  - mpileaks %%llvm_toolchain
+  toolchains:
+    llvm_toolchain:
+    - spec: "%c=llvm"
+      when: "%c"
+    - spec: "%cxx=llvm"
+      when: "%cxx"
+  packages:
+    callpath:
+      require:
+      - "%c=gcc"
+  concretizer:
+    unify: false
+""",
+    ],
+)
+def test_dependency_propagation_in_environments(spack_yaml, tmp_path, mutable_config):
+    """Tests that we can enforce compiler preferences using %% in environments."""
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -18,6 +18,7 @@ import spack.spec_parser
 import spack.store
 import spack.variant
 import spack.version as vn
+from spack.enums import PropagationPolicy
 from spack.error import SpecError, UnsatisfiableSpecError
 from spack.spec import ArchSpec, DependencySpec, Spec, SpecFormatSigilError, SpecFormatStringError
 from spack.variant import (
@@ -2380,6 +2381,34 @@ def test_constrain_symbolically(constraints, expected):
             {"virtuals": ("mpi", "lapack"), "direct": True},
             " %[virtuals=lapack,mpi] callpath",
             "DependencySpec('', 'callpath', depflag=0, virtuals=('lapack', 'mpi'), direct=True)",
+        ),
+        (
+            "",
+            "callpath",
+            {
+                "virtuals": ("mpi", "lapack"),
+                "direct": True,
+                "propagation": PropagationPolicy.PREFERENCE,
+            },
+            " %%[virtuals=lapack,mpi] callpath",
+            "DependencySpec('', 'callpath', depflag=0, virtuals=('lapack', 'mpi'), direct=True,"
+            " propagation=PropagationPolicy.PREFERENCE)",
+        ),
+        (
+            "",
+            "callpath",
+            {"virtuals": (), "direct": True, "propagation": PropagationPolicy.PREFERENCE},
+            " %%callpath",
+            "DependencySpec('', 'callpath', depflag=0, virtuals=(), direct=True,"
+            " propagation=PropagationPolicy.PREFERENCE)",
+        ),
+        (
+            "mpileaks+foo",
+            "callpath+bar",
+            {"virtuals": (), "direct": True, "propagation": PropagationPolicy.PREFERENCE},
+            "mpileaks+foo %%callpath+bar",
+            "DependencySpec('mpileaks+foo', 'callpath+bar', depflag=0, virtuals=(), direct=True,"
+            " propagation=PropagationPolicy.PREFERENCE)",
         ),
     ],
 )

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -921,6 +921,46 @@ def specfile_for(default_mock_concretization):
             ],
             "foo ^[when='%c'] c=gcc",
         ),
+        # Test dependency propagation
+        (
+            "foo %%gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "foo"),
+                Token(SpecTokens.DEPENDENCY, "%%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "gcc"),
+            ],
+            "foo %%gcc",
+        ),
+        (
+            "foo %%c,cxx=gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "foo"),
+                Token(SpecTokens.DEPENDENCY, "%%c,cxx=gcc", virtuals="c,cxx", substitute="gcc"),
+            ],
+            "foo %%c,cxx=gcc",
+        ),
+        (
+            "foo %%[when='%c'] c=gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "foo"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, "%%["),
+                Token(SpecTokens.KEY_VALUE_PAIR, "when='%c'"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, "] c=gcc", virtuals="c", substitute="gcc"),
+            ],
+            "foo %%[when='%c'] c=gcc",
+        ),
+        (
+            "foo %%[when='%c' virtuals=c] gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "foo"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, "%%["),
+                Token(SpecTokens.KEY_VALUE_PAIR, "when='%c'"),
+                Token(SpecTokens.KEY_VALUE_PAIR, "virtuals=c"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, "]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "gcc"),
+            ],
+            "foo %%[when='%c'] c=gcc",
+        ),
     ],
 )
 def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_package):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/py_numpy/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/py_numpy/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.generic import Package
+from spack_repo.builtin_mock.build_systems.python import PythonExtension
+
+from spack.package import *
+
+
+class PyNumpy(Package, PythonExtension):
+    """A package which extends python, depends on C and C++, and has a pure build dependency"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/py-numpy-1.0.tar.gz"
+
+    version("2.3.4", md5="00000000000000000000000000000120")
+
+    extends("python")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("cmake", type="build")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/trilinos/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/trilinos/package.py
@@ -1,0 +1,23 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Trilinos(Package):
+    """A package which has pure build dependencies, run dependencies, and link dependencies."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/trilinos-1.0.tar.gz"
+
+    version("16.1.0", md5="00000000000000000000000000000120")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("cmake", type="build")
+
+    depends_on("py-numpy", type="run")
+
+    depends_on("mpi")
+    depends_on("callpath")


### PR DESCRIPTION
fixes #51244 
depends on #51314

This PR allows using `%%` to set preferences on input specs, and is particularly useful when dealing with `unify: false` environments.

An example of an environment that can be concretized with this PR is:
```yaml
spack:
  definitions:
  - compilers: ["%%llvm_gfortran", "%%c,cxx,fortran=gcc"]
  specs:
  - matrix:
    - [mpileaks, hdf5, trilinos]
    - [$compilers]
  toolchains:
    llvm_gfortran:
    - spec: "%c=llvm"
      when: "%c"
    - spec: "%cxx=llvm"
      when: "%cxx"
    - spec: "%fortran=gcc"
      when: "%fortran"
  packages:
    callpath:
      require:
      - "%c=gcc"
  concretizer:
    unify: false
```
which will produce the following result for `mpileaks %%llvm_gfortran`:
<img width="2550" height="1863" alt="2025-10-01_11-53" src="https://github.com/user-attachments/assets/2b614685-f96e-46c7-933c-474fed191767" />

`%%` is now a *propagated* preference. i.e., it forces everything in a node's sub-DAG to use the preference unless it is impossible.

To allow for exceptions using `%`, `%%`, and spec syntax while still allowing global preferences in `packages.yaml`,  the penalty taken for not fulfilling a `%%` preference is higher than that of a preference in `packages.yaml`. In this way we can propagate compilers to the `link,run` closure of a node, and set global preferences for other nodes.

The performance penalty for using `%%` is not insignificant, but it is also not present when *not* using `%%`. This has essentially zero cost for solves that do not use the new functionality.