### PR TITLE
bootstrap: delay searching for a compiler until we need it

### DIFF
--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -41,8 +41,15 @@ def _select_best_version(
     node.versions.versions = [spack.version.from_string(f"={best_version}")]
 
 
+def _add_compilers_if_missing() -> None:
+    arch = spack.spec.ArchSpec.default_arch()
+    if not spack.compilers.config.compilers_for_arch(arch):
+        spack.compilers.config.find_compilers()
+
+
 class ClingoBootstrapConcretizer:
     def __init__(self, configuration):
+        _add_compilers_if_missing()
         self.host_platform = spack.platforms.host()
         self.host_os = self.host_platform.default_operating_system()
         self.host_target = spack.vendor.archspec.cpu.host().family

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -8,14 +8,12 @@ import os
 import sys
 from typing import Any, Dict, Generator, MutableSequence, Sequence
 
-import spack.compilers.config
 import spack.config
 import spack.environment
 import spack.modules
 import spack.paths
 import spack.platforms
 import spack.repo
-import spack.spec
 import spack.store
 import spack.util.path
 from spack.llnl.util import tty
@@ -138,12 +136,6 @@ def _bootstrap_config_scopes() -> Sequence["spack.config.ConfigScope"]:
     return config_scopes
 
 
-def _add_compilers_if_missing() -> None:
-    arch = spack.spec.ArchSpec.default_arch()
-    if not spack.compilers.config.compilers_for_arch(arch):
-        spack.compilers.config.find_compilers()
-
-
 @contextlib.contextmanager
 def _ensure_bootstrap_configuration() -> Generator:
     spack.repo.PATH.repos  # ensure this is instantiated from current config.
@@ -161,8 +153,5 @@ def _ensure_bootstrap_configuration() -> Generator:
         spack.config.set("bootstrap", user_configuration["bootstrap"])
         spack.config.set("config", user_configuration["config"])
         spack.config.set("repos", user_configuration["repos"])
-        # We may need to compile code from sources, so ensure we
-        # have compilers for the current platform
-        _add_compilers_if_missing()
         with spack.modules.disable_modules(), spack_python_interpreter():
             yield

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -7,6 +7,7 @@ import pathlib
 import pytest
 
 import spack.bootstrap
+import spack.bootstrap.clingo
 import spack.bootstrap.config
 import spack.bootstrap.core
 import spack.compilers.config
@@ -136,6 +137,7 @@ def test_bootstrap_disables_modulefile_generation(mutable_config):
 def test_bootstrap_search_for_compilers_with_no_environment(no_packages_yaml, mock_packages):
     assert not spack.compilers.config.all_compilers(init_config=False)
     with spack.bootstrap.ensure_bootstrap_configuration():
+        spack.bootstrap.clingo._add_compilers_if_missing()
         assert spack.compilers.config.all_compilers(init_config=False)
     assert not spack.compilers.config.all_compilers(init_config=False)
 
@@ -147,6 +149,7 @@ def test_bootstrap_search_for_compilers_with_environment_active(
 ):
     assert not spack.compilers.config.all_compilers(init_config=False)
     with spack.bootstrap.ensure_bootstrap_configuration():
+        spack.bootstrap.clingo._add_compilers_if_missing()
         assert spack.compilers.config.all_compilers(init_config=False)
     assert not spack.compilers.config.all_compilers(init_config=False)
 


### PR DESCRIPTION
Currently, we always search for missing compilers when we swap to bootstrap configuration. This operation is somewhat expensive, and is needed only when bootstrapping `clingo` from sources. 

In this PR we delay this search so that we don't pay the price if we _don't need_ to bootstrap from sources.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
