### PR TITLE
config.py: don't  clear original in use_configuration

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1909,8 +1909,6 @@ def use_configuration(
 ) -> Generator[Configuration, None, None]:
     """Use the configuration scopes passed as arguments within the context manager.
 
-    This function invalidates caches, and is therefore very slow.
-
     Args:
         *scopes_or_paths: scope objects or paths to be used
 
@@ -1921,7 +1919,7 @@ def use_configuration(
 
     # Normalize input and construct a Configuration object
     configuration = create_from(*scopes_or_paths)
-    CONFIG.clear_caches(), configuration.clear_caches()
+    configuration.clear_caches()
 
     saved_config, CONFIG = CONFIG, configuration
 


### PR DESCRIPTION
I don't see a good reason why using temporary *new* config should affect
*current* config scopes already read from disk.

The downside is that when enabling bootstrap config, it forces Spack to reread
user config again, which is inefficient. That's the only use case in Spack of this
function.

Maybe the idea is that if current config shares a scope with new config, and
during `use_configuration` this shared scope is modified on disk, then changes
are not reflected in-memory when reverting back to original config?

As far as I can see, that's not a use case in Spack itself, more a curiosity of
tests.

As for `create_from`, it is memoized, so that may explain why caches are cleared
on this "new" object.
