### PR TITLE
Add a test: `spack logs` for failed builds

### DIFF
--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -143,5 +143,7 @@ def test_dump_logs_failure(
         with pytest.raises(spack.error.InstallError):
             e.install_all()
 
-        output = logs("canfail")
-        assert "'succeed' was false" in output
+        with stdout_as_buffered_text_stream() as redirected_stdout:
+            ((cmdline_spec, concrete_spec),) = e.concretized_specs()
+            spack.cmd.logs._logs(cmdline_spec, concrete_spec)
+            assert "'succeed' was false" in _rewind_collect_and_decode(redirected_stdout)

--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -14,6 +14,8 @@ import pytest
 import spack
 import spack.cmd.logs
 import spack.concretize
+import spack.environment as ev
+import spack.error
 import spack.main
 import spack.spec
 from spack.main import SpackCommand
@@ -120,3 +122,26 @@ def test_dump_logs(install_mockery, mock_fetch, mock_archive, mock_packages, dis
         with stdout_as_buffered_text_stream() as redirected_stdout:
             spack.cmd.logs._logs(cmdline_spec, concrete_spec)
             assert _rewind_collect_and_decode(redirected_stdout) == installed_log_content
+
+
+@pytest.mark.disable_clean_stage_check
+def test_dump_logs_failure(
+    install_mockery,
+    mock_fetch,
+    mock_archive,
+    mock_packages,
+    disable_capture,
+    mutable_mock_env_path,
+):
+    env = SpackCommand("env")
+    env("create", "test")
+    e = ev.read("test")
+    e.add("canfail")
+    e.concretize()
+
+    with e:
+        with pytest.raises(spack.error.InstallError):
+            e.install_all()
+
+        output = logs("canfail")
+        assert "'succeed' was false" in output

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/canfail/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/canfail/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+import sys
 
 from spack_repo.builtin_mock.build_systems.generic import Package
 
@@ -28,6 +29,8 @@ class Canfail(Package):
         return result
 
     def install(self, spec, prefix):
+        sys.stdout.write("Inside canfail install method")
         if not self.succeed:
+            sys.stderr.write("[in canfail install process] 'succeed' was false")
             raise InstallError("'succeed' was false")
         touch(join_path(prefix, "an_installation_file"))


### PR DESCRIPTION
This just adds a test: no new logic.

Test `spack logs` when a build fails.