### PR TITLE
python 3.14: fix `canfail` related tests

### DIFF
--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/canfail/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/canfail/package.py
@@ -1,8 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
-
 from spack_repo.builtin_mock.build_systems.generic import Package
 
 from spack.package import *
@@ -13,19 +11,9 @@ class Canfail(Package):
 
     homepage = "http://www.example.com"
     url = "http://www.example.com/a-1.0.tar.gz"
+    succeed = True
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
-
-    def set_install_succeed(self):
-        os.environ["CANFAIL_SUCCEED"] = "1"
-
-    def set_install_fail(self):
-        os.environ.pop("CANFAIL_SUCCEED", None)
-
-    @property
-    def succeed(self):
-        result = True if "CANFAIL_SUCCEED" in os.environ else False
-        return result
 
     def install(self, spec, prefix):
         if not self.succeed:


### PR DESCRIPTION
The tests that rely on canfail to fail dynamically are broken under a
forkserver multiprocessing strategy, because the environment variables set in
the parent process are not inherited by the subprocess of the installer (at least
not the second invocation after changes in the parent process).

We can just use attributes because the package is serialized in case of spawn
and forkserver (and obvsly it works with forking).

However, the amazing spack builder logic caches the builder per package
instance, and the builder copies the package's `__dict__`, meaning we have to
force that cache to be cleared after mutating a package property. That's likely
the reason environment variables were used.


