### PR TITLE
spack compiler info now accepts compiler aliases

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -12,7 +12,7 @@ import spack.config
 import spack.llnl.util.tty as tty
 import spack.spec
 import spack.store
-from spack.aliases import LEGACY_COMPILER_TO_BUILTIN, BUILTIN_TO_LEGACY_COMPILER
+from spack.aliases import BUILTIN_TO_LEGACY_COMPILER, LEGACY_COMPILER_TO_BUILTIN
 from spack.cmd.common import arguments
 from spack.llnl.util.lang import index_by
 from spack.llnl.util.tty.colify import colify
@@ -221,7 +221,8 @@ def compiler_list(args):
     # convert them to '' (in which case it still evaluates to False but is a
     # string type). Tuples produced by this are guaranteed to be comparable in
     # Python 3
-    def convert_str(tuple_container): return tuple(str(x) if x else "" for x in tuple_container)
+    def convert_str(tuple_container):
+        return tuple(str(x) if x else "" for x in tuple_container)
 
     index_str_keys = list((convert_str(x), y) for x, y in index.items())
     ordered_sections = sorted(index_str_keys, key=lambda item: item[0])

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -12,7 +12,7 @@ import spack.config
 import spack.llnl.util.tty as tty
 import spack.spec
 import spack.store
-from spack.aliases import LEGACY_COMPILER_TO_BUILTIN
+from spack.aliases import LEGACY_COMPILER_TO_BUILTIN, BUILTIN_TO_LEGACY_COMPILER
 from spack.cmd.common import arguments
 from spack.llnl.util.lang import index_by
 from spack.llnl.util.tty.colify import colify
@@ -137,7 +137,7 @@ def compiler_remove(args):
 def compiler_info(args):
     """Print info about all compilers matching a spec."""
     query = spack.spec.Spec(args.compiler_spec)
-    # Replace legacy compiler name by its builtin name if available
+    #  Replace legacy compiler name by its builtin name if available
     query.name = LEGACY_COMPILER_TO_BUILTIN.get(query.name, query.name)
     all_compilers = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
 
@@ -182,9 +182,19 @@ def compiler_list(args):
     def _is_compiler(x):
         return x.name in supported_compilers and x.package.supported_languages and not x.external
 
+    def _is_aliased(x):
+        return x.name in BUILTIN_TO_LEGACY_COMPILER
+
+    def _build_alias_spec(x):
+        alias_spec = x.copy(deps=False)
+        alias_spec.name = BUILTIN_TO_LEGACY_COMPILER[x.name]
+        return alias_spec
+
     compilers_from_store = [x for x in spack.store.STORE.db.query() if _is_compiler(x)]
     compilers_from_yaml = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
     compilers = compilers_from_yaml + compilers_from_store
+    aliases_compilers = [_build_alias_spec(x) for x in compilers if _is_aliased(x)]
+    compilers += aliases_compilers
 
     if args.remote:
         compilers.extend(
@@ -211,7 +221,7 @@ def compiler_list(args):
     # convert them to '' (in which case it still evaluates to False but is a
     # string type). Tuples produced by this are guaranteed to be comparable in
     # Python 3
-    convert_str = lambda tuple_container: tuple(str(x) if x else "" for x in tuple_container)
+    def convert_str(tuple_container): return tuple(str(x) if x else "" for x in tuple_container)
 
     index_str_keys = list((convert_str(x), y) for x, y in index.items())
     ordered_sections = sorted(index_str_keys, key=lambda item: item[0])

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -12,6 +12,7 @@ import spack.config
 import spack.llnl.util.tty as tty
 import spack.spec
 import spack.store
+from spack.aliases import LEGACY_COMPILER_TO_BUILTIN
 from spack.cmd.common import arguments
 from spack.llnl.util.lang import index_by
 from spack.llnl.util.tty.colify import colify
@@ -136,6 +137,8 @@ def compiler_remove(args):
 def compiler_info(args):
     """Print info about all compilers matching a spec."""
     query = spack.spec.Spec(args.compiler_spec)
+    # Replace legacy compiler name by its builtin name if available
+    query.name = LEGACY_COMPILER_TO_BUILTIN.get(query.name, query.name)
     all_compilers = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
 
     compilers = [x for x in all_compilers if x.satisfies(query)]

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -248,6 +248,7 @@ def test_compilers_shows_packages_yaml(
     assert out.count("gcc@7.7.7") == 1
 
 
+@pytest.mark.not_on_windows("path format conflict")
 @pytest.mark.parametrize(
     "externals",
     [
@@ -295,6 +296,7 @@ def test_compilers_list_outputs_alias(externals, no_packages_yaml, working_env, 
     assert out.count("clang@14.0.2") == 1
 
 
+@pytest.mark.not_on_windows("path format conflict")
 @pytest.mark.parametrize(
     "externals, expected",
     [

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -324,31 +324,29 @@ def test_compilers_list_outputs_alias(externals, no_packages_yaml, working_env, 
                 },
             ),
             (
-                """gcc@=7.7.7 build_system=generic languages:=c,cxx,fortran platform=test os=foobar target=x86_64:
-  prefix: /path/to/fake
-  compilers:
-    c: /path/to/fake/gcc
-    cxx: /path/to/fake/g++
-    fortran: /path/to/fake/gfortran
-  flags:
-    fflags = -ffree-form
-  modules: 
-    gcc/7.7.7
-    foobar
-
-""",
-                """llvm@=14.0.2+clang~flang+lld build_system=generic languages:=c,cxx platform=test os=foobar target=x86_64:
-  prefix: /path/to/fake
-  compilers:
-    c: /path/to/fake/clang
-    cxx: /path/to/fake/clang++
-  flags:
-    fflags = -ffree-form
-  modules: 
-    llvm/14.0.2
-    foobar
-
-""",
+                """gcc@=7.7.7 build_system=generic languages:=c,cxx,fortran platform=test os=foobar target=x86_64:\n"""  # noqa: E501
+                """  prefix: /path/to/fake\n"""
+                """  compilers:\n"""
+                """    c: /path/to/fake/gcc\n"""
+                """    cxx: /path/to/fake/g++\n"""
+                """    fortran: /path/to/fake/gfortran\n"""
+                """  flags:\n"""
+                """    fflags = -ffree-form\n"""
+                """  modules: \n"""
+                """    gcc/7.7.7\n"""
+                """    foobar\n"""
+                """\n""",
+                """llvm@=14.0.2+clang~flang+lld build_system=generic languages:=c,cxx platform=test os=foobar target=x86_64:\n"""  # noqa: E501
+                """  prefix: /path/to/fake\n"""
+                """  compilers:\n"""
+                """    c: /path/to/fake/clang\n"""
+                """    cxx: /path/to/fake/clang++\n"""
+                """  flags:\n"""
+                """    fflags = -ffree-form\n"""
+                """  modules: \n"""
+                """    llvm/14.0.2\n"""
+                """    foobar\n"""
+                """\n""",
             ),
         )
     ],

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -246,3 +246,55 @@ def test_compilers_shows_packages_yaml(
 
     out = compiler("list", fail_on_error=True)
     assert out.count("gcc@7.7.7") == 1
+
+
+@pytest.mark.parametrize(
+    "externals",
+    [
+        (
+            {
+                "spec": "gcc@=7.7.7 languages=c,cxx,fortran os=foobar target=x86_64",
+                "prefix": "/path/to/fake",
+                "modules": ["gcc/7.7.7", "foobar"],
+                "extra_attributes": {
+                    "compilers": {
+                        "c": "/path/to/fake/gcc",
+                        "cxx": "/path/to/fake/g++",
+                        "fortran": "/path/to/fake/gfortran",
+                    },
+                    "flags": {"fflags": "-ffree-form"},
+                },
+            },
+            {
+                "spec": "llvm@=14.0.2 languages=c,cxx os=foobar target=x86_64",
+                "prefix": "/path/to/fake",
+                "modules": ["llvm/14.0.2", "foobar"],
+                "extra_attributes": {
+                    "compilers": {
+                        "c": "/path/to/fake/clang",
+                        "cxx": "/path/to/fake/clang++",
+                    },
+                    "flags": {"fflags": "-ffree-form"},
+                },
+            },
+        )
+    ],
+)
+def test_compilers_list_outputs_alias(
+    externals, no_packages_yaml, working_env, compilers_dir
+):
+    """Spack should list bultin and legacy (alias) compilers"""
+    gcc_spec = externals[0]
+    llvm_spec = externals[1]
+    gcc_entry = {"externals": [gcc_spec]}
+    llvm_entry = {"externals": [llvm_spec]}
+
+    packages = spack.config.get("packages")
+    packages["gcc"] = gcc_entry
+    packages["llvm"] = llvm_entry
+    spack.config.set("packages", packages)
+
+    out = compiler("list", fail_on_error=True)
+    assert out.count("gcc@7.7.7") == 1
+    assert out.count("llvm@14.0.2") == 1
+    assert out.count("clang@14.0.2") == 1

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -270,19 +270,14 @@ def test_compilers_shows_packages_yaml(
                 "prefix": "/path/to/fake",
                 "modules": ["llvm/14.0.2", "foobar"],
                 "extra_attributes": {
-                    "compilers": {
-                        "c": "/path/to/fake/clang",
-                        "cxx": "/path/to/fake/clang++",
-                    },
+                    "compilers": {"c": "/path/to/fake/clang", "cxx": "/path/to/fake/clang++"},
                     "flags": {"fflags": "-ffree-form"},
                 },
             },
         )
     ],
 )
-def test_compilers_list_outputs_alias(
-    externals, no_packages_yaml, working_env, compilers_dir
-):
+def test_compilers_list_outputs_alias(externals, no_packages_yaml, working_env, compilers_dir):
     """Spack should list bultin and legacy (alias) compilers"""
     gcc_spec = externals[0]
     llvm_spec = externals[1]
@@ -304,35 +299,32 @@ def test_compilers_list_outputs_alias(
     "externals, expected",
     [
         (
-          (
-            {
-                "spec": "gcc@=7.7.7 languages=c,cxx,fortran os=foobar target=x86_64",
-                "prefix": "/path/to/fake",
-                "modules": ["gcc/7.7.7", "foobar"],
-                "extra_attributes": {
-                    "compilers": {
-                        "c": "/path/to/fake/gcc",
-                        "cxx": "/path/to/fake/g++",
-                        "fortran": "/path/to/fake/gfortran",
+            (
+                {
+                    "spec": "gcc@=7.7.7 languages=c,cxx,fortran os=foobar target=x86_64",
+                    "prefix": "/path/to/fake",
+                    "modules": ["gcc/7.7.7", "foobar"],
+                    "extra_attributes": {
+                        "compilers": {
+                            "c": "/path/to/fake/gcc",
+                            "cxx": "/path/to/fake/g++",
+                            "fortran": "/path/to/fake/gfortran",
+                        },
+                        "flags": {"fflags": "-ffree-form"},
                     },
-                    "flags": {"fflags": "-ffree-form"},
                 },
-            },
-            {
-                "spec": "llvm@=14.0.2 languages=c,cxx os=foobar target=x86_64",
-                "prefix": "/path/to/fake",
-                "modules": ["llvm/14.0.2", "foobar"],
-                "extra_attributes": {
-                    "compilers": {
-                        "c": "/path/to/fake/clang",
-                        "cxx": "/path/to/fake/clang++",
+                {
+                    "spec": "llvm@=14.0.2 languages=c,cxx os=foobar target=x86_64",
+                    "prefix": "/path/to/fake",
+                    "modules": ["llvm/14.0.2", "foobar"],
+                    "extra_attributes": {
+                        "compilers": {"c": "/path/to/fake/clang", "cxx": "/path/to/fake/clang++"},
+                        "flags": {"fflags": "-ffree-form"},
                     },
-                    "flags": {"fflags": "-ffree-form"},
                 },
-            },
-          ),
-          (
-            """gcc@=7.7.7 build_system=generic languages:=c,cxx,fortran platform=test os=foobar target=x86_64:
+            ),
+            (
+                """gcc@=7.7.7 build_system=generic languages:=c,cxx,fortran platform=test os=foobar target=x86_64:
   prefix: /path/to/fake
   compilers:
     c: /path/to/fake/gcc
@@ -345,7 +337,7 @@ def test_compilers_list_outputs_alias(
     foobar
 
 """,
-            """llvm@=14.0.2+clang~flang+lld build_system=generic languages:=c,cxx platform=test os=foobar target=x86_64:
+                """llvm@=14.0.2+clang~flang+lld build_system=generic languages:=c,cxx platform=test os=foobar target=x86_64:
   prefix: /path/to/fake
   compilers:
     c: /path/to/fake/clang
@@ -356,8 +348,8 @@ def test_compilers_list_outputs_alias(
     llvm/14.0.2
     foobar
 
-"""
-          )
+""",
+            ),
         )
     ],
 )
@@ -381,6 +373,6 @@ def test_compilers_info_accepts_alias(
 
     expected_gcc, expected_llvm = expected
 
-    assert(expected_gcc == out_gcc)
-    assert(expected_llvm == out_llvm)
-    assert(expected_llvm == out_clang)
+    assert expected_gcc == out_gcc
+    assert expected_llvm == out_llvm
+    assert expected_llvm == out_clang

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -298,3 +298,89 @@ def test_compilers_list_outputs_alias(
     assert out.count("gcc@7.7.7") == 1
     assert out.count("llvm@14.0.2") == 1
     assert out.count("clang@14.0.2") == 1
+
+
+@pytest.mark.parametrize(
+    "externals, expected",
+    [
+        (
+          (
+            {
+                "spec": "gcc@=7.7.7 languages=c,cxx,fortran os=foobar target=x86_64",
+                "prefix": "/path/to/fake",
+                "modules": ["gcc/7.7.7", "foobar"],
+                "extra_attributes": {
+                    "compilers": {
+                        "c": "/path/to/fake/gcc",
+                        "cxx": "/path/to/fake/g++",
+                        "fortran": "/path/to/fake/gfortran",
+                    },
+                    "flags": {"fflags": "-ffree-form"},
+                },
+            },
+            {
+                "spec": "llvm@=14.0.2 languages=c,cxx os=foobar target=x86_64",
+                "prefix": "/path/to/fake",
+                "modules": ["llvm/14.0.2", "foobar"],
+                "extra_attributes": {
+                    "compilers": {
+                        "c": "/path/to/fake/clang",
+                        "cxx": "/path/to/fake/clang++",
+                    },
+                    "flags": {"fflags": "-ffree-form"},
+                },
+            },
+          ),
+          (
+            """gcc@=7.7.7 build_system=generic languages:=c,cxx,fortran platform=test os=foobar target=x86_64:
+  prefix: /path/to/fake
+  compilers:
+    c: /path/to/fake/gcc
+    cxx: /path/to/fake/g++
+    fortran: /path/to/fake/gfortran
+  flags:
+    fflags = -ffree-form
+  modules: 
+    gcc/7.7.7
+    foobar
+
+""",
+            """llvm@=14.0.2+clang~flang+lld build_system=generic languages:=c,cxx platform=test os=foobar target=x86_64:
+  prefix: /path/to/fake
+  compilers:
+    c: /path/to/fake/clang
+    cxx: /path/to/fake/clang++
+  flags:
+    fflags = -ffree-form
+  modules: 
+    llvm/14.0.2
+    foobar
+
+"""
+          )
+        )
+    ],
+)
+def test_compilers_info_accepts_alias(
+    externals, expected, no_packages_yaml, working_env, compilers_dir
+):
+    """Spack compiler info command shoud accept bultin and legacy (alias) argument"""
+    gcc_spec = externals[0]
+    llvm_spec = externals[1]
+    gcc_entry = {"externals": [gcc_spec]}
+    llvm_entry = {"externals": [llvm_spec]}
+
+    packages = spack.config.get("packages")
+    packages["gcc"] = gcc_entry
+    packages["llvm"] = llvm_entry
+    spack.config.set("packages", packages)
+
+    out_gcc = compiler("info", "gcc", fail_on_error=True)
+    out_llvm = compiler("info", "llvm", fail_on_error=True)
+    out_clang = compiler("info", "clang", fail_on_error=True)
+
+    expected_gcc, expected_llvm = expected
+
+    assert(expected_gcc == out_gcc)
+    assert(expected_llvm == out_llvm)
+    assert(expected_llvm == out_clang)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

# Fix #51415

This small PR fixes issue #51415. Now `spack compiler info` accepts compiler aliases as argument.

```
hippo91@MyPlace:~  $ spack compiler info llvm
llvm@=14.0.6+clang~cuda~flang+gold+libomptarget~libomptarget_debug~link_llvm_dylib~lld~lldb+llvm_dylib+lua~mlir+polly~python~split_dwarf~utils~z3 build_system=cmake build_type=Release compiler-rt=runtime generator=ninja libcxx=runtime libunwind=runtime openmp=runtime shlib_symbol_version=none targets:=all version_suffix=none platform=linux os=debian13 target=x86_64:
  prefix: /usr
  compilers:
    c: /usr/bin/clang-14
    cxx: /usr/bin/clang++-14

llvm@=19.1.7+clang~cuda~flang+gold+libomptarget~libomptarget_debug~link_llvm_dylib+lld~lldb+llvm_dylib+lua~mlir+offload+polly~python~split_dwarf~utils~z3~zstd build_system=cmake build_type=Release compiler-rt=runtime generator=ninja libcxx=runtime libunwind=runtime openmp=runtime shlib_symbol_version=none targets:=all version_suffix=none platform=linux os=debian13 target=x86_64:
  prefix: /usr
  compilers:
    c: /usr/bin/clang
    cxx: /usr/bin/clang++

hippo91@MyPlace:~  $ spack compiler info clang
llvm@=14.0.6+clang~cuda~flang+gold+libomptarget~libomptarget_debug~link_llvm_dylib~lld~lldb+llvm_dylib+lua~mlir+polly~python~split_dwarf~utils~z3 build_system=cmake build_type=Release compiler-rt=runtime generator=ninja libcxx=runtime libunwind=runtime openmp=runtime shlib_symbol_version=none targets:=all version_suffix=none platform=linux os=debian13 target=x86_64:
  prefix: /usr
  compilers:
    c: /usr/bin/clang-14
    cxx: /usr/bin/clang++-14

llvm@=19.1.7+clang~cuda~flang+gold+libomptarget~libomptarget_debug~link_llvm_dylib+lld~lldb+llvm_dylib+lua~mlir+offload+polly~python~split_dwarf~utils~z3~zstd build_system=cmake build_type=Release compiler-rt=runtime generator=ninja libcxx=runtime libunwind=runtime openmp=runtime shlib_symbol_version=none targets:=all version_suffix=none platform=linux os=debian13 target=x86_64:
  prefix: /usr
  compilers:
    c: /usr/bin/clang
    cxx: /usr/bin/clang++
```

The `spack compiler list` now outputs alias compilers:

```
hippo91@MyPlace:~/Programmation  $ spack compiler list
==> Available compilers
-- clang debian13-x86_64 ----------------------------------------
[e]  clang@19.1.7  [e]  clang@14.0.6

-- gcc debian13-x86_64 ------------------------------------------
[e]  gcc@14.2.0  [e]  gcc@12.4.0  [e]  gcc@10.2.1

-- llvm debian13-x86_64 -----------------------------------------
[e]  llvm@19.1.7  [e]  llvm@14.0.6
```


Closes #51415 