### PR TITLE
tests: improve `SpackCommand` and output capturing

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -576,7 +576,7 @@ def import_signing_key(base64_signing_key: str) -> None:
 
     # This command has the side-effect of creating the directory referred
     # to as GNUPGHOME in setup_environment()
-    list_output = spack_gpg("list", output=str)
+    list_output = spack_gpg("list")
 
     tty.debug("spack gpg list:")
     tty.debug(list_output)
@@ -588,13 +588,13 @@ def import_signing_key(base64_signing_key: str) -> None:
         with open(sign_key_path, "w", encoding="utf-8") as fd:
             fd.write(decoded_key)
 
-        key_import_output = spack_gpg("trust", sign_key_path, output=str)
+        key_import_output = spack_gpg("trust", sign_key_path)
         tty.debug(f"spack gpg trust {sign_key_path}")
         tty.debug(key_import_output)
 
     # Now print the keys we have for verifying and signing
-    trusted_keys_output = spack_gpg("list", "--trusted", output=str)
-    signing_keys_output = spack_gpg("list", "--signing", output=str)
+    trusted_keys_output = spack_gpg("list", "--trusted")
+    signing_keys_output = spack_gpg("list", "--signing")
 
     tty.debug("spack gpg list --trusted")
     tty.debug(trusted_keys_output)

--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -104,10 +104,9 @@ def test_blame_json(mock_packages):
 
 
 @pytest.mark.not_on_windows("git hangs")
-def test_blame_by_git(mock_packages, capfd):
+def test_blame_by_git(mock_packages):
     """Sanity check the blame command to make sure it works."""
-    with capfd.disabled():
-        out = blame("--git", "mpich")
+    out = blame("--git", "mpich")
     assert "class Mpich" in out
     assert '    homepage = "http://www.mpich.org"' in out
 
@@ -194,7 +193,7 @@ def test_ensure_full_history_shallow_works(mock_git_version_info, monkeypatch):
     ensure_full_history(repo_path, filename)
 
 
-def test_ensure_full_history_shallow_fails(mock_git_version_info, monkeypatch, capsys):
+def test_ensure_full_history_shallow_fails(mock_git_version_info, monkeypatch, capfd):
     """Ensure a git that supports '--unshallow' but fails generates useful error."""
     error_msg = "Mock git cannot fetch."
 
@@ -214,11 +213,11 @@ def test_ensure_full_history_shallow_fails(mock_git_version_info, monkeypatch, c
     with pytest.raises(SystemExit):
         ensure_full_history(repo_path, filename)
 
-    out = capsys.readouterr()
+    out = capfd.readouterr()
     assert error_msg in out[1]
 
 
-def test_ensure_full_history_shallow_old_git(mock_git_version_info, monkeypatch, capsys):
+def test_ensure_full_history_shallow_old_git(mock_git_version_info, monkeypatch, capfd):
     """Ensure a git that doesn't support '--unshallow' fails."""
 
     def _git(*args, **kwargs):
@@ -234,5 +233,5 @@ def test_ensure_full_history_shallow_old_git(mock_git_version_info, monkeypatch,
     with pytest.raises(SystemExit):
         ensure_full_history(repo_path, filename)
 
-    out = capsys.readouterr()
+    out = capfd.readouterr()
     assert "Use a newer" in out[1]

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -40,7 +40,7 @@ def test_root_get_and_set(mutable_config, scope):
         scope_args = ["--scope={0}".format(scope)]
 
     _bootstrap("root", path, *scope_args)
-    out = _bootstrap("root", *scope_args, output=str)
+    out = _bootstrap("root", *scope_args)
     if sys.platform == "win32":
         out = convert_to_posix_path(out)
     assert out.strip() == path
@@ -101,15 +101,13 @@ def test_reset_in_file_scopes_overwrites_backup_files(mutable_config):
     assert os.path.exists(backup_file)
 
 
-def test_list_sources(config, capsys):
+def test_list_sources(config):
     # Get the merged list and ensure we get our defaults
-    with capsys.disabled():
-        output = _bootstrap("list")
+    output = _bootstrap("list")
     assert "github-actions" in output
 
     # Ask for a specific scope and check that the list of sources is empty
-    with capsys.disabled():
-        output = _bootstrap("list", "--scope", "user")
+    output = _bootstrap("list", "--scope", "user")
     assert "No method available" in output
 
 

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -309,14 +309,14 @@ def test_checksum_url(mock_packages, config):
         spack_checksum(f"{pkg_cls.url}")
 
 
-def test_checksum_verification_fails(default_mock_concretization, capsys, can_fetch_versions):
+def test_checksum_verification_fails(default_mock_concretization, capfd, can_fetch_versions):
     spec = spack.concretize.concretize_one("zlib")
     pkg = spec.package
     versions = list(pkg.versions.keys())
     version_hashes = {versions[0]: "abadhash", Version("0.1"): "123456789"}
     with pytest.raises(SystemExit):
         spack.cmd.checksum.print_checksum_status(pkg, version_hashes)
-    out = str(capsys.readouterr())
+    out = str(capfd.readouterr())
     assert out.count("Correct") == 0
     assert "No previous checksum" in out
     assert "Invalid checksum" in out

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -359,7 +359,7 @@ def test_config_with_c_argument(mutable_empty_config):
     assert config_file in args.config_vars
 
     # Add the path to the config
-    config("add", args.config_vars[0], scope="command_line")
+    config("add", args.config_vars[0])
     output = config("get", "config")
     assert "config:\n  install_tree:\n    root: /path/to/config.yaml" in output
 

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -189,7 +189,7 @@ def test_get_name_urls(url, expected):
     assert name == expected
 
 
-def test_get_name_error(monkeypatch, capsys):
+def test_get_name_error(monkeypatch, capfd):
     """Test get_name UndetectableNameError exception path."""
 
     def _parse_name_offset(path, v):
@@ -201,7 +201,7 @@ def test_get_name_error(monkeypatch, capsys):
 
     with pytest.raises(SystemExit):
         spack.cmd.create.get_name(None, url)
-    captured = capsys.readouterr()
+    captured = capfd.readouterr()
     assert "Couldn't guess a name" in str(captured)
 
 

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -11,6 +11,7 @@ import spack.concretize
 import spack.environment as ev
 import spack.error
 import spack.llnl.util.filesystem as fs
+import spack.main
 import spack.repo
 import spack.spec
 import spack.store
@@ -110,7 +111,7 @@ def test_dev_build_before_until(tmp_path: pathlib.Path, install_mockery):
         with open(spec.package.filename, "w", encoding="utf-8") as f:
             f.write(spec.package.original_string)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(spack.main.SpackCommandError):
             dev_build("-u", "edit", "-b", "edit", "dev-build-test-install@0.0.0")
 
         bad_phase = "phase_that_does_not_exist"

--- a/lib/spack/spack/test/cmd/extensions.py
+++ b/lib/spack/spack/test/cmd/extensions.py
@@ -23,14 +23,13 @@ def python_database(mock_packages, mutable_database):
 
 @pytest.mark.not_on_windows("All Fetchers Failed")
 @pytest.mark.db
-def test_extensions(mock_packages, python_database, capsys):
+def test_extensions(mock_packages, python_database):
     ext2 = spack.concretize.concretize_one("py-extension2")
 
     def check_output(ni):
-        with capsys.disabled():
-            output = extensions("python")
-            packages = extensions("-s", "packages", "python")
-            installed = extensions("-s", "installed", "python")
+        output = extensions("python")
+        packages = extensions("-s", "packages", "python")
+        installed = extensions("-s", "installed", "python")
         assert "==> python@2.7.11" in output
         assert "==> 4 extensions" in output
         assert "py-extension1" in output

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -7,7 +7,6 @@ import sys
 
 import pytest
 
-import spack
 import spack.cmd.external
 import spack.config
 import spack.cray_manifest

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -6,8 +6,6 @@ import argparse
 import json
 import os
 import pathlib
-import sys
-from textwrap import dedent
 
 import pytest
 
@@ -137,28 +135,12 @@ def test_namespaces_shown_correctly(args, with_namespace, database):
 
 @pytest.mark.db
 def test_find_cli_output_format(database, mock_tty_stdout):
-    # Currently logging on Windows detaches stdout
-    # from the terminal so we miss some output during tests
-    # TODO: (johnwparent): Once logging is amended on Windows,
-    # restore this test
-    out = find("zmpi")
-    if not sys.platform == "win32":
-        assert out.endswith(
-            dedent(
-                """\
-      zmpi@1.0
-      ==> 1 installed package
-      """
-            )
-        )
-    else:
-        assert out.endswith(
-            dedent(
-                """\
-      zmpi@1.0
-      """
-            )
-        )
+    assert find("zmpi").endswith(
+        """\
+zmpi@1.0
+==> 1 installed package
+"""
+    )
 
 
 def _check_json_output(spec_list):
@@ -202,34 +184,34 @@ def test_find_json_deps(database):
 
 
 @pytest.mark.db
-def test_display_json(database, capsys):
+def test_display_json(database, capfd):
     specs = [
         spack.concretize.concretize_one(s)
         for s in ["mpileaks ^zmpi", "mpileaks ^mpich", "mpileaks ^mpich2"]
     ]
 
     cmd.display_specs_as_json(specs)
-    spec_list = json.loads(capsys.readouterr()[0])
+    spec_list = json.loads(capfd.readouterr()[0])
     _check_json_output(spec_list)
 
     cmd.display_specs_as_json(specs + specs + specs)
-    spec_list = json.loads(capsys.readouterr()[0])
+    spec_list = json.loads(capfd.readouterr()[0])
     _check_json_output(spec_list)
 
 
 @pytest.mark.db
-def test_display_json_deps(database, capsys):
+def test_display_json_deps(database, capfd):
     specs = [
         spack.concretize.concretize_one(s)
         for s in ["mpileaks ^zmpi", "mpileaks ^mpich", "mpileaks ^mpich2"]
     ]
 
     cmd.display_specs_as_json(specs, deps=True)
-    spec_list = json.loads(capsys.readouterr()[0])
+    spec_list = json.loads(capfd.readouterr()[0])
     _check_json_output_deps(spec_list)
 
     cmd.display_specs_as_json(specs + specs + specs, deps=True)
-    spec_list = json.loads(capsys.readouterr()[0])
+    spec_list = json.loads(capfd.readouterr()[0])
     _check_json_output_deps(spec_list)
 
 
@@ -322,9 +304,8 @@ def test_find_very_long(database, config):
 
 
 @pytest.mark.db
-def test_find_not_found(database, config, capsys):
-    with capsys.disabled():
-        output = find("foobarbaz", fail_on_error=False)
+def test_find_not_found(database, config):
+    output = find("foobarbaz", fail_on_error=False)
     assert "No package matches the query: foobarbaz" in output
     assert find.returncode == 1
 

--- a/lib/spack/spack/test/cmd/help.py
+++ b/lib/spack/spack/test/cmd/help.py
@@ -6,14 +6,14 @@ from spack.main import SpackCommand
 
 def test_reuse_after_help():
     """Test `spack help` can be called twice with the same SpackCommand."""
-    help_cmd = SpackCommand("help", subprocess=True)
+    help_cmd = SpackCommand("help")
     help_cmd()
     help_cmd()
 
 
 def test_help():
     """Sanity check the help command to make sure it works."""
-    help_cmd = SpackCommand("help", subprocess=True)
+    help_cmd = SpackCommand("help")
     out = help_cmd()
     assert "Common spack commands:" in out
     assert "Options:" in out
@@ -21,7 +21,7 @@ def test_help():
 
 def test_help_all():
     """Test the spack help --all flag"""
-    help_cmd = SpackCommand("help", subprocess=True)
+    help_cmd = SpackCommand("help")
     out = help_cmd("--all")
     assert "Commands:" in out
     assert "Options:" in out

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -13,10 +13,9 @@ pytestmark = [pytest.mark.usefixtures("mock_packages")]
 info = SpackCommand("info")
 
 
-def test_deprecated_option_warns(capfd):
+def test_deprecated_option_warns():
     info("--variants-by-name", "vtk-m")
-    output = capfd.readouterr()
-    assert "--variants-by-name is deprecated" in output.err
+    assert "--variants-by-name is deprecated" in info.output
 
 
 # no specs, more than one spec

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -132,7 +132,7 @@ def test_install_dirty_flag(arguments, expected):
     assert args.dirty == expected
 
 
-def test_package_output(capsys, install_mockery, mock_fetch):
+def test_package_output(install_mockery, mock_fetch):
     """
     Ensure output printed from pkgs is captured by output redirection.
     """
@@ -164,17 +164,14 @@ def test_package_output(capsys, install_mockery, mock_fetch):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_install_output_on_build_error(
-    mock_packages, mock_archive, mock_fetch, install_mockery, capfd
-):
+def test_install_output_on_build_error(mock_packages, mock_archive, mock_fetch, install_mockery):
     """
     This test used to assume receiving full output, but since we've updated
     spack to generate logs on the level of phases, it will only return the
     last phase, install.
     """
     # capfd interferes with Spack's capturing
-    with capfd.disabled():
-        out = install("-v", "build-error", fail_on_error=False)
+    out = install("-v", "build-error", fail_on_error=False)
     assert "Installing build-error" in out
 
 
@@ -204,12 +201,11 @@ def test_install_env_variables(mock_packages, mock_archive, mock_fetch, install_
 
 
 @pytest.mark.disable_clean_stage_check
-def test_show_log_on_error(mock_packages, mock_archive, mock_fetch, install_mockery, capfd):
+def test_show_log_on_error(mock_packages, mock_archive, mock_fetch, install_mockery):
     """
     Make sure --show-log-on-error works.
     """
-    with capfd.disabled():
-        out = install("--show-log-on-error", "build-error", fail_on_error=False)
+    out = install("--show-log-on-error", "build-error", fail_on_error=False)
     assert isinstance(install.error, spack.build_environment.ChildError)
     assert install.error.pkg.name == "build-error"
 
@@ -504,50 +500,45 @@ def test_extra_files_are_archived(mock_packages, mock_archive, mock_fetch, insta
 
 @pytest.mark.disable_clean_stage_check
 def test_cdash_report_concretization_error(
-    tmp_path: pathlib.Path, mock_fetch, install_mockery, capfd, conflict_spec
+    tmp_path: pathlib.Path, mock_fetch, install_mockery, conflict_spec
 ):
-    # capfd interferes with Spack's capturing
-    with capfd.disabled():
-        with fs.working_dir(str(tmp_path)):
-            with pytest.raises(SpackError):
-                install("--log-format=cdash", "--log-file=cdash_reports", conflict_spec)
-            report_dir = tmp_path / "cdash_reports"
-            assert report_dir in list(tmp_path.iterdir())
-            report_file = report_dir / "Update.xml"
-            assert report_file in list(report_dir.iterdir())
-            content = report_file.read_text()
-            assert "<UpdateReturnStatus>" in content
-            # The message is different based on using the
-            # new or the old concretizer
-            expected_messages = ("Conflicts in concretized spec", "conflicts with")
-            assert any(x in content for x in expected_messages)
+    with fs.working_dir(str(tmp_path)):
+        with pytest.raises(SpackError):
+            install("--log-format=cdash", "--log-file=cdash_reports", conflict_spec)
+        report_dir = tmp_path / "cdash_reports"
+        assert report_dir in list(tmp_path.iterdir())
+        report_file = report_dir / "Update.xml"
+        assert report_file in list(report_dir.iterdir())
+        content = report_file.read_text()
+        assert "<UpdateReturnStatus>" in content
+        # The message is different based on using the
+        # new or the old concretizer
+        expected_messages = ("Conflicts in concretized spec", "conflicts with")
+        assert any(x in content for x in expected_messages)
 
 
 @pytest.mark.not_on_windows("Windows log_output logs phase header out of order")
 @pytest.mark.disable_clean_stage_check
-def test_cdash_upload_build_error(tmp_path: pathlib.Path, mock_fetch, install_mockery, capfd):
-    # capfd interferes with Spack's capturing
-    with capfd.disabled():
-        with fs.working_dir(str(tmp_path)):
-            with pytest.raises(SpackError):
-                install(
-                    "--log-format=cdash",
-                    "--log-file=cdash_reports",
-                    "--cdash-upload-url=http://localhost/fakeurl/submit.php?project=Spack",
-                    "build-error",
-                )
-            report_dir = tmp_path / "cdash_reports"
-            assert report_dir in list(tmp_path.iterdir())
-            report_file = report_dir / "Build.xml"
-            assert report_file in list(report_dir.iterdir())
-            content = report_file.read_text()
-            assert "<Text>configure: error: in /path/to/some/file:</Text>" in content
+def test_cdash_upload_build_error(capfd, tmp_path: pathlib.Path, mock_fetch, install_mockery):
+    with fs.working_dir(str(tmp_path)):
+        with pytest.raises(SpackError):
+            install(
+                "--log-format=cdash",
+                "--log-file=cdash_reports",
+                "--cdash-upload-url=http://localhost/fakeurl/submit.php?project=Spack",
+                "build-error",
+            )
+        report_dir = tmp_path / "cdash_reports"
+        assert report_dir in list(tmp_path.iterdir())
+        report_file = report_dir / "Build.xml"
+        assert report_file in list(report_dir.iterdir())
+        content = report_file.read_text()
+        assert "<Text>configure: error: in /path/to/some/file:</Text>" in content
 
 
 @pytest.mark.disable_clean_stage_check
-def test_cdash_upload_clean_build(tmp_path: pathlib.Path, mock_fetch, install_mockery, capfd):
-    # capfd interferes with Spack's capturing of e.g., Build.xml output
-    with capfd.disabled(), fs.working_dir(str(tmp_path)):
+def test_cdash_upload_clean_build(tmp_path: pathlib.Path, mock_fetch, install_mockery):
+    with fs.working_dir(str(tmp_path)):
         install("--log-file=cdash_reports", "--log-format=cdash", "pkg-c")
         report_dir = tmp_path / "cdash_reports"
         assert report_dir in list(tmp_path.iterdir())
@@ -559,9 +550,8 @@ def test_cdash_upload_clean_build(tmp_path: pathlib.Path, mock_fetch, install_mo
 
 
 @pytest.mark.disable_clean_stage_check
-def test_cdash_upload_extra_params(tmp_path: pathlib.Path, mock_fetch, install_mockery, capfd):
-    # capfd interferes with Spack's capture of e.g., Build.xml output
-    with capfd.disabled(), fs.working_dir(str(tmp_path)):
+def test_cdash_upload_extra_params(tmp_path: pathlib.Path, mock_fetch, install_mockery):
+    with fs.working_dir(str(tmp_path)):
         install(
             "--log-file=cdash_reports",
             "--log-format=cdash",
@@ -581,9 +571,8 @@ def test_cdash_upload_extra_params(tmp_path: pathlib.Path, mock_fetch, install_m
 
 
 @pytest.mark.disable_clean_stage_check
-def test_cdash_buildstamp_param(tmp_path: pathlib.Path, mock_fetch, install_mockery, capfd):
-    # capfd interferes with Spack's capture of e.g., Build.xml output
-    with capfd.disabled(), fs.working_dir(str(tmp_path)):
+def test_cdash_buildstamp_param(tmp_path: pathlib.Path, mock_fetch, install_mockery):
+    with fs.working_dir(str(tmp_path)):
         cdash_track = "some_mocked_track"
         buildstamp_format = f"%Y%m%d-%H%M-{cdash_track}"
         buildstamp = time.strftime(buildstamp_format, time.localtime(int(time.time())))
@@ -603,10 +592,9 @@ def test_cdash_buildstamp_param(tmp_path: pathlib.Path, mock_fetch, install_mock
 
 @pytest.mark.disable_clean_stage_check
 def test_cdash_install_from_spec_json(
-    tmp_path: pathlib.Path, mock_fetch, install_mockery, capfd, mock_packages, mock_archive
+    tmp_path: pathlib.Path, mock_fetch, install_mockery, mock_packages, mock_archive
 ):
-    # capfd interferes with Spack's capturing
-    with capfd.disabled(), fs.working_dir(str(tmp_path)):
+    with fs.working_dir(str(tmp_path)):
         spec_json_path = str(tmp_path / "spec.json")
 
         pkg_spec = spack.concretize.concretize_one("pkg-c")
@@ -637,38 +625,25 @@ def test_cdash_install_from_spec_json(
 
 
 @pytest.mark.disable_clean_stage_check
-def test_build_error_output(mock_fetch, install_mockery, capfd):
-    with capfd.disabled():
-        msg = ""
-        try:
-            install("build-error")
-            assert False, "no exception was raised!"
-        except spack.build_environment.ChildError as e:
-            msg = e.long_message
-
-        assert "configure: error: in /path/to/some/file:" in msg
-        assert "configure: error: cannot run C compiled programs." in msg
+def test_build_error_output(capfd, mock_fetch, install_mockery):
+    with pytest.raises(spack.build_environment.ChildError):
+        install("build-error")
+    assert "configure: error: in /path/to/some/file:" in install.output
+    assert "configure: error: cannot run C compiled programs." in install.output
 
 
 @pytest.mark.disable_clean_stage_check
-def test_build_warning_output(mock_fetch, install_mockery, capfd):
-    with capfd.disabled():
-        msg = ""
-        try:
-            install("build-warnings")
-            assert False, "no exception was raised!"
-        except spack.build_environment.ChildError as e:
-            msg = e.long_message
-
-        assert "WARNING: ALL CAPITAL WARNING!" in msg
-        assert "foo.c:89: warning: some weird warning!" in msg
+def test_build_warning_output(mock_fetch, install_mockery):
+    with pytest.raises(spack.build_environment.ChildError):
+        install("build-warnings")
+    assert "WARNING: ALL CAPITAL WARNING!" in install.output
+    assert "foo.c:89: warning: some weird warning!" in install.output
 
 
-def test_cache_only_fails(mock_fetch, install_mockery, capfd):
+def test_cache_only_fails(mock_fetch, install_mockery):
     # libelf from cache fails to install, which automatically removes the
     # the libdwarf build task
-    with capfd.disabled():
-        out = install("--cache-only", "libdwarf", fail_on_error=False)
+    out = install("--cache-only", "libdwarf", fail_on_error=False)
 
     assert "Failed to install gcc-runtime" in out
     assert "Skipping build of libdwarf" in out
@@ -692,13 +667,12 @@ def test_install_only_dependencies(mock_fetch, install_mockery):
     assert not os.path.exists(root.prefix)
 
 
-def test_install_only_package(mock_fetch, install_mockery, capfd):
+def test_install_only_package(mock_fetch, install_mockery):
     msg = ""
-    with capfd.disabled():
-        try:
-            install("--only", "package", "dependent-install")
-        except spack.error.InstallError as e:
-            msg = str(e)
+    try:
+        install("--only", "package", "dependent-install")
+    except spack.error.InstallError as e:
+        msg = str(e)
 
     assert "Cannot proceed with dependent-install" in msg
     assert "1 uninstalled dependency" in msg
@@ -807,12 +781,12 @@ def test_install_no_add_in_env(
     # Activate the environment
     with e:
         # Assert using --no-add with a spec not in the env fails
-        inst_out = install("--fake", "--no-add", "boost", fail_on_error=False, output=str)
+        inst_out = install("--fake", "--no-add", "boost", fail_on_error=False)
 
         assert "Specs can be added to the environment with 'spack add " in inst_out
 
         # Without --add, ensure that two packages "a" get installed
-        inst_out = install("--fake", "pkg-a", output=str)
+        inst_out = install("--fake", "pkg-a")
         assert len([x for x in e.all_specs() if x.installed and x.name == "pkg-a"]) == 2
 
         # Install an unambiguous dependency spec (that already exists as a dep
@@ -820,7 +794,7 @@ def test_install_no_add_in_env(
         # but is not added to the environment.
         install("dyninst")
 
-        find_output = find("-l", output=str)
+        find_output = find("-l")
         assert "dyninst" in find_output
         assert "libdwarf" in find_output
         assert "libelf" in find_output
@@ -838,7 +812,7 @@ def test_install_no_add_in_env(
         install(str(mpi_spec_json_path))
         assert mpi_spec not in e.roots()
 
-        find_output = find("-l", output=str)
+        find_output = find("-l")
         assert mpi_spec.name in find_output
 
         # Install an unambiguous depependency spec (that already exists as a
@@ -859,14 +833,11 @@ def test_install_no_add_in_env(
         assert not any([s.name == "bowtie" for s in e.uninstalled_specs()])
 
 
-def test_install_help_does_not_show_cdash_options(capsys):
+def test_install_help_does_not_show_cdash_options():
     """
     Make sure `spack install --help` does not describe CDash arguments
     """
-    with pytest.raises(SystemExit):
-        install("--help")
-        captured = capsys.readouterr()
-        assert "CDash URL" not in captured.out
+    assert "CDash URL" not in install("--help")
 
 
 def test_install_help_cdash():
@@ -877,9 +848,8 @@ def test_install_help_cdash():
 
 
 @pytest.mark.disable_clean_stage_check
-def test_cdash_auth_token(tmp_path: pathlib.Path, mock_fetch, install_mockery, monkeypatch, capfd):
-    # capfd interferes with Spack's capturing
-    with fs.working_dir(str(tmp_path)), capfd.disabled():
+def test_cdash_auth_token(tmp_path: pathlib.Path, mock_fetch, install_mockery, monkeypatch):
+    with fs.working_dir(str(tmp_path)):
         monkeypatch.setenv("SPACK_CDASH_AUTH_TOKEN", "asdf")
         out = install("--fake", "-v", "--log-file=cdash_reports", "--log-format=cdash", "pkg-a")
         assert "Using CDash auth token from environment" in out
@@ -887,9 +857,8 @@ def test_cdash_auth_token(tmp_path: pathlib.Path, mock_fetch, install_mockery, m
 
 @pytest.mark.not_on_windows("Windows log_output logs phase header out of order")
 @pytest.mark.disable_clean_stage_check
-def test_cdash_configure_warning(tmp_path: pathlib.Path, mock_fetch, install_mockery, capfd):
-    # capfd interferes with Spack's capturing of e.g., Build.xml output
-    with capfd.disabled(), fs.working_dir(str(tmp_path)):
+def test_cdash_configure_warning(tmp_path: pathlib.Path, mock_fetch, install_mockery):
+    with fs.working_dir(str(tmp_path)):
         # Test would fail if install raised an error.
 
         # Ensure that even on non-x86_64 architectures, there are no
@@ -999,7 +968,6 @@ def test_installation_fail_tests(install_mockery, mock_fetch, name, method):
 # Unit tests should not be affected by the user's managed environments
 @pytest.mark.not_on_windows("Buildcache not supported on windows")
 def test_install_use_buildcache(
-    capsys,
     mutable_mock_env_path,
     mock_packages,
     mock_fetch,
@@ -1059,21 +1027,20 @@ def test_install_use_buildcache(
     # Configure the mirror where we put that buildcache w/ the compiler
     mirror("add", "test-mirror", mirror_url)
 
-    with capsys.disabled():
-        # Install using the matrix of possible combinations with --use-buildcache
-        for pkg, deps in itertools.product(["auto", "only", "never"], repeat=2):
-            tty.debug(
-                "Testing `spack install --use-buildcache package:{0},dependencies:{1}`".format(
-                    pkg, deps
-                )
+    # Install using the matrix of possible combinations with --use-buildcache
+    for pkg, deps in itertools.product(["auto", "only", "never"], repeat=2):
+        tty.debug(
+            "Testing `spack install --use-buildcache package:{0},dependencies:{1}`".format(
+                pkg, deps
             )
-            install_use_buildcache("package:{0},dependencies:{1}".format(pkg, deps))
-            install_use_buildcache("dependencies:{0},package:{1}".format(deps, pkg))
+        )
+        install_use_buildcache("package:{0},dependencies:{1}".format(pkg, deps))
+        install_use_buildcache("dependencies:{0},package:{1}".format(deps, pkg))
 
-        # Install using a default override option
-        # Alternative to --cache-only (always) or --no-cache (never)
-        for opt in ["auto", "only", "never"]:
-            install_use_buildcache(opt)
+    # Install using a default override option
+    # Alternative to --cache-only (always) or --no-cache (never)
+    for opt in ["auto", "only", "never"]:
+        install_use_buildcache(opt)
 
 
 @pytest.mark.not_on_windows("Windows logger I/O operation on closed file when install fails")
@@ -1111,7 +1078,7 @@ def test_invalid_concurrent_packages_flag(mutable_config):
     """Test that an invalid value for --concurrent-packages CLI flag raises a ValueError"""
     install = SpackCommand("install")
     with pytest.raises(ValueError, match="expected a positive integer"):
-        install("--concurrent-packages", "-2", fail_on_error=False)
+        install("--concurrent-packages", "-2")
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Feature disabled on windows due to locking")

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -626,18 +626,22 @@ def test_cdash_install_from_spec_json(
 
 @pytest.mark.disable_clean_stage_check
 def test_build_error_output(capfd, mock_fetch, install_mockery):
-    with pytest.raises(spack.build_environment.ChildError):
+    with pytest.raises(spack.build_environment.ChildError) as e:
         install("build-error")
     assert "configure: error: in /path/to/some/file:" in install.output
+    assert "configure: error: in /path/to/some/file:" in e.value.long_message
     assert "configure: error: cannot run C compiled programs." in install.output
+    assert "configure: error: cannot run C compiled programs." in e.value.long_message
 
 
 @pytest.mark.disable_clean_stage_check
 def test_build_warning_output(mock_fetch, install_mockery):
-    with pytest.raises(spack.build_environment.ChildError):
+    with pytest.raises(spack.build_environment.ChildError) as e:
         install("build-warnings")
     assert "WARNING: ALL CAPITAL WARNING!" in install.output
+    assert "WARNING: ALL CAPITAL WARNING!" in e.value.long_message
     assert "foo.c:89: warning: some weird warning!" in install.output
+    assert "foo.c:89: warning: some weird warning!" in e.value.long_message
 
 
 def test_cache_only_fails(mock_fetch, install_mockery):

--- a/lib/spack/spack/test/cmd/is_git_repo.py
+++ b/lib/spack/spack/test/cmd/is_git_repo.py
@@ -8,7 +8,6 @@ import sys
 
 import pytest
 
-import spack
 import spack.cmd
 import spack.fetch_strategy
 from spack.llnl.util.filesystem import mkdirp, working_dir

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -4,8 +4,6 @@
 
 import os
 import pathlib
-import sys
-from textwrap import dedent
 
 import pytest
 
@@ -25,25 +23,13 @@ def test_list():
 
 
 def test_list_cli_output_format(mock_tty_stdout):
-    out = list("mpileaks")
-    # Currently logging on Windows detaches stdout
-    # from the terminal so we miss some output during tests
-    # TODO: (johnwparent): Once logging is amended on Windows,
-    # restore this test
-    if not sys.platform == "win32":
-        out_str = dedent(
-            """\
-    mpileaks
-    ==> 1 packages
-    """
-        )
-    else:
-        out_str = dedent(
-            """\
-        mpileaks
-        """
-        )
-    assert out == out_str
+    assert (
+        list("mpileaks")
+        == """\
+mpileaks
+==> 1 packages
+"""
+    )
 
 
 def test_list_filter():

--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -11,10 +11,9 @@ from io import BytesIO, TextIOWrapper
 
 import pytest
 
-import spack
 import spack.cmd.logs
 import spack.concretize
-import spack.main
+import spack.error
 import spack.spec
 from spack.main import SpackCommand
 
@@ -47,25 +46,19 @@ def _rewind_collect_and_decode(rw_stream):
     return rw_stream.read().decode("utf-8")
 
 
-@pytest.fixture
-def disable_capture(capfd):
-    with capfd.disabled():
-        yield
-
-
 def test_logs_cmd_errors(install_mockery, mock_fetch, mock_archive, mock_packages):
     spec = spack.concretize.concretize_one("pkg-c")
     assert not spec.installed
 
-    with pytest.raises(spack.main.SpackCommandError, match="is not installed or staged"):
+    with pytest.raises(spack.error.SpackError, match="is not installed or staged"):
         logs("pkg-c")
 
-    with pytest.raises(spack.main.SpackCommandError, match="Too many specs"):
+    with pytest.raises(spack.error.SpackError, match="Too many specs"):
         logs("pkg-c mpi")
 
     install("pkg-c")
     os.remove(spec.package.install_log_path)
-    with pytest.raises(spack.main.SpackCommandError, match="No logs are available"):
+    with pytest.raises(spack.error.SpackError, match="No logs are available"):
         logs("pkg-c")
 
 
@@ -75,7 +68,7 @@ def _write_string_to_path(string, path):
         f.write(string.encode("utf-8"))
 
 
-def test_dump_logs(install_mockery, mock_fetch, mock_archive, mock_packages, disable_capture):
+def test_dump_logs(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test that ``spack log`` can find (and print) the logs for partial
     builds and completed installs.
 

--- a/lib/spack/spack/test/cmd/maintainers.py
+++ b/lib/spack/spack/test/cmd/maintainers.py
@@ -38,9 +38,8 @@ def test_unmaintained():
     assert out == sorted(set(spack.repo.all_package_names()) - set(MAINTAINED_PACKAGES))
 
 
-def test_all(capfd):
-    with capfd.disabled():
-        out = split(maintainers("--all"))
+def test_all():
+    out = split(maintainers("--all"))
     assert out == [
         "gcc-runtime:",
         "haampie",
@@ -60,14 +59,12 @@ def test_all(capfd):
         "user2",
     ]
 
-    with capfd.disabled():
-        out = split(maintainers("--all", "maintainers-1"))
+    out = split(maintainers("--all", "maintainers-1"))
     assert out == ["maintainers-1:", "user1,", "user2"]
 
 
-def test_all_by_user(capfd):
-    with capfd.disabled():
-        out = split(maintainers("--all", "--by-user"))
+def test_all_by_user():
+    out = split(maintainers("--all", "--by-user"))
     assert out == [
         "haampie:",
         "gcc-runtime",
@@ -87,8 +84,7 @@ def test_all_by_user(capfd):
         "maintainers-3",
     ]
 
-    with capfd.disabled():
-        out = split(maintainers("--all", "--by-user", "user1", "user2"))
+    out = split(maintainers("--all", "--by-user", "user1", "user2"))
     assert out == [
         "user1:",
         "maintainers-1,",
@@ -113,43 +109,36 @@ def test_no_args_by_user():
 
 
 def test_mutex_args_fail():
-    with pytest.raises(SystemExit):
+    with pytest.raises(spack.main.SpackCommandError):
         maintainers("--maintained", "--unmaintained")
 
 
-def test_maintainers_list_packages(capfd):
-    with capfd.disabled():
-        out = split(maintainers("maintainers-1"))
+def test_maintainers_list_packages():
+    out = split(maintainers("maintainers-1"))
     assert out == ["user1", "user2"]
 
-    with capfd.disabled():
-        out = split(maintainers("maintainers-1", "maintainers-2"))
+    out = split(maintainers("maintainers-1", "maintainers-2"))
     assert out == ["user1", "user2", "user3"]
 
-    with capfd.disabled():
-        out = split(maintainers("maintainers-2"))
+    out = split(maintainers("maintainers-2"))
     assert out == ["user2", "user3"]
 
 
-def test_maintainers_list_fails(capfd):
+def test_maintainers_list_fails():
     out = maintainers("pkg-a", fail_on_error=False)
     assert not out
     assert maintainers.returncode == 1
 
 
-def test_maintainers_list_by_user(capfd):
-    with capfd.disabled():
-        out = split(maintainers("--by-user", "user1"))
+def test_maintainers_list_by_user():
+    out = split(maintainers("--by-user", "user1"))
     assert out == ["maintainers-1", "maintainers-3", "py-extension1"]
 
-    with capfd.disabled():
-        out = split(maintainers("--by-user", "user1", "user2"))
+    out = split(maintainers("--by-user", "user1", "user2"))
     assert out == ["maintainers-1", "maintainers-2", "maintainers-3", "py-extension1"]
 
-    with capfd.disabled():
-        out = split(maintainers("--by-user", "user2"))
+    out = split(maintainers("--by-user", "user2"))
     assert out == ["maintainers-1", "maintainers-2", "maintainers-3", "py-extension1"]
 
-    with capfd.disabled():
-        out = split(maintainers("--by-user", "user3"))
+    out = split(maintainers("--by-user", "user3"))
     assert out == ["maintainers-2", "maintainers-3"]

--- a/lib/spack/spack/test/cmd/mark.py
+++ b/lib/spack/spack/test/cmd/mark.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("mutable_mock_env_path")
 
 @pytest.mark.db
 def test_mark_mode_required(mutable_database):
-    with pytest.raises(SystemExit):
+    with pytest.raises(SpackCommandError):
         mark("-a")
 
 

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -344,11 +344,10 @@ def test_group_arguments(
 
 
 @pytest.mark.skipif(not spack.cmd.pkg.get_grep(), reason="grep is not installed")
-def test_pkg_grep(mock_packages, capfd):
+def test_pkg_grep(mock_packages):
     # only splice-* mock packages have the string "splice" in them
     pkg("grep", "-l", "splice")
-    output, _ = capfd.readouterr()
-    assert output.strip() == "\n".join(
+    assert pkg.output.strip() == "\n".join(
         spack.repo.PATH.get_pkg_class(name).module.__file__
         for name in [
             "depends-on-manyvariants",
@@ -370,8 +369,7 @@ def test_pkg_grep(mock_packages, capfd):
     with pytest.raises(spack.main.SpackCommandError):
         pkg("grep", "abcdefghijklmnopqrstuvwxyz")
     assert pkg.returncode == 1
-    output, _ = capfd.readouterr()
-    assert output.strip() == ""
+    assert pkg.output.strip() == ""
 
     # ensure that we return > 1 for an error
     with pytest.raises(spack.main.SpackCommandError):

--- a/lib/spack/spack/test/cmd/print_shell_vars.py
+++ b/lib/spack/spack/test/cmd/print_shell_vars.py
@@ -5,9 +5,9 @@
 from spack.main import print_setup_info
 
 
-def test_print_shell_vars_sh(capsys):
+def test_print_shell_vars_sh(capfd):
     print_setup_info("sh")
-    out, _ = capsys.readouterr()
+    out, _ = capfd.readouterr()
 
     assert "_sp_sys_type=" in out
     assert "_sp_tcl_roots=" in out
@@ -15,9 +15,9 @@ def test_print_shell_vars_sh(capsys):
     assert "_sp_module_prefix" not in out
 
 
-def test_print_shell_vars_csh(capsys):
+def test_print_shell_vars_csh(capfd):
     print_setup_info("csh")
-    out, _ = capsys.readouterr()
+    out, _ = capfd.readouterr()
 
     assert "set _sp_sys_type = " in out
     assert "set _sp_tcl_roots = " in out
@@ -25,9 +25,9 @@ def test_print_shell_vars_csh(capsys):
     assert "set _sp_module_prefix = " not in out
 
 
-def test_print_shell_vars_sh_modules(capsys):
+def test_print_shell_vars_sh_modules(capfd):
     print_setup_info("sh", "modules")
-    out, _ = capsys.readouterr()
+    out, _ = capfd.readouterr()
 
     assert "_sp_sys_type=" in out
     assert "_sp_tcl_roots=" in out
@@ -35,9 +35,9 @@ def test_print_shell_vars_sh_modules(capsys):
     assert "_sp_module_prefix=" in out
 
 
-def test_print_shell_vars_csh_modules(capsys):
+def test_print_shell_vars_csh_modules(capfd):
     print_setup_info("csh", "modules")
-    out, _ = capsys.readouterr()
+    out, _ = capfd.readouterr()
 
     assert "set _sp_sys_type = " in out
     assert "set _sp_tcl_roots = " in out

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -26,8 +26,7 @@ env = spack.main.SpackCommand("env")
 def test_help_option():
     # Test 'spack repo --help' to check basic import works
     # and the command exits successfully
-    with pytest.raises(SystemExit):
-        repo("--help")
+    repo("--help")
     assert repo.returncode in (None, 0)
 
 
@@ -39,12 +38,12 @@ def test_create_add_list_remove(mutable_config, tmp_path: pathlib.Path):
 
     # Add the new repository and check it appears in the list output
     repo("add", "--scope=site", str(tmp_path / "spack_repo" / "mockrepo"))
-    output = repo("list", "--scope=site", output=str)
+    output = repo("list", "--scope=site")
     assert "mockrepo" in output
 
     # Then remove it and check it's not there
     repo("remove", "--scope=site", str(tmp_path / "spack_repo" / "mockrepo"))
-    output = repo("list", "--scope=site", output=str)
+    output = repo("list", "--scope=site")
     assert "mockrepo" not in output
 
 
@@ -57,28 +56,28 @@ def test_repo_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
     # Confirm that it is not removed when the scope is incorrect
     with pytest.raises(spack.main.SpackCommandError):
         repo("remove", "--scope=user", "mockrepo")
-    output = repo("list", output=str)
+    output = repo("list")
     assert "mockrepo" in output
 
     # Confirm that when the scope is specified, it is only removed from that scope
     repo("remove", "--scope=site", "mockrepo")
-    site_output = repo("list", "--scope=site", output=str)
-    system_output = repo("list", "--scope=system", output=str)
+    site_output = repo("list", "--scope=site")
+    system_output = repo("list", "--scope=system")
     assert "mockrepo" not in site_output
     assert "mockrepo" in system_output
 
     # Confirm that when the scope is not specified, it is removed from top scope with it present
     repo("add", "--scope=site", str(tmp_path / "spack_repo" / "mockrepo"))
     repo("remove", "mockrepo")
-    site_output = repo("list", "--scope=site", output=str)
-    system_output = repo("list", "--scope=system", output=str)
+    site_output = repo("list", "--scope=site")
+    system_output = repo("list", "--scope=system")
     assert "mockrepo" not in site_output
     assert "mockrepo" in system_output
 
     # Check that the `--all-scopes` option removes from all scopes
     repo("add", "--scope=site", str(tmp_path / "spack_repo" / "mockrepo"))
     repo("remove", "--all-scopes", "mockrepo")
-    output = repo("list", output=str)
+    output = repo("list")
     assert "mockrepo" not in output
 
 
@@ -638,7 +637,7 @@ def test_add_repo_auto_name_from_namespace(monkeypatch, tmp_path: pathlib.Path):
     assert repos_config["auto_name_repo"] == str(tmp_path)
 
 
-def test_add_repo_partial_repo_construction_warning(monkeypatch, capsys):
+def test_add_repo_partial_repo_construction_warning(monkeypatch, capfd):
     """Test that _add_repo issues warnings for repos that can't be constructed but
     succeeds if at least one can be."""
 
@@ -664,7 +663,7 @@ def test_add_repo_partial_repo_construction_warning(monkeypatch, capsys):
     assert key == "test_mixed_repo"
 
     # Check that a warning was issued for the failed repo
-    captured = capsys.readouterr()
+    captured = capfd.readouterr()
     assert "Skipping package repository" in captured.err
 
 
@@ -798,18 +797,18 @@ def test_repo_list_format_flags(
     )
 
     # Test default table format, which shows one line per package repository
-    table_output = repo("list", output=str)
+    table_output = repo("list")
     assert "[+] repo_one" in table_output
     assert "[+] repo_two" in table_output
     assert " -  uninitialized" in table_output
     assert "[-] misconfigured" in table_output
 
     # Test --namespaces flag
-    namespaces_output = repo("list", "--namespaces", output=str)
+    namespaces_output = repo("list", "--namespaces")
     assert namespaces_output.strip().split("\n") == ["repo_one", "repo_two"]
 
     # Test --names flag
-    config_names_output = repo("list", "--names", output=str)
+    config_names_output = repo("list", "--names")
     config_names_lines = config_names_output.strip().split("\n")
     assert config_names_lines == ["monorepo", "uninitialized", "misconfigured"]
 

--- a/lib/spack/spack/test/cmd/resource.py
+++ b/lib/spack/spack/test/cmd/resource.py
@@ -35,9 +35,8 @@ mock_hashes = (
 )
 
 
-def test_resource_list(mock_packages, capfd):
-    with capfd.disabled():
-        out = resource("list")
+def test_resource_list(mock_packages):
+    out = resource("list")
 
     for h in mock_hashes:
         assert h in out
@@ -57,22 +56,20 @@ def test_resource_list(mock_packages, capfd):
     assert "patched by: builtin_mock.patch-a-dependency" in out
 
 
-def test_resource_list_only_hashes(mock_packages, capfd):
-    with capfd.disabled():
-        out = resource("list", "--only-hashes")
+def test_resource_list_only_hashes(mock_packages):
+    out = resource("list", "--only-hashes")
 
     for h in mock_hashes:
         assert h in out
 
 
-def test_resource_show(mock_packages, capfd):
+def test_resource_show(mock_packages):
     test_hash = (
         "c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8"
         if sys.platform != "win32"
         else "3c5b65abcd6a3b2c714dbf7c31ff65fe3748a1adc371f030c283007ca5534f11"
     )
-    with capfd.disabled():
-        out = resource("show", test_hash)
+    out = resource("show", test_hash)
 
     assert out.startswith(test_hash)
     assert (

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -80,7 +80,7 @@ def flake8_package_with_errors(scope="function"):
     yield tmp
 
 
-def test_changed_files_from_git_rev_base(git, tmp_path: pathlib.Path, capfd):
+def test_changed_files_from_git_rev_base(git, tmp_path: pathlib.Path):
     """Test arbitrary git ref as base."""
     with working_dir(str(tmp_path)):
         git("init")
@@ -229,7 +229,7 @@ def test_fix_style(external_style_root):
 @pytest.mark.skipif(not ISORT, reason="isort is not installed.")
 @pytest.mark.skipif(not MYPY, reason="mypy is not installed.")
 @pytest.mark.skipif(not BLACK, reason="black is not installed.")
-def test_external_root(external_style_root, capfd):
+def test_external_root(external_style_root):
     """Ensure we can run in a separate root directory w/o configuration files."""
     tmp_path, py_file = external_style_root
 

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -13,6 +13,7 @@ import spack.cmd.test
 import spack.concretize
 import spack.config
 import spack.install_test
+import spack.main
 import spack.paths
 from spack.install_test import TestStatus
 from spack.llnl.util.filesystem import copy_tree, working_dir
@@ -47,9 +48,7 @@ def test_test_dirty_flag(arguments, expected):
     assert args.dirty == expected
 
 
-def test_test_dup_alias(
-    mock_test_stage, mock_packages, mock_archive, mock_fetch, install_mockery, capfd
-):
+def test_test_dup_alias(mock_test_stage, mock_packages, mock_archive, mock_fetch, install_mockery):
     """Ensure re-using an alias fails with suggestion to change."""
     install("--fake", "libdwarf")
 
@@ -57,8 +56,7 @@ def test_test_dup_alias(
     spack_test("run", "--alias", "libdwarf", "libdwarf")
 
     # Try again with the alias but don't let it fail on the error
-    with capfd.disabled():
-        out = spack_test("run", "--alias", "libdwarf", "libdwarf", fail_on_error=False)
+    out = spack_test("run", "--alias", "libdwarf", "libdwarf", fail_on_error=False)
 
     assert "already exists" in out and "Try another alias" in out
 
@@ -143,7 +141,6 @@ def test_cdash_output_test_error(
     mock_packages,
     mock_archive,
     mock_test_stage,
-    capfd,
 ):
     """Confirm stand-alone test error expected outputs in CDash reporting."""
     install("test-error")
@@ -184,12 +181,10 @@ def test_cdash_upload_clean_test(
         assert "<Text>" not in content
 
 
-def test_test_help_does_not_show_cdash_options(mock_test_stage, capsys):
+def test_test_help_does_not_show_cdash_options(mock_test_stage):
     """Make sure `spack test --help` does not describe CDash arguments"""
-    with pytest.raises(SystemExit):
-        spack_test("run", "--help")
-        captured = capsys.readouterr()
-        assert "CDash URL" not in captured.out
+    spack_test("run", "--help")
+    assert "CDash URL" not in spack_test.output
 
 
 def test_test_help_cdash(mock_test_stage):

--- a/lib/spack/spack/test/cmd/unit_test.py
+++ b/lib/spack/spack/test/cmd/unit_test.py
@@ -30,9 +30,8 @@ def test_list_with_keywords():
     assert cmd_test_py in output.strip()
 
 
-def test_list_long(capsys):
-    with capsys.disabled():
-        output = spack_test("--list-long")
+def test_list_long():
+    output = spack_test("--list-long")
     assert "unit_test.py::\n" in output
     assert "test_list" in output
     assert "test_list_with_pytest_arg" in output
@@ -47,9 +46,8 @@ def test_list_long(capsys):
     assert "test_test_deptype" in output
 
 
-def test_list_long_with_pytest_arg(capsys):
-    with capsys.disabled():
-        output = spack_test("--list-long", cmd_test_py)
+def test_list_long_with_pytest_arg():
+    output = spack_test("--list-long", cmd_test_py)
 
     assert "unit_test.py::\n" in output
     assert "test_list" in output

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -115,30 +115,29 @@ def test_url_summary(mock_packages):
     assert out_correct_versions == correct_versions
 
 
-def test_url_stats(capfd, mock_packages):
-    with capfd.disabled():
-        output = url("stats")
-        npkgs = "%d packages" % len(spack.repo.all_package_names())
-        assert npkgs in output
-        assert "url" in output
-        assert "git" in output
-        assert "schemes" in output
-        assert "versions" in output
-        assert "resources" in output
+def test_url_stats(mock_packages):
+    output = url("stats")
+    npkgs = "%d packages" % len(spack.repo.all_package_names())
+    assert npkgs in output
+    assert "url" in output
+    assert "git" in output
+    assert "schemes" in output
+    assert "versions" in output
+    assert "resources" in output
 
-        output = url("stats", "--show-issues")
-        npkgs = "%d packages" % len(spack.repo.all_package_names())
-        assert npkgs in output
-        assert "url" in output
-        assert "git" in output
-        assert "schemes" in output
-        assert "versions" in output
-        assert "resources" in output
+    output = url("stats", "--show-issues")
+    npkgs = "%d packages" % len(spack.repo.all_package_names())
+    assert npkgs in output
+    assert "url" in output
+    assert "git" in output
+    assert "schemes" in output
+    assert "versions" in output
+    assert "resources" in output
 
-        assert "Package URLs with md5 hashes" in output
-        assert "needs-relocation" in output
-        assert "https://cmake.org/files/v3.4/cmake-0.0.0.tar.gz" in output
+    assert "Package URLs with md5 hashes" in output
+    assert "needs-relocation" in output
+    assert "https://cmake.org/files/v3.4/cmake-0.0.0.tar.gz" in output
 
-        assert "Package URLs with http urls" in output
-        assert "zmpi" in output
-        assert "http://www.spack-fake-zmpi.org/downloads/zmpi-1.0.tar.gz" in output
+    assert "Package URLs with http urls" in output
+    assert "zmpi" in output
+    assert "http://www.spack-fake-zmpi.org/downloads/zmpi-1.0.tar.gz" in output

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -9,6 +9,7 @@ import sys
 import pytest
 
 import spack.concretize
+import spack.main
 import spack.util.spack_yaml as s_yaml
 from spack.installer import PackageInstaller
 from spack.llnl.util.filesystem import _windows_can_symlink
@@ -200,7 +201,7 @@ def test_view_fails_with_missing_projections_file(tmp_path: pathlib.Path):
     viewpath = str(tmp_path / "view")
     (tmp_path / "view").mkdir()
     projection_file = str(tmp_path / "nonexistent")
-    with pytest.raises(SystemExit):
+    with pytest.raises(spack.main.SpackCommandError):
         view("symlink", "--projection-file", projection_file, viewpath, "foo")
 
 

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -180,7 +180,7 @@ def test_multi_extension_search(hello_world_extension, extension_creator):
         assert ("Hello world") in spack.main.SpackCommand("hello-world")()
 
 
-def test_duplicate_module_load(hello_world_cmd, capsys):
+def test_duplicate_module_load(hello_world_cmd, capfd):
     """Ensure duplicate module load attempts are successful.
 
     The command module will already have been loaded once by the
@@ -190,7 +190,7 @@ def test_duplicate_module_load(hello_world_cmd, capsys):
     args = []
     hw_cmd = spack.cmd.get_command(hello_world_cmd.command_name)
     hw_cmd(parser, args)
-    captured = capsys.readouterr()
+    captured = capfd.readouterr()
     assert captured == ("Hello world!\n", "")
 
 
@@ -245,7 +245,7 @@ def test_extension_naming(tmp_path: pathlib.Path, extension_path, expected_excep
                 spack.cmd.get_module("no-such-command")
 
 
-def test_missing_command_function(extension_creator, capsys):
+def test_missing_command_function(extension_creator, capfd):
     """Ensure we die as expected if a command module does not have the
     expected command function defined.
     """
@@ -253,7 +253,7 @@ def test_missing_command_function(extension_creator, capsys):
         extension.add_command("bad-cmd", """\ndescription = "Empty command implementation"\n""")
         with pytest.raises(SystemExit):
             spack.cmd.get_module("bad-cmd")
-        capture = capsys.readouterr()
+        capture = capfd.readouterr()
         assert "must define function 'bad_cmd'." in capture[1]
 
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1628,7 +1628,7 @@ def test_included_optional_include_scopes():
 
 
 def test_included_path_string(
-    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, capsys
+    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, capfd
 ):
     path = tmp_path / "local" / "config.yaml"
     path.parent.mkdir()
@@ -1653,7 +1653,7 @@ def test_included_path_string(
     # Second pass uses the scopes previously built
     assert include._scopes is not None
     scopes = include.scopes(parent_scope)
-    captured = capsys.readouterr()[1]
+    captured = capfd.readouterr()[1]
     assert "Using existing scopes" in captured
 
 
@@ -1674,7 +1674,7 @@ def test_included_path_string_no_parent_path(
 
 
 def test_included_path_conditional_bad_when(
-    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, capsys
+    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, capfd
 ):
     path = tmp_path / "local"
     path.mkdir()
@@ -1687,7 +1687,7 @@ def test_included_path_conditional_bad_when(
     assert not include.evaluate_condition()
 
     scopes = include.scopes(mock_low_high_config.scopes["low"])
-    captured = capsys.readouterr()[1]
+    captured = capfd.readouterr()[1]
     assert "condition is not satisfied" in captured
     assert not scopes
 
@@ -1722,7 +1722,7 @@ def test_included_path_git_missing_args():
 
 
 def test_included_path_git_unsat(
-    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, capsys
+    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, capfd
 ):
     paths = ["config.yaml", "packages.yaml"]
     entry = {
@@ -1740,7 +1740,7 @@ def test_included_path_git_unsat(
     assert not include.optional and not include.evaluate_condition()
 
     scopes = include.scopes(mock_low_high_config.scopes["low"])
-    captured = capsys.readouterr()[1]
+    captured = capfd.readouterr()[1]
     assert "condition is not satisfied" in captured
     assert not scopes
 
@@ -1749,7 +1749,7 @@ def test_included_path_git_unsat(
     "key,value", [("branch", "main"), ("commit", "abcdef123456"), ("tag", "v1.0")]
 )
 def test_included_path_git(
-    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, key, value, capsys
+    tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, key, value, capfd
 ):
     monkeypatch.setattr(spack.paths, "user_cache_path", str(tmp_path))
 
@@ -1807,14 +1807,14 @@ def test_included_path_git(
     if key == "branch":
         assert include._scopes is not None
         scopes = include.scopes(parent_scope)
-        captured = capsys.readouterr()[1]
+        captured = capfd.readouterr()[1]
         assert "Using existing scopes" in captured
 
     # A direct clone now returns already cloned destination and debug message.
     # Again only need to run this test once.
     if key == "tag":
         assert include._clone() == include.destination
-        captured = capsys.readouterr()[1]
+        captured = capfd.readouterr()[1]
         assert "already cloned" in captured
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -40,6 +40,7 @@ import spack.error
 import spack.llnl.util.lang
 import spack.llnl.util.lock
 import spack.llnl.util.tty as tty
+import spack.llnl.util.tty.color
 import spack.modules.common
 import spack.package_base
 import spack.paths
@@ -2116,7 +2117,10 @@ def mock_fetch_url_text(mock_config_data, monkeypatch):
 
 @pytest.fixture(scope="function")
 def mock_tty_stdout(monkeypatch):
+    """Make sys.stdout.isatty() return True, while forcing no color output."""
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    with spack.llnl.util.tty.color.color_when("never"):
+        yield
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/container/cli.py
+++ b/lib/spack/spack/test/container/cli.py
@@ -10,10 +10,9 @@ import spack.main
 containerize = spack.main.SpackCommand("containerize")
 
 
-def test_command(default_config, container_config_dir, capsys):
-    with capsys.disabled():
-        with fs.working_dir(container_config_dir):
-            output = containerize()
+def test_command(default_config, container_config_dir):
+    with fs.working_dir(container_config_dir):
+        output = containerize()
     assert "FROM spack/ubuntu-jammy" in output
 
 
@@ -26,16 +25,15 @@ def test_listing_possible_os():
 
 @pytest.mark.maybeslow
 @pytest.mark.requires_executables("git")
-def test_bootstrap_phase(minimal_configuration, config_dumper, capsys):
+def test_bootstrap_phase(minimal_configuration, config_dumper):
     minimal_configuration["spack"]["container"]["images"] = {
         "os": "amazonlinux:2",
         "spack": {"resolve_sha": False},
     }
     spack_yaml_dir = config_dumper(minimal_configuration)
 
-    with capsys.disabled():
-        with fs.working_dir(spack_yaml_dir):
-            output = containerize()
+    with fs.working_dir(spack_yaml_dir):
+        output = containerize()
 
     # Check for the presence of the Git commands
     assert "git init" in output

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -15,7 +15,6 @@ import pytest
 
 import spack.vendor.archspec.cpu
 
-import spack
 import spack.cmd
 import spack.cmd.external
 import spack.compilers.config

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -243,7 +243,7 @@ def test_missing_upstream_build_dep(
 
 
 def test_removed_upstream_dep(
-    upstream_and_downstream_db, capsys, config, repo_builder: RepoBuilder
+    upstream_and_downstream_db, capfd, config, repo_builder: RepoBuilder
 ):
     upstream_db, downstream_db = upstream_and_downstream_db
 
@@ -269,7 +269,7 @@ def test_removed_upstream_dep(
         downstream_db._read_from_file(downstream_db._index_path)
         assert (
             f"Missing dependency not in database: y/{y.dag_hash(7)} needs z"
-            in capsys.readouterr().err
+            in capfd.readouterr().err
         )
 
 
@@ -989,7 +989,7 @@ def test_clear_failure_forced(mutable_database, monkeypatch, capfd):
 
 
 @pytest.mark.db
-def test_mark_failed(mutable_database, monkeypatch, tmp_path: pathlib.Path, capsys):
+def test_mark_failed(mutable_database, monkeypatch, tmp_path: pathlib.Path, capfd):
     """Add coverage to mark_failed."""
 
     def _raise_exc(lock):
@@ -1002,7 +1002,7 @@ def test_mark_failed(mutable_database, monkeypatch, tmp_path: pathlib.Path, caps
         monkeypatch.setattr(lk.Lock, "acquire_write", _raise_exc)
 
         spack.store.STORE.failure_tracker.mark(s)
-        out = str(capsys.readouterr()[1])
+        out = str(capfd.readouterr()[1])
         assert "Unable to mark pkg-a as failed" in out
 
     spack.store.STORE.failure_tracker.clear_all()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -334,7 +334,7 @@ def test_store(install_mockery, mock_fetch):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_failing_build(install_mockery, mock_fetch, capfd):
+def test_failing_build(install_mockery, mock_fetch):
     spec = spack.concretize.concretize_one("failing-build")
     pkg = spec.package
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -319,7 +319,7 @@ def test_installer_ensure_ready_errors(install_mockery, monkeypatch):
         installer._ensure_install_ready(spec.package)
 
 
-def test_ensure_locked_err(install_mockery, monkeypatch, tmp_path: pathlib.Path, capsys):
+def test_ensure_locked_err(install_mockery, monkeypatch, tmp_path: pathlib.Path, capfd):
     """Test _ensure_locked when a non-lock exception is raised."""
     mock_err_msg = "Mock exception error"
 
@@ -334,12 +334,12 @@ def test_ensure_locked_err(install_mockery, monkeypatch, tmp_path: pathlib.Path,
         with pytest.raises(RuntimeError):
             installer._ensure_locked("read", spec.package)
 
-        out = str(capsys.readouterr()[1])
+        out = str(capfd.readouterr()[1])
         assert "Failed to acquire a read lock" in out
         assert mock_err_msg in out
 
 
-def test_ensure_locked_have(install_mockery, tmp_path: pathlib.Path, capsys):
+def test_ensure_locked_have(install_mockery, tmp_path: pathlib.Path, capfd):
     """Test _ensure_locked when already have lock."""
     installer = create_installer(["trivial-install-test-package"], {})
     spec = installer.build_requests[0].pkg.spec
@@ -359,7 +359,7 @@ def test_ensure_locked_have(install_mockery, tmp_path: pathlib.Path, capsys):
         with pytest.raises(ulk.LockUpgradeError, match=err):
             installer._ensure_locked(lock_type, spec.package)
 
-        out = str(capsys.readouterr()[1])
+        out = str(capfd.readouterr()[1])
         assert "Failed to upgrade to a write lock" in out
         assert "exception when releasing read lock" in out
 
@@ -386,7 +386,7 @@ def test_ensure_locked_new_lock(install_mockery, tmp_path: pathlib.Path, lock_ty
         assert lock._writes == writes
 
 
-def test_ensure_locked_new_warn(install_mockery, monkeypatch, capsys):
+def test_ensure_locked_new_warn(install_mockery, monkeypatch, capfd):
     orig_pl = spack.database.SpecLocker.lock
 
     def _pl(db, spec, timeout):
@@ -404,7 +404,7 @@ def test_ensure_locked_new_warn(install_mockery, monkeypatch, capsys):
     assert ltype == lock_type
     assert lock is not None
 
-    out = str(capsys.readouterr()[1])
+    out = str(capfd.readouterr()[1])
     assert "Expected prefix lock timeout" in out
 
 
@@ -441,7 +441,7 @@ def test_dump_packages_deps_ok(install_mockery, tmp_path: pathlib.Path, mock_pac
     assert os.path.isfile(dest_pkg)
 
 
-def test_dump_packages_deps_errs(install_mockery, tmp_path: pathlib.Path, monkeypatch, capsys):
+def test_dump_packages_deps_errs(install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd):
     """Test error paths for dump_packages with dependencies."""
     orig_bpp = spack.store.STORE.layout.build_packages_path
     orig_dirname = spack.repo.Repo.dirname_for_package_name
@@ -478,7 +478,7 @@ def test_dump_packages_deps_errs(install_mockery, tmp_path: pathlib.Path, monkey
     with pytest.raises(spack.repo.RepoError, match=repo_err_msg):
         inst.dump_packages(spec, path)
 
-    out = str(capsys.readouterr()[1])
+    out = str(capfd.readouterr()[1])
     assert "Couldn't copy in provenance for cmake" in out
 
 
@@ -509,7 +509,7 @@ def test_clear_failures_success(tmp_path: pathlib.Path):
 
 
 @pytest.mark.not_on_windows("chmod does not prevent removal on Win")
-def test_clear_failures_errs(tmp_path: pathlib.Path, capsys):
+def test_clear_failures_errs(tmp_path: pathlib.Path, capfd):
     """Test the clear_failures exception paths."""
     failures = spack.database.FailureTracker(str(tmp_path), default_timeout=0.1)
     spec = spack.spec.Spec("pkg-a")
@@ -523,7 +523,7 @@ def test_clear_failures_errs(tmp_path: pathlib.Path, capsys):
     failures.clear_all()
 
     # Ensure expected warning generated
-    out = str(capsys.readouterr()[1])
+    out = str(capfd.readouterr()[1])
     assert "Unable to remove failure" in out
     failures.dir.chmod(0o750)
 
@@ -645,7 +645,7 @@ def test_installer_init_requests(install_mockery):
 
 
 @pytest.mark.parametrize("transitive", [True, False])
-def test_install_spliced(install_mockery, mock_fetch, monkeypatch, capsys, transitive):
+def test_install_spliced(install_mockery, mock_fetch, monkeypatch, transitive):
     """Test installing a spliced spec"""
     spec = spack.concretize.concretize_one("splice-t")
     dep = spack.concretize.concretize_one("splice-h+foo")
@@ -660,7 +660,7 @@ def test_install_spliced(install_mockery, mock_fetch, monkeypatch, capsys, trans
 
 
 @pytest.mark.parametrize("transitive", [True, False])
-def test_install_spliced_build_spec_installed(install_mockery, capfd, mock_fetch, transitive):
+def test_install_spliced_build_spec_installed(install_mockery, mock_fetch, transitive):
     """Test installing a spliced spec with the build spec already installed"""
     spec = spack.concretize.concretize_one("splice-t")
     dep = spack.concretize.concretize_one("splice-h+foo")
@@ -747,7 +747,7 @@ def test_installing_task_use_cache(install_mockery, monkeypatch):
     assert request.pkg_id in installer.installed
 
 
-def test_install_task_requeue_build_specs(install_mockery, monkeypatch, capfd):
+def test_install_task_requeue_build_specs(install_mockery, monkeypatch):
     """Check that a missing build_spec spec is added by _complete_task."""
 
     # This test also ensures coverage of most of the new
@@ -773,7 +773,7 @@ def test_install_task_requeue_build_specs(install_mockery, monkeypatch, capfd):
     assert inst.package_id(popped_task.pkg.spec) in installer.build_tasks
 
 
-def test_release_lock_write_n_exception(install_mockery, tmp_path: pathlib.Path, capsys):
+def test_release_lock_write_n_exception(install_mockery, tmp_path: pathlib.Path, capfd):
     """Test _release_lock for supposed write lock with exception."""
     installer = create_installer(["trivial-install-test-package"], {})
 
@@ -784,7 +784,7 @@ def test_release_lock_write_n_exception(install_mockery, tmp_path: pathlib.Path,
         assert lock._writes == 0
 
         installer._release_lock(pkg_id)
-        out = str(capsys.readouterr()[1])
+        out = str(capfd.readouterr()[1])
         msg = "exception when releasing write lock for {0}".format(pkg_id)
         assert msg in out
 
@@ -889,7 +889,7 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     assert expected_msg in out
 
 
-def test_cleanup_failed_err(install_mockery, tmp_path: pathlib.Path, monkeypatch, capsys):
+def test_cleanup_failed_err(install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd):
     """Test _cleanup_failed exception path."""
     msg = "Fake release_write exception"
 
@@ -905,7 +905,7 @@ def test_cleanup_failed_err(install_mockery, tmp_path: pathlib.Path, monkeypatch
         installer.failed[pkg_id] = lock
 
         installer._cleanup_failed(pkg_id)
-        out = str(capsys.readouterr()[1])
+        out = str(capfd.readouterr()[1])
         assert "exception when removing failure tracking" in out
         assert msg in out
 
@@ -921,7 +921,7 @@ def test_update_failed_no_dependent_task(install_mockery):
         assert installer.failed[task.pkg_id] is None
 
 
-def test_install_uninstalled_deps(install_mockery, monkeypatch, capsys):
+def test_install_uninstalled_deps(install_mockery, monkeypatch, capfd):
     """Test install with uninstalled dependencies."""
     installer = create_installer(["parallel-package-a"], {})
 
@@ -936,11 +936,11 @@ def test_install_uninstalled_deps(install_mockery, monkeypatch, capsys):
     with pytest.raises(spack.error.InstallError, match=msg):
         installer.install()
 
-    out = str(capsys.readouterr())
+    out = str(capfd.readouterr())
     assert "Detected uninstalled dependencies for" in out
 
 
-def test_install_failed(install_mockery, monkeypatch, capsys):
+def test_install_failed(install_mockery, monkeypatch, capfd):
     """Test install with failed install."""
     installer = create_installer(["parallel-package-a"], {})
 
@@ -950,12 +950,12 @@ def test_install_failed(install_mockery, monkeypatch, capsys):
     with pytest.raises(spack.error.InstallError, match="request failed"):
         installer.install()
 
-    out = str(capsys.readouterr())
+    out = str(capfd.readouterr())
     assert installer.build_requests[0].pkg_id in out
     assert "failed to install" in out
 
 
-def test_install_failed_not_fast(install_mockery, monkeypatch, capsys):
+def test_install_failed_not_fast(install_mockery, monkeypatch, capfd):
     """Test install with failed install."""
     installer = create_installer(["parallel-package-a"], {"fail_fast": False})
 
@@ -965,7 +965,7 @@ def test_install_failed_not_fast(install_mockery, monkeypatch, capsys):
     with pytest.raises(spack.error.InstallError, match="request failed"):
         installer.install()
 
-    out = str(capsys.readouterr())
+    out = str(capfd.readouterr())
     assert "failed to install" in out
     assert "Skipping build of parallel-package-a" in out
 
@@ -1045,7 +1045,7 @@ def test_install_fail_multi(install_mockery, mock_fetch, monkeypatch):
     assert not any(pkg_id.startswith("pkg-a-") for pkg_id in installer.installed)
 
 
-def test_install_fail_fast_on_detect(install_mockery, monkeypatch, capsys):
+def test_install_fail_fast_on_detect(install_mockery, monkeypatch, capfd):
     """Test fail_fast install when an install failure is detected."""
     a = spack.concretize.concretize_one("parallel-package-a")
 
@@ -1070,7 +1070,7 @@ def test_install_fail_fast_on_detect(install_mockery, monkeypatch, capsys):
     ), "Package a cannot install due to its dependencies failing"
     # check that b's active process got killed when c failed
 
-    assert f"{b_id} failed to install" in capsys.readouterr().err
+    assert f"{b_id} failed to install" in capfd.readouterr().err
 
 
 def _test_install_fail_fast_on_except_patch(installer, **kwargs):
@@ -1081,7 +1081,7 @@ def _test_install_fail_fast_on_except_patch(installer, **kwargs):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_install_fail_fast_on_except(install_mockery, monkeypatch, capsys):
+def test_install_fail_fast_on_except(install_mockery, monkeypatch, capfd):
     """Test fail_fast install when an install failure results from an error."""
     installer = create_installer(["pkg-a"], {"fail_fast": True})
 
@@ -1096,7 +1096,7 @@ def test_install_fail_fast_on_except(install_mockery, monkeypatch, capsys):
     with pytest.raises(spack.error.InstallError, match="mock patch failure"):
         installer.install()
 
-    out = str(capsys.readouterr())
+    out = str(capfd.readouterr())
     assert "Skipping build of pkg-a" in out
 
 

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -83,13 +83,13 @@ def test_get_version_no_git(working_env, monkeypatch):
     assert spack.spack_version == spack.get_version()
 
 
-def test_main_calls_get_version(capsys, working_env, monkeypatch):
+def test_main_calls_get_version(capfd, working_env, monkeypatch):
     # act like git is not found in the PATH
     monkeypatch.setattr(spack.util.git, "git", lambda: None)
 
     # make sure we get a bare version (without commit) when this happens
     spack.main.main(["-V"])
-    out, err = capsys.readouterr()
+    out, err = capfd.readouterr()
     assert spack.spack_version == out.strip()
 
 

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -7,7 +7,6 @@ import pathlib
 
 import pytest
 
-import spack
 import spack.util.module_cmd
 from spack.util.module_cmd import (
     get_path_args_from_module_line,

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -15,7 +15,6 @@ from contextlib import contextmanager
 
 import pytest
 
-import spack
 import spack.binary_distribution
 import spack.database
 import spack.deptypes as dt

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -378,10 +378,10 @@ def test_git_provenance_find_commit_ls_remote(
 
 @pytest.mark.require_provenance
 @pytest.mark.disable_clean_stage_check
-def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, capsys):
+def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, capfd):
     """Fail all attempts to resolve git commits"""
     monkeypatch.setattr(spack.package_base.PackageBase, "do_fetch", lambda *args, **kwargs: None)
     spec = spack.concretize.concretize_one("git-ref-package@develop")
-    captured = capsys.readouterr()
+    captured = capfd.readouterr()
     assert "commit" not in spec.variants
     assert "Warning: Unable to resolve the git commit" in captured.err

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -6,7 +6,6 @@ import pathlib
 
 import pytest
 
-import spack
 import spack.environment
 import spack.package_base
 import spack.paths
@@ -154,18 +153,18 @@ def test_repo_path_handles_package_removal(mock_packages, repo_builder: RepoBuil
 
 
 def test_repo_dump_virtuals(
-    tmp_path: pathlib.Path, mutable_mock_repo, mock_packages, ensure_debug, capsys
+    tmp_path: pathlib.Path, mutable_mock_repo, mock_packages, ensure_debug, capfd
 ):
     # Start with a package-less virtual
     vspec = spack.spec.Spec("something")
     mutable_mock_repo.dump_provenance(vspec, str(tmp_path))
-    captured = capsys.readouterr()[1]
+    captured = capfd.readouterr()[1]
     assert "does not have a package" in captured
 
     # Now with a virtual with a package
     vspec = spack.spec.Spec("externalvirtual")
     mutable_mock_repo.dump_provenance(vspec, str(tmp_path))
-    captured = capsys.readouterr()[1]
+    captured = capfd.readouterr()[1]
     assert "Installing" in captured
     assert "package.py" in os.listdir(str(tmp_path)), "Expected the virtual's package to be copied"
 
@@ -425,7 +424,7 @@ def test_mod_to_pkg_name_and_reverse():
     assert spack.util.naming.pkg_name_to_pkg_dir("none", package_api=(2, 0)) == "none"
 
 
-def test_repo_v2_invalid_module_name(tmp_path: pathlib.Path, capsys):
+def test_repo_v2_invalid_module_name(tmp_path: pathlib.Path, capfd):
     # Create a repo with a v2 structure
     root, _ = spack.repo.create_repo(str(tmp_path), namespace="repo_1", package_api=(2, 0))
     repo_dir = pathlib.Path(root)
@@ -453,12 +452,12 @@ class Uppercase(PackageBase):
     with spack.repo.use_repositories(str(repo_dir)) as repo:
         assert len(repo.all_package_names()) == 0
 
-    stderr = capsys.readouterr().err
+    stderr = capfd.readouterr().err
     assert "cannot be used because `zlib-ng` is not a valid Spack package module name" in stderr
     assert "cannot be used because `UPPERCASE` is not a valid Spack package module name" in stderr
 
 
-def test_repo_v2_module_and_class_to_package_name(tmp_path: pathlib.Path, capsys):
+def test_repo_v2_module_and_class_to_package_name(tmp_path: pathlib.Path):
     # Create a repo with a v2 structure
     root, _ = spack.repo.create_repo(str(tmp_path), namespace="repo_2", package_api=(2, 0))
     repo_dir = pathlib.Path(root)

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -883,13 +883,13 @@ def test_stage_create_replace_path(tmp_build_stage_dir):
     assert os.path.isdir(nondir)
 
 
-def test_cannot_access(capsys):
+def test_cannot_access(capfd):
     """Ensure can_access dies with the expected error."""
     with pytest.raises(SystemExit):
         # It's far more portable to use a non-existent filename.
         spack.stage.ensure_access("/no/such/file")
 
-    captured = capsys.readouterr()
+    captured = capfd.readouterr()
     assert "Insufficient permissions" in str(captured)
 
 

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -211,11 +211,11 @@ def test_test_functions_fails():
         spack.install_test.test_functions(str)
 
 
-def test_test_functions_pkgless(mock_packages, install_mockery, ensure_debug, capsys):
+def test_test_functions_pkgless(mock_packages, install_mockery, ensure_debug, capfd):
     """Confirm works for package providing a package-less virtual."""
     spec = spack.concretize.concretize_one("simple-standalone-test")
     fns = spack.install_test.test_functions(spec.package, add_virtuals=True)
-    out = capsys.readouterr()
+    out = capfd.readouterr()
     assert len(fns) == 2, "Expected two test functions"
     for f in fns:
         assert f[1].__name__ in ["test_echo", "test_skip"]
@@ -265,7 +265,7 @@ def test_package_copy_test_files_fails(mock_packages):
     assert "test suite is missing" in str(exc_info)
 
 
-def test_package_copy_test_files_skips(mock_packages, ensure_debug, capsys):
+def test_package_copy_test_files_skips(mock_packages, ensure_debug, capfd):
     """Confirm copy_test_files errors as expected if no package class found."""
     # Try with a non-concrete spec and package with a test suite
     MockSuite = collections.namedtuple("TestSuite", ["specs"])
@@ -273,7 +273,7 @@ def test_package_copy_test_files_skips(mock_packages, ensure_debug, capsys):
     vspec = spack.spec.Spec("something")
     pkg = MyPackage("SomePackage", vspec, MockSuite([]))
     spack.install_test.copy_test_files(pkg, vspec)
-    out = capsys.readouterr()[1]
+    out = capfd.readouterr()[1]
     assert "skipping test data copy" in out
     assert "no package class found" in out
 

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -9,7 +9,6 @@ from typing import List
 
 import pytest
 
-import spack
 import spack.llnl.util.filesystem as fs
 import spack.main
 import spack.util.executable as ex

--- a/lib/spack/spack/test/utilities.py
+++ b/lib/spack/spack/test/utilities.py
@@ -25,6 +25,5 @@ class SpackCommandArgs:
 
     def __call__(self, *argv, **kwargs):
         self.parser.add_command(self.command_name)
-        prepend = kwargs["global_args"] if "global_args" in kwargs else []
-        args, unknown = self.parser.parse_known_args(prepend + [self.command_name] + list(argv))
+        args, unknown = self.parser.parse_known_args([self.command_name] + list(argv))
         return args

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -276,7 +276,7 @@ class MockS3Client:
         raise self.ClientError
 
 
-def test_gather_s3_information(monkeypatch, capfd):
+def test_gather_s3_information(monkeypatch):
     mirror = spack.mirrors.mirror.Mirror(
         {
             "fetch": {
@@ -332,7 +332,7 @@ def test_remove_s3_url(monkeypatch, capfd):
     assert "Deleted keytwo" in err
 
 
-def test_s3_url_exists(monkeypatch, capfd):
+def test_s3_url_exists(monkeypatch):
     def get_s3_session(url, method="fetch"):
         return MockS3Client()
 


### PR DESCRIPTION
This PR refactors `SpackCommand` to significantly reduce test overhead and improve readability. By default, commands now run in-process, avoiding the performance hit of spawning new subprocesses for every command invocation.

Additionally, this PR overhauls how `stdout`/`stderr` are captured, fixing long-standing issues where output failed to capture correctly under `pytest`.

* Removed the `subprocess=...` argument. `SpackCommand` now runs strictly in-process (except for specific cases in `commands.py`).
* Replaced the pipe/thread capture mechanism with a temporary file approach. On Linux, this uses `O_TMPFILE`, so no actual file appears on the filesystem anyways. This removes the `_writer_daemon` subprocess, even if `subprocess=False`, and reduces overhead.
* Previously, `log_output` failed to capture child process output under `pytest` because `sys.stdout` is replaced by a pytest wrapper object with a different file descriptor than the actual OS-level fd `1`. The fix explicitly duplicates and redirects the set `{sys.stdout.fileno(), sys.stderr.fileno(), 1, 2}`.
* Move Spack command argument parsing in the try-catch block to ensure `SpackCommandError` is raised for parsing errors. This means that whenever a Spack command would have raised a `SystemExit`, it now raises `SpackCommandError` instead.
* Removed support for `io.StringIO` in `log_output()`, since its only use was `SpackCommand`.

Updates to tests:

*   Refactored tests to rely on `SpackCommand.output` (and `.returncode`) rather than `capsys` or `capfd` fixtures.
*   Removed unnecessary `with capsys.disabled():` blocks, as `SpackCommand` now handles capture contexts cleanly.
*   Updated tests that were passing invalid kwargs to `SpackCommand`.

