### PR TITLE
new_installer: display help

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -796,6 +796,11 @@ class BuildStatus:
 
         if self.search_mode:
             buffer.write(f"filter> {self.search_term}\033[K")
+        else:
+            buffer.write(
+                "\033[36m/\033[0m: filter  \033[36mv\033[0m: logs  "
+                "\033[36mn\033[0m/\033[36mp\033[0m: next/prev\033[K"
+            )
 
         # Clear any remaining lines from previous display
         buffer.write("\033[0J")


### PR DESCRIPTION
Show available commands in the last line of the new installer's terminal
UI.

Currently just `/`, `v`, `n/p`. I don't think a big help screen is
needed really. What's not displayed is Esc and q, but I think that's
natural. The reason to leave them out is to make the line compact, but
also to avoid having to communicate that q does not quit the installer,
but rather only returns from logs to overview.

<img width="328" height="114" alt="Screenshot 2025-11-12 at 10 18 19" src="https://github.com/user-attachments/assets/f334bbbd-fc6e-4667-a95f-1ea5aa1166e7" />

