### PR TITLE
solver: reduce items in edge optimizations

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2265,6 +2265,7 @@ opt_criterion(2, "providers on edges").
 #minimize{
     Weight@2,ParentNode,ProviderNode,node(X, Virtual)
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
+      max_dupes(Virtual, MaxDupes), MaxDupes > 1,
       not attr("root", ProviderNode),
       language(Virtual),
       depends_on(ParentNode, ProviderNode)
@@ -2275,10 +2276,11 @@ opt_criterion(1, "version badness on edges").
 #minimize{ 0@201: #true }.
 #minimize{ 0@1: #true }.
 #minimize{
-    Weight@1,ParentNode,PackageNode
-    : version_weight(PackageNode, Weight),
-      not attr("root", PackageNode),
-      depends_on(ParentNode, PackageNode)
+    Weight@1,ParentNode,node(X, Package)
+    : version_weight(node(X, Package), Weight),
+      multiple_unification_sets(Package),
+      not attr("root", node(X, Package)),
+      depends_on(ParentNode, node(X, Package))
 }.
 
 % Reduce symmetry on duplicates


### PR DESCRIPTION
Edge optimizations are a tie-breaker only for nodes that are allowed to have duplicates. As such, we can reduce the number of items entering the minimizations only to the ones that might be duplicated.

* **Spack:** 1.1.0.dev0 (https://github.com/spack/spack/commit/b1ed39ae38e8c6939eeb7bdf3f2920984445975b)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/65fb65e7ac15bdc8ccc70136136d2fb79a6969d9
* **Python:** 3.13.2
* **Platform:** linux-ubuntu20.04-icelake

[radiuss.optimization.csv](https://github.com/user-attachments/files/23315563/radiuss.optimization.csv)
[radiuss.develop.csv](https://github.com/user-attachments/files/23315566/radiuss.develop.csv)

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/c939f8be-7e74-4814-9f92-f2245fa8613a" />


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
