### PR TITLE
solver: disable concretization cache by default

### DIFF
--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -97,7 +97,7 @@ concretizer:
   # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.
   concretization_cache:
-    enable: true
+    enable: false
 
   # Options to control the behavior of the concretizer with external specs
   externals:

--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -96,6 +96,8 @@ concretizer:
 
   # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.
+  # Feature is experimental: enabling may result in potentially invalid concretizations
+  # if package recipes are changed, see: https://github.com/spack/spack/issues/51553
   concretization_cache:
     enable: false
 


### PR DESCRIPTION
The cache is not battle tested yet, and was about to ship with a serious bug, see #51553. Change the default to `false` so it can be opt-in until it's a bit more tested.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
