### PR TITLE
Configuration scopes: fix severe ordering issue when `-C` and `-e` are used together

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -81,12 +81,12 @@ From lowest to highest precedence:
 #. **user**: Stored in the home directory: ``~/.spack/``.
    These settings affect all instances of Spack and take higher precedence than site, system, plugin, or defaults scopes.
 
-#. **custom**: Stored in a custom directory specified by ``--config-scope``.
-   If multiple scopes are listed on the command line, they are ordered from lowest to highest precedence.
-
 #. **environment**: When using Spack :ref:`environments`, Spack reads additional configuration from the environment file.
    See :ref:`environment-configuration` for further details on these scopes.
    Environment scopes can be referenced from the command line as ``env:name`` (e.g., to reference environment ``foo``, use ``env:foo``).
+
+#. **custom**: Stored in a custom directory specified by ``--config-scope``.
+   If multiple scopes are listed on the command line, they are ordered from lowest to highest precedence.
 
 #. **command line**: Build settings specified on the command line take precedence over all other scopes.
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -3032,11 +3032,11 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             ensure_no_disallowed_env_config_mods(self._env_config_scope)
         return self._env_config_scope
 
-    def prepare_config_scope(
-        self, priority: ConfigScopePriority = ConfigScopePriority.ENVIRONMENT
-    ) -> None:
+    def prepare_config_scope(self) -> None:
         """Add the manifest's scope to the global configuration search path."""
-        spack.config.CONFIG.push_scope(self.env_config_scope, priority)
+        spack.config.CONFIG.push_scope(
+            self.env_config_scope, priority=ConfigScopePriority.ENVIRONMENT
+        )
 
     def deactivate_config_scope(self) -> None:
         """Remove the manifest's scope from the global config path."""

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -881,7 +881,7 @@ class SetEnvironmentAction(argparse.Action):
 def add_command_line_scopes(
     cfg: spack.config.Configuration,
     command_line_scopes: List[Any],  # str or _ENV but mypy can't type sentinels
-    add_environment: Callable[[ConfigScopePriority], None],
+    add_environment: Callable[[], None],
 ) -> None:
     """Add additional scopes from the ``--config-scope`` argument, either envs or dirs.
 
@@ -901,7 +901,7 @@ def add_command_line_scopes(
     for i, path in enumerate(command_line_scopes):
         # If an environment is set on the CLI, add its scope in the order it appears there.
         if path is _ENV:
-            add_environment(ConfigScopePriority.ENVIRONMENT)
+            add_environment()
             continue
 
         name = f"cmd_scope_{i}"
@@ -987,7 +987,7 @@ def _main(argv=None):
             e.print_context()
             env_format_error = e
 
-    def add_environment_scope(priority):
+    def add_environment_scope():
         if env_format_error:
             # Allow command to continue without env in case it is `spack config edit`
             # All other cases will raise in `finish_parse_and_run`
@@ -995,12 +995,12 @@ def _main(argv=None):
             return
         # do not call activate here, as it has a lot of expensive function calls to deal
         # with mutation of spack.config.CONFIG -- but we are still building the config.
-        env.manifest.prepare_config_scope(priority)
+        env.manifest.prepare_config_scope()
         spack.environment.environment._active_environment = env
 
     # add the environment *first*, if it is coming from an environment variable
     if env and _ENV not in (args.config_scopes or []):
-        add_environment_scope(priority=ConfigScopePriority.ENVIRONMENT)
+        add_environment_scope()
 
     # Push scopes from the command line last
     if args.config_scopes:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -406,7 +406,7 @@ def make_argument_parser(**kwargs):
         "--env",
         dest="env",
         metavar="ENV",
-        action=SetEnvironmentAction,
+        action="store",
         help="run with a specific environment (see spack env)",
     )
     env_group.add_argument(
@@ -414,7 +414,7 @@ def make_argument_parser(**kwargs):
         "--env-dir",
         dest="env_dir",
         metavar="DIR",
-        action=SetEnvironmentAction,
+        action="store",
         help="run with an environment directory (ignore managed environments)",
     )
     env_group.add_argument(
@@ -859,23 +859,6 @@ def resolve_alias(cmd_name: str, cmd: List[str]) -> Tuple[str, List[str]]:
 
 # sentinel scope marker for environments passed on the command line
 _ENV = object()
-
-
-class SetEnvironmentAction(argparse.Action):
-    """Records an environment both in the ``env`` attribute and in the ``config_scopes`` list.
-
-    We need to know where the environment appeared on the CLI set scope precedence.
-
-    """
-
-    def __call__(self, parser, namespace, name_or_dir, option_string):
-        setattr(namespace, self.dest, name_or_dir)
-
-        scopes = getattr(namespace, "config_scopes", None)
-        if scopes is None:
-            scopes = []
-        scopes.append(_ENV)
-        namespace.config_scopes = scopes
 
 
 def add_command_line_scopes(

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -900,9 +900,8 @@ def add_command_line_scopes(
 
     for i, path in enumerate(command_line_scopes):
         # If an environment is set on the CLI, add its scope in the order it appears there.
-        # Subsequent custom scopes will override it, and it will override prior custom scopes.
         if path is _ENV:
-            add_environment(ConfigScopePriority.CUSTOM)
+            add_environment(ConfigScopePriority.ENVIRONMENT)
             continue
 
         name = f"cmd_scope_{i}"

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -23,7 +23,7 @@ import sys
 import tempfile
 import traceback
 import warnings
-from typing import Any, Callable, List, Tuple
+from typing import List, Tuple
 
 import spack.vendor.archspec.cpu
 
@@ -862,31 +862,18 @@ _ENV = object()
 
 
 def add_command_line_scopes(
-    cfg: spack.config.Configuration,
-    command_line_scopes: List[Any],  # str or _ENV but mypy can't type sentinels
-    add_environment: Callable[[], None],
+    cfg: spack.config.Configuration, command_line_scopes: List[str]
 ) -> None:
     """Add additional scopes from the ``--config-scope`` argument, either envs or dirs.
 
     Args:
         cfg: configuration instance
         command_line_scopes: list of configuration scope paths
-        add_environment: method to add an environment scope if encountered
 
     Raises:
         spack.error.ConfigError: if the path is an invalid configuration scope
     """
-    # remove all but the last _ENV from CLI scopes, because we can only
-    # have a single environment active.
-    for _ in range(command_line_scopes.count(_ENV) - 1):
-        command_line_scopes.remove(_ENV)
-
     for i, path in enumerate(command_line_scopes):
-        # If an environment is set on the CLI, add its scope in the order it appears there.
-        if path is _ENV:
-            add_environment()
-            continue
-
         name = f"cmd_scope_{i}"
         scope = ev.environment_path_scope(name, path)
         if scope is None:
@@ -981,13 +968,13 @@ def _main(argv=None):
         env.manifest.prepare_config_scope()
         spack.environment.environment._active_environment = env
 
-    # add the environment *first*, if it is coming from an environment variable
-    if env and _ENV not in (args.config_scopes or []):
+    # add the environment
+    if env:
         add_environment_scope()
 
     # Push scopes from the command line last
     if args.config_scopes:
-        add_command_line_scopes(spack.config.CONFIG, args.config_scopes, add_environment_scope)
+        add_command_line_scopes(spack.config.CONFIG, args.config_scopes)
     spack.config.CONFIG.push_scope(
         spack.config.InternalConfigScope("command_line"), priority=ConfigScopePriority.COMMAND_LINE
     )

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -107,11 +107,6 @@ exit 1
     assert spack.spack_version == spack.get_version()
 
 
-def fail_if_add_env():
-    """Pass to add_command_line_scopes. Will raise if called"""
-    assert False, "Should not add env from scope test."
-
-
 def test_bad_command_line_scopes(tmp_path: pathlib.Path, config):
     cfg = spack.config.Configuration()
     file_path = tmp_path / "file_instead_of_dir"
@@ -120,10 +115,10 @@ def test_bad_command_line_scopes(tmp_path: pathlib.Path, config):
     file_path.write_text("")
 
     with pytest.raises(spack.error.ConfigError):
-        spack.main.add_command_line_scopes(cfg, [str(file_path)], fail_if_add_env)
+        spack.main.add_command_line_scopes(cfg, [str(file_path)])
 
     with pytest.raises(spack.error.ConfigError):
-        spack.main.add_command_line_scopes(cfg, [str(non_existing_path)], fail_if_add_env)
+        spack.main.add_command_line_scopes(cfg, [str(non_existing_path)])
 
 
 def test_add_command_line_scopes(tmp_path: pathlib.Path, mutable_config):
@@ -137,7 +132,7 @@ config:
 """
         )
 
-    spack.main.add_command_line_scopes(mutable_config, [str(tmp_path)], fail_if_add_env)
+    spack.main.add_command_line_scopes(mutable_config, [str(tmp_path)])
     assert mutable_config.get("config:verify_ssl") is False
     assert mutable_config.get("config:dirty") is False
 
@@ -167,12 +162,12 @@ spack:
         )
 
     config = spack.config.Configuration()
-    spack.main.add_command_line_scopes(config, ["example", str(tmp_path)], fail_if_add_env)
+    spack.main.add_command_line_scopes(config, ["example", str(tmp_path)])
     assert len(config.scopes) == 2
     assert config.get("config:install_tree:root") == "/tmp/second"
 
     config = spack.config.Configuration()
-    spack.main.add_command_line_scopes(config, [str(tmp_path), "example"], fail_if_add_env)
+    spack.main.add_command_line_scopes(config, [str(tmp_path), "example"])
     assert len(config.scopes) == 2
     assert config.get("config:install_tree:root") == "/tmp/first"
 
@@ -240,9 +235,7 @@ packages:
 
     assert not spack.config.get("config:dirty")
 
-    spack.main.add_command_line_scopes(
-        mock_low_high_config, [os.path.dirname(filename)], fail_if_add_env
-    )
+    spack.main.add_command_line_scopes(mock_low_high_config, [os.path.dirname(filename)])
 
     assert spack.config.get("config:dirty")
     python_reqs = spack.config.get("packages")["python"]["require"]
@@ -269,15 +262,11 @@ def test_include_duplicate_source(mutable_config):
 
     system_config = {"config": {"debug": False}}
     write_configs(system_filename, system_config)
-    spack.main.add_command_line_scopes(
-        mutable_config, [os.path.dirname(system_filename)], fail_if_add_env
-    )
+    spack.main.add_command_line_scopes(mutable_config, [os.path.dirname(system_filename)])
 
     site_config = {"config": {"debug": True}}
     write_configs(site_filename, site_config)
-    spack.main.add_command_line_scopes(
-        mutable_config, [os.path.dirname(site_filename)], fail_if_add_env
-    )
+    spack.main.add_command_line_scopes(mutable_config, [os.path.dirname(site_filename)])
 
     # Ensure takes the last value of the option pushed onto the stack
     assert mutable_config.get("config:debug") == site_config["config"]["debug"]
@@ -293,9 +282,7 @@ def test_include_recurse_limit(tmp_path: pathlib.Path, mutable_config):
         syaml.dump_config(include_list, f)
 
     with pytest.raises(spack.config.RecursiveIncludeError, match="recursion exceeded"):
-        spack.main.add_command_line_scopes(
-            mutable_config, [os.path.dirname(include_path)], fail_if_add_env
-        )
+        spack.main.add_command_line_scopes(mutable_config, [os.path.dirname(include_path)])
 
 
 # TODO: Fix this once recursive includes are processed in the expected order.
@@ -339,7 +326,7 @@ include:
     write(b_yaml, include_contents([debug_yaml, d_yaml] if child == "b" else [d_yaml]))
     write(c_yaml, include_contents([debug_yaml, d_yaml] if child == "c" else [d_yaml]))
 
-    spack.main.add_command_line_scopes(mutable_config, [str(tmp_path)], fail_if_add_env)
+    spack.main.add_command_line_scopes(mutable_config, [str(tmp_path)])
 
     try:
         assert mutable_config.get("config:debug") is expected

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -107,7 +107,7 @@ exit 1
     assert spack.spack_version == spack.get_version()
 
 
-def fail_if_add_env(env):
+def fail_if_add_env():
     """Pass to add_command_line_scopes. Will raise if called"""
     assert False, "Should not add env from scope test."
 

--- a/share/spack/qa/environment_activation.py
+++ b/share/spack/qa/environment_activation.py
@@ -1,0 +1,14 @@
+import spack.config
+import spack.environment
+
+KEY = "concretizer:unify"
+
+before = spack.config.CONFIG.get(KEY)
+with spack.environment.active_environment().manifest.use_config():
+    within = spack.config.CONFIG.get(KEY)
+after = spack.config.CONFIG.get(KEY)
+
+if before == within == after:
+    print(f"SUCCESS: {before}")
+else:
+    print(f"FAILURE: {before} -> {within} -> {after}")

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -254,7 +254,7 @@ contains 'unify: when_possible' spack -C $QA_DIR/scopes/wp config get concretize
 contains 'unify: false' \
          spack -C $QA_DIR/scopes/wp -C $QA_DIR/scopes/false config get concretizer
 
-contains 'unify: true' \
+contains 'unify: false' \
          spack -C $QA_DIR/scopes/wp \
                -C $QA_DIR/scopes/false \
                -e $QA_DIR/scopes/true \
@@ -272,7 +272,7 @@ contains 'unify: false' \
                -C $QA_DIR/scopes/false \
          config get concretizer
 
-contains 'unify: true' \
+contains 'unify: false' \
          spack -C $QA_DIR/scopes/wp \
                -C $QA_DIR/scopes/false \
                -D $QA_DIR/scopes/true \
@@ -289,3 +289,9 @@ contains 'unify: false' \
                -C $QA_DIR/scopes/wp \
                -C $QA_DIR/scopes/false \
               config get concretizer
+
+contains 'SUCCESS' spack -C $QA_DIR/scopes/wp -e $QA_DIR/scopes/true python "$SHARE_DIR/qa/environment_activation.py"
+contains 'SUCCESS' spack -e $QA_DIR/scopes/true -C $QA_DIR/scopes/wp python "$SHARE_DIR/qa/environment_activation.py"
+contains 'SUCCESS' spack -C $QA_DIR/scopes/false -e $QA_DIR/scopes/true -C $QA_DIR/scopes/wp python "$SHARE_DIR/qa/environment_activation.py"
+contains 'SUCCESS' spack -C $QA_DIR/scopes/false -C $QA_DIR/scopes/wp -e $QA_DIR/scopes/true python "$SHARE_DIR/qa/environment_activation.py"
+contains 'SUCCESS' spack -C $QA_DIR/scopes/wp -C $QA_DIR/scopes/false -e $QA_DIR/scopes/true python "$SHARE_DIR/qa/environment_activation.py"


### PR DESCRIPTION
Fixes #51459.

#50853 attempted to make configuration (envs and config scopes) specified on the CLI merge in CLI order, but did not quite succeed.  Environments, when loaded, would still appear out of order in the scope stack. This fixes the issues and establishes, after much discussion, the ordering we want for configuration scopes specified on the CLI:

1. Ordering of scopes will be enforced *within* the same option on the CLI, e.g. bar is higher precedence in `-C foo -C bar`;
2. Ordering *across* options is counterintuitive, and the `-e` option (or the active environment via `SPACK_ENV`) should always be lower priority than `-C` or `-c` options; and
4. `-C` options have lower priority than `-c`.

Environments are now added using `ConfigScopePriority.ENVIRONMENT` in all cases. Since they are the only entity using that scope priority, it's safe to activate and deactivate them.

Documentation has been updated to reflect that the CUSTOM scopes have higher priority than ENVIRONMENT.
