### PR TITLE
Package API docs: remove version from header

### DIFF
--- a/lib/spack/docs/package_api.rst
+++ b/lib/spack/docs/package_api.rst
@@ -7,8 +7,8 @@
    :description lang=en:
       An overview of the Spack Package API, a stable interface for package authors to interact with the Spack framework.
 
-Spack Package API v2.2
-======================
+Spack Package API
+=================
 
 This document describes the Spack Package API (:mod:`spack.package`), the stable interface for Spack package authors.
 It is assumed you have already read the :doc:`Spack Packaging Guide <packaging_guide_creation>`.


### PR DESCRIPTION
Version was out of date, and did not belong in the header to begin with.
