### PR TITLE
spack repo remove: allow removing from unspecified scope

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -22,6 +22,7 @@ import spack.util.parallel
 import spack.util.web as web_util
 from spack.cmd.common import arguments
 from spack.error import SpackError
+from spack.llnl.string import plural, comma_or
 
 description = "manage mirrors (source and binary)"
 section = "config"
@@ -147,10 +148,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     remove_parser = sp.add_parser("remove", aliases=["rm"], help=mirror_remove.__doc__)
     remove_parser.add_argument("name", help="mnemonic name for mirror", metavar="mirror")
     remove_parser.add_argument(
-        "--scope",
-        action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope(),
-        help="configuration scope to modify",
+        "--scope", action=arguments.ConfigScope, default=None, help="configuration scope to modify"
     )
 
     # Set-Url
@@ -349,7 +347,15 @@ def mirror_add(args):
 
 def mirror_remove(args):
     """remove a mirror by name"""
-    spack.mirrors.utils.remove(args.name, args.scope)
+    name = args.name
+    scopes = [args.scope] if args.scope else list(spack.config.CONFIG.scopes.keys())
+
+    removed = False
+    for scope in scopes:
+        removed |= spack.mirrors.utils.remove(name, scope)
+
+    if not removed:
+        tty.die(f"No mirror with name {name} in {comma_or(scopes)} scope")
 
 
 def _configure_mirror(args):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -22,7 +22,7 @@ import spack.util.parallel
 import spack.util.web as web_util
 from spack.cmd.common import arguments
 from spack.error import SpackError
-from spack.llnl.string import plural, comma_or
+from spack.llnl.string import comma_or
 
 description = "manage mirrors (source and binary)"
 section = "config"

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -150,7 +150,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     remove_parser.add_argument(
         "--scope", action=arguments.ConfigScope, default=None, help="configuration scope to modify"
     )
-
+    remove_parser.add_argument(
+        "--all-scopes",
+        action="store_true",
+        default=False,
+        help="remove from all config scopes (default: highest scope with matching mirror)",
+    )
     # Set-Url
     set_url_parser = sp.add_parser("set-url", help=mirror_set_url.__doc__)
     set_url_parser.add_argument("name", help="mnemonic name for mirror", metavar="mirror")
@@ -353,6 +358,8 @@ def mirror_remove(args):
     removed = False
     for scope in scopes:
         removed |= spack.mirrors.utils.remove(name, scope)
+        if removed and not args.all_scopes:
+            return
 
     if not removed:
         tty.die(f"No mirror with name {name} in {comma_or(scopes)} scope")

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -357,7 +357,11 @@ def mirror_remove(args):
 
     removed = False
     for scope in scopes:
-        removed |= spack.mirrors.utils.remove(name, scope)
+        removed_from_this_scope = spack.mirrors.utils.remove(name, scope)
+        if removed_from_this_scope:
+            tty.msg(f"Removed mirror {name} from {scope} scope")
+
+        removed |= removed_from_this_scope
         if removed and not args.all_scopes:
             return
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -115,6 +115,12 @@ def setup_parser(subparser: argparse.ArgumentParser):
     remove_parser.add_argument(
         "--scope", action=arguments.ConfigScope, default=None, help="configuration scope to modify"
     )
+    remove_parser.add_argument(
+        "--all-scopes",
+        action="store_true",
+        default=False,
+        help="remove from all config scopes (default: highest scope with matching repo)",
+    )
 
     # Migrate
     migrate_parser = sp.add_parser("migrate", help=repo_migrate.__doc__)
@@ -253,6 +259,8 @@ def repo_remove(args):
     found_and_removed = False
     for scope in scopes:
         found_and_removed |= _remove_repo(args.namespace_or_path, scope)
+        if found_and_removed and not args.all_scopes:
+            return
     if not found_and_removed:
         tty.die(f"No repository with path or namespace: {args.namespace_or_path}")
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -113,10 +113,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         "namespace_or_path", help="namespace or path of a Spack package repository"
     )
     remove_parser.add_argument(
-        "--scope",
-        action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope(),
-        help="configuration scope to modify",
+        "--scope", action=arguments.ConfigScope, default=None, help="configuration scope to modify"
     )
 
     # Migrate
@@ -252,8 +249,16 @@ def repo_add(args):
 
 def repo_remove(args):
     """remove a repository from Spack's configuration"""
-    namespace_or_path = args.namespace_or_path
-    repos: Dict[str, str] = spack.config.get("repos", scope=args.scope)
+    scopes = [args.scope] if args.scope else list(spack.config.CONFIG.scopes.keys())
+    found_and_removed = False
+    for scope in scopes:
+        found_and_removed |= _remove_repo(args.namespace_or_path, scope)
+    if not found_and_removed:
+        tty.die(f"No repository with path or namespace: {args.namespace_or_path}")
+
+
+def _remove_repo(namespace_or_path, scope):
+    repos: Dict[str, str] = spack.config.get("repos", scope=scope)
 
     if namespace_or_path in repos:
         # delete by name (from config)
@@ -262,7 +267,7 @@ def repo_remove(args):
         # delete by namespace or path (requires constructing the repo)
         canon_path = spack.util.path.canonicalize_path(namespace_or_path)
         descriptors = spack.repo.RepoDescriptors.from_config(
-            spack.repo.package_repository_lock(), spack.config.CONFIG, scope=args.scope
+            spack.repo.package_repository_lock(), spack.config.CONFIG, scope=scope
         )
         for name, descriptor in descriptors.items():
             descriptor.initialize(fetch=False)
@@ -277,11 +282,12 @@ def repo_remove(args):
                 key = name
                 break
         else:
-            tty.die(f"No repository with path or namespace: {namespace_or_path}")
+            return False
 
     del repos[key]
-    spack.config.set("repos", repos, args.scope)
-    tty.msg(f"Removed repository '{namespace_or_path}'.")
+    spack.config.set("repos", repos, scope)
+    tty.msg(f"Removed repository '{namespace_or_path}' from scope '{scope}'.")
+    return True
 
 
 def repo_list(args):

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -133,12 +133,11 @@ def remove(name, scope):
     if not mirrors:
         mirrors = syaml.syaml_dict()
 
-    if name not in mirrors:
-        tty.die("No mirror with name %s" % name)
-
-    mirrors.pop(name)
+    removed = mirrors.pop(name, False)
     spack.config.set("mirrors", mirrors, scope=scope)
-    tty.msg("Removed mirror %s." % name)
+    if removed:
+        tty.msg(f"Removed mirror {name} from {scope} scope")
+    return bool(removed)
 
 
 class MirrorStatsForOneSpec:

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -135,8 +135,6 @@ def remove(name, scope):
 
     removed = mirrors.pop(name, False)
     spack.config.set("mirrors", mirrors, scope=scope)
-    if removed:
-        tty.msg(f"Removed mirror {name} from {scope} scope")
     return bool(removed)
 
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -285,6 +285,31 @@ mpich@1.0
     assert not any(spec.satisfies(y) for spec in mirror_specs for y in expected_exclude)
 
 
+def test_mirror_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
+    # add a new mirror to two scopes
+    mirror("add", "--scope=site", "mock", str(tmp_path / "mock_mirror"))
+    mirror("add", "--scope=system", "mock", str(tmp_path / "mock_mirror"))
+
+    # Confirm that it is not removed when the scope is incorrect
+    with pytest.raises(spack.main.SpackCommandError):
+        mirror("remove", "--scope=user", "mock")
+    output = mirror("list", output=str)
+    assert "mock" in output
+
+    # Confirm that when the scope is specified, it is only removed from that scope
+    mirror("remove", "--scope=site", "mock")
+    site_output = mirror("list", "--scope=site", output=str)
+    system_output = mirror("list", "--scope=system", output=str)
+    assert "mock" not in site_output
+    assert "mock" in system_output
+
+    # Confirm that when the scope is not specified, it is removed from all scopes
+    mirror("add", "--scope=site", "mock", str(tmp_path / "mockrepo"))
+    mirror("remove", "mock")
+    output = mirror("list", output=str)
+    assert "mock" not in output
+
+
 def test_mirror_crud(mutable_config, capsys):
     with capsys.disabled():
         mirror("add", "mirror", "http://spack.io")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -291,7 +291,7 @@ def test_mirror_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
     mirror("add", "--scope=system", "mock", str(tmp_path / "mock_mirror"))
 
     # Confirm that it is not removed when the scope is incorrect
-    with pytest.raises(spack.main.SpackCommandError):
+    with pytest.raises(SpackCommandError):
         mirror("remove", "--scope=user", "mock")
     output = mirror("list", output=str)
     assert "mock" in output

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -303,9 +303,17 @@ def test_mirror_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
     assert "mock" not in site_output
     assert "mock" in system_output
 
-    # Confirm that when the scope is not specified, it is removed from all scopes
+    # Confirm that when the scope is not specified, it is removed from top scope
     mirror("add", "--scope=site", "mock", str(tmp_path / "mockrepo"))
     mirror("remove", "mock")
+    site_output = mirror("list", "--scope=site", output=str)
+    system_output = mirror("list", "--scope=system", output=str)
+    assert "mock" not in site_output
+    assert "mock" in system_output
+
+    # Check that the `--all-scopes` option works
+    mirror("add", "--scope=site", "mock", str(tmp_path / "mockrepo"))
+    mirror("remove", "--all-scopes", "mock")
     output = mirror("list", output=str)
     assert "mock" not in output
 

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -49,6 +49,30 @@ def test_create_add_list_remove(mutable_config, tmp_path: pathlib.Path):
     assert "mockrepo" not in output
 
 
+def test_repo_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
+    # Create and add a new repo
+    repo("create", str(tmp_path), "mockrepo")
+    repo("add", "--scope=site", str(tmp_path / "spack_repo" / "mockrepo"))
+    repo("add", "--scope=system", str(tmp_path / "spack_repo" / "mockrepo"))
+
+    # Confirm that it is not removed when the scope is incorrect
+    with pytest.raises(Exception, match="No repository with path or namespace"):
+        repo("remove", "--scope=user", "mockrepo")
+
+    # Confirm that when the scope is specified, it is only removed from that scope
+    repo("remove", "--scope=site", "mockrepo")
+    site_output = repo("list", "--scope=site", output=str)
+    system_output = repo("list", "--scope=system", output=str)
+    assert "mockrepo" not in site_output
+    assert "mockrepo" in system_output
+
+    # Confirm that when the scope is not specified, it is removed from all scopes
+    repo("add", "--scope=site", str(tmp_path / "spack_repo" / "mockrepo"))
+    repo("remove", "mockrepo")
+    output = repo("list", output=str)
+    assert "mockrepo" not in output
+
+
 def test_env_repo_path_vars_substitution(
     tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, monkeypatch
 ):

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -67,9 +67,17 @@ def test_repo_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
     assert "mockrepo" not in site_output
     assert "mockrepo" in system_output
 
-    # Confirm that when the scope is not specified, it is removed from all scopes
+    # Confirm that when the scope is not specified, it is removed from top scope with it present
     repo("add", "--scope=site", str(tmp_path / "spack_repo" / "mockrepo"))
     repo("remove", "mockrepo")
+    site_output = repo("list", "--scope=site", output=str)
+    system_output = repo("list", "--scope=system", output=str)
+    assert "mockrepo" not in site_output
+    assert "mockrepo" in system_output
+
+    # Check that the `--all-scopes` option removes from all scopes
+    repo("add", "--scope=site", str(tmp_path / "spack_repo" / "mockrepo"))
+    repo("remove", "--all-scopes", "mockrepo")
     output = repo("list", output=str)
     assert "mockrepo" not in output
 

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -17,11 +17,10 @@ import spack.repo
 import spack.repo_migrate
 from spack.error import SpackError
 from spack.llnl.util.filesystem import working_dir
-from spack.main import SpackCommand
 from spack.util.executable import Executable
 
 repo = spack.main.SpackCommand("repo")
-env = SpackCommand("env")
+env = spack.main.SpackCommand("env")
 
 
 def test_help_option():
@@ -56,8 +55,10 @@ def test_repo_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
     repo("add", "--scope=system", str(tmp_path / "spack_repo" / "mockrepo"))
 
     # Confirm that it is not removed when the scope is incorrect
-    with pytest.raises(Exception, match="No repository with path or namespace"):
+    with pytest.raises(spack.main.SpackCommandError):
         repo("remove", "--scope=user", "mockrepo")
+    output = repo("list", output=str)
+    assert "mockrepo" in output
 
     # Confirm that when the scope is specified, it is only removed from that scope
     repo("remove", "--scope=site", "mockrepo")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1486,7 +1486,7 @@ _spack_mirror_add() {
 _spack_mirror_remove() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --all-scopes"
     else
         _mirrors
     fi
@@ -1495,7 +1495,7 @@ _spack_mirror_remove() {
 _spack_mirror_rm() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --all-scopes"
     else
         _mirrors
     fi
@@ -1839,7 +1839,7 @@ _spack_repo_set() {
 _spack_repo_remove() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --all-scopes"
     else
         _repos
     fi
@@ -1848,7 +1848,7 @@ _spack_repo_remove() {
 _spack_repo_rm() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --all-scopes"
     else
         _repos
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2405,20 +2405,24 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password-var
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password-variable -r -d 'environment variable containing password to use to connect to this OCI mirror'
 
 # spack mirror remove
-set -g __fish_spack_optspecs_spack_mirror_remove h/help scope=
+set -g __fish_spack_optspecs_spack_mirror_remove h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l all-scopes -f -a all_scopes
+complete -c spack -n '__fish_spack_using_command mirror remove' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching mirror)'
 
 # spack mirror rm
-set -g __fish_spack_optspecs_spack_mirror_rm h/help scope=
+set -g __fish_spack_optspecs_spack_mirror_rm h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l all-scopes -f -a all_scopes
+complete -c spack -n '__fish_spack_using_command mirror rm' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching mirror)'
 
 # spack mirror set-url
 set -g __fish_spack_optspecs_spack_mirror_set_url h/help push fetch scope= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
@@ -2859,20 +2863,24 @@ complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_b
 complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
-set -g __fish_spack_optspecs_spack_repo_remove h/help scope=
+set -g __fish_spack_optspecs_spack_repo_remove h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command repo remove' -l all-scopes -f -a all_scopes
+complete -c spack -n '__fish_spack_using_command repo remove' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching repo)'
 
 # spack repo rm
-set -g __fish_spack_optspecs_spack_repo_rm h/help scope=
+set -g __fish_spack_optspecs_spack_repo_rm h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command repo rm' -l all-scopes -f -a all_scopes
+complete -c spack -n '__fish_spack_using_command repo rm' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching repo)'
 
 # spack repo migrate
 set -g __fish_spack_optspecs_spack_repo_migrate h/help dry-run fix


### PR DESCRIPTION
Currently, the following fails:

```
spack repo add --scope spack /path/to/repo
spack repo rm /path/to/repo
```
It fails because the `spack repo remove` command requires a scope to remove from, and assumes `--scope user` if unspecified.

This PR changes this to remove the matching repo from any scope if the scope is unspecified. Because portions of the repo could be defined at different config levels, it removes the specified repo from every scope. Removing from a specific scope is still supported, using the `--scope` argument.

The analogous bug exists and is fixed in the analogous manner for `spack mirror remove` in this PR as well.

Includes tests.