### PR TITLE
parallel.py: branch on multiprocessing start method

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """High-level functions to concretize list of specs"""
 import importlib
+import multiprocessing
 import sys
 import time
 from typing import Iterable, List, Optional, Sequence, Tuple, Union
@@ -142,7 +143,7 @@ def concretize_separately(
     num_procs = min(len(args), spack.config.determine_number_of_jobs(parallel=True))
 
     msg = "Starting concretization"
-    if sys.platform not in ("darwin", "win32") and num_procs > 1:
+    if multiprocessing.get_start_method() == "fork" and num_procs > 1:
         msg += f" pool with {num_procs} processes"
     tty.msg(msg)
 

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -73,11 +73,12 @@ def imap_unordered(
     Raises:
         RuntimeError: if any error occurred in the worker processes
     """
-    from spack.subprocess_context import GlobalStateMarshaler
 
-    if sys.platform in ("darwin", "win32") or len(list_of_args) == 1:
+    if multiprocessing.get_start_method() != "fork" or len(list_of_args) == 1:
         yield from map(f, list_of_args)
         return
+
+    from spack.subprocess_context import GlobalStateMarshaler
 
     marshaler = GlobalStateMarshaler()
     with multiprocessing.Pool(


### PR DESCRIPTION
Branch on start method instead of platform, because the start method on
Linux changed from fork to forkserver in Python 3.14.

