### PR TITLE
tengine.py: remove memoized

### DIFF
--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -15,6 +15,7 @@ import spack.error
 import spack.modules
 import spack.modules.common
 import spack.repo
+import spack.tengine
 from spack.cmd import MultipleSpecsMatch, NoSpecMatches
 from spack.cmd.common import arguments
 from spack.llnl.util import filesystem, tty
@@ -137,6 +138,7 @@ def loads(module_type, specs, args, out=None):
     """Prompt the list of modules associated with a list of specs"""
     check_module_set_name(args.module_set_name)
     out = sys.stdout if out is None else out
+    template_env = spack.tengine.make_environment()
 
     # Get a comprehensive list of specs
     if args.recurse_dependencies:
@@ -166,6 +168,7 @@ def loads(module_type, specs, args, out=None):
                 get_full_path=False,
                 module_set_name=args.module_set_name,
                 required=False,
+                template_env=template_env,
             ),
         )
         for spec in specs
@@ -199,6 +202,7 @@ def find(module_type, specs, args):
     check_module_set_name(args.module_set_name)
 
     single_spec = one_spec_or_raise(specs)
+    template_env = spack.tengine.make_environment()
 
     if args.recurse_dependencies:
         dependency_specs_to_retrieve = list(
@@ -215,6 +219,7 @@ def find(module_type, specs, args):
                 args.full_path,
                 module_set_name=args.module_set_name,
                 required=False,
+                template_env=template_env,
             )
             for spec in dependency_specs_to_retrieve
         ]
@@ -226,6 +231,7 @@ def find(module_type, specs, args):
                 args.full_path,
                 module_set_name=args.module_set_name,
                 required=True,
+                template_env=template_env,
             )
         )
     except spack.modules.common.ModuleNotFoundError as e:
@@ -244,11 +250,11 @@ def rm(module_type, specs, args):
     check_module_set_name(args.module_set_name)
 
     module_cls = spack.modules.module_types[module_type]
-    module_exist = lambda x: os.path.exists(module_cls(x, args.module_set_name).layout.filename)
 
-    specs_with_modules = [spec for spec in specs if module_exist(spec)]
+    template_env = spack.tengine.make_environment()
 
-    modules = [module_cls(spec, args.module_set_name) for spec in specs_with_modules]
+    modules = [module_cls(spec, args.module_set_name, template_env=template_env) for spec in specs]
+    modules = [m for m in modules if os.path.exists(m.layout.filename)]
 
     if not modules:
         tty.die("No module file matches your query")
@@ -257,7 +263,7 @@ def rm(module_type, specs, args):
     if not args.yes_to_all:
         msg = "You are about to remove {0} module files for:\n"
         tty.msg(msg.format(module_type))
-        spack.cmd.display_specs(specs_with_modules, long=True)
+        spack.cmd.display_specs([m.spec for m in modules], long=True)
         print("")
         answer = tty.get_yes_or_no("Do you want to proceed?")
         if not answer:
@@ -295,9 +301,13 @@ def refresh(module_type, specs, args):
 
     cls = spack.modules.module_types[module_type]
 
+    template_env = spack.tengine.make_environment()
+
     # Skip unknown packages.
     writers = [
-        cls(spec, args.module_set_name) for spec in specs if spack.repo.PATH.exists(spec.name)
+        cls(spec, args.module_set_name, template_env=template_env)
+        for spec in specs
+        if spack.repo.PATH.exists(spec.name)
     ]
 
     # Filter excluded packages early

--- a/lib/spack/spack/hooks/module_file_generation.py
+++ b/lib/spack/spack/hooks/module_file_generation.py
@@ -7,6 +7,7 @@ from typing import Optional, Set
 import spack.config
 import spack.modules
 import spack.spec
+import spack.tengine
 from spack.llnl.util import tty
 
 
@@ -15,6 +16,7 @@ def _for_each_enabled(
 ) -> None:
     """Calls a method for each enabled module"""
     set_names: Set[str] = set(spack.config.get("modules", {}).keys())
+    template_env = spack.tengine.make_environment()
     for name in set_names:
         enabled = spack.config.get(f"modules:{name}:enable")
         if not enabled:
@@ -22,7 +24,9 @@ def _for_each_enabled(
             continue
 
         for module_type in enabled:
-            generator = spack.modules.module_types[module_type](spec, name, explicit)
+            generator = spack.modules.module_types[module_type](
+                spec, name, explicit, template_env=template_env
+            )
             try:
                 getattr(generator, method_name)()
             except RuntimeError as e:

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -28,7 +28,13 @@ module_types: Dict[str, Type[BaseModuleFileWriter]] = {
 
 
 def get_module(
-    module_type, spec: spack.spec.Spec, get_full_path, module_set_name="default", required=True
+    module_type,
+    spec: spack.spec.Spec,
+    get_full_path,
+    module_set_name="default",
+    required=True,
+    *,
+    template_env=None,
 ):
     """Retrieve the module file for a given spec and module type.
 
@@ -47,6 +53,8 @@ def get_module(
             Otherwise, this returns the module name.
         module_set_name: the named module configuration set from modules.yaml
             for which to retrieve the module.
+        template_env: Optional template environment to use when generating module
+            files.
 
     Returns:
         The module name or path. May return ``None`` if the module is not
@@ -66,7 +74,7 @@ def get_module(
         else:
             return module.use_name
     else:
-        writer = module_types[module_type](spec, module_set_name)
+        writer = module_types[module_type](spec, module_set_name, template_env=template_env)
         if not os.path.isfile(writer.layout.filename):
             fmt_str = "{name}{@version}{/hash:7}"
             if not writer.conf.excluded:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -33,8 +33,6 @@ import re
 import string
 from typing import List, Optional
 
-import spack.vendor.jinja2
-
 import spack.build_environment
 import spack.config
 import spack.deptypes as dt
@@ -774,9 +772,15 @@ class BaseModuleFileWriter:
     modulerc_header: List[str]
 
     def __init__(
-        self, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+        self,
+        spec: spack.spec.Spec,
+        module_set_name: str,
+        explicit: Optional[bool] = None,
+        *,
+        template_env=None,
     ) -> None:
         self.spec = spec
+        self.template_env = template_env or tengine.make_environment()
 
         m = self.module
 
@@ -872,15 +876,14 @@ class BaseModuleFileWriter:
         template_name = self._get_template()
 
         try:
-            env = tengine.make_environment()
-            template = env.get_template(template_name)
-        except spack.vendor.jinja2.TemplateNotFound:
+            template = self.template_env.get_template(template_name)
+        except LookupError as e:
             # If the template was not found raise an exception with a little
             # more information
             msg = "template '{0}' was not found for '{1}'"
             name = type(self).__name__
             msg = msg.format(template_name, name)
-            raise ModulesTemplateNotFoundError(msg)
+            raise ModulesTemplateNotFoundError(msg) from e
 
         # Construct the context following the usual hierarchy of updates:
         # 1. start with the default context from the module writer class

--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -64,11 +64,10 @@ class Context(metaclass=ContextMeta):
         return dict(d)
 
 
-@spack.llnl.util.lang.memoized
 def make_environment(dirs: Optional[Tuple[str, ...]] = None):
     """Returns a configured environment for template rendering."""
     # Import at this scope to avoid slowing Spack startup down
-    import spack.vendor.jinja2
+    from spack.vendor.jinja2 import Environment, FileSystemLoader
 
     if dirs is None:
         # Default directories where to search for templates
@@ -77,9 +76,9 @@ def make_environment(dirs: Optional[Tuple[str, ...]] = None):
         dirs = tuple(canonicalize_path(d) for d in itertools.chain(builtins, extensions))
 
     # Loader for the templates
-    loader = spack.vendor.jinja2.FileSystemLoader(dirs)
+    loader = FileSystemLoader(dirs)
     # Environment of the template engine
-    env = spack.vendor.jinja2.Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
+    env = Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
     # Custom filters
     _set_filters(env)
     return env

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import pickle
 import stat
 
 import pytest
@@ -223,10 +222,3 @@ def test_check_module_set_name(mutable_config):
 
     with pytest.raises(spack.error.ConfigError, match=msg):
         spack.cmd.modules.check_module_set_name("third")
-
-
-@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
-def test_module_writers_are_pickleable(default_mock_concretization, module_type):
-    s = default_mock_concretization("mpileaks")
-    writer = spack.modules.module_types[module_type](s, "default")
-    assert pickle.loads(pickle.dumps(writer)).spec == s

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -171,7 +171,7 @@ def test_repo_dump_virtuals(
 
 @pytest.mark.parametrize("repos", [["mock"], ["extra"], ["mock", "extra"], ["extra", "mock"]])
 def test_repository_construction_doesnt_use_globals(
-    nullify_globals, tmp_path: pathlib.Path, repos, repo_builder: RepoBuilder
+    repo_builder: RepoBuilder, nullify_globals, tmp_path: pathlib.Path, repos
 ):
     def _repo_descriptors(repos):
         descriptors = {}


### PR DESCRIPTION
* Remove `memoized` annotation from `make_environment` because its return value depends on the `spack.config.CONFIG` global.
* Do dependency injection of the `jinja2.Environment` instance instead
* Maintain "performance" by constructing `jinja2.Environment` once ahead of time in all batch operations in `spack.cmd.*` 
* While at it: drop a top-level import of `spack.vendor.jinja2.TemplateNotFound`; replace with its specific enough builtin base class to avoid redundant imports. Saves ~10ms startup time.