### PR TITLE
ci: disable PerfPowerServices process on macos

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -210,13 +210,17 @@ jobs:
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg kcov
+    # See https://github.com/actions/runner-images/issues/13358
+    - name: Unlock another CPU core on x86_64 MacOS
+      if: matrix.os == 'macos-15-intel'
+      run: |
+        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
+        sudo killall PerfPowerServices || true
     - name: Run unit tests
       env:
         SPACK_TEST_PARALLEL: 4
         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
       run: |
-        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
-        sudo killall PerfPowerServices || true
         git --version
         . .github/workflows/bin/setup_git.sh
         . share/spack/setup-env.sh

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -215,6 +215,8 @@ jobs:
         SPACK_TEST_PARALLEL: 4
         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
       run: |
+        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
+        sudo killall PerfPowerServices || true
         git --version
         . .github/workflows/bin/setup_git.sh
         . share/spack/setup-env.sh


### PR DESCRIPTION
It looks like the macos-15-intel runners have a service taking 100% CPU, try to disable/kill it.
