### PR TITLE
test/cmd/info.py: set COLUMNS

### DIFF
--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -141,7 +141,8 @@ def test_info_fields(pkg_query, extra_args):
     ],
 )
 @pytest.mark.parametrize("by_name", [True, False])
-def test_info_output(by_name, args, in_output, not_in_output):
+def test_info_output(by_name, args, in_output, not_in_output, monkeypatch):
+    monkeypatch.setenv("COLUMNS", "80")
     by_name_arg = ["--by-name"] if by_name else ["--by-when"]
     output = info(*(by_name_arg + args))
 


### PR DESCRIPTION
This tests fails when COLUMNS=97 or higher, or when running tests in parallel. Fix
it by setting COLUMNS=80. This is what shutil.get_terminal_size uses
first.

The test explicitly checks for wrapping behavior with `\n` in the regex.

