### PR TITLE
fix errors due to ast removals in python 3.14

### DIFF
--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -27,7 +27,7 @@ class RemoveDocstrings(ast.NodeTransformer):
     def remove_docstring(self, node):
         def unused_string(node):
             """Criteria for unassigned body strings."""
-            return isinstance(node, ast.Expr) and isinstance(node.value, ast.Str)
+            return isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
 
         if node.body:
             node.body = [child for child in node.body if not unused_string(child)]

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -830,7 +830,7 @@ class Unparser:
         # is an integer literal then we need to either parenthesize
         # it or add an extra space to get 3 .__abs__().
         num_type = getattr(ast, "Constant", getattr(ast, "Num", None))
-        if isinstance(node.value, num_type) and isinstance(node.value.n, int):
+        if isinstance(node.value, num_type) and isinstance(node.value.value, int):
             self.write(" ")
         self.write(".")
         self.write(node.attr)


### PR DESCRIPTION
Ref: https://docs.python.org/dev/whatsnew/3.14.html#removed

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
