### PR TITLE
macos unit tests: reduce parallelism, use Python 3.13

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -210,9 +210,11 @@ jobs:
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg kcov
+#    - name: Setup tmate session
+#      uses: mxschmitt/action-tmate@v3
     - name: Run unit tests
       env:
-        SPACK_TEST_PARALLEL: 4
+        SPACK_TEST_PARALLEL: 2
         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
       run: |
         git --version
@@ -220,8 +222,7 @@ jobs:
         . share/spack/setup-env.sh
         $(which spack) bootstrap disable spack-install
         $(which spack) solve zlib
-        common_args=(--dist loadfile --tx '3*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
-        $(which spack) unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}"
+        PYTHONPATH=$PWD/lib/spack/ pytest -n $SPACK_TEST_PARALLEL  --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x
     - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
       with:
         name: coverage-${{ matrix.os }}-python${{ matrix.python-version }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -210,8 +210,8 @@ jobs:
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg kcov
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+#    - name: Setup tmate session
+#      uses: mxschmitt/action-tmate@v3
     - name: Run unit tests
       env:
         SPACK_TEST_PARALLEL: 4
@@ -222,7 +222,7 @@ jobs:
         . share/spack/setup-env.sh
         $(which spack) bootstrap disable spack-install
         $(which spack) solve zlib
-        PYTHONPATH=$PWD/lib/spack/ pytest --dist=loadscope -n $SPACK_TEST_PARALLEL  --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x
+        PYTHONPATH=$PWD/lib/spack/ pytest --dist=loadscope -n $SPACK_TEST_PARALLEL --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml
     - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
       with:
         name: coverage-${{ matrix.os }}-python${{ matrix.python-version }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -210,11 +210,11 @@ jobs:
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg kcov
-#    - name: Setup tmate session
-#      uses: mxschmitt/action-tmate@v3
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Run unit tests
       env:
-        SPACK_TEST_PARALLEL: 2
+        SPACK_TEST_PARALLEL: 4
         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
       run: |
         git --version
@@ -222,7 +222,7 @@ jobs:
         . share/spack/setup-env.sh
         $(which spack) bootstrap disable spack-install
         $(which spack) solve zlib
-        PYTHONPATH=$PWD/lib/spack/ pytest -n $SPACK_TEST_PARALLEL  --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x
+        PYTHONPATH=$PWD/lib/spack/ pytest --dist=loadscope -n $SPACK_TEST_PARALLEL  --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x
     - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
       with:
         name: coverage-${{ matrix.os }}-python${{ matrix.python-version }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -195,7 +195,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-15-intel, macos-latest]
-        python-version: ["3.11"]
+        python-version: ["3.13"]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
@@ -220,7 +220,7 @@ jobs:
         . share/spack/setup-env.sh
         $(which spack) bootstrap disable spack-install
         $(which spack) solve zlib
-        common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
+        common_args=(--dist loadfile --tx '3*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
         $(which spack) unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}"
     - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
       with:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2475,7 +2475,6 @@ class PackageInstaller:
                     # handled in complete_task()
                     task.error_result = e
 
-            time.sleep(0.1)
             # Check if any tasks have completed and add to list
             done = [task for task in active_tasks if task.poll()]
             try:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1283,6 +1283,9 @@ class BuildTask(Task):
         self._setup_install_dir(pkg)
 
         # Create a child process to do the actual installation.
+        self._start_build_process()
+
+    def _start_build_process(self):
         self.process_handle = spack.build_environment.start_build_process(
             self.pkg, build_process, self.request.install_args
         )
@@ -1382,6 +1385,26 @@ class BuildTask(Task):
         """Terminate any processes this task still has running."""
         if self.process_handle:
             self.process_handle.terminate()
+
+
+class MockBuildProcess:
+    def complete(self) -> bool:
+        return True
+
+    def terminate(self) -> None:
+        pass
+
+
+class FakeBuildTask(BuildTask):
+    """Blocking BuildTask executed directly in the main thread. Used for --fake installs."""
+
+    process_handle = MockBuildProcess()  # type: ignore[assignment]
+
+    def _start_build_process(self):
+        build_process(self.pkg, self.request.install_args)
+
+    def poll(self):
+        return True
 
 
 class RewireTask(Task):
@@ -1600,7 +1623,12 @@ class PackageInstaller:
             request: the associated install request
             all_deps: dictionary of all dependencies and associated dependents
         """
-        cls = RewireTask if pkg.spec.spliced else BuildTask
+        cls: type[Task] = BuildTask
+        if pkg.spec.spliced:
+            cls = RewireTask
+        elif request.install_args.get("fake"):
+            cls = FakeBuildTask
+
         task = cls(pkg, request=request, status=BuildStatus.QUEUED, installed=self.installed)
         for dep_id in task.dependencies:
             all_deps[dep_id].add(package_id(pkg.spec))

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -151,6 +151,7 @@ def test_monkey_patching_test_log_file():
 
 # Windows context manager's __exit__ fails with ValueError ("I/O operation
 # on closed file").
+@pytest.mark.needs_logger
 @pytest.mark.not_on_windows("Does not run on windows")
 def test_install_time_test_callback(tmp_path: pathlib.Path, config, mock_packages, mock_stage):
     """Confirm able to run stand-alone test as a post-install callback."""

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -578,7 +578,7 @@ def test_env_install_include_concrete_env(unify, install_mockery, mock_fetch, mu
 
 def test_env_roots_marked_explicit(install_mockery, mock_fetch):
     install = SpackCommand("install")
-    install("dependent-install")
+    install("--fake", "dependent-install")
 
     # Check one explicit, one implicit install
     dependent = spack.store.STORE.db.query(explicit=True)
@@ -624,7 +624,7 @@ def test_activate_adds_transitive_run_deps_to_path(install_mockery, mock_fetch, 
 
     e = ev.read("test")
     with e:
-        install("--add", "depends-on-run-env")
+        install("--add", "--fake", "depends-on-run-env")
 
     env_variables = {}
     spack.environment.shell.activate(e).apply_modifications(env_variables)
@@ -865,7 +865,7 @@ def test_env_status_broken_view(
     tmp_path: pathlib.Path,
 ):
     with ev.create_in_dir(tmp_path):
-        install("--add", "trivial-install-test-package")
+        install("--add", "--fake", "trivial-install-test-package")
 
     # switch to a new repo that doesn't include the installed package
     # test that Spack detects the missing package and warns the user
@@ -884,7 +884,7 @@ def test_env_activate_broken_view(
     mutable_mock_env_path, mock_archive, mock_fetch, mock_custom_repository, install_mockery
 ):
     with ev.create("test"):
-        install("--add", "trivial-install-test-package")
+        install("--add", "--fake", "trivial-install-test-package")
 
     # switch to a new repo that doesn't include the installed package
     # test that Spack detects the missing package and fails gracefully
@@ -3034,7 +3034,7 @@ spack:
         )
 
     with ev.Environment(envdir):
-        install()
+        install("--fake")
 
     # make sure transitive run type deps are in the view
     for pkg in ("dtrun1", "dtrun3"):
@@ -3579,7 +3579,7 @@ spack:
     )
 
     with ev.read("test") as e:
-        install()
+        install("--fake")
 
         spec = e.specs_by_hash[e.concretized_order[0]]
         view_prefix = e.default_view.get_projection_for_spec(spec)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -41,6 +41,9 @@ buildcache = SpackCommand("buildcache")
 find = SpackCommand("find")
 
 
+pytestmark = pytest.mark.needs_logger
+
+
 @pytest.fixture()
 def noop_install(monkeypatch):
     def noop(*args, **kwargs):
@@ -1084,7 +1087,7 @@ def test_padded_install_runtests_root(install_mockery, mock_fetch):
     output = install(
         "--verbose", "--test=root", "--no-cache", "test-build-callbacks", fail_on_error=False
     )
-    assert output.count("method not implemented") == 1
+    assert output.count("method not implemented") == 2
 
 
 @pytest.mark.regression("35337")

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -63,6 +63,7 @@ def test_test_dup_alias(
     assert "already exists" in out and "Try another alias" in out
 
 
+@pytest.mark.needs_logger
 def test_test_output(mock_test_stage, mock_packages, mock_archive, mock_fetch, install_mockery):
     """Ensure output printed from pkgs is captured by output redirection."""
     install("printing-package")
@@ -162,6 +163,7 @@ def test_cdash_output_test_error(
         assert "Command exited with status 1" in content
 
 
+@pytest.mark.needs_logger
 def test_cdash_upload_clean_test(
     tmp_path: pathlib.Path,
     mock_fetch,

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -37,9 +37,11 @@ import spack.config
 import spack.directives_meta
 import spack.environment as ev
 import spack.error
+import spack.installer
 import spack.llnl.util.lang
 import spack.llnl.util.lock
 import spack.llnl.util.tty as tty
+import spack.llnl.util.tty.log
 import spack.modules.common
 import spack.package_base
 import spack.paths
@@ -2431,3 +2433,40 @@ def config_two_gccs(mutable_config):
             },
         ],
     )
+
+
+class MockLogger:
+    """Mock logger that does nothing"""
+
+    def __init__(self, *args, **kwargs):
+        self.echo = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def force_echo(self, *args, **kwargs):
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _no_log_output(monkeypatch, request):
+    """Doesn't fork/spawn a new logger when installing mock packages in tests, unless the test is
+    marked with "needs_logger".
+    """
+    needs_logger = request.node.get_closest_marker(name="needs_logger")
+    if not needs_logger:
+        monkeypatch.setattr(spack.llnl.util.tty.log, "log_output", MockLogger)
+        monkeypatch.setattr(spack.installer, "log_output", MockLogger)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_level():
+    """Resets the log level after tests"""
+    yield
+    spack.llnl.util.tty._debug = 0
+    spack.llnl.util.tty._verbose = False
+    spack.llnl.util.tty._stacktrace = False

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -23,7 +23,7 @@ except ImportError:
     pass
 
 
-pytestmark = pytest.mark.not_on_windows("does not run on windows")
+pytestmark = [pytest.mark.not_on_windows("does not run on windows"), pytest.mark.needs_logger]
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -84,6 +84,7 @@ def test_write_test_result(mock_packages, mock_test_stage):
         assert spec.name in msg
 
 
+@pytest.mark.needs_logger
 def test_test_not_installed(mock_packages, install_mockery, mock_test_stage):
     """Attempt to perform stand-alone test for not_installed package."""
     spec = spack.concretize.concretize_one("trivial-smoke-test")
@@ -99,6 +100,7 @@ def test_test_not_installed(mock_packages, install_mockery, mock_test_stage):
     "arguments,status,msg",
     [({}, TestStatus.SKIPPED, "Skipped"), ({"externals": True}, TestStatus.NO_TESTS, "No tests")],
 )
+@pytest.mark.needs_logger
 def test_test_external(
     mock_packages, install_mockery, mock_test_stage, monkeypatch, arguments, status, msg
 ):
@@ -150,6 +152,7 @@ def test_test_spec_run_once(mock_packages, install_mockery, mock_test_stage):
         test_suite()
 
 
+@pytest.mark.needs_logger
 @pytest.mark.not_on_windows("Cannot find echo executable")
 def test_test_spec_passes(mock_packages, install_mockery, mock_test_stage, monkeypatch):
     spec = spack.concretize.concretize_one("simple-standalone-test")

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,4 @@ markers =
   not_on_windows: mark tests that are skipped on Windows
   only_windows: mark tests that are skipped everywhere but Windows
   require_provenance: tests that have enough infrastructure to test git binary provenance
+  needs_logger: mark tests that need to fork/spawn a logger process


### PR DESCRIPTION
Currently, we are oversubscribing macos-latest runners by 1 cpu, and we are using all macos-15-intel CPUs. This commit wants to check if, using less parallelism, we could get faster unit tests in CI.

Also, bump Python from 3.11 to 3.13

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
