### PR TITLE
Cache lookup of compilers

### DIFF
--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -41,8 +41,15 @@ def _select_best_version(
     node.versions.versions = [spack.version.from_string(f"={best_version}")]
 
 
+def _add_compilers_if_missing() -> None:
+    arch = spack.spec.ArchSpec.default_arch()
+    if not spack.compilers.config.compilers_for_arch(arch):
+        spack.compilers.config.find_compilers()
+
+
 class ClingoBootstrapConcretizer:
     def __init__(self, configuration):
+        _add_compilers_if_missing()
         self.host_platform = spack.platforms.host()
         self.host_os = self.host_platform.default_operating_system()
         self.host_target = spack.vendor.archspec.cpu.host().family

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -8,14 +8,12 @@ import os
 import sys
 from typing import Any, Dict, Generator, MutableSequence, Sequence
 
-import spack.compilers.config
 import spack.config
 import spack.environment
 import spack.modules
 import spack.paths
 import spack.platforms
 import spack.repo
-import spack.spec
 import spack.store
 import spack.util.path
 from spack.llnl.util import tty
@@ -138,12 +136,6 @@ def _bootstrap_config_scopes() -> Sequence["spack.config.ConfigScope"]:
     return config_scopes
 
 
-def _add_compilers_if_missing() -> None:
-    arch = spack.spec.ArchSpec.default_arch()
-    if not spack.compilers.config.compilers_for_arch(arch):
-        spack.compilers.config.find_compilers()
-
-
 @contextlib.contextmanager
 def _ensure_bootstrap_configuration() -> Generator:
     spack.repo.PATH.repos  # ensure this is instantiated from current config.
@@ -161,8 +153,5 @@ def _ensure_bootstrap_configuration() -> Generator:
         spack.config.set("bootstrap", user_configuration["bootstrap"])
         spack.config.set("config", user_configuration["config"])
         spack.config.set("repos", user_configuration["repos"])
-        # We may need to compile code from sources, so ensure we
-        # have compilers for the current platform
-        _add_compilers_if_missing()
         with spack.modules.disable_modules(), spack_python_interpreter():
             yield

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -254,14 +254,30 @@ def name_os_target(spec: spack.spec.Spec) -> Tuple[str, str, str]:
 class CompilerFactory:
     """Class aggregating all ways of constructing a list of compiler specs from config entries."""
 
+    # Cache of compilers parsed from packages.yaml
+    _packages_yaml_cache: Dict[bytes, List[spack.spec.Spec]] = {}
+
+    @staticmethod
+    def clear_cache() -> None:
+        CompilerFactory._packages_yaml_cache.clear()
+
     @staticmethod
     def from_packages_yaml(
         configuration: spack.config.Configuration, *, scope: Optional[str] = None
     ) -> List[spack.spec.Spec]:
         """Returns the compiler specs defined in the "packages" section of the configuration"""
+        key = None
+        # Fast path for the most common case of retrieving the compilers from the merged scopes
+        if scope is None:
+            key = configuration.ensure_unwrapped().content_hash(
+                sections=["packages", "concretizer", "repos"]
+            )
+            if key in CompilerFactory._packages_yaml_cache:
+                return CompilerFactory._packages_yaml_cache[key]
+
         externals_dicts = []
         compiler_package_names = supported_compilers()
-        packages_yaml = configuration.get("packages", scope=scope)
+        packages_yaml = configuration.deepcopy_as_builtin("packages", scope=scope)
         for name, entry in packages_yaml.items():
             if name not in compiler_package_names:
                 continue
@@ -280,6 +296,8 @@ class CompilerFactory:
                 externals_dicts.append(current)
 
         external_parser = ExternalSpecsParser(externals_dicts)
+        if key is not None:
+            CompilerFactory._packages_yaml_cache[key] = external_parser.all_specs()
         return external_parser.all_specs()
 
     @staticmethod

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -29,6 +29,8 @@ schemas are in submodules of :py:mod:`spack.schema`.
 import contextlib
 import copy
 import functools
+import hashlib
+import json
 import os
 import os.path
 import pathlib
@@ -720,6 +722,25 @@ class Configuration:
         return syaml.deepcopy_as_builtin(
             self.get_config(section, scope=scope), line_info=line_info
         )
+
+    def content_hash(
+        self, *, sections: Optional[List[str]] = None, scope: Optional[str] = None
+    ) -> bytes:
+        """Return the hash of the current config content.
+
+        Args:
+            sections: list of sections to include in the hash. If None or empty,
+                all sections are included.
+            scope: scope to include in the hash. If None, the entire merged config is considered.
+        """
+        hasher = hashlib.sha256()
+        selected = [x for x in SECTION_SCHEMAS if x in sections] if sections else SECTION_SCHEMAS
+        for config_section in selected:
+            part = json.dumps(
+                self.deepcopy_as_builtin(config_section, scope=scope), sort_keys=True
+            )
+            hasher.update(part.encode("utf-8"))
+        return hasher.digest()
 
     def _filter_overridden(self, scopes: List[ConfigScope]):
         """Filter out overridden scopes.

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -25,6 +25,7 @@ import spack.archspec
 import spack.deptypes
 import spack.repo
 import spack.spec
+import spack.util.spack_yaml as syaml
 from spack.error import SpackError
 from spack.llnl.util import tty
 
@@ -128,7 +129,11 @@ def extract_dicts_from_configuration(packages_yaml) -> List[ExternalDict]:
     if "all" in packages_yaml:
         default_required_target = _required_target(packages_yaml["all"])
 
-    for name, entry in packages_yaml.items():
+    for pkg_name in packages_yaml:
+        if "externals" not in packages_yaml[pkg_name]:
+            continue
+
+        entry = syaml.deepcopy_as_builtin(packages_yaml[pkg_name])
         pkg_required_target = _required_target(entry) or default_required_target
         partial_result = [current for current in entry.get("externals", [])]
         if pkg_required_target:

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -284,26 +284,32 @@ def _normalize_packages_yaml(packages_yaml: Dict[str, Any]) -> None:
             entry.setdefault("externals", []).extend(specs)
 
 
+_CACHE_IMPLICIT_EXTERNALS = {}
+
+
 def external_config_with_implicit_externals(
     configuration: spack.config.Configuration,
 ) -> Dict[str, Any]:
-    # Read packages.yaml and normalize it so that it will not contain entries referring to
-    # virtual packages.
-    packages_yaml = configuration.deepcopy_as_builtin("packages", line_info=True)
-    _normalize_packages_yaml(packages_yaml)
+    key = configuration.content_hash(sections=["packages", "repos", "concretizer"])
+    if key not in _CACHE_IMPLICIT_EXTERNALS:
+        # Read packages.yaml and normalize it so that it will not contain entries referring to
+        # virtual packages. Do a fast buil-tin deepcopy so that we don't modify the cached result.
+        packages_yaml = configuration.deepcopy_as_builtin("packages", line_info=True)
+        _normalize_packages_yaml(packages_yaml)
 
-    # Add externals for libc from compilers on Linux
-    if not using_libc_compatibility():
-        return packages_yaml
+        # Add externals for libc from compilers on Linux
+        if not using_libc_compatibility():
+            return packages_yaml
 
-    seen = set()
-    for compiler in spack.compilers.config.all_compilers_from(configuration):
-        libc = spack.compilers.libraries.CompilerPropertyDetector(compiler).default_libc()
-        if libc and libc not in seen:
-            seen.add(libc)
-            entry = {"spec": f"{libc}", "prefix": libc.external_path}
-            packages_yaml.setdefault(libc.name, {}).setdefault("externals", []).append(entry)
-    return packages_yaml
+        seen = set()
+        for compiler in spack.compilers.config.all_compilers_from(configuration):
+            libc = spack.compilers.libraries.CompilerPropertyDetector(compiler).default_libc()
+            if libc and libc not in seen:
+                seen.add(libc)
+                entry = {"spec": f"{libc}", "prefix": libc.external_path}
+                packages_yaml.setdefault(libc.name, {}).setdefault("externals", []).append(entry)
+        _CACHE_IMPLICIT_EXTERNALS[key] = packages_yaml
+    return _CACHE_IMPLICIT_EXTERNALS[key]
 
 
 def all_libcs() -> Set[spack.spec.Spec]:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1109,7 +1109,8 @@ class _EdgeMap(collections.abc.Mapping):
             selected = (d for d in selected if d.spec.name == child)
 
         # Filter by allowed dependency types
-        selected = (dep for dep in selected if not dep.depflag or (depflag & dep.depflag))
+        if depflag != dt.ALL:
+            selected = (dep for dep in selected if not dep.depflag or (depflag & dep.depflag))
 
         # Filter by virtuals
         if virtuals is not None:

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -7,6 +7,7 @@ import pathlib
 import pytest
 
 import spack.bootstrap
+import spack.bootstrap.clingo
 import spack.bootstrap.config
 import spack.bootstrap.core
 import spack.compilers.config
@@ -136,6 +137,7 @@ def test_bootstrap_disables_modulefile_generation(mutable_config):
 def test_bootstrap_search_for_compilers_with_no_environment(no_packages_yaml, mock_packages):
     assert not spack.compilers.config.all_compilers(init_config=False)
     with spack.bootstrap.ensure_bootstrap_configuration():
+        spack.bootstrap.clingo._add_compilers_if_missing()
         assert spack.compilers.config.all_compilers(init_config=False)
     assert not spack.compilers.config.all_compilers(init_config=False)
 
@@ -147,6 +149,7 @@ def test_bootstrap_search_for_compilers_with_environment_active(
 ):
     assert not spack.compilers.config.all_compilers(init_config=False)
     with spack.bootstrap.ensure_bootstrap_configuration():
+        spack.bootstrap.clingo._add_compilers_if_missing()
         assert spack.compilers.config.all_compilers(init_config=False)
     assert not spack.compilers.config.all_compilers(init_config=False)
 


### PR DESCRIPTION
Modifications:
- [x] Adds a new method to `spack.config.Configuration` to return the content hash of some configuration sections. This hash can then be used in the "key" for global caches.
- [x] Cache lookup of compilers

Benchmarked on:

* **Spack:** 1.2.0.dev0 (https://github.com/spack/spack/commit/18c26c731f973d0c250ba2149b91f7e0cdf89926)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/7134022c6c6221cb26062aca31f19d9fb683bd13
* **Python:** 3.13.2
* **Platform:** linux-ubuntu20.04-icelake

[radiuss.develop.csv](https://github.com/user-attachments/files/23768180/radiuss.develop.csv)
[radiuss.pr.csv](https://github.com/user-attachments/files/23768181/radiuss.pr.csv)

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/59a04dd7-c481-4f49-98a2-ff572abbdbdc" />

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
