### PR TITLE
schema/ci: fix comment typo/sentence length

### DIFF
--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -82,7 +82,7 @@ dynamic_mapping_schema = {
             "required": ["endpoint"],
             "properties": {
                 "name": {"type": "string"},
-                # "endpoint" cannot have http patternProperties constaint as it is a required field
+                # "endpoint" cannot have http patternProperties constraint since it is required
                 # Constrain is applied in code
                 "endpoint": {"type": "string"},
                 "timeout": {"type": "integer", "minimum": 0},


### PR DESCRIPTION
This PR is a quick fix to a typo. Reworded the "sentence" to avoid flake8 length error.