### PR TITLE
Spack: bump version in develop to v1.2.0.dev0

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -10,7 +10,7 @@ import spack.paths
 import spack.util.git
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "1.1.0.dev0"
+__version__ = "1.2.0.dev0"
 spack_version = __version__
 
 #: The current Package API version implemented by this version of Spack. The Package API defines


### PR DESCRIPTION
`releases/v1.1` branched off at bd1b90893b6a25edecf5ad868e1aca6026f8de36
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
