### PR TITLE
solver: simplify encoding of versions

### DIFF
--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -33,14 +33,10 @@ def _select_best_version(
 ) -> None:
     """Try to attach the best known version to a node"""
     constraint = spack.version.from_string(valid_versions)
-    allowed_versions = [
-        (v, info) for v, info in pkg_cls.versions.items() if v.satisfies(constraint)
-    ]
+    allowed_versions = [v for v in pkg_cls.versions if v.satisfies(constraint)]
     try:
-        best_version, _ = max(
-            allowed_versions, key=spack.package_base.concretization_version_order
-        )
-    except (KeyError, ValueError):
+        best_version = spack.package_base.sort_by_pkg_preference(allowed_versions, pkg=pkg_cls)[0]
+    except (KeyError, ValueError, IndexError):
         return
     node.versions.versions = [spack.version.from_string(f"={best_version}")]
 

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -21,7 +21,6 @@ import spack.config
 import spack.package_base
 import spack.platforms
 import spack.repo
-import spack.solver.versions
 import spack.spec
 import spack.traverse
 import spack.version
@@ -39,7 +38,7 @@ def _select_best_version(
     ]
     try:
         best_version, _ = max(
-            allowed_versions, key=spack.solver.versions.concretization_version_order
+            allowed_versions, key=spack.package_base.concretization_version_order
         )
     except (KeyError, ValueError):
         return

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -61,7 +61,6 @@ from spack.llnl.util.filesystem import (
 )
 from spack.llnl.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.resource import Resource
-from spack.solver.versions import concretization_version_order
 from spack.util.package_hash import package_hash
 from spack.util.typing import SupportsRichComparison
 from spack.version import GitVersion, StandardVersion, VersionError, is_git_version
@@ -2596,10 +2595,25 @@ def sort_by_pkg_preference(
     pkg: Union[PackageBase, Type[PackageBase]],
 ) -> List[Union[GitVersion, StandardVersion]]:
     """Sorts the list of versions passed in input according to the preferences in the package. The
-    return value does not contain duplicate versions.
+    return value does not contain duplicate versions. Most preferred versions first.
     """
     s = [(v, pkg.versions.get(v, {})) for v in dedupe(versions)]
     return [v for v, _ in sorted(s, reverse=True, key=concretization_version_order)]
+
+
+def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardVersion], dict]):
+    """Version order key for concretization, where preferred > not preferred,
+    not deprecated > deprecated, finite > any infinite component; only if all are
+    the same, do we use default version ordering."""
+    version, info = version_info
+    return (
+        info.get("preferred", False),
+        not info.get("deprecated", False),
+        not isinstance(version, GitVersion),
+        not version.isdevelop(),
+        not version.is_prerelease(),
+        version,
+    )
 
 
 class PackageStillNeededError(InstallError):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -19,6 +19,7 @@ import sys
 import textwrap
 import time
 import traceback
+from collections.abc import Sequence
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from spack.vendor.typing_extensions import Literal
@@ -59,7 +60,7 @@ from spack.llnl.util.filesystem import (
     islink,
     symlink,
 )
-from spack.llnl.util.lang import ClassProperty, classproperty, memoized
+from spack.llnl.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.resource import Resource
 from spack.solver.versions import concretization_version_order
 from spack.util.package_hash import package_hash
@@ -2588,6 +2589,18 @@ def preferred_version(pkg: Union[PackageBase, Type[PackageBase]]):
 
     version, _ = max(pkg.versions.items(), key=concretization_version_order)
     return version
+
+
+def sort_by_pkg_preference(
+    versions: Sequence[Union[GitVersion, StandardVersion]],
+    *,
+    pkg: Union[PackageBase, Type[PackageBase]],
+) -> List[Union[GitVersion, StandardVersion]]:
+    """Sorts the list of versions passed in input according to the preferences in the package. The
+    return value does not contain duplicate versions.
+    """
+    s = [(v, pkg.versions.get(v, {})) for v in dedupe(versions)]
+    return [v for v, _ in sorted(s, reverse=True, key=concretization_version_order)]
 
 
 class PackageStillNeededError(InstallError):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -19,7 +19,6 @@ import sys
 import textwrap
 import time
 import traceback
-from collections.abc import Sequence
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from spack.vendor.typing_extensions import Literal
@@ -2592,7 +2591,7 @@ def preferred_version(pkg: Union[PackageBase, Type[PackageBase]]):
 
 
 def sort_by_pkg_preference(
-    versions: Sequence[Union[GitVersion, StandardVersion]],
+    versions: Iterable[Union[GitVersion, StandardVersion]],
     *,
     pkg: Union[PackageBase, Type[PackageBase]],
 ) -> List[Union[GitVersion, StandardVersion]]:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -15,7 +15,6 @@ import random
 import re
 import sys
 import time
-import typing
 import warnings
 from contextlib import contextmanager
 from typing import (
@@ -88,7 +87,7 @@ from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector
 from .runtimes import RuntimePropertyRecorder, all_libcs, external_config_with_implicit_externals
-from .versions import DeclaredVersion, Provenance, concretization_version_order
+from .versions import DeclaredVersion, Provenance
 
 GitOrStandardVersion = Union[spack.version.GitVersion, spack.version.StandardVersion]
 
@@ -1459,6 +1458,7 @@ class SpackSolverSetup:
         self.assumptions: List[Tuple["clingo.Symbol", bool]] = []  # type: ignore[name-defined]
         self.declared_versions: Dict[str, List[DeclaredVersion]] = collections.defaultdict(list)
         self.possible_versions: Dict[str, Set[GitOrStandardVersion]] = collections.defaultdict(set)
+        self.versions_from_yaml: Dict[str, List[GitOrStandardVersion]] = {}
         self.git_commit_versions: Dict[str, Dict[GitOrStandardVersion, str]] = (
             collections.defaultdict(dict)
         )
@@ -1502,38 +1502,28 @@ class SpackSolverSetup:
         # If true, we have to load the code for synthesizing splices
         self.enable_splicing: bool = spack.config.CONFIG.get("concretizer:splice:automatic")
 
-    def pkg_version_rules(self, pkg):
-        """Output declared versions of a package.
-
-        This uses self.declared_versions so that we include any versions
-        that arise from a spec.
-        """
-
-        def key_fn(version):
-            # Origins are sorted by "provenance" first, see the Provenance enumeration above
-            return version.origin, version.idx
-
-        if isinstance(pkg, str):
-            pkg = self.pkg_class(pkg)
-
+    def pkg_version_rules(self, pkg: Type[spack.package_base.PackageBase]) -> None:
+        """Declares known versions, their origins, and their weights."""
         declared_versions = self.declared_versions[pkg.name]
-        partially_sorted_versions = sorted(set(declared_versions), key=key_fn)
+        version_provenance: Dict[GitOrStandardVersion, List[Provenance]] = {}
+        for item in declared_versions:
+            version_provenance.setdefault(item.version, []).append(item.origin)
 
-        most_to_least_preferred = []
-        for _, group in itertools.groupby(partially_sorted_versions, key=key_fn):
-            most_to_least_preferred.extend(
-                list(sorted(group, reverse=True, key=lambda x: vn.ver(x.version)))
+        ordered_versions = spack.package_base.sort_by_pkg_preference(
+            [item.version for item in declared_versions], pkg=pkg
+        )
+        # Account for preferences in packages.yaml, if any
+        if pkg.name in self.versions_from_yaml:
+            ordered_versions = spack.llnl.util.lang.dedupe(
+                self.versions_from_yaml[pkg.name] + ordered_versions
             )
 
-        for weight, declared_version in enumerate(most_to_least_preferred):
-            self.gen.fact(
-                fn.pkg_fact(
-                    pkg.name,
-                    fn.version_declared(
-                        declared_version.version, weight, str(declared_version.origin)
-                    ),
+        for weight, declared_version in enumerate(ordered_versions):
+            self.gen.fact(fn.pkg_fact(pkg.name, fn.version_declared(declared_version, weight)))
+            for origin in version_provenance[declared_version]:
+                self.gen.fact(
+                    fn.pkg_fact(pkg.name, fn.version_origin(declared_version, str(origin)))
                 )
-            )
 
         for v in self.possible_versions[pkg.name]:
             if pkg.needs_commit(v):
@@ -2590,16 +2580,12 @@ class SpackSolverSetup:
             # All the versions from the corresponding package.py file. Since concepts
             # like being a "develop" version or being preferred exist only at a
             # package.py level, sort them in this partial list here
-            package_py_versions = sorted(
-                pkg_cls.versions.items(), key=concretization_version_order, reverse=True
-            )
+            from_package_py = list(pkg_cls.versions.items())
 
             if require_checksum and pkg_cls.has_code:
-                package_py_versions = [
-                    x for x in package_py_versions if _is_checksummed_version(x)
-                ]
+                from_package_py = [x for x in from_package_py if _is_checksummed_version(x)]
 
-            for idx, (v, version_info) in enumerate(package_py_versions):
+            for v, version_info in from_package_py:
                 if version_info.get("deprecated", False):
                     self.deprecated_versions[pkg_name].add(v)
                     if not allow_deprecated:
@@ -2607,7 +2593,7 @@ class SpackSolverSetup:
 
                 self.possible_versions[pkg_name].add(v)
                 self.declared_versions[pkg_name].append(
-                    DeclaredVersion(version=v, idx=idx, origin=Provenance.PACKAGE_PY)
+                    DeclaredVersion(version=v, idx=0, origin=Provenance.PACKAGE_PY)
                 )
 
             if pkg_name not in packages_yaml or "version" not in packages_yaml[pkg_name]:
@@ -2615,29 +2601,31 @@ class SpackSolverSetup:
 
             # TODO(psakiev) Need facts about versions
             # - requires_commit (associated with tag or branch)
-            version_defs: List[GitOrStandardVersion] = []
+            from_packages_yaml: List[GitOrStandardVersion] = []
 
             for vstr in packages_yaml[pkg_name]["version"]:
                 v = vn.ver(vstr)
 
                 if isinstance(v, vn.GitVersion):
                     if not require_checksum or v.is_commit:
-                        version_defs.append(v)
+                        from_packages_yaml.append(v)
                 else:
                     matches = [x for x in self.possible_versions[pkg_name] if x.satisfies(v)]
                     matches.sort(reverse=True)
                     if not matches:
                         raise spack.error.ConfigError(
                             f"Preference for version {v} does not match any known "
-                            f"version of {pkg_name} (in its package.py or any external)"
+                            f"version of {pkg_name}"
                         )
-                    version_defs.extend(matches)
+                    from_packages_yaml.extend(matches)
 
-            for weight, vdef in enumerate(spack.llnl.util.lang.dedupe(version_defs)):
+            from_packages_yaml = list(spack.llnl.util.lang.dedupe(from_packages_yaml))
+            for v in from_packages_yaml:
                 self.declared_versions[pkg_name].append(
-                    DeclaredVersion(version=vdef, idx=weight, origin=Provenance.PACKAGES_YAML)
+                    DeclaredVersion(version=v, idx=0, origin=Provenance.PACKAGES_YAML)
                 )
-                self.possible_versions[pkg_name].add(vdef)
+                self.possible_versions[pkg_name].add(v)
+            self.versions_from_yaml[pkg_name] = from_packages_yaml
 
     def define_ad_hoc_versions_from_specs(
         self, specs, origin, *, allow_deprecated: bool, require_checksum: bool
@@ -3403,7 +3391,7 @@ class SpackSolverSetup:
             for s in spec_group[key]:
                 yield _spec_with_default_name(s, pkg_name)
 
-    def pkg_class(self, pkg_name: str) -> typing.Type[spack.package_base.PackageBase]:
+    def pkg_class(self, pkg_name: str) -> Type[spack.package_base.PackageBase]:
         request = pkg_name
         if pkg_name in self.explicitly_required_namespaces:
             namespace = self.explicitly_required_namespaces[pkg_name]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -87,7 +87,7 @@ from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector
 from .runtimes import RuntimePropertyRecorder, all_libcs, external_config_with_implicit_externals
-from .versions import DeclaredVersion, Provenance
+from .versions import Provenance
 
 GitOrStandardVersion = Union[spack.version.GitVersion, spack.version.StandardVersion]
 
@@ -1447,6 +1447,7 @@ class SpackSolverSetup:
     """Class to set up and run a Spack concretization solve."""
 
     gen: "ProblemInstanceBuilder"
+    possible_versions: Dict[str, Dict[GitOrStandardVersion, List[Provenance]]]
 
     def __init__(self, tests: spack.concretize.TestsType = False):
         self.possible_graph = create_graph_analyzer()
@@ -1456,8 +1457,8 @@ class SpackSolverSetup:
         self.possible_virtuals: Set[str] = set()
 
         self.assumptions: List[Tuple["clingo.Symbol", bool]] = []  # type: ignore[name-defined]
-        self.declared_versions: Dict[str, List[DeclaredVersion]] = collections.defaultdict(list)
-        self.possible_versions: Dict[str, Set[GitOrStandardVersion]] = collections.defaultdict(set)
+        # pkg_name -> version -> list of possible origins (package.py, installed, etc.)
+        self.possible_versions = collections.defaultdict(lambda: collections.defaultdict(list))
         self.versions_from_yaml: Dict[str, List[GitOrStandardVersion]] = {}
         self.git_commit_versions: Dict[str, Dict[GitOrStandardVersion, str]] = (
             collections.defaultdict(dict)
@@ -1504,13 +1505,9 @@ class SpackSolverSetup:
 
     def pkg_version_rules(self, pkg: Type[spack.package_base.PackageBase]) -> None:
         """Declares known versions, their origins, and their weights."""
-        declared_versions = self.declared_versions[pkg.name]
-        version_provenance: Dict[GitOrStandardVersion, List[Provenance]] = {}
-        for item in declared_versions:
-            version_provenance.setdefault(item.version, []).append(item.origin)
-
+        version_provenance = self.possible_versions[pkg.name]
         ordered_versions = spack.package_base.sort_by_pkg_preference(
-            [item.version for item in declared_versions], pkg=pkg
+            self.possible_versions[pkg.name], pkg=pkg
         )
         # Account for preferences in packages.yaml, if any
         if pkg.name in self.versions_from_yaml:
@@ -2591,10 +2588,7 @@ class SpackSolverSetup:
                     if not allow_deprecated:
                         continue
 
-                self.possible_versions[pkg_name].add(v)
-                self.declared_versions[pkg_name].append(
-                    DeclaredVersion(version=v, idx=0, origin=Provenance.PACKAGE_PY)
-                )
+                self.possible_versions[pkg_name][v].append(Provenance.PACKAGE_PY)
 
             if pkg_name not in packages_yaml or "version" not in packages_yaml[pkg_name]:
                 continue
@@ -2621,10 +2615,7 @@ class SpackSolverSetup:
 
             from_packages_yaml = list(spack.llnl.util.lang.dedupe(from_packages_yaml))
             for v in from_packages_yaml:
-                self.declared_versions[pkg_name].append(
-                    DeclaredVersion(version=v, idx=0, origin=Provenance.PACKAGES_YAML)
-                )
-                self.possible_versions[pkg_name].add(v)
+                self.possible_versions[pkg_name][v].append(Provenance.PACKAGES_YAML)
             self.versions_from_yaml[pkg_name] = from_packages_yaml
 
     def define_ad_hoc_versions_from_specs(
@@ -2633,8 +2624,7 @@ class SpackSolverSetup:
         """Add concrete versions to possible versions from lists of CLI/dev specs."""
         for s in traverse.traverse_nodes(specs):
             # If there is a concrete version on the CLI *that we know nothing
-            # about*, add it to the known versions. Use idx=0, which is the
-            # best possible, so they're guaranteed to be used preferentially.
+            # about*, add it to the known versions.
             version = s.versions.concrete
 
             if version is None or (any((v == version) for v in self.possible_versions[s.name])):
@@ -2648,9 +2638,7 @@ class SpackSolverSetup:
             if not allow_deprecated and version in self.deprecated_versions[s.name]:
                 continue
 
-            declared = DeclaredVersion(version=version, idx=0, origin=origin)
-            self.declared_versions[s.name].append(declared)
-            self.possible_versions[s.name].add(version)
+            self.possible_versions[s.name][version].append(origin)
 
     def _supported_targets(self, compiler_name, compiler_version, targets):
         """Get a list of which targets are supported by the compiler.
@@ -2839,7 +2827,7 @@ class SpackSolverSetup:
         for pkg_name, versions in sorted(constraint_map.items()):
             possible_versions = set(sum([versions_for(v) for v in versions], []))
             for version in sorted(possible_versions):
-                self.possible_versions[pkg_name].add(version)
+                self.possible_versions[pkg_name][version].append(Provenance.VIRTUAL_CONSTRAINT)
 
     def define_compiler_version_constraints(self):
         for constraint in sorted(self.compiler_version_constraints):
@@ -2936,19 +2924,12 @@ class SpackSolverSetup:
             # - Add versions to possible versions
             # - Add OS to possible OS's
 
-            # is traverse deterministic?
             for dep in spec.traverse():
-                self.possible_versions[dep.name].add(dep.version)
+                provenance = Provenance.INSTALLED
                 if isinstance(dep.version, vn.GitVersion):
-                    self.declared_versions[dep.name].append(
-                        DeclaredVersion(
-                            version=dep.version, idx=0, origin=Provenance.INSTALLED_GIT_VERSION
-                        )
-                    )
-                else:
-                    self.declared_versions[dep.name].append(
-                        DeclaredVersion(version=dep.version, idx=0, origin=Provenance.INSTALLED)
-                    )
+                    provenance = Provenance.INSTALLED_GIT_VERSION
+
+                self.possible_versions[dep.name][dep.version].append(provenance)
                 self.possible_oses.add(dep.os)
 
     def define_concrete_input_specs(self, specs, possible):
@@ -3364,10 +3345,7 @@ class SpackSolverSetup:
                 # If concrete an not yet defined, conditionally define it, like we do for specs
                 # from the command line.
                 if not require_checksum or _is_checksummed_git_version(v):
-                    self.declared_versions[name].append(
-                        DeclaredVersion(version=v, idx=0, origin=Provenance.PACKAGE_REQUIREMENT)
-                    )
-                    self.possible_versions[name].add(v)
+                    self.possible_versions[name][v].append(Provenance.PACKAGE_REQUIREMENT)
 
     def _specs_from_requires(self, pkg_name, section):
         """Collect specs from a requirement rule"""

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1995,23 +1995,6 @@ build_priority(PackageNode, 200) :- build(PackageNode), attr("node", PackageNode
 build_priority(PackageNode, 0)   :- build(PackageNode), attr("node", PackageNode), treat_node_as_concrete(PackageNode).
 build_priority(PackageNode, 0)   :- concrete(PackageNode), attr("node", PackageNode).
 
-% don't assign versions from installed packages unless reuse is enabled
-% NOTE: that "installed" means the declared version was only included because
-% that package happens to be installed, NOT because it was asked for on the
-% command line.  If the user specifies a hash, the origin will be "spec".
-%
-% TODO: There's a slight inconsistency with this: if the user concretizes
-% and installs `foo ^bar`, for some build dependency `bar`, and then later
-% does a `spack install --fresh foo ^bar/abcde` (i.e.,the hash of `bar`, it
-% currently *won't* force versions for `bar`'s build dependencies -- `--fresh`
-% will instead build the latest bar. When we actually include transitive
-% build deps in the solve, consider using them as a preference to resolve this.
-%:- attr("version", node(ID, Package), Version),
-%   version_weight(node(ID, Package), Weight),
-%   pkg_fact(Package, version_declared(Version, Weight, "installed")),
-%   not optimize_for_reuse().
-
-
 % This statement, which is a hidden feature of clingo, let us avoid cycles in the DAG
 #edge (A, B) : depends_on(A, B).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -298,23 +298,6 @@ error(100, multiple_values_error, Attribute, Package)
 % Version semantics
 %-----------------------------------------------------------------------------
 
-% Versions are declared with a weight and an origin, which indicates where the
-% version was declared (e.g. "package_py" or "external").
-pkg_fact(Package, version_declared(Version, Weight)) :- pkg_fact(Package, version_declared(Version, Weight, _)).
-
-% We can't emit the same version **with the same weight** from two different sources
-:- pkg_fact(Package, version_declared(Version, Weight, Origin1)),
-   pkg_fact(Package, version_declared(Version, Weight, Origin2)),
-   Origin1 < Origin2,
-   internal_error("Two versions with identical weights").
-
-% We cannot use a version declared for an installed package if we end up building it
-:- pkg_fact(Package, version_declared(Version, Weight, "installed")),
-   attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   not attr("hash", node(ID, Package), _),
-   internal_error("Reuse version weight used for built package").
-
 % versions are declared w/priority -- declared with priority implies declared
 pkg_fact(Package, version_declared(Version)) :- pkg_fact(Package, version_declared(Version, _)).
 
@@ -350,22 +333,23 @@ error(100, "Package '{0}' needs the deprecated version '{1}', and this is not al
 
 % we can't use a weight from an installed spec if we are building it
 % and vice-versa
-:- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   pkg_fact(Package, version_declared(Version, Weight, "installed")),
-   build(node(ID, Package)),
-   internal_error("Reuse version weight used for build package").
 
-:- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   not pkg_fact(Package, version_declared(Version, Weight, "installed")),
-   not pkg_fact(Package, version_declared(Version, Weight, "installed_git_version")),
+1 { allowed_versions(Version): pkg_fact(Package, version_origin(Version, Origin)),
+    Origin != "installed"}
+  :- attr("version", node(ID, Package), Version),
+     build(node(ID, Package)).
+
+% We cannot use a version declared for an installed package if we end up building it
+:- not pkg_fact(Package, version_origin(Version, "installed")),
+   not pkg_fact(Package, version_origin(Version, "installed_git_version")),
+   attr("version", node(ID, Package), Version),
    concrete(node(ID, Package)),
-   internal_error("Build version weight used for reused package").
+   internal_error("Reuse version weight used for built package").
 
-1 { version_weight(node(ID, Package), Weight) : pkg_fact(Package, version_declared(Version, Weight)) } 1
+version_weight(node(ID, Package), Weight)
   :- attr("version", node(ID, Package), Version),
      attr("node", node(ID, Package)),
+     pkg_fact(Package, version_declared(Version, Weight)),
      internal_error("version weights must exist and be unique").
 
 % node_version_satisfies implies that exactly one of the satisfying versions
@@ -2022,10 +2006,10 @@ build_priority(PackageNode, 0)   :- concrete(PackageNode), attr("node", PackageN
 % currently *won't* force versions for `bar`'s build dependencies -- `--fresh`
 % will instead build the latest bar. When we actually include transitive
 % build deps in the solve, consider using them as a preference to resolve this.
-:- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   pkg_fact(Package, version_declared(Version, Weight, "installed")),
-   not optimize_for_reuse().
+%:- attr("version", node(ID, Package), Version),
+%   version_weight(node(ID, Package), Weight),
+%   pkg_fact(Package, version_declared(Version, Weight, "installed")),
+%   not optimize_for_reuse().
 
 
 % This statement, which is a hidden feature of clingo, let us avoid cycles in the DAG

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -13,7 +13,7 @@ import spack.util.libc
 import spack.version
 
 from .core import SourceContext, fn, using_libc_compatibility
-from .versions import DeclaredVersion, Provenance
+from .versions import Provenance
 
 
 class RuntimePropertyRecorder:
@@ -168,10 +168,7 @@ class RuntimePropertyRecorder:
         for s in (imposed_spec, when_spec):
             if not s.versions.concrete:
                 continue
-            self._setup.possible_versions[s.name].add(s.version)
-            self._setup.declared_versions[s.name].append(
-                DeclaredVersion(version=s.version, idx=0, origin=Provenance.RUNTIME)
-            )
+            self._setup.possible_versions[s.name][s.version].append(Provenance.RUNTIME)
 
         self.runtime_conditions.add((imposed_spec, when_spec))
         self.reset()

--- a/lib/spack/spack/solver/versions.py
+++ b/lib/spack/spack/solver/versions.py
@@ -15,6 +15,7 @@ def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardV
     return (
         info.get("preferred", False),
         not info.get("deprecated", False),
+        not isinstance(version, GitVersion),
         not version.isdevelop(),
         not version.is_prerelease(),
         version,
@@ -36,8 +37,6 @@ class Provenance(enum.IntEnum):
     PACKAGE_PY = enum.auto()
     # An installed spec
     INSTALLED = enum.auto()
-    # An external spec declaration
-    EXTERNAL = enum.auto()
     # lower provenance for installed git refs so concretizer prefers StandardVersion installs
     INSTALLED_GIT_VERSION = enum.auto()
     # A runtime injected from another package (e.g. a compiler)
@@ -51,7 +50,7 @@ class DeclaredVersion(NamedTuple):
     """Data class to contain information on declared versions used in the solve"""
 
     #: String representation of the version
-    version: str
+    version: Union[GitVersion, StandardVersion]
     #: Unique index assigned to this version
     idx: int
     #: Provenance of the version

--- a/lib/spack/spack/solver/versions.py
+++ b/lib/spack/spack/solver/versions.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
-from typing import NamedTuple, Tuple, Union
+from typing import Tuple, Union
 
 from spack.version import GitVersion, StandardVersion
 
@@ -39,19 +39,10 @@ class Provenance(enum.IntEnum):
     INSTALLED = enum.auto()
     # lower provenance for installed git refs so concretizer prefers StandardVersion installs
     INSTALLED_GIT_VERSION = enum.auto()
+    # Synthetic versions for virtual packages
+    VIRTUAL_CONSTRAINT = enum.auto()
     # A runtime injected from another package (e.g. a compiler)
     RUNTIME = enum.auto()
 
     def __str__(self):
         return f"{self._name_.lower()}"
-
-
-class DeclaredVersion(NamedTuple):
-    """Data class to contain information on declared versions used in the solve"""
-
-    #: String representation of the version
-    version: Union[GitVersion, StandardVersion]
-    #: Unique index assigned to this version
-    idx: int
-    #: Provenance of the version
-    origin: Provenance

--- a/lib/spack/spack/solver/versions.py
+++ b/lib/spack/spack/solver/versions.py
@@ -2,24 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
-from typing import Tuple, Union
-
-from spack.version import GitVersion, StandardVersion
-
-
-def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardVersion], dict]):
-    """Version order key for concretization, where preferred > not preferred,
-    not deprecated > deprecated, finite > any infinite component; only if all are
-    the same, do we use default version ordering."""
-    version, info = version_info
-    return (
-        info.get("preferred", False),
-        not info.get("deprecated", False),
-        not isinstance(version, GitVersion),
-        not version.isdevelop(),
-        not version.is_prerelease(),
-        version,
-    )
 
 
 class Provenance(enum.IntEnum):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2000,10 +2000,13 @@ spack:
             # Version badness should be > 0 only for reused specs. For instance, for pkg-b
             # the version provenance is:
             #
-            # version_declared("pkg-b","1.0",0,"package_py").
-            # version_declared("pkg-b","0.9",1,"package_py").
-            # version_declared("pkg-b","1.0",2,"installed").
-            # version_declared("pkg-b","0.9",3,"installed").
+            # pkg_fact("pkg-b", version_declared("1.0", 0)).
+            # pkg_fact("pkg-b", version_origin("1.0", "installed")).
+            # pkg_fact("pkg-b", version_origin("1.0", "package_py")).
+            # pkg_fact("pkg-b", version_declared("0.9", 1)).
+            # pkg_fact("pkg-b", version_origin("0.9", "installed")).
+            # pkg_fact("pkg-b", version_origin("0.9", "package_py")).
+
             weights = {}
             for x in [x for x in result.criteria if x.name == "version badness (non roots)"]:
                 if x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
@@ -2011,7 +2014,7 @@ spack:
                 else:
                     weights["built"] = x.value
 
-            assert weights["reused"] > 2 and weights["built"] == 0
+            assert weights["reused"] == 1 and weights["built"] == 0
 
             result_spec = result.specs[0]
             assert result_spec.satisfies("^pkg-b@1.0")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -34,7 +34,6 @@ import spack.solver.asp
 import spack.solver.core
 import spack.solver.reuse
 import spack.solver.runtimes
-import spack.solver.versions
 import spack.spec
 import spack.test.conftest
 import spack.util.file_cache
@@ -3123,7 +3122,7 @@ def test_concretization_version_order():
     result = [
         v
         for v, _ in sorted(
-            versions, key=spack.solver.versions.concretization_version_order, reverse=True
+            versions, key=spack.package_base.concretization_version_order, reverse=True
         )
     ]
     assert result == [


### PR DESCRIPTION
Due to historical reasons, in `develop` we are encoding version data as a triplet of:
1. The version itself
2. A possible index for that version (used to sort it later)
3. The origin of the version

In time, we added more version origins that _do not need_ an index. Also, the `EXTERNAL` origin is not needed anymore, since externals are now treated like any other installed spec.

This PR, therefore, simplifies the encoding of versions in the solver so that:
- Each version has a single version weight, regardless of its origin
- Each version may be associated with multiple origins 

It also removes unneeded data structures in the code.

**Encoding before**
```
pkg_fact("mpileaks",namespace("builtin_mock")).
pkg_fact("mpileaks",version_declared("2.3",0,"package_py")).
pkg_fact("mpileaks",version_declared("2.2",1,"package_py")).
pkg_fact("mpileaks",version_declared("2.1",2,"package_py")).
pkg_fact("mpileaks",version_declared("1.0",3,"package_py")).
pkg_fact("mpileaks",version_declared("2.3",4,"installed")).
```

**Encoding after**
```
pkg_fact("mpileaks",namespace("builtin_mock")).
pkg_fact("mpileaks",version_declared("2.3",0)).
pkg_fact("mpileaks",version_origin("2.3","installed")).
pkg_fact("mpileaks",version_origin("2.3","package_py")).
pkg_fact("mpileaks",version_declared("2.2",1)).
pkg_fact("mpileaks",version_origin("2.2","package_py")).
pkg_fact("mpileaks",version_declared("2.1",2)).
pkg_fact("mpileaks",version_origin("2.1","package_py")).
pkg_fact("mpileaks",version_declared("1.0",3)).
pkg_fact("mpileaks",version_origin("1.0","package_py")).
```


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
