### PR TITLE
reuse.py: avoid _create_external_parser

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -17,6 +17,8 @@ import spack.solver.reuse
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
+from spack.solver.reuse import create_external_parser
+from spack.solver.runtimes import external_config_with_implicit_externals
 
 from ..enums import InstallRecordStatus
 
@@ -330,8 +332,13 @@ def _find_query(args, env):
     q_args = query_arguments(args)
     concretized_but_not_installed = []
     if args.show_configured_externals:
+        packages_with_externals = external_config_with_implicit_externals(spack.config.CONFIG)
+        completion_mode = spack.config.CONFIG.get("concretizer:externals:completion")
         results = spack.solver.reuse.SpecFilter.from_packages_yaml(
-            spack.config.CONFIG, include=[], exclude=[]
+            external_parser=create_external_parser(packages_with_externals, completion_mode),
+            packages_with_externals=packages_with_externals,
+            include=[],
+            exclude=[],
         ).selected_specs()
     elif env:
         all_env_specs = env.all_specs()

--- a/lib/spack/spack/test/concretization/compiler_runtimes.py
+++ b/lib/spack/spack/test/concretization/compiler_runtimes.py
@@ -16,13 +16,21 @@ import spack.repo
 import spack.solver.asp
 import spack.spec
 from spack.environment.environment import ViewDescriptor
-from spack.solver.reuse import SpecFilter
+from spack.solver.reuse import SpecFilter, create_external_parser
+from spack.solver.runtimes import external_config_with_implicit_externals
 from spack.version import Version
 
 
 def _concretize_with_reuse(*, root_str, reused_str, config):
     reused_spec = spack.concretize.concretize_one(reused_str)
-    external_specs = SpecFilter.from_packages_yaml(config, include=[], exclude=[]).selected_specs()
+    packages_with_externals = external_config_with_implicit_externals(config)
+    completion_mode = config.get("concretizer:externals:completion")
+    external_specs = SpecFilter.from_packages_yaml(
+        external_parser=create_external_parser(packages_with_externals, completion_mode),
+        packages_with_externals=packages_with_externals,
+        include=[],
+        exclude=[],
+    ).selected_specs()
     setup = spack.solver.asp.SpackSolverSetup(tests=False)
     driver = spack.solver.asp.PyclingoDriver()
     result, _, _ = driver.solve(

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -20,7 +20,8 @@ import spack.util.spack_yaml as syaml
 import spack.version
 from spack.installer import PackageInstaller
 from spack.solver.asp import InternalConcretizerError, UnsatisfiableSpecError
-from spack.solver.reuse import SpecFilter
+from spack.solver.reuse import SpecFilter, create_external_parser
+from spack.solver.runtimes import external_config_with_implicit_externals
 from spack.spec import Spec
 from spack.util.url import path_to_file_url
 
@@ -1320,8 +1321,13 @@ def test_requirements_on_compilers_and_reuse(
     reused_nodes = list(reused_spec.traverse())
     update_packages_config(packages_yaml)
     root_specs = [Spec(input_spec)]
+    packages_with_externals = external_config_with_implicit_externals(mutable_config)
+    completion_mode = mutable_config.get("concretizer:externals:completion")
     external_specs = SpecFilter.from_packages_yaml(
-        mutable_config, include=[], exclude=[]
+        external_parser=create_external_parser(packages_with_externals, completion_mode),
+        packages_with_externals=packages_with_externals,
+        include=[],
+        exclude=[],
     ).selected_specs()
 
     with spack.config.override("concretizer:reuse", True):
@@ -1505,8 +1511,13 @@ packages:
     update_packages_config(packages_yaml)
     initial_mpileaks = spack.concretize.concretize_one("mpileaks+debug")
     reused_nodes = list(initial_mpileaks.traverse())
+    packages_with_externals = external_config_with_implicit_externals(mutable_config)
+    completion_mode = mutable_config.get("concretizer:externals:completion")
     external_specs = SpecFilter.from_packages_yaml(
-        mutable_config, include=[], exclude=[]
+        external_parser=create_external_parser(packages_with_externals, completion_mode),
+        packages_with_externals=packages_with_externals,
+        include=[],
+        exclude=[],
     ).selected_specs()
 
     # Ask for just "mpileaks" and check the spec is reused

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -455,7 +455,7 @@ def test_reusable_externals_cray_manifest(temporary_store, manifest_file):
     spec = temporary_store.db.query_local()[0]
 
     # Reusable if imported locally
-    assert spack.solver.reuse._is_reusable(spec, packages={}, local=True)
+    assert spack.solver.reuse._is_reusable(spec, packages_with_externals={}, local=True)
 
     # If cray manifest entries end up in a build cache somehow, they are not reusable
-    assert not spack.solver.reuse._is_reusable(spec, packages={}, local=False)
+    assert not spack.solver.reuse._is_reusable(spec, packages_with_externals={}, local=False)


### PR DESCRIPTION
The function `_create_external_parser` is called for each reuse source, and triggers some expensive code paths down the line. Fix by calling it once ahead of time.

Also some renaming:

* `packages` -> `packages_with_externals`
* `_create_external_parser` -> `create_external_parser`