### PR TITLE
new_installer.py: implement `--use-buildcache`, `--cache-only`, `--use-cache` and `--only`

### DIFF
--- a/lib/spack/spack/installer_build_graph.py
+++ b/lib/spack/spack/installer_build_graph.py
@@ -1,0 +1,630 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Tests for BuildGraph class in new_installer"""
+from typing import Dict, List, Tuple, Union
+
+import pytest
+
+import spack.deptypes as dt
+import spack.error
+import spack.spec
+import spack.store
+from spack.new_installer import BuildGraph
+
+
+def create_dag(
+    nodes: List[str], edges: List[Tuple[str, str, Union[dt.DepType, Tuple[dt.DepType, ...]]]]
+) -> Dict[str, spack.spec.Spec]:
+    """
+    Create a DAG of concrete specs, as a mapping from package name to Spec.
+
+    Arguments:
+        nodes: list of package names
+        edges: list of tuples (parent, child, deptype)
+    """
+    specs = {name: spack.spec.Spec(name) for name in nodes}
+    for parent, child, deptypes in edges:
+        depflag = deptypes if isinstance(deptypes, dt.DepFlag) else dt.canonicalize(deptypes)
+        specs[parent].add_dependency_edge(specs[child], depflag=depflag, virtuals=())
+
+    # Mark all specs as concrete
+    for spec in specs.values():
+        spec._mark_concrete()
+
+    return specs
+
+
+def install_spec_in_db(spec: spack.spec.Spec, store: spack.store.Store):
+    """Helper to install a spec in the database for testing."""
+    prefix = store.layout.path_for_spec(spec)
+    spec.set_prefix(prefix)
+    # Use the layout to create a proper installation directory structure
+    store.layout.create_install_directory(spec)
+    store.db.add(spec, explicit=False)
+
+
+@pytest.fixture
+def mock_specs():
+    """Create a set of mock specs for testing.
+
+    DAG structure:
+        root -> dep1 -> dep2
+        root -> dep3
+    """
+    return create_dag(
+        nodes=["root", "dep1", "dep2", "dep3"],
+        edges=[
+            ("root", "dep1", ("build", "link")),
+            ("root", "dep3", ("build", "link")),
+            ("dep1", "dep2", ("build", "link")),
+        ],
+    )
+
+
+@pytest.fixture
+def diamond_dag():
+    """Create a diamond-shaped DAG to test shared dependencies.
+
+    DAG structure:
+        root -> dep1 -> shared
+        root -> dep2 -> shared
+    """
+    return create_dag(
+        nodes=["root", "dep1", "dep2", "shared"],
+        edges=[
+            ("root", "dep1", ("build", "link")),
+            ("root", "dep2", ("build", "link")),
+            ("dep1", "shared", ("build", "link")),
+            ("dep2", "shared", ("build", "link")),
+        ],
+    )
+
+
+@pytest.fixture
+def specs_with_build_deps():
+    """Create specs with different dependency types for testing build dep filtering.
+
+    DAG structure:
+        root -> link_dep (link only)
+        root -> build_dep (build only)
+        root -> all_dep (build, link, run)
+    """
+    return create_dag(
+        nodes=["root", "link_dep", "build_dep", "all_dep"],
+        edges=[
+            ("root", "link_dep", "link"),
+            ("root", "build_dep", "build"),
+            ("root", "all_dep", ("build", "link", "run")),
+        ],
+    )
+
+
+@pytest.fixture
+def complex_pruning_dag():
+    """Create a complex DAG for testing re-parenting logic.
+
+    DAG structure:
+        parent1 -> middle -> child1
+        parent2 -> middle -> child2
+
+    When 'middle' is installed and pruned, both parent1 and parent2 should
+    become direct parents of both child1 and child2 (full Cartesian product).
+    """
+    return create_dag(
+        nodes=["parent1", "parent2", "middle", "child1", "child2"],
+        edges=[
+            ("parent1", "middle", ("build", "link")),
+            ("parent2", "middle", ("build", "link")),
+            ("middle", "child1", ("build", "link")),
+            ("middle", "child2", ("build", "link")),
+        ],
+    )
+
+
+class TestBuildGraph:
+    """Tests for the BuildGraph class."""
+
+    def test_basic_graph_construction(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test basic graph construction with all specs to be installed."""
+        specs = [mock_specs["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Root should be in roots set
+        assert mock_specs["root"].dag_hash() in graph.roots
+        # All uninstalled specs should be in nodes
+        assert len(graph.nodes) == 4  # root, dep1, dep2, dep3
+        # Root should have 2 children (dep1, dep3)
+        assert len(graph.parent_to_child[mock_specs["root"].dag_hash()]) == 2
+
+    def test_install_package_only_mode(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that install_package=False removes root specs from graph."""
+        specs = [mock_specs["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=False,  # Only install dependencies
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Root should NOT be in nodes when install_package=False
+        assert mock_specs["root"].dag_hash() not in graph.nodes
+        # But its dependencies should be
+        assert mock_specs["dep1"].dag_hash() in graph.nodes
+
+    def test_install_deps_false_with_uninstalled_deps(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that install_deps=False raises error when dependencies are not installed."""
+        specs = [mock_specs["root"]]
+
+        # Should raise error because dependencies are not installed
+        with pytest.raises(
+            spack.error.InstallError, match="package only mode.*dependency.*not installed"
+        ):
+            BuildGraph(
+                specs=specs,
+                root_policy="auto",
+                dependencies_policy="auto",
+                include_build_deps=False,
+                install_package=True,
+                install_deps=False,  # Don't install dependencies
+                database=temporary_store.db,
+            )
+
+    def test_multiple_roots(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test graph construction with multiple root specs."""
+        specs = [mock_specs["root"], mock_specs["dep1"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Both should be in roots
+        assert mock_specs["root"].dag_hash() in graph.roots
+        assert mock_specs["dep1"].dag_hash() in graph.roots
+
+    def test_parent_child_mappings(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that parent-child mappings are correctly constructed."""
+        spec_root = mock_specs["root"]
+        specs = [spec_root]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Verify parent_to_child and child_to_parent are inverse mappings
+        for parent, children in graph.parent_to_child.items():
+            for child in children:
+                assert child in graph.child_to_parent
+                assert parent in graph.child_to_parent[child]
+
+    def test_diamond_dag_with_shared_dependency(
+        self, diamond_dag: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test graph construction with a diamond DAG where a dependency has multiple parents."""
+        specs = [diamond_dag["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Shared dependency should have two parents
+        shared_hash = diamond_dag["shared"].dag_hash()
+        assert len(graph.child_to_parent[shared_hash]) == 2
+        # Both dep1 and dep2 should be parents of shared
+        assert diamond_dag["dep1"].dag_hash() in graph.child_to_parent[shared_hash]
+        assert diamond_dag["dep2"].dag_hash() in graph.child_to_parent[shared_hash]
+
+    def test_pruning_installed_specs(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that installed specs are correctly pruned from the graph."""
+        # Install dep2 in the database
+        dep2 = mock_specs["dep2"]
+        install_spec_in_db(dep2, temporary_store)
+
+        specs = [mock_specs["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # dep2 should be pruned since it's installed
+        assert dep2.dag_hash() not in graph.nodes
+        # But dep1 (its parent) should still be in the graph
+        assert mock_specs["dep1"].dag_hash() in graph.nodes
+        # And dep1 should have no children (since dep2 was pruned)
+        assert len(graph.parent_to_child[mock_specs["dep1"].dag_hash()]) == 0
+
+    def test_pruning_with_shared_dependency_partially_installed(
+        self, diamond_dag: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that pruning a shared dependency correctly updates all parents."""
+        # Install the shared dependency
+        shared = diamond_dag["shared"]
+        install_spec_in_db(shared, temporary_store)
+
+        specs = [diamond_dag["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Shared should be pruned
+        assert shared.dag_hash() not in graph.nodes
+        # Both dep1 and dep2 should have no children
+        assert len(graph.parent_to_child[diamond_dag["dep1"].dag_hash()]) == 0
+        assert len(graph.parent_to_child[diamond_dag["dep2"].dag_hash()]) == 0
+
+    def test_include_build_deps_false_installed_root(self, specs_with_build_deps, temporary_store):
+        """Test that build dependencies are excluded for an installed root package.
+
+        When a root spec is already installed, build deps are excluded regardless of
+        include_build_deps setting, because installed packages only need link/run deps.
+        """
+        # Install the root so build deps are excluded
+        root = specs_with_build_deps["root"]
+        root.set_prefix(temporary_store.layout.path_for_spec(root))
+        temporary_store.db.add(root, explicit=True)
+
+        specs = [root]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="cache_only",  # Use cache_only to exclude build deps
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=False,  # Only install dependencies
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # build_dep should NOT be in the graph (build-only dependency)
+        assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes
+        # link_dep and all_dep should be in the graph
+        assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
+
+    def test_cache_only_policy_excludes_build_deps_for_uninstalled_package(
+        self, specs_with_build_deps: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that cache_only policy excludes build deps even for uninstalled packages."""
+        # Do NOT install the root - it's uninstalled
+        root = specs_with_build_deps["root"]
+        specs = [root]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="cache_only",  # cache_only policy
+            dependencies_policy="auto",
+            include_build_deps=False,  # Don't include build deps
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # build_dep should NOT be in the graph (build-only dependency excluded by cache_only)
+        assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes
+        # link_dep and all_dep should be in the graph
+        assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
+        # root should be in the graph
+        assert root.dag_hash() in graph.nodes
+
+    def test_include_build_deps_true(
+        self, specs_with_build_deps: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that build dependencies are included when include_build_deps=True."""
+        specs = [specs_with_build_deps["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=True,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # All dependencies should be in the graph
+        assert specs_with_build_deps["build_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
+
+    def test_install_deps_false_with_all_deps_installed(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test successful package-only install when all dependencies are already installed."""
+        # Install all dependencies
+        for dep_name in ["dep1", "dep2", "dep3"]:
+            install_spec_in_db(mock_specs[dep_name], temporary_store)
+
+        specs = [mock_specs["root"]]
+
+        # Should succeed since all dependencies are installed
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=False,
+            database=temporary_store.db,
+        )
+
+        # Only the root should be in the graph
+        assert len(graph.nodes) == 1
+        assert mock_specs["root"].dag_hash() in graph.nodes
+        # Root should have no children (all deps pruned)
+        assert len(graph.parent_to_child.get(mock_specs["root"].dag_hash(), [])) == 0
+
+    def test_build_deps_excluded_for_installed_packages(
+        self, specs_with_build_deps: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that build deps are excluded for installed packages even if include_build_deps."""
+        # Install link_dep
+        link_dep = specs_with_build_deps["link_dep"]
+        install_spec_in_db(link_dep, temporary_store)
+
+        specs = [specs_with_build_deps["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=True,  # Even with this set to True
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # link_dep should be pruned (it's installed)
+        assert link_dep.dag_hash() not in graph.nodes
+        # build_dep and all_dep should be in the graph
+        assert specs_with_build_deps["build_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
+
+    def test_pruning_creates_cartesian_product_of_connections(
+        self, complex_pruning_dag: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that pruning creates full Cartesian product of parent-child connections.
+
+        When a node with multiple parents and multiple children is pruned,
+        all parents should be connected to all children (parents × children).
+
+        DAG structure:
+            parent1 -> middle -> child1
+            parent2 -> middle -> child2
+
+        After pruning 'middle':
+            parent1 -> child1
+            parent1 -> child2
+            parent2 -> child1
+            parent2 -> child2
+        """
+        # Install the middle node
+        middle = complex_pruning_dag["middle"]
+        install_spec_in_db(middle, temporary_store)
+
+        # Use parent1 as the root to build the graph
+        specs = [complex_pruning_dag["parent1"], complex_pruning_dag["parent2"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        parent1_hash = complex_pruning_dag["parent1"].dag_hash()
+        parent2_hash = complex_pruning_dag["parent2"].dag_hash()
+        middle_hash = middle.dag_hash()
+        child1_hash = complex_pruning_dag["child1"].dag_hash()
+        child2_hash = complex_pruning_dag["child2"].dag_hash()
+
+        # middle should be pruned since it's installed
+        assert middle_hash not in graph.nodes
+
+        # All other nodes should be in the graph
+        assert parent1_hash in graph.nodes
+        assert parent2_hash in graph.nodes
+        assert child1_hash in graph.nodes
+        assert child2_hash in graph.nodes
+
+        # Verify full Cartesian product: each parent should be connected to each child
+        # parent1 -> child1, child2
+        assert child1_hash in graph.parent_to_child[parent1_hash]
+        assert child2_hash in graph.parent_to_child[parent1_hash]
+
+        # parent2 -> child1, child2
+        assert child1_hash in graph.parent_to_child[parent2_hash]
+        assert child2_hash in graph.parent_to_child[parent2_hash]
+
+        # Verify reverse mapping: each child should have both parents
+        # child1 <- parent1, parent2
+        assert parent1_hash in graph.child_to_parent[child1_hash]
+        assert parent2_hash in graph.child_to_parent[child1_hash]
+
+        # child2 <- parent1, parent2
+        assert parent1_hash in graph.child_to_parent[child2_hash]
+        assert parent2_hash in graph.child_to_parent[child2_hash]
+
+        # middle should not appear in any parent-child relationships
+        assert middle_hash not in graph.parent_to_child
+        assert middle_hash not in graph.child_to_parent
+
+    def test_empty_graph_all_specs_installed(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that the graph is empty when all specs are already installed."""
+        # Install all specs in the DAG
+        for spec_name in ["root", "dep1", "dep2", "dep3"]:
+            install_spec_in_db(mock_specs[spec_name], temporary_store)
+
+        specs = [mock_specs["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # All nodes should be pruned, resulting in an empty graph
+        assert len(graph.nodes) == 0
+        assert len(graph.parent_to_child) == 0
+        assert len(graph.child_to_parent) == 0
+
+    def test_empty_graph_install_package_false_all_deps_installed(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test empty graph when install_package=False and all dependencies are installed."""
+        # Install all dependencies (but not the root)
+        for dep_name in ["dep1", "dep2", "dep3"]:
+            install_spec_in_db(mock_specs[dep_name], temporary_store)
+
+        specs = [mock_specs["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=False,  # Don't install the root
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Root is pruned because install_package=False
+        # Dependencies are pruned because they're installed
+        # Result: empty graph
+        assert len(graph.nodes) == 0
+        assert len(graph.parent_to_child) == 0
+        assert len(graph.child_to_parent) == 0
+
+    def test_pruning_leaf_node(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that pruning a leaf node (no children) works correctly.
+
+        This ensures the pruning logic handles the boundary condition where
+        a node has no children to re-wire.
+        """
+        # Install dep2, which is a leaf node (no children)
+        dep2 = mock_specs["dep2"]
+        install_spec_in_db(dep2, temporary_store)
+
+        specs = [mock_specs["root"]]
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        dep2_hash = dep2.dag_hash()
+        dep1_hash = mock_specs["dep1"].dag_hash()
+
+        # dep2 should be pruned
+        assert dep2_hash not in graph.nodes
+        # dep1 (parent of dep2) should have no children now
+        assert len(graph.parent_to_child[dep1_hash]) == 0
+        # dep2 should not appear in any mappings
+        assert dep2_hash not in graph.parent_to_child
+        assert dep2_hash not in graph.child_to_parent
+
+    def test_pruning_root_node_with_install_package_false(
+        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    ):
+        """Test that pruning a root node (no parents in the context) works correctly.
+
+        When install_package=False, root nodes are marked for pruning. This ensures
+        the pruning logic handles the boundary condition where a node has no parents.
+        """
+        specs = [mock_specs["dep1"]]  # Use dep1 as the "root" for this test
+
+        graph = BuildGraph(
+            specs=specs,
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=False,  # Prune the root
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        dep1_hash = mock_specs["dep1"].dag_hash()
+        dep2_hash = mock_specs["dep2"].dag_hash()
+
+        # dep1 should be pruned (it's the root and install_package=False)
+        assert dep1_hash not in graph.nodes
+        # dep2 (child of dep1) should still be in the graph
+        assert dep2_hash in graph.nodes
+        # dep2 should have no parents now (its only parent was pruned)
+        assert dep2_hash not in graph.child_to_parent or len(graph.child_to_parent[dep2_hash]) == 0
+        # dep1 should not appear in any mappings
+        assert dep1_hash not in graph.parent_to_child
+        assert dep1_hash not in graph.child_to_parent

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -938,80 +938,117 @@ Nodes = Dict[str, spack.spec.Spec]
 Edges = Dict[str, Set[str]]
 
 
-def _init_build_graph(
-    specs: List[spack.spec.Spec],
-    root_policy: InstallPolicy,
-    dependencies_policy: InstallPolicy,
-    include_build_deps: bool,
-    install_package: bool,
-    db: spack.database.Database,
-) -> Tuple[Nodes, Edges, Edges]:
-    """Construct a build graph from the given specs. This includes only packages that need to be
-    installed. Installed packages are pruned from the graph, and build dependencies are only
-    included when necessary."""
-    nodes = {s.dag_hash(): s for s in specs}
-    parent_to_child: Dict[str, Set[str]] = {}
-    child_to_parent: Dict[str, Set[str]] = {}
-    specs_to_prune: Set[str] = set()
-    db = spack.store.STORE.db
-    stack: List[Tuple[spack.spec.Spec, InstallPolicy]] = [(s, root_policy) for s in nodes.values()]
+class BuildGraph:
+    """Represents the dependency graph for package installation."""
 
-    with db.read_transaction():
-        while stack:
-            spec, install_policy = stack.pop()
-            key = spec.dag_hash()
-            _, record = db.query_by_spec_hash(key)
+    def __init__(
+        self,
+        specs: List[spack.spec.Spec],
+        root_policy: InstallPolicy,
+        dependencies_policy: InstallPolicy,
+        include_build_deps: bool,
+        install_package: bool,
+        install_deps: bool,
+        database: spack.database.Database,
+    ):
+        """Construct a build graph from the given specs. This includes only packages that need to
+        be installed. Installed packages are pruned from the graph, and build dependencies are only
+        included when necessary."""
+        self.roots = {s.dag_hash() for s in specs}
+        self.nodes = {s.dag_hash(): s for s in specs}
+        self.parent_to_child: Dict[str, Set[str]] = {}
+        self.child_to_parent: Dict[str, Set[str]] = {}
+        specs_to_prune: Set[str] = set()
+        stack: List[Tuple[spack.spec.Spec, InstallPolicy]] = [
+            (s, root_policy) for s in self.nodes.values()
+        ]
 
-            # Set the install prefix for each spec based on the db record or store layout
-            if record and record.path:
-                spec.set_prefix(record.path)
-            else:
-                spec.set_prefix(spack.store.STORE.layout.path_for_spec(spec))
+        with database.read_transaction():
+            while stack:
+                spec, install_policy = stack.pop()
+                key = spec.dag_hash()
+                _, record = database.query_by_spec_hash(key)
 
-            # Conditionally include build dependencies based on policy and install status
-            if record and record.installed:
-                specs_to_prune.add(key)
-                dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
-            elif install_policy == "cache_only" and not include_build_deps:
-                dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
-            else:
-                dependencies = spec.dependencies(deptype=dt.BUILD | dt.LINK | dt.RUN)
+                # Set the install prefix for each spec based on the db record or store layout
+                if record and record.path:
+                    spec.set_prefix(record.path)
+                else:
+                    spec.set_prefix(spack.store.STORE.layout.path_for_spec(spec))
 
-            parent_to_child[key] = {d.dag_hash() for d in dependencies}
+                # Conditionally include build dependencies based on policy and install status
+                if record and record.installed:
+                    specs_to_prune.add(key)
+                    dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
+                elif install_policy == "cache_only" and not include_build_deps:
+                    dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
+                else:
+                    dependencies = spec.dependencies(deptype=dt.BUILD | dt.LINK | dt.RUN)
 
-            # Enqueue new dependencies
-            for d in dependencies:
-                if d.dag_hash() in nodes:
-                    continue
-                nodes[d.dag_hash()] = d
-                stack.append((d, dependencies_policy))
+                self.parent_to_child[key] = {d.dag_hash() for d in dependencies}
 
-    # Construct reverse lookup from child to parent
-    for parent, children in parent_to_child.items():
-        for child in children:
-            if child in child_to_parent:
-                child_to_parent[child].add(parent)
-            else:
-                child_to_parent[child] = {parent}
+                # Enqueue new dependencies
+                for d in dependencies:
+                    if d.dag_hash() in self.nodes:
+                        continue
+                    self.nodes[d.dag_hash()] = d
+                    stack.append((d, dependencies_policy))
 
-    # If we're not installing the package itself, mark root specs for pruning too
-    if not install_package:
-        specs_to_prune.update(s.dag_hash() for s in specs)
+        # Construct reverse lookup from child to parent
+        for parent, children in self.parent_to_child.items():
+            for child in children:
+                if child in self.child_to_parent:
+                    self.child_to_parent[child].add(parent)
+                else:
+                    self.child_to_parent[child] = {parent}
 
-    # Prune specs from the build graph. Their parents become parents of their children,
-    # and their children become children of their parents.
-    for key in specs_to_prune:
-        for parent in child_to_parent.get(key, ()):
-            parent_to_child[parent].remove(key)
-            parent_to_child[parent].update(parent_to_child.get(key, ()))
-        for child in parent_to_child.get(key, ()):
-            child_to_parent[child].remove(key)
-            child_to_parent[child].update(child_to_parent.get(key, ()))
-        parent_to_child.pop(key, None)
-        child_to_parent.pop(key, None)
-        nodes.pop(key, None)
+        # If we're not installing the package itself, mark root specs for pruning too
+        if not install_package:
+            specs_to_prune.update(s.dag_hash() for s in specs)
 
-    return nodes, parent_to_child, child_to_parent
+        # Prune specs from the build graph. Their parents become parents of their children and
+        # their children become children of their parents.
+        for key in specs_to_prune:
+            for parent in self.child_to_parent.get(key, ()):
+                self.parent_to_child[parent].remove(key)
+                self.parent_to_child[parent].update(self.parent_to_child.get(key, ()))
+            for child in self.parent_to_child.get(key, ()):
+                self.child_to_parent[child].remove(key)
+                self.child_to_parent[child].update(self.child_to_parent.get(key, ()))
+            self.parent_to_child.pop(key, None)
+            self.child_to_parent.pop(key, None)
+            self.nodes.pop(key, None)
+
+        # If we're not installing dependencies, verify that all remaining nodes in the build graph
+        # after pruning are roots. If there are any non-root nodes, it means there are uninstalled
+        # dependencies that we're not supposed to install.
+        if not install_deps:
+            non_root_spec = next((v for k, v in self.nodes.items() if k not in self.roots), None)
+            if non_root_spec is not None:
+                raise spack.error.InstallError(
+                    f"Failed to install in package only mode: dependency {non_root_spec} is not "
+                    "installed"
+                )
+
+    def enqueue_parents(self, dag_hash: str, pending_builds: List[str]) -> None:
+        """After a spec is installed, remove it from the graph and enqueue any parents that are
+        now ready to install.
+
+        Args:
+            dag_hash: The dag_hash of the spec that was just installed
+            pending_builds: List to append parent specs that are ready to build
+        """
+        # Remove the finished job from the mappings
+        self.parent_to_child.pop(dag_hash, None)
+        parents = self.child_to_parent.get(dag_hash)
+
+        if not parents:
+            return
+
+        for parent in parents:
+            children = self.parent_to_child[parent]
+            children.remove(dag_hash)
+            if not children:
+                pending_builds.append(parent)
 
 
 class PackageInstaller:
@@ -1065,7 +1102,6 @@ class PackageInstaller:
         # verbose and concurrent_packages are not worth erroring out for
 
         specs = [pkg.spec for pkg in packages]
-        self.roots = {s.dag_hash() for s in specs}
 
         self.root_policy: InstallPolicy = root_policy
         self.dependencies_policy: InstallPolicy = dependencies_policy
@@ -1074,31 +1110,22 @@ class PackageInstaller:
         # Buffer for incoming, partially received state data from child processes
         self.state_buffers: Dict[int, str] = {}
 
-        self.nodes, self.parent_to_child, self.child_to_parent = _init_build_graph(
+        # Build the dependency graph
+        self.build_graph = BuildGraph(
             specs,
             root_policy,
             dependencies_policy,
             include_build_deps,
             install_package,
+            install_deps,
             spack.store.STORE.db,
         )
-
-        # If we're not installing dependencies, verify that all remaining nodes in the build graph
-        # after pruning are roots. If there are any non-root nodes, it means there are uninstalled
-        # dependencies that we're not supposed to install.
-        if not install_deps:
-            non_root_spec = next((v for k, v in self.nodes.items() if k not in self.roots), None)
-            if non_root_spec is not None:
-                raise spack.error.InstallError(
-                    f"Failed to install in package only mode: dependency {non_root_spec} is not "
-                    "installed"
-                )
 
         #: check what specs we could fetch from binaries (checks against cache, not remotely)
         spack.binary_distribution.BINARY_INDEX.update()
         self.binary_cache_for_spec = {
             s.dag_hash(): spack.binary_distribution.BINARY_INDEX.find_by_hash(s.dag_hash())
-            for s in self.nodes.values()
+            for s in self.build_graph.nodes.values()
         }
         self.unsigned = unsigned
         self.dirty = dirty
@@ -1107,7 +1134,7 @@ class PackageInstaller:
 
         #: queue of packages ready to install (no children)
         self.pending_builds = [
-            parent for parent, children in self.parent_to_child.items() if not children
+            parent for parent, children in self.build_graph.parent_to_child.items() if not children
         ]
 
         if explicit is True:
@@ -1118,23 +1145,9 @@ class PackageInstaller:
             self.explicit = explicit
 
         self.running_builds: Dict[int, ChildInfo] = {}
-        self.build_status = BuildStatus(len(self.nodes))
+        self.build_status = BuildStatus(len(self.build_graph.nodes))
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
         self.reports: Dict[str, spack.report.RequestRecord] = {}
-
-    def _enqueue_parents(self, dag_hash: str) -> None:
-        # the job dag_hash has finished, so remove it from the mappings
-        # and enqueue any parents that are now ready to install
-        self.parent_to_child.pop(dag_hash, None)
-        parents = self.child_to_parent.get(dag_hash)
-
-        if not parents:
-            return
-        for parent in parents:
-            children = self.parent_to_child[parent]
-            children.remove(dag_hash)
-            if not children:
-                self.pending_builds.append(parent)
 
     def install(self) -> None:
         # This installer has not implemented the per-spec exclusive locks during installation.
@@ -1246,7 +1259,9 @@ class PackageInstaller:
                 # ready.
                 if to_insert_in_database and self._save_to_db(to_insert_in_database):
                     for entry in to_insert_in_database:
-                        self._enqueue_parents(entry.spec.dag_hash())
+                        self.build_graph.enqueue_parents(
+                            entry.spec.dag_hash(), self.pending_builds
+                        )
                     to_insert_in_database.clear()
 
                 # Again, the first job should start immediately and does not require a token.
@@ -1311,9 +1326,11 @@ class PackageInstaller:
         dag_hash = self.pending_builds.pop()
         explicit = dag_hash in self.explicit
         mirrors = self.binary_cache_for_spec[dag_hash]
-        install_policy = self.root_policy if dag_hash in self.roots else self.dependencies_policy
+        install_policy = (
+            self.root_policy if dag_hash in self.build_graph.roots else self.dependencies_policy
+        )
         child_info = start_build(
-            self.nodes[dag_hash],
+            self.build_graph.nodes[dag_hash],
             explicit,
             mirrors,
             self.unsigned,

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -943,6 +943,7 @@ def _init_build_graph(
     root_policy: InstallPolicy,
     dependencies_policy: InstallPolicy,
     include_build_deps: bool,
+    install_package: bool,
     db: spack.database.Database,
 ) -> Tuple[Nodes, Edges, Edges]:
     """Construct a build graph from the given specs. This includes only packages that need to be
@@ -951,7 +952,7 @@ def _init_build_graph(
     nodes = {s.dag_hash(): s for s in specs}
     parent_to_child: Dict[str, Set[str]] = {}
     child_to_parent: Dict[str, Set[str]] = {}
-    installed_specs: Set[str] = set()
+    specs_to_prune: Set[str] = set()
     db = spack.store.STORE.db
     stack: List[Tuple[spack.spec.Spec, InstallPolicy]] = [(s, root_policy) for s in nodes.values()]
 
@@ -969,7 +970,7 @@ def _init_build_graph(
 
             # Conditionally include build dependencies based on policy and install status
             if record and record.installed:
-                installed_specs.add(key)
+                specs_to_prune.add(key)
                 dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
             elif install_policy == "cache_only" and not include_build_deps:
                 dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
@@ -993,9 +994,13 @@ def _init_build_graph(
             else:
                 child_to_parent[child] = {parent}
 
-    # Prune installed specs from the build graph. Their parents become parents of their children,
+    # If we're not installing the package itself, mark root specs for pruning too
+    if not install_package:
+        specs_to_prune.update(s.dag_hash() for s in specs)
+
+    # Prune specs from the build graph. Their parents become parents of their children,
     # and their children become children of their parents.
-    for key in installed_specs:
+    for key in specs_to_prune:
         for parent in child_to_parent.get(key, ()):
             parent_to_child[parent].remove(key)
             parent_to_child[parent].update(parent_to_child.get(key, ()))
@@ -1004,7 +1009,7 @@ def _init_build_graph(
             child_to_parent[child].update(child_to_parent.get(key, ()))
         parent_to_child.pop(key, None)
         child_to_parent.pop(key, None)
-        del nodes[key]
+        nodes.pop(key, None)
 
     return nodes, parent_to_child, child_to_parent
 
@@ -1037,6 +1042,7 @@ class PackageInstaller:
         root_policy: InstallPolicy = "auto",
         dependencies_policy: InstallPolicy = "auto",
     ) -> None:
+        assert install_package or install_deps, "Must install package, dependencies or both"
 
         if overwrite:
             raise NotImplementedError("Overwrite installs are not implemented")
@@ -1044,10 +1050,6 @@ class PackageInstaller:
             raise NotImplementedError("Fail-fast installs are not implemented")
         elif fake:
             raise NotImplementedError("Fake installs are not implemented")
-        elif not install_deps:
-            raise NotImplementedError("Not installing dependencies is not implemented")
-        elif not install_package:
-            raise NotImplementedError("Not installing the specified package is not implemented")
         elif install_source:
             raise NotImplementedError("Installing sources is not implemented")
         elif keep_prefix:
@@ -1073,8 +1075,24 @@ class PackageInstaller:
         self.state_buffers: Dict[int, str] = {}
 
         self.nodes, self.parent_to_child, self.child_to_parent = _init_build_graph(
-            specs, root_policy, dependencies_policy, include_build_deps, spack.store.STORE.db
+            specs,
+            root_policy,
+            dependencies_policy,
+            include_build_deps,
+            install_package,
+            spack.store.STORE.db,
         )
+
+        # If we're not installing dependencies, verify that all remaining nodes in the build graph
+        # after pruning are roots. If there are any non-root nodes, it means there are uninstalled
+        # dependencies that we're not supposed to install.
+        if not install_deps:
+            non_root_spec = next((v for k, v in self.nodes.items() if k not in self.roots), None)
+            if non_root_spec is not None:
+                raise spack.error.InstallError(
+                    f"Failed to install in package only mode: dependency {non_root_spec} is not "
+                    "installed"
+                )
 
         #: check what specs we could fetch from binaries (checks against cache, not remotely)
         spack.binary_distribution.BINARY_INDEX.update()

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -299,6 +299,7 @@ def worker_function(
     if os.path.exists(spec.prefix):
         shutil.rmtree(spec.prefix)
 
+    # Try to install from buildcache, unless user asked for source only
     if install_policy != "source_only":
         if mirrors and install_from_buildcache(mirrors, spec, unsigned, state_stream):
             spack.hooks.post_install(spec, explicit)
@@ -1037,13 +1038,15 @@ class BuildGraph:
             dag_hash: The dag_hash of the spec that was just installed
             pending_builds: List to append parent specs that are ready to build
         """
-        # Remove the finished job from the mappings
+        # Remove node and edges from the node in the build graph
         self.parent_to_child.pop(dag_hash, None)
-        parents = self.child_to_parent.get(dag_hash)
+        self.nodes.pop(dag_hash, None)
+        parents = self.child_to_parent.pop(dag_hash, None)
 
         if not parents:
             return
 
+        # Enqueue any parents and remove edges to the installed child
         for parent in parents:
             children = self.parent_to_child[parent]
             children.remove(dag_hash)

--- a/lib/spack/spack/test/installer_build_graph.py
+++ b/lib/spack/spack/test/installer_build_graph.py
@@ -20,7 +20,7 @@ def create_dag(
     Create a DAG of concrete specs, as a mapping from package name to Spec.
 
     Arguments:
-        nodes: list of package names
+        nodes: list of unique package names
         edges: list of tuples (parent, child, deptype)
     """
     specs = {name: spack.spec.Spec(name) for name in nodes}

--- a/lib/spack/spack/test/installer_build_graph.py
+++ b/lib/spack/spack/test/installer_build_graph.py
@@ -12,14 +12,14 @@ if sys.platform == "win32":
 
 import spack.deptypes as dt
 import spack.error
-import spack.spec
-import spack.store
 from spack.new_installer import BuildGraph
+from spack.spec import Spec
+from spack.store import Store
 
 
 def create_dag(
     nodes: List[str], edges: List[Tuple[str, str, Union[dt.DepType, Tuple[dt.DepType, ...]]]]
-) -> Dict[str, spack.spec.Spec]:
+) -> Dict[str, Spec]:
     """
     Create a DAG of concrete specs, as a mapping from package name to Spec.
 
@@ -27,7 +27,7 @@ def create_dag(
         nodes: list of unique package names
         edges: list of tuples (parent, child, deptype)
     """
-    specs = {name: spack.spec.Spec(name) for name in nodes}
+    specs = {name: Spec(name) for name in nodes}
     for parent, child, deptypes in edges:
         depflag = deptypes if isinstance(deptypes, dt.DepFlag) else dt.canonicalize(deptypes)
         specs[parent].add_dependency_edge(specs[child], depflag=depflag, virtuals=())
@@ -39,7 +39,7 @@ def create_dag(
     return specs
 
 
-def install_spec_in_db(spec: spack.spec.Spec, store: spack.store.Store):
+def install_spec_in_db(spec: Spec, store: Store):
     """Helper to install a spec in the database for testing."""
     prefix = store.layout.path_for_spec(spec)
     spec.set_prefix(prefix)
@@ -129,14 +129,10 @@ def complex_pruning_dag():
 class TestBuildGraph:
     """Tests for the BuildGraph class."""
 
-    def test_basic_graph_construction(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
-    ):
+    def test_basic_graph_construction(self, mock_specs: Dict[str, Spec], temporary_store: Store):
         """Test basic graph construction with all specs to be installed."""
-        specs = [mock_specs["root"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[mock_specs["root"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -152,14 +148,10 @@ class TestBuildGraph:
         # Root should have 2 children (dep1, dep3)
         assert len(graph.parent_to_child[mock_specs["root"].dag_hash()]) == 2
 
-    def test_install_package_only_mode(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
-    ):
+    def test_install_package_only_mode(self, mock_specs: Dict[str, Spec], temporary_store: Store):
         """Test that install_package=False removes root specs from graph."""
-        specs = [mock_specs["root"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[mock_specs["root"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -174,17 +166,15 @@ class TestBuildGraph:
         assert mock_specs["dep1"].dag_hash() in graph.nodes
 
     def test_install_deps_false_with_uninstalled_deps(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
     ):
         """Test that install_deps=False raises error when dependencies are not installed."""
-        specs = [mock_specs["root"]]
-
         # Should raise error because dependencies are not installed
         with pytest.raises(
             spack.error.InstallError, match="package only mode.*dependency.*not installed"
         ):
             BuildGraph(
-                specs=specs,
+                specs=[mock_specs["root"]],
                 root_policy="auto",
                 dependencies_policy="auto",
                 include_build_deps=False,
@@ -193,14 +183,10 @@ class TestBuildGraph:
                 database=temporary_store.db,
             )
 
-    def test_multiple_roots(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
-    ):
+    def test_multiple_roots(self, mock_specs: Dict[str, Spec], temporary_store: Store):
         """Test graph construction with multiple root specs."""
-        specs = [mock_specs["root"], mock_specs["dep1"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[mock_specs["root"], mock_specs["dep1"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -213,15 +199,11 @@ class TestBuildGraph:
         assert mock_specs["root"].dag_hash() in graph.roots
         assert mock_specs["dep1"].dag_hash() in graph.roots
 
-    def test_parent_child_mappings(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
-    ):
+    def test_parent_child_mappings(self, mock_specs: Dict[str, Spec], temporary_store: Store):
         """Test that parent-child mappings are correctly constructed."""
         spec_root = mock_specs["root"]
-        specs = [spec_root]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[spec_root],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -237,13 +219,11 @@ class TestBuildGraph:
                 assert parent in graph.child_to_parent[child]
 
     def test_diamond_dag_with_shared_dependency(
-        self, diamond_dag: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+        self, diamond_dag: Dict[str, Spec], temporary_store: Store
     ):
         """Test graph construction with a diamond DAG where a dependency has multiple parents."""
-        specs = [diamond_dag["root"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[diamond_dag["root"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -259,18 +239,14 @@ class TestBuildGraph:
         assert diamond_dag["dep1"].dag_hash() in graph.child_to_parent[shared_hash]
         assert diamond_dag["dep2"].dag_hash() in graph.child_to_parent[shared_hash]
 
-    def test_pruning_installed_specs(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
-    ):
+    def test_pruning_installed_specs(self, mock_specs: Dict[str, Spec], temporary_store: Store):
         """Test that installed specs are correctly pruned from the graph."""
         # Install dep2 in the database
         dep2 = mock_specs["dep2"]
         install_spec_in_db(dep2, temporary_store)
 
-        specs = [mock_specs["root"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[mock_specs["root"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -287,17 +263,14 @@ class TestBuildGraph:
         assert len(graph.parent_to_child[mock_specs["dep1"].dag_hash()]) == 0
 
     def test_pruning_with_shared_dependency_partially_installed(
-        self, diamond_dag: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+        self, diamond_dag: Dict[str, Spec], temporary_store: Store
     ):
         """Test that pruning a shared dependency correctly updates all parents."""
         # Install the shared dependency
         shared = diamond_dag["shared"]
         install_spec_in_db(shared, temporary_store)
-
-        specs = [diamond_dag["root"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[diamond_dag["root"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -312,95 +285,78 @@ class TestBuildGraph:
         assert len(graph.parent_to_child[diamond_dag["dep1"].dag_hash()]) == 0
         assert len(graph.parent_to_child[diamond_dag["dep2"].dag_hash()]) == 0
 
-    def test_include_build_deps_false_installed_root(self, specs_with_build_deps, temporary_store):
-        """Test that build dependencies are excluded for an installed root package.
-
-        When a root spec is already installed, build deps are excluded regardless of
-        include_build_deps setting, because installed packages only need link/run deps.
-        """
-        # Install the root so build deps are excluded
-        root = specs_with_build_deps["root"]
-        root.set_prefix(temporary_store.layout.path_for_spec(root))
-        temporary_store.db.add(root, explicit=True)
-
-        specs = [root]
-
-        graph = BuildGraph(
-            specs=specs,
-            root_policy="cache_only",  # Use cache_only to exclude build deps
-            dependencies_policy="auto",
-            include_build_deps=False,
-            install_package=False,  # Only install dependencies
-            install_deps=True,
-            database=temporary_store.db,
-        )
-
-        # build_dep should NOT be in the graph (build-only dependency)
-        assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes
-        # link_dep and all_dep should be in the graph
-        assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
-        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
-
-    def test_cache_only_policy_excludes_build_deps_for_uninstalled_package(
-        self, specs_with_build_deps: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    def test_installed_root_excludes_build_deps_even_when_requested(
+        self, specs_with_build_deps: Dict[str, Spec], temporary_store: Store
     ):
-        """Test that cache_only policy excludes build deps even for uninstalled packages."""
-        # Do NOT install the root - it's uninstalled
+        """Test that installed root specs never include build deps, even with
+        include_build_deps=True."""
         root = specs_with_build_deps["root"]
-        specs = [root]
+        install_spec_in_db(root, temporary_store)
 
         graph = BuildGraph(
-            specs=specs,
-            root_policy="cache_only",  # cache_only policy
+            specs=[root],
+            root_policy="auto",
             dependencies_policy="auto",
-            include_build_deps=False,  # Don't include build deps
+            include_build_deps=True,  # Should be ignored for installed root
             install_package=True,
             install_deps=True,
             database=temporary_store.db,
         )
 
-        # build_dep should NOT be in the graph (build-only dependency excluded by cache_only)
+        # build_dep should NOT be in the graph (installed root never needs build deps)
         assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes
-        # link_dep and all_dep should be in the graph
+        # link_dep and all_dep should be in the graph (link/run deps)
         assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
         assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
-        # root should be in the graph
-        assert root.dag_hash() in graph.nodes
 
-    def test_include_build_deps_true(
-        self, specs_with_build_deps: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+    def test_cache_only_excludes_build_deps(
+        self, specs_with_build_deps: Dict[str, Spec], temporary_store: Store
     ):
-        """Test that build dependencies are included when include_build_deps=True."""
-        specs = [specs_with_build_deps["root"]]
-
+        """Test that cache_only policy excludes build deps when include_build_deps=False."""
         graph = BuildGraph(
-            specs=specs,
-            root_policy="auto",
+            specs=[specs_with_build_deps["root"]],
+            root_policy="cache_only",
             dependencies_policy="auto",
+            include_build_deps=False,  # exclude build deps when possible
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes
+        assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
+
+    def test_cache_only_includes_build_deps_when_requested(
+        self, specs_with_build_deps: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test that cache_only policy includes build deps when include_build_deps=True."""
+        graph = BuildGraph(
+            specs=[specs_with_build_deps["root"]],
+            root_policy="cache_only",
+            dependencies_policy="cache_only",
             include_build_deps=True,
             install_package=True,
             install_deps=True,
             database=temporary_store.db,
         )
 
-        # All dependencies should be in the graph
+        # All dependencies should be in the graph, including build_dep
         assert specs_with_build_deps["build_dep"].dag_hash() in graph.nodes
         assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
         assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
 
     def test_install_deps_false_with_all_deps_installed(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
     ):
         """Test successful package-only install when all dependencies are already installed."""
         # Install all dependencies
         for dep_name in ["dep1", "dep2", "dep3"]:
             install_spec_in_db(mock_specs[dep_name], temporary_store)
 
-        specs = [mock_specs["root"]]
-
         # Should succeed since all dependencies are installed
         graph = BuildGraph(
-            specs=specs,
+            specs=[mock_specs["root"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -415,39 +371,13 @@ class TestBuildGraph:
         # Root should have no children (all deps pruned)
         assert len(graph.parent_to_child.get(mock_specs["root"].dag_hash(), [])) == 0
 
-    def test_build_deps_excluded_for_installed_packages(
-        self, specs_with_build_deps: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
-    ):
-        """Test that build deps are excluded for installed packages even if include_build_deps."""
-        # Install link_dep
-        link_dep = specs_with_build_deps["link_dep"]
-        install_spec_in_db(link_dep, temporary_store)
-
-        specs = [specs_with_build_deps["root"]]
-
-        graph = BuildGraph(
-            specs=specs,
-            root_policy="auto",
-            dependencies_policy="auto",
-            include_build_deps=True,  # Even with this set to True
-            install_package=True,
-            install_deps=True,
-            database=temporary_store.db,
-        )
-
-        # link_dep should be pruned (it's installed)
-        assert link_dep.dag_hash() not in graph.nodes
-        # build_dep and all_dep should be in the graph
-        assert specs_with_build_deps["build_dep"].dag_hash() in graph.nodes
-        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
-
     def test_pruning_creates_cartesian_product_of_connections(
-        self, complex_pruning_dag: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+        self, complex_pruning_dag: Dict[str, Spec], temporary_store: Store
     ):
         """Test that pruning creates full Cartesian product of parent-child connections.
 
         When a node with multiple parents and multiple children is pruned,
-        all parents should be connected to all children (parents × children).
+        all parents should be connected to all children (parents x children).
 
         DAG structure:
             parent1 -> middle -> child1
@@ -464,10 +394,8 @@ class TestBuildGraph:
         install_spec_in_db(middle, temporary_store)
 
         # Use parent1 as the root to build the graph
-        specs = [complex_pruning_dag["parent1"], complex_pruning_dag["parent2"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[complex_pruning_dag["parent1"], complex_pruning_dag["parent2"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -514,17 +442,15 @@ class TestBuildGraph:
         assert middle_hash not in graph.child_to_parent
 
     def test_empty_graph_all_specs_installed(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
     ):
         """Test that the graph is empty when all specs are already installed."""
         # Install all specs in the DAG
         for spec_name in ["root", "dep1", "dep2", "dep3"]:
             install_spec_in_db(mock_specs[spec_name], temporary_store)
 
-        specs = [mock_specs["root"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[mock_specs["root"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -539,17 +465,15 @@ class TestBuildGraph:
         assert len(graph.child_to_parent) == 0
 
     def test_empty_graph_install_package_false_all_deps_installed(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
     ):
         """Test empty graph when install_package=False and all dependencies are installed."""
         # Install all dependencies (but not the root)
         for dep_name in ["dep1", "dep2", "dep3"]:
             install_spec_in_db(mock_specs[dep_name], temporary_store)
 
-        specs = [mock_specs["root"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[mock_specs["root"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -565,9 +489,7 @@ class TestBuildGraph:
         assert len(graph.parent_to_child) == 0
         assert len(graph.child_to_parent) == 0
 
-    def test_pruning_leaf_node(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
-    ):
+    def test_pruning_leaf_node(self, mock_specs: Dict[str, Spec], temporary_store: Store):
         """Test that pruning a leaf node (no children) works correctly.
 
         This ensures the pruning logic handles the boundary condition where
@@ -577,10 +499,8 @@ class TestBuildGraph:
         dep2 = mock_specs["dep2"]
         install_spec_in_db(dep2, temporary_store)
 
-        specs = [mock_specs["root"]]
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[mock_specs["root"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -601,17 +521,15 @@ class TestBuildGraph:
         assert dep2_hash not in graph.child_to_parent
 
     def test_pruning_root_node_with_install_package_false(
-        self, mock_specs: Dict[str, spack.spec.Spec], temporary_store: spack.store.Store
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
     ):
         """Test that pruning a root node (no parents in the context) works correctly.
 
         When install_package=False, root nodes are marked for pruning. This ensures
         the pruning logic handles the boundary condition where a node has no parents.
         """
-        specs = [mock_specs["dep1"]]  # Use dep1 as the "root" for this test
-
         graph = BuildGraph(
-            specs=specs,
+            specs=[mock_specs["dep1"]],
             root_policy="auto",
             dependencies_policy="auto",
             include_build_deps=False,
@@ -628,7 +546,7 @@ class TestBuildGraph:
         # dep2 (child of dep1) should still be in the graph
         assert dep2_hash in graph.nodes
         # dep2 should have no parents now (its only parent was pruned)
-        assert dep2_hash not in graph.child_to_parent or len(graph.child_to_parent[dep2_hash]) == 0
+        assert not graph.child_to_parent.get(dep2_hash)
         # dep1 should not appear in any mappings
         assert dep1_hash not in graph.parent_to_child
         assert dep1_hash not in graph.child_to_parent

--- a/lib/spack/spack/test/installer_build_graph.py
+++ b/lib/spack/spack/test/installer_build_graph.py
@@ -2,9 +2,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests for BuildGraph class in new_installer"""
+import sys
 from typing import Dict, List, Tuple, Union
 
 import pytest
+
+if sys.platform == "win32":
+    pytest.skip("Skipping new installer tests on Windows", allow_module_level=True)
 
 import spack.deptypes as dt
 import spack.error


### PR DESCRIPTION
Implement various flags that influence the build graph the new installer works on. Turn this graph into a class of its own: `BuildGraph`.

* Implement cache related flags: `--use-buildcache (dependencies/package):(always,never,auto)`, `--cache-only`, `--use-cache`
* Implement `--only` flag:
  * `--only dependencies` is implemented by pruning roots just like already installed packages are pruned, and 
  * `--only package` is implemented by raising if after pruning non-roots are in the install queue.

Plus add a bunch of tests related to the build graph object, which run in ~0.4s.