### PR TITLE
Win: stop importing readline

### DIFF
--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -17,6 +17,7 @@ description = "launch an interpreter as spack would launch a command"
 section = "developer"
 level = "long"
 
+IS_WINDOWS = sys.platform == "win32"
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
@@ -134,12 +135,14 @@ def python_interpreter(args):
             propagate_exceptions_from(console)
             console.runsource(args.python_command)
         else:
-            # Provides readline support, allowing user to use arrow keys
-            console.push("import readline")
-            # Provide tabcompletion
-            console.push("from rlcompleter import Completer")
-            console.push("readline.set_completer(Completer(locals()).complete)")
-            console.push('readline.parse_and_bind("tab: complete")')
+            # no readline module on Windows
+            if not IS_WINDOWS:
+                # Provides readline support, allowing user to use arrow keys
+                console.push("import readline")
+                # Provide tabcompletion
+                console.push("from rlcompleter import Completer")
+                console.push("readline.set_completer(Completer(locals()).complete)")
+                console.push('readline.parse_and_bind("tab: complete")')
 
             console.interact(
                 "Spack version %s\nPython %s, %s %s"

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -19,6 +19,7 @@ level = "long"
 
 IS_WINDOWS = sys.platform == "win32"
 
+
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "-V",


### PR DESCRIPTION
The readline module is not available on Windows out of the box, this results in a bunch if output like:

```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
ModuleNotFoundError: No module named 'readline'
Traceback (most recent call last):
  File "<console>", line 1, in <module>
NameError: name 'readline' is not defined. Did you forget to import 'readline'?
Traceback (most recent call last):
  File "<console>", line 1, in <module>
NameError: name 'readline' is not defined. Did you forget to import 'readline'?
```

Everytime you load Spack's python shell on Windows.
This has been a bug for a while I just finally got tired of the output