### PR TITLE
provider_index.py: speed up providers_for

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -360,7 +360,6 @@ nitpick_ignore = [
     ("py:class", "concurrent.futures._base.Executor"),
     ("py:class", "multiprocessing.context.Process"),
     # Spack classes that are private and we don't want to expose
-    ("py:class", "spack.provider_index._IndexBase"),
     ("py:class", "spack.repo._PrependFileLoader"),
     ("py:class", "spack_repo.builtin.build_systems._checks.BuilderWithDefaults"),
     # Spack classes that intersphinx is unable to resolve

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -813,7 +813,7 @@ class RepoPath:
             if spec.name in all_packages
         ]
         if not providers:
-            raise UnknownPackageError(virtual if isinstance(virtual, str) else virtual.name)
+            raise UnknownPackageError(virtual if isinstance(virtual, str) else virtual.fullname)
         return providers
 
     @autospec
@@ -1278,11 +1278,10 @@ class Repo:
         """Index of patches and packages they're defined on."""
         return self.index["patches"]
 
-    @autospec
-    def providers_for(self, vpkg_spec: "spack.spec.Spec") -> List["spack.spec.Spec"]:
-        providers = self.provider_index.providers_for(vpkg_spec)
+    def providers_for(self, virtual: Union[str, "spack.spec.Spec"]) -> List["spack.spec.Spec"]:
+        providers = self.provider_index.providers_for(virtual)
         if not providers:
-            raise UnknownPackageError(vpkg_spec.fullname)
+            raise UnknownPackageError(virtual if isinstance(virtual, str) else virtual.fullname)
         return providers
 
     @autospec

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -805,15 +805,15 @@ class RepoPath:
                 self._patch_index.update(repo.patch_index)
         return self._patch_index
 
-    @autospec
-    def providers_for(self, virtual_spec: "spack.spec.Spec") -> List["spack.spec.Spec"]:
+    def providers_for(self, virtual: Union[str, "spack.spec.Spec"]) -> List["spack.spec.Spec"]:
+        all_packages = self._all_package_names_set(include_virtuals=False)
         providers = [
             spec
-            for spec in self.provider_index.providers_for(virtual_spec)
-            if spec.name in self._all_package_names_set(include_virtuals=False)
+            for spec in self.provider_index.providers_for(virtual)
+            if spec.name in all_packages
         ]
         if not providers:
-            raise UnknownPackageError(virtual_spec.fullname)
+            raise UnknownPackageError(virtual if isinstance(virtual, str) else virtual.name)
         return providers
 
     @autospec


### PR DESCRIPTION
This change optimizes the `providers_for` call so it runs 150x faster, leading
to another 8-9% reduction in "setup" time of the solver.

The optimization is the following:

* Do not convert from `str` to `Spec` when the virtual is just a package name
  (checked with `.isalnum()`). This avoids running the slow Spec parser. We
   don't really have to know if the package name is really valid because of the
   check against the dictionary with package names next; just have to rule out
   version, variant, and other symbols.
* If the input is just a package name, avoid running `intersects`, since that's
  always true.
* Do not sort the list of providers, but let the call site do this. In the
  solver, this is not needed, and would be pure overhead. Other call sites
   like the `spack providers` command already had their own sort call.

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/a5de8cef-9a85-4abd-830d-cc4a91dfdfab" />
