### PR TITLE
improve the error message when fetch strategy is broken

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1768,7 +1768,10 @@ def _for_package_version(pkg, version=None):
             kwargs["git"] = pkg.version_or_package_attr("git", ref_version)
             kwargs["submodules"] = pkg.version_or_package_attr("submodules", ref_version, False)
 
-        fetcher = GitFetchStrategy(**kwargs)
+        try:
+            fetcher = GitFetchStrategy(**kwargs)
+        except ValueError as exc:
+            raise ValueError(f"failed to fetch pkg {pkg}") from exc
         return fetcher
 
     # If it's not a known version, try to extrapolate one by URL


### PR DESCRIPTION
Previously you would get the inscrutable

```console
Traceback (most recent call last):
  File "/home/runderwood/git/contrib/spack/bin/spack", line 49, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/main.py", line 1128, in main
    return _main(argv)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/main.py", line 1080, in _main
    return finish_parse_and_run(parser, cmd_name, args, env_format_error)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/main.py", line 1108, in finish_parse_and_run
    pdb.runctx("_invoke_command(command, parser, args, unknown)", globals(), locals())
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/pdb.py", line 2348, in runctx
    run(statement, globals, locals)
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/pdb.py", line 2335, in run
    Pdb().run(statement, globals, locals)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/bdb.py", line 666, in run
    exec(cmd, globals, locals)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/main.py", line 652, in _invoke_command
    return_val = command(parser, args)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/cmd/concretize.py", line 44, in concretize
    concretized_specs = env.concretize(tests=tests)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/environment/environment.py", line 1557, in concretize
    return self._concretize_together(tests=tests)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/environment/environment.py", line 1662, in _concretize_together
    concretized_specs = spack.concretize.concretize_together(
        specs_to_concretize, tests=tests
    )
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/concretize.py", line 54, in concretize_together
    concrete_specs = _concretize_specs_together(to_concretize, tests=tests)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/concretize.py", line 37, in _concretize_specs_together
    result = Solver().solve(abstract_specs, tests=tests, allow_deprecated=allow_deprecated)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 4164, in solve
    result, _, _ = self.solve_with_stats(specs, **kwargs)
                   ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 4152, in solve_with_stats
    result = self.driver.solve(
        setup, specs, reuse=reusable_specs, output=output, allow_deprecated=allow_deprecated
    )
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 1257, in solve
    result = self._run_clingo(specs, setup, problem_repr, control_file_paths, timer)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 1135, in _run_clingo
    answers = builder.build_specs(spec_attrs)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 3860, in build_specs
    root._finalize_concretization()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/spec.py", line 2983, in _finalize_concretization
    spec._cached_hash(ht.package_hash, force=True)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/spec.py", line 2244, in _cached_hash
    hash_string = self.spec_hash(hash)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/spec.py", line 2214, in spec_hash
    return hash.override(self)
           ~~~~~~~~~~~~~^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/hash_types.py", line 63, in _content_hash_override
    return pkg.content_hash()
           ~~~~~~~~~~~~~~~~^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/package_base.py", line 1849, in content_hash
    source_id = fs.for_package_version(self).source_id()
                ~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/fetch_strategy.py", line 1699, in for_package_version
    return _for_package_version(pkg, version)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/fetch_strategy.py", line 1771, in _for_package_version
    fetcher = GitFetchStrategy(**kwargs)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/fetch_strategy.py", line 842, in __init__
    super().__init__(**forwarded_args)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/fetch_strategy.py", line 692, in __init__
    raise ValueError(f"{self.__class__} requires {self.url_attr} argument.")
ValueError: <class 'spack.fetch_strategy.GitFetchStrategy'> requires git argument.
```

Now you get the more helpful

```console
Traceback (most recent call last):
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/fetch_strategy.py", line 1772, in _for_package_version
    fetcher = GitFetchStrategy(**kwargs)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/fetch_strategy.py", line 842, in __init__
    super().__init__(**forwarded_args)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/fetch_strategy.py", line 692, in __init__
    raise ValueError(f"{self.__class__} requires {self.url_attr} argument.")
ValueError: <class 'spack.fetch_strategy.GitFetchStrategy'> requires git argument.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runderwood/git/contrib/spack/bin/spack", line 49, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/main.py", line 1128, in main
    return _main(argv)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/main.py", line 1080, in _main
    return finish_parse_and_run(parser, cmd_name, args, env_format_error)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/main.py", line 1111, in finish_parse_and_run
    return _invoke_command(command, parser, args, unknown)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/main.py", line 652, in _invoke_command
    return_val = command(parser, args)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/cmd/concretize.py", line 44, in concretize
    concretized_specs = env.concretize(tests=tests)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/environment/environment.py", line 1557, in concretize
    return self._concretize_together(tests=tests)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/environment/environment.py", line 1662, in _concretize_together
    concretized_specs = spack.concretize.concretize_together(
        specs_to_concretize, tests=tests
    )
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/concretize.py", line 54, in concretize_together
    concrete_specs = _concretize_specs_together(to_concretize, tests=tests)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/concretize.py", line 37, in _concretize_specs_together
    result = Solver().solve(abstract_specs, tests=tests, allow_deprecated=allow_deprecated)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 4164, in solve
    result, _, _ = self.solve_with_stats(specs, **kwargs)
                   ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 4152, in solve_with_stats
    result = self.driver.solve(
        setup, specs, reuse=reusable_specs, output=output, allow_deprecated=allow_deprecated
    )
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 1257, in solve
    result = self._run_clingo(specs, setup, problem_repr, control_file_paths, timer)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 1135, in _run_clingo
    answers = builder.build_specs(spec_attrs)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/solver/asp.py", line 3860, in build_specs
    root._finalize_concretization()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/spec.py", line 2983, in _finalize_concretization
    spec._cached_hash(ht.package_hash, force=True)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/spec.py", line 2244, in _cached_hash
    hash_string = self.spec_hash(hash)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/spec.py", line 2214, in spec_hash
    return hash.override(self)
           ~~~~~~~~~~~~~^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/hash_types.py", line 63, in _content_hash_override
    return pkg.content_hash()
           ~~~~~~~~~~~~~~~~^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/package_base.py", line 1849, in content_hash
    source_id = fs.for_package_version(self).source_id()
                ~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/fetch_strategy.py", line 1699, in for_package_version
    return _for_package_version(pkg, version)
  File "/home/runderwood/git/contrib/spack/lib/spack/spack/fetch_strategy.py", line 1774, in _for_package_version
    raise ValueError(f"failed to fetch pkg {pkg}") from exc
ValueError: failed to fetch pkg <spack_repo.builtin.packages.r_libpressio.package.RLibpressio object at 0x7f67ae236d50>
```
