### PR TITLE
Reduce overhead of `spack install pkg` for develop environments.

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -344,6 +344,9 @@ def _maybe_add_and_concretize(args, env, specs):
     if args.only_concrete:
         return
 
+    if not args.add and not env.needs_concretize():
+        return
+
     # Otherwise, we will modify the environment.
     with env.write_transaction():
         # `spack add` adds these specs.

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -51,7 +51,7 @@ class Dependency:
         assert isinstance(spec, spack.spec.Spec)
 
         self.pkg = pkg
-        self.spec = spec.copy()
+        self._spec = spec
 
         # This dict maps condition specs to lists of Patch objects, just
         # as the patches dict on packages does.
@@ -59,13 +59,18 @@ class Dependency:
         self.depflag = depflag
 
     @property
+    def spec(self):
+        return self._spec
+
+    @property
     def name(self) -> str:
         """Get the name of the dependency package."""
-        return self.spec.name
+        return self._spec.name
 
     def merge(self, other: "Dependency"):
         """Merge constraints, deptypes, and patches of other into self."""
-        self.spec.constrain(other.spec)
+        self._spec = self._spec.copy()
+        self._spec.constrain(other.spec)
         self.depflag |= other.depflag
 
         # concatenate patch lists, or just copy them in
@@ -76,9 +81,13 @@ class Dependency:
             else:
                 self.patches[cond] = other.patches[cond]
 
+    def constrain(self, spec, deps):
+        self._spec = self._spec.copy()
+        return self._spec.constrain(spec, deps=False)
+
     def __repr__(self) -> str:
         types = dt.flag_to_chars(self.depflag)
         if self.patches:
-            return f"<Dependency: {self.pkg.name} -> {self.spec} [{types}, {self.patches}]>"
+            return f"<Dependency: {self.pkg.name} -> {self._spec} [{types}, {self.patches}]>"
         else:
-            return f"<Dependency: {self.pkg.name} -> {self.spec} [{types}]>"
+            return f"<Dependency: {self.pkg.name} -> {self._spec} [{types}]>"

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -128,7 +128,7 @@ def _make_when_spec(value: WhenType) -> Optional[spack.spec.Spec]:
         return spack.spec.Spec()
 
     # This is conditional on the spec
-    return spack.spec.Spec(value)
+    return spack.spec.Spec.get_spec(value)
 
 
 SubmoduleCallback = Callable[[spack.package_base.PackageBase], Union[str, List[str], bool]]
@@ -314,7 +314,7 @@ def _depends_on(
         dependency = Dependency(pkg, spec, depflag=depflag)
         deps_by_name[spec.name] = dependency
     else:
-        dependency.spec.constrain(spec, deps=False)
+        dependency.constrain(spec, deps=False)
         dependency.depflag |= depflag
 
     # apply patches to the dependency
@@ -350,7 +350,7 @@ def conflicts(conflict_spec: SpecType, when: WhenType = None, msg: Optional[str]
         # Save in a list the conflicts and the associated custom messages
         conflict_spec_list = pkg.conflicts.setdefault(when_spec, [])
         msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
-        conflict_spec_list.append((spack.spec.Spec(conflict_spec), msg_with_name))
+        conflict_spec_list.append((spack.spec.Spec.get_spec(conflict_spec), msg_with_name))
 
     return _execute_conflicts
 
@@ -376,7 +376,7 @@ def depends_on(
         patches: single result of :py:func:`patch` directive, a
             ``str`` to be passed to ``patch``, or a list of these
     """
-    dep_spec = spack.spec.Spec(spec)
+    dep_spec = spack.spec.Spec.get_spec(spec)
 
     def _execute_depends_on(pkg: Type[spack.package_base.PackageBase]):
         _depends_on(pkg, dep_spec, when=when, type=type, patches=patches)
@@ -420,7 +420,7 @@ def _execute_redistribute(
     if not when_spec:
         return
     if source is False:
-        max_constraint = spack.spec.Spec(f"{pkg.name}@{when_spec.versions}")
+        max_constraint = spack.spec.Spec.get_spec(f"{pkg.name}@{when_spec.versions}")
         if not max_constraint.satisfies(when_spec):
             raise DirectiveError("Source distribution can only be disabled for versions")
 
@@ -451,14 +451,14 @@ def extends(spec, when=None, type=("build", "run"), patches=None):
         if not when_spec:
             return
 
-        dep_spec = spack.spec.Spec(spec)
+        dep_spec = spack.spec.Spec.get_spec(spec)
 
         _depends_on(pkg, dep_spec, when=when, type=type, patches=patches)
 
         # When extending python, also add a dependency on python-venv. This is done so that
         # Spack environment views are Python virtual environments.
         if dep_spec.name == "python" and not pkg.name == "python-venv":
-            _depends_on(pkg, spack.spec.Spec("python-venv"), when=when, type=("build", "run"))
+            _depends_on(pkg, spack.spec.Spec.get_spec("python-venv"), when=when, type=("build", "run"))
 
         pkg.extendees[dep_spec.name] = (dep_spec, when_spec)
 
@@ -481,12 +481,13 @@ def provides(*specs: SpecType, when: WhenType = None):
         when_spec = _make_when_spec(when)
         if not when_spec:
             return
+        when_spec = when_spec.copy()
 
         # ``when`` specs for ``provides()`` need a name, as they are used
         # to build the ProviderIndex.
         when_spec.name = pkg.name
 
-        spec_objs = [spack.spec.Spec(x) for x in specs]
+        spec_objs = [spack.spec.Spec.get_spec(x) for x in specs]
         spec_names = [x.name for x in spec_objs]
         if len(spec_names) > 1:
             pkg.provided_together.setdefault(when_spec, []).append(set(spec_names))
@@ -531,7 +532,7 @@ def can_splice(
             )
         if when_spec is None:
             return
-        pkg.splice_specs[when_spec] = (spack.spec.Spec(target), match_variants)
+        pkg.splice_specs[when_spec] = (spack.spec.Spec.get_spec(target), match_variants)
 
     return _execute_can_splice
 
@@ -937,7 +938,7 @@ def requires(
         # Save in a list the requirements and the associated custom messages
         requirement_list = pkg.requirements.setdefault(when_spec, [])
         msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
-        requirements = tuple(spack.spec.Spec(s) for s in requirement_specs)
+        requirements = tuple(spack.spec.Spec.get_spec(s) for s in requirement_specs)
         requirement_list.append((requirements, policy, msg_with_name))
 
     return _execute_requires

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1490,6 +1490,14 @@ class Environment:
         if modified_roots:
             self.write()
 
+    def needs_concretize(self):
+        force = spack.config.get("concretizer:force")
+        if force:
+            return True
+
+        new_user_specs = list(set(self.user_specs) - set(self.concretized_user_specs))
+        return len(new_user_specs) > 0
+
     def concretize(
         self, force: Optional[bool] = None, tests: Union[bool, Sequence] = False
     ) -> Sequence[SpecPair]:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1519,6 +1519,7 @@ def _anonymous_star(dep: DependencySpec, dep_format: str) -> str:
 @lang.lazy_lexicographic_ordering(set_hash=False)
 class Spec:
     compiler = DeprecatedCompilerSpec()
+    spec_cache = {}
 
     @staticmethod
     def default_arch():
@@ -1526,6 +1527,17 @@ class Spec:
         s = Spec()
         s.architecture = ArchSpec.default_arch()
         return s
+
+    @staticmethod
+    def get_spec(spec_like, external_path=None, external_modules=None):
+        cache_key = (spec_like, external_path, external_modules)
+        if cache_key in Spec.spec_cache:
+            return Spec.spec_cache[cache_key]
+
+        result = Spec(spec_like)
+        Spec.spec_cache[cache_key] = result
+
+        return result
 
     def __init__(self, spec_like=None, *, external_path=None, external_modules=None):
         """Create a new Spec.
@@ -1539,9 +1551,15 @@ class Spec:
             external_modules: list of external modules, if this is an external package
                 using modules.
         """
+
         # Copy if spec_like is a Spec.
         if isinstance(spec_like, Spec):
             self._dup(spec_like)
+            return
+
+        cache_key = (spec_like, external_path, external_modules)
+        if cache_key in Spec.spec_cache:
+            self._dup(Spec.spec_cache[cache_key])
             return
 
         # init an empty spec that matches anything.
@@ -1564,6 +1582,9 @@ class Spec:
 
         # Python __hash__ is handled separately from the cached spec hashes
         self._dunder_hash = None
+
+        # Cache for Python __hash__ value, computed lazily
+        self._pyhash = None
 
         # cache of package for this spec
         self._package = None
@@ -1632,11 +1653,13 @@ class Spec:
     def clear_dependencies(self):
         """Trim the dependencies of this spec."""
         self._dependencies.clear()
+        self._pyhash = None
 
     def clear_edges(self):
         """Trim the dependencies and dependents of this spec."""
         self._dependencies.clear()
         self._dependents.clear()
+        self._pyhash = None
 
     def detach(self, deptype="all"):
         """Remove any reference that dependencies have of this node.
@@ -1984,6 +2007,7 @@ class Spec:
         )
         self._dependencies.add(edge)
         dependency_spec._dependents.add(edge)
+        self._pyhash = None
 
     #
     # Public interface
@@ -3170,6 +3194,8 @@ class Spec:
         if other.concrete and not self.concrete and other.satisfies(self):
             self._finalize_concretization()
 
+        self._pyhash = None
+
         return changed
 
     def _constrain_dependencies(self, other: "Spec", resolve_virtuals: bool = True) -> bool:
@@ -3706,6 +3732,7 @@ class Spec:
 
         self.abstract_hash = other.abstract_hash
 
+        self._pyhash = other._pyhash
         if self._concrete:
             self._dunder_hash = other._dunder_hash
             for h in ht.HASHES:
@@ -4609,6 +4636,7 @@ class Spec:
                     if (dep_name not in edge.virtuals) and (not dep_name == edge.spec.name):
                         new_dependencies.add(edge)
             spec._dependencies = new_dependencies
+            spec._pyhash = None
 
     def _virtuals_provided(self, root):
         """Return set of virtuals provided by self in the context of root"""
@@ -4860,6 +4888,7 @@ class Spec:
         """
         Clears all cached hashes in a Spec, while preserving other properties.
         """
+        self._pyhash = None
         for h in ht.HASHES:
             if h.attr not in ignore:
                 if hasattr(self, h.attr):
@@ -4877,10 +4906,15 @@ class Spec:
                 self._dunder_hash = self.dag_hash_bit_prefix(64)
             return self._dunder_hash
 
+        if self._pyhash:
+            return self._pyhash
+
         # This is the normal hash for lazy_lexicographic_ordering. It's
         # slow for large specs because it traverses the whole spec graph,
         # so we hope it only runs on abstract specs, which are small.
-        return hash(lang.tuplify(self._cmp_iter))
+        result = hash(lang.tuplify(self._cmp_iter))
+        self._pyhash = result
+        return result
 
     def __reduce__(self):
         return Spec.from_dict, (self.to_dict(hash=ht.dag_hash),)


### PR DESCRIPTION
We are moving to using spack to drive day to day development of a group of related packages. In the process we have noticed that there is a someoverhead running some commands like `spack install` for an incremental build where only a small number of files in one or two packages were modified when compared to directly running the packages build system.

Combined with #51367 and the reduced install task sleep time from #51491 this reduces the time for a no-op install of a development environment with 94 packages (including dependencies) from 8s to 2.8s for me. It also provides a similar reduction in time for `spack build-env --dump env.txt mypkg` which we frequently use to start a shell with the build environment.

@psakievich 