### PR TITLE
Modify .gitignore for site scope README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ spack-db.*
 # except spack and site scopes that ship with spack
 /etc/spack/*
 !/etc/spack/defaults
-!/etc/spack/site
+!/etc/spack/site/README.md
 
 ###########################
 # Python-specific ignores #

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ spack-db.*
 *.out.log
 
 # Configuration: Ignore everything in /etc/spack,
-# except spack and site scopes that ship with spack
+# except defaults and site scopes that ship with spack
 /etc/spack/*
 !/etc/spack/defaults
 !/etc/spack/site/README.md


### PR DESCRIPTION
Updated .gitignore to only include the README.md in the site scope. It is the only thing we ship.  We have an automated process to push to the site scope and now updating our spack submodule is broken since the change became git tracked.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
