### PR TITLE
gha: test canonicalization with python 3.14

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -93,7 +93,7 @@ jobs:
     name: package.py canonicalization
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/spack/all-pythons:2025-07-25
+      image: ghcr.io/spack/all-pythons:2025-10-10
 
     steps:
       - name: Checkout Spack (current)
@@ -113,6 +113,6 @@ jobs:
       - name: Test package.py canonicalization
         run: spack-current/.github/workflows/bin/canonicalize.py
           --spack $PWD/spack-previous $PWD/spack-current
-          --python python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13
+          --python python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13 python3.14
           --input-dir spack-packages/repos/spack_repo/builtin/packages/
           --output-dir canonicalized


### PR DESCRIPTION
Update:

```
# for x in 6 7 8 9 10 11 12 13 14; do python3.$x --version; done 
Python 3.6.15
Python 3.7.17
Python 3.8.20
Python 3.9.24
Python 3.10.19
Python 3.11.14
Python 3.12.12
Python 3.13.8
Python 3.14.0
```