### PR TITLE
solver: refactor rule to derive `trigger_condition_holds`

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -426,13 +426,48 @@ cannot_hold(TriggerID, PackageNode)
 
 trigger_condition_holds(ID, RequestorNode) :-
   trigger_node(ID, PackageNode, RequestorNode);
-  attr(Name, node(X, A1))             : condition_requirement(ID, Name, A1),             condition_nodes(ID, PackageNode, node(X, A1));
-  attr(Name, node(X, A1), A2)         : condition_requirement(ID, Name, A1, A2),         condition_nodes(ID, PackageNode, node(X, A1));
-  attr(Name, node(X, A1), A2, A3)     : condition_requirement(ID, Name, A1, A2, A3),     condition_nodes(ID, PackageNode, node(X, A1)), not node_attributes_with_custom_rules(Name);
-  attr(Name, node(X, A1), A2, A3, A4) : condition_requirement(ID, Name, A1, A2, A3, A4), condition_nodes(ID, PackageNode, node(X, A1));
-  % Special cases
-  attr("depends_on", node(X, A1), node(Y, A2), A3) : condition_requirement(ID, "depends_on", A1, A2, A3), condition_nodes(ID, PackageNode, node(X, A1)), condition_nodes(ID, PackageNode, node(Y, A2));
+  satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1))         : condition_requirement(ID, Name, A1);
+  satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2))     : condition_requirement(ID, Name, A1, A2);
+  satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3)) : condition_requirement(ID, Name, A1, A2, A3);
+  satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3, A4)) : condition_requirement(ID, Name, A1, A2, A3, A4);
   not cannot_hold(ID, PackageNode).
+
+satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1)) :-
+  trigger_node(ID, PackageNode, _),
+  attr(Name, node(X, A1)),
+  condition_requirement(ID, Name, A1),
+  condition_nodes(ID, PackageNode, node(X, A1)).
+
+satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2)) :-
+  trigger_node(ID, PackageNode, _),
+  attr(Name, node(X, A1), A2),
+  condition_requirement(ID, Name, A1, A2),
+  condition_nodes(ID, PackageNode, node(X, A1)).
+
+satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3)) :-
+  trigger_node(ID, PackageNode, _),
+  attr(Name, node(X, A1), A2, A3),
+  condition_requirement(ID, Name, A1, A2, A3),
+  condition_nodes(ID, PackageNode, node(X, A1)),
+  not node_attributes_with_custom_rules(Name).
+
+satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3, A4)) :-
+  trigger_node(ID, PackageNode, _),
+  attr(Name, node(X, A1), A2, A3, A4),
+  condition_requirement(ID, Name, A1, A2, A3, A4),
+  condition_nodes(ID, PackageNode, node(X, A1)).
+
+satisfied(trigger(PackageNode), condition_requirement(ID, "depends_on", A1, A2, A3)) :-
+  trigger_node(ID, PackageNode, _),
+  attr("depends_on", node(X, A1), node(Y, A2), A3),
+  condition_requirement(ID, "depends_on", A1, A2, A3),
+  condition_nodes(ID, PackageNode, node(X, A1)),
+  condition_nodes(ID, PackageNode, node(Y, A2)).
+
+satisfied(trigger(PackageNode), condition_requirement(ID, "concrete_variant_request", A1, A2, A3)) :-
+  trigger_node(ID, PackageNode, _),
+  condition_requirement(ID, "concrete_variant_request", A1, A2, A3),
+  condition_nodes(ID, PackageNode, node(X, A1)).
 
 condition_with_concrete_variant(ID, Package, Variant) :- condition_requirement(ID, "concrete_variant_request", Package, Variant, _).
 


### PR DESCRIPTION
This refactor has been extracted from #51417

It's a standalone PR because it seems to reduce the variance or our benchmark, by moving the time spent from `solve` to `ground`. On:

* **Spack:** 1.1.0.dev0 (https://github.com/spack/spack/commit/d8a24378fb9ae583689fa930c2fcd77f46738e07)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/414923949605c9e83ae099db61bea2b0ad48a5cc
* **Python:** 3.13.2
* **Platform:** linux-ubuntu20.04-icelake

[radiuss.develop.csv](https://github.com/user-attachments/files/22763357/radiuss.develop.csv)
[radiuss.pr.csv](https://github.com/user-attachments/files/22763361/radiuss.pr.csv)

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/c349ecd5-b948-4d49-80a0-d4136dc5d105" />




<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
