### PR TITLE
Check for 'commit' variant only if not developing

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3936,7 +3936,7 @@ def _specs_with_commits(spec):
 
     pkg_class._resolve_git_provenance(spec)
 
-    if "commit" not in spec.variants:
+    if "commit" not in spec.variants and not spec.is_develop:
         tty.warn(
             f"Unable to resolve the git commit for {spec.name}. "
             "An installation of this binary won't have complete binary provenance."


### PR DESCRIPTION
Remove warning for develop specs since they control their own source provenance

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
