### PR TITLE
Spec.satisfies: bugfix abstract specs with conditional deps

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3534,9 +3534,7 @@ class Spec:
                         lhs_edge.spec
                         for lhs_edge in candidate_edges
                         if ((lhs_edge.depflag & rhs_edge.depflag) ^ rhs_edge.depflag) == 0
-                        and rhs_edge.when._satisfies(
-                            lhs_edge.when, resolve_virtuals=resolve_virtuals
-                        )
+                        and rhs_edge.when._satisfies(lhs_edge.when, resolve_virtuals=False)
                     ]
                     if not candidates or not any(
                         x._satisfies(rhs_edge.spec, resolve_virtuals=resolve_virtuals)
@@ -3579,7 +3577,7 @@ class Spec:
                 candidate_edges = [
                     lhs_edge
                     for lhs_edge in lhs_edges[current_dependency_name]
-                    if rhs_edge.when._satisfies(lhs_edge.when, resolve_virtuals=resolve_virtuals)
+                    if rhs_edge.when._satisfies(lhs_edge.when, resolve_virtuals=False)
                 ]
 
             if not candidate_edges:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -621,6 +621,11 @@ class TestSpecSemantics:
         assert concrete.satisfies("^[when='^notapackage'] zmpi")
         assert not concrete.satisfies("^[when='^mpi'] zmpi")
 
+    def test_abstract_satisfies_conditional_dep(self):
+        assert Spec("pkg-a ^[when=%c] gcc").satisfies("pkg-a ^[when=%c] gcc")
+        assert Spec("pkg-a %[when=%c] gcc").satisfies("pkg-a %[when=%c] gcc")
+        assert Spec("pkg-a ^[when=^c] gcc").satisfies("pkg-a ^[when=^c] gcc")
+
     def test_satisfies_single_valued_variant(self):
         """Tests that the case reported in
         https://github.com/spack/spack/pull/2386#issuecomment-282147639


### PR DESCRIPTION
fixes #51703

Fixes a bug reported on slack that led to failures in matrix exclusions for toolchains.