### PR TITLE
avoid expensive module level code

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -97,8 +97,10 @@ SECTION_SCHEMAS: Dict[str, Any] = {
 
 # Same as above, but including keys for environments
 # this allows us to unify config reading between configs and environments
-_ALL_SCHEMAS: Dict[str, Any] = copy.deepcopy(SECTION_SCHEMAS)
-_ALL_SCHEMAS.update({spack.schema.env.TOP_LEVEL_KEY: spack.schema.env.schema})
+_ALL_SCHEMAS: Dict[str, Any] = {
+    **SECTION_SCHEMAS,
+    spack.schema.env.TOP_LEVEL_KEY: spack.schema.env.schema,
+}
 
 #: Path to the main configuration scope
 CONFIGURATION_DEFAULTS_PATH = ("defaults", os.path.join(spack.paths.etc_path, "defaults"))
@@ -1765,7 +1767,7 @@ class ConfigPath:
                 # value (if it's valid).
                 try:
                     syaml.load_config(path)
-                except spack.util.spack_yaml.SpackYAMLError as e:
+                except syaml.SpackYAMLError as e:
                     raise ValueError(
                         "Remainder of path is not a valid key"
                         f" and does not parse as a value {path}"

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -93,10 +93,6 @@ GitOrStandardVersion = Union[spack.version.GitVersion, spack.version.StandardVer
 
 TransformFunction = Callable[[spack.spec.Spec, List[AspFunction]], List[AspFunction]]
 
-#: strip comments and whitespace from ASP code
-_STRIP_COMMENTS_RE = re.compile(r"\%[^\n]*\n")
-_STRIP_NEWLINES_RE = re.compile(r"\s*\n\s*")
-
 EMPTY_SPEC = spack.spec.Spec()
 
 

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -131,6 +131,7 @@ class TestPatches:
     def restore(self):
         if not self.module_patches and not self.class_patches:
             return
+        # this code path is only followed in tests, so use inline imports
         from pydoc import locate
 
         for module_name, attr_name, value in self.module_patches:

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -15,7 +15,6 @@ import importlib
 import io
 import multiprocessing
 import pickle
-import pydoc
 from types import ModuleType
 from typing import Any
 
@@ -130,13 +129,17 @@ class TestPatches:
         self.class_patches = list((x, y, serialize(z)) for (x, y, z) in class_patches)
 
     def restore(self):
+        if not self.module_patches and not self.class_patches:
+            return
+        from pydoc import locate
+
         for module_name, attr_name, value in self.module_patches:
             value = pickle.load(value)
             module = importlib.import_module(module_name)
             setattr(module, attr_name, value)
         for class_fqn, attr_name, value in self.class_patches:
             value = pickle.load(value)
-            cls = pydoc.locate(class_fqn)
+            cls = locate(class_fqn)
             setattr(cls, attr_name, value)
 
 


### PR DESCRIPTION
* don't import `pydoc` (code path only followed when running test)
* remove unused compiled regexes in asp.py
* avoid deepcopy in config.py when shallow copy suffices
