### PR TITLE
stale: add more labels for issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -31,7 +31,7 @@ jobs:
             This issue was closed because it had no activity for 30 days after being marked stale.
             If you feel this is in error, please feel free to reopen this issue.
           stale-issue-label: 'stale'
-          any-of-issue-labels: 'build-error,unreproducible'
+          any-of-issue-labels: 'build-error,unreproducible,question,documentation,environments'
           exempt-issue-labels: 'pinned,triage,impact-low,impact-medium,impact-high'
 
           # Pull requests configuration


### PR DESCRIPTION
actions/stale will also look into issues labeled as "question", "documentation", or "environments"

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
