### PR TITLE
Port tests to Windows by removing pytest markers

### DIFF
--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -5,14 +5,10 @@
 import pathlib
 import shutil
 
-import pytest
-
 import spack.binary_distribution as bd
 import spack.concretize
 import spack.mirrors.mirror
 from spack.installer import PackageInstaller
-
-pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_build_tarball_overwrite(install_mockery, mock_fetch, monkeypatch, tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -19,6 +19,7 @@ import spack.repo as repo
 import spack.util.git
 from spack.spec import Spec
 from spack.test.conftest import MockHTTPResponse, RepoBuilder
+from spack.util.executable import which
 from spack.version import Version
 
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
@@ -188,6 +189,7 @@ def test_pipeline_dag(config, repo_builder: RepoBuilder):
         assert all([s in a_deps_direct for s in [spec_a["pkg-b"], spec_a["pkg-c"]]])
 
 
+@pytest.mark.skipif(not (which("gpg") or which("gpg2")), reason="require gpg to be installed")
 def test_import_signing_key(mock_gnupghome):
     signing_key_dir = spack_paths.mock_gpg_keys_path
     signing_key_path = os.path.join(signing_key_dir, "package-signing-key")

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -188,7 +188,6 @@ def test_pipeline_dag(config, repo_builder: RepoBuilder):
         assert all([s in a_deps_direct for s in [spec_a["pkg-b"], spec_a["pkg-c"]]])
 
 
-@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_import_signing_key(mock_gnupghome):
     signing_key_dir = spack_paths.mock_gpg_keys_path
     signing_key_path = os.path.join(signing_key_dir, "package-signing-key")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -31,8 +31,6 @@ install = SpackCommand("install")
 buildcache = SpackCommand("buildcache")
 uninstall = SpackCommand("uninstall")
 
-pytestmark = pytest.mark.not_on_windows("does not run on windows")
-
 
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.regression("8083")

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -10,10 +10,7 @@ import spack.concretize
 import spack.platforms
 from spack.multimethod import NoSuchMethodError
 
-pytestmark = [
-    pytest.mark.usefixtures("mock_packages", "config"),
-    pytest.mark.not_on_windows("Not running on windows"),
-]
+pytestmark = pytest.mark.usefixtures("mock_packages", "config")
 
 
 @pytest.fixture(scope="module", params=["multimethod", "multimethod-inheritor"])


### PR DESCRIPTION
Supersedes #47746 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
