### PR TITLE
Allow using buildcaches with Python 3.14

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2043,6 +2043,8 @@ def _tar_strip_component(tar: tarfile.TarFile, prefix: str):
 
 def extract_buildcache_tarball(tarfile_path: str, destination: str) -> None:
     with closing(tarfile.open(tarfile_path, "r")) as tar:
+        # Needed so that Python 3.14 and above don't error with AbsoluteLinkError
+        tar.extraction_filter = lambda member, path: member
         # Remove common prefix from tarball entries and directly extract them to the install dir.
         tar.extractall(
             path=destination, members=_tar_strip_component(tar, prefix=_ensure_common_prefix(tar))


### PR DESCRIPTION
fixes #51458

Python 3.12 introduced an extraction filter for `tarfile`, that is used when the `.extract()` and `.extractall()` methods are called. This filter is invoked before a file is extracted and can decide to raise an exception. For backward compatibility, up to Python 3.13 the default filter is `fully_trusted()`, which doesn't perform any check. More information about this feature can be found at:

*  https://peps.python.org/pep-0706/
*   https://www.andy-pearce.com/blog/posts/2024/Mar/whats-new-in-python-312-library-changes/#data-compression-and-archiving-tarfile

Python 3.14 changed the default extraction filter in a breaking way, switching from `.fully_trusted()` to `.data_filter()`. This new filter raises an `AbsoluteLinkError` when extracting buildaches that have links to absolute paths.

This PR sets the extraction filter to the equivalent of `.fully_trusted()`, in a way that is compatible with old Python versions.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
