### PR TITLE
python 3.14: fix path to url conversion

### DIFF
--- a/lib/spack/spack/test/util/util_url.py
+++ b/lib/spack/spack/test/util/util_url.py
@@ -20,6 +20,8 @@ def test_url_local_file_path(tmp_path: pathlib.Path):
     with open(path, "wb") as f:
         f.write(b"hello world")
 
+    assert url_util.path_to_file_url(path).startswith("file://")
+
     # Go from path -> url -> path.
     roundtrip = url_util.local_file_path(url_util.path_to_file_url(path))
 

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -6,11 +6,11 @@
 Utility functions for parsing, formatting, and manipulating URLs.
 """
 
-import os
 import posixpath
 import re
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Optional
 
 from spack.util.path import sanitize_filename
@@ -40,9 +40,7 @@ def local_file_path(url):
 
 
 def path_to_file_url(path):
-    if not os.path.isabs(path):
-        path = os.path.abspath(path)
-    return urllib.parse.urljoin("file:", urllib.request.pathname2url(path))
+    return Path(path).absolute().as_uri()
 
 
 def file_url_string_to_path(url):


### PR DESCRIPTION
`urljoin` behaves differently since python 3.14, use pathlib onliner instead.