### PR TITLE
directives: speed up depends_on

### DIFF
--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -39,7 +39,7 @@ class Dependency:
 
     """
 
-    __slots__ = ["pkg", "spec", "patches", "depflag"]
+    __slots__ = "pkg", "spec", "patches", "depflag"
 
     def __init__(
         self,

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -2,10 +2,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Data structures that represent Spack's dependency relationships."""
-from typing import Dict, List, Type
+from typing import TYPE_CHECKING, Dict, List, Type
 
 import spack.deptypes as dt
 import spack.spec
+
+if TYPE_CHECKING:
+    import spack.package_base
+    import spack.patch
 
 
 class Dependency:
@@ -35,10 +39,12 @@ class Dependency:
 
     """
 
+    __slots__ = ["pkg", "spec", "patches", "depflag"]
+
     def __init__(
         self,
         pkg: Type["spack.package_base.PackageBase"],
-        spec: "spack.spec.Spec",
+        spec: spack.spec.Spec,
         depflag: dt.DepFlag = dt.DEFAULT,
     ):
         """Create a new Dependency.
@@ -48,33 +54,18 @@ class Dependency:
             spec: Spec indicating dependency requirements
             type: strings describing dependency relationship
         """
-        assert isinstance(spec, spack.spec.Spec)
-
         self.pkg = pkg
-        self.spec = spec.copy()
+        self.spec = spec
 
         # This dict maps condition specs to lists of Patch objects, just
         # as the patches dict on packages does.
-        self.patches: Dict[spack.spec.Spec, "List[spack.patch.Patch]"] = {}
+        self.patches: Dict[spack.spec.Spec, List["spack.patch.Patch"]] = {}
         self.depflag = depflag
 
     @property
     def name(self) -> str:
         """Get the name of the dependency package."""
         return self.spec.name
-
-    def merge(self, other: "Dependency"):
-        """Merge constraints, deptypes, and patches of other into self."""
-        self.spec.constrain(other.spec)
-        self.depflag |= other.depflag
-
-        # concatenate patch lists, or just copy them in
-        for cond, p in other.patches.items():
-            if cond in self.patches:
-                current_list = self.patches[cond]
-                current_list.extend(p for p in other.patches[cond] if p not in current_list)
-            else:
-                self.patches[cond] = other.patches[cond]
 
     def __repr__(self) -> str:
         types = dt.flag_to_chars(self.depflag)

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -314,7 +314,9 @@ def _depends_on(
         dependency = Dependency(pkg, spec, depflag=depflag)
         deps_by_name[spec.name] = dependency
     else:
-        dependency.spec.constrain(spec, deps=False)
+        copy = spec.copy()
+        copy.constrain(spec, deps=False)
+        dependency.spec = copy
         dependency.depflag |= depflag
 
     # apply patches to the dependency

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -314,7 +314,7 @@ def _depends_on(
         dependency = Dependency(pkg, spec, depflag=depflag)
         deps_by_name[spec.name] = dependency
     else:
-        copy = spec.copy()
+        copy = dependency.spec.copy()
         copy.constrain(spec, deps=False)
         dependency.spec = copy
         dependency.depflag |= depflag

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/patch_several_dependencies/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/patch_several_dependencies/package.py
@@ -22,7 +22,11 @@ class PatchSeveralDependencies(Package):
 
     # single patch file in repo
     depends_on("libelf", patches="foo.patch")
-    depends_on("libelf@0.8.10", patches="foo.patch", when="+foo")
+    # The following 3 directives are all under the same when clause, to be combined in
+    # the metadata for this package class
+    depends_on("libelf@0.8.10", patches="foo.patch", type="link", when="+foo")
+    depends_on("libelf", type="build", when="+foo")
+    depends_on("libelf@0.8:", when="+foo")
 
     # using a list of patches in one depends_on
     depends_on(
@@ -31,8 +35,8 @@ class PatchSeveralDependencies(Package):
             patch("bar.patch"),  # nested patch directive
             patch("baz.patch", when="@20111030"),  # and with a conditional
         ],
-        when="@1.0",
-    )  # with a depends_on conditional
+        when="@1.0",  # with a depends_on conditional
+    )
 
     # URL patches
     depends_on(


### PR DESCRIPTION
Copy the spec in `Dependency` only when modified.

For me this speeds up load time by about 18%: 32.4s -> 26.4s (linux x86_64), 13.5s -> 11.0s (darwin aarch)

```
time python3 -c 'import spack.repo; x = list(spack.repo.PATH.all_package_classes())'
```

Tested on a single spec, best of three, I see a ~5% improvement for "setup" phase of the solver.