### PR TITLE
installer: consolidate source/cache args

### DIFF
--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -294,8 +294,8 @@ class SourceBootstrapper(Bootstrapper):
             PackageInstaller(
                 [concrete_spec.package],
                 fail_fast=True,
-                package_use_cache=False,
-                dependencies_use_cache=False,
+                root_policy="source_only",
+                dependencies_policy="source_only",
             ).install()
 
         if _try_import_from_store(module, query_spec=concrete_spec, query_info=info):

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -40,6 +40,8 @@ from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
 from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Set, Tuple, Union
 
+from spack.vendor.typing_extensions import Literal
+
 import spack.binary_distribution
 import spack.build_environment
 import spack.builder
@@ -59,6 +61,9 @@ import spack.util.lock
 
 if TYPE_CHECKING:
     import spack.package_base
+
+#: Type for specifying installation source modes
+InstallPolicy = Literal["auto", "cache_only", "source_only"]
 
 #: How often to update a spinner in seconds
 SPINNER_INTERVAL = 0.1
@@ -959,9 +964,6 @@ class PackageInstaller:
         self,
         packages: List["spack.package_base.PackageBase"],
         *,
-        cache_only: bool = False,
-        dependencies_cache_only: bool = False,
-        dependencies_use_cache: bool = True,
         dirty: bool = False,
         explicit: Union[Set[str], bool] = False,
         overwrite: Optional[Union[List[str], Set[str]]] = None,
@@ -973,25 +975,22 @@ class PackageInstaller:
         install_source: bool = False,
         keep_prefix: bool = False,
         keep_stage: bool = False,
-        package_cache_only: bool = False,
-        package_use_cache: bool = True,
         restage: bool = True,
         skip_patch: bool = False,
         stop_at: Optional[str] = None,
         stop_before: Optional[str] = None,
         tests: Union[bool, List[str], Set[str]] = False,
         unsigned: Optional[bool] = None,
-        use_cache: bool = False,
         verbose: bool = False,
         concurrent_packages: Optional[int] = None,
+        root_policy: InstallPolicy = "auto",
+        dependencies_policy: InstallPolicy = "auto",
     ) -> None:
 
-        if cache_only:
+        if root_policy == "cache_only" or dependencies_policy == "cache_only":
             raise NotImplementedError("Cache-only installs are not implemented")
-        elif dependencies_cache_only:
-            raise NotImplementedError("Dependencies cache-only installs are not implemented")
-        elif not dependencies_use_cache:
-            raise NotImplementedError("Not using cache for dependencies is not implemented")
+        elif root_policy == "source_only" or dependencies_policy == "source_only":
+            raise NotImplementedError("Source-only installs are not implemented")
         elif dirty:
             raise NotImplementedError("Dirty installs are not implemented")
         elif overwrite:
@@ -1012,10 +1011,6 @@ class PackageInstaller:
             raise NotImplementedError("Keeping install prefixes is not implemented")
         elif keep_stage:
             raise NotImplementedError("Keeping build stages is not implemented")
-        elif package_cache_only:
-            raise NotImplementedError("Package cache only installs are not implemented")
-        elif not package_use_cache:
-            raise NotImplementedError("Not using package cache is not implemented")
         elif not restage:
             raise NotImplementedError("Restaging builds is not implemented")
         elif skip_patch:
@@ -1026,8 +1021,6 @@ class PackageInstaller:
             raise NotImplementedError("Stopping before an install phase is not implemented")
         elif tests is not False:
             raise NotImplementedError("Tests during install are not implemented")
-        elif use_cache:
-            raise NotImplementedError("Using cache only is not implemented")
         # verbose and concurrent_packages are not worth erroring out for
 
         specs = [pkg.spec for pkg in packages]

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -371,7 +371,9 @@ def test_update_sbang(tmp_path: pathlib.Path, temporary_mirror, mock_fetch, inst
         new_prefix, new_sbang_shebang = s.prefix, sbang.sbang_shebang_line()
         assert old_prefix != new_prefix
         assert old_sbang_shebang != new_sbang_shebang
-        PackageInstaller([s.package], cache_only=True, unsigned=True).install()
+        PackageInstaller(
+            [s.package], root_policy="cache_only", dependencies_policy="cache_only", unsigned=True
+        ).install()
 
         # Check that the sbang line refers to the new install tree
         new_contents = f"""\

--- a/lib/spack/spack/test/buildrequest.py
+++ b/lib/spack/spack/test/buildrequest.py
@@ -56,29 +56,21 @@ def test_build_request_strings(install_mockery):
 
 
 @pytest.mark.parametrize(
-    "package_cache_only,dependencies_cache_only,package_deptypes,dependencies_deptypes",
+    "root_policy,dependencies_policy,package_deptypes,dependencies_deptypes",
     [
-        (False, False, dt.BUILD | dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
-        (True, False, dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
-        (False, True, dt.BUILD | dt.LINK | dt.RUN, dt.LINK | dt.RUN),
-        (True, True, dt.LINK | dt.RUN, dt.LINK | dt.RUN),
+        ("auto", "auto", dt.BUILD | dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
+        ("cache_only", "auto", dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
+        ("auto", "cache_only", dt.BUILD | dt.LINK | dt.RUN, dt.LINK | dt.RUN),
+        ("cache_only", "cache_only", dt.LINK | dt.RUN, dt.LINK | dt.RUN),
     ],
 )
 def test_build_request_deptypes(
-    install_mockery,
-    package_cache_only,
-    dependencies_cache_only,
-    package_deptypes,
-    dependencies_deptypes,
+    install_mockery, root_policy, dependencies_policy, package_deptypes, dependencies_deptypes
 ):
     s = spack.concretize.concretize_one("dependent-install")
 
     build_request = inst.BuildRequest(
-        s.package,
-        {
-            "package_cache_only": package_cache_only,
-            "dependencies_cache_only": dependencies_cache_only,
-        },
+        s.package, {"root_policy": root_policy, "dependencies_policy": dependencies_policy}
     )
 
     actual_package_deptypes = build_request.get_depflags(s.package)

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -472,7 +472,11 @@ def test_push_and_install_with_mirror_marked_unsigned_does_not_require_extra_fla
 
     spec.package.do_uninstall(force=True)
     PackageInstaller(
-        [spec.package], explicit=True, cache_only=True, unsigned=True if signed else None
+        [spec.package],
+        explicit=True,
+        root_policy="cache_only",
+        dependencies_policy="cache_only",
+        unsigned=True if signed else None,
     ).install()
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1209,32 +1209,11 @@ def install_mockery(temporary_store: spack.store.Store, mutable_config, mock_pac
     temporary_store.failure_tracker.clear_all()
 
 
-@pytest.fixture(scope="module")
-def temporary_mirror_dir(tmp_path_factory: pytest.TempPathFactory):
-    dir = tmp_path_factory.mktemp("mirror")
-    yield str(dir)
-
-
 @pytest.fixture(scope="function")
-def temporary_mirror(temporary_mirror_dir):
-    mirror_url = url_util.path_to_file_url(temporary_mirror_dir)
-    mirror_cmd("add", "--scope", "site", "test-mirror-func", mirror_url)
-    yield temporary_mirror_dir
-    mirror_cmd("rm", "--scope=site", "test-mirror-func")
-
-
-@pytest.fixture(scope="function")
-def mutable_temporary_mirror_dir(tmp_path_factory: pytest.TempPathFactory):
-    dir = tmp_path_factory.mktemp("mirror")
-    yield str(dir)
-
-
-@pytest.fixture(scope="function")
-def mutable_temporary_mirror(mutable_temporary_mirror_dir):
-    mirror_url = url_util.path_to_file_url(mutable_temporary_mirror_dir)
-    mirror_cmd("add", "--scope", "site", "test-mirror-func", mirror_url)
-    yield mutable_temporary_mirror_dir
-    mirror_cmd("rm", "--scope=site", "test-mirror-func")
+def temporary_mirror(mutable_config, tmp_path_factory):
+    mirror_dir = tmp_path_factory.mktemp("mirror")
+    mirror_cmd("add", "test-mirror-func", mirror_dir.as_uri())
+    yield str(mirror_dir)
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -594,8 +594,8 @@ def test_install_from_binary_with_missing_patch_succeeds(
     PackageInstaller(
         [s.package],
         explicit=True,
-        package_cache_only=True,
-        dependencies_cache_only=True,
+        root_policy="cache_only",
+        dependencies_policy="cache_only",
         unsigned=True,
     ).install()
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -27,9 +27,7 @@ import spack.package_prefs as prefs
 import spack.repo
 import spack.spec
 import spack.store
-import spack.test.conftest
 import spack.util.lock as lk
-from spack.installer import PackageInstaller
 from spack.main import SpackCommand
 from spack.test.conftest import RepoBuilder
 
@@ -142,8 +140,8 @@ def test_install_from_cache_errors(install_mockery):
     with pytest.raises(
         spack.error.InstallError, match="No binary found when cache-only was specified"
     ):
-        PackageInstaller(
-            [spec.package], package_cache_only=True, dependencies_cache_only=True
+        inst.PackageInstaller(
+            [spec.package], root_policy="cache_only", dependencies_policy="cache_only"
         ).install()
     assert not spec.package.installed_from_binary_cache
 
@@ -669,7 +667,7 @@ def test_install_spliced_build_spec_installed(install_mockery, capfd, mock_fetch
 
     # Do the splice.
     out = spec.splice(dep, transitive)
-    PackageInstaller([out.build_spec.package]).install()
+    inst.PackageInstaller([out.build_spec.package]).install()
 
     installer = create_installer([out], {"verbose": True, "fail_fast": True})
     installer._init_queue()
@@ -688,19 +686,14 @@ def test_install_spliced_build_spec_installed(install_mockery, capfd, mock_fetch
     "root_str", ["splice-t^splice-h~foo", "splice-h~foo", "splice-vt^splice-a"]
 )
 def test_install_splice_root_from_binary(
-    mutable_mock_env_path,
-    install_mockery,
-    mock_fetch,
-    mutable_temporary_mirror,
-    transitive,
-    root_str,
+    mutable_mock_env_path, install_mockery, mock_fetch, temporary_mirror, transitive, root_str
 ):
     """Test installing a spliced spec with the root available in binary cache"""
     # Test splicing and rewiring a spec with the same name, different hash.
     original_spec = spack.concretize.concretize_one(root_str)
     spec_to_splice = spack.concretize.concretize_one("splice-h+foo")
 
-    PackageInstaller([original_spec.package, spec_to_splice.package]).install()
+    inst.PackageInstaller([original_spec.package, spec_to_splice.package]).install()
 
     out = original_spec.splice(spec_to_splice, transitive)
 
@@ -709,7 +702,7 @@ def test_install_splice_root_from_binary(
         "push",
         "--unsigned",
         "--update-index",
-        mutable_temporary_mirror,
+        temporary_mirror,
         str(original_spec),
         str(spec_to_splice),
     )
@@ -717,7 +710,7 @@ def test_install_splice_root_from_binary(
     uninstall = SpackCommand("uninstall")
     uninstall("-ay")
 
-    PackageInstaller([out.package], unsigned=True).install()
+    inst.PackageInstaller([out.package], unsigned=True).install()
 
     assert len(spack.store.STORE.db.query()) == len(list(out.traverse()))
 


### PR DESCRIPTION
Simplify the 6 installer args related to cache vs source to 2:

* `root_policy: Literal["auto","cache_only","source_only"]`
* `dependencies_policy: Literal["auto","cache_only","source_only"]`

This way no invalid state can be represented, and there are not
overlapping options.

I used Literal in favor of an enum since it doesn't need another import
on the call site.

The refactor exposed a two bugs: the package installer `cache_only`
argument was ignored, leading to a test that did two source builds
instead of one source build followed by a cache install. Fixing
this, it turned out that it also modified site scope config, which was
never used, because another test fixture pulls in `mutable_config`
without the site scope.

(It also reduces the number of unsupported options in the new
installer by 4 /s)
