### PR TITLE
Fix path expansion in CI handling of includes

### DIFF
--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -15,8 +15,8 @@ import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
 import spack.schema
 import spack.spec
-import spack.util.spack_yaml as syaml
 import spack.util.path as path_util
+import spack.util.spack_yaml as syaml
 
 from .common import (
     SPACK_RESERVED_TAGS,

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -16,6 +16,7 @@ import spack.mirrors.mirror
 import spack.schema
 import spack.spec
 import spack.util.spack_yaml as syaml
+import spack.util.path as path_util
 
 from .common import (
     SPACK_RESERVED_TAGS,
@@ -140,9 +141,10 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             )
 
         def _rewrite_include(path, orig_root, new_root):
-            if os.path.isabs(path):
+            expanded_path = path_util.substitute_path_variables(path)
+            if os.path.isabs(expanded_path):
                 return path
-            abs_path = os.path.normpath(os.path.join(orig_root, path))
+            abs_path = path_util.canonicalize_path(path, orig_root)
             return os.path.relpath(abs_path, start=new_root)
 
         # If there are no includes, just copy


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Bugfix