### PR TITLE
spec.py: improve error on patch modification

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3619,8 +3619,8 @@ class Spec:
                     except spack.error.PatchLookupError as e:
                         raise spack.error.SpecError(
                             f"{e}. This usually means the patch was modified or removed. "
-                            "To fix this, either reconcretize or use the original package "
-                            "repository"
+                            "To fix this, either reconcretize, use the original package "
+                            "repository, or clear the misc cache with spack clean -m."
                         ) from e
 
                     self._patches.append(patch)


### PR DESCRIPTION
This PR adds a hint to clear the misc cache when spack errors due to a modified patch.

While working on a patch, I encountered this error and the current message didn't help me.
I only figured this out by finding issue #45472.

Closes #45472
