### PR TITLE
restore SPACK_SYSTEM_CONFIG_PATH env override

### DIFF
--- a/etc/spack/include.yaml
+++ b/etc/spack/include.yaml
@@ -14,6 +14,7 @@ include:
 
   # system configuration scope
   - name: "system"
+    path_override_env_var: SPACK_SYSTEM_CONFIG_PATH
     path: "/etc/spack"
     optional: true
     when: '"SPACK_DISABLE_LOCAL_CONFIG" not in env'


### PR DESCRIPTION
#51162 silently removed the [documented](https://spack.readthedocs.io/en/latest/configuration.html#overriding-local-configuration) `SPACK_SYSTEM_CONFIG_PATH` env variable overwrite for the system scope. This restores it.