### PR TITLE
spack audit: check dependencies with an upper bound on versions

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -1006,6 +1006,7 @@ def _issues_in_depends_on_directive(pkgs, error_cls):
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         filename = spack.repo.PATH.filename_for_package_name(pkg_name)
 
+        bounded_deps = {}
         for when, deps_by_name in pkg_cls.dependencies.items():
             for dep_name, dep in deps_by_name.items():
 
@@ -1090,12 +1091,28 @@ def _issues_in_depends_on_directive(pkgs, error_cls):
                     max_infinity in v and min_infinity not in v for v in when.versions
                 )
                 if bounded_dependency and unbounded_condition:
-                    summary = (
-                        f"{pkg_name}: {dep.spec} has an upper bound for all versions of {pkg_name}"
-                    )
-                    errors.append(
-                        error_cls(summary=summary, details=[f"when={when}", f"in {filename}"])
-                    )
+                    bounded_deps.setdefault(dep.spec.name, []).append((dep.spec, when))
+
+        for dep_name, cases in bounded_deps.items():
+            # One case is usually fine
+            if len(cases) == 1:
+                continue
+
+            # Multiple directives, but imposing the same upper bound, are also fine
+            try:
+                upper_bounds = {v.hi for d, _ in cases for v in d.versions}
+                if len(upper_bounds) == 1:
+                    continue
+            except AttributeError as e:
+                warnings.warn(f"{pkg_name}: {e}")
+
+            for dependency, when in cases:
+                summary = (
+                    f"{pkg_name}: {dependency} has an upper bound for all versions of {pkg_name}"
+                )
+                errors.append(
+                    error_cls(summary=summary, details=[f"when={when}", f"in {filename}"])
+                )
 
     return errors
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -59,6 +59,7 @@ import spack.spec
 import spack.util.crypto
 import spack.util.spack_yaml as syaml
 import spack.variant
+import spack.version
 from spack.llnl.string import plural
 
 #: Map an audit tag to a list of callables implementing checks
@@ -1079,6 +1080,22 @@ def _issues_in_depends_on_directive(pkgs, error_cls):
                         errors.append(
                             error_cls(summary=summary, details=[error_msg, f"in {filename}"])
                         )
+
+                # Check we don't have unbounded version ranges in the "when" condition, and bounded
+                # version ranges in the depends on spec
+                max_infinity = spack.version.StandardVersion.typemax()
+                min_infinity = spack.version.StandardVersion.typemin()
+                bounded_dependency = all(max_infinity not in v for v in dep.spec.versions)
+                unbounded_condition = all(
+                    max_infinity in v and min_infinity not in v for v in when.versions
+                )
+                if bounded_dependency and unbounded_condition:
+                    summary = (
+                        f"{pkg_name}: {dep.spec} has an upper bound for all versions of {pkg_name}"
+                    )
+                    errors.append(
+                        error_cls(summary=summary, details=[f"when={when}", f"in {filename}"])
+                    )
 
     return errors
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -61,6 +61,7 @@ import spack.util.spack_yaml as syaml
 import spack.variant
 import spack.version
 from spack.llnl.string import plural
+from spack.version import ClosedOpenRange
 
 #: Map an audit tag to a list of callables implementing checks
 CALLBACKS = {}
@@ -1100,11 +1101,15 @@ def _issues_in_depends_on_directive(pkgs, error_cls):
 
             # Multiple directives, but imposing the same upper bound, are also fine
             try:
-                upper_bounds = {v.hi for d, _ in cases for v in d.versions}
-                if len(upper_bounds) == 1:
+                upper_bounds = {
+                    max(v.hi for v in d.versions if isinstance(v, ClosedOpenRange))
+                    for d, _ in cases
+                }
+                if len(upper_bounds) <= 1:
                     continue
-            except AttributeError as e:
+            except (AttributeError, ValueError) as e:
                 warnings.warn(f"{pkg_name}: {e}")
+                continue
 
             for dependency, when in cases:
                 summary = (


### PR DESCRIPTION
Right now it's possible to write dependencies like:
```
depends_on("python@3.3:3.12", when="@2.20:")
```
This may become an issue when the most recent version of a package is updated, but we forget to add an upper bound to the "when=" condition above.

In complex packages, with many dependencies, this may result in older version of some nodes being selected - and that can cause issues like https://github.com/spack/spack-packages/pull/2330

Here, we add an audit that reports when a dependency has multiple, and different, upper bounds without a similarly bounded `when=` condition.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
