### PR TITLE
Git Fetch: Use filters to improve efficiency of single commit clones

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -982,10 +982,12 @@ class GitFetchStrategy(VCSFetchStrategy):
 
             with working_dir(dest):
                 checkout_args = ["checkout"]
+                checkout_kwargs = {}
                 if not debug:
-                    checkout_args.append("--quiet")
+                    checkout_args.extend(["--quiet", "--no-progress"])
+                    checkout_kwargs["error"] = str
                 checkout_args.append(self.commit)
-                git(*checkout_args)
+                git(*checkout_args, **checkout_kwargs)
 
         else:
             # Can be more efficient if not checking out a specific commit.
@@ -1094,10 +1096,12 @@ class GitFetchStrategy(VCSFetchStrategy):
             sparse_args.append("--cone")
 
             checkout_args = ["checkout", git_ref]
+            checkout_kwargs = {}
 
             if not spack.config.get("config:debug"):
                 clone_args.insert(1, "--quiet")
                 checkout_args.insert(1, "--quiet")
+                checkout_kwargs["error"] = str
 
             with temp_cwd():
                 git(*clone_args)
@@ -1108,7 +1112,7 @@ class GitFetchStrategy(VCSFetchStrategy):
 
             with working_dir(dest):
                 git(*sparse_args)
-                git(*checkout_args)
+                git(*checkout_args, **checkout_kwargs)
 
     def submodule_operations(self):
         dest = self.stage.source_path

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -960,10 +960,15 @@ class GitFetchStrategy(VCSFetchStrategy):
         if self.commit:
             # Need to do a regular clone and check out everything if
             # they asked for a particular commit.
-            clone_args = ["clone", self.url]
+            clone_args = ["clone"]
             if not debug:
-                clone_args.insert(1, "--quiet")
+                clone_args.append("--quiet")
+
+            if self.git_version >= spack.version.Version("2.19.2"):
+                clone_args.extend(["--no-checkout", "--filter=blob:none"]) 
+
             with temp_cwd():
+                clone_args.append(self.url)
                 git(*clone_args)
                 repo_name = get_single_file(".")
                 if self.stage:
@@ -976,9 +981,10 @@ class GitFetchStrategy(VCSFetchStrategy):
                 )
 
             with working_dir(dest):
-                checkout_args = ["checkout", self.commit]
+                checkout_args = ["checkout"]
                 if not debug:
-                    checkout_args.insert(1, "--quiet")
+                    checkout_args.append("--quiet")
+                checkout_args.append(self.commit)
                 git(*checkout_args)
 
         else:
@@ -1058,8 +1064,7 @@ class GitFetchStrategy(VCSFetchStrategy):
             )
             self._clone_src()
         else:
-            # default to depth=2 to allow for retention of some git properties
-            depth = kwargs.get("depth", 2)
+            depth = kwargs.get("depth", 1)
             needs_fetch = self.branch or self.tag
             git_ref = self.branch or self.tag or self.commit
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -965,7 +965,7 @@ class GitFetchStrategy(VCSFetchStrategy):
                 clone_args.append("--quiet")
 
             if self.git_version >= spack.version.Version("2.19.2"):
-                clone_args.extend(["--no-checkout", "--filter=blob:none"]) 
+                clone_args.extend(["--no-checkout", "--filter=blob:none"])
 
             with temp_cwd():
                 clone_args.append(self.url)


### PR DESCRIPTION
Using modern git features the source size clone can be dropped dramatically.  Also set sparse depth to 2. The comment that git information was lost with depth=1 is not correct. It seems to be the information was lost because we intentionally pruned it in the past.

``` console
$ git clone git@github.com:sandialabs/seacas full-clone
$ git -C full-clone checkout 82ef9aa4b6da1a2531137108cb987627011e8083

$ git clone --no-checkout --filter=blob:none git@github.com:sandialabs/seacas partial-clone
$ git -C partial-clone checkout 82ef9aa4b6da1a2531137108cb987627011e8083

$ du -sh *
527M	full-clone
164M	partial-clone
```

``` console
##############
# Pre this change
##############
$ time spack stage seacas commit=82ef9aa4b6da1a2531137108cb987627011e8083
==> Staged seacas in /var/folders/ln/1_3kxbwd35s_ylsjlm3zmqmc00307v/T/psakiev/spack-stage/spack-stage-seacas-master-ffxyz7tuq4uvojo6cwo3cujafbihwjui

real	4m28.214s
user	1m4.617s
sys	0m29.960s

$ du -sh $(spack location -s seacas)
514M

##############
# With this change
##############
$ time spack stage seacas commit=82ef9aa4b6da1a2531137108cb987627011e8083
remote: Enumerating objects: 5882, done.
remote: Counting objects: 100% (2548/2548), done.
remote: Compressing objects: 100% (1898/1898), done.
remote: Total 5882 (delta 990), reused 650 (delta 650), pack-reused 3334 (from 3)
Receiving objects: 100% (5882/5882), 35.58 MiB | 2.43 MiB/s, done.
Resolving deltas: 100% (2038/2038), done.
==> Staged seacas in /var/folders/ln/1_3kxbwd35s_ylsjlm3zmqmc00307v/T/psakiev/spack-stage/spack-stage-seacas-master-ffxyz7tuq4uvojo6cwo3cujafbihwjui

real	1m19.563s
user	0m30.345s
sys	0m6.523s

$ du -sh $(spack location -s seacas)
163M
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
