### PR TITLE
spack create: fix order of build system selection

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -829,8 +829,8 @@ class BuildSystemAndLanguageGuesser:
             ]
 
             # Determine the build system based on the files contained in the archive.
-            for file in self._file_entries:
-                for pattern, build_system in clues:
+            for pattern, build_system in clues:
+                for file in self._file_entries:
                     if pattern.search(file):
                         self.build_system = build_system
                         return


### PR DESCRIPTION
When choosing a build system, Spack looks for the presence of certain file names indicative of popular build systems. It does this using a list of clues (regex, build system tuples).

The comment above this list notes that order is important, as certain high-level build systems (CMake, Autotools) may be mixed with older low-level build systems (Makefile) and we want to choose the higher-level build system instead.

However, due to the order of for-loops, we were actually ignoring the order of the list and instead iterating over files in alphabetical order. This would result in things like MakefilePackage being chosen over PythonPackage if both are a match.

This PR fixes the for-loop order to match the comment.