### PR TITLE
solver: project `imposed_nodes/3` to `imposed_nodes/2`

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2756,7 +2756,7 @@ class SpackSolverSetup:
 
             self.gen.newline()
 
-        i = 0  # TODO compute per-target offset?
+        i = 0
         for target in candidate_targets:
             self.gen.fact(fn.target(target.name))
             self.gen.fact(fn.target_family(target.name, target.family.name))

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -587,7 +587,7 @@ imposed_packages(ID, A1) :- imposed_constraint(ID, _, A1, _, _).
 imposed_packages(ID, A1) :- imposed_constraint(ID, _, A1, _, _, _).
 imposed_packages(ID, A1) :- imposed_constraint(ID, "depends_on", _, A1, _).
 
-imposed_nodes(EffectID, node(NodeID, Package), node(X, A1))
+imposed_nodes(node(NodeID, Package), node(X, A1))
   :- trigger_and_effect(Package, TriggerID, EffectID),
      imposed_packages(EffectID, A1),
      condition_set(node(NodeID, Package), node(X, A1)),
@@ -598,21 +598,21 @@ imposed_nodes(EffectID, node(NodeID, Package), node(X, A1))
 
 self_build_requirement(node(X, Package), node(Y, Package)) :- build_requirement(node(X, Package), node(Y, Package)).
 
-imposed_nodes(ConditionID, PackageNode, node(X, A1))
+imposed_nodes(PackageNode, node(X, A1))
   :- imposed_packages(ConditionID, A1),
      condition_set(PackageNode, node(X, A1)),
      attr("hash", PackageNode, ConditionID).
 
 :- imposed_packages(ID, A1), impose(ID, PackageNode), not condition_set(PackageNode, node(_, A1)),
    internal_error("Imposing constraint outside of condition set").
-:- imposed_packages(ID, A1), impose(ID, PackageNode), not imposed_nodes(ID, PackageNode, node(_, A1)),
+:- imposed_packages(ID, A1), impose(ID, PackageNode), not imposed_nodes(PackageNode, node(_, A1)),
    internal_error("Imposing constraint outside of imposed_nodes").
 
 % Conditions that hold impose may impose constraints on other specs
-attr(Name, node(X, A1))             :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1),             imposed_nodes(ID, PackageNode, node(X, A1)).
-attr(Name, node(X, A1), A2)         :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2),         imposed_nodes(ID, PackageNode, node(X, A1)), not node_attributes_with_custom_rules(Name).
-attr(Name, node(X, A1), A2, A3)     :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3),     imposed_nodes(ID, PackageNode, node(X, A1)), not node_attributes_with_custom_rules(Name).
-attr(Name, node(X, A1), A2, A3, A4) :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3, A4), imposed_nodes(ID, PackageNode, node(X, A1)).
+attr(Name, node(X, A1))             :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1),             imposed_nodes(PackageNode, node(X, A1)).
+attr(Name, node(X, A1), A2)         :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2),         imposed_nodes(PackageNode, node(X, A1)), not node_attributes_with_custom_rules(Name).
+attr(Name, node(X, A1), A2, A3)     :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3),     imposed_nodes(PackageNode, node(X, A1)), not node_attributes_with_custom_rules(Name).
+attr(Name, node(X, A1), A2, A3, A4) :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3, A4), imposed_nodes(PackageNode, node(X, A1)).
 
 % Provider set is relevant only for literals, since it's the only place where `^[virtuals=foo] bar`
 % might appear in the HEAD of a rule
@@ -637,7 +637,7 @@ provider(ProviderNode, VirtualNode) :- attr("provider_set", ProviderNode, Virtua
 % should not make foo:=a,b,c possible
 attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
   :- impose(ID, PackageNode),
-     imposed_nodes(ID, PackageNode, node(X, A1)),
+     imposed_nodes(PackageNode, node(X, A1)),
      imposed_constraint(ID, "concrete_variant_set", A1, Variant, Value).
 
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -588,10 +588,7 @@ imposed_packages(ID, A1) :- imposed_constraint(ID, _, A1, _, _, _).
 imposed_packages(ID, A1) :- imposed_constraint(ID, "depends_on", _, A1, _).
 
 imposed_nodes(node(NodeID, Package), node(X, A1))
-  :- trigger_and_effect(Package, TriggerID, EffectID),
-     imposed_packages(EffectID, A1),
-     condition_set(node(NodeID, Package), node(X, A1)),
-     trigger_requestor_node(TriggerID, node(NodeID, Package)),
+  :- condition_set(node(NodeID, Package), node(X, A1)),
      % We don't want to add build requirements to imposed nodes, to avoid
      % unsat problems when we deal with self-dependencies: gcc@14 %gcc@10
      not self_build_requirement(node(NodeID, Package), node(X, A1)).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1826,9 +1826,9 @@ error(100, "Cannot find compatible targets for {0} and {1}", Package, Dependency
 % Intermediate step for performance reasons
 % When the integrity constraint above was formulated including this logic
 % we suffered a substantial performance penalty
-node_target_compatible(PackageNode, Target)
- :- attr("node_target", PackageNode, MyTarget),
-    target_compatible(Target, MyTarget).
+node_target_compatible(ChildNode, ParentTarget)
+ :- attr("node_target", ChildNode, ChildTarget),
+    target_compatible(ParentTarget, ChildTarget).
 
 #defined target_satisfies/2.
 compiler(Compiler) :- target_supported(Compiler, _, _).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1804,7 +1804,7 @@ attr("node_os", PackageNode, OS) :- attr("node_os_set", PackageNode, OS), attr("
 %-----------------------------------------------------------------------------
 
 % Each node has only one target chosen among the known targets
-{ attr("node_target", PackageNode, Target) : target(Target) } :- attr("node", PackageNode).
+1 { attr("node_target", PackageNode, Target) : target(Target) } 1 :- attr("node", PackageNode).
 
 % If a node must satisfy a target constraint, enforce it
 error(10, "'{0} target={1}' cannot satisfy constraint 'target={2}'", Package, Target, Constraint)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2137,7 +2137,7 @@ opt_criterion(48, "preferred providers (non-roots)").
 
 compiler_penalty(PackageNode, C-1) :-
    C = #count { CompilerNode : node_compiler(PackageNode, CompilerNode) },
-   node_compiler(PackageNode, _).
+   node_compiler(PackageNode, _), C > 0.
 
 opt_criterion(46, "number of compilers used on the same node").
 #minimize{ 0@246: #true }.

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -46,7 +46,7 @@
 #show provider/2.
 #show condition_nodes/2.
 #show trigger_node/3.
-#show imposed_nodes/3.
+#show imposed_nodes/2.
 #show variant_single_value/2.
 
 % debug

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -30,7 +30,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, Name, Package),
-  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
+  imposed_nodes(node(ID1, Package1), node(ID, Package)).
 
 condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
@@ -41,7 +41,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, Name, Package, A1),
-  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
+  imposed_nodes(node(ID1, Package1), node(ID, Package)).
 
 condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
@@ -52,7 +52,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, Name, Package, A1, A2),
-  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
+  imposed_nodes(node(ID1, Package1), node(ID, Package)).
 
 condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
@@ -63,7 +63,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, Name, Package, A1, A2, A3),
-  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
+  imposed_nodes(node(ID1, Package1), node(ID, Package)).
 
 % special condition cause for dependency conditions
 % we can't simply impose the existence of the node for dependency conditions
@@ -77,7 +77,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, "dependency_holds", Parent, Package, Type),
-  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)),
+  imposed_nodes(node(ID1, Package1), node(ID, Package)),
   attr("depends_on", node(X, Parent), node(ID, Package), Type).
 
 % The literal startcauses is used to separate the variables that are part of the error from the


### PR DESCRIPTION
Project out the EffectID from the current facts to remove redundancy in the encoding.

This is probably worth doing for consistentcy, but it's not a huge improvement:

[radiuss.develop.csv](https://github.com/user-attachments/files/23722670/radiuss.develop.csv)
[radiuss.pr.csv](https://github.com/user-attachments/files/23722673/radiuss.pr.csv)

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/6bad9ec0-0a0e-48eb-b56b-82c3c7f92c4a" />



<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
