### PR TITLE
Add MacOS Tahoe as compatible with Sequoia to help with migrations

### DIFF
--- a/lib/spack/spack/solver/os_compatibility.lp
+++ b/lib/spack/spack/solver/os_compatibility.lp
@@ -11,6 +11,7 @@
 %=============================================================================
 
 % macOS
+os_compatible("tahoe", "sequoia").
 os_compatible("sequoia", "sonoma").
 os_compatible("sonoma", "ventura").
 os_compatible("ventura", "monterey").


### PR DESCRIPTION
Right now if you upgrade to MacOS Tahoe you'll loose the ability to reuse any of your previous installations.
This PR modifies the os compatibility rules to allow users to reuse previously installed packages on Tahoe.