### PR TITLE
repo.py: remove `is_package_file`

### DIFF
--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -500,24 +500,6 @@ def test_part(
             # call from the error
             stack = traceback.extract_stack()[:-1]
 
-            # Package files have a line added at import time, so we re-read
-            # the file to make line numbers match. We have to subtract two
-            # from the line number because the original line number is
-            # inflated once by the import statement and the lines are
-            # displaced one by the import statement.
-            for i, entry in enumerate(stack):
-                filename, lineno, function, text = entry
-                if spack.repo.is_package_file(filename):
-                    with open(filename, encoding="utf-8") as f:
-                        lines = f.readlines()
-                    new_lineno = lineno - 2
-                    text = lines[new_lineno]
-                    if isinstance(entry, tuple):
-                        new_entry = (filename, new_lineno, function, text)
-                        stack[i] = new_entry  # type: ignore[call-overload]
-                    elif isinstance(entry, list):
-                        stack[i][1] = new_lineno  # type: ignore[index]
-
             # Format and print the stack
             out = traceback.format_list(stack)
             for line in out:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -10,7 +10,6 @@ import functools
 import importlib
 import importlib.machinery
 import importlib.util
-import inspect
 import itertools
 import os
 import re
@@ -320,23 +319,6 @@ def autospec(function):
         return function(self, spec_like, *args, **kwargs)
 
     return converter
-
-
-def is_package_file(filename):
-    """Determine whether we are in a package file from a repo."""
-    # Package files are named `package.py` and are not in lib/spack/spack
-    # We have to remove the file extension because it can be .py and can be
-    # .pyc depending on context, and can differ between the files
-    import spack.package_base  # break cycle
-
-    filename_noext = os.path.splitext(filename)[0]
-    packagebase_filename_noext = os.path.splitext(inspect.getfile(spack.package_base.PackageBase))[
-        0
-    ]
-    return (
-        filename_noext != packagebase_filename_noext
-        and os.path.basename(filename_noext) == "package"
-    )
 
 
 class SpackNamespace(types.ModuleType):


### PR DESCRIPTION
This function had issues, such as checking redundantly whether the provided path was not the module file in which `PackageBase` was defined (namely `package_base.py`), while also requiring that the base name is `package.py`.

However, the entire function can be removed, because the single call site's use case was redundant.

As a happy side effect, it drops the dependency of `spack.repo` on `spack.package_base`, reducing the number of problematic import statements.

> The overall number of problematic import statements decreased by 1 from 23 to 22.