### PR TITLE
solver: fix issue with conditional language dependencies

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -789,10 +789,22 @@ attr("hash", node(X, BuildDependency), BuildHash) :-
   attr("direct_dependency", ParentNode, node_requirement("hash", BuildDependency, BuildHash)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
-
+% For a spec like `hdf5 %cxx=gcc` we need to ensure that
+% 1. gcc is a provider for cxx
+% 2. hdf5 depends on that provider for cxx
 1 { attr("provider_set", node(X, BuildDependency), node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1 :-
   attr("direct_dependency", ParentNode, node_requirement("provider_set", BuildDependency, Virtual)),
   direct_dependency(ParentNode, node(X, BuildDependency)).
+
+error(10, "{0} cannot have a dependency on {1}", Package, Virtual)
+  :- attr("direct_dependency", node(ID, Package), node_requirement("provider_set", BuildDependency, Virtual)),
+     direct_dependency(node(ID, Package), node(X, BuildDependency)),
+     not attr("virtual_on_edge", node(ID, Package), node(X, BuildDependency), Virtual).
+
+% For a spec like `hdf5 %cxx` we need to ensure that the virtual is needed on a direct edge
+error(10, "{0} cannot have a dependency on {1}", Package, Virtual)
+  :- attr("direct_dependency", node(ID, Package), node_requirement("virtual_node", Virtual)),
+     not attr("virtual_on_edge", node(ID, Package), _, Virtual).
 
 % Reconstruct virtual dependencies for reused specs
 attr("virtual_on_edge", node(X, A1), node(Y, A2), Virtual)

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -70,7 +70,7 @@ def test_transitive_installed_dependents(mock_packages, database):
     with color_when(False):
         out = dependents("--installed", "--transitive", "fake")
 
-    lines = [li for li in out.strip().split("\n") if not li.startswith("--")]
+    lines = [li for li in out.strip().split("\n") if li and not li.startswith("--")]
     hashes = set([re.split(r"\s+", li)[0] for li in lines])
 
     expected = set(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4700,3 +4700,17 @@ packages:
     mpileaks = spack.concretize.concretize_one("mpileaks %c=gcc@12")
 
     assert mpileaks.satisfies("%c=gcc@12")
+
+
+@pytest.mark.regression("51683")
+def test_activating_variant_for_conditional_language_dependency(default_mock_concretization):
+    """Tests that a dependency on a conditional language can be concretized, and that the solver
+    turn on the correct variant to enable the language dependency
+    """
+    # To trigger the bug, we need at least another node needing fortran, in this case mpich
+    s = default_mock_concretization("mpileaks %fortran=gcc %mpi=mpich")
+    assert s.satisfies("+fortran")
+
+    # Try just asking for fortran, without the provider
+    s = default_mock_concretization("mpileaks %fortran %mpi=mpich")
+    assert s.satisfies("+fortran")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/callpath/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/callpath/package.py
@@ -16,6 +16,7 @@ class Callpath(Package):
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("dyninst")
     depends_on("mpi")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/mpileaks/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/mpileaks/package.py
@@ -22,11 +22,14 @@ class Mpileaks(Package):
     variant("opt", default=False, description="Optimized variant")
     variant("shared", default=True, description="Build shared library")
     variant("static", default=True, description="Build static library")
+    variant("fortran", default=False, description="Enable fortran API")
 
     depends_on("mpi")
     depends_on("callpath")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="+fortran")
 
     # Will be used to try raising an exception
     libs = None


### PR DESCRIPTION
fixes #51683

Add a couple of integrity constraints so that the solver can correctly turn on variants needed to activate conditional language dependencies.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
