### PR TITLE
solver: move a debug print from `level=2` to `level=1`

### DIFF
--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -301,8 +301,7 @@ class RequirementParser:
         except spack.error.SpackError as e:
             tty.debug(
                 f"[{__name__}] Rejecting the default '{constraint}' requirement "
-                f"on '{pkg_name}': {str(e)}",
-                level=2,
+                f"on '{pkg_name}': {str(e)}"
             )
             return True
         return False


### PR DESCRIPTION
The other prints in the same function are at `level=1`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
