### PR TITLE
asp.py: do not sort pkg.dependencies and versions

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2782,8 +2782,8 @@ class SpackSolverSetup:
     def define_version_constraints(self):
         """Define what version_satisfies(...) means in ASP logic."""
 
-        for pkg_name, versions in sorted(self.possible_versions.items()):
-            for v in sorted(versions):
+        for pkg_name, versions in self.possible_versions.items():
+            for v in versions:
                 if v in self.git_commit_versions[pkg_name]:
                     sha = self.git_commit_versions[pkg_name].get(v)
                     if sha:
@@ -2792,11 +2792,12 @@ class SpackSolverSetup:
                         self.gen.fact(fn.pkg_fact(pkg_name, fn.version_needs_commit(v)))
         self.gen.newline()
 
-        for pkg_name, versions in sorted(self.version_constraints):
+        for pkg_name, versions in self.version_constraints:
             # generate facts for each package constraint and the version
             # that satisfies it
-            for v in sorted(v for v in self.possible_versions[pkg_name] if v.satisfies(versions)):
-                self.gen.fact(fn.pkg_fact(pkg_name, fn.version_satisfies(versions, v)))
+            for v in self.possible_versions[pkg_name]:
+                if v.satisfies(versions):
+                    self.gen.fact(fn.pkg_fact(pkg_name, fn.version_satisfies(versions, v)))
             self.gen.newline()
 
     def collect_virtual_constraints(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1957,8 +1957,8 @@ class SpackSolverSetup:
                 return result
             return result + [fn.attr("extends", pkg.name, input_spec.name)]
 
-        for cond, deps_by_name in sorted(pkg.dependencies.items()):
-            for _, dep in sorted(deps_by_name.items()):
+        for cond, deps_by_name in pkg.dependencies.items():
+            for _, dep in deps_by_name.items():
                 depflag = dep.depflag
                 # Skip test dependencies if they're not requested
                 if not self.tests:


### PR DESCRIPTION
Currently there's an inconsistency between `package_dependencies_rules` and `conflict_rules`.

The former runs `sorted(...)` on `pkg.dependencies`, the latter does not on `pkg.conflicts`.

I think dropping the sort is better, cause (A) it's faster, and (B) as far as I can see not needed for the concretizer cache and deterministic performance.

The concretization cache and deterministic performance works by running sort on all facts as strings before looking in the cache and running clingo (after "setup", the section is named "ordering"). The only variable in this is `condition_id` which is a global counter. But this is also deterministic because we have a deterministic order on the packages (sorted by name), and the `pkg.dependencies` and `pkg.conflicts` dictionaries only depend on the order of directives in package.py files.

The second change in this PR is not sorting versions. This sorting is taken care of when sorting all facts already, and sorting strings is faster than sorting version objects.

This gives about 5-6% speedup in the setup phase of the concretizer.
