### PR TITLE
tests: win32 subprocess fix

### DIFF
--- a/lib/spack/spack/bootstrap/__init__.py
+++ b/lib/spack/spack/bootstrap/__init__.py
@@ -10,20 +10,22 @@ from .core import (
     ensure_core_dependencies,
     ensure_gpg_in_path_or_raise,
     ensure_patchelf_in_path_or_raise,
+    ensure_winsdk_external_or_raise,
 )
 from .environment import BootstrapEnvironment, ensure_environment_dependencies
 from .status import status_message
 
 __all__ = [
-    "is_bootstrapping",
-    "ensure_bootstrap_configuration",
-    "ensure_core_dependencies",
-    "ensure_gpg_in_path_or_raise",
-    "ensure_clingo_importable_or_raise",
-    "ensure_patchelf_in_path_or_raise",
     "all_core_root_specs",
-    "ensure_environment_dependencies",
     "BootstrapEnvironment",
+    "ensure_bootstrap_configuration",
+    "ensure_clingo_importable_or_raise",
+    "ensure_core_dependencies",
+    "ensure_environment_dependencies",
+    "ensure_gpg_in_path_or_raise",
+    "ensure_patchelf_in_path_or_raise",
+    "ensure_winsdk_external_or_raise",
+    "is_bootstrapping",
     "status_message",
     "store_path",
 ]

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -554,7 +554,9 @@ def ensure_winsdk_external_or_raise() -> None:
     """
     if set(["win-sdk", "wgl"]).issubset(spack.config.get("packages").keys()):
         return
-    externals = spack.detection.by_path(["win-sdk", "wgl"])
+    tty.debug("Detecting Windows SDK and WGL installations")
+    # find the externals sequentially to avoid subprocesses being spawned
+    externals = spack.detection.by_path(["win-sdk", "wgl"], max_workers=1)
     if not set(["win-sdk", "wgl"]) == externals.keys():
         missing_packages_lst = []
         if "wgl" not in externals:

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -103,7 +103,11 @@ def concretize_separately(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
     """
-    from spack.bootstrap import ensure_bootstrap_configuration, ensure_clingo_importable_or_raise
+    from spack.bootstrap import (
+        ensure_bootstrap_configuration,
+        ensure_clingo_importable_or_raise,
+        ensure_winsdk_external_or_raise,
+    )
 
     to_concretize = [abstract for abstract, concrete in spec_list if not concrete]
     args = [
@@ -118,6 +122,10 @@ def concretize_separately(
     except ImportError:
         with ensure_bootstrap_configuration():
             ensure_clingo_importable_or_raise()
+
+    # ensure we don't try to detect winsdk in parallel
+    if sys.platform == "win32":
+        ensure_winsdk_external_or_raise()
 
     # Ensure all the indexes have been built or updated, since
     # otherwise the processes in the pool may timeout on waiting

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1179,8 +1179,7 @@ class PyclingoDriver:
             A tuple of the solve result, the timer for the different phases of the
             solve, and the internal statistics from clingo.
         """
-        # avoid circular import
-        from spack.bootstrap.core import ensure_winsdk_external_or_raise
+        from spack.bootstrap import ensure_winsdk_external_or_raise
 
         output = output or DEFAULT_OUTPUT_CONFIGURATION
         timer = spack.util.timer.Timer()
@@ -1192,7 +1191,6 @@ class PyclingoDriver:
         # needs to modify active config scope, so cannot be run within
         # bootstrap config scope
         if sys.platform == "win32":
-            tty.debug("Ensuring basic dependencies {win-sdk, wgl} available")
             ensure_winsdk_external_or_raise()
 
         # assemble a list of the control files needed for this problem. Some are conditionally

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -28,7 +28,7 @@ import spack.vendor.archspec.cpu.microarchitecture
 import spack.vendor.archspec.cpu.schema
 
 import spack.binary_distribution
-import spack.bootstrap.core
+import spack.bootstrap
 import spack.caches
 import spack.compilers.config
 import spack.compilers.libraries
@@ -995,16 +995,10 @@ def monkeypatch_session():
         yield monkeypatch
 
 
-@pytest.fixture(scope="session", autouse=True)
-def mock_wsdk_externals(monkeypatch_session):
-    """Skip check for required external packages on Windows during testing
-    Note: In general this should cover this behavior for all tests,
-    however any session scoped fixture involving concretization should
-    include this fixture
-    """
-    monkeypatch_session.setattr(
-        spack.bootstrap.core, "ensure_winsdk_external_or_raise", _return_none
-    )
+@pytest.fixture(autouse=True)
+def mock_wsdk_externals(monkeypatch):
+    """Skip check for required external packages on Windows during testing."""
+    monkeypatch.setattr(spack.bootstrap, "ensure_winsdk_external_or_raise", _return_none)
 
 
 @pytest.fixture(scope="function")
@@ -1090,7 +1084,6 @@ def _store_dir_and_cache(tmp_path_factory: pytest.TempPathFactory):
 @pytest.fixture(scope="session")
 def mock_store(
     tmp_path_factory: pytest.TempPathFactory,
-    mock_wsdk_externals,
     mock_packages_repo,
     mock_configuration_scopes,
     _store_dir_and_cache: Tuple[Path, Path],
@@ -1105,6 +1098,7 @@ def mock_store(
 
     """
     store_path, store_cache = _store_dir_and_cache
+    _mock_wsdk_externals = spack.bootstrap.ensure_winsdk_external_or_raise
 
     # Make the DB filesystem read-only to ensure constructors don't modify anything in it.
     # We want Spack to be able to point to a DB on a read-only filesystem easily.
@@ -1117,7 +1111,11 @@ def mock_store(
                 with spack.repo.use_repositories(mock_packages_repo):
                     # make the DB filesystem writable only while we populate it
                     _recursive_chmod(store_path, 0o755)
-                    _populate(store.db)
+                    try:
+                        spack.bootstrap.ensure_winsdk_external_or_raise = _return_none
+                        _populate(store.db)
+                    finally:
+                        spack.bootstrap.ensure_winsdk_external_or_raise = _mock_wsdk_externals
                     _recursive_chmod(store_path, 0o555)
 
         _recursive_chmod(store_cache, 0o755)


### PR DESCRIPTION
Avoid that `ensure_winsdk_external_or_raise` runs in parallel during
parallel concretization (in the future).

Also ensure that the monkeypatch state is propagated to child processes,
which requires a function scope fixture.

