### PR TITLE
Added example auth for Azure Container Registry to docs

### DIFF
--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -384,6 +384,23 @@ The username is always ``AWS``.
 
 See also `AWS's documentation <https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html>`_.
 
+Azure Container Registry
+""""""""""""""""""""""""
+
+To authenticate with an Azure Container Registry that has RBAC enabled, you can use the Azure CLI to generate a temporary password for your managed identity.
+The username is always ``00000000-0000-0000-0000-000000000000``.
+
+.. code-block:: console
+
+    $ export AZURE_ACR_PASSWORD=$(az acr login --name <registry-name> --expose-token --output tsv --query accessToken)
+    $ spack mirror add \
+          --oci-username 00000000-0000-0000-0000-000000000000 \
+          --oci-password-variable AZURE_ACR_PASSWORD \
+          my_registry \
+          oci://<registry-name>.azurecr.io/my/image
+
+See also `Azure's documentation <https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#az-acr-login-with---expose-token>`_.
+
 
 Build Cache and Container Images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Included an example that demostrates how to authenticate to Azure Container Regirstry when using managed identites and RBAC