### PR TITLE
spack change: allow modifications to concrete specs

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -438,6 +438,42 @@ The supplied location will become the build-directory for that package in all fu
    For example, most ``autotool`` and ``makefile`` packages do not support out-of-source builds while all ``CMake`` packages do.
    Understanding these nuances is up to the software developers and we strongly encourage developers to only redirect the build directory if they understand their package's build-system.
 
+Modifying Specs in an Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``spack change`` command allows the user to change individual specs in a Spack environment.
+
+By default, ``spack change`` operates on the abstract specs of an environment.
+The command a list of spec arguments.
+For each argument, the root spec with the same name as the provided spec is modified to satisfy the provided spec.
+For example, in an environment with the root spec ``hdf5+mpi+fortran``, then
+
+.. code-block:: console
+
+   spack change hdf5~mpi+cxx
+
+will change the root spec to ``hdf5~mpi+cxx+fortran``.
+
+When more complex matching semantics are necessary, the ``--match-spec`` argument replaces the spec name as the selection criterion.
+When using the ``--match-spec`` argument, the spec name is not required.
+In the same environment,
+
+.. code-block:: console
+
+   spack change --match-spec "+fortran" +hl
+
+will constrain the ``hdf5`` spec to ``+hl``.
+
+By default, the ``spack change`` command will result in an error and no change to the environment if it will not modify a single spec.
+Use the ``--all`` option to allow ``spack change`` to modify multiple specs.
+
+The ``--concrete`` option allows ``spack change`` to modify the concrete specs of an environment as well as the abstract specs.
+Multiple concrete specs may be modified, even for a change that modifies only a single abstract spec.
+The concrete specs are modified without any constraints from the packages, so this may create invalid specs that will not build properly if applied without caution.
+
+The ``--no-abstract`` option allows for modifying concrete specs without modifying abstract specs.
+It allows changes to be applied to non-root nodes in the environment, and other changes that do not modify any root specs.
+
 Loading
 ^^^^^^^
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -464,12 +464,17 @@ In the same environment,
 
 will constrain the ``hdf5`` spec to ``+hl``.
 
-By default, the ``spack change`` command will result in an error and no change to the environment if it will not modify a single spec.
-Use the ``--all`` option to allow ``spack change`` to modify multiple specs.
+By default, the ``spack change`` command will result in an error and no change to the environment if it will modify more than one abstract spec.
+Use the ``--all`` option to allow ``spack change`` to modify multiple abstract specs.
 
 The ``--concrete`` option allows ``spack change`` to modify the concrete specs of an environment as well as the abstract specs.
 Multiple concrete specs may be modified, even for a change that modifies only a single abstract spec.
-The concrete specs are modified without any constraints from the packages, so this may create invalid specs that will not build properly if applied without caution.
+The ``--all`` option does not affect how many concrete specs may be modified.
+
+.. warning::
+
+   Concrete specs are modified without any constraints from the packages.
+   The ``spack change --concrete`` command  may create invalid specs that will not build properly if applied without caution.
 
 The ``--concrete-only`` option allows for modifying concrete specs without modifying abstract specs.
 It allows changes to be applied to non-root nodes in the environment, and other changes that do not modify any root specs.

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -471,7 +471,7 @@ The ``--concrete`` option allows ``spack change`` to modify the concrete specs o
 Multiple concrete specs may be modified, even for a change that modifies only a single abstract spec.
 The concrete specs are modified without any constraints from the packages, so this may create invalid specs that will not build properly if applied without caution.
 
-The ``--no-abstract`` option allows for modifying concrete specs without modifying abstract specs.
+The ``--concrete-only`` option allows for modifying concrete specs without modifying abstract specs.
 It allows changes to be applied to non-root nodes in the environment, and other changes that do not modify any root specs.
 
 Loading

--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import warnings
 
 import spack.cmd
+import spack.environment
 import spack.spec
 from spack.cmd.common import arguments
 
@@ -19,33 +21,66 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--list-name",
         dest="list_name",
         default="specs",
-        help="name of the list to remove specs from",
+        help="name of the list to remove abstract specs from",
     )
     subparser.add_argument(
-        "--match-spec", dest="match_spec", help="if name is ambiguous, supply a spec to match"
+        "--match-spec",
+        dest="match_spec",
+        help="change all specs matching match-spec (default is match by spec name)",
     )
     subparser.add_argument(
         "-a",
         "--all",
         action="store_true",
-        help="change all matching specs (allow changing more than one spec)",
+        help="change all matching abstract specs (allow changing more than one abstract spec)",
     )
+    subparser.add_argument(
+        "--no-abstract",
+        action="store_false",
+        default=True,
+        dest="abstract",
+        help="do not change abstract specs in the environment",
+    )
+    subparser.add_argument(
+        "--concrete",
+        action="store_true",
+        default=False,
+        help="change concrete specs in the environment",
+    )
+
     arguments.add_common_arguments(subparser, ["specs"])
 
 
 def change(parser, args):
+    if args.all and not args.abstract:
+        warnings.warn("'spack change --all' argument is ignored with '--no-abstract'")
+    if args.list_name and not args.abstract:
+        warnings.warn("'spack change --list-name' argument is ignored with '--no-abstract'")
+
     env = spack.cmd.require_active_env(cmd_name="change")
 
+    match_spec = None
+    if args.match_spec:
+        match_spec = spack.spec.Spec(args.match_spec)
+    specs = spack.cmd.parse_specs(args.specs)
+
     with env.write_transaction():
-        if args.match_spec:
-            match_spec = spack.spec.Spec(args.match_spec)
-        else:
-            match_spec = None
-        for spec in spack.cmd.parse_specs(args.specs):
-            env.change_existing_spec(
-                spec,
-                list_name=args.list_name,
-                match_spec=match_spec,
-                allow_changing_multiple_specs=args.all,
-            )
+        if args.abstract:
+            try:
+                for spec in specs:
+                    env.change_existing_spec(
+                        spec,
+                        list_name=args.list_name,
+                        match_spec=match_spec,
+                        allow_changing_multiple_specs=args.all,
+                    )
+            except (ValueError, spack.environment.SpackEnvironmentError) as e:
+                msg = "Cannot change abstract specs."
+                msg += " Try again with '--no-abstract' to change concrete specs only."
+                raise ValueError(msg) from e
+
+        if args.concrete:
+            for spec in specs:
+                env.mutate(selector=match_spec or spack.spec.Spec(spec.name), mutator=spec)
+
         env.write()

--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -35,6 +35,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="change all matching abstract specs (allow changing more than one abstract spec)",
     )
     subparser.add_argument(
+        "-c",
         "--concrete",
         action="store_true",
         default=False,

--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -35,27 +35,26 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="change all matching abstract specs (allow changing more than one abstract spec)",
     )
     subparser.add_argument(
-        "--no-abstract",
-        action="store_false",
-        default=True,
-        dest="abstract",
-        help="do not change abstract specs in the environment",
-    )
-    subparser.add_argument(
         "--concrete",
         action="store_true",
         default=False,
         help="change concrete specs in the environment",
     )
-
+    subparser.add_argument(
+        "-C",
+        "--concrete-only",
+        action="store_true",
+        default=False,
+        help="change only concrete specs in the environment",
+    )
     arguments.add_common_arguments(subparser, ["specs"])
 
 
 def change(parser, args):
-    if args.all and not args.abstract:
-        warnings.warn("'spack change --all' argument is ignored with '--no-abstract'")
-    if args.list_name and not args.abstract:
-        warnings.warn("'spack change --list-name' argument is ignored with '--no-abstract'")
+    if args.all and args.concrete_only:
+        warnings.warn("'spack change --all' argument is ignored with '--concrete-only'")
+    if args.list_name and args.concrete_only:
+        warnings.warn("'spack change --list-name' argument is ignored with '--concrete-only'")
 
     env = spack.cmd.require_active_env(cmd_name="change")
 
@@ -65,7 +64,7 @@ def change(parser, args):
     specs = spack.cmd.parse_specs(args.specs)
 
     with env.write_transaction():
-        if args.abstract:
+        if not args.concrete_only:
             try:
                 for spec in specs:
                     env.change_existing_spec(
@@ -76,10 +75,10 @@ def change(parser, args):
                     )
             except (ValueError, spack.environment.SpackEnvironmentError) as e:
                 msg = "Cannot change abstract specs."
-                msg += " Try again with '--no-abstract' to change concrete specs only."
+                msg += " Try again with '--concrete-only' to change concrete specs only."
                 raise ValueError(msg) from e
 
-        if args.concrete:
+        if args.concrete or args.concrete_only:
             for spec in specs:
                 env.mutate(selector=match_spec or spack.spec.Spec(spec.name), mutator=spec)
 

--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -54,7 +54,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def change(parser, args):
     if args.all and args.concrete_only:
         warnings.warn("'spack change --all' argument is ignored with '--concrete-only'")
-    if args.list_name and args.concrete_only:
+    if args.list_name != "specs" and args.concrete_only:
         warnings.warn("'spack change --list-name' argument is ignored with '--concrete-only'")
 
     env = spack.cmd.require_active_env(cmd_name="change")

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -12,7 +12,7 @@ import re
 import shutil
 import stat
 import warnings
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import spack
 import spack.concretize
@@ -1467,29 +1467,51 @@ class Environment:
     def apply_develop(self, spec: spack.spec.Spec, path: Optional[str] = None):
         """Mutate concrete specs to include dev_path provenance pointing to path.
 
-        This does not do any other aspect of concretization. It will fail if any existing concrete
-        spec for the same package does not satisfy the given develop spec."""
-        # Find all specs that this develop request applies to
-        modify_specs = []
-        for dep in self.all_specs_generator():
-            if dep.name == spec.name:
-                if not dep.satisfies(spec):
-                    raise SpackEnvironmentDevelopError(
-                        f"Develop spec '{spec}' conflicts with concrete specs in environment."
-                        " Try again with 'spack develop --no-modify-concrete-specs'"
-                        " and run 'spack concretize --force' to apply your changes."
-                    )
-                modify_specs.append(dep)
-
-        # Manipulate dev_path variant on modify_specs
-        for s in modify_specs:
+        This will fail if any existing concrete spec for the same package does not satisfy the
+        given develop spec."""
+        def apply_dev_path(spec):
             # Remove any existing dev_path variant in all cases
             # If setting a path, add the new variant
-            s.variants.pop("dev_path", None)
-            if path:
-                s.variants["dev_path"] = vt.VariantValue(
-                    vt.VariantType.SINGLE, "dev_path", (path,)
-                )
+            spec.variants.pop("dev_path", None)
+            if not path:
+                return
+            spec.variants["dev_path"] = vt.VariantValue(vt.VariantType.SINGLE, "dev_path", (path,))
+
+        msg = (
+            f"Develop spec '{spec}' conflicts with concrete specs in environment."
+            " Try again with 'spack develop --no-modify-concrete-specs'"
+            " and run 'spack concretize --force' to apply your changes."
+        )
+        selector = spack.spec.Spec(spec.name)
+        self.mutate(selector=selector, mutator=apply_dev_path, validator=spec, msg=msg)
+
+    def mutate(
+        self,
+        selector: spack.spec.Spec,
+        mutator: Callable,
+        validator: Optional[spack.spec.Spec] = None,
+        msg: Optional[str] = None
+    ):
+        """Mutate concrete specs of an environment
+
+        Mutate any spec that matches ``selector``. Invalidate caches on parents of mutated specs.
+        If a validator spec is supplied, throw an error if a selected spec does not satisfy the
+        validator.
+        """
+        # Find all specs that this mutation applies to
+        modify_specs = []
+        for dep in self.all_specs_generator():
+            if dep.satisfies(selector):
+                if not dep.satisfies(validator or selector):
+                    if not msg:
+                        msg = f"spec {dep} satisfies selector {selector}"
+                        msg += " but not validator {validator}"
+                    raise SpackEnvironmentDevelopError(msg)
+                modify_specs.append(dep)
+
+        # Manipulate selected specs
+        for s in modify_specs:
+            mutator(s)
 
         # Identify roots modified and invalidate all dependent hashes
         modified_roots = []

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1474,9 +1474,9 @@ class Environment:
 
         mutator = spack.spec.Spec()
         if path:
-            variant = vt.VariantValue(vt.VariantType.SINGLE, "dev_path", (path,))
+            variant = vt.SingleValuedVariant("dev_path", path)
         else:
-            variant = None
+            variant = vt.VariantValueRemoval("dev_path")
         mutator.variants["dev_path"] = variant
 
         msg = (

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1507,7 +1507,7 @@ class Environment:
                 if not dep.satisfies(validator or selector):
                     if not msg:
                         msg = f"spec {dep} satisfies selector {selector}"
-                        msg += " but not validator {validator}"
+                        msg += f" but not validator {validator}"
                     raise SpackEnvironmentDevelopError(msg)
                 modify_specs.append(dep)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1370,10 +1370,10 @@ class Environment:
                 that should be changed. If not set, it is assumed we are
                 looking for a spec with the same name as ``change_spec``.
         """
-        if not (change_spec.name or (match_spec and match_spec.name)):
+        if not (change_spec.name or match_spec):
             raise ValueError(
-                "Must specify a spec name to identify a single spec"
-                " in the environment that will be changed"
+                "Must specify a spec name or match spec to identify a single spec"
+                " in the environment that will be changed (or multiple with '--all')"
             )
         match_spec = match_spec or Spec(change_spec.name)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -12,7 +12,7 @@ import re
 import shutil
 import stat
 import warnings
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import spack
 import spack.concretize
@@ -1468,29 +1468,30 @@ class Environment:
         """Mutate concrete specs to include dev_path provenance pointing to path.
 
         This will fail if any existing concrete spec for the same package does not satisfy the
+
         given develop spec."""
-        def apply_dev_path(spec):
-            # Remove any existing dev_path variant in all cases
-            # If setting a path, add the new variant
-            spec.variants.pop("dev_path", None)
-            if not path:
-                return
-            spec.variants["dev_path"] = vt.VariantValue(vt.VariantType.SINGLE, "dev_path", (path,))
+        selector = spack.spec.Spec(spec.name)
+
+        mutator = spack.spec.Spec()
+        if path:
+            variant = vt.VariantValue(vt.VariantType.SINGLE, "dev_path", (path,))
+        else:
+            variant = None
+        mutator.variants["dev_path"] = variant
 
         msg = (
             f"Develop spec '{spec}' conflicts with concrete specs in environment."
             " Try again with 'spack develop --no-modify-concrete-specs'"
             " and run 'spack concretize --force' to apply your changes."
         )
-        selector = spack.spec.Spec(spec.name)
-        self.mutate(selector=selector, mutator=apply_dev_path, validator=spec, msg=msg)
+        self.mutate(selector, mutator, validator=spec, msg=msg)
 
     def mutate(
         self,
         selector: spack.spec.Spec,
-        mutator: Callable,
+        mutator: spack.spec.Spec,
         validator: Optional[spack.spec.Spec] = None,
-        msg: Optional[str] = None
+        msg: Optional[str] = None,
     ):
         """Mutate concrete specs of an environment
 
@@ -1500,6 +1501,7 @@ class Environment:
         """
         # Find all specs that this mutation applies to
         modify_specs = []
+        modified_specs = []
         for dep in self.all_specs_generator():
             if dep.satisfies(selector):
                 if not dep.satisfies(validator or selector):
@@ -1511,11 +1513,13 @@ class Environment:
 
         # Manipulate selected specs
         for s in modify_specs:
-            mutator(s)
+            modified = s.mutate(mutator, rehash=False)
+            if modified:
+                modified_specs.append(s)
 
         # Identify roots modified and invalidate all dependent hashes
         modified_roots = []
-        for parent in traverse.traverse_nodes(modify_specs, direction="parents"):
+        for parent in traverse.traverse_nodes(modified_specs, direction="parents"):
             # record whether this parent is a root before we modify the hash
             if parent.dag_hash() in self.specs_by_hash:
                 modified_roots.append((parent, parent.dag_hash()))

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4900,9 +4900,10 @@ class Spec:
             if variant == self.variants.get(name, None):
                 continue
 
-            # Special VariantValueRemoval type for variants that need to be removed
-            self.variants.pop(name, None)
-            if not isinstance(variant, vt.VariantValueRemoval):
+            old_variant = self.variants.pop(name, None)
+            if not isinstance(variant, vt.VariantValueRemoval):  # sigil type for removing variant
+                if old_variant:
+                    variant.type = old_variant.type  # coerce variant type to match
                 self.variants[name] = variant
             changed = True
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4879,7 +4879,10 @@ class Spec:
         if len(mutator.dependencies()) > 0:
             raise SpecMutationError(f"Cannot mutate dependencies: spec {self} mutator {mutator}")
 
-        if mutator.versions != vn.VersionList(":") and not mutator.versions.concrete:
+        if (
+            mutator.versions != vn.VersionList(":")
+            and not mutator.versions.concrete_range_as_version
+        ):
             raise SpecMutationError(
                 f"Cannot mutate abstract version: spec {self} mutator {mutator}"
             )
@@ -4903,7 +4906,7 @@ class Spec:
                 self.variants[name] = variant
             changed = True
 
-        for name, flags in mutator.compiler_flags:
+        for name, flags in mutator.compiler_flags.items():
             if not flags or flags == self.compiler_flags[name]:
                 continue
             self.compiler_flags[name] = flags

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4856,6 +4856,85 @@ class Spec:
 
         return spec
 
+    def mutate(self, mutator, rehash=True) -> bool:
+        """Mutate concrete spec to match constraints represented by mutator.
+
+        Mutation can modify the spec version, variants, compiler flags, and architecture.
+        Mutation cannot change the spec name, namespace, dependencies, or abstract_hash.
+        Any attribute which is unset will not be touched.
+        Variant values can be replaced with the literal ``None`` to remove the variant.
+        ``None`` as a variant value is represented by ``VariantValue(..., (None,))``.
+
+        If ``rehash``, concrete spec and its dependents have hashes updated.
+
+        Returns whether the spec was modified by the mutation"""
+        assert self.concrete
+
+        if mutator.name and mutator.name != self.name:
+            raise SpecMutationError(f"Cannot mutate spec name: spec {self} mutator {mutator}")
+
+        if mutator.namespace and mutator.namespace != self.namespace:
+            raise SpecMutationError(f"Cannot mutate spec namespace: spec {self} mutator {mutator}")
+
+        if len(mutator.dependencies()) > 0:
+            raise SpecMutationError(f"Cannot mutate dependencies: spec {self} mutator {mutator}")
+
+        if mutator.versions != vn.VersionList(":") and not mutator.versions.concrete:
+            raise SpecMutationError(
+                f"Cannot mutate abstract version: spec {self} mutator {mutator}"
+            )
+
+        if mutator.abstract_hash and mutator.abstract_hash != self.abstract_hash:
+            raise SpecMutationError(f"Cannot mutate abstract_hash: spec {self} mutator {mutator}")
+
+        changed = False
+
+        if mutator.versions != vn.VersionList(":") and self.versions != mutator.versions:
+            self.versions = mutator.versions
+            changed = True
+
+        for name, variant in mutator.variants.items():
+            if variant == self.variants.get(name, None):
+                continue
+
+            # None instead of VariantValue(..., (None,)) used as a sigil to remove variant
+            self.variants.pop(name, None)
+            if variant is not None:
+                self.variants[name] = variant
+            changed = True
+
+        for name, flags in mutator.compiler_flags:
+            if not flags or flags == self.compiler_flags[name]:
+                continue
+            self.compiler_flags[name] = flags
+            changed = True
+
+        if mutator.architecture:
+            if mutator.platform and mutator.platform != self.architecture.platform:
+                self.architecture.platform = mutator.platform
+                changed = True
+            if mutator.os and mutator.os != self.architecture.os:
+                self.architecture.os = mutator.os
+                changed = True
+            if mutator.target and mutator.target != self.architecture.target:
+                self.architecture.target = mutator.target
+                changed = True
+
+        if changed and rehash:
+            roots = []
+            for parent in spack.traverse.traverse_nodes([self], direction="parents"):
+                if not parent.dependents():
+                    roots.append(parent)
+                # invalidate hashes
+                parent._mark_root_concrete(False)
+                parent.clear_caches()
+
+            for root in roots:
+                # compute new hashes on full DAGs
+                root._finalize_concretization()
+
+        return changed
+
     def clear_caches(self, ignore: Tuple[str, ...] = ()) -> None:
         """
         Clears all cached hashes in a Spec, while preserving other properties.
@@ -5724,3 +5803,7 @@ class SpliceError(spack.error.SpecError):
 
 class InvalidEdgeError(spack.error.SpecError):
     """Raised when an edge doesn't pass validation checks."""
+
+
+class SpecMutationError(spack.error.SpecError):
+    """Raised when a mutation is attempted with invalid attributes."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4900,9 +4900,9 @@ class Spec:
             if variant == self.variants.get(name, None):
                 continue
 
-            # None instead of VariantValue(..., (None,)) used as a sigil to remove variant
+            # Special VariantValueRemoval type for variants that need to be removed
             self.variants.pop(name, None)
-            if variant is not None:
+            if not isinstance(variant, vt.VariantValueRemoval):
                 self.variants[name] = variant
             changed = True
 

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import platform
+
 import pytest
 
+import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.spec
 from spack.main import SpackCommand
-
 
 pytestmark = [
     pytest.mark.usefixtures("mutable_config", "mutable_mock_env_path", "mutable_mock_repo"),

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -135,7 +135,7 @@ def test_mutate_from_cli_no_abstract():
     with pytest.raises(ValueError, match="Cannot change abstract spec"):
         _ = _test_mutate_from_cli(args)
 
-    args.insert(0, "--no-abstract")
+    args = ["--concrete-only"] + args[1:]
     roots = _test_mutate_from_cli(args, create=False)
 
     for root in roots:

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -1,0 +1,150 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import platform
+import pytest
+
+import spack.config
+import spack.environment as ev
+import spack.spec
+from spack.main import SpackCommand
+
+
+pytestmark = [
+    pytest.mark.usefixtures("mutable_config", "mutable_mock_env_path", "mutable_mock_repo"),
+    pytest.mark.not_on_windows("Envs unsupported on Windows"),
+]
+
+# See lib/spack/spack/platforms/test.py for how targets are defined on the Test platform
+test_targets = ("m1", "aarch64") if platform.machine() == "arm64" else ("core2", "x86_64")
+
+change = SpackCommand("change")
+
+
+@pytest.mark.parametrize("dep", [True, False])
+@pytest.mark.parametrize(
+    "orig_constraint,mutated_constraint",
+    [
+        ("@3.23.1", "@3.4.3"),
+        ("cflags=-O3", "cflags=-O0 -g"),
+        ("os=debian6", "os=redhat6"),
+        (f"target={test_targets[0]}", f"target={test_targets[1]}"),
+        ("build_system=generic", "build_system=foo"),
+        (
+            f"@3.4.3 cflags=-g os=debian6 target={test_targets[1]} build_system=generic",
+            f"@3.23.1 cflags=-O3 os=redhat6 target={test_targets[0]} build_system=foo",
+        ),
+    ],
+)
+def test_mutate_internals(dep, orig_constraint, mutated_constraint):
+    """
+    Check that Environment.mutate and Spec.mutate work for several different constraint types.
+
+    Includes check that environment.mutate rehashing gets the same answer as spec.mutate rehashing.
+    """
+    ev.create("test")
+    env = ev.read("test")
+
+    spack.config.set("packages:cmake", {"require": orig_constraint})
+
+    root_name = "cmake-client" if dep else "cmake"
+    env.add(root_name)
+    env.concretize()
+
+    root_spec = next(env.roots()).copy()
+    cmake_spec = root_spec["cmake"] if dep else root_spec
+    orig_hash = root_spec.dag_hash()
+
+    for spec in env.all_specs_generator():
+        if spec.name == "cmake":
+            assert spec.satisfies(orig_constraint)
+
+    selector = spack.spec.Spec("cmake")
+    mutator = spack.spec.Spec(mutated_constraint)
+    env.mutate(selector=selector, mutator=mutator)
+    cmake_spec.mutate(mutator)
+
+    for spec in env.all_specs_generator():
+        if spec.name == "cmake":
+            assert spec.satisfies(mutated_constraint)
+    assert cmake_spec.satisfies(mutated_constraint)
+
+    new_hash = next(env.roots()).dag_hash()
+    assert new_hash != orig_hash
+    assert root_spec.dag_hash() != orig_hash
+    assert root_spec.dag_hash() == new_hash
+
+
+@pytest.mark.parametrize("constraint", ["foo", "foo.bar", "foo%cmake@1.0", "foo@1.1:", "foo/abc"])
+def test_mutate_spec_invalid(constraint):
+    spec = spack.concretize.concretize_one("cmake-client")
+    with pytest.raises(spack.spec.SpecMutationError):
+        spec.mutate(spack.spec.Spec(constraint))
+
+
+def _test_mutate_from_cli(args, create=True):
+    if create:
+        ev.create("test")
+
+    env = ev.read("test")
+
+    if create:
+        env.add("cmake-client%cmake@3.4.3")
+        env.add("cmake-client%cmake@3.23.1")
+        env.concretize()
+        env.write()
+
+    with env:
+        change(*args)
+
+    return list(env.roots())
+
+
+def test_mutate_from_cli():
+    match_spec = "%cmake@3.4.3"
+    constraint = "@3.0"
+    args = ["--concrete", f"--match-spec={match_spec}", constraint]
+    roots = _test_mutate_from_cli(args)
+
+    assert any(r.satisfies(match_spec) for r in roots)
+    for root in roots:
+        if root.satisfies("match_spec"):
+            assert root.satisfies(constraint)
+
+
+def test_mutate_from_cli_multiple():
+    match_spec = "%cmake@3.4.3"
+    constraint1 = "@3.0"
+    constraint2 = "build_system=foo"
+    args = ["--concrete", f"--match-spec={match_spec}", constraint1, constraint2]
+    roots = _test_mutate_from_cli(args)
+
+    assert any(r.satisfies(match_spec) for r in roots)
+    for root in roots:
+        if root.satisfies("match_spec"):
+            assert root.satisfies(constraint1)
+            assert root.satisfies(constraint2)
+
+
+def test_mutate_from_cli_no_abstract():
+    match_spec = "cmake"
+    constraint = "@3.0"
+    args = ["--concrete", f"--match-spec={match_spec}", constraint]
+
+    with pytest.raises(ValueError, match="Cannot change abstract spec"):
+        _ = _test_mutate_from_cli(args)
+
+    args.insert(0, "--no-abstract")
+    roots = _test_mutate_from_cli(args, create=False)
+
+    for root in roots:
+        assert root[match_spec].satisfies(constraint)
+
+
+def test_mutate_from_cli_all_no_match_spec():
+    constraint = "cmake-client@3.0"
+    args = ["--concrete", "--all", constraint]
+    roots = _test_mutate_from_cli(args)
+
+    for root in roots:
+        assert root.satisfies(constraint)

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -27,7 +27,7 @@ change = SpackCommand("change")
     "orig_constraint,mutated_constraint",
     [
         ("@3.23.1", "@3.4.3"),
-        ("cflags=-O3", "cflags=-O0 -g"),
+        ("cflags=-O3", "cflags='-O0 -g'"),
         ("os=debian6", "os=redhat6"),
         (f"target={test_targets[0]}", f"target={test_targets[1]}"),
         ("build_system=generic", "build_system=foo"),
@@ -54,6 +54,7 @@ def test_mutate_internals(dep, orig_constraint, mutated_constraint):
 
     root_spec = next(env.roots()).copy()
     cmake_spec = root_spec["cmake"] if dep else root_spec
+    orig_cmake_spec = cmake_spec.copy()
     orig_hash = root_spec.dag_hash()
 
     for spec in env.all_specs_generator():
@@ -69,6 +70,10 @@ def test_mutate_internals(dep, orig_constraint, mutated_constraint):
         if spec.name == "cmake":
             assert spec.satisfies(mutated_constraint)
     assert cmake_spec.satisfies(mutated_constraint)
+
+    # Make sure that we're not changing variant types single/multi
+    for name, variant in cmake_spec.variants.items():
+        assert variant.type == orig_cmake_spec.variants[name].type
 
     new_hash = next(env.roots()).dag_hash()
     assert new_hash != orig_hash

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -56,6 +56,7 @@ class VariantType(enum.IntEnum):
     BOOL = 1
     SINGLE = 2
     MULTI = 3
+    INDICATOR = 4  # special type for placeholder variant values
 
     @property
     def string(self) -> str:
@@ -64,7 +65,10 @@ class VariantType(enum.IntEnum):
             return "bool"
         elif self == VariantType.SINGLE:
             return "single"
-        return "multi"
+        elif self == VariantType.MULTI:
+            return "multi"
+        else:
+            return "indicator"
 
 
 class Variant:
@@ -494,6 +498,13 @@ def SingleValuedVariant(
 
 def BoolValuedVariant(name: str, value: bool, propagate: bool = False) -> VariantValue:
     return VariantValue(VariantType.BOOL, name, (value,), propagate=propagate)
+
+
+class VariantValueRemoval(VariantValue):
+    """Indicator class for Spec.mutate to remove a variant"""
+
+    def __init__(self, name):
+        super().__init__(VariantType.INDICATOR, name, (None,))
 
 
 # The class below inherit from Sequence to disguise as a tuple and comply

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -681,7 +681,7 @@ _spack_cd() {
 _spack_change() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --list-name --match-spec -a --all --no-abstract --concrete"
+        SPACK_COMPREPLY="-h --help -l --list-name --match-spec -a --all --concrete -C --concrete-only"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -681,7 +681,7 @@ _spack_cd() {
 _spack_change() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --list-name --match-spec -a --all --concrete -C --concrete-only"
+        SPACK_COMPREPLY="-h --help -l --list-name --match-spec -a --all -c --concrete -C --concrete-only"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -681,7 +681,7 @@ _spack_cd() {
 _spack_change() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --list-name --match-spec -a --all"
+        SPACK_COMPREPLY="-h --help -l --list-name --match-spec -a --all --no-abstract --concrete"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -601,7 +601,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_enable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap enable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap disable
@@ -609,7 +609,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_disable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap disable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap reset
@@ -624,14 +624,14 @@ set -g __fish_spack_optspecs_spack_bootstrap_root h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap root' -f -a '(__fish_complete_directories)'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap list
 set -g __fish_spack_optspecs_spack_bootstrap_list h/help scope=
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap add
@@ -640,7 +640,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap add' -f -a '(__
 complete -c spack -n '__fish_spack_using_command_pos 1 bootstrap add' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -f -a trust
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -d 'enable the source immediately upon addition'
@@ -817,7 +817,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirro
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -d 'override any configured mirrors with this mirror URL'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -f -a output_file
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -d 'file where rebuild info should be written'
-complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -d 'configuration scope containing mirrors to check'
 
 # spack buildcache download
@@ -1099,7 +1099,7 @@ complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolcha
 complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1113,7 +1113,7 @@ complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchai
 complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1125,7 +1125,7 @@ complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -
 complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler rm
@@ -1135,14 +1135,14 @@ complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler list
 set -g __fish_spack_optspecs_spack_compiler_list h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'list also compilers from registered buildcaches'
@@ -1151,7 +1151,7 @@ complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'li
 set -g __fish_spack_optspecs_spack_compiler_ls h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -d 'list also compilers from registered buildcaches'
@@ -1161,14 +1161,14 @@ set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -d 'list also compilers from registered buildcaches'
@@ -1231,7 +1231,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a update -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a revert -d 'revert configuration files to their state before update'
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
@@ -1787,7 +1787,7 @@ complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -d 'one or more alternative search paths for finding externals'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
 complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
@@ -2377,7 +2377,7 @@ set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsig
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -f -a 'binary source'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -d 'specify the mirror type: for both binary and source use ``--type binary --type source`` (default)'
@@ -2411,7 +2411,7 @@ set -g __fish_spack_optspecs_spack_mirror_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror rm
@@ -2419,7 +2419,7 @@ set -g __fish_spack_optspecs_spack_mirror_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror set-url
@@ -2431,7 +2431,7 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -f -a p
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -d 'set only the URL used for uploading'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -f -a fetch
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -d 'set only the URL used for downloading'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2473,7 +2473,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2498,14 +2498,14 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-var
 set -g __fish_spack_optspecs_spack_mirror_list h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -d 'configuration scope to read from'
 
 # spack mirror ls
 set -g __fish_spack_optspecs_spack_mirror_ls h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -d 'configuration scope to read from'
 
 # spack module
@@ -2818,7 +2818,7 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 set -g __fish_spack_optspecs_spack_repo_list h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo list' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo list' -l names -d 'show configuration names only'
@@ -2829,7 +2829,7 @@ complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -d 'sh
 set -g __fish_spack_optspecs_spack_repo_ls h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -d 'show configuration names only'
@@ -2845,7 +2845,7 @@ complete -c spack -n '__fish_spack_using_command repo add' -l name -r -f -a name
 complete -c spack -n '__fish_spack_using_command repo add' -l name -r -d 'config name for the package repository, defaults to the namespace of the repository'
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
 
 # spack repo set
@@ -2857,7 +2857,7 @@ complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -f 
 complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -d 'destination to clone git repository into'
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
@@ -2865,7 +2865,7 @@ set -g __fish_spack_optspecs_spack_repo_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
 
 # spack repo rm
@@ -2873,7 +2873,7 @@ set -g __fish_spack_optspecs_spack_repo_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
 
 # spack repo migrate
@@ -2893,7 +2893,7 @@ complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -f -a remote
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -d 'name of remote to check for branches, tags, or commits'
-complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
+complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -f -a branch
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -d 'name of a branch to change to'

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -915,7 +915,7 @@ complete -c spack -n '__fish_spack_using_command cd' -l first -f -a find_first
 complete -c spack -n '__fish_spack_using_command cd' -l first -d 'use the first match if multiple packages match the spec'
 
 # spack change
-set -g __fish_spack_optspecs_spack_change h/help l/list-name= match-spec= a/all no-abstract concrete
+set -g __fish_spack_optspecs_spack_change h/help l/list-name= match-spec= a/all concrete C/concrete-only
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 change' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command change' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command change' -s h -l help -d 'show this help message and exit'
@@ -925,10 +925,10 @@ complete -c spack -n '__fish_spack_using_command change' -l match-spec -r -f -a 
 complete -c spack -n '__fish_spack_using_command change' -l match-spec -r -d 'change all specs matching match-spec (default is match by spec name)'
 complete -c spack -n '__fish_spack_using_command change' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command change' -s a -l all -d 'change all matching abstract specs (allow changing more than one abstract spec)'
-complete -c spack -n '__fish_spack_using_command change' -l no-abstract -f -a abstract
-complete -c spack -n '__fish_spack_using_command change' -l no-abstract -d 'do not change abstract specs in the environment'
 complete -c spack -n '__fish_spack_using_command change' -l concrete -f -a concrete
 complete -c spack -n '__fish_spack_using_command change' -l concrete -d 'change concrete specs in the environment'
+complete -c spack -n '__fish_spack_using_command change' -s C -l concrete-only -f -a concrete_only
+complete -c spack -n '__fish_spack_using_command change' -s C -l concrete-only -d 'change only concrete specs in the environment'
 
 # spack checksum
 set -g __fish_spack_optspecs_spack_checksum h/help keep-stage b/batch l/latest p/preferred a/add-to-package verify j/jobs=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -601,7 +601,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_enable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap enable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap disable
@@ -609,7 +609,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_disable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap disable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap reset
@@ -624,14 +624,14 @@ set -g __fish_spack_optspecs_spack_bootstrap_root h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap root' -f -a '(__fish_complete_directories)'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap list
 set -g __fish_spack_optspecs_spack_bootstrap_list h/help scope=
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap add
@@ -640,7 +640,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap add' -f -a '(__
 complete -c spack -n '__fish_spack_using_command_pos 1 bootstrap add' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -f -a trust
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -d 'enable the source immediately upon addition'
@@ -817,7 +817,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirro
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -d 'override any configured mirrors with this mirror URL'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -f -a output_file
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -d 'file where rebuild info should be written'
-complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -d 'configuration scope containing mirrors to check'
 
 # spack buildcache download
@@ -915,7 +915,7 @@ complete -c spack -n '__fish_spack_using_command cd' -l first -f -a find_first
 complete -c spack -n '__fish_spack_using_command cd' -l first -d 'use the first match if multiple packages match the spec'
 
 # spack change
-set -g __fish_spack_optspecs_spack_change h/help l/list-name= match-spec= a/all concrete C/concrete-only
+set -g __fish_spack_optspecs_spack_change h/help l/list-name= match-spec= a/all c/concrete C/concrete-only
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 change' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command change' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command change' -s h -l help -d 'show this help message and exit'
@@ -925,8 +925,8 @@ complete -c spack -n '__fish_spack_using_command change' -l match-spec -r -f -a 
 complete -c spack -n '__fish_spack_using_command change' -l match-spec -r -d 'change all specs matching match-spec (default is match by spec name)'
 complete -c spack -n '__fish_spack_using_command change' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command change' -s a -l all -d 'change all matching abstract specs (allow changing more than one abstract spec)'
-complete -c spack -n '__fish_spack_using_command change' -l concrete -f -a concrete
-complete -c spack -n '__fish_spack_using_command change' -l concrete -d 'change concrete specs in the environment'
+complete -c spack -n '__fish_spack_using_command change' -s c -l concrete -f -a concrete
+complete -c spack -n '__fish_spack_using_command change' -s c -l concrete -d 'change concrete specs in the environment'
 complete -c spack -n '__fish_spack_using_command change' -s C -l concrete-only -f -a concrete_only
 complete -c spack -n '__fish_spack_using_command change' -s C -l concrete-only -d 'change only concrete specs in the environment'
 
@@ -1099,7 +1099,7 @@ complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolcha
 complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1113,7 +1113,7 @@ complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchai
 complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1125,7 +1125,7 @@ complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -
 complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler rm
@@ -1135,14 +1135,14 @@ complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler list
 set -g __fish_spack_optspecs_spack_compiler_list h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'list also compilers from registered buildcaches'
@@ -1151,7 +1151,7 @@ complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'li
 set -g __fish_spack_optspecs_spack_compiler_ls h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -d 'list also compilers from registered buildcaches'
@@ -1161,14 +1161,14 @@ set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -d 'list also compilers from registered buildcaches'
@@ -1231,7 +1231,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a update -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a revert -d 'revert configuration files to their state before update'
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
@@ -1787,7 +1787,7 @@ complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -d 'one or more alternative search paths for finding externals'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
 complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
@@ -2377,7 +2377,7 @@ set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsig
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -f -a 'binary source'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -d 'specify the mirror type: for both binary and source use ``--type binary --type source`` (default)'
@@ -2411,7 +2411,7 @@ set -g __fish_spack_optspecs_spack_mirror_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror rm
@@ -2419,7 +2419,7 @@ set -g __fish_spack_optspecs_spack_mirror_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror set-url
@@ -2431,7 +2431,7 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -f -a p
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -d 'set only the URL used for uploading'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -f -a fetch
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -d 'set only the URL used for downloading'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2473,7 +2473,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2498,14 +2498,14 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-var
 set -g __fish_spack_optspecs_spack_mirror_list h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -d 'configuration scope to read from'
 
 # spack mirror ls
 set -g __fish_spack_optspecs_spack_mirror_ls h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -d 'configuration scope to read from'
 
 # spack module
@@ -2818,7 +2818,7 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 set -g __fish_spack_optspecs_spack_repo_list h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo list' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo list' -l names -d 'show configuration names only'
@@ -2829,7 +2829,7 @@ complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -d 'sh
 set -g __fish_spack_optspecs_spack_repo_ls h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -d 'show configuration names only'
@@ -2845,7 +2845,7 @@ complete -c spack -n '__fish_spack_using_command repo add' -l name -r -f -a name
 complete -c spack -n '__fish_spack_using_command repo add' -l name -r -d 'config name for the package repository, defaults to the namespace of the repository'
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
 
 # spack repo set
@@ -2857,7 +2857,7 @@ complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -f 
 complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -d 'destination to clone git repository into'
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
@@ -2865,7 +2865,7 @@ set -g __fish_spack_optspecs_spack_repo_remove h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
 
 # spack repo rm
@@ -2873,7 +2873,7 @@ set -g __fish_spack_optspecs_spack_repo_rm h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
 
 # spack repo migrate
@@ -2893,7 +2893,7 @@ complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -f -a remote
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -d 'name of remote to check for branches, tags, or commits'
-complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults site user spack env:test command_line'
 complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -f -a branch
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -d 'name of a branch to change to'

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -915,16 +915,20 @@ complete -c spack -n '__fish_spack_using_command cd' -l first -f -a find_first
 complete -c spack -n '__fish_spack_using_command cd' -l first -d 'use the first match if multiple packages match the spec'
 
 # spack change
-set -g __fish_spack_optspecs_spack_change h/help l/list-name= match-spec= a/all
+set -g __fish_spack_optspecs_spack_change h/help l/list-name= match-spec= a/all no-abstract concrete
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 change' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command change' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command change' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command change' -s l -l list-name -r -f -a list_name
-complete -c spack -n '__fish_spack_using_command change' -s l -l list-name -r -d 'name of the list to remove specs from'
+complete -c spack -n '__fish_spack_using_command change' -s l -l list-name -r -d 'name of the list to remove abstract specs from'
 complete -c spack -n '__fish_spack_using_command change' -l match-spec -r -f -a match_spec
-complete -c spack -n '__fish_spack_using_command change' -l match-spec -r -d 'if name is ambiguous, supply a spec to match'
+complete -c spack -n '__fish_spack_using_command change' -l match-spec -r -d 'change all specs matching match-spec (default is match by spec name)'
 complete -c spack -n '__fish_spack_using_command change' -s a -l all -f -a all
-complete -c spack -n '__fish_spack_using_command change' -s a -l all -d 'change all matching specs (allow changing more than one spec)'
+complete -c spack -n '__fish_spack_using_command change' -s a -l all -d 'change all matching abstract specs (allow changing more than one abstract spec)'
+complete -c spack -n '__fish_spack_using_command change' -l no-abstract -f -a abstract
+complete -c spack -n '__fish_spack_using_command change' -l no-abstract -d 'do not change abstract specs in the environment'
+complete -c spack -n '__fish_spack_using_command change' -l concrete -f -a concrete
+complete -c spack -n '__fish_spack_using_command change' -l concrete -d 'change concrete specs in the environment'
 
 # spack checksum
 set -g __fish_spack_optspecs_spack_checksum h/help keep-stage b/batch l/latest p/preferred a/add-to-package verify j/jobs=


### PR DESCRIPTION
This PR adds an option to the ``spack change`` command to modify concrete specs.

This option bypasses all guardrails, and can result in incompatible specs -- it is expected to be useful primarily to package developers who understand the compatibilities of their packages.

Example:

In a concretized environment with the root `hdf5`, the command

```
spack change --concrete hdf5 build_type=Debug
```
will change the abstract root to `hdf5 build_type=Debug` and will apply the change to the concrete spec without requiring reconcretization.

PR also adds a `--no-abstract` option, for cases in which either it is undesirable to modify the root spec or the desired change to the concrete specs would not be represented on the root spec, e.g. changes to non-root nodes.

Includes unit tests and docs.
