### PR TITLE
bugfix: display `when` conditions with dependencies in `spack info`

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -326,7 +326,7 @@ def print_tests(pkg: PackageBase, args: Namespace) -> None:
 
 def _fmt_when(when: "spack.spec.Spec", indent: int) -> str:
     return color.colorize(
-        f"{indent * ' '}@B{{when}} {color.cescape(when.format(color=color.get_color_when()))}"
+        f"{indent * ' '}@B{{when}} {color.cescape(when._long_spec(color=color.get_color_when()))}"
     )
 
 

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -128,6 +128,17 @@ def test_info_fields(pkg_query, extra_args):
             [r"when\s*build_system=cmake"],
             [r"when\s*build_system=autotools"],
         ),
+        (
+            ["optional-dep-test"],
+            [
+                r"when \^pkg-g",
+                r"when \%intel",
+                r"when \%intel\@64\.1",
+                r"when \%clang@34\:40",
+                r"when \^pkg\-f",
+            ],
+            [],
+        ),
     ],
 )
 @pytest.mark.parametrize("by_name", [True, False])


### PR DESCRIPTION
#51137 displays `when` conditions for dependencies, but it doesn't display direct or transitive dependencies in conditions. This is used frequently for things like

* `when="^python@3.10:"`: optional deps for particular pythons
* `when="%clang@34:"`: optional deps depending on build compiler

- [x] change format for when from `Spec.format()` to `_long_spec()`
- [x] add a test

Try `spack info py-sphinx-theme-builder` or `spack -m info optional-dep-test` to see.