### PR TITLE
SymlinkError: inherit from OSError so they can be caught like os.symlink

### DIFF
--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -3191,7 +3191,7 @@ else:
     rename = os.rename
 
 
-class SymlinkError(RuntimeError):
+class SymlinkError(OSError):
     """Exception class for errors raised while creating symlinks,
     junctions and hard links
     """


### PR DESCRIPTION
Make Spack's symlink and `os.symlink` error interface compatible with the same try/catch blocks.