### PR TITLE
`config`: use `prefer_modify: true` to adjust edit preferences

### DIFF
--- a/etc/spack/include.yaml
+++ b/etc/spack/include.yaml
@@ -4,6 +4,7 @@ include:
     path_override_env_var: SPACK_USER_CONFIG_PATH
     path: "~/.spack"
     optional: true
+    prefer_modify: true
     when: '"SPACK_DISABLE_LOCAL_CONFIG" not in env'
 
   # site configuration scope

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -81,6 +81,9 @@ We would then configure the ``include.yaml`` file as follows:
 
 If the condition is satisfied, then the ``main`` branch of the repository will be cloned and the settings for the two files integrated into Spack's configuration.
 
+.. versionadded:: 1.1
+   ``git:``, ``branch:``, ``commit:``, and ``tag:`` attributes.
+
 Precedence
 ~~~~~~~~~~
 
@@ -96,11 +99,28 @@ If you want one file to take precedence over another, you can put the include wi
    - git: https://github.com/org/git-repo-scope
      commit: 95c59784bd02ea248bf905d79d063df38e087b19
 
+``prefer_modify``
+^^^^^^^^^^^^^^^^^
+
+When you use commands like ``spack compiler find``, ``spack external find``, ``spack config edit`` or ``spack config add``, they modify the topmost writable scope in the current configuration.
+Scopes can tell Spack to prefer to edit their included scopes instead, using ``prefer_modify``:
+
+.. code-block:: yaml
+
+   include:
+   - name: "preferred"
+     path: /path/to/scope/we/want-to-write
+     prefer_modify: true
+
+Now, if the including scope is the highest precedence scope and would otherwise be selected automatically by one fo these commands, they will instead prefer to edit ``preferred``.
+The including scope can still be modified by using the ``--scope`` argument (e.g., ``spack compiler find --scope NAME``).
+
 .. warning::
 
    Recursive includes are not currently processed in a breadth-first manner, so the value of a configuration option that is altered by multiple included files may not be what you expect.
    This will be addressed in a future update.
 
+.. versionadded:: 1.1 The ``prefer_modify:`` attribute.
 
 Overriding local paths
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -119,6 +139,9 @@ If not, Spack will instead use the ``path:`` specified in configuration.
 .. note::
 
    ``path_override_env_var:`` is currently only supported for ``path:`` includes, not ``git:`` includes.
+
+.. versionadded:: 1.1
+   The ``path_override_env_var:`` attribute.
 
 Named configuration scopes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -209,6 +232,9 @@ The newly included ``user`` scope will *completely* override the builtin ``user`
 
    Using ``name:`` to override the ``defaults`` scope can have *very* unexpected consequences and is not advised.
 
+.. versionadded:: 1.1
+   The ``name:`` attribute.
+
 Overriding built-in scopes with ``include::``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -240,3 +266,6 @@ You can see that ``spack``, ``user``, and ``site`` are overridden::
 And if you run ``spack config blame``, the settings from these scopes will no longer show up.
 ``defaults`` are not overridden as they are needed by Spack to function.
 This allows you to create completely isolated environments that do not bring in external settings.
+
+.. versionadded:: 1.1
+   ``include::`` with two colons for overriding.

--- a/lib/spack/spack/schema/include.py
+++ b/lib/spack/spack/schema/include.py
@@ -28,6 +28,7 @@ properties: Dict[str, Any] = {
                         "path": {"type": "string"},
                         "sha256": {"type": "string"},
                         "optional": {"type": "boolean"},
+                        "prefer_modify": {"type": "boolean"},
                     },
                     "required": ["path"],
                     "additionalProperties": False,

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1271,6 +1271,8 @@ def include_config_factory(mock_include_scope):
 
 
 def test_modify_scope_precedence(working_env, include_config_factory, tmp_path):
+    """Test how spack selects the scope to modify when commands write config."""
+
     cfg = include_config_factory()
 
     # ensure highest precedence writable scope is selected by default
@@ -1278,7 +1280,9 @@ def test_modify_scope_precedence(working_env, include_config_factory, tmp_path):
 
     include_yaml = tmp_path / "include.yaml"
     subdir = tmp_path / "subdir"
+    subdir2 = tmp_path / "subdir2"
     subdir.mkdir()
+    subdir2.mkdir()
 
     with include_yaml.open("w", encoding="utf-8") as f:
         f.write(
@@ -1320,6 +1324,30 @@ def test_modify_scope_precedence(working_env, include_config_factory, tmp_path):
 
     # if the top scope prefers another, ensure it is selected
     assert cfg.highest_precedence_scope().name == "subdir"
+
+    cfg.remove_scope("override")
+
+    with include_yaml.open("w", encoding="utf-8") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+                include::
+                  - name: "subdir"
+                    path: "subdir"
+                  - name: "subdir2"
+                    path: "subdir2"
+                    prefer_modify: true
+                """
+            )
+        )
+
+    cfg.push_scope(
+        spack.config.DirectoryConfigScope("override", str(tmp_path)),
+        priority=ConfigScopePriority.CONFIG_FILES,
+    )
+
+    # if there are multiple scopes and one is preferred, make sure it's that one
+    assert cfg.highest_precedence_scope().name == "subdir2"
 
 
 def test_local_config_can_be_disabled(working_env, include_config_factory):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1270,6 +1270,58 @@ def include_config_factory(mock_include_scope):
     yield make_config
 
 
+def test_modify_scope_precedence(working_env, include_config_factory, tmp_path):
+    cfg = include_config_factory()
+
+    # ensure highest precedence writable scope is selected by default
+    assert cfg.highest_precedence_scope().name == "tmp_path"
+
+    include_yaml = tmp_path / "include.yaml"
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+
+    with include_yaml.open("w", encoding="utf-8") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+                include::
+                  - name: "subdir"
+                    path: "subdir"
+                """
+            )
+        )
+
+    cfg.push_scope(
+        spack.config.DirectoryConfigScope("override", str(tmp_path)),
+        priority=ConfigScopePriority.CONFIG_FILES,
+    )
+
+    # ensure override scope is selected when it is on top
+    assert cfg.highest_precedence_scope().name == "override"
+
+    cfg.remove_scope("override")
+
+    with include_yaml.open("w", encoding="utf-8") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+                include::
+                  - name: "subdir"
+                    path: "subdir"
+                    prefer_modify: true
+                """
+            )
+        )
+
+    cfg.push_scope(
+        spack.config.DirectoryConfigScope("override", str(tmp_path)),
+        priority=ConfigScopePriority.CONFIG_FILES,
+    )
+
+    # if the top scope prefers another, ensure it is selected
+    assert cfg.highest_precedence_scope().name == "subdir"
+
+
 def test_local_config_can_be_disabled(working_env, include_config_factory):
     """Ensure that SPACK_DISABLE_LOCAL_CONFIG disables configurations with `when:`."""
     os.environ["SPACK_DISABLE_LOCAL_CONFIG"] = "true"


### PR DESCRIPTION
#51162 allows users to specify configuration scopes as configuration, but it also changes the `spack` scope to be the default edit scope. This can be extremely confusing to users, as it causes `spack compiler find`, `spack external find`, `spack config add`, etc. to be written into the spack instance by default instead of into `~/.spack`.

`~/.spack` is a better choice if it's configured, as we do not know if the user actually owns the spack instance. It's also what people are used to, and it's going to cause a lot of consternation if we switch this default up on people.

This PR introduces a new `prefer_modify: true` option on `include:` that allows the including scope to hand off edit precedence to an included scope. The including scope is still modifiable if specified explicitly by name (e.g., `--scope spack`) but if it is selected by default, we'll edit its `prefer_modify` scope instead.

- [x] Add `prefer_modify:` option to `include:`
- [x] Make the default `spack` scope specify the user scope as `prefer_modify:`.
- [x] Add documentation and update `include:` docs with `versionadded` directives.
- [x] make the `user` scope `prefer_modify:` in `$spack/etc/spack/include.yaml`
