### PR TITLE
spack install: deprecate --dont-restage

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -50,7 +50,6 @@ def install_kwargs_from_args(args):
         "fail_fast": args.fail_fast,
         "keep_prefix": args.keep_prefix,
         "keep_stage": args.keep_stage,
-        "restage": not args.dont_restage,
         "install_source": args.install_source,
         "verbose": args.verbose or args.install_verbose,
         "fake": args.fake,
@@ -109,7 +108,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "--dont-restage",
         action="store_true",
-        help="if a partial install is detected, don't delete prior state",
+        help="deprecated option (no longer has any effect; restaging is always performed)",
     )
 
     cache_group = subparser.add_mutually_exclusive_group()
@@ -306,6 +305,13 @@ def _die_require_env():
 def install(parser, args):
     # TODO: unify args.verbose?
     tty.set_verbose(args.verbose or args.install_verbose)
+
+    if args.dont_restage:
+        tty.warn(
+            "The '--dont-restage' option is deprecated and will be removed in Spack v1.3.0. "
+            "Use 'spack develop' for packages where you want to preserve manual modifications to "
+            "source code."
+        )
 
     if args.help_cdash:
         arguments.print_cdash_help()

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -796,7 +796,6 @@ class BuildRequest:
             ("root_policy", "auto"),
             ("keep_prefix", False),
             ("keep_stage", False),
-            ("restage", False),
             ("skip_patch", False),
             ("tests", False),
             ("unsigned", None),
@@ -1469,7 +1468,6 @@ class PackageInstaller:
         install_source: bool = False,
         keep_prefix: bool = False,
         keep_stage: bool = False,
-        restage: bool = False,
         skip_patch: bool = False,
         stop_at: Optional[str] = None,
         stop_before: Optional[str] = None,
@@ -1494,7 +1492,6 @@ class PackageInstaller:
             keep_prefix: Keep install prefix on failure. By default, destroys it.
             keep_stage: By default, stage is destroyed only if there are no exceptions during
                 build. Set to True to keep the stage even with exceptions.
-            restage: Force spack to restage the package source.
             skip_patch: Skip patch stage of build if True.
             stop_before: stop execution before this installation phase (or None)
             stop_at: last installation phase to be executed (or None)
@@ -1532,7 +1529,6 @@ class PackageInstaller:
             "keep_stage": keep_stage,
             "overwrite": overwrite or [],
             "root_policy": root_policy,
-            "restage": restage,
             "skip_patch": skip_patch,
             "stop_at": stop_at,
             "stop_before": stop_before,
@@ -2584,8 +2580,7 @@ class BuildProcessInstaller:
         # a --destroy-stage option), so we can override a default choice
         # to destroy
         self.keep_stage = is_develop or install_args.get("keep_stage", False)
-        # whether to restage
-        self.restage = (not is_develop) and install_args.get("restage", False)
+        self.restage = not is_develop
 
         # whether to skip the patch phase
         self.skip_patch = install_args.get("skip_patch", False)

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1085,7 +1085,6 @@ class PackageInstaller:
         install_source: bool = False,
         keep_prefix: bool = False,
         keep_stage: bool = False,
-        restage: bool = True,
         skip_patch: bool = False,
         stop_at: Optional[str] = None,
         stop_before: Optional[str] = None,
@@ -1108,8 +1107,6 @@ class PackageInstaller:
             raise NotImplementedError("Installing sources is not implemented")
         elif keep_prefix:
             raise NotImplementedError("Keeping install prefixes is not implemented")
-        elif not restage:
-            raise NotImplementedError("Restaging builds is not implemented")
         elif stop_at is not None:
             raise NotImplementedError("Stopping at an install phase is not implemented")
         elif stop_before is not None:

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -142,7 +142,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
     spack.store.STORE.failure_tracker.clear(s, True)
 
     s.package.set_install_succeed()
-    PackageInstaller([s.package], explicit=True, restage=True).install()
+    PackageInstaller([s.package], explicit=True).install()
     assert rm_prefix_checker.removed
     assert s.package.spec.installed
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -625,7 +625,7 @@ def test_prepare_for_install_on_installed(install_mockery, monkeypatch):
     installer = create_installer(["dependent-install"], {})
     request = installer.build_requests[0]
 
-    install_args = {"keep_prefix": True, "keep_stage": True, "restage": False}
+    install_args = {"keep_prefix": True, "keep_stage": True}
     task = create_build_task(request.pkg, install_args)
     installer.installed.add(task.pkg_id)
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2103,7 +2103,7 @@ complete -c spack -n '__fish_spack_using_command install' -l keep-prefix -d 'don
 complete -c spack -n '__fish_spack_using_command install' -l keep-stage -f -a keep_stage
 complete -c spack -n '__fish_spack_using_command install' -l keep-stage -d 'don'"'"'t remove the build stage if installation succeeds'
 complete -c spack -n '__fish_spack_using_command install' -l dont-restage -f -a dont_restage
-complete -c spack -n '__fish_spack_using_command install' -l dont-restage -d 'if a partial install is detected, don'"'"'t delete prior state'
+complete -c spack -n '__fish_spack_using_command install' -l dont-restage -d 'deprecated option (no longer has any effect; restaging is always performed)'
 complete -c spack -n '__fish_spack_using_command install' -l use-cache -f -a use_cache
 complete -c spack -n '__fish_spack_using_command install' -l use-cache -d 'check for pre-built Spack packages in mirrors (default)'
 complete -c spack -n '__fish_spack_using_command install' -l no-cache -f -a use_cache


### PR DESCRIPTION
Since 2017 restaging is the default, and --dont-restage was added
for backwards compatibility. In my opinion --dont-restage is now
redundant, and can be made a no-op in the upcoming release
already as it violates the invariant that the DAG hash reflects the
source code. Users can use `spack develop` to make changes to
the sources instead.

Changes:
- Remove 'restage' parameter from `PackageInstaller.__init__()` in both
  installer.py and `new_installer.py`
- Remove restage from `install_args` dictionary and BuildRequest defaults
- Remove self.restage attribute from BuildProcessInstaller
- Update `test_prepare_for_install_on_installed` to remove restage
  parameter
- The --dont-restage flag remains as a deprecated no-op with warning

This also makes the new installer closer to the default installer in behavior.