### PR TITLE
new_installer.py: implement spack install -pN

### DIFF
--- a/etc/spack/defaults/base/config.yaml
+++ b/etc/spack/defaults/base/config.yaml
@@ -150,28 +150,20 @@ config:
   # If set to 'urllib', Spack will use python built-in libs to fetch
   url_fetch_method: urllib
 
-  # The maximum number of jobs to use for the build system (e.g. `make`), when
-  # the -j flag is not given on the command line. Defaults to 16 when not set.
-  # Note that the maximum number of jobs is limited by the number of cores
-  # available, taking thread affinity into account when supported.
-  # For instance:
-  # - With `build_jobs: 16` and 4 cores available `spack install` will run `make -j4`
-  # - With `build_jobs: 16` and 32 cores available `spack install` will run `make -j16`
-  # - With `build_jobs: 2` and 4 cores available `spack install -j6` will run `make -j6`
+  # The maximum number of jobs to use for the build. When using the old
+  # installer, this is the number of jobs per package. In the new installer,
+  # this is the global maximum number of jobs across all packages. When fewer
+  # cores are available, Spack will use fewer jobs. The `-j` command line
+  # argument overrides this option.
   build_jobs: 16
 
-  # The maximum number of concurrent package builds a single Spack instance will run,
-  # when the `-p` / `--concurrent-packages`  flag is not given on the command line.
-  # Defaults to 1 when not set.
-  # Generally, big builds like LLVM are going to perform better with a higher -j, and
-  # builds with lots of dependencies may build better with higher -p. It is currently
-  # up to the user to balance between -j (build_jobs) and -p (concurrent_packages)
-  # on `spack install`, but this will be less of an issue in the future when we
-  # introduce support for the gmake job server and allow more dynamic parallelism.
-  # This, like `build_jobs`, is also limited by available cores.
-  # Note: This option has no effect on windows, as parallel builds are disabled on
-  # windows due to a lack of filesystem locks.
-  concurrent_packages: 1
+  # The maximum number of concurrent package builds a single Spack process
+  # will perform. The default value of 0 means no package parallelism when using
+  # the old installer, and unlimited package parallelism (other than the limit
+  # set by build_jobs) when using the new installer. Setting this to 1 will
+  # disable package parallelism in both installers. This option is ignored on
+  # Windows.
+  concurrent_packages: 0
 
   # Which installer to use: "old" or "new". The new installer is experimental.
   installer: old

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1528,8 +1528,11 @@ class PackageInstaller:
             explicit = {pkg.spec.dag_hash() for pkg in packages} if explicit else set()
 
         if concurrent_packages is None:
-            concurrent_packages = int(spack.config.get("config:concurrent_packages", default=1))
-        self.concurrent_packages = max(1, concurrent_packages)
+            concurrent_packages = spack.config.get("config:concurrent_packages", default=1)
+        # The value 0 means no concurrency in the old installer.
+        if concurrent_packages == 0:
+            concurrent_packages = 1
+        self.concurrent_packages = concurrent_packages
 
         install_args = {
             "dependencies_policy": dependencies_policy,

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1233,7 +1233,6 @@ class PackageInstaller:
             raise NotImplementedError("Stopping before an install phase is not implemented")
         elif tests is not False:
             raise NotImplementedError("Tests during install are not implemented")
-        # verbose and concurrent_packages are not worth erroring out for
 
         specs = [pkg.spec for pkg in packages]
 
@@ -1286,6 +1285,15 @@ class PackageInstaller:
         self.running_builds: Dict[int, ChildInfo] = {}
         self.build_status = BuildStatus(len(self.build_graph.nodes))
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
+        if concurrent_packages is None:
+            concurrent_packages_config = spack.config.get("config:concurrent_packages", 0)
+            # The value 0 in config means no limit (other than self.jobs)
+            if concurrent_packages_config == 0:
+                self.capacity = sys.maxsize
+            else:
+                self.capacity = concurrent_packages_config
+        else:
+            self.capacity = concurrent_packages
         self.reports: Dict[str, spack.report.RequestRecord] = {}
 
     def install(self) -> None:
@@ -1329,10 +1337,11 @@ class PackageInstaller:
                 self._start(selector, jobserver)
 
             while self.pending_builds or self.running_builds or to_insert_in_database:
-                # Only monitor the jobserver if we have pending builds.
-                if self.pending_builds and jobserver.r not in selector.get_map():
+                # Only monitor the jobserver if we have pending builds and capacity.
+                can_schedule_more = self.pending_builds and self.capacity > 0
+                if can_schedule_more and jobserver.r not in selector.get_map():
                     selector.register(jobserver.r, selectors.EVENT_READ, "jobserver")
-                elif not self.pending_builds and jobserver.r in selector.get_map():
+                elif not can_schedule_more and jobserver.r in selector.get_map():
                     selector.unregister(jobserver.r)
 
                 jobserver_token_available = False
@@ -1360,6 +1369,7 @@ class PackageInstaller:
 
                 for pid in finished_pids:
                     build = self.running_builds.pop(pid)
+                    self.capacity += 1
                     jobserver.release()
                     build.cleanup(selector)
                     if build.proc.exitcode == 0:
@@ -1400,10 +1410,11 @@ class PackageInstaller:
                     self._start(selector, jobserver)
 
                 # For the rest we try to obtain tokens from the jobserver.
-                if self.pending_builds and jobserver_token_available:
-                    # Then we try to schedule as many jobs as we can acquire tokens for.
-                    max_new_jobs = len(self.pending_builds)
-                    for _ in range(jobserver.acquire(max_new_jobs)):
+                if self.pending_builds and self.capacity > 0 and jobserver_token_available:
+                    # Schedule as many jobs as we can acquire tokens for.
+                    max_new_jobs = min(len(self.pending_builds), self.capacity)
+                    num_acquired = jobserver.acquire(max_new_jobs)
+                    for _ in range(num_acquired):
                         self._start(selector, jobserver)
 
                 # Finally update the UI
@@ -1447,6 +1458,7 @@ class PackageInstaller:
             db.lock.release_write(db._write)
 
     def _start(self, selector: selectors.BaseSelector, jobserver: JobServer) -> None:
+        self.capacity -= 1
         dag_hash = self.pending_builds.pop()
         explicit = dag_hash in self.explicit
         spec = self.build_graph.nodes[dag_hash]

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -12,7 +12,8 @@ if sys.platform == "win32":
     pytest.skip("No Windows support", allow_module_level=True)
 
 import spack.error
-from spack.new_installer import OVERWRITE_GARBAGE_SUFFIX, PrefixPivoter
+import spack.spec
+from spack.new_installer import OVERWRITE_GARBAGE_SUFFIX, PackageInstaller, PrefixPivoter
 
 
 @pytest.fixture
@@ -199,3 +200,30 @@ class TestPrefixPivoterFailureRecovery:
         assert (existing_prefix / "partial_file").exists()
         # Backup directory, failed prefix, and empty garbage directory should exist
         assert len(list(tmp_path.iterdir())) == 3
+
+
+class TestPackageInstallerConstructor:
+    """Tests for PackageInstaller constructor, especially capacity initialization."""
+
+    def test_capacity_explicit_concurrent_packages(self, temporary_store, mock_packages):
+        """Test that capacity is set correctly when concurrent_packages is explicitly provided."""
+        spec = spack.spec.Spec("trivial-install-test-package")
+        spec._mark_concrete()
+        assert PackageInstaller([spec.package], concurrent_packages=5).capacity == 5
+        assert PackageInstaller([spec.package], concurrent_packages=1).capacity == 1
+
+    def test_capacity_from_config_default_one(
+        self, temporary_store, mock_packages, mutable_config
+    ):
+        """Test that config value of 0 is treated as unlimited."""
+        mutable_config.set("config:concurrent_packages", 0)
+        spec = spack.spec.Spec("trivial-install-test-package")
+        spec._mark_concrete()
+        assert PackageInstaller([spec.package]).capacity == sys.maxsize
+
+    def test_capacity_from_config_non_zero(self, temporary_store, mock_packages, mutable_config):
+        """Test that non-0 config values are used as-is."""
+        mutable_config.set("config:concurrent_packages", 1)
+        spec = spack.spec.Spec("trivial-install-test-package")
+        spec._mark_concrete()
+        assert PackageInstaller([spec.package]).capacity == 1


### PR DESCRIPTION
Closes #51633 

In the new installer, `-j` is a global number of jobs shared by
concurrent package builds. The `-p` flag was so far not implemented, and
parallelism was effectively only limited by `-j`.

Sometimes though, it's useful to limit the number of concurrent package
builds when disk space in the stage dir is limited, or concurrent
fetching is undesirable.

With this change, package concurrency can be limited with `-pN`, while
keeping the CPU load (managed by `-j`) constant. (In an ideal world).

Tests can be added after #51622 is merged.
