### PR TITLE
Fixups for spack info

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -2,15 +2,16 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 import argparse
 import os
 import textwrap
+from typing import Any, Optional
 
 import spack.cmd
 import spack.config
 import spack.deptypes as dt
 import spack.environment as ev
+import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.reporters
@@ -127,6 +128,40 @@ class SetConcurrentPackages(argparse.Action):
         spack.config.set("config:concurrent_packages", concurrent_packages, scope="command_line")
 
         setattr(namespace, "concurrent_packages", concurrent_packages)
+
+
+class DeprecatedStoreTrueAction(argparse.Action):
+    """Like the builtin store_true, but prints a deprecation warning."""
+
+    def __init__(
+        self,
+        option_strings,
+        dest: str,
+        default: Optional[Any] = False,
+        required: bool = False,
+        help: Optional[str] = None,
+        removed_in: Optional[str] = None,
+        instructions: Optional[str] = None,
+    ):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=0,
+            const=True,
+            required=required,
+            help=help,
+            default=default,
+        )
+        self.removed_in = removed_in
+        self.instructions = instructions
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        instructions = [] if not self.instructions else [self.instructions]
+        tty.warn(
+            f"{option_string} is deprecated and will be removed in {self.removed_in}.",
+            *instructions,
+        )
+        setattr(namespace, self.dest, self.const)
 
 
 class DeptypeAction(argparse.Action):

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -129,7 +129,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
     # deprecated for the more generic --by-name, but still here until we can remove it
     subparser.add_argument(
-        "--variants-by-name", dest="by_name", action="store_true", help=argparse.SUPPRESS
+        "--variants-by-name",
+        dest="by_name",
+        action=arguments.DeprecatedStoreTrueAction,
+        help=argparse.SUPPRESS,
+        removed_in="a future Spack release",
+        instructions="use --by-name instead",
     )
     arguments.add_common_arguments(subparser, ["spec"])
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 import textwrap
 from argparse import Namespace
-from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO, Tuple
 
 import spack.builder
 import spack.cmd
@@ -191,7 +191,7 @@ def print_dependency_suggestion(pkg: PackageBase) -> None:
     big_variants = [
         (name, val)
         for n, (name, val) in variant_counts
-        # counts >= 40 and skip if the user already disabled the variant
+        # make a note of variants with large counts that aren't already toggled by the user.
         if n >= 20 and not (name in pkg.spec.variants and pkg.spec.variants[name].value != val)
     ]
 
@@ -349,10 +349,14 @@ def _print_definition(
         name_field: name and optional info, e.g. a default; should be short.
         values_field: possible values for the entry; Wrapped if long.
         description: description of the field (wrapped if overly long)
-        max_name_len:
+        max_name_len: max length of any definition to be printed
         indent: size of leading indent for entry
         when: optional when condition
         out: stream to print to
+
+    Caller is expected to calculate the max name length in advance and pass it to
+    ``_print_definition``.
+
     """
     out = out or sys.stdout
     cols = shutil.get_terminal_size().columns
@@ -408,10 +412,6 @@ def _print_definition(
         )
         out.write(formatted_description)
         out.write("\n")
-
-
-K = TypeVar("K", bound=SupportsRichComparison)
-V = TypeVar("V")
 
 
 def print_header(header: str, when_indexed_dictionary: Dict, formatter: Formatter) -> bool:

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -13,9 +13,10 @@ pytestmark = [pytest.mark.usefixtures("mock_packages")]
 info = SpackCommand("info")
 
 
-@pytest.mark.parametrize("extra_args", [[], ["--variants-by-name"]])
-def test_it_just_runs(extra_args):
-    info(*extra_args, "vtk-m")
+def test_deprecated_option_warns(capfd):
+    info("--variants-by-name", "vtk-m")
+    output = capfd.readouterr()
+    assert "--variants-by-name is deprecated" in output.err
 
 
 # no specs, more than one spec


### PR DESCRIPTION
These commits add some cleanup items requested by @alalazo on #51137. 

I noticed that in 3.13, argparse actually added a `deprecated=True` option to arguments, but we can't use that yet since 3.13 is too new. I added a `DeprecatedStoreTrueAction` to `spack.cmd.common.arguments` here that we can use to deprecate arguments (and I suppose we can generalize it for other actions later).  It does more than the `deprecated=True`, e.g.:

```python
    # deprecated for the more generic --by-name, but still here until we can remove it
    subparser.add_argument(
        "--variants-by-name",
        dest="by_name",
        action=arguments.DeprecatedStoreTrueAction,
        help=argparse.SUPPRESS,
        removed_in="a future Spack release",
        instructions="use --by-name instead",
    )
```

and prints:

```console
> spack info --variants-by-name
==> Warning: --variants-by-name is deprecated and will be removed in a future Spack release.
  use --by-name instead
```
