### PR TITLE
unit tests: use `builtin.mock` instead of `builtin`

### DIFF
--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4249,7 +4249,7 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     assert len(before) == 1000
 
     # cleanup should be run after the 1,001st execution
-    spack.concretize.concretize_one("py-black")
+    spack.concretize.concretize_one("hdf5")
 
     # ensure that half the elements were removed and that one more was created
     after = names()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -430,7 +430,7 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="function")
-def use_concretization_cache(mutable_config, tmp_path: Path):
+def use_concretization_cache(mock_packages, mutable_config, tmp_path: Path):
     """Enables the use of the concretization cache"""
     conc_cache_dir = tmp_path / "concretization"
     conc_cache_dir.mkdir()


### PR DESCRIPTION
#50905 added a few tests that are using the `builtin` repository instead of `builtin.mock`. This is a fix to that small issue.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
