### PR TITLE
Concretizer: remove unused rule

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -336,16 +336,6 @@ error(100, "Cannot select a single version for virtual '{0}'", Virtual)
   :- attr("virtual_node", node(ID, Virtual)),
      2 { attr("version", node(ID, Virtual), Version) }.
 
-% This exists only to improve error messages: normally selecting a
-% version with a choice rule is penalized. This avoids the penalty
-% when the version comes from an activated requirement.
-% Oddly, does not seem to work if I relocate it to error_messages.lp
-{ attr("version", node(ID, Package), Version) } :-
-  requirement_group_member(ConditionID, Package, RequirementID),
-  activate_requirement(node(ID, Package), RequirementID),
-  pkg_fact(Package, condition_effect(ConditionID, EffectID)),
-  imposed_constraint(EffectID, "node_version_satisfies", Package, Version).
-
 % If we select a deprecated version, mark the package as deprecated
 attr("deprecated", node(ID, Package), Version) :-
      attr("version", node(ID, Package), Version),

--- a/lib/spack/spack/test/error_messages.py
+++ b/lib/spack/spack/test/error_messages.py
@@ -180,14 +180,8 @@ class W4(Package):
     depends_on("w2")
     depends_on("w2@:2.0", when="@:2.0")
 
-    # test_errmsg_requirements_1 stresses these constraints by asking
-    # for "w4@:2.0 ^w3@2.1". On develop, the error message was never
-    # good; in this PR, the error message "used to be" good and is now
-    # not so good (see W3 definition for more details: this does not
-    # seem to be an issue with requirements)
     depends_on("w3")
-    depends_on("w3+v1", when="@2.0") # EX1
-    # depends_on("w3~v1", when="@2.0") # EX2
+    depends_on("w3+v1", when="@2.0")
 """,
 )
 
@@ -201,12 +195,7 @@ class W3(Package):
 
     variant("v1", default=True)
 
-    # conflicts("+v1", when="@2.1")
-    # This requirement is equivalent to prior conflict. If you swap
-    # it in, the error message is still not good (so that points to
-    # an issue with error messages that is not related to requirements)
-    requires("~v1", when="@2.1") # EX1
-    # requires("+v1", when="@2.1") # EX2
+    requires("~v1", when="@2.1")
 
     depends_on("w1")
 """,
@@ -285,10 +274,7 @@ class T2(Package):
 
     variant("v1", default=True)
 
-    # It used to be that swapping `require` for `conflicts` would
-    # improve the error message.
     requires("~v1", when="@:2.0")
-    # conflicts("+v1", when="@:2.0")
 
     depends_on("t1")
 """,


### PR DESCRIPTION
See: https://github.com/spack/spack/pull/45800/files#r2500399252

This rule is not currently demonstrably improving any error messages (link provides more context, but this rule originally improved error messages for externals in #45800, but a large change to how externals were handled landed and merged before #45800 did).

Also clean up some comments in the `error_messages` test module.