### PR TITLE
`format-rst.py`: Ignore advice about quoting double-colon overrides

### DIFF
--- a/.github/workflows/bin/format-rst.py
+++ b/.github/workflows/bin/format-rst.py
@@ -59,6 +59,9 @@ END_OF_SENTENCE = re.compile(
 DOCUTILS_SETTING = {"report_level": 5, "raw_enabled": False, "file_insertion_enabled": False}
 
 
+DOUBLE_COLON_WARNING = re.compile(r"\-\s*([^: ]+)::.*\n\+\s*'\1:':")
+
+
 def _warning(msg: str) -> str:
     return f"\033[1;33mwarning:\033[0m {msg}"
 
@@ -190,7 +193,13 @@ def _format_code_blocks(document: nodes.document, path: str) -> List[Warning]:
                 tofile=f"{path}:{line} (suggested, NOT required)",
             )
         )
-        if diff:
+
+        # ignore suggestions to quote double colons like this:
+        #
+        # -  build_stage::
+        # +  'build_stage:':
+        #
+        if diff and not DOUBLE_COLON_WARNING.search(diff):
             issues.append(CodeBlockWarning(path, line, "formatting suggested:", diff))
     return issues
 


### PR DESCRIPTION
Warnings like this can be quite noisy:

```diff
warning: module_file_support.rst:314: formatting suggested:
--- module_file_support.rst:314 (original)
+++ module_file_support.rst:314 (suggested, NOT required)
@@ -9,7 +9,7 @@
       # This anonymous spec selects any package that
       # depends on mpi. The double colon at the
       # end clears the set of rules that matched so far.
-      ^mpi::
+      '^mpi:':
         environment:
           prepend_path:
             PATH: "{^mpi.prefix}/bin"
```

And we nearly always want to ignore them.

- [x] add a regular expression to catch this in diffs reported by `format-rst.py`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
