### PR TITLE
test_updated_completion_scripts: Generalize command completion message

### DIFF
--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -264,16 +264,14 @@ def test_updated_completion_scripts(shell, tmp_path: pathlib.Path):
     width = 72
     lines = textwrap.wrap(
         "It looks like Spack's command-line interface has been modified. "
-        "If differences are more than your global 'include:' scopes, please "
-        "update Spack's shell tab completion scripts by running:",
+        "If differences are more than your custom scopes, please update "
+        "Spack's shell tab completion scripts by running:",
         width,
     )
     lines.append("\n    spack commands --update-completion\n")
     lines.extend(
         textwrap.wrap(
-            "and adding the changed files (minus your global 'include:' scopes) "
-            "to your pull request.",
-            width,
+            "and adding the changed files (minus your custom scopes) to your pull request.", width
         )
     )
     msg = "\n".join(lines)


### PR DESCRIPTION
FYI @tgamblin 

This PR generalized the error message from `test_updated_completion_scripts` since [#51162](https://github.com/spack/spack/pull/51162) expanded possible customizations.

If you're doing development on Spack with custom configuration settings, you'll get a failure in `test_updated_completion_scripts` that currently reads:

```
...
 >       assert filecmp.cmp(old_script, new_script), msg
E       AssertionError: It looks like Spack's command-line interface has been modified. If
E         differences are more than your global 'include:' scopes, please update
E         Spack's shell tab completion scripts by running:
E         
E             spack commands --update-completion
E         
E         and adding the changed files (minus your global 'include:' scopes) to
E         your pull request.
E       assert False
...
```

which now reads:

```
...
 >       assert filecmp.cmp(old_script, new_script), msg
E       AssertionError: It looks like Spack's command-line interface has been modified. If
E         differences are more than your custom scopes, please update Spack's
E         shell tab completion scripts by running:
E         
E             spack commands --update-completion
E         
E         and adding the changed files (minus your custom scopes) to your pull
E         request.
E       assert False
...
```