### PR TITLE
Git Fetch: Optimize clone for commits

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -27,7 +27,7 @@ import spack.package_base
 import spack.repo
 import spack.spec
 import spack.stage
-import spack.util.executable
+import spack.util.git
 import spack.util.gpg as gpg_util
 import spack.util.timer as timer
 import spack.util.url as url_util
@@ -782,13 +782,6 @@ def validate_git_versions(
         with spack.stage.Stage(fetcher) as stage:
             known_commit = pkg.versions[version]["commit"]
             try:
-                # TODO(psakiev) we should be able to get all this validation from a single clone
-                # that has the metadata rather than fetching each version
-                # We probably want 
-                #    - git init
-                #    - git fetch --tags --filter=blob:none (for all trilinos tags this is 118 MB)
-                #    for v in versions:
-                #        found_commit = git rev-parse v["tag"]^{}
                 stage.fetch()
             except spack.error.FetchError:
                 tty.error(
@@ -803,12 +796,9 @@ def validate_git_versions(
             # commit that is located in the package.py file.
             if "tag" in pkg.versions[version]:
                 tag = pkg.versions[version]["tag"]
-                try:
-                    with fs.working_dir(stage.source_path):
-                        found_commit = fetcher.git(
-                            "rev-list", "-n", "1", tag, output=str, error=str
-                        ).strip()
-                except spack.util.executable.ProcessError:
+                url = pkg.version_or_package_attr("git", version)
+                found_commit = spack.util.git.get_commit_sha(url, tag)
+                if not found_commit:
                     tty.error(
                         f"Invalid tag for {pkg.name}@{version}\n"
                         f"    {tag} could not be found in the git repository."

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -784,6 +784,11 @@ def validate_git_versions(
             try:
                 # TODO(psakiev) we should be able to get all this validation from a single clone
                 # that has the metadata rather than fetching each version
+                # We probably want 
+                #    - git init
+                #    - git fetch --tags --filter=blob:none (for all trilinos tags this is 118 MB)
+                #    for v in versions:
+                #        found_commit = git rev-parse v["tag"]^{}
                 stage.fetch()
             except spack.error.FetchError:
                 tty.error(

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -782,6 +782,8 @@ def validate_git_versions(
         with spack.stage.Stage(fetcher) as stage:
             known_commit = pkg.versions[version]["commit"]
             try:
+                # TODO(psakiev) we should be able to get all this validation from a single clone
+                # that has the metadata rather than fetching each version
                 stage.fetch()
             except spack.error.FetchError:
                 tty.error(

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -961,12 +961,11 @@ class GitFetchStrategy(VCSFetchStrategy):
 
         kwargs = {"debug": spack.config.get("config:debug"), "git_exe": self.git, "dest": name}
 
-        with temp_cwd():
+        with temp_cwd(ignore_cleanup_errors=True):
             if self.commit:
                 try:
                     spack.util.git.git_init_fetch(self.url, self.commit, depth, **kwargs)
                 except spack.util.executable.ProcessError:
-                    # TODO(psakeiv) debug message?
                     spack.util.git.git_clone(self.url, fetch_ref, True, depth, **kwargs)
             else:
                 spack.util.git.git_clone(self.url, fetch_ref, self.get_full_repo, depth, **kwargs)
@@ -977,11 +976,6 @@ class GitFetchStrategy(VCSFetchStrategy):
             if self.stage:
                 self.stage.srcdir = repo_name
             shutil.copytree(repo_name, dest, symlinks=True)
-            shutil.rmtree(
-                repo_name,
-                ignore_errors=False,
-                onerror=fs.readonly_file_handler(ignore_errors=True),
-            )
         return
 
     def submodule_operations(self):

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1599,17 +1599,22 @@ def _for_package_version(pkg, version=None):
         version = pkg.version
 
     # if it's a commit, we must use a GitFetchStrategy
-    commit_sha = pkg.spec.variants.get("commit", None)
-    if isinstance(version, spack.version.GitVersion) or commit_sha:
+    commit_var = pkg.spec.variants.get("commit", None)
+    commit = commit_var.value if commit_var else None
+    tag = None
+    if isinstance(version, spack.version.GitVersion) or commit:
         if not hasattr(pkg, "git"):
             raise spack.error.FetchError(
                 f"Cannot fetch git version for {pkg.name}. Package has no 'git' attribute"
             )
-        # Populate the version with comparisons to other commits
         if isinstance(version, spack.version.GitVersion):
+            # Populate the version with comparisons to other commits
             from spack.version.git_ref_lookup import GitRefLookup
 
             version.attach_lookup(GitRefLookup(pkg.name))
+
+            if not commit and version.is_commit:
+                commit = version.ref
 
         # For GitVersion, we have no way to determine whether a ref is a branch or tag
         # Fortunately, we handle branches and tags identically, except tags are
@@ -1619,16 +1624,14 @@ def _for_package_version(pkg, version=None):
         # Branches cannot be cached, so we tell the fetcher not to cache tags/branches
 
         # TODO(psakiev) eventually we should  only need to clone based on the commit
-        ref_type = None
-        ref_value = None
-        if commit_sha:
-            ref_type = "commit"
-            ref_value = commit_sha.value
-        else:
-            ref_type = "commit" if version.is_commit else "tag"
-            ref_value = version.ref
 
-        kwargs = {ref_type: ref_value, "no_cache": ref_type != "commit"}
+        # commit stashed on version
+        version_meta_data = pkg.versions.get(version)
+        if not commit:
+            commit = version_meta_data.get("commit")
+        tag = version_meta_data.get("tag") or version_meta_data.get("branch")
+
+        kwargs = {"commit": commit, "tag": tag, "no_cache": bool(not commit)}
         kwargs["git"] = pkg.version_or_package_attr("git", version)
         kwargs["submodules"] = pkg.version_or_package_attr("submodules", version, False)
         kwargs["git_sparse_paths"] = pkg.version_or_package_attr("git_sparse_paths", version, None)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -47,6 +47,7 @@ import spack.llnl.util.tty as tty
 import spack.oci.opener
 import spack.util.archive
 import spack.util.crypto as crypto
+import spack.util.executable
 import spack.util.git
 import spack.util.url as url_util
 import spack.util.web as web_util
@@ -951,21 +952,23 @@ class GitFetchStrategy(VCSFetchStrategy):
         # Default to spack source path
         dest = self.stage.source_path
         tty.debug(f"Cloning git repository: {self._repo_info()}")
-
-        git = self.git
-        debug = spack.config.get("config:debug")
-        ref = self.commit or self.tag or self.branch
         depth = None if self.get_full_repo else 1
+
         with temp_cwd():
-            spack.util.git.git_fetch_by_ref(
-                self.git,
-                self.url,
-                ref,
-                sparse_paths=self.git_sparse_paths,
-                debug=spack.config.get("config:debug"), 
-                depth=depth,
-                dest=self.package.name
-            )
+            destination = (os.path.join(os.getcwd(), self.package.name),)
+            for ref in [self.commit, self.tag, self.branch]:
+                try:
+                    spack.util.git.git_fetch_by_ref(
+                        self.git,
+                        self.url,
+                        ref,
+                        sparse_paths=self.git_sparse_paths,
+                        debug=spack.config.get("config:debug"),
+                        depth=depth,
+                        dest=destination,
+                    )
+                except spack.util.executable.ProcessError:
+                    continue
             repo_name = get_single_file(".")
             if self.stage:
                 self.stage.srcdir = repo_name
@@ -976,86 +979,6 @@ class GitFetchStrategy(VCSFetchStrategy):
                 onerror=fs.readonly_file_handler(ignore_errors=True),
             )
         return
-
-
-        if self.commit:
-            # Need to do a regular clone and check out everything if
-            # they asked for a particular commit.
-            clone_args = ["clone", self.url]
-            if not debug:
-                clone_args.insert(1, "--quiet")
-            with temp_cwd():
-                git(*clone_args)
-                repo_name = get_single_file(".")
-                if self.stage:
-                    self.stage.srcdir = repo_name
-                shutil.copytree(repo_name, dest, symlinks=True)
-                shutil.rmtree(
-                    repo_name,
-                    ignore_errors=False,
-                    onerror=fs.readonly_file_handler(ignore_errors=True),
-                )
-
-            with working_dir(dest):
-                checkout_args = ["checkout", self.commit]
-                if not debug:
-                    checkout_args.insert(1, "--quiet")
-                git(*checkout_args)
-
-        else:
-            # Can be more efficient if not checking out a specific commit.
-            args = ["clone"]
-            if not debug:
-                args.append("--quiet")
-
-            # If we want a particular branch ask for it.
-            if self.branch:
-                args.extend(["--branch", self.branch])
-            elif self.tag and self.git_version >= spack.version.Version("1.8.5.2"):
-                args.extend(["--branch", self.tag])
-
-            # Try to be efficient if we're using a new enough git.
-            # This checks out only one branch's history
-            if self.git_version >= spack.version.Version("1.7.10"):
-                if self.get_full_repo:
-                    args.append("--no-single-branch")
-                else:
-                    args.append("--single-branch")
-
-            with temp_cwd():
-                # Yet more efficiency: only download a 1-commit deep
-                # tree, if the in-use git and protocol permit it.
-                if (
-                    (not self.get_full_repo)
-                    and self.git_version >= spack.version.Version("1.7.1")
-                    and self.protocol_supports_shallow_clone()
-                ):
-                    args.extend(["--depth", "1"])
-
-                args.extend([self.url])
-                git(*args)
-
-                repo_name = get_single_file(".")
-                if self.stage:
-                    self.stage.srcdir = repo_name
-                shutil.move(repo_name, dest)
-
-            with working_dir(dest):
-                # For tags, be conservative and check them out AFTER
-                # cloning.  Later git versions can do this with clone
-                # --branch, but older ones fail.
-                if self.tag and self.git_version < spack.version.Version("1.8.5.2"):
-                    # pull --tags returns a "special" error code of 1 in
-                    # older versions that we have to ignore.
-                    # see: https://github.com/git/git/commit/19d122b
-                    pull_args = ["pull", "--tags"]
-                    co_args = ["checkout", self.tag]
-                    if not spack.config.get("config:debug"):
-                        pull_args.insert(1, "--quiet")
-                        co_args.insert(1, "--quiet")
-
-                    git(*pull_args, ignore_errors=1)
-                    git(*co_args)
 
     def _sparse_clone_src(self, **kwargs):
         """Use git's sparse checkout feature to clone portions of a git repository"""

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -962,19 +962,13 @@ class GitFetchStrategy(VCSFetchStrategy):
         with temp_cwd():
             if self.commit:
                 try:
-                    tty.msg("calling init")
                     spack.util.git.git_init_fetch(self.url, self.commit, depth, **kwargs)
                 except spack.util.executable.ProcessError:
                     # TODO(psakeiv) debug message?
-                    tty.msg("calling clone")
-                    spack.util.git.git_clone(
-                        self.url, fetch_ref, self.get_full_repo, depth, **kwargs
-                    )
+                    spack.util.git.git_clone(self.url, fetch_ref, True, depth, **kwargs)
             else:
-                tty.msg("calling clone")
                 spack.util.git.git_clone(self.url, fetch_ref, self.get_full_repo, depth, **kwargs)
             # if checkout_ref:
-            tty.msg("calling checkout")
             spack.util.git.git_checkout(checkout_ref, self.git_sparse_paths, **kwargs)
 
             repo_name = get_single_file(".")

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -953,23 +953,30 @@ class GitFetchStrategy(VCSFetchStrategy):
         dest = self.stage.source_path
         tty.debug(f"Cloning git repository: {self._repo_info()}")
         depth = None if self.get_full_repo else 1
+        name = "src"
+        if self.package:
+            name = self.package.name
 
         with temp_cwd():
-            destination = (os.path.join(os.getcwd(), self.package.name),)
+            destination = (os.path.join(os.getcwd(), name),)
             for ref in [self.commit, self.tag, self.branch]:
-                try:
-                    spack.util.git.git_fetch_by_ref(
-                        self.git,
-                        self.url,
-                        ref,
-                        sparse_paths=self.git_sparse_paths,
-                        debug=spack.config.get("config:debug"),
-                        depth=depth,
-                        dest=destination,
-                    )
-                except spack.util.executable.ProcessError:
-                    continue
-            repo_name = get_single_file(".")
+                if ref:
+                    try:
+                        spack.util.git.git_fetch_by_ref(
+                            self.git,
+                            self.url,
+                            ref,
+                            sparse_paths=self.git_sparse_paths,
+                            debug=spack.config.get("config:debug"),
+                            depth=depth,
+                            dest=destination,
+                        )
+                    except spack.util.executable.ProcessError:
+                        continue
+            try:
+                repo_name = get_single_file(".")
+            except ValueError:
+                raise spack.error.SpackError("Git fetcher failed")
             if self.stage:
                 self.stage.srcdir = repo_name
             shutil.copytree(repo_name, dest, symlinks=True)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -923,10 +923,17 @@ class GitFetchStrategy(VCSFetchStrategy):
             tty.debug(f"Already fetched {self.stage.source_path}")
             return
 
-        if self.git_sparse_paths:
-            self._sparse_clone_src()
-        else:
-            self._clone_src()
+        ref = self.commit or self.tag or self.branch
+
+        depth = None if self.get_full_repo else 1
+        spack.util.git.git_fetch_by_ref(
+            self.git,
+            self.url,
+            ref,
+            sparse_paths=self.git_sparse_paths,
+            debug=spac.config.get("config:debug"), 
+            depth=depth,
+        )
         self.submodule_operations()
 
     def bare_clone(self, dest: str) -> None:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -826,9 +826,8 @@ class GitFetchStrategy(VCSFetchStrategy):
         "get_full_repo",
         "submodules_delete",
         "git_sparse_paths",
+        "skip_checkout",
     ]
-
-    git_version_re = r"git version (\S+)"
 
     def __init__(self, **kwargs):
 
@@ -847,6 +846,9 @@ class GitFetchStrategy(VCSFetchStrategy):
         self.submodules_delete = kwargs.get("submodules_delete", False)
         self.get_full_repo = kwargs.get("get_full_repo", False)
         self.git_sparse_paths = kwargs.get("git_sparse_paths", None)
+        # skipping checkout with a blobless clone is an efficient way to traverse meta-data
+        # see https://bhupesh.me/minimalist-guide-git-clone/
+        self.skip_checkout = kwargs.get("skip_checkout", False)
 
     @property
     def git_version(self):
@@ -968,8 +970,8 @@ class GitFetchStrategy(VCSFetchStrategy):
                     spack.util.git.git_clone(self.url, fetch_ref, True, depth, **kwargs)
             else:
                 spack.util.git.git_clone(self.url, fetch_ref, self.get_full_repo, depth, **kwargs)
-            # if checkout_ref:
-            spack.util.git.git_checkout(checkout_ref, self.git_sparse_paths, **kwargs)
+            if not self.skip_checkout:
+                spack.util.git.git_checkout(checkout_ref, self.git_sparse_paths, **kwargs)
 
             repo_name = get_single_file(".")
             if self.stage:
@@ -981,75 +983,6 @@ class GitFetchStrategy(VCSFetchStrategy):
                 onerror=fs.readonly_file_handler(ignore_errors=True),
             )
         return
-
-    def _sparse_clone_src(self, **kwargs):
-        """Use git's sparse checkout feature to clone portions of a git repository"""
-        dest = self.stage.source_path
-        git = self.git
-
-        if self.git_version < spack.version.Version("2.26.0"):
-            # technically this should be supported for 2.25, but bumping for OS issues
-            # see https://github.com/spack/spack/issues/45771
-            # code paths exist where the package is not set.  Assure some indentifier for the
-            # package that was configured  for sparse checkout exists in the error message
-            identifier = str(self.url)
-            if self.package:
-                identifier += f" ({self.package.name})"
-            tty.warn(
-                (
-                    f"{identifier} is configured for git sparse-checkout "
-                    "but the git version is too old to support sparse cloning. "
-                    "Cloning the full repository instead."
-                )
-            )
-            self._clone_src()
-        else:
-            # default to depth=2 to allow for retention of some git properties
-            depth = kwargs.get("depth", 2)
-            needs_fetch = self.branch or self.tag
-            git_ref = self.branch or self.tag or self.commit
-
-            assert git_ref
-
-            clone_args = ["clone"]
-
-            if needs_fetch:
-                clone_args.extend(["--branch", git_ref])
-
-            if self.get_full_repo:
-                clone_args.append("--no-single-branch")
-            else:
-                clone_args.append("--single-branch")
-
-            clone_args.extend(
-                [f"--depth={depth}", "--no-checkout", "--filter=blob:none", self.url]
-            )
-
-            sparse_args = ["sparse-checkout", "set"]
-
-            if callable(self.git_sparse_paths):
-                sparse_args.extend(self.git_sparse_paths())
-            else:
-                sparse_args.extend([p for p in self.git_sparse_paths])
-
-            sparse_args.append("--cone")
-
-            checkout_args = ["checkout", git_ref]
-
-            if not spack.config.get("config:debug"):
-                clone_args.insert(1, "--quiet")
-                checkout_args.insert(1, "--quiet")
-
-            with temp_cwd():
-                git(*clone_args)
-                repo_name = get_single_file(".")
-                if self.stage:
-                    self.stage.srcdir = repo_name
-                shutil.move(repo_name, dest)
-
-            with working_dir(dest):
-                git(*sparse_args)
-                git(*checkout_args)
 
     def submodule_operations(self):
         dest = self.stage.source_path
@@ -1096,12 +1029,6 @@ class GitFetchStrategy(VCSFetchStrategy):
 
             self.git(*co_args)
             self.git(*clean_args)
-
-    def protocol_supports_shallow_clone(self):
-        """Shallow clone operations (``--depth #``) are not supported by the basic
-        HTTP protocol or by no-protocol file specifications.
-        Use (e.g.) ``https://`` or ``file://`` instead."""
-        return not (self.url.startswith("http://") or self.url.startswith("/"))
 
     def __str__(self):
         return f"[git] {self._repo_info()}"

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -923,17 +923,7 @@ class GitFetchStrategy(VCSFetchStrategy):
             tty.debug(f"Already fetched {self.stage.source_path}")
             return
 
-        ref = self.commit or self.tag or self.branch
-
-        depth = None if self.get_full_repo else 1
-        spack.util.git.git_fetch_by_ref(
-            self.git,
-            self.url,
-            ref,
-            sparse_paths=self.git_sparse_paths,
-            debug=spac.config.get("config:debug"), 
-            depth=depth,
-        )
+        self._clone_src()
         self.submodule_operations()
 
     def bare_clone(self, dest: str) -> None:
@@ -964,6 +954,29 @@ class GitFetchStrategy(VCSFetchStrategy):
 
         git = self.git
         debug = spack.config.get("config:debug")
+        ref = self.commit or self.tag or self.branch
+        depth = None if self.get_full_repo else 1
+        with temp_cwd():
+            spack.util.git.git_fetch_by_ref(
+                self.git,
+                self.url,
+                ref,
+                sparse_paths=self.git_sparse_paths,
+                debug=spack.config.get("config:debug"), 
+                depth=depth,
+                dest=self.package.name
+            )
+            repo_name = get_single_file(".")
+            if self.stage:
+                self.stage.srcdir = repo_name
+            shutil.copytree(repo_name, dest, symlinks=True)
+            shutil.rmtree(
+                repo_name,
+                ignore_errors=False,
+                onerror=fs.readonly_file_handler(ignore_errors=True),
+            )
+        return
+
 
         if self.commit:
             # Need to do a regular clone and check out everything if

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1619,7 +1619,6 @@ def _for_package_version(pkg, version=None):
         else:
             version_meta_data = pkg.versions.get(version)
 
-
         # For GitVersion, we have no way to determine whether a ref is a branch or tag
         # Fortunately, we handle branches and tags identically, except tags are
         # handled slightly more conservatively for older versions of git.

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1615,6 +1615,10 @@ def _for_package_version(pkg, version=None):
 
             if not commit and version.is_commit:
                 commit = version.ref
+            version_meta_data = pkg.versions.get(version.std_version)
+        else:
+            version_meta_data = pkg.versions.get(version)
+
 
         # For GitVersion, we have no way to determine whether a ref is a branch or tag
         # Fortunately, we handle branches and tags identically, except tags are
@@ -1626,10 +1630,10 @@ def _for_package_version(pkg, version=None):
         # TODO(psakiev) eventually we should  only need to clone based on the commit
 
         # commit stashed on version
-        version_meta_data = pkg.versions.get(version)
-        if not commit:
-            commit = version_meta_data.get("commit")
-        tag = version_meta_data.get("tag") or version_meta_data.get("branch")
+        if version_meta_data:
+            if not commit:
+                commit = version_meta_data.get("commit")
+            tag = version_meta_data.get("tag") or version_meta_data.get("branch")
 
         kwargs = {"commit": commit, "tag": tag, "no_cache": bool(not commit)}
         kwargs["git"] = pkg.version_or_package_attr("git", version)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -857,9 +857,8 @@ class GitFetchStrategy(VCSFetchStrategy):
         """Given a git executable, return the Version (this will fail if
         the output cannot be parsed into a valid Version).
         """
-        version_output = git_exe("--version", output=str)
-        m = re.search(GitFetchStrategy.git_version_re, version_output)
-        return spack.version.Version(m.group(1))
+        version_string = ".".join(map(str, git_exe.version))
+        return spack.version.Version(version_string)
 
     @property
     def git(self):
@@ -957,22 +956,26 @@ class GitFetchStrategy(VCSFetchStrategy):
         name = self.package.name if self.package else "spack-clone"
         checkout_ref = self.commit or self.tag or self.branch
         fetch_ref = self.tag or self.branch
-        full_clone = self.get_full_repo or not fetch_ref
 
         kwargs = {"debug": spack.config.get("config:debug"), "git_exe": self.git, "dest": name}
 
         with temp_cwd():
             if self.commit:
                 try:
-                    spack.util.git.git_init_fetch(self.url, self.commit, **kwargs)
+                    tty.msg("calling init")
+                    spack.util.git.git_init_fetch(self.url, self.commit, depth, **kwargs)
                 except spack.util.executable.ProcessError:
                     # TODO(psakeiv) debug message?
-                    spack.util.git.git_clone(self.url, fetch_ref, full_clone, **kwargs)
-                finally:
-                    spack.util.git.git_checkout(self.commit, self.git_sparse_paths, **kwargs)
+                    tty.msg("calling clone")
+                    spack.util.git.git_clone(
+                        self.url, fetch_ref, self.get_full_repo, depth, **kwargs
+                    )
             else:
-                spack.util.git.git_clone(self.url, fetch_ref, full_clone, **kwargs)
-                spack.util.git.git_checkout(checkout_ref, self.git_sparse_paths, **kwargs)
+                tty.msg("calling clone")
+                spack.util.git.git_clone(self.url, fetch_ref, self.get_full_repo, depth, **kwargs)
+            # if checkout_ref:
+            tty.msg("calling checkout")
+            spack.util.git.git_checkout(checkout_ref, self.git_sparse_paths, **kwargs)
 
             repo_name = get_single_file(".")
             if self.stage:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -956,19 +956,22 @@ class GitFetchStrategy(VCSFetchStrategy):
         depth = None if self.get_full_repo else 1
         name = self.package.name if self.package else "spack-clone"
         checkout_ref = self.commit or self.tag or self.branch
-        fetch_ref = self.tag or self.branch or "--all"
+        fetch_ref = self.tag or self.branch
         full_clone = self.get_full_repo or not fetch_ref
 
         kwargs = {"debug": spack.config.get("config:debug"), "git_exe": self.git, "dest": name}
 
         with temp_cwd():
-            try:
-                # try to first fetch via highest precdent i.e. commit > tag > branch
-                spack.util.git.git_init_fetch(url, checkout_ref, **kwargs)
-            except spack.util.executable.ProcessError:
-                # if something failed with git then try again but add "--all"
-                spack.util.git.git_init_fetch(url, fetch_ref, **kwargs)
-            finally:
+            if self.commit:
+                try:
+                    spack.util.git.git_init_fetch(self.url, self.commit, **kwargs)
+                except spack.util.executable.ProcessError:
+                    # TODO(psakeiv) debug message?
+                    spack.util.git.git_clone(self.url, fetch_ref, full_clone, **kwargs)
+                finally:
+                    spack.util.git.git_checkout(self.commit, self.git_sparse_paths, **kwargs)
+            else:
+                spack.util.git.git_clone(self.url, fetch_ref, full_clone, **kwargs)
                 spack.util.git.git_checkout(checkout_ref, self.git_sparse_paths, **kwargs)
 
             repo_name = get_single_file(".")

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -952,31 +952,26 @@ class GitFetchStrategy(VCSFetchStrategy):
         # Default to spack source path
         dest = self.stage.source_path
         tty.debug(f"Cloning git repository: {self._repo_info()}")
+
         depth = None if self.get_full_repo else 1
-        name = "src"
-        if self.package:
-            name = self.package.name
+        name = self.package.name if self.package else "spack-clone"
+        checkout_ref = self.commit or self.tag or self.branch
+        fetch_ref = self.tag or self.branch or "--all"
+        full_clone = self.get_full_repo or not fetch_ref
+
+        kwargs = {"debug": spack.config.get("config:debug"), "git_exe": self.git, "dest": name}
 
         with temp_cwd():
-            destination = (os.path.join(os.getcwd(), name),)
-            for ref in [self.commit, self.tag, self.branch]:
-                if ref:
-                    try:
-                        spack.util.git.git_fetch_by_ref(
-                            self.git,
-                            self.url,
-                            ref,
-                            sparse_paths=self.git_sparse_paths,
-                            debug=spack.config.get("config:debug"),
-                            depth=depth,
-                            dest=destination,
-                        )
-                    except spack.util.executable.ProcessError:
-                        continue
             try:
-                repo_name = get_single_file(".")
-            except ValueError:
-                raise spack.error.SpackError("Git fetcher failed")
+                # try to first fetch via highest precdent i.e. commit > tag > branch
+                spack.util.git.git_init_fetch(url, checkout_ref, **kwargs)
+            except spack.util.executable.ProcessError:
+                # if something failed with git then try again but add "--all"
+                spack.util.git.git_init_fetch(url, fetch_ref, **kwargs)
+            finally:
+                spack.util.git.git_checkout(checkout_ref, self.git_sparse_paths, **kwargs)
+
+            repo_name = get_single_file(".")
             if self.stage:
                 self.stage.srcdir = repo_name
             shutil.copytree(repo_name, dest, symlinks=True)

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -1229,14 +1229,14 @@ def windows_sfn(path: os.PathLike):
 
 
 @contextmanager
-def temp_cwd():
+def temp_cwd(ignore_cleanup_errors=False):
     tmp_dir = tempfile.mkdtemp()
     try:
         with working_dir(tmp_dir):
             yield tmp_dir
     finally:
         kwargs = {}
-        if sys.platform == "win32":
+        if sys.platform == "win32" or ignore_cleanup_errors:
             kwargs["ignore_errors"] = False
             kwargs["onerror"] = readonly_file_handler(ignore_errors=True)
         shutil.rmtree(tmp_dir, **kwargs)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2430,3 +2430,26 @@ def config_two_gccs(mutable_config):
             },
         ],
     )
+
+
+@pytest.fixture(scope="function")
+def mock_util_executable(monkeypatch):
+    logger = []
+    should_fail = []
+    registered_reponses = {}
+
+    def mock_call(self, *args, **kwargs):
+        cmd = self.exe + list(args)
+        str_cmd = " ".join(cmd)
+        logger.append(str_cmd)
+        for failure_key in should_fail:
+            if failure_key in str_cmd:
+                self.returncode = 1
+                return
+        for key, value in registered_reponses.items():
+            if str_cmd == key:
+                return value
+        self.returncode = 0
+
+    monkeypatch.setattr(spack.util.executable.Executable, "__call__", mock_call)
+    yield logger, should_fail, registered_reponses

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2440,14 +2440,16 @@ def mock_util_executable(monkeypatch):
 
     def mock_call(self, *args, **kwargs):
         cmd = self.exe + list(args)
-        str_cmd = " ".join(cmd)
+        str_cmd = " ".join(map(str, cmd))
         logger.append(str_cmd)
         for failure_key in should_fail:
             if failure_key in str_cmd:
                 self.returncode = 1
+                if kwargs.get("fail_on_error", True):
+                    raise spack.util.executable.ProcessError(f"Failed: {str_cmd}")
                 return
         for key, value in registered_reponses.items():
-            if str_cmd == key:
+            if key in str_cmd:
                 return value
         self.returncode = 0
 

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -26,6 +26,7 @@ from spack.variant import SingleValuedVariant
 from spack.version import Version
 
 _mock_transport_error = "Mock HTTP transport error"
+min_opt_string = ".".join(map(str, spack.util.git.MIN_OPT_VERSION))
 
 
 @pytest.fixture(params=[None, "1.8.5.2", "1.8.5.1", "1.7.10", "1.7.1", "1.7.0"])
@@ -245,7 +246,7 @@ def test_get_full_repo(
 ):
     """Ensure that we can clone a full repository."""
 
-    if git_version < Version("1.7.1"):
+    if git_version < Version(min_opt_string):
         pytest.skip("Not testing get_full_repo for older git {0}".format(git_version))
 
     secure = True

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -54,21 +54,18 @@ def git_version(git, request, monkeypatch):
 
 
 @pytest.fixture
-def mock_bad_git(monkeypatch):
+def mock_bad_git(mock_util_executable):
     """
     Test GitFetchStrategy behavior with a bad git command for git >= 1.7.1
     to trigger a SpackError.
     """
 
-    def bad_git(*args, **kwargs):
-        """Raise a SpackError with the transport message."""
-        raise spack.error.SpackError(_mock_transport_error)
-
-    # Patch the fetch strategy to think it's using a git version that
-    # will error out when git is called.
-    monkeypatch.setattr(GitFetchStrategy, "git", bad_git)
-    monkeypatch.setattr(GitFetchStrategy, "git_version", Version("1.7.1"))
-    yield
+    _, should_fail, registered_respones = mock_util_executable
+    should_fail.extend([
+        "clone",
+        "fetch"
+    ])
+    registered_respones["git --version"] = "1.7.1"
 
 
 def test_bad_git(tmp_path: pathlib.Path, mock_bad_git):

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -16,6 +16,7 @@ import spack.fetch_strategy
 import spack.package_base
 import spack.platforms
 import spack.repo
+import spack.util.git
 from spack.fetch_strategy import GitFetchStrategy
 from spack.llnl.util.filesystem import mkdirp, touch, working_dir
 from spack.package_base import PackageBase
@@ -36,7 +37,7 @@ def git_version(git, request, monkeypatch):
     paths for old versions still work, we fake it out here and make it
     use the backward-compatibility code paths with newer git versions.
     """
-    real_git_version = spack.fetch_strategy.GitFetchStrategy.version_from_git(git)
+    real_git_version = Version(spack.util.git.extract_git_version_str(git))
 
     if request.param is None:
         # Don't patch; run with the real git_version method.
@@ -49,7 +50,7 @@ def git_version(git, request, monkeypatch):
         # Patch the fetch strategy to think it's using a lower git version.
         # we use this to test what we'd need to do with older git versions
         # using a newer git installation.
-        monkeypatch.setattr(GitFetchStrategy, "git_version", test_git_version)
+        monkeypatch.setattr(spack.util.git, "extract_git_version_str", lambda _: request.param)
         yield test_git_version
 
 
@@ -61,11 +62,8 @@ def mock_bad_git(mock_util_executable):
     """
 
     _, should_fail, registered_respones = mock_util_executable
-    should_fail.extend([
-        "clone",
-        "fetch"
-    ])
-    registered_respones["git --version"] = "1.7.1"
+    should_fail.extend(["clone", "fetch"])
+    registered_respones["--version"] = "1.7.1"
 
 
 def test_bad_git(tmp_path: pathlib.Path, mock_bad_git):

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -80,3 +80,46 @@ def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info
 
         with pytest.raises(exe.ProcessError):
             spack.util.git.pull_checkout_branch("main")
+
+
+def test_mock_git(mock_util_executable):
+    log, should_fail, _ = mock_util_executable
+    should_fail.append("clone")
+    git = exe.Executable("git")
+    git("clone")
+    assert git.returncode == 1
+    git("status")
+    assert git.returncode == 0
+    assert "clone" in "\n".join(log)
+    assert "status" in "\n".join(log)
+
+
+@pytest.mark.parametrize(
+    "git_version,ommitted_opts",
+    (("2.18.0", ["--filter=blob:none"]), ("1.8.0", ["--filter=blob:none", "--depth"])),
+)
+def test_git_fetch_by_ref_ommissions(mock_util_executable, git_version, ommitted_opts):
+    log, _, registered_responses = mock_util_executable
+    registered_responses["git --version"] = git_version
+    git = exe.Executable("git")
+    url = "https://foo.git"
+    ref = "v1.2.3"
+    spack.util.git.git_fetch_by_ref(git, url, ref)
+    for opt in ommitted_opts:
+        assert all(opt not in call for call in log)
+
+
+@pytest.mark.parametrize("git_version,too_old", (("2.5.0", False), ("1.8.0", True)))
+def test_git_fetch_by_ref_respect_commit_version_limits(
+    mock_util_executable, git_version, too_old
+):
+    _, _, registered_responses = mock_util_executable
+    registered_responses["git --version"] = git_version
+    git = exe.Executable("git")
+    url = "https://foo.git"
+    ref = "a" * 40
+    if too_old:
+        with pytest.raises(exe.ProcessError):
+            spack.util.git.git_fetch_by_ref(git, url, ref)
+    else:
+        spack.util.git.git_fetch_by_ref(git, url, ref)

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -81,6 +81,7 @@ def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info
         with pytest.raises(exe.ProcessError):
             spack.util.git.pull_checkout_branch("main")
 
+
 @pytest.mark.parametrize(
     "input,answer",
     (["git version 1.7.1", (1, 7, 1)], ["git version 2.34.1.windows.2", (2, 34, 1, 2)]),

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -82,10 +82,10 @@ def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info
             spack.util.git.pull_checkout_branch("main")
 
 
-def test_mock_git(mock_util_executable):
+def test_mock_git_exe(mock_util_executable):
     log, should_fail, _ = mock_util_executable
     should_fail.append("clone")
-    git = exe.Executable("git")
+    git = spack.util.git.GitExecutable()
     git("clone")
     assert git.returncode == 1
     git("status")
@@ -95,13 +95,29 @@ def test_mock_git(mock_util_executable):
 
 
 @pytest.mark.parametrize(
+    "git_version", ("1.5.0", "1.3.0")
+)
+def test_git_exe_conditional_option(mock_util_executable, git_version):
+    log, _, registered_responses = mock_util_executable
+    min_version = (1,4,1)
+    registered_responses["git --version"] = git_version
+    git = spack.util.git.GitExecutable("git")
+    mock_opt = spack.util.git.VersionConditionalOption("--maybe", min_version=min_version)
+    args = mock_opt(git.version)
+    if git.version >= min_version:
+        assert "--maybe" in args
+    else:
+        assert not args
+
+
+@pytest.mark.parametrize(
     "git_version,ommitted_opts",
     (("2.18.0", ["--filter=blob:none"]), ("1.8.0", ["--filter=blob:none", "--depth"])),
 )
 def test_git_fetch_by_ref_ommissions(mock_util_executable, git_version, ommitted_opts):
     log, _, registered_responses = mock_util_executable
     registered_responses["git --version"] = git_version
-    git = exe.Executable("git")
+    git = spack.util.git.GitExecutable("git")
     url = "https://foo.git"
     ref = "v1.2.3"
     spack.util.git.git_fetch_by_ref(git, url, ref)
@@ -115,7 +131,7 @@ def test_git_fetch_by_ref_respect_commit_version_limits(
 ):
     _, _, registered_responses = mock_util_executable
     registered_responses["git --version"] = git_version
-    git = exe.Executable("git")
+    git = spack.util.git.GitExecutable("git")
     url = "https://foo.git"
     ref = "a" * 40
     if too_old:

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -86,7 +86,8 @@ def test_mock_git_exe(mock_util_executable):
     log, should_fail, _ = mock_util_executable
     should_fail.append("clone")
     git = spack.util.git.GitExecutable()
-    git("clone")
+    with pytest.raises(exe.ProcessError):
+        git("clone")
     assert git.returncode == 1
     git("status")
     assert git.returncode == 0
@@ -121,7 +122,3 @@ def test_git_init_fetch_ommissions(mock_util_executable, git_version, ommitted_o
     spack.util.git.git_init_fetch(url, ref, git_exe=git)
     for opt in ommitted_opts:
         assert all(opt not in call for call in log)
-
-
-# test url only
-# test git fetch commit but git too old or fails so fall back

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -82,6 +82,17 @@ def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info
             spack.util.git.pull_checkout_branch("main")
 
 
+@pytest.mark.parametrize(
+    "input,answer",
+    (["git version 1.7.1", (1, 7, 1)], ["git version 2.34.1.windows.2", (2, 34, 1, 2)]),
+)
+def test_extract_git_version(mock_util_executable, input, answer):
+    log, _, registered_responses = mock_util_executable
+    registered_responses["git --version"] = input
+    git = spack.util.git.GitExecutable()
+    assert git.version == answer
+
+
 def test_mock_git_exe(mock_util_executable):
     log, should_fail, _ = mock_util_executable
     should_fail.append("clone")

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -94,12 +94,10 @@ def test_mock_git_exe(mock_util_executable):
     assert "status" in "\n".join(log)
 
 
-@pytest.mark.parametrize(
-    "git_version", ("1.5.0", "1.3.0")
-)
+@pytest.mark.parametrize("git_version", ("1.5.0", "1.3.0"))
 def test_git_exe_conditional_option(mock_util_executable, git_version):
     log, _, registered_responses = mock_util_executable
-    min_version = (1,4,1)
+    min_version = (1, 4, 1)
     registered_responses["git --version"] = git_version
     git = spack.util.git.GitExecutable("git")
     mock_opt = spack.util.git.VersionConditionalOption("--maybe", min_version=min_version)
@@ -114,28 +112,16 @@ def test_git_exe_conditional_option(mock_util_executable, git_version):
     "git_version,ommitted_opts",
     (("2.18.0", ["--filter=blob:none"]), ("1.8.0", ["--filter=blob:none", "--depth"])),
 )
-def test_git_fetch_by_ref_ommissions(mock_util_executable, git_version, ommitted_opts):
+def test_git_init_fetch_ommissions(mock_util_executable, git_version, ommitted_opts):
     log, _, registered_responses = mock_util_executable
     registered_responses["git --version"] = git_version
     git = spack.util.git.GitExecutable("git")
     url = "https://foo.git"
     ref = "v1.2.3"
-    spack.util.git.git_fetch_by_ref(git, url, ref)
+    spack.util.git.git_init_fetch(git, url, ref)
     for opt in ommitted_opts:
         assert all(opt not in call for call in log)
 
 
-@pytest.mark.parametrize("git_version,too_old", (("2.5.0", False), ("1.8.0", True)))
-def test_git_fetch_by_ref_respect_commit_version_limits(
-    mock_util_executable, git_version, too_old
-):
-    _, _, registered_responses = mock_util_executable
-    registered_responses["git --version"] = git_version
-    git = spack.util.git.GitExecutable("git")
-    url = "https://foo.git"
-    ref = "a" * 40
-    if too_old:
-        with pytest.raises(exe.ProcessError):
-            spack.util.git.git_fetch_by_ref(git, url, ref)
-    else:
-        spack.util.git.git_fetch_by_ref(git, url, ref)
+# test url only
+# test git fetch commit but git too old or fails so fall back

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -81,14 +81,13 @@ def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info
         with pytest.raises(exe.ProcessError):
             spack.util.git.pull_checkout_branch("main")
 
-
 @pytest.mark.parametrize(
     "input,answer",
     (["git version 1.7.1", (1, 7, 1)], ["git version 2.34.1.windows.2", (2, 34, 1, 2)]),
 )
 def test_extract_git_version(mock_util_executable, input, answer):
-    log, _, registered_responses = mock_util_executable
-    registered_responses["git --version"] = input
+    _, _, registered_responses = mock_util_executable
+    registered_responses["--version"] = input
     git = spack.util.git.GitExecutable()
     assert git.version == answer
 

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -118,7 +118,7 @@ def test_git_init_fetch_ommissions(mock_util_executable, git_version, ommitted_o
     git = spack.util.git.GitExecutable("git")
     url = "https://foo.git"
     ref = "v1.2.3"
-    spack.util.git.git_init_fetch(git, url, ref)
+    spack.util.git.git_init_fetch(url, ref, git_exe=git)
     for opt in ommitted_opts:
         assert all(opt not in call for call in log)
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -208,15 +208,22 @@ class VersionConditionalOption:
             return []
 
 
-DEPTH = VersionConditionalOption("--depth", 1, min_version=(1, 9, 0))
+# The earliest git version where we start trying to optimizie clones
+# git@1.8.5 is when branch could also accept tag so we don't have to track ref types as closely
+MIN_OPT_VERSION = (1, 8, 5, 2)
+
+
+# Technically the flags existed earlier but we are pruning our logic to 1.8.5 or greater
+BRANCH = VersionConditionalOption("--branch", min_version=MIN_OPT_VERSION)
+SINGLE_BRANCH = VersionConditionalOption("--single-branch", min_version=MIN_OPT_VERSION)
+NO_SINGLE_BRANCH = VersionConditionalOption("--no-single-branch", min_version=MIN_OPT_VERSION)
+# Depth was introduced in 1.7.11 but isn't worth much without the --branch options
+DEPTH = VersionConditionalOption("--depth", 1, min_version=MIN_OPT_VERSION)
+
 FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2, 19, 0))
 NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2, 34, 0))
 # technically sparse-checkout was added in 2.25, but we go forward since the model we use only works with the `--cone` option
 SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", "set", min_version=(2, 34, 0))
-# This is when branch could also accept tag
-BRANCH = VersionConditionalOption("--branch", min_version=(1, 8, 5))
-SINGLE_BRANCH = VersionConditionalOption("--single-branch", min_version=(1, 7, 10))
-NO_SINGLE_BRANCH = VersionConditionalOption("--no-single-branch", min_version=(1, 7, 10))
 
 
 def _exec_git_commands(git_exe, cmds, debug, dest=None):
@@ -231,21 +238,7 @@ def _exec_git_commands(git_exe, cmds, debug, dest=None):
             git_exe(*cmd)
 
 
-def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
-    git_exe = git_exe or git(required=True)
-    version = git_exe.version
-    if ref and is_git_commit_sha(ref) and version < (2, 5, 0):
-        raise exe.ProcessError("Git older than 2.5 detected, can't fetch commit directly")
-    init = ["init"]
-    fetch = ["fetch"]
-
-    if not debug:
-        fetch.append("--quiet")
-    if depth:
-        fetch.extend(DEPTH(version, str(depth)))
-
-    fetch.extend([*FILTER_BLOB_NONE(version), ref])
-    cmds = [init, fetch]
+def _exec_git_commands_unique_dir(git_exe, cmds, debug, dest=None):
     if dest:
         # mimic creating a dir and clean up if there is a failure like git clone
         assert not os.path.isdir(dest)
@@ -261,6 +254,31 @@ def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
         _exec_git_commands(git_exe, cmds, debug, dest)
 
 
+def protocol_supports_shallow_clone(url):
+    """Shallow clone operations (``--depth #``) are not supported by the basic
+    HTTP protocol or by no-protocol file specifications.
+    Use (e.g.) ``https://`` or ``file://`` instead."""
+    return not (url.startswith("http://") or url.startswith("/"))
+
+
+def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
+    git_exe = git_exe or git(required=True)
+    version = git_exe.version
+    if ref and is_git_commit_sha(ref) and version < (2, 5, 0):
+        raise exe.ProcessError("Git older than 2.5 detected, can't fetch commit directly")
+    init = ["init"]
+    fetch = ["fetch"]
+
+    if not debug:
+        fetch.append("--quiet")
+    if depth and protocol_supports_shallow_clone(url):
+        fetch.extend(DEPTH(version, str(depth)))
+
+    fetch.extend([*FILTER_BLOB_NONE(version), ref])
+    cmds = [init, fetch]
+    _exec_git_commands_unique_dir(git_exe, cmds, debug, dest)
+
+
 def git_checkout(
     ref: Optional[str] = None,
     sparse_paths: List[str] = [],
@@ -272,8 +290,8 @@ def git_checkout(
     checkout = ["checkout"]
     sparse_checkout = SPARSE_CHECKOUT(git_exe.version)
 
-    if not debug:
-        checkout.append("--quiet")
+    # if not debug:
+    # checkout.append("--quiet")
     if ref:
         checkout.append(ref)
 
@@ -298,22 +316,32 @@ def git_clone(
     git_exe = git_exe or git(required=True)
     version = git_exe.version
     clone = ["clone"]
+    # only need fetch if it's a really old git so we don't fail a checkout
+    old = version < MIN_OPT_VERSION
+    fetch = ["fetch"]
+
     if not debug:
         clone.append("--quiet")
-    if depth:
+        fetch.append("--quiet")
+
+    if not old and depth and not full_repo and protocol_supports_shallow_clone(url):
         clone.extend(DEPTH(version, str(depth)))
 
-    if ref:
-        clone.extend([*BRANCH(version, ref)])
     if full_repo:
-        clone.extend(NO_SINGLE_BRANCH(version))
-    else:
-        clone.extend(SINGLE_BRANCH(version))
+        if old:
+            fetch.extend(["--all"])
+        else:
+            clone.extend(NO_SINGLE_BRANCH(version))
+    elif ref and not is_git_commit_sha(ref):
+        if old:
+            fetch.extend(["origin", ref])
+        else:
+            clone.extend([*SINGLE_BRANCH(version), *BRANCH(version, ref)])
 
     clone.extend([*FILTER_BLOB_NONE(version), *NO_CHECKOUT(version), url])
 
     if dest:
         clone.append(dest)
-
-    cmds = [clone]
-    _exec_git_commands(git_exe, cmds, debug)
+    _exec_git_commands(git_exe, [clone], debug)
+    if old:
+        _exec_git_commands(git_exe, [fetch], debug, dest)

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -228,15 +228,10 @@ SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", "set", min_version
 
 
 def _exec_git_commands(git_exe, cmds, debug, dest=None):
-    if dest:
-        dest_cmd = ["-C", dest]
-        cmds = [dest_cmd + cmd for cmd in cmds]
+    dest_args = ["-C", dest] if dest else []
+    error_stream = sys.stdout if debug else os.devnull  # swallow extra output for non-debug
     for cmd in cmds:
-        if not debug:
-            # swallow extra output that leasks to str for non-debug case
-            git_exe(*cmd, error=str)
-        else:
-            git_exe(*cmd)
+        git_exe(*dest_args, *cmd, error=error_stream)
 
 
 def _exec_git_commands_unique_dir(git_exe, cmds, debug, dest=None):

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -30,7 +30,7 @@ def _find_git() -> Optional[str]:
 
 
 def extract_git_version_str(git_exe):
-    v_str = git_exe("--version", output=str).strip().split()[-1]
+    v_str = git_exe("--version", output=str).strip().split()[-1].replace("windows.", "")
     return v_str
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -222,7 +222,8 @@ DEPTH = VersionConditionalOption("--depth", 1, min_version=MIN_OPT_VERSION)
 
 FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2, 19, 0))
 NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2, 34, 0))
-# technically sparse-checkout was added in 2.25, but we go forward since the model we use only works with the `--cone` option
+# technically sparse-checkout was added in 2.25, but we go forward since the model we use only
+# works with the `--cone` option
 SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", "set", min_version=(2, 34, 0))
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -268,6 +268,7 @@ def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
     if ref and is_git_commit_sha(ref) and version < (2, 5, 0):
         raise exe.ProcessError("Git older than 2.5 detected, can't fetch commit directly")
     init = ["init"]
+    remote = ["remote", "add", "origin", url]
     fetch = ["fetch"]
 
     if not debug:
@@ -276,7 +277,7 @@ def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
         fetch.extend(DEPTH(version, str(depth)))
 
     fetch.extend([*FILTER_BLOB_NONE(version), url, ref])
-    cmds = [init, fetch]
+    cmds = [init, remote, fetch]
     _exec_git_commands_unique_dir(git_exe, cmds, debug, dest)
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -223,7 +223,7 @@ DEPTH = VersionConditionalOption("--depth", 1, min_version=MIN_OPT_VERSION)
 FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2, 19, 0))
 NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2, 34, 0))
 # technically sparse-checkout was added in 2.25, but we go forward since the model we use only
-# works with the `--cone` option
+# works with the `--clone` option
 SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", "set", min_version=(2, 34, 0))
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -35,6 +35,8 @@ def extract_git_version_str(git_exe):
 
 
 class GitExecutable(exe.Executable):
+    """Specialized executable that encodes the git version for optimized option selection"""
+
     def __init__(self, name=None):
         if not name:
             name = _find_git()
@@ -48,6 +50,44 @@ class GitExecutable(exe.Executable):
             v_string = extract_git_version_str(self)
             self._version = tuple(int(i) for i in v_string.split("."))
         return self._version
+
+
+class VersionConditionalOption:
+    def __init__(self, key, value=None, min_version=(0, 0, 0), max_version=(99, 99, 99)):
+        self.key = key
+        self.value = value
+        self.min_version = min_version
+        self.max_version = max_version
+
+    def __call__(self, exe_version, value=None) -> List:
+        if (self.min_version <= exe_version) and (self.max_version >= exe_version):
+            option = [self.key]
+            if value:
+                option.append(value)
+            elif self.value:
+                option.append(self.value)
+            return option
+        else:
+            return []
+
+
+# The earliest git version where we start trying to optimize clones
+# git@1.8.5 is when branch could also accept tag so we don't have to track ref types as closely
+# This also corresponds to system git on RHEL7
+MIN_OPT_VERSION = (1, 8, 5, 2)
+
+# Technically the flags existed earlier but we are pruning our logic to 1.8.5 or greater
+BRANCH = VersionConditionalOption("--branch", min_version=MIN_OPT_VERSION)
+SINGLE_BRANCH = VersionConditionalOption("--single-branch", min_version=MIN_OPT_VERSION)
+NO_SINGLE_BRANCH = VersionConditionalOption("--no-single-branch", min_version=MIN_OPT_VERSION)
+# Depth was introduced in 1.7.11 but isn't worth much without the --branch options
+DEPTH = VersionConditionalOption("--depth", 1, min_version=MIN_OPT_VERSION)
+
+FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2, 19, 0))
+NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2, 34, 0))
+# technically sparse-checkout was added in 2.25, but we go forward since the model we use only
+# works with the `--cone` option
+SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", "set", min_version=(2, 34, 0))
 
 
 @overload
@@ -189,44 +229,6 @@ def get_commit_sha(path: str, ref: str) -> Optional[str]:
     return None
 
 
-class VersionConditionalOption:
-    def __init__(self, key, value=None, min_version=(0, 0, 0), max_version=(99, 99, 99)):
-        self.key = key
-        self.value = value
-        self.min_version = min_version
-        self.max_version = max_version
-
-    def __call__(self, exe_version, value=None) -> List:
-        if (self.min_version <= exe_version) and (self.max_version >= exe_version):
-            option = [self.key]
-            if value:
-                option.append(value)
-            elif self.value:
-                option.append(self.value)
-            return option
-        else:
-            return []
-
-
-# The earliest git version where we start trying to optimize clones
-# git@1.8.5 is when branch could also accept tag so we don't have to track ref types as closely
-# This also corresponds to system git on RHEL7
-MIN_OPT_VERSION = (1, 8, 5, 2)
-
-# Technically the flags existed earlier but we are pruning our logic to 1.8.5 or greater
-BRANCH = VersionConditionalOption("--branch", min_version=MIN_OPT_VERSION)
-SINGLE_BRANCH = VersionConditionalOption("--single-branch", min_version=MIN_OPT_VERSION)
-NO_SINGLE_BRANCH = VersionConditionalOption("--no-single-branch", min_version=MIN_OPT_VERSION)
-# Depth was introduced in 1.7.11 but isn't worth much without the --branch options
-DEPTH = VersionConditionalOption("--depth", 1, min_version=MIN_OPT_VERSION)
-
-FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2, 19, 0))
-NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2, 34, 0))
-# technically sparse-checkout was added in 2.25, but we go forward since the model we use only
-# works with the `--cone` option
-SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", "set", min_version=(2, 34, 0))
-
-
 def _exec_git_commands(git_exe, cmds, debug, dest=None):
     dest_args = ["-C", dest] if dest else []
     error_stream = sys.stdout if debug else os.devnull  # swallow extra output for non-debug
@@ -258,16 +260,18 @@ def protocol_supports_shallow_clone(url):
 
 
 def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
-    """Utilize ``git init`` and then ``git fetch`` for a targeted, minimal clone of a single git ref
+    """Utilize ``git init`` and then ``git fetch`` for a minimal clone of a single git ref
     This method runs git init, repo add, fetch to get a minimal set of source data.
     Profiling has shown this method can be 10-20% less storage than purely using sparse-checkout,
     and is even smaller than git clone --depth 1. This makes it the preferred method for single
     commit checkouts and source mirror population.
 
     There is a trade off since less git data means less flexibility with additional git operations.
-    Technically adding the remote is not necessary, but we do it since there are test cases where we may want to fetch additional data.
+    Technically adding the remote is not necessary, but we do it since there are test cases where
+    we may want to fetch additional data.
 
-    Checkout is explicitly deferred to a second method so we can intercept and add sparse-checkout options uniformly whether we use `git clone` or `init fetch`
+    Checkout is explicitly deferred to a second method so we can intercept and add sparse-checkout
+    options uniformly whether we use `git clone` or `init fetch`
     """
     git_exe = git_exe or git(required=True)
     version = git_exe.version

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -5,7 +5,6 @@
 
 import os
 import re
-import shutil
 import sys
 from typing import List, Optional, overload
 
@@ -22,10 +21,16 @@ def is_git_commit_sha(string: str) -> bool:
     return len(string) == 40 and bool(COMMIT_VERSION.match(string))
 
 
+@spack.llnl.util.lang.memoized
+def _find_git() -> Optional[str]:
+    """Find the git executable in the system path."""
+    return exe.which_string("git", required=False)
+
+
 class GitExecutable(exe.Executable):
     def __init__(self, name=None):
         if not name:
-            name = "git"
+            name = _find_git()
         super().__init__(name)
         self._version = None
 
@@ -36,12 +41,6 @@ class GitExecutable(exe.Executable):
             v_string = self.__call__("--version", output=str).strip().split()[-1]
             self._version = tuple(int(i) for i in v_string.split("."))
         return self._version
-
-
-@spack.llnl.util.lang.memoized
-def _find_git() -> Optional[str]:
-    """Find the git executable in the system path."""
-    return exe.which_string("git", required=False)
 
 
 @overload
@@ -61,7 +60,7 @@ def git(required: bool = False) -> Optional[exe.Executable]:
             raise exe.CommandNotFoundError("spack requires 'git'. Make sure it is in your path.")
         return None
 
-    git = exe.Executable(git_path)
+    git = GitExecutable(git_path)
 
     # If we're running under pytest, add this to ignore the fix for CVE-2022-39253 in
     # git 2.38.1+. Do this in one place; we need git to do this in all parts of Spack.
@@ -182,14 +181,15 @@ def get_commit_sha(path: str, ref: str) -> Optional[str]:
 
     return None
 
-class VersionConditionalOption:
-    def __init__(self, key, value=None, min_version=(0,0,0), max_version=(99,99,99)):
-        self.key=key
-        self.value=value
-        self.min_version=min_version
-        self.max_version=max_version
 
-    def __call__(self, exe_version, value=None)->List:
+class VersionConditionalOption:
+    def __init__(self, key, value=None, min_version=(0, 0, 0), max_version=(99, 99, 99)):
+        self.key = key
+        self.value = value
+        self.min_version = min_version
+        self.max_version = max_version
+
+    def __call__(self, exe_version, value=None) -> List:
         if (self.min_version <= exe_version) and (self.max_version >= exe_version):
             option = [self.key]
             if value:
@@ -200,53 +200,69 @@ class VersionConditionalOption:
         else:
             return []
 
-DEPTH = VersionConditionalOption("--depth", 1, min_version=(1,9,0))
-FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2,19,0))
-NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2,34,0))
+
+DEPTH = VersionConditionalOption("--depth", 1, min_version=(1, 9, 0))
+FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2, 19, 0))
+NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2, 34, 0))
 # technically sparse-checkout was added in 2.25, but we go forward since the model we use only works with the `--cone` option
-SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", min_version=(2,34,0))
+SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", min_version=(2, 34, 0))
 
 
-def git_fetch_by_ref(git_exe: GitExecutable, url, ref, depth=1, sparse_paths=[], debug=False, dest=None):
-    if is_git_commit_sha(ref) and git_exe.version < (
-        2,
-        5,
-        0,
-    ):
-        raise spack.util.executable.ProcessError(
-            "Git version older than 2.5 and fetch by ref for commit can't be used"
-        )
-    init = ["init"]
-    fetch = ["fetch"]
-    checkout = ["checkout"]
-    sparse_checkout = SPARSE_CHECKOUT(git_exe.version)
-    if sparse_paths and sparse_checkout:
-        sparse_checkout.extend([*sparse_paths, "--cone"])
+def _exec_git_commands(git_exe, cmds, debug, dest=None):
+    def _exec(git_exe, cmds, debug):
+        for cmd in cmds:
+            if not debug:
+                # swallow extra output that leasks to str for non-debug case
+                git_exe(*cmd, error=str)
+            else:
+                git_exe(*cmd)
 
     if dest:
-        init.append(dest)
+        assert not os.path.isdir(dest)
+        dest_cmd = ["-C", dest]
+        cmds = [dest_cmd + cmd for cmd in cmds]
+        # TODO(psakiev) what to do about cleaning up stale directories?
+        # clean up ?
+        _exec(git_exe, cmds, debug)
+    else:
+        _exec(git_exe, cmds, debug)
+
+
+def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
+    git_exe = git_exe or git(required=True)
+    init = ["init"]
+    remote = ["remote", "add", "origin", url]
+    fetch = ["fetch"]
+
     if not debug:
         fetch.append("--quiet")
-        checkout.append("--quiet")
-    checkout.append("FETCH_HEAD")
-
     if depth:
         fetch.extend(DEPTH(git_exe.version, str(depth)))
 
-    fetch.extend([*FILTER_BLOB_NONE(git_exe.version), url, ref])
+    fetch.extend([*FILTER_BLOB_NONE(git_exe.version)])
+    fetch.extend(["origin", ref])
+    cmds = [init, remote, fetch]
+    _exec_git_commands(git_exe, cmds, debug, dest)
 
-    cmds = [init, fetch]
+
+def git_checkout(ref=None, sparse_paths=[], debug=False, dest=None, git_exe=None):
+    git_exe = git_exe or git(required=True)
+    checkout = ["checkout"]
+    sparse_checkout = SPARSE_CHECKOUT(git_exe.version)
+
+    if sparse_paths and sparse_checkout:
+        sparse_checkout.extend([*sparse_paths, "--cone"])
+
+    if not debug:
+        checkout.append("--quiet")
+    checkout.append(ref or "FETCH_HEAD")
+
+    if not ref:
+        # TODO(psakiev) what to do if there is no checkout ref?
+        raise Exception()
+
+    cmds = []
     if sparse_checkout:
         cmds.append(sparse_checkout)
     cmds.append(checkout)
-
-    if dest:
-        dest_cmd = ["-C", dest]
-        cmds = [ dest_cmd + cmd for cmd in cmds]
-
-    for cmd in cmds:
-        if not debug:
-            # swallow extra output that leasks to str for non-debug case
-            git_exe(*cmd, error=str)
-        else:
-            git_exe(*cmd)
+    _exec_git_commands(git_exe, cmds, debug, dest)

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -189,13 +189,13 @@ class VersionConditionalOption:
         self.min_version=min_version
         self.max_version=max_version
 
-    def __call__(self, exe_version, value=None):
+    def __call__(self, exe_version, value=None)->List:
         if (self.min_version <= exe_version) and (self.max_version >= exe_version):
             option = [self.key]
             if value:
-                return option.append(value)
+                option.append(value)
             elif self.value:
-                return option.append(self.value)
+                option.append(self.value)
             return option
         else:
             return []

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import shutil
 import sys
 from typing import List, Optional, overload
 
@@ -223,6 +224,9 @@ def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, d
     fetch.add_arguments(url, ref)
 
     if dest:
+        if os.path.isdir(dest):
+            shutil.rmtree(dest)
+        os.mkdir(dest)
         git_exe.add_default_arg("-C", dest)
     init()
     fetch()

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import shutil
 import sys
 from typing import List, Optional, overload
 
@@ -206,46 +207,59 @@ FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2
 NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2, 34, 0))
 # technically sparse-checkout was added in 2.25, but we go forward since the model we use only works with the `--cone` option
 SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", min_version=(2, 34, 0))
+# This is when branch could also accept tag
+BRANCH = VersionConditionalOption("--branch", min_version=(1, 8, 5))
+SINGLE_BRANCH = VersionConditionalOption("--single-branch", min_version=(1, 7, 10))
+NO_SINGLE_BRANCH = VersionConditionalOption("--no-single-branch", min_version=(1, 7, 10))
 
 
 def _exec_git_commands(git_exe, cmds, debug, dest=None):
-    def _exec(git_exe, cmds, debug):
-        for cmd in cmds:
-            if not debug:
-                # swallow extra output that leasks to str for non-debug case
-                git_exe(*cmd, error=str)
-            else:
-                git_exe(*cmd)
-
     if dest:
-        assert not os.path.isdir(dest)
         dest_cmd = ["-C", dest]
         cmds = [dest_cmd + cmd for cmd in cmds]
-        # TODO(psakiev) what to do about cleaning up stale directories?
-        # clean up ?
-        _exec(git_exe, cmds, debug)
-    else:
-        _exec(git_exe, cmds, debug)
+    for cmd in cmds:
+        if not debug:
+            # swallow extra output that leasks to str for non-debug case
+            git_exe(*cmd, error=str)
+        else:
+            git_exe(*cmd)
 
 
 def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
     git_exe = git_exe or git(required=True)
+    version = git_exe.version
+    if ref and is_git_commit_sha(ref) and version < (2, 5, 0):
+        raise exe.ProcessError("Git older than 2.5 detected, can't fetch commit directly")
     init = ["init"]
-    remote = ["remote", "add", "origin", url]
     fetch = ["fetch"]
 
     if not debug:
         fetch.append("--quiet")
     if depth:
-        fetch.extend(DEPTH(git_exe.version, str(depth)))
+        fetch.extend(DEPTH(version, str(depth)))
 
-    fetch.extend([*FILTER_BLOB_NONE(git_exe.version)])
-    fetch.extend(["origin", ref])
-    cmds = [init, remote, fetch]
-    _exec_git_commands(git_exe, cmds, debug, dest)
+    fetch.extend([*FILTER_BLOB_NONE(version), ref])
+    cmds = [init, fetch]
+    if dest:
+        # mimic creating a dir and clean up if there is a failure like git clone
+        assert not os.path.isdir(dest)
+        os.mkdir(dest)
+        try:
+            _exec_git_commands(git_exe, cmds, debug, dest)
+        except exe.ProcessError:
+            shutil.rmdir(dest)
+            raise
+    else:
+        _exec_git_commands(git_exe, cmds, debug, dest)
 
 
-def git_checkout(ref=None, sparse_paths=[], debug=False, dest=None, git_exe=None):
+def git_checkout(
+    ref: Optional[str] = None,
+    sparse_paths: List[str] = [],
+    debug: bool = False,
+    dest: Optional[str] = None,
+    git_exe: Optional[GitExecutable] = None,
+):
     git_exe = git_exe or git(required=True)
     checkout = ["checkout"]
     sparse_checkout = SPARSE_CHECKOUT(git_exe.version)
@@ -257,12 +271,41 @@ def git_checkout(ref=None, sparse_paths=[], debug=False, dest=None, git_exe=None
         checkout.append("--quiet")
     checkout.append(ref or "FETCH_HEAD")
 
-    if not ref:
-        # TODO(psakiev) what to do if there is no checkout ref?
-        raise Exception()
-
     cmds = []
     if sparse_checkout:
         cmds.append(sparse_checkout)
     cmds.append(checkout)
     _exec_git_commands(git_exe, cmds, debug, dest)
+
+
+def git_clone(
+    url: str,
+    ref: Optional[str] = None,
+    full_repo: bool = False,
+    depth: Optional[int] = None,
+    debug: bool = False,
+    dest: Optional[str] = None,
+    git_exe: Optional[GitExecutable] = None,
+):
+    git_exe = git_exe or git(required=True)
+    version = git_exe.version
+    clone = ["clone"]
+    if not debug:
+        clone.append("--quiet")
+    if depth:
+        clone.extend(DEPTH(version, str(depth)))
+
+    if ref:
+        clone.extend([*BRANCH(version, ref)])
+    if full_repo:
+        clone.extend(NO_SINGLE_BRANCH(version))
+    else:
+        clone.extend(SINGLE_BRANCH(version))
+
+    clone.extend([*FILTER_BLOB_NONE(version), *NO_CHECKOUT(version), ref])
+
+    if dest:
+        clone.append(dest)
+
+    cmds = [clone]
+    _exec_git_commands(git_exe, cmds, debug)

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -22,6 +22,22 @@ def is_git_commit_sha(string: str) -> bool:
     return len(string) == 40 and bool(COMMIT_VERSION.match(string))
 
 
+class GitExecutable(exe.Executable):
+    def __init__(self, name=None):
+        if not name:
+            name = "git"
+        super().__init__(name)
+        self._version = None
+
+    @property
+    def version(self):
+        # lazy init git version
+        if not self._version:
+            v_string = self.__call__("--version", output=str).strip().split()[-1]
+            self._version = tuple(int(i) for i in v_string.split("."))
+        return self._version
+
+
 @spack.llnl.util.lang.memoized
 def _find_git() -> Optional[str]:
     """Find the git executable in the system path."""
@@ -174,7 +190,7 @@ class VersionConditionalOption:
         self.max_version=max_version
 
     def __call__(self, exe_version, value=None):
-        if (self.min_version >= exe_version) and (self.max_version <= exe_version):
+        if (self.min_version <= exe_version) and (self.max_version >= exe_version):
             option = [self.key]
             if value:
                 return option.append(value)
@@ -187,61 +203,12 @@ class VersionConditionalOption:
 DEPTH = VersionConditionalOption("--depth", 1, min_version=(1,9,0))
 FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2,19,0))
 NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2,34,0))
-
-class GitCommandExecutor(exe.Executable):
-    def __init__(self, name):
-        super().__init__(name)
-
-    def _extract_git_version(self):
-        v_string = self.__call__("--version", output=str).strip().split()[-1]
-        self.version tuple(int(i) for i in v_string.split("."))
+# technically sparse-checkout was added in 2.25, but we go forward since the model we use only works with the `--cone` option
+SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", min_version=(2,34,0))
 
 
-class GitCommandArgumentAssembler:
-    def __init__(self, cmd_name, git_exe=None, min_version=(1, 0, 0)):
-        self.git_exe = git_exe or git(required=True)
-        self.version = self.extract_git_version(self.git_exe)
-        self.cmd_min_version = min_version
-        self.name = cmd_name
-        self.args = []
-        # make command unusable for invalid git versions
-        if self.cmd_min_version <= self.version:
-            self.args.append(self.name)
-
-    def add_arguments(self, *args, min_version=(1, 0, 0)):
-        if min_version < self.cmd_min_version:
-            return
-        if self.version >= min_version:
-            self.args.extend(args)
-
-    def __call__(self, *args, **exe_args):
-        if self.args:
-            cmd = self.args + list(args)
-            return self.git_exe(*cmd, **exe_args)
-
-def _git_add_dest(git_exe, dest):
-    if os.path.isdir(dest):
-        shutil.rmtree(dest)
-    os.mkdir(dest)
-    git_exe.add_default_arg("-C", dest)
-
-
-def git_fetch_full_repo(git_exe, url, ref=None, bare = False, debug=False, dest=None):
-    clone = GitCommandArgumentAssembler("clone", git_exe)
-    if debug:
-        clone.add_arguments("--quiet")
-    if bare:
-        clone.add_arguments("--bare")
-    if ref or bare:
-        clone.add_arguments("--filter=blob:none", min_version=(2, 19, 0))
-    if dest:
-        _git_add_dest(git_exe, dest)
-    clone()
-
-
-
-def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, dest="."):
-    if is_git_commit_sha(ref) and GitCommandArgumentAssembler.extract_git_version(git_exe) < (
+def git_fetch_by_ref(git_exe: GitExecutable, url, ref, depth=1, sparse_paths=[], debug=False, dest=None):
+    if is_git_commit_sha(ref) and git_exe.version < (
         2,
         5,
         0,
@@ -249,37 +216,37 @@ def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, d
         raise spack.util.executable.ProcessError(
             "Git version older than 2.5 and fetch by ref for commit can't be used"
         )
-    init = GitCommandArgumentAssembler("init", git_exe)
-    fetch = GitCommandArgumentAssembler("fetch", git_exe)
-    checkout = GitCommandArgumentAssembler("checkout", git_exe)
-    # technically sparse-checkout was added in 2.25, but we go forward since the model while 
-    # condition: pass assumes `--cone` is a valid arument
-    sparse_checkout = GitCommandArgumentAssembler(
-        "sparse-checkout", git_exe, min_version=(2, 34, 0)
-    )
-
-    init.add_arguments(dest)
-    checkout.add_arguments("FETCH_HEAD")
-    if not debug:
-        fetch.add_arguments("--quiet")
-        checkout.add_arguments("--quiet")
-
-    if depth:
-        fetch.add_arguments("--depth", str(depth), min_version=(1, 9, 0))
-    fetch.add_arguments("--filter=blob:none", min_version=(2, 19, 0))
-    fetch.add_arguments(url, ref)
+    init = ["init"]
+    fetch = ["fetch"]
+    checkout = ["checkout"]
+    sparse_checkout = SPARSE_CHECKOUT(git_exe.version)
+    if sparse_paths and sparse_checkout:
+        sparse_checkout.extend([*sparse_paths, "--cone"])
 
     if dest:
-        _git_add_dest(git_exe, dest)
-    init()
-    fetch()
-
-    if sparse_paths:
-        sparse_checkout.add_arguments(*sparse_paths)
-        sparse_checkout.add_arguments("--cone")
-        sparse_checkout()
-
+        init.append(dest)
     if not debug:
-        checkout(error=str)
-    else:
-        checkout()
+        fetch.append("--quiet")
+        checkout.append("--quiet")
+    checkout.append("FETCH_HEAD")
+
+    if depth:
+        fetch.extend(DEPTH(git_exe.version, str(depth)))
+
+    fetch.extend([*FILTER_BLOB_NONE(git_exe.version), url, ref])
+
+    cmds = [init, fetch]
+    if sparse_checkout:
+        cmds.append(sparse_checkout)
+    cmds.append(checkout)
+
+    if dest:
+        dest_cmd = ["-C", dest]
+        cmds = [ dest_cmd + cmd for cmd in cmds]
+
+    for cmd in cmds:
+        if not debug:
+            # swallow extra output that leasks to str for non-debug case
+            git_exe(*cmd, error=str)
+        else:
+            git_exe(*cmd)

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -164,3 +164,73 @@ def get_commit_sha(path: str, ref: str) -> Optional[str]:
             continue
 
     return None
+
+
+class GitCommandArgumentAssembler:
+    def __init__(self, cmd_name, git_exe=None, min_version=(1, 0, 0)):
+        self.git_exe = git_exe or git(required=True)
+        self.version = self.extract_git_version(self.git_exe)
+        self.cmd_min_version = min_version
+        self.name = cmd_name
+        self.args = []
+        # make command unusable for invalid git versions
+        if self.cmd_min_version <= self.version:
+            self.args.append(self.name)
+
+    @staticmethod
+    def extract_git_version(git_exe):
+        v_string = git_exe("--version").strip()
+        return tuple(int(i) for i in v_string.split("."))
+
+    def add_arguments(self, *args, min_version=(1, 0, 0)):
+        if min_version < self.cmd_min_version:
+            return
+        if self.version >= min_version:
+            self.args.extend(args)
+
+    def __call__(self, *args, **exe_args):
+        if self.args:
+            cmd = self.args + list(args)
+            return self.git_exe(*cmd, **exe_args)
+
+
+def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, clone_dir="."):
+    if is_git_commit_sha(ref) and GitCommandArgumentAssembler.extract_git_version(git_exe) < (
+        2,
+        5,
+        0,
+    ):
+        raise spack.util.executable.ProcessError(
+            "Git version older than 2.5 and fetch by ref for commit can't be used"
+        )
+    init = GitCommandArgumentAssembler("init", git_exe)
+    fetch = GitCommandArgumentAssembler("fetch", git_exe)
+    checkout = GitCommandArgumentAssembler("checkout", git_exe)
+
+    init.add_arguments(clone_dir)
+    checkout.add_arguments("FETCH_HEAD")
+    if debug:
+        fetch.add_arguments("--quiet")
+        checkout.add_arguments("--quiet")
+
+    if depth:
+        fetch.add_arguments("--depth", str(depth), min_version=(1, 9, 0))
+    fetch.add_arguments("--filter=blob:none", min_version=(2, 19, 0))
+    fetch.add_arguments(url, ref)
+
+    init()
+    fetch()
+
+    if sparse_paths:
+        # technically sparse-checkout was added in 2.25, but we go forward since the model we implemented assumes `--cone` is a valid arument
+        sparse_checkout = GitCommandArgumentAssembler(
+            "sparse-checkout", git_exe, min_version=(2, 34, 0)
+        )
+        sparse_checkout.add_arguments(*sparse_paths)
+        sparse_checkout.add_arguments("--cone")
+        sparse_checkout()
+
+    if debug:
+        checkout(error=str)
+    else:
+        checkout()

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -212,7 +212,6 @@ class VersionConditionalOption:
 # git@1.8.5 is when branch could also accept tag so we don't have to track ref types as closely
 MIN_OPT_VERSION = (1, 8, 5, 2)
 
-
 # Technically the flags existed earlier but we are pruning our logic to 1.8.5 or greater
 BRANCH = VersionConditionalOption("--branch", min_version=MIN_OPT_VERSION)
 SINGLE_BRANCH = VersionConditionalOption("--single-branch", min_version=MIN_OPT_VERSION)

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -166,6 +166,36 @@ def get_commit_sha(path: str, ref: str) -> Optional[str]:
 
     return None
 
+class VersionConditionalOption:
+    def __init__(self, key, value=None, min_version=(0,0,0), max_version=(99,99,99)):
+        self.key=key
+        self.value=value
+        self.min_version=min_version
+        self.max_version=max_version
+
+    def __call__(self, exe_version, value=None):
+        if (self.min_version >= exe_version) and (self.max_version <= exe_version):
+            option = [self.key]
+            if value:
+                return option.append(value)
+            elif self.value:
+                return option.append(self.value)
+            return option
+        else:
+            return []
+
+DEPTH = VersionConditionalOption("--depth", 1, min_version=(1,9,0))
+FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2,19,0))
+NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2,34,0))
+
+class GitCommandExecutor(exe.Executable):
+    def __init__(self, name):
+        super().__init__(name)
+
+    def _extract_git_version(self):
+        v_string = self.__call__("--version", output=str).strip().split()[-1]
+        self.version tuple(int(i) for i in v_string.split("."))
+
 
 class GitCommandArgumentAssembler:
     def __init__(self, cmd_name, git_exe=None, min_version=(1, 0, 0)):
@@ -178,11 +208,6 @@ class GitCommandArgumentAssembler:
         if self.cmd_min_version <= self.version:
             self.args.append(self.name)
 
-    @staticmethod
-    def extract_git_version(git_exe):
-        v_string = git_exe("--version", output=str).strip().split()[-1]
-        return tuple(int(i) for i in v_string.split("."))
-
     def add_arguments(self, *args, min_version=(1, 0, 0)):
         if min_version < self.cmd_min_version:
             return
@@ -193,6 +218,26 @@ class GitCommandArgumentAssembler:
         if self.args:
             cmd = self.args + list(args)
             return self.git_exe(*cmd, **exe_args)
+
+def _git_add_dest(git_exe, dest):
+    if os.path.isdir(dest):
+        shutil.rmtree(dest)
+    os.mkdir(dest)
+    git_exe.add_default_arg("-C", dest)
+
+
+def git_fetch_full_repo(git_exe, url, ref=None, bare = False, debug=False, dest=None):
+    clone = GitCommandArgumentAssembler("clone", git_exe)
+    if debug:
+        clone.add_arguments("--quiet")
+    if bare:
+        clone.add_arguments("--bare")
+    if ref or bare:
+        clone.add_arguments("--filter=blob:none", min_version=(2, 19, 0))
+    if dest:
+        _git_add_dest(git_exe, dest)
+    clone()
+
 
 
 def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, dest="."):
@@ -207,7 +252,8 @@ def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, d
     init = GitCommandArgumentAssembler("init", git_exe)
     fetch = GitCommandArgumentAssembler("fetch", git_exe)
     checkout = GitCommandArgumentAssembler("checkout", git_exe)
-    # technically sparse-checkout was added in 2.25, but we go forward since the model we implemented assumes `--cone` is a valid arument
+    # technically sparse-checkout was added in 2.25, but we go forward since the model while 
+    # condition: pass assumes `--cone` is a valid arument
     sparse_checkout = GitCommandArgumentAssembler(
         "sparse-checkout", git_exe, min_version=(2, 34, 0)
     )
@@ -224,10 +270,7 @@ def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, d
     fetch.add_arguments(url, ref)
 
     if dest:
-        if os.path.isdir(dest):
-            shutil.rmtree(dest)
-        os.mkdir(dest)
-        git_exe.add_default_arg("-C", dest)
+        _git_add_dest(git_exe, dest)
     init()
     fetch()
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -179,7 +179,7 @@ class GitCommandArgumentAssembler:
 
     @staticmethod
     def extract_git_version(git_exe):
-        v_string = git_exe("--version").strip()
+        v_string = git_exe("--version", output=str).strip().split()[-1]
         return tuple(int(i) for i in v_string.split("."))
 
     def add_arguments(self, *args, min_version=(1, 0, 0)):
@@ -194,7 +194,7 @@ class GitCommandArgumentAssembler:
             return self.git_exe(*cmd, **exe_args)
 
 
-def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, clone_dir="."):
+def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, dest="."):
     if is_git_commit_sha(ref) and GitCommandArgumentAssembler.extract_git_version(git_exe) < (
         2,
         5,
@@ -206,10 +206,14 @@ def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, c
     init = GitCommandArgumentAssembler("init", git_exe)
     fetch = GitCommandArgumentAssembler("fetch", git_exe)
     checkout = GitCommandArgumentAssembler("checkout", git_exe)
+    # technically sparse-checkout was added in 2.25, but we go forward since the model we implemented assumes `--cone` is a valid arument
+    sparse_checkout = GitCommandArgumentAssembler(
+        "sparse-checkout", git_exe, min_version=(2, 34, 0)
+    )
 
-    init.add_arguments(clone_dir)
+    init.add_arguments(dest)
     checkout.add_arguments("FETCH_HEAD")
-    if debug:
+    if not debug:
         fetch.add_arguments("--quiet")
         checkout.add_arguments("--quiet")
 
@@ -218,19 +222,17 @@ def git_fetch_by_ref(git_exe, url, ref, depth=1, sparse_paths=[], debug=False, c
     fetch.add_arguments("--filter=blob:none", min_version=(2, 19, 0))
     fetch.add_arguments(url, ref)
 
+    if dest:
+        git_exe.add_default_arg("-C", dest)
     init()
     fetch()
 
     if sparse_paths:
-        # technically sparse-checkout was added in 2.25, but we go forward since the model we implemented assumes `--cone` is a valid arument
-        sparse_checkout = GitCommandArgumentAssembler(
-            "sparse-checkout", git_exe, min_version=(2, 34, 0)
-        )
         sparse_checkout.add_arguments(*sparse_paths)
         sparse_checkout.add_arguments("--cone")
         sparse_checkout()
 
-    if debug:
+    if not debug:
         checkout(error=str)
     else:
         checkout()

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -222,7 +222,7 @@ DEPTH = VersionConditionalOption("--depth", 1, min_version=MIN_OPT_VERSION)
 FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2, 19, 0))
 NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2, 34, 0))
 # technically sparse-checkout was added in 2.25, but we go forward since the model we use only
-# works with the `--clone` option
+# works with the `--cone` option
 SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", "set", min_version=(2, 34, 0))
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -11,6 +11,7 @@ from typing import List, Optional, overload
 
 from spack.vendor.typing_extensions import Literal
 
+import spack.llnl.util.filesystem as fs
 import spack.llnl.util.lang
 import spack.util.executable as exe
 
@@ -28,6 +29,11 @@ def _find_git() -> Optional[str]:
     return exe.which_string("git", required=False)
 
 
+def extract_git_version_str(git_exe):
+    v_str = git_exe("--version", output=str).strip().split()[-1]
+    return v_str
+
+
 class GitExecutable(exe.Executable):
     def __init__(self, name=None):
         if not name:
@@ -39,7 +45,7 @@ class GitExecutable(exe.Executable):
     def version(self):
         # lazy init git version
         if not self._version:
-            v_string = self.__call__("--version", output=str).strip().split()[-1]
+            v_string = extract_git_version_str(self)
             self._version = tuple(int(i) for i in v_string.split("."))
         return self._version
 
@@ -206,7 +212,7 @@ DEPTH = VersionConditionalOption("--depth", 1, min_version=(1, 9, 0))
 FILTER_BLOB_NONE = VersionConditionalOption("--filter=blob:none", min_version=(2, 19, 0))
 NO_CHECKOUT = VersionConditionalOption("--no-checkout", min_version=(2, 34, 0))
 # technically sparse-checkout was added in 2.25, but we go forward since the model we use only works with the `--cone` option
-SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", min_version=(2, 34, 0))
+SPARSE_CHECKOUT = VersionConditionalOption("sparse-checkout", "set", min_version=(2, 34, 0))
 # This is when branch could also accept tag
 BRANCH = VersionConditionalOption("--branch", min_version=(1, 8, 5))
 SINGLE_BRANCH = VersionConditionalOption("--single-branch", min_version=(1, 7, 10))
@@ -247,7 +253,9 @@ def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
         try:
             _exec_git_commands(git_exe, cmds, debug, dest)
         except exe.ProcessError:
-            shutil.rmdir(dest)
+            shutil.rmtree(
+                dest, ignore_errors=False, onerror=fs.readonly_file_handler(ignore_errors=True)
+            )
             raise
     else:
         _exec_git_commands(git_exe, cmds, debug, dest)
@@ -264,16 +272,16 @@ def git_checkout(
     checkout = ["checkout"]
     sparse_checkout = SPARSE_CHECKOUT(git_exe.version)
 
-    if sparse_paths and sparse_checkout:
-        sparse_checkout.extend([*sparse_paths, "--cone"])
-
     if not debug:
         checkout.append("--quiet")
-    checkout.append(ref or "FETCH_HEAD")
+    if ref:
+        checkout.append(ref)
 
     cmds = []
-    if sparse_checkout:
+    if sparse_paths and sparse_checkout:
+        sparse_checkout.extend([*sparse_paths, "--cone"])
         cmds.append(sparse_checkout)
+
     cmds.append(checkout)
     _exec_git_commands(git_exe, cmds, debug, dest)
 
@@ -302,7 +310,7 @@ def git_clone(
     else:
         clone.extend(SINGLE_BRANCH(version))
 
-    clone.extend([*FILTER_BLOB_NONE(version), *NO_CHECKOUT(version), ref])
+    clone.extend([*FILTER_BLOB_NONE(version), *NO_CHECKOUT(version), url])
 
     if dest:
         clone.append(dest)

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -290,8 +290,8 @@ def git_checkout(
     checkout = ["checkout"]
     sparse_checkout = SPARSE_CHECKOUT(git_exe.version)
 
-    # if not debug:
-    # checkout.append("--quiet")
+    if not debug:
+        checkout.append("--quiet")
     if ref:
         checkout.append(ref)
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -51,14 +51,14 @@ class GitExecutable(exe.Executable):
 
 
 @overload
-def git(required: Literal[True]) -> exe.Executable: ...
+def git(required: Literal[True]) -> GitExecutable: ...
 
 
 @overload
-def git(required: bool = ...) -> Optional[exe.Executable]: ...
+def git(required: bool = ...) -> Optional[GitExecutable]: ...
 
 
-def git(required: bool = False) -> Optional[exe.Executable]:
+def git(required: bool = False) -> Optional[GitExecutable]:
     """Get a git executable. Raises CommandNotFoundError if ``required`` and git is not found."""
     git_path = _find_git()
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -275,7 +275,7 @@ def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
     if depth and protocol_supports_shallow_clone(url):
         fetch.extend(DEPTH(version, str(depth)))
 
-    fetch.extend([*FILTER_BLOB_NONE(version), ref])
+    fetch.extend([*FILTER_BLOB_NONE(version), url, ref])
     cmds = [init, fetch]
     _exec_git_commands_unique_dir(git_exe, cmds, debug, dest)
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -208,8 +208,9 @@ class VersionConditionalOption:
             return []
 
 
-# The earliest git version where we start trying to optimizie clones
+# The earliest git version where we start trying to optimize clones
 # git@1.8.5 is when branch could also accept tag so we don't have to track ref types as closely
+# This also corresponds to system git on RHEL7
 MIN_OPT_VERSION = (1, 8, 5, 2)
 
 # Technically the flags existed earlier but we are pruning our logic to 1.8.5 or greater
@@ -257,8 +258,22 @@ def protocol_supports_shallow_clone(url):
 
 
 def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
+    """Utilize ``git init`` and then ``git fetch`` for a targeted, minimal clone of a single git ref
+    This method runs git init, repo add, fetch to get a minimal set of source data.
+    Profiling has shown this method can be 10-20% less storage than purely using sparse-checkout,
+    and is even smaller than git clone --depth 1. This makes it the preferred method for single
+    commit checkouts and source mirror population.
+
+    There is a trade off since less git data means less flexibility with additional git operations.
+    Technically adding the remote is not necessary, but we do it since there are test cases where we may want to fetch additional data.
+
+    Checkout is explicitly deferred to a second method so we can intercept and add sparse-checkout options uniformly whether we use `git clone` or `init fetch`
+    """
     git_exe = git_exe or git(required=True)
     version = git_exe.version
+    # minimum criteria for fetching a single commit, but also requires server to be configured
+    # fall-back to a process error so an old git version or a fetch failure from an nonsupporting
+    # server can be caught the same way.
     if ref and is_git_commit_sha(ref) and version < (2, 5, 0):
         raise exe.ProcessError("Git older than 2.5 detected, can't fetch commit directly")
     init = ["init"]
@@ -282,6 +297,12 @@ def git_checkout(
     dest: Optional[str] = None,
     git_exe: Optional[GitExecutable] = None,
 ):
+    """A generic method for running ``git checkout`` that integrates sparse-checkout
+    Several methods in this module explicitly delay checkout so sparse-checkout can be called.
+    It is intended to be used with ``git clone --no-checkout`` or ``git init && git fetch``.
+    There is minimal impact to performance since the initial clone operation filters blobs and
+    has to download a minimal subset of git data.
+    """
     git_exe = git_exe or git(required=True)
     checkout = ["checkout"]
     sparse_checkout = SPARSE_CHECKOUT(git_exe.version)
@@ -309,6 +330,11 @@ def git_clone(
     dest: Optional[str] = None,
     git_exe: Optional[GitExecutable] = None,
 ):
+    """A git clone that prefers deferring expensive blob fetching for modern git installations
+    This is our fallback method for capturing more git data than the ``init && fetch`` model.
+    It is still optimized to capture a minimal set of ``./.git`` data and expects to be paired with
+    a call to ``git checkout`` to fully download the source code.
+    """
     git_exe = git_exe or git(required=True)
     version = git_exe.version
     clone = ["clone"]


### PR DESCRIPTION
Intended to resolve #51552.  Closes/supersedes #51529 and #51550 

## Issue resolving feature
____

This PR adds the
```
git init
git fetch <url> <ref>
git checkout <ref>
```
workflow to be the first case we test. As outlined in #51552 this is the most efficient way to clone a single commit. We should predominantly be cloning single commits going forward so we want the most optimal workflow.

I tried hard to make this a one size fits all command since `fetch` and `clone` take many of the same options we use i.e. `--single-branch` , `--depth`, etc.

However two main issues arose:

1. For fetchers that are only give the URL the logic gets more and more complicated to fetch the correct ref, while clone does this for you. Getting the correct arguments for fetch/checkout is also tricky in the fallback case.
2. Directory management gets complicated since we have to clean up after ourselves.

So I implemented a fall back if the `init/fetch` path fails to still use `git clone`. 

## Other additions
____

This PR moves the majority of our git logic in the fetcher to `spack/util/git.py` with the following changes:

- Adds a `GitExecutable` class that stores the version of the git exe as a tuple of ints
- Adds a testing fixure to mock executables so we can test our flag handling without requiring the full executable to be installed/called
- Adds a `VersionConditionalOption` class that can be called to assemble options for the basic git commands we use over and over again.
- Unified the sparse checkout function with the `init/fetch` and `clone` code paths
- Prefer `--filter=blob:none` in all cases and add a checkout so we only get the blobs we need.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
