### PR TITLE
various micro optimizations

### DIFF
--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -21,6 +21,8 @@ class SpecHashDescriptor:
 
     We currently use different hashes for different use cases."""
 
+    __slots__ = "depflag", "package_hash", "name", "attr", "override"
+
     def __init__(
         self,
         depflag: dt.DepFlag,
@@ -31,14 +33,10 @@ class SpecHashDescriptor:
         self.depflag = depflag
         self.package_hash = package_hash
         self.name = name
+        self.attr = f"_{name}"
         HASHES.append(self)
         # Allow spec hashes to have an alternate computation method
         self.override = override
-
-    @property
-    def attr(self):
-        """Private attribute stored on spec"""
-        return "_" + self.name
 
     def __call__(self, spec):
         """Run this hash on the provided spec."""

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -34,7 +34,7 @@ class AspObject:
 
 def _id(thing: Any) -> Union[str, int, AspObject]:
     """Quote string if needed for it to be a valid identifier."""
-    if isinstance(thing, bool):
+    if thing is True or thing is False:
         return f'"{thing}"'
     elif isinstance(thing, (AspObject, int)):
         return thing

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4075,8 +4075,10 @@ class Spec:
         if self.name:
             parts.append(self.name)
 
-        if self.versions and self.versions != vn.any_version:
-            parts.append(f"@{self.versions}")
+        if self.versions:
+            version_str = str(self.versions)
+            if version_str and version_str != ":":  # only include if not full range
+                parts.append(f"@{version_str}")
 
         compiler_flags_str = str(self.compiler_flags)
         if compiler_flags_str:

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -1165,9 +1165,7 @@ class VersionList(VersionType):
         if not self.versions:
             return ""
 
-        return ",".join(
-            f"={v}" if isinstance(v, StandardVersion) else str(v) for v in self.versions
-        )
+        return ",".join(f"={v}" if type(v) is StandardVersion else str(v) for v in self.versions)
 
     def __repr__(self) -> str:
         return str(self.versions)


### PR DESCRIPTION
* Add `__slots__` to SpecHashDescriptor, and precompute its hash
  attr to avoid a property function call, as it is referenced in
  `Spec.__init__`, which is called by the spec parser every time.
* Replace `isinstance(x, bool)` with `x is True or x is False`, which
  avoids a function call and is slightly faster in solver/core.py
* In `Spec.__str__` simply call `str(version)` and deal with the special
  case of `":"` which we don't like to print. That's faster than doing a
  comparison against "any version", which is a branch that's often
  false and requires iterating over version components twice.
* In `VersionList.__str__` use `type(x) is StandardVersion`, because
  it's a final type. This is faster than `isinstance(x, StandardVersion)`
  and it's called a lot.

