### PR TITLE
stage.py: simplify restage

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -50,7 +50,6 @@ def install_kwargs_from_args(args):
         "fail_fast": args.fail_fast,
         "keep_prefix": args.keep_prefix,
         "keep_stage": args.keep_stage,
-        "restage": not args.dont_restage,
         "install_source": args.install_source,
         "verbose": args.verbose or args.install_verbose,
         "fake": args.fake,
@@ -109,7 +108,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "--dont-restage",
         action="store_true",
-        help="if a partial install is detected, don't delete prior state",
+        help="deprecated option (no longer has any effect; restaging is always performed)",
     )
 
     cache_group = subparser.add_mutually_exclusive_group()
@@ -306,6 +305,13 @@ def _die_require_env():
 def install(parser, args):
     # TODO: unify args.verbose?
     tty.set_verbose(args.verbose or args.install_verbose)
+
+    if args.dont_restage:
+        tty.warn(
+            "The '--dont-restage' option is deprecated and will be removed in Spack v1.3.0. "
+            "Use 'spack develop' for packages where you want to preserve manual modifications to "
+            "source code."
+        )
 
     if args.help_cdash:
         arguments.print_cdash_help()

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -127,12 +127,6 @@ class FetchStrategy:
     def expand(self):
         """Expand the downloaded archive into the stage source path."""
 
-    def reset(self):
-        """Revert to freshly downloaded state.
-
-        For archive files, this may just re-expand the archive.
-        """
-
     def archive(self, destination):
         """Create an archive of the downloaded data for a mirror.
 
@@ -583,26 +577,6 @@ class URLFetchStrategy(FetchStrategy):
 
         verify_checksum(self.archive_file, self.digest, self.url, self._effective_url)
 
-    @_needs_stage
-    def reset(self):
-        """
-        Removes the source path if it exists, then re-expands the archive.
-        """
-        if not self.archive_file:
-            raise NoArchiveFileError(
-                f"Tried to reset {self.__class__.__name__} before fetching",
-                f"Failed on reset() for URL{self.url}",
-            )
-
-        # Remove everything but the archive from the stage
-        for filename in os.listdir(self.stage.path):
-            abspath = os.path.join(self.stage.path, filename)
-            if abspath != self.archive_file:
-                shutil.rmtree(abspath, ignore_errors=True)
-
-        # Expand the archive again
-        self.expand()
-
     def __repr__(self):
         return f"{self.__class__.__name__}<{self.url}>"
 
@@ -785,11 +759,6 @@ class GoFetchStrategy(VCSFetchStrategy):
         # Move the directory to the well-known stage source path
         repo_root = _ensure_one_stage_entry(self.stage.path)
         shutil.move(repo_root, self.stage.source_path)
-
-    @_needs_stage
-    def reset(self):
-        with working_dir(self.stage.source_path):
-            self.go("clean")
 
     def __str__(self):
         return "[go] %s" % self.url
@@ -1140,18 +1109,6 @@ class GitFetchStrategy(VCSFetchStrategy):
                     args.insert(1, "--quiet")
                 git(*args)
 
-    @_needs_stage
-    def reset(self):
-        with working_dir(self.stage.source_path):
-            co_args = ["checkout", "."]
-            clean_args = ["clean", "-f"]
-            if spack.config.get("config:debug"):
-                co_args.insert(1, "--quiet")
-                clean_args.insert(1, "--quiet")
-
-            self.git(*co_args)
-            self.git(*clean_args)
-
     def protocol_supports_shallow_clone(self):
         """Shallow clone operations (``--depth #``) are not supported by the basic
         HTTP protocol or by no-protocol file specifications.
@@ -1270,12 +1227,6 @@ class CvsFetchStrategy(VCSFetchStrategy):
     def archive(self, destination):
         super().archive(destination, exclude="CVS")
 
-    @_needs_stage
-    def reset(self):
-        self._remove_untracked_files()
-        with working_dir(self.stage.source_path):
-            self.cvs("update", "-C", ".")
-
     def __str__(self):
         return "[cvs] %s" % self.url
 
@@ -1362,12 +1313,6 @@ class SvnFetchStrategy(VCSFetchStrategy):
 
     def archive(self, destination):
         super().archive(destination, exclude=".svn")
-
-    @_needs_stage
-    def reset(self):
-        self._remove_untracked_files()
-        with working_dir(self.stage.source_path):
-            self.svn("revert", ".", "-R")
 
     def __str__(self):
         return "[svn] %s" % self.url
@@ -1465,21 +1410,6 @@ class HgFetchStrategy(VCSFetchStrategy):
 
     def archive(self, destination):
         super().archive(destination, exclude=".hg")
-
-    @_needs_stage
-    def reset(self):
-        with working_dir(self.stage.path):
-            source_path = self.stage.source_path
-            scrubbed = "scrubbed-source-tmp"
-
-            args = ["clone"]
-            if self.revision:
-                args += ["-r", self.revision]
-            args += [source_path, scrubbed]
-            self.hg(*args)
-
-            shutil.rmtree(source_path, ignore_errors=True)
-            shutil.move(scrubbed, source_path)
 
     def __str__(self):
         return f"[hg] {self.url}"

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -796,7 +796,6 @@ class BuildRequest:
             ("root_policy", "auto"),
             ("keep_prefix", False),
             ("keep_stage", False),
-            ("restage", False),
             ("skip_patch", False),
             ("tests", False),
             ("unsigned", None),
@@ -1469,7 +1468,6 @@ class PackageInstaller:
         install_source: bool = False,
         keep_prefix: bool = False,
         keep_stage: bool = False,
-        restage: bool = False,
         skip_patch: bool = False,
         stop_at: Optional[str] = None,
         stop_before: Optional[str] = None,
@@ -1494,7 +1492,6 @@ class PackageInstaller:
             keep_prefix: Keep install prefix on failure. By default, destroys it.
             keep_stage: By default, stage is destroyed only if there are no exceptions during
                 build. Set to True to keep the stage even with exceptions.
-            restage: Force spack to restage the package source.
             skip_patch: Skip patch stage of build if True.
             stop_before: stop execution before this installation phase (or None)
             stop_at: last installation phase to be executed (or None)
@@ -1532,7 +1529,6 @@ class PackageInstaller:
             "keep_stage": keep_stage,
             "overwrite": overwrite or [],
             "root_policy": root_policy,
-            "restage": restage,
             "skip_patch": skip_patch,
             "stop_at": stop_at,
             "stop_before": stop_before,
@@ -2584,8 +2580,7 @@ class BuildProcessInstaller:
         # a --destroy-stage option), so we can override a default choice
         # to destroy
         self.keep_stage = is_develop or install_args.get("keep_stage", False)
-        # whether to restage
-        self.restage = (not is_develop) and install_args.get("restage", False)
+        self.restage = not is_develop
 
         # whether to skip the patch phase
         self.skip_patch = install_args.get("skip_patch", False)

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1085,7 +1085,6 @@ class PackageInstaller:
         install_source: bool = False,
         keep_prefix: bool = False,
         keep_stage: bool = False,
-        restage: bool = True,
         skip_patch: bool = False,
         stop_at: Optional[str] = None,
         stop_before: Optional[str] = None,
@@ -1108,8 +1107,6 @@ class PackageInstaller:
             raise NotImplementedError("Installing sources is not implemented")
         elif keep_prefix:
             raise NotImplementedError("Keeping install prefixes is not implemented")
-        elif not restage:
-            raise NotImplementedError("Restaging builds is not implemented")
         elif stop_at is not None:
             raise NotImplementedError("Stopping at an install phase is not implemented")
         elif stop_before is not None:

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -662,10 +662,9 @@ class Stage(LockableStagingDir):
             tty.debug(f"Already staged {self.name} in {self.path}")
 
     def restage(self):
-        """Removes the expanded archive path if it exists, then re-expands
-        the archive.
-        """
-        self.fetcher.reset()
+        """Removes the stage directory and recreates it from scratch."""
+        self.destroy()
+        self.create()
 
     def destroy(self):
         """Removes this stage directory."""
@@ -880,7 +879,7 @@ class DevelopStage(LockableStagingDir):
         self.created = False
 
     def restage(self):
-        self.destroy()
+        """Recreate the development stage link."""
         self.create()
 
     def cache_local(self):

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -142,7 +142,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
     spack.store.STORE.failure_tracker.clear(s, True)
 
     s.package.set_install_succeed()
-    PackageInstaller([s.package], explicit=True, restage=True).install()
+    PackageInstaller([s.package], explicit=True).install()
     assert rm_prefix_checker.removed
     assert s.package.spec.installed
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -625,7 +625,7 @@ def test_prepare_for_install_on_installed(install_mockery, monkeypatch):
     installer = create_installer(["dependent-install"], {})
     request = installer.build_requests[0]
 
-    install_args = {"keep_prefix": True, "keep_stage": True, "restage": False}
+    install_args = {"keep_prefix": True, "keep_stage": True}
     task = create_build_task(request.pkg, install_args)
     installer.installed.add(task.pkg_id)
 

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -587,8 +587,13 @@ class TestStage:
 
             assert "foobar" in os.listdir(stage.source_path)
 
-            # Make sure the file is not there after restage.
+            # Make sure the stage is completely cleared after restage.
             stage.restage()
+            # After restage (destroy + create), the stage is empty
+            assert not stage.expanded
+            # Need to fetch and expand again
+            stage.fetch()
+            stage.expand_archive()
             check_fetch(stage, self.stage_name)
             assert "foobar" not in os.listdir(stage.source_path)
         check_destroy(stage, self.stage_name)

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -142,8 +142,6 @@ def test_archive_file_errors(tmp_path: pathlib.Path, mutable_config, mock_archiv
                 fetcher.archive(str(tmp_path))
             with pytest.raises(fs.NoArchiveFileError):
                 fetcher.expand()
-            with pytest.raises(fs.NoArchiveFileError):
-                fetcher.reset()
             stage.fetch()
             with pytest.raises(fs.NoDigestError):
                 fetcher.check()

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2103,7 +2103,7 @@ complete -c spack -n '__fish_spack_using_command install' -l keep-prefix -d 'don
 complete -c spack -n '__fish_spack_using_command install' -l keep-stage -f -a keep_stage
 complete -c spack -n '__fish_spack_using_command install' -l keep-stage -d 'don'"'"'t remove the build stage if installation succeeds'
 complete -c spack -n '__fish_spack_using_command install' -l dont-restage -f -a dont_restage
-complete -c spack -n '__fish_spack_using_command install' -l dont-restage -d 'if a partial install is detected, don'"'"'t delete prior state'
+complete -c spack -n '__fish_spack_using_command install' -l dont-restage -d 'deprecated option (no longer has any effect; restaging is always performed)'
 complete -c spack -n '__fish_spack_using_command install' -l use-cache -f -a use_cache
 complete -c spack -n '__fish_spack_using_command install' -l use-cache -d 'check for pre-built Spack packages in mirrors (default)'
 complete -c spack -n '__fish_spack_using_command install' -l no-cache -f -a use_cache


### PR DESCRIPTION
On top of #51604 

* restage is in general implemented as destroy() followed by create()
* for DevelopStage do not call destroy()
* remove FetchStrategy.reset(), which no longer has any call sites

This simplifies Spack staging while ensuring that DAG hashes reflect the
source code properly.

Edit: needs more work.