### PR TITLE
build_environment.py: Prevent deadlock on install process join

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1360,7 +1360,8 @@ def start_build_process(
             if m:
                 jobserver_fd1 = Connection(int(m.group(1)))
                 jobserver_fd2 = Connection(int(m.group(2)))
-
+        if pkg.name == "paraview":
+            import ipdb; ipdb.set_trace()
         p = BuildProcess(
             target=_setup_pkg_and_run,
             args=(
@@ -1410,18 +1411,17 @@ def complete_build_process(process: BuildProcess):
         typ = "exit" if process.exitcode >= 0 else "signal"
         return f"{typ} {abs(process.exitcode)}"
 
-    timeout = process.timeout
-    process.join(timeout=timeout)
-    if process.is_alive():
-        warnings.warn(f"Terminating process, since the timeout of {timeout}s was exceeded")
-        process.terminate()
-
     try:
         # Check if information from the read pipe has been received.
         child_result = process.read_pipe.recv()
     except EOFError:
         raise InstallError(f"The process has stopped unexpectedly ({exitcode_msg(process)})")
 
+    timeout = process.timeout
+    process.join(timeout=timeout)
+    if process.is_alive():
+        warnings.warn(f"Terminating process, since the timeout of {timeout}s was exceeded")
+        process.terminate()
     # If returns a StopPhase, raise it
     if isinstance(child_result, spack.error.StopPhase):
         raise child_result

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1360,8 +1360,7 @@ def start_build_process(
             if m:
                 jobserver_fd1 = Connection(int(m.group(1)))
                 jobserver_fd2 = Connection(int(m.group(2)))
-        if pkg.name == "paraview":
-            import ipdb; ipdb.set_trace()
+
         p = BuildProcess(
             target=_setup_pkg_and_run,
             args=(
@@ -1416,9 +1415,10 @@ def complete_build_process(process: BuildProcess):
         child_result = process.read_pipe.recv()
     except EOFError:
         raise InstallError(f"The process has stopped unexpectedly ({exitcode_msg(process)})")
+    finally:
+        timeout = process.timeout
+        process.join(timeout=timeout)
 
-    timeout = process.timeout
-    process.join(timeout=timeout)
     if process.is_alive():
         warnings.warn(f"Terminating process, since the timeout of {timeout}s was exceeded")
         process.terminate()

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1418,10 +1418,9 @@ def complete_build_process(process: BuildProcess):
     finally:
         timeout = process.timeout
         process.join(timeout=timeout)
-
-    if process.is_alive():
-        warnings.warn(f"Terminating process, since the timeout of {timeout}s was exceeded")
-        process.terminate()
+        if process.is_alive():
+            warnings.warn(f"Terminating process, since the timeout of {timeout}s was exceeded")
+            process.terminate()
     # If returns a StopPhase, raise it
     if isinstance(child_result, spack.error.StopPhase):
         raise child_result


### PR DESCRIPTION
Currently in `build_environment.complete_build_process` we call `join` on the child installer process before we call `recv` on the write pipe. 

This can lead to a deadlock if the child is blocking on the send call to the write pipe.
Per the python docs, `Communication.send` does not claim to block, however, if you dig into the implementation of `send` on Windows, it uses `_winapi.WriteFile(self._handle, buf, overlapped=True)` under the hood, which, with an `OVERLAPPED` (async) handle and an anonymous pipe, will return false if the pipe buffer is full, per the win32 docs:
```
If the pipe buffer is full when an application uses the WriteFile function to write to a pipe,
the write operation may not finish immediately. 
The write operation will be completed when a read operation makes more system buffer space available for the 
pipe.
```
The `send` method then calls `waitres = _winapi.WaitForMultipleObjects([ov.event], False, INFINITE)` which hangs infinitely until the child process is killed or the parent process frees up buffer space with a read. 

So if Spack's child installer process fills up that buffer with a send, it will hang on that send until the buffer is emptied, but if the parent process is waiting on a join to perform that read, Spack will deadlock and hang.

We are observing this with VTK and Paraview in CI (as can be observed here: https://gitlab.spack.io/spack/spack-packages/-/jobs/18409638, which is costing us approx 18 hours of CI time for _each_ of these failures. 
In these instances, Spack is sending 12kb into the pipe buffer, which exceeds the default buffer size of 8kb, leading to a deadlock.

Just moving the `recv` call to before the join empties the buffer, and ensures we can gracefully join the child. 

