### PR TITLE
solver: fix a bug in the initialization of the static analyzer

### DIFF
--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -259,9 +259,9 @@ class StaticAnalysis(NoStaticAnalysis):
         store: spack.store.Store,
         binary_index: spack.binary_distribution.BinaryCacheIndex,
     ):
-        super().__init__(configuration=configuration, repo=repo)
         self.store = store
         self.binary_index = binary_index
+        super().__init__(configuration=configuration, repo=repo)
 
     @lang.memoized
     def providers_for(self, virtual_str: str) -> List[spack.spec.Spec]:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4344,7 +4344,7 @@ def test_env_include_packages_url(
     """Test inclusion of a (GitHub) URL."""
     develop_url = "https://github.com/fake/fake/blob/develop/"
     default_packages = develop_url + "etc/fake/defaults/packages.yaml"
-    sha256 = "8b3f2438e920d204949ff12c542805765e2bcef2e2fa06d80f08f65f56d7e44a"
+    sha256 = "8d428c600b215e3b4a207a08236659dfc2c9ae2782c35943a00ee4204a135702"
     spack_yaml = tmp_path / "spack.yaml"
     with open(spack_yaml, "w", encoding="utf-8") as f:
         f.write(

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -87,3 +87,5 @@ packages:
           compilers:
             c: /path/bin/clang
             cxx: /path/bin/clang++
+  glibc:
+    buildable: false

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1537,11 +1537,11 @@ spack:
   - fftw~mpi
 """,
         """
-    spack:
-      specs:
-      - ascent+adios2
-      - fftw~mpi
-    """,
+spack:
+  specs:
+  - ascent+adios2
+  - fftw~mpi
+""",
     ],
 )
 def test_static_analysis_in_environments(spack_yaml, tmp_path, mutable_config):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1509,3 +1509,52 @@ spack:
     with ev.Environment(tmp_path) as e:
         with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="failed to concretize"):
             e.concretize()
+
+
+@pytest.mark.parametrize(
+    "spack_yaml",
+    [
+        # Specs with reuse on
+        """
+spack:
+  specs:
+  - trilinos
+  - mpileaks
+  concretizer:
+    reuse: true
+""",
+        # Package with conditional dependency
+        """
+spack:
+  specs:
+  - ascent+adios2
+  - fftw+mpi
+""",
+        """
+spack:
+  specs:
+  - ascent~adios2
+  - fftw~mpi
+""",
+        """
+    spack:
+      specs:
+      - ascent+adios2
+      - fftw~mpi
+    """,
+    ],
+)
+def test_static_analysis_in_environments(spack_yaml, tmp_path, mutable_config):
+    """Tests that concretizations with and without static analysis produce the same results."""
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(spack_yaml)
+    with ev.Environment(tmp_path) as e:
+        e.concretize()
+        no_static_analysis = {x.dag_hash() for x in e.concrete_roots()}
+
+    mutable_config.set("concretizer:static_analysis", True)
+    with ev.Environment(tmp_path) as e:
+        e.concretize()
+        static_analysis = {x.dag_hash() for x in e.concrete_roots()}
+
+    assert no_static_analysis == static_analysis

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -53,9 +53,9 @@ def test_rfc_remote_local_path_no_dest():
 
 
 packages_yaml_sha256 = (
-    "8b3f2438e920d204949ff12c542805765e2bcef2e2fa06d80f08f65f56d7e44a"
+    "8d428c600b215e3b4a207a08236659dfc2c9ae2782c35943a00ee4204a135702"
     if sys.platform != "win32"
-    else "a6cc145ade51aa03583392d9d58ea13c5c525c8147c31fde4cbe2114e5471818"
+    else "6c094ec3ee1eb5068860cdd97d8da965bf281be29e60ab9afc8f6e4d72d24f21"
 )
 
 


### PR DESCRIPTION
In some cases the static analyzer might need to access self.store before it's set. Fix this by moving the call to super() after self.store initialization.

Also, adds unit tests

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
