### PR TITLE
[WIP] No satisfying version: faster failures

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3595,7 +3595,11 @@ class SpecBuilder:
             variant.append(value)
 
     def version(self, node, version):
-        self._specs[node].versions = vn.VersionList([vn.Version(version)])
+        try:
+            self._specs[node].versions = vn.VersionList([vn.Version(version)])
+        except:
+            import pdb; pdb.set_trace()
+            raise
 
     def node_flag(self, node, node_flag):
         self._specs[node].compiler_flags.add_flag(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3595,11 +3595,7 @@ class SpecBuilder:
             variant.append(value)
 
     def version(self, node, version):
-        try:
-            self._specs[node].versions = vn.VersionList([vn.Version(version)])
-        except:
-            import pdb; pdb.set_trace()
-            raise
+        self._specs[node].versions = vn.VersionList([vn.Version(version)])
 
     def node_flag(self, node, node_flag):
         self._specs[node].compiler_flags.add_flag(

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -575,13 +575,13 @@ impose(EffectID, node(X, Package))
 pkg_fact(PackageName, version_origin(VersionConstraint, "BadVersion")) :- 
   build(node(PackageID, PackageName)), 
   imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
-  impose(EffectID, _),
+  impose(EffectID, node(PackageID, PackageName)),
   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
 attr("version", node(PackageID, PackageName), VersionConstraint) :-
   build(node(PackageID, PackageName)), 
   imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
-  impose(EffectID, _),
+  impose(EffectID, node(PackageID, PackageName)),
   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
 % Effects of subconditions hold if the trigger holds and the

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -570,6 +570,48 @@ impose(EffectID, node(X, Package))
      trigger_condition_holds(TriggerID, node(X, Package)),
      not do_not_impose(EffectID, node(X, Package)).
 
+%error(1, "No version satisfies {0}", VersionConstraint) :- 
+%    impose(EffectID, node(PackageID, PackageName)),
+%    imposed_constraint(EffectID, "version", VersionConstraint),
+%    not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
+
+%error(1, "No versions! {0}", VersionConstraint) :- 
+%    impose(EffectID, node(PackageID, PackageName)),
+%    imposed_constraint(EffectID, "version", PackageName, VersionConstraint).
+
+%This hangs
+%error(0, "No versions! {0}", VersionConstraint) :- 
+%    imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint).
+
+%This resolves quickly
+%:- imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint).
+
+%This resolves quickly
+%:- imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+%   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
+
+%This resolves quickly
+%:- build(node(PackageID, PackageName)), 
+%  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+%  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
+
+%pkg_fact(PackageName, version_declared(VersionConstraint, 200)) :- 
+%  build(node(PackageID, PackageName)), 
+%  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+%  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
+
+%attr("version", node(PackageID, PackageName), VersionConstraint) :-
+%  build(node(PackageID, PackageName)), 
+%  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+%  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
+
+%error(1, "Impossible version mandated on {0} - {1}", PackageName, VersionConstraint) :- 
+%  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+%  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
+
+%{ attr("version", node(ID, Package), Version) : pkg_fact(Package, version_satisfies(Constraint, Version)) }
+%  :- attr("node_version_satisfies", node(ID, Package), Constraint).
+
 % Effects of subconditions hold if the trigger holds and the
 % primary condition holds
 impose(EffectID, node(X, Package))

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -572,47 +572,12 @@ impose(EffectID, node(X, Package))
      trigger_condition_holds(TriggerID, node(X, Package)),
      not do_not_impose(EffectID, node(X, Package)).
 
-%error(1, "No version satisfies {0}", VersionConstraint) :- 
-%    impose(EffectID, node(PackageID, PackageName)),
-%    imposed_constraint(EffectID, "version", VersionConstraint),
-%    not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
-
-%error(1, "No versions! {0}", VersionConstraint) :- 
-%    impose(EffectID, node(PackageID, PackageName)),
-%    imposed_constraint(EffectID, "version", PackageName, VersionConstraint).
-
-%This hangs
-%error(0, "No versions! {0}", VersionConstraint) :- 
-%    imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint).
-
-%This resolves quickly
-%:- imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint).
-
-%This resolves quickly
-%:- imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
-%   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
-
-%This resolves quickly
-%:- build(node(PackageID, PackageName)), 
-%  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
-%  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
-
-%pkg_fact(PackageName, version_declared(VersionConstraint, 200)) :- 
-%  build(node(PackageID, PackageName)), 
-%  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
-%  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
-
 pkg_fact(PackageName, version_origin(VersionConstraint, "BadVersion")) :- 
   build(node(PackageID, PackageName)), 
   imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
 attr("version", node(PackageID, PackageName), VersionConstraint) :-
-  build(node(PackageID, PackageName)), 
-  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
-  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
-
-error(1, "Impossible version mandated on {0} - {1}", PackageName, VersionConstraint) :-
   build(node(PackageID, PackageName)), 
   imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -327,11 +327,11 @@ attr("deprecated", node(ID, Package), Version) :-
 
 % I don't think this can be hit: deprecated versions are not declared if
 % they are not allowed
-error(100, "Package '{0}' needs the deprecated version '{1}', and this is not allowed", Package, Version)
-  :- deprecated_versions_not_allowed(),
-     attr("version", node(ID, Package), Version),
-     build(node(ID, Package)),
-     pkg_fact(Package, deprecated_version(Version)).
+%error(100, "Package '{0}' needs the deprecated version '{1}', and this is not allowed", Package, Version)
+%  :- deprecated_versions_not_allowed(),
+%     attr("version", node(ID, Package), Version),
+%     build(node(ID, Package)),
+%     pkg_fact(Package, deprecated_version(Version)).
 
 % we can't use a weight from an installed spec if we are building it
 % and vice-versa
@@ -602,10 +602,15 @@ impose(EffectID, node(X, Package))
 %  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
 %  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
-%attr("version", node(PackageID, PackageName), VersionConstraint) :-
-%  build(node(PackageID, PackageName)), 
-%  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
-%  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
+pkg_fact(PackageName, version_origin(VersionConstraint, "madeup")) :- 
+  build(node(PackageID, PackageName)), 
+  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
+
+attr("version", node(PackageID, PackageName), VersionConstraint) :-
+  build(node(PackageID, PackageName)), 
+  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
 %error(1, "Impossible version mandated on {0} - {1}", PackageName, VersionConstraint) :- 
 %  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -575,11 +575,13 @@ impose(EffectID, node(X, Package))
 pkg_fact(PackageName, version_origin(VersionConstraint, "BadVersion")) :- 
   build(node(PackageID, PackageName)), 
   imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+  impose(EffectID, _),
   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
 attr("version", node(PackageID, PackageName), VersionConstraint) :-
   build(node(PackageID, PackageName)), 
   imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+  impose(EffectID, _),
   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
 % Effects of subconditions hold if the trigger holds and the

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -336,7 +336,7 @@ attr("deprecated", node(ID, Package), Version) :-
 % we can't use a weight from an installed spec if we are building it
 % and vice-versa
 
-1 { allowed_versions(Version): pkg_fact(Package, version_origin(Version, Origin)),
+1 { allowed_versions(Version): real_or_simulated_version_origin(Package, Version, Origin),
     Origin != "installed"}
   :- attr("version", node(ID, Package), Version),
      build(node(ID, Package)).
@@ -572,7 +572,9 @@ impose(EffectID, node(X, Package))
      trigger_condition_holds(TriggerID, node(X, Package)),
      not do_not_impose(EffectID, node(X, Package)).
 
-pkg_fact(PackageName, version_origin(VersionConstraint, "BadVersion")) :- 
+real_or_simulated_version_origin(Package, Version, Origin) :- pkg_fact(Package, version_origin(Version, Origin)).
+
+real_or_simulated_version_origin(PackageName, VersionConstraint, "BadVersion") :-
   build(node(PackageID, PackageName)), 
   imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
   impose(EffectID, node(PackageID, PackageName)),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -325,6 +325,8 @@ attr("deprecated", node(ID, Package), Version) :-
      not external(node(ID, Package)),
      pkg_fact(Package, deprecated_version(Version)).
 
+% I don't think this can be hit: deprecated versions are not declared if
+% they are not allowed
 error(100, "Package '{0}' needs the deprecated version '{1}', and this is not allowed", Package, Version)
   :- deprecated_versions_not_allowed(),
      attr("version", node(ID, Package), Version),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -602,7 +602,7 @@ impose(EffectID, node(X, Package))
 %  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
 %  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
-pkg_fact(PackageName, version_origin(VersionConstraint, "madeup")) :- 
+pkg_fact(PackageName, version_origin(VersionConstraint, "BadVersion")) :- 
   build(node(PackageID, PackageName)), 
   imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
@@ -612,12 +612,10 @@ attr("version", node(PackageID, PackageName), VersionConstraint) :-
   imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
   not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
-%error(1, "Impossible version mandated on {0} - {1}", PackageName, VersionConstraint) :- 
-%  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
-%  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
-
-%{ attr("version", node(ID, Package), Version) : pkg_fact(Package, version_satisfies(Constraint, Version)) }
-%  :- attr("node_version_satisfies", node(ID, Package), Constraint).
+error(1, "Impossible version mandated on {0} - {1}", PackageName, VersionConstraint) :-
+  build(node(PackageID, PackageName)), 
+  imposed_constraint(EffectID, "node_version_satisfies", PackageName, VersionConstraint),
+  not pkg_fact(PackageName, version_satisfies(VersionConstraint, _)).
 
 % Effects of subconditions hold if the trigger holds and the
 % primary condition holds


### PR DESCRIPTION
See: https://github.com/spack/spack/pull/45800#issuecomment-3550594574

If a version is imposed via a constraint, but there is no satisfying version, still apply it (but generate an error)

Just generating an error in these conditions seems slow. The reported issue in the above PR appears to be addressed with this change.

TODO

- [ ] Benchmarking