### PR TITLE
install: Avoid env.write_transacation when concretize is a no-op.

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -343,6 +343,9 @@ def _maybe_add_and_concretize(args, env, specs):
     if args.only_concrete:
         return
 
+    if not args.add and not env.needs_concretize():
+        return
+
     # Otherwise, we will modify the environment.
     with env.write_transaction():
         # `spack add` adds these specs.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1511,6 +1511,14 @@ class Environment:
         if modified_roots:
             self.write()
 
+    def needs_concretize(self):
+        force = spack.config.get("concretizer:force")
+        if force:
+            return True
+
+        new_user_specs = list(set(self.user_specs) - set(self.concretized_user_specs))
+        return len(new_user_specs) > 0
+
     def concretize(
         self, force: Optional[bool] = None, tests: Union[bool, Sequence] = False
     ) -> Sequence[SpecPair]:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -817,7 +817,10 @@ spack:
             )
         env_cmd("create", "test", "./spack.yaml")
         with ev.read("test") as current_env:
-            current_env.concretize()
+            with current_env.write_transaction():
+                current_env.concretize()
+                current_env.write(regenerate=False)
+
             install_cmd("--keep-stage")
 
             concrete_spec = list(current_env.roots())[0]


### PR DESCRIPTION
Split out of #51518 based on review comments. @haampie 