### PR TITLE
Use `gethostname` instead of `getfqdn` to speed-up macOS unit tests in CI

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -66,7 +66,7 @@ from spack.directory_layout import (
 )
 from spack.error import SpackError
 from spack.util.crypto import bit_length
-from spack.util.socket import _getfqdn
+from spack.util.socket import _gethostname
 
 from .enums import InstallRecordStatus
 
@@ -1103,7 +1103,7 @@ class Database:
             self._state_is_inconsistent = True
             return
 
-        temp_file = str(self._index_path) + (".%s.%s.temp" % (_getfqdn(), os.getpid()))
+        temp_file = str(self._index_path) + (".%s.%s.temp" % (_gethostname(), os.getpid()))
 
         # Write a temporary database file them move it into place
         try:

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -17,7 +17,7 @@ import spack.package_prefs
 import spack.paths
 import spack.spec
 import spack.store
-from spack.util.socket import _getfqdn
+from spack.util.socket import _gethostname
 
 #: OS-imposed character limit for shebang line: 127 for Linux; 511 for Mac.
 #: Different Linux distributions have different limits, but 127 is the
@@ -209,7 +209,7 @@ def install_sbang():
         os.chown(sbang_bin_dir, os.stat(sbang_bin_dir).st_uid, grp.getgrnam(group_name).gr_gid)
 
     # copy over the fresh copy of `sbang`
-    sbang_tmp_path = os.path.join(sbang_bin_dir, f".sbang.{_getfqdn()}.{os.getpid()}.tmp")
+    sbang_tmp_path = os.path.join(sbang_bin_dir, f".sbang.{_gethostname()}.{os.getpid()}.tmp")
     shutil.copy(spack.paths.sbang_script, sbang_tmp_path)
 
     # set permissions on `sbang` (including group if set in configuration)

--- a/lib/spack/spack/util/socket.py
+++ b/lib/spack/spack/util/socket.py
@@ -9,11 +9,11 @@ import spack.llnl.util.lang
 
 
 @spack.llnl.util.lang.memoized
-def _getfqdn():
+def _gethostname():
     """Memoized version of `getfqdn()`.
 
     If we call `getfqdn()` too many times, DNS can be very slow. We only need to call it
     one time per process, so we cache it here.
 
     """
-    return socket.getfqdn()
+    return socket.gethostname()


### PR DESCRIPTION
Extracted from #51469

For reference, removing `socket.getfqdn` improved the unit tests time on macOS:
- https://github.com/spack/spack/actions/runs/18898746357/job/53941706508
- https://github.com/spack/spack/actions/runs/18898746357/job/53941706508

It's another instance of https://github.com/spack/spack/pull/46554 that got in through the `sbang` hook in #47590. Since hooks are run on the child and on macOS the sub-processes are "spawned" (not "forked"), memoization doesn't help.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
