### PR TITLE
env: fix issues removing environments when env_root is a symlink

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -290,7 +290,7 @@ def create_temp_env_directory():
 
 def _tty_info(msg):
     """tty.info like function that prints the equivalent printf statement for eval."""
-    decorated = f'{colorize("@*b{==>}")} {msg}\n'
+    decorated = f"{colorize('@*b{==>}')} {msg}\n"
     executor = "echo" if sys.platform == "win32" else "printf"
     print(f"{executor} {shlex.quote(decorated)};")
 
@@ -609,7 +609,7 @@ def _env_untrack_or_remove(
             spack.environment.environment.environment_dir_from_name(bad_env_name, exists_ok=True)
         )
         tty.msg(f"Successfully removed environment '{bad_env_name}'")
-        removed_env_names.append(env.name)
+        removed_env_names.append(bad_env_name)
 
     # Following the design of linux rm we should exit with a status of 1
     # anytime we cannot delete every environment the user asks for.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -185,8 +185,7 @@ def valid_env_name(name):
 def validate_env_name(name):
     if not valid_env_name(name):
         raise ValueError(
-            ("'%s': names must start with a letter, and only contain letters, numbers, _, and -.")
-            % name
+            f"{name}: names may only contain letters, numbers, _, and -, and may not start with -."
         )
     return name
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -90,15 +90,24 @@ def env_root_path() -> str:
 def environment_name(path: Union[str, pathlib.Path]) -> str:
     """Human-readable representation of the environment.
 
-    This is the path for directory environments, and just the name
+    This is the path for independent environments, and just the name
     for managed environments.
     """
     env_root = pathlib.Path(env_root_path()).resolve()
-    path_str = str(path)
-    if path_str.startswith(str(env_root)):
-        return str(pathlib.Path(path_str).relative_to(env_root))
+    path_path = pathlib.Path(path)
+
+    # If an environment name / directory in the configured environment root resolves
+    # to the same location as the path of a given environment, we know the environment
+    # is tracked or managed else we return the path like all other independent
+    # environments.
+    #
+    # Additionally we must resolve the env_root / name path as the root might itself
+    # be a symlink to another location. (Common use case is ~/.spack/environments/
+    # pointing to a set of dotfiles managed in a git repository.)
+    if (env_root / path_path.name).resolve() == path_path.resolve():
+        return path_path.name
     else:
-        return path_str
+        return str(path)
 
 
 def ensure_no_disallowed_env_config_mods(scope: spack.config.ConfigScope) -> None:
@@ -177,10 +186,7 @@ def valid_env_name(name):
 def validate_env_name(name):
     if not valid_env_name(name):
         raise ValueError(
-            (
-                "'%s': names must start with a letter, and only contain "
-                "letters, numbers, _, and -."
-            )
+            ("'%s': names must start with a letter, and only contain letters, numbers, _, and -.")
             % name
         )
     return name
@@ -543,7 +549,7 @@ def validate_included_envs_concrete(include_concrete: List[str]) -> None:
             non_concrete_envs.add(Environment(env_path).name)
 
     if non_concrete_envs:
-        msg = "The following environment(s) are not concrete: {0}\n" "Please run:".format(
+        msg = "The following environment(s) are not concrete: {0}\nPlease run:".format(
             ", ".join(non_concrete_envs)
         )
         for env in non_concrete_envs:
@@ -2603,7 +2609,7 @@ def _top_level_key(data):
     Returns:
         Either 'spack' or 'env'
     """
-    msg = 'cannot find top level attribute "spack" or "env"' "in the environment"
+    msg = 'cannot find top level attribute "spack" or "env" in the environment'
     assert any(x in data for x in ("spack", "env")), msg
     if "spack" in data:
         return "spack"
@@ -2901,10 +2907,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
                 or the list does not exist
         """
         defs = self.configuration.get("definitions", [])
-        msg = (
-            f"cannot remove {user_spec} from the '{list_name}' definition, "
-            f"no valid list exists"
-        )
+        msg = f"cannot remove {user_spec} from the '{list_name}' definition, no valid list exists"
 
         for idx, item in self._iterate_on_definitions(defs, list_name=list_name, err_msg=msg):
             try:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -96,14 +96,13 @@ def environment_name(path: Union[str, pathlib.Path]) -> str:
     env_root = pathlib.Path(env_root_path()).resolve()
     path_path = pathlib.Path(path)
 
-    # If an environment name / directory in the configured environment root resolves
-    # to the same location as the path of a given environment, we know the environment
-    # is tracked or managed else we return the path like all other independent
-    # environments.
+    # For a managed environment created in Spack, env.path is ENV_ROOT/NAME
+    # For a tracked environment from `spack env track`, the path is symlinked to ENV_ROOT/NAME
+    # So if ENV_ROOT/NAME resolves to env.path we know the environment is tracked/managed.
+    # Otherwise, it is an independent environment and  we return the path.
     #
-    # Additionally we must resolve the env_root / name path as the root might itself
-    # be a symlink to another location. (Common use case is ~/.spack/environments/
-    # pointing to a set of dotfiles managed in a git repository.)
+    # We resolve both paths fully because the env_root itself could also be a symlink,
+    # and any directory in env.path could be a symlink.
     if (env_root / path_path.name).resolve() == path_path.resolve():
         return path_path.name
     else:


### PR DESCRIPTION
Found when testing #51433. 

When a user's configured `environments_root` is a symlink we previously marked any environments in the directory as invalid when removing it. This caused a `variable env used before assignment` error due to the bug on line no. 612. 

When investigating why the environments were marked as invalid @becker33 and I found that we were not correctly resolving the edge case when the env root was a symlink filled with additional possible symlinks pointing at tracked environments.