### PR TITLE
Bugfix: List the component prefix not the root

### DIFF
--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -45,7 +45,7 @@ def _fetch_manifests(
              callable to read each manifest, and a list of blobs in the mirror.
     """
     manifest_file_to_mtime_mapping, read_fn = get_entries_from_cache(
-        url=mirror.fetch_url, tmpspecsdir=tmpspecsdir
+        mirror.fetch_url, tmpspecsdir, BuildcacheComponent.MANIFEST
     )
     url_to_list = url_util.join(
         mirror.fetch_url, spack.binary_distribution.buildcache_relative_blobs_path()
@@ -74,7 +74,9 @@ def _delete_manifests_from_cache_aws(
 
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
 
-    include_pattern = cache_class.get_buildcache_component_include_pattern()
+    include_pattern = cache_class.get_buildcache_component_include_pattern(
+        BuildcacheComponent.MANIFEST
+    )
 
     file_count_before_deletion = len(list(pathlib.Path(tmpspecsdir).rglob(include_pattern)))
 

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -44,6 +44,7 @@ from spack.url_buildcache import (
     URLBuildcacheEntry,
     URLBuildcacheEntryV2,
     compression_writer,
+    get_entries_from_cache,
     get_url_buildcache_class,
     get_valid_spec_file,
 )
@@ -1320,3 +1321,41 @@ def test_default_index_not_modified(mock_index):
 
     assert fetcher.conditional_fetch().fresh
     assert not mock_index.fetched_blob()
+
+
+@pytest.mark.usefixtures("install_mockery", "mock_packages")
+def test_get_entries_from_cache_nested_mirrors(monkeypatch, tmp_path: pathlib.Path):
+    """Make sure URLBuildcacheEntry behaves as expected"""
+
+    # Create a temp mirror directory for buildcache usage
+    mirror_dir = tmp_path / "mirror_dir"
+    mirror_url = url_util.path_to_file_url(str(mirror_dir))
+
+    # Install and push libdwarf to the root mirror
+    s = spack.concretize.concretize_one("libdwarf")
+    install_cmd("--fake", s.name)
+    buildcache_cmd("push", "-u", str(mirror_dir), s.name)
+
+    # Install and push libzlib to the nested mirror
+    s = spack.concretize.concretize_one("zlib")
+    install_cmd("--fake", s.name)
+    buildcache_cmd("push", "-u", str(mirror_dir / "nested"), s.name)
+
+    spec_manifests, _ = get_entries_from_cache(
+        str(mirror_url), str(tmp_path / "stage"), BuildcacheComponent.SPEC
+    )
+
+    nested_mirror_url = url_util.path_to_file_url(str(mirror_dir / "nested"))
+    spec_manifests_nested, _ = get_entries_from_cache(
+        str(nested_mirror_url), str(tmp_path / "stage"), BuildcacheComponent.SPEC
+    )
+
+    # Expected specs in root mirror
+    #   - gcc-runtime
+    #   - compiler-wrapper
+    #   - libelf
+    #   - libdwarf
+    assert len(spec_manifests) == 4
+    # Expected specs in nested mirror
+    #   - zlib
+    assert len(spec_manifests_nested) == 1


### PR DESCRIPTION
Recursively listing a buildcache from the root will result in finding components in other buildcaches that may also exist under that same root. This can lead to degraded performance and errors for many build cache operations.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
