### PR TITLE
repo.py: fix checking out commits

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1735,11 +1735,13 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         remote = git("config", f"branch.{self.branch}.remote", output=str).strip()
 
                     if self.commit:
-                        spack.util.git.pull_checkout_commit(self.commit, git_exe=git)
+                        spack.util.git.pull_checkout_commit(
+                            self.commit, remote=remote, depth=depth, git_exe=git
+                        )
 
                     elif self.tag:
                         spack.util.git.pull_checkout_tag(
-                            self.tag, remote, depth=depth, git_exe=git
+                            self.tag, remote=remote, depth=depth, git_exe=git
                         )
 
                     elif self.branch:

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -35,7 +35,7 @@ def test_modified_files(mock_git_package_changes):
 
 def test_init_git_repo(git, tmp_path: pathlib.Path):
     repo_url = "https://github.com/spack/spack.git"
-    destination = tmp_path / "test_git_init"
+    destination = str(tmp_path / "test_git_init")
 
     with working_dir(destination, create=True):
         spack.util.git.init_git_repo(repo_url)
@@ -43,9 +43,9 @@ def test_init_git_repo(git, tmp_path: pathlib.Path):
         assert "No commits yet" in git("status", output=str)
 
 
-def test_pull_checkout_commit(git, tmp_path: pathlib.Path, mock_git_version_info):
+def test_pull_checkout_commit_any_remote(git, tmp_path: pathlib.Path, mock_git_version_info):
     repo, _, commits = mock_git_version_info
-    destination = tmp_path / "test_git_checkout_commit"
+    destination = str(tmp_path / "test_git_checkout_commit")
 
     with working_dir(destination, create=True):
         spack.util.git.init_git_repo(repo)
@@ -54,9 +54,21 @@ def test_pull_checkout_commit(git, tmp_path: pathlib.Path, mock_git_version_info
         assert commits[0] in git("rev-parse", "HEAD", output=str)
 
 
+def test_pull_checkout_commit_specific_remote(git, tmp_path: pathlib.Path, mock_git_version_info):
+    """Test fetching a specific commit from a specific remote."""
+    repo, _, commits = mock_git_version_info
+    destination = str(tmp_path / "test_git_checkout_commit_from_remote")
+
+    with working_dir(destination, create=True):
+        spack.util.git.init_git_repo(repo)
+        spack.util.git.pull_checkout_commit(commits[0], remote="origin", depth=1)
+
+        assert commits[0] in git("rev-parse", "HEAD", output=str)
+
+
 def test_pull_checkout_tag(git, tmp_path: pathlib.Path, mock_git_version_info):
     repo, _, _ = mock_git_version_info
-    destination = tmp_path / "test_git_checkout_tag"
+    destination = str(tmp_path / "test_git_checkout_tag")
 
     with working_dir(destination, create=True):
         spack.util.git.init_git_repo(repo)
@@ -67,7 +79,7 @@ def test_pull_checkout_tag(git, tmp_path: pathlib.Path, mock_git_version_info):
 
 def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info):
     repo, _, _ = mock_git_version_info
-    destination = tmp_path / "test_git_checkout_branch"
+    destination = str(tmp_path / "test_git_checkout_branch")
 
     with working_dir(destination, create=True):
         spack.util.git.init_git_repo(repo)

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -130,12 +130,39 @@ def init_git_repo(
     git_exe("config", "feature.manyFiles", "true", ignore_errors=True)
 
 
-def pull_checkout_commit(commit: str, git_exe: Optional[exe.Executable] = None):
-    """Fetch all remotes and checkout the specified commit."""
+def pull_checkout_commit(
+    commit: str,
+    remote: Optional[str] = None,
+    depth: Optional[int] = None,
+    git_exe: Optional[exe.Executable] = None,
+):
+    """Checkout the specified commit (fetched if necessary)."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", "--quiet", "--progress", "--all")
-    git_exe("checkout", commit)
+    # Do not do any fetching if the commit is already present.
+    try:
+        git_exe("checkout", "--quiet", commit, error=os.devnull)
+        return
+    except exe.ProcessError:
+        pass
+
+    # First try to fetch the specific commit from a specific remote. This allows fixed depth, but
+    # the server needs to support it.
+    if remote is not None:
+        try:
+            flags = [] if depth is None else [f"--depth={depth}"]
+            git_exe("fetch", "--quiet", "--progress", *flags, remote, commit, error=os.devnull)
+            git_exe("checkout", "--quiet", commit)
+            return
+        except exe.ProcessError:
+            pass
+
+    # Fall back to fetching all while unshallowing, to guarantee we get the commit. The depth flag
+    # is equivalent to --unshallow, and needed cause git can pedantically error with
+    # "--unshallow on a complete repository does not make sense".
+    remote_flag = "--all" if remote is None else remote
+    git_exe("fetch", "--quiet", "--progress", "--depth=2147483647", remote_flag)
+    git_exe("checkout", "--quiet", commit)
 
 
 def pull_checkout_tag(


### PR DESCRIPTION
Fix an issue where `git fetch --all` does not unshallow.

Ensure that `git fetch --all` happens only in the worst case.

* Don't fetch if commit is locally available
* If the server supports direct fetching of commits, do that with
  `--depth=N`
* If nothing works: do `git fetch --all --depth=<large number>`.
