### PR TITLE
Added support for OAuth 2.0 response

### DIFF
--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -294,7 +294,7 @@ class OCIAuthHandler(urllib.request.BaseHandler):
         response = self.parent.open(request, timeout=timeout)
         try:
             response_json = json.load(response)
-            token = response_json["token"]
+            token = response_json["access_token"]
             assert type(token) is str
         except Exception as e:
             raise ValueError(f"Malformed token response from {challenge.realm}") from e

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -294,7 +294,9 @@ class OCIAuthHandler(urllib.request.BaseHandler):
         response = self.parent.open(request, timeout=timeout)
         try:
             response_json = json.load(response)
-            token = response_json["access_token"]
+            token = response_json.get("token")
+            if token is None:
+                token = response_json.get("access_token")
             assert type(token) is str
         except Exception as e:
             raise ValueError(f"Malformed token response from {challenge.realm}") from e

--- a/lib/spack/spack/test/oci/mock_registry.py
+++ b/lib/spack/spack/test/oci/mock_registry.py
@@ -391,6 +391,8 @@ class MockBearerTokenServer(DummyServer):
             return self.public_auth(req)
         elif service == "private.example.com":
             return self.private_auth(req)
+        elif service == "oauth.example.com":
+            return self.oauth_auth(req)
 
         return MockHTTPResponse(404, "Not found")
 
@@ -398,6 +400,10 @@ class MockBearerTokenServer(DummyServer):
         # No need to login with username and password for the public registry
         assert req.get_header("Authorization") is None
         return MockHTTPResponse.with_json(200, "OK", body={"token": "public_token"})
+
+    def oauth_auth(self, req: Request):
+        assert req.get_header("Authorization") is None
+        return MockHTTPResponse.with_json(200, "OK", body={"access_token": "oauth_token"})
 
     def private_auth(self, req: Request):
         # For the private registry we need to login with username and password

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -221,6 +221,7 @@ def test_get_bearer_challenge():
     [
         ("public.example.com/spack-registry:latest", "public_token"),
         ("private.example.com/spack-registry:latest", "private_token"),
+        ("oauth.example.com/spack-registry:latest", "oauth_token"),
     ],
 )
 def test_automatic_oci_bearer_authentication(image_ref: str, token: str):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Closes: #51517 

Add support for strict OAuth 2.0 responses where the token is returned in `access_token` This allows support for OCI registries such as Azure Container Registry.
