### PR TITLE
spack env create: allow creation from environment dir

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -81,7 +81,8 @@ The ``.spack-env`` subdirectory also contains:
   It allows the environment to build the same, in theory, even on different versions of Spack with different packages!
 * ``logs/``: A subdirectory containing the build logs for the packages in this environment.
 
-Spack Environments can also be created from either the user input, or manifest, file or the lockfile.
+Spack Environments can also be created from another environment.
+Environments can be created from the manifest file (the user input), the lockfile, or the entire environment at once.
 Create an environment from a manifest using:
 
 .. code-block:: console
@@ -108,6 +109,18 @@ Create an environment from a ``spack.lock`` file using:
    $ spack env create myenv spack.lock
 
 The resulting environment, when on the same or a compatible machine, is guaranteed to initially have the same concrete specs as the original.
+
+Create an environment from an entire environment using:
+
+.. code-block:: console
+
+   $ spack env create myenv /path/to/env
+
+The resulting environment will include the concrete specs from the original
+(as when created from a lockfile) and all of the config options
+specified in the original (as when created from a manifest file). It will also
+include any other files included in the environment directory, such as repos
+or source code, that could be referenced in the environment by relative path.
 
 .. note::
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -110,14 +110,15 @@ Create an environment from a ``spack.lock`` file using:
 
 The resulting environment, when on the same or a compatible machine, is guaranteed to initially have the same concrete specs as the original.
 
-Create an environment from an entire environment using:
+Create an environment from an entire environment using either the environment name or path:
 
 .. code-block:: console
 
    $ spack env create myenv /path/to/env
+   $ spack env create myenv2 myenv
 
-The resulting environment will include the concrete specs from the original (as when created from a lockfile) and all of the config options specified in the original (as when created from a manifest file).
-It will also include any other files included in the environment directory, such as repos or source code, that could be referenced in the environment by relative path.
+The resulting environment will include the concrete specs from the original if the original is concretized (as when created from a lockfile) and all of the config options and abstract specs specified in the original (as when created from a manifest file).
+It will also include any other files included in the environment directory, such as repos or source code, as they could be referenced in the environment by relative path.
 
 .. note::
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -116,11 +116,8 @@ Create an environment from an entire environment using:
 
    $ spack env create myenv /path/to/env
 
-The resulting environment will include the concrete specs from the original
-(as when created from a lockfile) and all of the config options
-specified in the original (as when created from a manifest file). It will also
-include any other files included in the environment directory, such as repos
-or source code, that could be referenced in the environment by relative path.
+The resulting environment will include the concrete specs from the original (as when created from a lockfile) and all of the config options specified in the original (as when created from a manifest file).
+It will also include any other files included in the environment directory, such as repos or source code, that could be referenced in the environment by relative path.
 
 .. note::
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -88,7 +88,7 @@ def env_create_setup_parser(subparser):
         "envfile",
         nargs="?",
         default=None,
-        help="manifest or lock file (ends with '.json' or '.lock')",
+        help="manifest or lock file (ends with '.json' or '.lock') or an environment name or path",
     )
     subparser.add_argument(
         "--include-concrete",

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -143,7 +143,7 @@ def _env_create(
     Arguments:
         name_or_path (str): name of the environment to create, or path to it
         init_file (str or file): optional initialization file -- can be
-            a JSON lockfile (*.lock, *.json) or YAML manifest file
+            a JSON lockfile (*.lock, *.json), YAML manifest file, or env dir
         dir (bool): if True, create an environment in a directory instead
             of a named environment
         keep_relative (bool): if True, develop paths are copied verbatim into

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -11,7 +11,6 @@ import pathlib
 import re
 import shutil
 import stat
-import sys
 import warnings
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -370,8 +370,8 @@ def create_in_dir(
         include_concrete: concrete environment names/paths to be included
     """
     # If the initfile is a named environment, get its path
-    if init_file and exists(init_file):
-        init_file = read(init_file).path
+    if init_file and exists(str(init_file)):
+        init_file = read(str(init_file)).path
     initialize_environment_dir(root, envfile=init_file)
 
     if with_view is None and keep_relative:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2706,7 +2706,7 @@ def initialize_environment_dir(
         if not (envfile / "spack.yaml").is_file():
             msg = f"cannot initialize environment, {envfile} is not a valid environment"
             raise SpackEnvironmentError(msg)
-        shutil.copytree(envfile, environment_dir)
+        shutil.copytree(envfile, environment_dir, dirs_exist_ok=True)
         return
 
     _ensure_env_dir()

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -40,7 +40,7 @@ import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack import traverse
 from spack.installer import PackageInstaller
-from spack.llnl.util.filesystem import islink, readlink, symlink
+from spack.llnl.util.filesystem import copy_tree, islink, readlink, symlink
 from spack.llnl.util.link_tree import ConflictingSpecsError
 from spack.schema.env import TOP_LEVEL_KEY
 from spack.spec import Spec
@@ -2707,14 +2707,7 @@ def initialize_environment_dir(
         if not (envfile / "spack.yaml").is_file():
             msg = f"cannot initialize environment, {envfile} is not a valid environment"
             raise SpackEnvironmentError(msg)
-        if sys.version_info < (3, 8, 0):
-            # shutil.copytree added dirs_exit_ok arg in 3.8
-            # prior to 3.8 distutils was the only standard library to support this
-            import distutils  # novermin
-
-            distutils.dir_util.copy_tree(envfile, environment_dir)  # novermin
-        else:
-            shutil.copytree(envfile, environment_dir, dirs_exist_ok=True)  # novermin
+        copy_tree(str(envfile), str(environment_dir))
         return
 
     _ensure_env_dir()

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -370,7 +370,7 @@ def create_in_dir(
         include_concrete: concrete environment names/paths to be included
     """
     # If the initfile is a named environment, get its path
-    if exists(init_file):
+    if init_file and exists(init_file):
         init_file = read(init_file).path
     initialize_environment_dir(root, envfile=init_file)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -369,6 +369,9 @@ def create_in_dir(
             otherwise they are made absolute
         include_concrete: concrete environment names/paths to be included
     """
+    # If the initfile is a named environment, get its path
+    if exists(init_file):
+        init_file = read(init_file).path
     initialize_environment_dir(root, envfile=init_file)
 
     if with_view is None and keep_relative:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -11,6 +11,7 @@ import pathlib
 import re
 import shutil
 import stat
+import sys
 import warnings
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
@@ -2706,7 +2707,14 @@ def initialize_environment_dir(
         if not (envfile / "spack.yaml").is_file():
             msg = f"cannot initialize environment, {envfile} is not a valid environment"
             raise SpackEnvironmentError(msg)
-        shutil.copytree(envfile, environment_dir, dirs_exist_ok=True)
+        if sys.version_info < (3, 8, 0):
+            # shutil.copytree added dirs_exit_ok arg in 3.8
+            # prior to 3.8 distutils was the only standard library to support this
+            import distutils  # novermin
+
+            distutils.dir_util.copy_tree(envfile, environment_dir)  # novermin
+        else:
+            shutil.copytree(envfile, environment_dir, dirs_exist_ok=True)  # novermin
         return
 
     _ensure_env_dir()

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -362,7 +362,7 @@ def create_in_dir(
 
     Args:
         root: directory where to create the environment.
-        init_file: either a lockfile, a manifest file, or None
+        init_file: either a lockfile, a manifest file, an env directory, or None
         with_view: whether a view should be maintained for the environment. If the value is a
             string, it specifies the path to the view
         keep_relative: if True, develop paths are copied verbatim into the new environment file,
@@ -395,7 +395,12 @@ def create_in_dir(
     env = Environment(root)
 
     if init_file:
-        init_file_dir = os.path.abspath(os.path.dirname(init_file))
+        if os.path.isdir(init_file):
+            init_file_dir = init_file
+            copied = True
+        else:
+            init_file_dir = os.path.abspath(os.path.dirname(init_file))
+            copied = False
 
         if not keep_relative:
             if env.path != init_file_dir:
@@ -403,13 +408,15 @@ def create_in_dir(
                 # spack.yaml file in another directory, and moreover we want
                 # dev paths in this environment to refer to their original
                 # locations.
-                _rewrite_relative_dev_paths_on_relocation(env, init_file_dir)
-                _rewrite_relative_repos_paths_on_relocation(env, init_file_dir)
+                # If the full env was copied including internal files, only rewrite
+                # relative paths outside of env
+                _rewrite_relative_dev_paths_on_relocation(env, init_file_dir, copied_env=copied)
+                _rewrite_relative_repos_paths_on_relocation(env, init_file_dir, copied_env=copied)
 
     return env
 
 
-def _rewrite_relative_dev_paths_on_relocation(env, init_file_dir):
+def _rewrite_relative_dev_paths_on_relocation(env, init_file_dir, copied_env=False):
     """When initializing the environment from a manifest file and we plan
     to store the environment in a different directory, we have to rewrite
     relative paths to absolute ones."""
@@ -425,6 +432,10 @@ def _rewrite_relative_dev_paths_on_relocation(env, init_file_dir):
             if entry["path"] == expanded_path:
                 continue
 
+            # If copied and it's inside the env, we copied it and don't need to relativize
+            if copied_env and expanded_path.startswith(init_file_dir):
+                continue
+
             tty.debug("Expanding develop path for {0} to {1}".format(name, expanded_path))
 
             dev_specs[name]["path"] = expanded_path
@@ -437,7 +448,7 @@ def _rewrite_relative_dev_paths_on_relocation(env, init_file_dir):
         env._re_read()
 
 
-def _rewrite_relative_repos_paths_on_relocation(env, init_file_dir):
+def _rewrite_relative_repos_paths_on_relocation(env, init_file_dir, copied_env=False):
     """When initializing the environment from a manifest file and we plan
     to store the environment in a different directory, we have to rewrite
     relative repo paths to absolute ones and expand environment variables."""
@@ -454,6 +465,10 @@ def _rewrite_relative_repos_paths_on_relocation(env, init_file_dir):
 
             # Skip if the substituted and expanded path is the same (e.g. when absolute)
             if entry == expanded_path:
+                continue
+
+            # If copied and it's inside the env, we copied it and don't need to relativize
+            if copied_env and expanded_path.startswith(init_file_dir):
                 continue
 
             tty.debug("Expanding repo path for {0} to {1}".format(entry, expanded_path))
@@ -2679,9 +2694,17 @@ def initialize_environment_dir(
         return
 
     envfile = pathlib.Path(envfile)
-    if not envfile.exists() or not envfile.is_file():
+    if not envfile.exists():
         msg = f"cannot initialize environment, {envfile} is not a valid file"
         raise SpackEnvironmentError(msg)
+
+    if envfile.is_dir():
+        # initialization file is an entire env directory
+        if not (envfile / "spack.yaml").is_file():
+            msg = f"cannot initialize environment, {envfile} is not a valid environment"
+            raise SpackEnvironmentError(msg)
+        shutil.copytree(envfile, environment_dir)
+        return
 
     _ensure_env_dir()
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1043,7 +1043,8 @@ spack:
     assert not e2.specs_by_hash
 
 
-def test_init_from_env(environment_from_manifest):
+@pytest.mark.parametrize("use_name", (True, False))
+def test_init_from_env(use_name, environment_from_manifest):
     """Test that an environment can be instantiated from an environment dir"""
     e1 = environment_from_manifest(
         """
@@ -1068,7 +1069,7 @@ spack:
     e1.concretize()
     e1.write()
 
-    e2 = _env_create("test2", init_file=e1.path)
+    e2 = _env_create("test2", init_file="test" if use_name else e1.path)
 
     for s1, s2 in zip(e1.user_specs, e2.user_specs):
         assert s1 == s2

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1086,6 +1086,11 @@ spack:
         )
 
 
+def test_init_from_env_no_spackfile(tmp_path):
+    with pytest.raises(ev.SpackEnvironmentError, match="not a valid environment"):
+        _env_create("test", init_file=str(tmp_path))
+
+
 def test_init_from_yaml_relative_includes(tmp_path: pathlib.Path):
     files = [
         "relative_copied/packages.yaml",

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1043,6 +1043,48 @@ spack:
     assert not e2.specs_by_hash
 
 
+def test_init_from_env(environment_from_manifest):
+    """Test that an environment can be instantiated from an environment dir"""
+    e1 = environment_from_manifest(
+        """
+spack:
+  specs:
+  - mpileaks
+  - hypre
+  - libelf
+"""
+    )
+
+    with e1:
+        # Test that relative paths in the env are not rewritten
+        # Test that relative paths outside the env are
+        dev_config = {
+            "libelf": {"spec": "libelf", "path": "./libelf"},
+            "mpileaks": {"spec": "mpileaks", "path": "../mpileaks"},
+        }
+        spack.config.set("develop", dev_config)
+        fs.touch(os.path.join(e1.path, "libelf"))
+
+    e1.concretize()
+    e1.write()
+
+    e2 = _env_create("test2", init_file=e1.path)
+
+    for s1, s2 in zip(e1.user_specs, e2.user_specs):
+        assert s1 == s2
+
+    assert e2.concretized_order == e1.concretized_order
+    assert e2.concretized_user_specs == e1.concretized_user_specs
+    assert e2.specs_by_hash == e1.specs_by_hash
+
+    assert os.path.exists(os.path.join(e2.path, "libelf"))
+    with e2:
+        assert e2.dev_specs["libelf"]["path"] == "./libelf"
+        assert e2.dev_specs["mpileaks"]["path"] == os.path.join(
+            os.path.dirname(e1.path), "mpileaks"
+        )
+
+
 def test_init_from_yaml_relative_includes(tmp_path: pathlib.Path):
     files = [
         "relative_copied/packages.yaml",


### PR DESCRIPTION
Currently, when an environment is created from another environment's lockfile, it loses all config information. This not relevant if the environment is installed as-is, but matters when reconcretizing.

Additionally, other artifacts in the environment (such as repos or developer source) are either ignored or rewritten into absolute paths to the original environment.

This PR introduces a capability to create an environment as a copy of another entire environment. It uses the same syntax as before (`spack env create myenv /path/to/env/spack.{yaml,lock}`), but allows referencing the environment dir.

```
spack env create myenv /path/to/env
```
or the environment name
```
spack env create myenv2 myenv
```

This copies the entire environment dir, and only rewrites relative paths that point outside the environment (e.g. `path: ../../foo`).

includes unit test and docs updates.
