### PR TITLE
error.py: enforce args are str

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -807,7 +807,9 @@ class Database:
 
         def check(cond, msg):
             if not cond:
-                raise CorruptDatabaseError(f"Spack database is corrupt: {msg}", self._index_path)
+                raise CorruptDatabaseError(
+                    f"Spack database is corrupt: {msg}", str(self._index_path)
+                )
 
         check("database" in fdata, "no 'database' attribute in JSON DB.")
 
@@ -829,7 +831,7 @@ class Database:
             return CorruptDatabaseError(
                 f"Invalid record in Spack database: hash: {hash_key}, cause: "
                 f"{type(error).__name__}: {error}",
-                self._index_path,
+                str(self._index_path),
             )
 
         # Build up the database in three passes:

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -265,7 +265,9 @@ def _depends_on(
         return
 
     if not spec.name:
-        raise DependencyError(f"Invalid dependency specification in package '{pkg.name}':", spec)
+        raise DependencyError(
+            f"Invalid dependency specification in package '{pkg.name}':", str(spec)
+        )
     if pkg.name == spec.name:
         raise CircularReferenceError(f"Package '{pkg.name}' cannot depend on itself.")
 

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import inspect
 import sys
+from typing import Optional
 
 import spack.llnl.util.tty as tty
 
@@ -24,7 +24,7 @@ class SpackError(Exception):
     Subclasses can be found in the modules they have to do with.
     """
 
-    def __init__(self, message, long_message=None):
+    def __init__(self, message: str, long_message: Optional[str] = None) -> None:
         super().__init__()
         self.message = message
         self._long_message = long_message
@@ -78,16 +78,13 @@ class SpackError(Exception):
         sys.exit(1)
 
     def __str__(self):
-        msg = self.message
         if self._long_message:
-            msg += "\n    %s" % self._long_message
-        return msg
+            return f"{self.message}\n    {self._long_message}"
+        return self.message
 
     def __repr__(self):
-        args = [repr(self.message), repr(self.long_message)]
-        args = ",".join(args)
-        qualified_name = inspect.getmodule(self).__name__ + "." + type(self).__name__
-        return qualified_name + "(" + args + ")"
+        qualified_name = type(self).__module__ + "." + type(self).__name__
+        return f"{qualified_name}({repr(self.message)}, {repr(self.long_message)})"
 
     def __reduce__(self):
         return type(self), (self.message, self.long_message)

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -433,7 +433,7 @@ class SpecParser:
             )
             raise SpecParsingError(msg, self.ctx.current_token, self.literal_str)
         if root_spec.concrete:
-            raise spack.error.SpecError(root_spec, "^" + str(dependency))
+            raise spack.error.SpecError(str(root_spec), "^" + str(dependency))
         return dependency, parser_warnings
 
     def _apply_toolchain(self, spec: "spack.spec.Spec", name: str) -> None:


### PR DESCRIPTION
Error handling itself raises eventually during `sys.stderr.write` which
expects a string (and not a path or spec instance).

