### PR TITLE
env/spec: improve pickling

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1034,8 +1034,16 @@ class Environment:
     def unify(self, value):
         self._unify = value
 
-    def __reduce__(self):
-        return _create_environment, (self.path,)
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop("txlock", None)
+        state.pop("_repo", None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.txlock = lk.Lock(self._transaction_lock_path)
+        self._repo = None
 
     def _re_read(self):
         """Reinitialize the environment object."""


### PR DESCRIPTION
Changes pickling of Spec and Environment, so that it's more robust and
ultimately allows parallel concretization on platforms and python
versions where forking is not enabled or discouraged.

* Environment pickling uses the disk state as a source of truth. This is
   dangerous cause it doesn't reflect in-memory changes, but also causes a
   deadlock: when the Environment is serialized and sent to a subprocess
   while the parent process holds a write lock (e.g. during concretization),
   the subprocess has to take a read lock to restore the environment from
   disk.
   
   This is solved by replacing the `__reduce__` implementation with
   `__getstate__` and `__setstate__`, popping the non-pickleable items such
   as the lock which owns a file object.
* Make pickling better by preserving `Spec` object identity. If a list
  of `Spec` objects is passed to a subprocess, ensure that whenever they
  share dependencies for which `a is b` holds, this also holds in the
  subprocess. That reduces serialization work and size, while avoiding
  common bugs in the subprocess related to "seen" sets during traversal.
  It would also speed up `==` and set/dict operations with these Specs.

Regarding performance, it seems similar. Previously serializing an env was
instant, and deserializing slow (from disk). Now we always serialize and
deserialize in a faster way, but all in all not much is saved. However, there
is a performance improvement when serializing say a list of specs, but that
doesn't happen frequently in Spack.