### PR TITLE
fetch: work around Anubis AI protection

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -429,7 +429,9 @@ class URLFetchStrategy(FetchStrategy):
     def _fetch_urllib(self, url, chunk_size=65536):
         save_file = self.stage.save_filename
 
-        request = urllib.request.Request(url, headers={"User-Agent": web_util.SPACK_USER_AGENT})
+        request = urllib.request.Request(
+            url, headers={"User-Agent": web_util.SPACK_USER_AGENT, "Accept": "*/*"}
+        )
 
         if os.path.lexists(save_file):
             os.remove(save_file)


### PR DESCRIPTION
More and more sites are deploying AI protection measures such as Anubis. This can cause errors like this when fetching:
```
$ spack fetch -M gobject-introspection
==> Fetching https://download.gnome.org/sources/gobject-introspection/1.78/gobject-introspection-1.78.1.tar.xz
    [100%]    1.06 MB @    6.2 MB/s
==> Fetching https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490/commits.patch
    [100%]    3.13 KB @    7.2 MB/s
==> Warning: The contents of $SPACK_STAGE/spack-stage--hdurcup-patch-8085a21385aba2370ba0859f7d0c5f0a6d6a051ab3c0ea0b8881d567d6356299/commits.patch fetched from https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490/commits.patch  looks like HTML. This can indicate a broken URL, or an internet gateway issue.
==> Error: sha256 checksum failed for $SPACK_STAGE/spack-stage--hdurcup-patch-8085a21385aba2370ba0859f7d0c5f0a6d6a051ab3c0ea0b8881d567d6356299/commits.patch
Expected 8085a21385aba2370ba0859f7d0c5f0a6d6a051ab3c0ea0b8881d567d6356299 but got 32c02388fa2e59f4882951e43c4de715775c10e107bc5a3ddec8d3d70ed9d512. File size = 3132 bytes. Contents = b'<!doctype html><...n></body></html>'. URL = https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490/commits.patch
```

After comparing the request headers sent by Python's urllib and curl, it seems that setting `Accept: */*` is enough to make fetching work again.

Related: #50124