### PR TITLE
concretization cache: rebuild specs from spec_attrs on cache hit

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -462,7 +462,7 @@ class Result:
         min_cost, _, _ = self.answers[0]
         builder = SpecBuilder(self.abstract_specs, hash_lookup=self.hash_lookup)
         answers = builder.build_specs(self.spec_attrs)
-        self.answers[0][2] = answers
+        self.answers[0] = (min_cost, 0, answers)
 
     def clear_caches(self):
         self._concrete_specs = None
@@ -570,6 +570,10 @@ class Result:
             serial_answer = serial_answer + (serial_answer_dict,)
             serial_answers.append(serial_answer)
         ret["answers"] = serial_answers
+        ret["spec_attrs"] = self.spec_attrs
+        ret["hash_lookup"] = {}
+        for hash, spec in (self.hash_lookup or {}).items():
+            ret["hash_lookup"][hash] = spec.to_dict()
         ret["specs_by_input"] = {}
         input_specs = {} if not self.specs_by_input else self.specs_by_input
         for input, spec in input_specs.items():
@@ -611,6 +615,15 @@ class Result:
         result.nmodels = obj.get("nmodels")
         result.satisfiable = obj.get("satisfiable")
         result._unsolved_specs = []
+        spec_attr_lists = obj.get("spec_attrs", None)
+        if spec_attr_lists is not None:
+            result.spec_attrs = []
+            for name, args in spec_attr_lists:
+                rest = [x if isinstance(x, str) else NodeArgument(x[0], x[1]) for x in args]
+                result.spec_attrs.append((name, tuple(rest)))
+        result.hash_lookup = {}
+        for h, spec_dict in obj.get("hash_lookup", {}).items():
+            result.hash_lookup[h] = _dict_to_spec(spec_dict)
         answers = []
         for answer in obj.get("answers", []):
             loaded_answer = answer[:2]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -351,6 +351,10 @@ class Result:
         self._concrete_specs = None
         self._unsolved_specs = None
 
+        # Cached intermediate results for refinalizing specs
+        self.hash_lookup = None
+        self.spec_attrs = None
+
     def format_core(self, core):
         """
         Format an unsatisfiable core for human readability
@@ -445,6 +449,25 @@ class Result:
 
         conflicts = self.format_minimal_cores()
         raise SolverError(constraints, conflicts=conflicts)
+
+    def refinalize(self):
+        """Recompute specs from a cached concretization result"""
+        # TODO: types are wonky here
+        # answers is a list that only ever has one entry
+        if not self.answers:
+            return
+
+        self.clear_caches()
+
+        min_cost, _, _ = self.answers[0]
+        builder = SpecBuilder(self.abstract_specs, hash_lookup=self.hash_lookup)
+        answers = builder.build_specs(self.spec_attrs)
+        self.answers[0][2] = answers
+
+    def clear_caches(self):
+        self._concrete_specs = None
+        self._unsolved_specs = None
+        self._concrete_specs_by_input = None
 
     @property
     def specs(self):
@@ -623,7 +646,6 @@ class Result:
             # self.cores
             # self.possible_dependencies
         )
-        print(eq)
         return all(eq)
 
 
@@ -1123,7 +1145,8 @@ class PyclingoDriver:
         if result.satisfiable:
             timer.start("construct_specs")
             # get the best model
-            builder = SpecBuilder(specs, hash_lookup=setup.reusable_and_possible)
+            result.hash_lookup = setup.reusable_and_possible
+            builder = SpecBuilder(specs, hash_lookup=result.hash_lookup)
             min_cost, best_model = min(models)
 
             # first check for errors
@@ -1131,8 +1154,10 @@ class PyclingoDriver:
             error_handler.raise_if_errors()
 
             # build specs from spec attributes in the model
-            spec_attrs = [(name, tuple(rest)) for name, *rest in extract_args(best_model, "attr")]
-            answers = builder.build_specs(spec_attrs)
+            result.spec_attrs = [
+                (name, tuple(rest)) for name, *rest in extract_args(best_model, "attr")
+            ]
+            answers = builder.build_specs(result.spec_attrs)
 
             # add best spec to the results
             result.answers.append((list(min_cost), 0, answers))
@@ -1252,7 +1277,9 @@ class PyclingoDriver:
         timer.stop("cache-check")
 
         # run the solver and store the result, if it wasn't cached already
-        if not result:
+        if result and result.spec_attrs:  # if not spec_attrs this cache is invalid
+            result.refinalize()
+        else:
             problem_repr = "\n".join(problem)
             result = self._run_clingo(specs, setup, problem_repr, control_file_paths, timer)
             if conc_cache_enabled and self._conc_cache:

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -17,6 +17,7 @@ import spack.vendor.jinja2
 import spack.archspec
 import spack.binary_distribution
 import spack.cmd
+import spack.cmd.diff
 import spack.compilers.config
 import spack.concretize
 import spack.config
@@ -248,6 +249,12 @@ class Changing(Package):
     variant("fum", default=True, description="nope")
     variant("fum2", default=True, description="nope")
 {% endif %}
+
+    def install(self, spec, prefix):
+        touch(prefix.one)
+{% if change_install %}
+        touch(prefix.two)
+{% endif %}
 """
 
     with spack.repo.use_repositories(root, override=False) as repos:
@@ -257,6 +264,7 @@ class Changing(Package):
                 ("delete_version", True),
                 ("delete_variant", False),
                 ("add_variant", False),
+                ("change_install", False),
             ]
 
             def __init__(self):
@@ -4276,6 +4284,22 @@ def test_when_possible_above_all(mutable_config, mock_packages):
         assert criteria[0].name == "number of input specs not concretized"
 
 
+def test_concretization_cache_changing_package(
+    use_concretization_cache, repo_with_changing_recipe, mutable_config
+):
+    """Tests that package_hash is not being cached by concretization_cache."""
+    spack.config.set("concretizer:reuse", False)
+
+    spec1 = spack.concretize.concretize_one("changing")
+    repo_with_changing_recipe.change({"change_install": True, "delete_version": False})
+    spec2 = spack.concretize.concretize_one("changing")
+
+    assert spec1.package_hash != spec2.package_hash
+    comparison = spack.cmd.diff.compare_specs(spec1, spec2)
+    assert {fn.name for fn in comparison["a_not_b"]} == {"hash", "package_hash"}
+    assert {fn.name for fn in comparison["b_not_a"]} == {"hash", "package_hash"}
+
+
 def test_concretization_cache_roundtrip(
     mock_packages, use_concretization_cache, monkeypatch, mutable_config
 ):
@@ -4320,6 +4344,10 @@ def test_concretization_cache_roundtrip_result(use_concretization_cache):
     result1 = solver.solve(specs)
     result2 = solver.solve(specs)
 
+    # We have to check spec equality first because that recomputes internal caches
+    # which are checked as part of the equality check
+    # TODO: fix this so caches aren't checked on equality checks
+    assert set(result1.specs) == set(result2.specs)
     assert result1 == result2
 
 


### PR DESCRIPTION
fixes #51553

This resolves a bug that the concretization cache can return invalid results if the `package_hash` has changed since the initial concretization was cached.

@tgamblin @alalazo
