### PR TITLE
repo: memoized pkg_class construction

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1381,6 +1381,7 @@ class Repo:
         """
         return not self.exists(pkg_name) or self.get_pkg_class(pkg_name).virtual
 
+    @spack.llnl.util.lang.memoized
     def get_pkg_class(self, pkg_name: str) -> Type["spack.package_base.PackageBase"]:
         """Get the class for the package out of its module.
 


### PR DESCRIPTION
For a given `Repo`, the same `pkg_name` always corresponds to the same class.

* **Spack:** 1.2.0.dev0 (https://github.com/spack/spack/commit/d13bbc11c5957ab7ad635b20377a832a4638a4c6)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/fb2abb24fd8caa3c860e0b39621a091f6ff22609
* **Python:** 3.13.2
* **Platform:** linux-ubuntu20.04-icelake

[radiuss.pr.csv](https://github.com/user-attachments/files/23790375/radiuss.pr.csv)
[radiuss.develop.csv](https://github.com/user-attachments/files/23790376/radiuss.develop.csv)

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/e2ecc143-f51f-4f36-ba38-78804eeb9999" />


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
