### PR TITLE
binary_distribution: remove MirrorForSpec

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -200,18 +200,6 @@ class BinaryCacheIndex:
 
             self._index_file_cache_initialized = True
 
-    def clear(self):
-        """For testing purposes we need to be able to empty the cache and
-        clear associated data structures."""
-        if self._index_file_cache:
-            self._index_file_cache.destroy()
-            self._index_file_cache = file_cache.FileCache(self._index_cache_root)
-        self._local_index_cache = {}
-        self._specs_already_associated = set()
-        self._last_fetch_times = {}
-        self._mirrors_for_spec = {}
-        self._known_specs = {}
-
     def _write_local_index_cache(self):
         self._init_local_index_cache()
         cache_key = self._index_contents_key
@@ -2211,10 +2199,6 @@ def update_cache_and_get_specs():
     """
     BINARY_INDEX.update()
     return BINARY_INDEX.get_all_built_specs()
-
-
-def clear_spec_cache():
-    BINARY_INDEX.clear()
 
 
 def get_keys(

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -92,7 +92,6 @@ from .url_buildcache import (
     BuildcacheManifest,
     InvalidMetadataFile,
     ListMirrorSpecsError,
-    MirrorForSpec,
     MirrorURLAndVersion,
     URLBuildcacheEntry,
     get_entries_from_cache,
@@ -159,10 +158,6 @@ class BinaryCacheIndex:
     At the moment, everything in this class is initialized as lazily as
     possible, so that it avoids slowing anything in spack down until
     absolutely necessary.
-
-    TODO: What's the cost if, e.g., we realize in the middle of a spack
-    install that the cache is out of date, and we fetch directly?  Does it
-    mean we should have paid the price to update the cache earlier?
     """
 
     def __init__(self, cache_root: Optional[str] = None):
@@ -184,12 +179,12 @@ class BinaryCacheIndex:
 
         # mapping from mirror urls to the time.time() of the last index fetch and a bool indicating
         # whether the fetch succeeded or not.
-        self._last_fetch_times: Dict[MirrorURLAndVersion, float] = {}
+        self._last_fetch_times: Dict[MirrorURLAndVersion, Tuple[float, bool]] = {}
 
-        # _mirrors_for_spec is a dictionary mapping DAG hashes to lists of
-        # entries indicating mirrors where that concrete spec can be found.
-        # Each entry is a MirrorURLAndVersion.
-        self._mirrors_for_spec: Dict[str, List[MirrorForSpec]] = {}
+        #: Dictionary mapping DAG hashes of specs to Spec objects
+        self._known_specs: Dict[str, spack.spec.Spec] = {}
+        #: Dictionary mapping DAG hashes of specs to a list of mirrors where they can be found
+        self._mirrors_for_spec: Dict[str, List[MirrorURLAndVersion]] = {}
 
     def _init_local_index_cache(self):
         if not self._index_file_cache_initialized:
@@ -215,6 +210,7 @@ class BinaryCacheIndex:
         self._specs_already_associated = set()
         self._last_fetch_times = {}
         self._mirrors_for_spec = {}
+        self._known_specs = {}
 
     def _write_local_index_cache(self):
         self._init_local_index_cache()
@@ -232,6 +228,7 @@ class BinaryCacheIndex:
         if clear_existing:
             self._specs_already_associated = set()
             self._mirrors_for_spec = {}
+            self._known_specs = {}
 
         for url_and_version in self._local_index_cache:
             cache_entry = self._local_index_cache[url_and_version]
@@ -244,9 +241,6 @@ class BinaryCacheIndex:
                 self._specs_already_associated.add(cached_index_hash)
 
     def _associate_built_specs_with_mirror(self, cache_key, url_and_version: MirrorURLAndVersion):
-        mirror_url = url_and_version.url
-        layout_version = url_and_version.version
-
         with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
             db = BuildCacheDatabase(tmpdir)
 
@@ -257,8 +251,8 @@ class BinaryCacheIndex:
                     db._read_from_file(pathlib.Path(cache_path))
             except spack.database.InvalidDatabaseVersionError as e:
                 tty.warn(
-                    "you need a newer Spack version to read the buildcache index "
-                    f"for the following v{layout_version} mirror: '{mirror_url}'. "
+                    "you need a newer Spack version to read the buildcache index for the "
+                    f"following v{url_and_version.version} mirror: '{url_and_version.url}'. "
                     f"{e.database_version_message}"
                 )
                 return
@@ -270,104 +264,56 @@ class BinaryCacheIndex:
                 if s.external or db._data[s.dag_hash()].in_buildcache
             ]
 
-            for indexed_spec in spec_list:
-                dag_hash = indexed_spec.dag_hash()
+            for spec in spec_list:
+                dag_hash = spec.dag_hash()
+                mirrors = self._mirrors_for_spec.get(dag_hash)
 
-                if dag_hash not in self._mirrors_for_spec:
-                    self._mirrors_for_spec[dag_hash] = []
+                if mirrors is None:
+                    self._mirrors_for_spec[dag_hash] = [url_and_version]
+                    self._known_specs[dag_hash] = spec
+                elif url_and_version not in mirrors:
+                    mirrors.append(url_and_version)
 
-                for entry in self._mirrors_for_spec[dag_hash]:
-                    # A binary mirror can only have one spec per DAG hash, so
-                    # if we already have an entry under this DAG hash for this
-                    # mirror url/layout version, we're done.
-                    if (
-                        entry.url_and_version.url == mirror_url
-                        and entry.url_and_version.version == layout_version
-                    ):
-                        break
-                else:
-                    self._mirrors_for_spec[dag_hash].append(
-                        MirrorForSpec(url_and_version, indexed_spec)
-                    )
+    def get_all_built_specs(self) -> List[spack.spec.Spec]:
+        """Returns a list of all concrete specs known to be available in a binary cache."""
+        return list(self._known_specs.values())
 
-    def get_all_built_specs(self):
-        spec_list = []
-        for dag_hash in self._mirrors_for_spec:
-            # in the absence of further information, all concrete specs
-            # with the same DAG hash are equivalent, so we can just
-            # return the first one in the list.
-            if len(self._mirrors_for_spec[dag_hash]) > 0:
-                spec_list.append(self._mirrors_for_spec[dag_hash][0].spec)
+    def find_built_spec(self, spec: spack.spec.Spec) -> List[MirrorURLAndVersion]:
+        """Returns a list of MirrorURLAndVersion objects indicating which mirrors have the given
+        concrete spec.
 
-        return spec_list
-
-    def find_built_spec(self, spec, mirrors_to_check=None):
-        """Look in our cache for the built spec corresponding to ``spec``.
-
-        If the spec can be found among the configured binary mirrors, a
-        list is returned that contains the concrete spec and the mirror url
-        of each mirror where it can be found.  Otherwise, ``None`` is
-        returned.
-
-        This method does not trigger reading anything from remote mirrors, but
-        rather just checks if the concrete spec is found within the cache.
+        This method does not trigger reading anything from remote mirrors, but rather just checks
+        if the concrete spec is found within the cache.
 
         The cache can be updated by calling ``update()`` on the cache.
 
         Args:
-            spec (spack.spec.Spec): Concrete spec to find
-            mirrors_to_check: Optional mapping containing mirrors to check.  If
-                None, just assumes all configured mirrors.
-
-        Returns:
-            An list of objects containing the found specs and mirror url where
-            each can be found, e.g.::
-
-                [
-                    {
-                        "spec": "<concrete-spec>",
-                        "mirror_url": "<mirror-root-url>"
-                    }
-                ]
+            spec: Concrete spec to find
         """
-        return self.find_by_hash(spec.dag_hash(), mirrors_to_check=mirrors_to_check)
+        return self.find_by_hash(spec.dag_hash())
 
-    def find_by_hash(self, find_hash, mirrors_to_check=None):
+    def find_by_hash(self, dag_hash: str) -> List[MirrorURLAndVersion]:
         """Same as find_built_spec but uses the hash of a spec.
 
         Args:
-            find_hash (str): hash of the spec to search
-            mirrors_to_check: Optional mapping containing mirrors to check.  If
-                None, just assumes all configured mirrors.
+            dag_hash: hash of the spec to search
         """
-        if find_hash not in self._mirrors_for_spec:
-            return []
-        results = self._mirrors_for_spec[find_hash]
-        if not mirrors_to_check:
-            return results
-        mirror_urls = mirrors_to_check.values()
-        return [r for r in results if r.url_and_version.url in mirror_urls]
+        return self._mirrors_for_spec.get(dag_hash, [])
 
-    def update_spec(self, spec: spack.spec.Spec, found_list: List[MirrorForSpec]):
-        """
-        Take list of ``{"mirror_url": m, "spec": s}`` objects and update the local
-        ``built_spec_cache``.
-        """
+    def update_spec(self, spec: spack.spec.Spec, found_list: List[MirrorURLAndVersion]) -> None:
+        """Update the cache with a new list of mirrors for a given spec."""
         spec_dag_hash = spec.dag_hash()
 
         if spec_dag_hash not in self._mirrors_for_spec:
             self._mirrors_for_spec[spec_dag_hash] = found_list
+            self._known_specs[spec_dag_hash] = spec
         else:
             current_list = self._mirrors_for_spec[spec_dag_hash]
             for new_entry in found_list:
-                for cur_entry in current_list:
-                    if new_entry.url_and_version == cur_entry.url_and_version:
-                        cur_entry.spec = new_entry.spec
-                        break
-                else:
-                    current_list.append(MirrorForSpec(new_entry.url_and_version, new_entry.spec))
+                if new_entry not in current_list:
+                    current_list.append(new_entry)
 
-    def update(self, with_cooldown=False):
+    def update(self, with_cooldown: bool = False) -> None:
         """Make sure local cache of buildcache index files is up to date.
         If the same mirrors are configured as the last time this was called
         and none of the remote buildcache indices have changed, calling this
@@ -1713,17 +1659,15 @@ def try_fetch(url_to_fetch):
 def download_tarball(
     spec: spack.spec.Spec,
     unsigned: Optional[bool] = False,
-    mirrors_for_spec: Optional[List[MirrorForSpec]] = None,
+    mirrors_for_spec: Optional[List[MirrorURLAndVersion]] = None,
 ) -> Optional[spack.stage.Stage]:
     """Download binary tarball for given package
 
     Args:
         spec: a concrete spec
         unsigned: if ``True`` or ``False`` override the mirror signature verification defaults
-        mirrors_for_spec (list): Optional list of concrete specs and mirrors
-            obtained by calling binary_distribution.get_mirrors_for_spec().
-            These will be checked in order first before looking in other
-            configured mirrors.
+        mirrors_for_spec: Optional list of mirrors known to have the spec. These will be checked
+            in order first before looking in other configured mirrors.
 
     Returns:
         ``None`` if the tarball could not be downloaded, the signature verified
@@ -1745,7 +1689,7 @@ def download_tarball(
     # look in all configured mirrors if needed, as maybe the spec
     # we need was in an un-indexed mirror.  No need to check any
     # mirror for the spec twice though.
-    try_first = [i.url_and_version for i in mirrors_for_spec] if mirrors_for_spec else []
+    try_first = mirrors_for_spec or []
     try_next = [
         MirrorURLAndVersion(mirror.fetch_url, layout)
         for mirror in configured_mirrors
@@ -2193,12 +2137,10 @@ def install_single_spec(spec, unsigned=False, force=False):
         install_root_node(node, unsigned=unsigned, force=force)
 
 
-def try_direct_fetch(spec, mirrors=None):
-    """
-    Try to find the spec directly on the configured mirrors
-    """
-    found_specs: List[MirrorForSpec] = []
-    binary_mirrors = spack.mirrors.mirror.MirrorCollection(mirrors=mirrors, binary=True).values()
+def try_direct_fetch(spec: spack.spec.Spec) -> List[MirrorURLAndVersion]:
+    """Try to find the spec directly on the configured mirrors"""
+    found_specs: List[MirrorURLAndVersion] = []
+    binary_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True).values()
 
     for layout_version in SUPPORTED_LAYOUT_VERSIONS:
         for mirror in binary_mirrors:
@@ -2221,42 +2163,33 @@ def try_direct_fetch(spec, mirrors=None):
             fetched_spec = spack.spec.Spec.from_dict(spec_dict)
             fetched_spec._mark_concrete()
 
-            found_specs.append(
-                MirrorForSpec(MirrorURLAndVersion(mirror.fetch_url, layout_version), fetched_spec)
-            )
+            found_specs.append(MirrorURLAndVersion(mirror.fetch_url, layout_version))
 
     return found_specs
 
 
-def get_mirrors_for_spec(spec=None, mirrors_to_check=None, index_only=False):
+def get_mirrors_for_spec(
+    spec: spack.spec.Spec, index_only: bool = False
+) -> List[MirrorURLAndVersion]:
     """
-    Check if concrete spec exists on mirrors and return a list
-    indicating the mirrors on which it can be found
+    Check if concrete spec exists on mirrors and return a list indicating the mirrors on which it
+    can be found
 
     Args:
-        spec (spack.spec.Spec): The spec to look for in binary mirrors
-        mirrors_to_check (dict): Optionally override the configured mirrors
-            with the mirrors in this dictionary.
-        index_only (bool): When ``index_only`` is set to ``True``, only the local
-            cache is checked, no requests are made.
-
-    Return:
-        A list of objects, each containing a ``mirror_url`` and ``spec`` key
-        indicating all mirrors where the spec can be found.
+        spec: The spec to look for in binary mirrors
+        index_only: When ``index_only`` is set to ``True``, only the local cache is checked, no
+            requests are made.
     """
-    if spec is None:
+    if not spack.mirrors.mirror.MirrorCollection(binary=True):
+        tty.debug("No Spack mirrors are currently configured")
         return []
 
-    if not spack.mirrors.mirror.MirrorCollection(mirrors=mirrors_to_check, binary=True):
-        tty.debug("No Spack mirrors are currently configured")
-        return {}
-
-    results = BINARY_INDEX.find_built_spec(spec, mirrors_to_check=mirrors_to_check)
+    results = BINARY_INDEX.find_built_spec(spec)
 
     # The index may be out-of-date. If we aren't only considering indices, try
     # to fetch directly since we know where the file should be.
     if not results and not index_only:
-        results = try_direct_fetch(spec, mirrors=mirrors_to_check)
+        results = try_direct_fetch(spec)
         # We found a spec by the direct fetch approach, we might as well
         # add it to our mapping.
         if results:

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -255,9 +255,7 @@ def create_already_built_pruner(check_index_only: bool = True) -> PrunerCallback
         if not spec_locations:
             return RebuildDecision(True, "not found anywhere")
 
-        urls = ",".join(
-            [f"{loc.url_and_version.url}@v{loc.url_and_version.version}" for loc in spec_locations]
-        )
+        urls = ",".join(f"{loc.url}@v{loc.version}" for loc in spec_locations)
         message = f"up-to-date [{urls}]"
         return RebuildDecision(False, message)
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -457,7 +457,7 @@ def ci_rebuild(args):
         # jobs in subsequent stages.
         tty.msg("No need to rebuild {0}, found hash match at: ".format(job_spec_pkg_name))
         for match in matches:
-            tty.msg("    {0}".format(match.url_and_version.url))
+            tty.msg("    {0}".format(match.url))
 
         # Now we are done and successful
         return 0

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -446,7 +446,7 @@ def _process_binary_cache_tarball(
         pkg: the package being installed
         explicit: the package was explicitly requested by the user
         unsigned: if ``True`` or ``False`` override the mirror signature verification defaults
-        mirrors_for_spec: Optional list of concrete specs and mirrors
+        mirrors_for_spec: Optional list of mirrors to look for the spec.
         obtained by calling binary_distribution.get_mirrors_for_spec().
         timer: timer to keep track of binary install phases.
 
@@ -502,10 +502,10 @@ def _try_install_from_binary_cache(
     tty.debug(f"Searching for binary cache of {package_id(pkg.spec)}")
 
     with timer.measure("search"):
-        matches = binary_distribution.get_mirrors_for_spec(pkg.spec, index_only=True)
+        mirrors = binary_distribution.get_mirrors_for_spec(pkg.spec, index_only=True)
 
     return _process_binary_cache_tarball(
-        pkg, explicit, unsigned, mirrors_for_spec=matches, timer=timer
+        pkg, explicit, unsigned, mirrors_for_spec=mirrors, timer=timer
     )
 
 

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -182,7 +182,8 @@ def test_built_spec_cache(install_mockery, tmp_path: pathlib.Path):
 
     for s in [gspec, cspec]:
         results = spack.binary_distribution.get_mirrors_for_spec(s)
-        assert any([r.spec == s for r in results])
+        assert len(results) == 1
+        assert results[0].url == url_util.path_to_file_url(str(tmp_path))
 
 
 def fake_dag_hash(spec, length=None):

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -427,7 +427,7 @@ class URLBuildcacheEntry:
         magic_string = "-----BEGIN PGP SIGNED MESSAGE-----"
         if manifest_contents.startswith(magic_string):
             if verify:
-                # Rry to verify and raise if we fail
+                # Try to verify and raise if we fail
                 with TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
                     manifest_path = os.path.join(tmpdir, "manifest.json.sig")
                     with open(manifest_path, "w", encoding="utf-8") as fd:
@@ -436,10 +436,9 @@ class URLBuildcacheEntry:
                         raise NoVerifyException("Signature could not be verified")
 
             return spack.spec.Spec.extract_json_from_clearsig(manifest_contents)
-        else:
-            if verify:
-                raise NoVerifyException("Required signature was not found on manifest")
-            return json.loads(manifest_contents)
+        elif verify:
+            raise NoVerifyException("Required signature was not found on manifest")
+        return json.loads(manifest_contents)
 
     def read_manifest(self, manifest_url: Optional[str] = None) -> BuildcacheManifest:
         """Read and process the the buildcache entry manifest.
@@ -1363,8 +1362,7 @@ class MirrorURLAndVersion:
     track of downloaded/processed buildcache index files from remote mirrors
     in some layout version."""
 
-    url: str
-    version: int
+    __slots__ = ("url", "version")
 
     def __init__(self, url: str, version: int):
         self.url = url
@@ -1374,9 +1372,9 @@ class MirrorURLAndVersion:
         return f"{self.url}__v{self.version}"
 
     def __eq__(self, other):
-        if isinstance(other, MirrorURLAndVersion):
-            return self.url == other.url and self.version == other.version
-        return False
+        if not isinstance(other, MirrorURLAndVersion):
+            return NotImplemented
+        return self.url == other.url and self.version == other.version
 
     def __hash__(self):
         return hash((self.url, self.version))
@@ -1385,18 +1383,6 @@ class MirrorURLAndVersion:
     def from_string(cls, s: str):
         parts = s.split("__v")
         return cls(parts[0], int(parts[1]))
-
-
-class MirrorForSpec:
-    """Simple holder for a mirror (represented by a url and a layout version) and
-    an associated concrete spec"""
-
-    url_and_version: MirrorURLAndVersion
-    spec: spack.spec.Spec
-
-    def __init__(self, url_and_version: MirrorURLAndVersion, spec: spack.spec.Spec):
-        self.url_and_version = url_and_version
-        self.spec = spec
 
 
 class InvalidMetadataFile(spack.error.SpackError):


### PR DESCRIPTION
Partially extracted from #51434 

Currently `BinaryCacheIndex._mirrors_for_spec` is a mapping of dag hash
to a list of `MirrorForSpec` (basically tuple of mirror and spec). However,
by design this is always the same unique spec. Instead, make it data oriented
and remove the `MirrorForSpec` intermediate object, which is more efficient
as a data structure and simplifies code.

Secondly, remove `mirrors_to_check` as an argument, which had a bug but
is ultimately unused.

Also sprinkle various type hints.

