### PR TITLE
merge_yaml: avoid deepcopy

### DIFF
--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -713,6 +713,7 @@ def test_repo_set_git_config(mutable_config):
     repo("set", "--scope=user", "--path", "subdir1", "--path", "subdir2", "test-repo")
 
     # Check that the user config has the updated entry
+    spack.config.CONFIG.clear_caches()  # todo: fix.
     user_repos = spack.config.get("repos", scope="user")
     assert user_repos["test-repo"]["paths"] == ["subdir1", "subdir2"]
     assert user_repos["test-repo"]["destination"] == "/custom/path"


### PR DESCRIPTION
internal state is not entirely correct with this change, but submitted to see
how it affects tests, which do lots of config reading.

EDIT: OK, this helps a lot. Suggest most significant time saver of unit tests
would be to move to ordinary dicts to avoid the yaml parsing overhead
additionally to the deepcopy slowness.
