### PR TITLE
find_libraries: switch default runtime seach to default linktime search

### DIFF
--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -2352,7 +2352,7 @@ def find_libraries(
     root: str,
     shared: bool = True,
     recursive: bool = False,
-    runtime: bool = True,
+    runtime: bool = False,
     max_depth: Optional[int] = None,
 ) -> LibraryList:
     """Returns an iterable of full paths to libraries found in a root dir.

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -97,7 +97,7 @@ def test_pkg_attributes(install_mockery, mock_fetch, monkeypatch):
 
     lib_suffix = ".so"
     if sys.platform == "win32":
-        lib_suffix = ".dll"
+        lib_suffix = ".lib"
     elif sys.platform == "darwin":
         lib_suffix = ".dylib"
 

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -58,7 +58,7 @@ def header_list():
 plat_static_ext = "lib" if sys.platform == "win32" else "a"
 
 
-plat_shared_ext = "dll" if sys.platform == "win32" else "so"
+plat_shared_ext = "lib" if sys.platform == "win32" else "so"
 
 
 plat_apple_shared_ext = "dylib"

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -27,10 +27,10 @@ def library_list():
         if sys.platform != "win32"
         else [
             "/dir1/liblapack.lib",
-            "/dir2/libpython3.6.dll",
+            "/dir2/libpython3.6.lib",
             "/dir1/libblas.lib",
-            "/dir3/libz.dll",
-            "libmpi.dll.20.10.1",
+            "/dir3/libz.lib",
+            "libmpi.lib.20.10.1",
         ]
     )
 
@@ -75,7 +75,7 @@ class TestLibraryList:
             [
                 "/dir1/liblapack.%s" % plat_static_ext,
                 "/dir2/libpython3.6.%s"
-                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"),
+                % (plat_apple_shared_ext if sys.platform != "win32" else "lib"),
                 "/dir1/libblas.%s" % plat_static_ext,
                 "/dir3/libz.%s" % plat_shared_ext,
                 "libmpi.%s.20.10.1" % plat_shared_ext,
@@ -91,7 +91,7 @@ class TestLibraryList:
             [
                 "/dir1/liblapack.%s" % plat_static_ext,
                 "/dir2/libpython3.6.%s"
-                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"),
+                % (plat_apple_shared_ext if sys.platform != "win32" else "lib"),
                 "/dir1/libblas.%s" % plat_static_ext,
                 "/dir3/libz.%s" % plat_shared_ext,
                 "libmpi.%s.20.10.1" % plat_shared_ext,

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/attributes_foo/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/attributes_foo/package.py
@@ -17,7 +17,7 @@ class AttributesFoo(BundlePackage):
     def install(self, spec, prefix):
         lib_suffix = ".so"
         if sys.platform == "win32":
-            lib_suffix = ".dll"
+            lib_suffix = ".lib"
         elif sys.platform == "darwin":
             lib_suffix = ".dylib"
         mkdirp(prefix.include)


### PR DESCRIPTION
When dealing with shared libraries, Windows has a .lib, which is linked against, and a .dll, which is run against. Currently find_libraries defaults to search for the runtime dlls, however in the vast majority of uses cases, we want to be searching for the import library. As such, we should default to searching for the linktime libraries by defaulting `runtime` to false.

