### PR TITLE
bootstrap: update the versions of a few CMake dependencies

### DIFF
--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -11,19 +11,30 @@ JSON file for a similar platform.
 """
 import pathlib
 import sys
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Type
 
 import spack.vendor.archspec.cpu
 
 import spack.compilers.config
 import spack.compilers.libraries
 import spack.config
+import spack.package_base
 import spack.platforms
+import spack.repo
 import spack.spec
 import spack.traverse
 import spack.version
 
 from .config import spec_for_current_python
+
+
+def _select_best_version(pkg_cls: Type["spack.package_base.PackageBase"], node: spack.spec.Spec):
+    """Try to attach the best known version to a node"""
+    try:
+        best_version = spack.package_base.preferred_version(pkg_cls)
+    except KeyError:
+        return
+    node.versions.versions = [spack.version.from_string(f"={best_version}")]
 
 
 class ClingoBootstrapConcretizer:
@@ -119,13 +130,32 @@ class ClingoBootstrapConcretizer:
         s = spack.spec.Spec.from_specfile(str(self.prototype_path()))
         s._mark_concrete(False)
 
-        # Tweak it to conform to the host architecture
+        # These are nodes in the cmake stack, whose versions are frequently deprecated for
+        # security reasons. In case there is no external cmake on this machine, we'll update
+        # their versions to the most preferred according to the repository we know.
+        to_be_updated = {
+            pkg_name: spack.repo.PATH.get_pkg_class(pkg_name)
+            for pkg_name in [
+                "ca-certificates-mozilla",
+                "openssl",
+                "curl",
+                "cmake",
+                "libiconv",
+                "ncurses",
+            ]
+        }
+
+        # Tweak it to conform to the host architecture + update the version of a few dependencies
         for node in s.traverse():
             node.architecture.os = str(self.host_os)
             node.architecture = self.host_architecture
 
             if node.name == "gcc-runtime":
                 node.versions = self.host_compiler.versions
+
+            if node.name in to_be_updated:
+                pkg_cls = to_be_updated[node.name]
+                _select_best_version(pkg_cls=pkg_cls, node=node)
 
         # Can't use re2c@3.1 with Python 3.6
         if self.host_python.satisfies("@3.6"):

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -21,6 +21,7 @@ import spack.config
 import spack.package_base
 import spack.platforms
 import spack.repo
+import spack.solver.versions
 import spack.spec
 import spack.traverse
 import spack.version
@@ -28,11 +29,19 @@ import spack.version
 from .config import spec_for_current_python
 
 
-def _select_best_version(pkg_cls: Type["spack.package_base.PackageBase"], node: spack.spec.Spec):
+def _select_best_version(
+    pkg_cls: Type["spack.package_base.PackageBase"], node: spack.spec.Spec, valid_versions: str
+) -> None:
     """Try to attach the best known version to a node"""
+    constraint = spack.version.from_string(valid_versions)
+    allowed_versions = [
+        (v, info) for v, info in pkg_cls.versions.items() if v.satisfies(constraint)
+    ]
     try:
-        best_version = spack.package_base.preferred_version(pkg_cls)
-    except KeyError:
+        best_version, _ = max(
+            allowed_versions, key=spack.solver.versions.concretization_version_order
+        )
+    except (KeyError, ValueError):
         return
     node.versions.versions = [spack.version.from_string(f"={best_version}")]
 
@@ -132,17 +141,18 @@ class ClingoBootstrapConcretizer:
 
         # These are nodes in the cmake stack, whose versions are frequently deprecated for
         # security reasons. In case there is no external cmake on this machine, we'll update
-        # their versions to the most preferred according to the repository we know.
+        # their versions to the most preferred, within the valid range, according to the
+        # repository we know.
         to_be_updated = {
-            pkg_name: spack.repo.PATH.get_pkg_class(pkg_name)
-            for pkg_name in [
-                "ca-certificates-mozilla",
-                "openssl",
-                "curl",
-                "cmake",
-                "libiconv",
-                "ncurses",
-            ]
+            pkg_name: (spack.repo.PATH.get_pkg_class(pkg_name), valid_versions)
+            for pkg_name, valid_versions in {
+                "ca-certificates-mozilla": ":",
+                "openssl": "3:3",
+                "curl": "8:8",
+                "cmake": "3.16:3",
+                "libiconv": "1:1",
+                "ncurses": "6:6",
+            }.items()
         }
 
         # Tweak it to conform to the host architecture + update the version of a few dependencies
@@ -154,8 +164,8 @@ class ClingoBootstrapConcretizer:
                 node.versions = self.host_compiler.versions
 
             if node.name in to_be_updated:
-                pkg_cls = to_be_updated[node.name]
-                _select_best_version(pkg_cls=pkg_cls, node=node)
+                pkg_cls, valid_versions = to_be_updated[node.name]
+                _select_best_version(pkg_cls=pkg_cls, node=node, valid_versions=valid_versions)
 
         # Can't use re2c@3.1 with Python 3.6
         if self.host_python.satisfies("@3.6"):

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -21,7 +21,6 @@ import spack.config
 import spack.package_base
 import spack.platforms
 import spack.repo
-import spack.solver.asp
 import spack.solver.versions
 import spack.spec
 import spack.traverse
@@ -194,7 +193,7 @@ class ClingoBootstrapConcretizer:
             if "libc" in edge.virtuals:
                 edge.spec = self.host_libc
 
-        spack.solver.asp._inject_patches_variant(s)
+        spack.spec._inject_patches_variant(s)
         s._finalize_concretization()
 
         # Work around the fact that the installer calls Spec.dependents() and

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -21,6 +21,7 @@ import spack.config
 import spack.package_base
 import spack.platforms
 import spack.repo
+import spack.solver.asp
 import spack.solver.versions
 import spack.spec
 import spack.traverse
@@ -152,11 +153,17 @@ class ClingoBootstrapConcretizer:
                 "cmake": "3.16:3",
                 "libiconv": "1:1",
                 "ncurses": "6:6",
+                "m4": "1.4",
             }.items()
         }
 
         # Tweak it to conform to the host architecture + update the version of a few dependencies
         for node in s.traverse():
+            # Clear patches, we'll compute them correctly later
+            node.patches.clear()
+            if "patches" in node.variants:
+                del node.variants["patches"]
+
             node.architecture.os = str(self.host_os)
             node.architecture = self.host_architecture
 
@@ -187,6 +194,7 @@ class ClingoBootstrapConcretizer:
             if "libc" in edge.virtuals:
                 edge.spec = self.host_libc
 
+        spack.solver.asp._inject_patches_variant(s)
         s._finalize_concretization()
 
         # Work around the fact that the installer calls Spec.dependents() and

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2575,7 +2575,7 @@ def deprecated_version(pkg: PackageBase, version: Union[str, StandardVersion]) -
     return details is not None and details.get("deprecated", False)
 
 
-def preferred_version(pkg: PackageBase):
+def preferred_version(pkg: Union[PackageBase, Type[PackageBase]]):
     """
     Returns a sorted list of the preferred versions of the package.
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -50,7 +50,6 @@ import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.package_base
 import spack.package_prefs
-import spack.patch
 import spack.platforms
 import spack.repo
 import spack.solver.splicing
@@ -3842,7 +3841,7 @@ class SpecBuilder:
         roots = [spec.root for spec in self._specs.values()]
         roots = dict((id(r), r) for r in roots)
         for root in roots.values():
-            _inject_patches_variant(root)
+            spack.spec._inject_patches_variant(root)
 
         # Add external paths to specs with just external modules
         for s in self._specs.values():
@@ -3954,79 +3953,6 @@ def _specs_with_commits(spec):
         " does not meet commit syntax requirements."
     )
     assert vn.is_git_commit_sha(spec.variants["commit"].value), invalid_commit_msg
-
-
-def _inject_patches_variant(root: spack.spec.Spec) -> None:
-    # This dictionary will store object IDs rather than Specs as keys
-    # since the Spec __hash__ will change as patches are added to them
-    spec_to_patches: Dict[int, Set[spack.patch.Patch]] = {}
-    for s in root.traverse():
-        # After concretizing, assign namespaces to anything left.
-        # Note that this doesn't count as a "change".  The repository
-        # configuration is constant throughout a spack run, and
-        # normalize and concretize evaluate Packages using Repo.get(),
-        # which respects precedence.  So, a namespace assignment isn't
-        # changing how a package name would have been interpreted and
-        # we can do it as late as possible to allow as much
-        # compatibility across repositories as possible.
-        if s.namespace is None:
-            s.namespace = spack.repo.PATH.repo_for_pkg(s.name).namespace
-
-        if s.concrete:
-            continue
-
-        # Add any patches from the package to the spec.
-        node_patches = {
-            patch
-            for cond, patch_list in spack.repo.PATH.get_pkg_class(s.fullname).patches.items()
-            if s.satisfies(cond)
-            for patch in patch_list
-        }
-        if node_patches:
-            spec_to_patches[id(s)] = node_patches
-
-    # Also record all patches required on dependencies by depends_on(..., patch=...)
-    for dspec in root.traverse_edges(deptype=dt.ALL, cover="edges", root=False):
-        if dspec.spec.concrete:
-            continue
-
-        pkg_deps = spack.repo.PATH.get_pkg_class(dspec.parent.fullname).dependencies
-
-        edge_patches: List[spack.patch.Patch] = []
-        for cond, deps_by_name in pkg_deps.items():
-            dependency = deps_by_name.get(dspec.spec.name)
-            if not dependency:
-                continue
-
-            if not dspec.parent.satisfies(cond):
-                continue
-
-            for pcond, patch_list in dependency.patches.items():
-                if dspec.spec.satisfies(pcond):
-                    edge_patches.extend(patch_list)
-
-        if edge_patches:
-            spec_to_patches.setdefault(id(dspec.spec), set()).update(edge_patches)
-
-    for spec in root.traverse():
-        if id(spec) not in spec_to_patches:
-            continue
-
-        patches = list(spec_to_patches[id(spec)])
-        variant: vt.VariantValue = spec.variants.setdefault(
-            "patches", vt.MultiValuedVariant("patches", ())
-        )
-        variant.set(*(p.sha256 for p in patches))
-        # FIXME: Monkey patches variant to store patches order
-        ordered_hashes = [(*p.ordering_key, p.sha256) for p in patches if p.ordering_key]
-        ordered_hashes.sort()
-        tty.debug(
-            f"Ordered hashes [{spec.name}]: "
-            + ", ".join("/".join(str(e) for e in t) for t in ordered_hashes)
-        )
-        setattr(
-            variant, "_patches_in_order_of_appearance", [sha256 for _, _, sha256 in ordered_hashes]
-        )
 
 
 def _ensure_external_path_if_external(spec: spack.spec.Spec) -> None:


### PR DESCRIPTION
fixes #51410

The current JSON prototype contains a few versions that have been deprecated, or removed, in the builtin repository.

Before Spack v1.0 it would have been fine to update the JSON file. Since the core tool and the packages were tied together, we knew which versions we could expect from a given commit of Spack.

Since now the builtin repository is detached, and we don't know at which commit it's used, it would be better not to assume that a certain version of a dependency is available.

Therefore, try to use, for the nodes that get frequent deprecations, the "best" version according to the current configuration.

Note: all the failing nodes are CMake dependencies, so currently bootstrapping issues are limited to cases where binaries cannot be used, and there is no CMake available on the machine.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
