### PR TITLE
config: use `get_config` instead of `get` where appropriate

### DIFF
--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -261,7 +261,7 @@ class CompilerFactory:
         """Returns the compiler specs defined in the "packages" section of the configuration"""
         externals_dicts = []
         compiler_package_names = supported_compilers()
-        packages_yaml = configuration.get("packages", scope=scope)
+        packages_yaml = configuration.get_config("packages", scope=scope)
         for name, entry in packages_yaml.items():
             if name not in compiler_package_names:
                 continue

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1812,7 +1812,7 @@ class ConfigPath:
                 quoted = True
             element = element.strip("'\"")
 
-            if any([append, prepend, override, quoted]):
+            if append or prepend or override or quoted:
                 element = syaml.syaml_str(element)
                 if append:
                     element.append = True

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -388,7 +388,7 @@ class MirrorCollection(Mapping[str, Mirror]):
         mirrors_data = (
             mirrors.items()
             if mirrors is not None
-            else spack.config.get("mirrors", scope=scope).items()
+            else spack.config.CONFIG.get_config("mirrors", scope=scope).items()
         )
         mirrors = (Mirror(data=mirror, name=name) for name, mirror in mirrors_data)
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -93,8 +93,10 @@ class PackagePrefs:
         if all:
             pkglist.append("all")
 
+        packages = spack.config.CONFIG.get_config("packages")
+
         for pkg in pkglist:
-            pkg_entry = spack.config.get("packages").get(pkg)
+            pkg_entry = packages.get(pkg)
             if not pkg_entry:
                 continue
 
@@ -137,8 +139,9 @@ class PackagePrefs:
     @classmethod
     def preferred_variants(cls, pkg_name):
         """Return a VariantMap of preferred variants/values for a spec."""
+        packages = spack.config.CONFIG.get_config("packages")
         for pkg_cls in (pkg_name, "all"):
-            variants = spack.config.get("packages").get(pkg_cls, {}).get("variants", "")
+            variants = packages.get(pkg_cls, {}).get("variants", "")
             if variants:
                 break
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -673,7 +673,7 @@ class RepoPath:
         """Create a RepoPath from a configuration object."""
         overrides = {
             pkg_name: data["package_attributes"]
-            for pkg_name, data in config.get("packages").items()
+            for pkg_name, data in config.get_config("packages").items()
             if pkg_name != "all" and "package_attributes" in data
         }
 
@@ -1886,7 +1886,7 @@ class RepoDescriptors(Mapping[str, RepoDescriptor]):
         return RepoDescriptors(
             {
                 name: parse_config_descriptor(name, cfg, lock)
-                for name, cfg in config.get("repos", scope=scope).items()
+                for name, cfg in config.get_config("repos", scope=scope).items()
             }
         )
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2569,7 +2569,7 @@ class SpackSolverSetup:
         self, possible_pkgs: Set[str], *, require_checksum: bool, allow_deprecated: bool
     ):
         """Declare any versions in specs not declared in packages."""
-        packages_yaml = spack.config.get("packages")
+        packages_yaml = spack.config.CONFIG.get_config("packages")
         for pkg_name in sorted(possible_pkgs):
             pkg_cls = self.pkg_class(pkg_name)
 
@@ -3313,7 +3313,7 @@ class SpackSolverSetup:
         versions. If they are abstract and statically have no match, then we
         need to throw an error. This function assumes all possible versions are already
         registered in self.possible_versions."""
-        for pkg_name, d in spack.config.get("packages").items():
+        for pkg_name, d in spack.config.CONFIG.get_config("packages").items():
             if pkg_name == "all" or "require" not in d:
                 continue
 

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -472,10 +472,9 @@ class MinimalDuplicatesCounter(NoDuplicatesCounter):
 
         gen.h2("Packages with multiple possible nodes (build-tools)")
         default = spack.config.CONFIG.get("concretizer:duplicates:max_dupes:default", 2)
+        duplicates = spack.config.CONFIG.get("concretizer:duplicates:max_dupes", {})
         for package_name in sorted(self.possible_dependencies() & build_tools):
-            max_dupes = spack.config.CONFIG.get(
-                f"concretizer:duplicates:max_dupes:{package_name}", default
-            )
+            max_dupes = duplicates.get(package_name, default)
             gen.fact(fn.max_dupes(package_name, max_dupes))
             if max_dupes > 1:
                 gen.fact(fn.multiple_unification_sets(package_name))
@@ -488,9 +487,7 @@ class MinimalDuplicatesCounter(NoDuplicatesCounter):
 
         gen.h2("Maximum number of nodes (other virtuals)")
         for package_name in sorted(self.possible_virtuals() - self._link_run_virtuals):
-            max_dupes = spack.config.CONFIG.get(
-                f"concretizer:duplicates:max_dupes:{package_name}", default
-            )
+            max_dupes = duplicates.get(package_name, default)
             gen.fact(fn.max_dupes(package_name, max_dupes))
         gen.newline()
 

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -209,7 +209,7 @@ class RequirementParser:
         return spec, condition, message
 
     def _raw_yaml_data(self, pkg_name: str, *, section: str, virtual: bool = False):
-        config = self.config.get("packages")
+        config = self.config.get_config("packages")
         data = config.get(pkg_name, {}).get(section, [])
         kind = RequirementKind.PACKAGE
 

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -330,7 +330,7 @@ class SpecParser:
         self.toolchains = {}
         configuration = getattr(spack.config, "CONFIG", None)
         if configuration is not None:
-            self.toolchains = configuration.get("toolchains", {})
+            self.toolchains = configuration.get_config("toolchains")
         self.parsed_toolchains: Dict[str, "spack.spec.Spec"] = {}
 
     def tokens(self) -> List[Token]:

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -207,13 +207,13 @@ def create(configuration: spack.config.Configuration) -> Store:
         configuration: configuration to create a store.
     """
     configuration = configuration or spack.config.CONFIG
-    config_dict = configuration.get("config")
+    config_dict = configuration.get_config("config")
     root, unpadded_root, projections = parse_install_tree(config_dict)
-    hash_length = configuration.get("config:install_hash_length")
+    hash_length = config_dict.get("install_hash_length")
 
     install_roots = [
         install_properties["install_tree"]
-        for install_properties in configuration.get("upstreams", {}).values()
+        for install_properties in configuration.get_config("upstreams").values()
     ]
     upstreams = _construct_upstream_dbs_from_install_roots(install_roots)
 


### PR DESCRIPTION
The call `cfg.get("section")` goes through a parsing step etc, whereas `cf.get_config("section")` is dedicated API for this use case.