### PR TITLE
docs: allow text fragments in url

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,6 +1,6 @@
 # using forks of sphinx/furo to account for changes not yet merged upstream
 # sphinx==8.2.3
-git+https://github.com/haampie/sphinx.git@8df10d919a842aa34cda8449e4d63a8cdde41b54#egg=sphinx
+git+https://github.com/haampie/sphinx.git@7e36aafa051069360e396c8de4463b82f8db6daf#egg=sphinx
 sphinxcontrib-programoutput==0.18
 sphinxcontrib-svg2pdfconverter==1.3.0
 sphinx-copybutton==0.5.2

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,10 +1,12 @@
-sphinx==8.2.3
+# using forks of sphinx/furo to account for changes not yet merged upstream
+# sphinx==8.2.3
+git+https://github.com/haampie/sphinx.git@8df10d919a842aa34cda8449e4d63a8cdde41b54#egg=sphinx
 sphinxcontrib-programoutput==0.18
 sphinxcontrib-svg2pdfconverter==1.3.0
 sphinx-copybutton==0.5.2
 sphinx-last-updated-by-git==0.3.8
 sphinx-sitemap==2.9.0
-# fork of furo with a few changes that are not merged upstream
+# furo==2024.04.27
 git+https://github.com/haampie/furo.git@c1d161cb9e04b481ec3331db981aacfa132ecaa6#egg=furo
 python-levenshtein==0.27.1
 docutils==0.21.2


### PR DESCRIPTION
Use Sphinx 8.2.3 with this patch: https://github.com/sphinx-doc/sphinx/pull/13921, so that it's easier to link particular paragraphs in the text using Text Fragments.

Without this, the `#:~:text=...` bit is removed upon page load, which I want to be able to copy from the URL bar when pointing to certain sections.
