### PR TITLE
Solver: fix bug removing early return for dev specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3941,11 +3941,12 @@ def _specs_with_commits(spec):
 
     pkg_class._resolve_git_provenance(spec)
 
-    if "commit" not in spec.variants and not spec.is_develop:
-        tty.warn(
-            f"Unable to resolve the git commit for {spec.name}. "
-            "An installation of this binary won't have complete binary provenance."
-        )
+    if "commit" not in spec.variants:
+        if not spec.is_develop:
+            tty.warn(
+                f"Unable to resolve the git commit for {spec.name}. "
+                "An installation of this binary won't have complete binary provenance."
+            )
         return
 
     # check integrity of user specified commit shas


### PR DESCRIPTION
Bug introduced in #51507 since dev specs still need an early return, just omit the warning message.
Without the early return we continue in the function and get a failure looking for the commit variant in the spec's variant dictionary.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
