### PR TITLE
Update github workflow: vermin 1.7.0

### DIFF
--- a/.github/workflows/requirements/style/requirements.txt
+++ b/.github/workflows/requirements/style/requirements.txt
@@ -4,7 +4,7 @@ flake8==7.3.0
 isort==6.1.0
 mypy==1.18.2
 types-six==1.17.0.20250515
-vermin==1.6.0
+vermin==1.7.0
 pylint==3.3.9
 docutils==0.22.2
 ruamel.yaml==0.18.15


### PR DESCRIPTION
After having released version [1.7.0](https://github.com/netromdk/vermin/releases/tag/v1.7.0) of Vermin, it would make sense to also use it for the Spack workflows.

This PR makes the same change that was merged (by @alalazo) in `spack-packages` just a few hours ago: https://github.com/spack/spack-packages/pull/1953.