### PR TITLE
Memoize call to discover entry points for Spack extensions

### DIFF
--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -132,6 +132,7 @@ def get_extension_paths():
     return paths
 
 
+@spack.llnl.util.lang.memoized
 def extension_paths_from_entry_points() -> List[str]:
     """Load extensions from a Python package's entry points.
 
@@ -146,6 +147,8 @@ def extension_paths_from_entry_points() -> List[str]:
     The function ``get_spack_extensions`` returns paths to the package's
     spack extensions
 
+    This function assumes that the state of entry points doesn't change from the first time it's
+    called. E.g., it doesn't support any new installation of packages between two calls.
     """
     extension_paths: List[str] = []
     for entry_point in spack.llnl.util.lang.get_entry_points(group="spack.extensions"):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -37,6 +37,7 @@ import spack.config
 import spack.directives_meta
 import spack.environment as ev
 import spack.error
+import spack.extensions
 import spack.llnl.util.lang
 import spack.llnl.util.lock
 import spack.llnl.util.tty as tty
@@ -2459,3 +2460,13 @@ def mock_util_executable(monkeypatch):
 
     monkeypatch.setattr(spack.util.executable.Executable, "__call__", mock_call)
     yield logger, should_fail, registered_reponses
+
+
+@pytest.fixture()
+def reset_extension_paths():
+    """Clears the cache used for entry points, both in setup and tear-down.
+    Needed if a test stresses parts related to computing paths for Spack extensions
+    """
+    spack.extensions.extension_paths_from_entry_points.cache_clear()
+    yield
+    spack.extensions.extension_paths_from_entry_points.cache_clear()

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -65,7 +65,7 @@ def entry_points_factory(tmp_path: pathlib.Path):
 
 
 @pytest.fixture()
-def mock_get_entry_points(tmp_path: pathlib.Path, monkeypatch):
+def mock_get_entry_points(tmp_path: pathlib.Path, reset_extension_paths, monkeypatch):
     entry_points = entry_points_factory(tmp_path)
     monkeypatch.setattr(spack.llnl.util.lang, "get_entry_points", entry_points)
 


### PR DESCRIPTION
This function is a wrapper around
```
importlib.metadata.entry_points
```
and, every time it's called, it performs a filesystem search for entry points. This makes the function call very slow:
```
$ spack python -m timeit -s "import spack.extensions" -- "spack.extensions.extension_paths_from_entry_points()"
100 loops, best of 5: 2.53 msec per loop
```

By memoizing it, we lose the ability to discover new entry points in case a new package has been installed within a single Spack execution, but makes the execution much faster for later calls:
```
$ spack python -m timeit -s "import spack.extensions" -- "spack.extensions.extension_paths_from_entry_points()"
5000000 loops, best of 5: 55.4 nsec per loop
```

Since discovering packages installed when Spack was in the middle of the execution is not among our use cases, it may be worth considering memoizing this function.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
