### PR TITLE
tests: no networking

### DIFF
--- a/lib/spack/spack/test/cmd/audit.py
+++ b/lib/spack/spack/test/cmd/audit.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pytest
 
+import spack.audit
 from spack.main import SpackCommand
+from spack.test.conftest import MockHTTPResponse
 
 audit = SpackCommand("audit")
 
@@ -33,7 +35,10 @@ def test_audit_configs(mutable_config, mock_packages):
     assert audit.returncode == 1
 
 
-def test_audit_packages_https(mutable_config, mock_packages):
+def test_audit_packages_https(mutable_config, mock_packages, monkeypatch):
+    """Test audit packages-https with mocked network calls."""
+    monkeypatch.setattr(spack.audit, "urlopen", lambda url: MockHTTPResponse(200, "OK"))
+
     # Without providing --all should fail
     audit("packages-https", fail_on_error=False)
     # The mock configuration has duplicate definitions of some compilers

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -24,6 +24,7 @@ import spack.repo
 import spack.spec
 import spack.stage
 import spack.util.spack_yaml as syaml
+import spack.util.web
 import spack.version
 from spack.ci import gitlab as gitlab_generator
 from spack.ci.common import PipelineDag, PipelineOptions, SpackCIConfig
@@ -2001,6 +2002,7 @@ def fetch_versions_match(monkeypatch):
         return {v: pkg_cls.versions[v]["sha256"] for v in url_by_version}
 
     monkeypatch.setattr(spack.stage, "get_checksums_for_versions", get_checksums_for_versions)
+    monkeypatch.setattr(spack.util.web, "url_exists", lambda url: True)
 
 
 @pytest.fixture
@@ -2014,6 +2016,7 @@ def fetch_versions_invalid(monkeypatch):
         }
 
     monkeypatch.setattr(spack.stage, "get_checksums_for_versions", get_checksums_for_versions)
+    monkeypatch.setattr(spack.util.web, "url_exists", lambda url: True)
 
 
 @pytest.mark.parametrize("versions", [["2.1.4"], ["2.1.4", "2.1.5"]])

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+import spack.url
 from spack.main import SpackCommand
 from spack.version import Version
 
@@ -13,27 +14,31 @@ versions = SpackCommand("versions")
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
 
 
+def _mock_find_versions_of_archive(*args, **kwargs):
+    return {
+        Version("1.3.1"): "https://zlib.net/zlib-1.3.1.tar.gz",
+        Version("1.3"): "https://zlib.net/zlib-1.3.tar.gz",
+        Version("1.2.13"): "https://zlib.net/zlib-1.2.13.tar.gz",
+    }
+
+
 def test_safe_versions():
     """Only test the safe versions of a package."""
+    assert versions("--safe", "zlib") == "  1.2.11\n  1.2.8\n  1.2.3\n"
 
-    versions("--safe", "zlib")
 
-
-@pytest.mark.maybeslow
-def test_remote_versions():
+def test_remote_versions(monkeypatch):
     """Test a package for which remote versions should be available."""
+    monkeypatch.setattr(spack.url, "find_versions_of_archive", _mock_find_versions_of_archive)
+    assert versions("zlib") == "  1.2.11\n  1.2.8\n  1.2.3\n  1.3.1\n  1.3\n  1.2.13\n"
 
-    versions("zlib")
 
-
-@pytest.mark.maybeslow
-def test_remote_versions_only():
+def test_remote_versions_only(monkeypatch):
     """Test a package for which remote versions should be available."""
+    monkeypatch.setattr(spack.url, "find_versions_of_archive", _mock_find_versions_of_archive)
+    assert versions("--remote", "zlib") == "  1.3.1\n  1.3\n  1.2.13\n"
 
-    versions("--remote", "zlib")
 
-
-@pytest.mark.usefixtures("mock_packages")
 def test_new_versions_only(monkeypatch):
     """Test a package for which new versions should be available."""
     from spack_repo.builtin_mock.packages.brillig.package import Brillig  # type: ignore[import]
@@ -62,22 +67,27 @@ def test_new_versions_only(monkeypatch):
     assert v.strip(" \n\t") == "99.99.99\n  3.2.1"
 
 
-@pytest.mark.maybeslow
-def test_no_unchecksummed_versions():
+def test_no_unchecksummed_versions(monkeypatch):
     """Test a package for which no unchecksummed versions are available."""
+
+    def mock_find_versions_of_archive(*args, **kwargs):
+        """Mock find_versions_of_archive to avoid network calls."""
+        # Return some fake versions for bzip2
+        return {
+            Version("1.0.8"): "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
+            Version("1.0.7"): "https://sourceware.org/pub/bzip2/bzip2-1.0.7.tar.gz",
+        }
+
+    monkeypatch.setattr(spack.url, "find_versions_of_archive", mock_find_versions_of_archive)
 
     versions("bzip2")
 
 
-@pytest.mark.maybeslow
 def test_versions_no_url():
     """Test a package with versions but without a ``url`` attribute."""
+    assert versions("attributes-foo-app") == "  1.0\n"
 
-    versions("attributes-foo-app")
 
-
-@pytest.mark.maybeslow
 def test_no_versions_no_url():
     """Test a package without versions or a ``url`` attribute."""
-
-    versions("no-url-or-version")
+    assert versions("no-url-or-version") == ""


### PR DESCRIPTION
* Avoid networking in unit tests :)
* Test the actual output of the `spack versions` command instead of running it as a smoke test

<details>
<summary> For future reference: </summary>

```python
@pytest.fixture(autouse=True)
def error_on_external_network_access(monkeypatch):
    original_connect = socket.socket.connect

    def guarded_connect(self, address):
        host = address[0] if isinstance(address, tuple) else address
        if host in ["127.0.0.1", "localhost", "::1"] or (
            isinstance(host, str) and host.startswith("/")
        ):
            return original_connect(self, address)

        pytest.fail(f"External network access attempted to {address} during tests.")

    monkeypatch.setattr(socket.socket, "connect", guarded_connect)
```

</details>