### PR TITLE
spack checksum: fix broken help message

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -190,7 +190,7 @@ class SpackHelpFormatter(argparse.RawTextHelpFormatter):
             first_newline = result.index("\n")
             header, rest = result[:first_newline], result[first_newline:]
 
-        return color.colorize(f"@c{{{color.cescape(header)}}}{rest}")
+        return color.colorize(f"@c{{{color.cescape(header)}}}{color.cescape(rest)}")
 
     def add_arguments(self, actions):
         actions = sorted(actions, key=operator.attrgetter("option_strings"))


### PR DESCRIPTION
Bug introduced in #51484

Before:
```console
$ spack checksum -h
==> Error: Incomplete color format: '@' in '@c{  package               }name or spec (e.g. ``cmake`` or ``cmake@3.18``)
'
```

After:
```console
$ spack checksum -h
usage: spack checksum [-h] [--keep-stage] [--batch] [--latest] [--preferred] [--add-to-package | --verify] [-j JOBS] package [versions ...]

checksum available versions of a package

positional arguments:
  package               name or spec (e.g. ``cmake`` or ``cmake@3.18``)
  versions              checksum these specific versions (if omitted, Spack searches for remote versions)

options:
  --add-to-package, -a  add new versions to package
  --batch, -b           don't ask which versions to checksum
  --keep-stage          don't clean up staging area when command completes
  --latest, -l          checksum the latest available version
  --preferred, -p       checksum the known Spack preferred version
  --verify              verify known package checksums
  -h, --help            show this help message and exit
  -j, --jobs JOBS       explicitly set number of parallel jobs

examples:
  `spack checksum zlib@1.2` autodetects versions 1.2.0 to 1.2.13 from the remote
  `spack checksum zlib 1.2.13` checksums exact version 1.2.13 directly without search
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
