### PR TITLE
Don't spawn a process for `--fake` installs

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2475,7 +2475,6 @@ class PackageInstaller:
                     # handled in complete_task()
                     task.error_result = e
 
-            time.sleep(0.1)
             # Check if any tasks have completed and add to list
             done = [task for task in active_tasks if task.poll()]
             try:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1283,6 +1283,9 @@ class BuildTask(Task):
         self._setup_install_dir(pkg)
 
         # Create a child process to do the actual installation.
+        self._start_build_process()
+
+    def _start_build_process(self):
         self.process_handle = spack.build_environment.start_build_process(
             self.pkg, build_process, self.request.install_args
         )
@@ -1382,6 +1385,26 @@ class BuildTask(Task):
         """Terminate any processes this task still has running."""
         if self.process_handle:
             self.process_handle.terminate()
+
+
+class MockBuildProcess:
+    def complete(self) -> bool:
+        return True
+
+    def terminate(self) -> None:
+        pass
+
+
+class FakeBuildTask(BuildTask):
+    """Blocking BuildTask executed directly in the main thread. Used for --fake installs."""
+
+    process_handle = MockBuildProcess()  # type: ignore[assignment]
+
+    def _start_build_process(self):
+        build_process(self.pkg, self.request.install_args)
+
+    def poll(self):
+        return True
 
 
 class RewireTask(Task):
@@ -1600,7 +1623,12 @@ class PackageInstaller:
             request: the associated install request
             all_deps: dictionary of all dependencies and associated dependents
         """
-        cls = RewireTask if pkg.spec.spliced else BuildTask
+        cls: type[Task] = BuildTask
+        if pkg.spec.spliced:
+            cls = RewireTask
+        elif request.install_args.get("fake"):
+            cls = FakeBuildTask
+
         task = cls(pkg, request=request, status=BuildStatus.QUEUED, installed=self.installed)
         for dep_id in task.dependencies:
             all_deps[dep_id].add(package_id(pkg.spec))

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2475,6 +2475,8 @@ class PackageInstaller:
                     # handled in complete_task()
                     task.error_result = e
 
+            # 10 ms to avoid busy waiting
+            time.sleep(0.01)
             # Check if any tasks have completed and add to list
             done = [task for task in active_tasks if task.poll()]
             try:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -578,7 +578,7 @@ def test_env_install_include_concrete_env(unify, install_mockery, mock_fetch, mu
 
 def test_env_roots_marked_explicit(install_mockery, mock_fetch):
     install = SpackCommand("install")
-    install("dependent-install")
+    install("--fake", "dependent-install")
 
     # Check one explicit, one implicit install
     dependent = spack.store.STORE.db.query(explicit=True)
@@ -624,7 +624,7 @@ def test_activate_adds_transitive_run_deps_to_path(install_mockery, mock_fetch, 
 
     e = ev.read("test")
     with e:
-        install("--add", "depends-on-run-env")
+        install("--add", "--fake", "depends-on-run-env")
 
     env_variables = {}
     spack.environment.shell.activate(e).apply_modifications(env_variables)
@@ -865,7 +865,7 @@ def test_env_status_broken_view(
     tmp_path: pathlib.Path,
 ):
     with ev.create_in_dir(tmp_path):
-        install("--add", "trivial-install-test-package")
+        install("--add", "--fake", "trivial-install-test-package")
 
     # switch to a new repo that doesn't include the installed package
     # test that Spack detects the missing package and warns the user
@@ -884,7 +884,7 @@ def test_env_activate_broken_view(
     mutable_mock_env_path, mock_archive, mock_fetch, mock_custom_repository, install_mockery
 ):
     with ev.create("test"):
-        install("--add", "trivial-install-test-package")
+        install("--add", "--fake", "trivial-install-test-package")
 
     # switch to a new repo that doesn't include the installed package
     # test that Spack detects the missing package and fails gracefully
@@ -3034,7 +3034,7 @@ spack:
         )
 
     with ev.Environment(envdir):
-        install()
+        install("--fake")
 
     # make sure transitive run type deps are in the view
     for pkg in ("dtrun1", "dtrun3"):
@@ -3579,7 +3579,7 @@ spack:
     )
 
     with ev.read("test") as e:
-        install()
+        install("--fake")
 
         spec = e.specs_by_hash[e.concretized_order[0]]
         view_prefix = e.default_view.get_projection_for_spec(spec)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1084,7 +1084,7 @@ def test_padded_install_runtests_root(install_mockery, mock_fetch):
     output = install(
         "--verbose", "--test=root", "--no-cache", "test-build-callbacks", fail_on_error=False
     )
-    assert output.count("method not implemented") == 1
+    assert "method not implemented [undefined-build-test]" in output
 
 
 @pytest.mark.regression("35337")


### PR DESCRIPTION
Modifications:
- [x] Don't spawn a process for `--fake` installs
- [x] `sleep` for 10ms instead of 100ms in the installer

On an Intel-based macOS laptop:
<img width="2131" height="1324" alt="Screenshot from 2025-10-31 10-36-15" src="https://github.com/user-attachments/assets/8d35d7f3-449b-4bb4-873e-f75cd1ec08df" />

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
