### PR TITLE
log.py: remove redundant retry wrapper

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -59,7 +59,6 @@ import spack.report
 import spack.rewiring
 import spack.spec
 import spack.store
-import spack.util.executable
 import spack.util.path
 import spack.util.timer as timer
 from spack.llnl.string import ordinal


### PR DESCRIPTION
* `except select.error` is dead code since Python 3.3 as it's an alias for `OSError`, caught earlier.
* `e.errno == errno.EINTR` retry is the default since Python 3.5 (PEP 475)