### PR TITLE
oci: do not store index twice

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -381,6 +381,10 @@ class BinaryCacheIndex:
             MirrorURLAndVersion(m.fetch_url, layout_version)
             for layout_version in SUPPORTED_LAYOUT_VERSIONS
             for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+            # TODO: OCI does not have a versioned layout. Get rid of this once we no longer support
+            # URL layout v2.
+            if not spack.oci.image.is_oci_url(m.fetch_url)
+            or layout_version == SUPPORTED_LAYOUT_VERSIONS[0]
         ]
         items_to_remove = []
         spec_cache_clear_needed = False
@@ -1742,7 +1746,7 @@ def download_tarball(
 
     try_next = []
     for try_layout in SUPPORTED_LAYOUT_VERSIONS:
-        try_next.extend([MirrorURLAndVersion(i.fetch_url, try_layout) for i in configured_mirrors])
+        try_next.extend(MirrorURLAndVersion(i.fetch_url, try_layout) for i in configured_mirrors)
     urls_and_versions = try_first + [uv for uv in try_next if uv not in try_first]
 
     # TODO: turn `mirrors_for_spec` into a list of Mirror instances, instead of doing that here.
@@ -1765,6 +1769,9 @@ def download_tarball(
 
         # TODO: refactor this to some "nice" place.
         if spack.oci.image.is_oci_url(fetch_url):
+            # TODO: OCI does not have a concept of layout versions, get rid of this notion.
+            if layout_version != SUPPORTED_LAYOUT_VERSIONS[0]:
+                continue
             ref = ImageReference.from_url(fetch_url).with_tag(_oci_default_tag(spec))
 
             # Fetch the manifest
@@ -2187,6 +2194,9 @@ def try_direct_fetch(spec, mirrors=None):
 
     for layout_version in SUPPORTED_LAYOUT_VERSIONS:
         for mirror in binary_mirrors:
+            # TODO: OCI-support
+            if spack.oci.image.is_oci_url(mirror.fetch_url):
+                continue
             # layout_version could eventually come from the mirror config
             cache_class = get_url_buildcache_class(layout_version=layout_version)
             cache_entry = cache_class(mirror.fetch_url, spec)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1710,7 +1710,9 @@ def try_fetch(url_to_fetch):
 
 
 def download_tarball(
-    spec: spack.spec.Spec, unsigned: Optional[bool] = False, mirrors_for_spec=None
+    spec: spack.spec.Spec,
+    unsigned: Optional[bool] = False,
+    mirrors_for_spec: Optional[List[MirrorForSpec]] = None,
 ) -> Optional[spack.stage.Stage]:
     """Download binary tarball for given package
 
@@ -1743,14 +1745,17 @@ def download_tarball(
     # we need was in an un-indexed mirror.  No need to check any
     # mirror for the spec twice though.
     try_first = [i.url_and_version for i in mirrors_for_spec] if mirrors_for_spec else []
-
-    try_next = []
-    for try_layout in SUPPORTED_LAYOUT_VERSIONS:
-        try_next.extend(MirrorURLAndVersion(i.fetch_url, try_layout) for i in configured_mirrors)
+    try_next = [
+        MirrorURLAndVersion(mirror.fetch_url, layout)
+        for mirror in configured_mirrors
+        for layout in SUPPORTED_LAYOUT_VERSIONS
+    ]
     urls_and_versions = try_first + [uv for uv in try_next if uv not in try_first]
 
     # TODO: turn `mirrors_for_spec` into a list of Mirror instances, instead of doing that here.
-    def fetch_url_to_mirror(url_and_version):
+    def fetch_url_to_mirror(
+        url_and_version: MirrorURLAndVersion,
+    ) -> Tuple[spack.mirrors.mirror.Mirror, int]:
         url = url_and_version.url
         layout_version = url_and_version.version
         for mirror in configured_mirrors:


### PR DESCRIPTION
This is the least invasive fix to ensure OCI build caches do not fetch
an index twice and store it under `_v2` and `_v3` in cache, while also
not fetching it yet a third by dropping the `_v*` suffix.

Databases can get quite big, so this is pure overhead for OCI, since 
the v2 and v3 suffixes apply to URL based build caches only.

Once v2 support is dropped, and with v4 being unlikely to happen, I
think this ad-hoc fix is fine. The v2 related code can simply be
removed in a future Spack release (maybe already Spack v1.1).
