### PR TITLE
Allow specifying included scopes on the command line if corresponding directories/files do not exists

### DIFF
--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -195,7 +195,9 @@ def _root(args):
         spack.config.set("bootstrap:root", args.path, scope=args.scope)
     elif args.scope:
         if args.scope not in spack.config.readable_scope_names():
-            raise RuntimeError(f"Scope {args.scope} is not readable, cannot report root")
+            spack.llnl.util.tty.die(
+                f"The argument --scope={args.scope} must refer to an existing scope."
+            )
 
     root = spack.config.get("bootstrap:root", default=None, scope=args.scope)
     if root:

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -73,15 +73,6 @@ def _add_scope_option(parser):
     )
 
 
-def _add_read_scope_option(parser):
-    parser.add_argument(
-        "--scope",
-        action=arguments.ConfigScope,
-        type=arguments.config_scope_readable_validator,
-        help="configuration scope to read/modify",
-    )
-
-
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     sp = subparser.add_subparsers(dest="subcommand")
 
@@ -120,7 +111,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
 
     list = sp.add_parser("list", help="list all the sources of software to bootstrap Spack")
-    _add_read_scope_option(list)
+    list.add_argument(
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read/modify",
+    )
 
     add = sp.add_parser("add", help="add a new source for bootstrapping")
     _add_scope_option(add)
@@ -198,8 +194,8 @@ def _root(args):
     if args.path:
         spack.config.set("bootstrap:root", args.path, scope=args.scope)
     elif args.scope:
-        # validate
-        pass
+        if args.scope not in spack.config.readable_scope_names():
+            raise RuntimeError(f"Scope {args.scope} is not readable, cannot report root")
 
     root = spack.config.get("bootstrap:root", default=None, scope=args.scope)
     if root:

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -72,6 +72,10 @@ def _add_scope_option(parser):
         "--scope", action=arguments.ConfigScope, help="configuration scope to read/modify"
     )
 
+def _add_read_scope_option(parser):
+    parser.add_argument(
+        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read/modify"
+    )
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     sp = subparser.add_subparsers(dest="subcommand")
@@ -111,7 +115,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
 
     list = sp.add_parser("list", help="list all the sources of software to bootstrap Spack")
-    _add_scope_option(list)
+    _add_read_scope_option(list)
 
     add = sp.add_parser("add", help="add a new source for bootstrapping")
     _add_scope_option(add)
@@ -188,6 +192,9 @@ def _reset(args):
 def _root(args):
     if args.path:
         spack.config.set("bootstrap:root", args.path, scope=args.scope)
+    elif args.scope:
+        # validate
+        pass
 
     root = spack.config.get("bootstrap:root", default=None, scope=args.scope)
     if root:

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -72,10 +72,15 @@ def _add_scope_option(parser):
         "--scope", action=arguments.ConfigScope, help="configuration scope to read/modify"
     )
 
+
 def _add_read_scope_option(parser):
     parser.add_argument(
-        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read/modify"
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read/modify",
     )
+
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     sp = subparser.add_subparsers(dest="subcommand")

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -194,7 +194,7 @@ def _root(args):
     if args.path:
         spack.config.set("bootstrap:root", args.path, scope=args.scope)
     elif args.scope:
-        if args.scope not in spack.config.readable_scope_names():
+        if args.scope not in spack.config.existing_scope_names():
             spack.llnl.util.tty.die(
                 f"The argument --scope={args.scope} must refer to an existing scope."
             )

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -192,6 +192,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     check.add_argument(
         "--scope",
         action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
         default=lambda: spack.config.default_modify_scope(),
         help="configuration scope containing mirrors to check",
     )

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -5,7 +5,7 @@
 import argparse
 import os
 import textwrap
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import spack.cmd
 import spack.config
@@ -200,6 +200,13 @@ class ConfigScope(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values)
+
+
+def config_scope_readable_validator(value):
+    if value not in spack.config.readable_scope_names():
+        raise ValueError(f"Invalid scope argument {value} "
+                        "for config read operation, scope context does not exist") 
+    return value
 
 
 def _cdash_reporter(namespace):

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -203,7 +203,7 @@ class ConfigScope(argparse.Action):
 
 
 def config_scope_readable_validator(value):
-    if value not in spack.config.readable_scope_names():
+    if value not in spack.config.existing_scope_names():
         raise ValueError(
             f"Invalid scope argument {value} "
             "for config read operation, scope context does not exist"

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -5,7 +5,7 @@
 import argparse
 import os
 import textwrap
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import spack.cmd
 import spack.config
@@ -204,8 +204,10 @@ class ConfigScope(argparse.Action):
 
 def config_scope_readable_validator(value):
     if value not in spack.config.readable_scope_names():
-        raise ValueError(f"Invalid scope argument {value} "
-                        "for config read operation, scope context does not exist") 
+        raise ValueError(
+            f"Invalid scope argument {value} "
+            "for config read operation, scope context does not exist"
+        )
     return value
 
 

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -48,7 +48,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     find_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        type=arguments.config_scope_readable_validator
+        type=arguments.config_scope_readable_validator,
         default=lambda: spack.config.default_modify_scope("packages"),
         help="configuration scope to modify",
     )
@@ -67,7 +67,10 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     # List
     list_parser = sp.add_parser("list", aliases=["ls"], help="list available compilers")
     list_parser.add_argument(
-        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read from"
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read from",
     )
     list_parser.add_argument(
         "--remote", action="store_true", help="list also compilers from registered buildcaches"
@@ -77,7 +80,10 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     info_parser = sp.add_parser("info", help="show compiler paths")
     info_parser.add_argument("compiler_spec")
     info_parser.add_argument(
-        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read from"
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read from",
     )
 
 

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -48,6 +48,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     find_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator
         default=lambda: spack.config.default_modify_scope("packages"),
         help="configuration scope to modify",
     )
@@ -66,7 +67,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     # List
     list_parser = sp.add_parser("list", aliases=["ls"], help="list available compilers")
     list_parser.add_argument(
-        "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
+        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read from"
     )
     list_parser.add_argument(
         "--remote", action="store_true", help="list also compilers from registered buildcaches"
@@ -76,7 +77,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     info_parser = sp.add_parser("info", help="show compiler paths")
     info_parser.add_argument("compiler_spec")
     info_parser.add_argument(
-        "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
+        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read from"
     )
 
 

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -48,7 +48,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     find_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        type=arguments.config_scope_readable_validator,
         default=lambda: spack.config.default_modify_scope("packages"),
         help="configuration scope to modify",
     )

--- a/lib/spack/spack/cmd/compilers.py
+++ b/lib/spack/spack/cmd/compilers.py
@@ -14,7 +14,7 @@ level = "short"
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
-        "--scope", action=arguments.ConfigScope, help="configuration scope to read/modify"
+        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read/modify"
     )
     subparser.add_argument(
         "--remote", action="store_true", help="list also compilers from registered buildcaches"

--- a/lib/spack/spack/cmd/compilers.py
+++ b/lib/spack/spack/cmd/compilers.py
@@ -14,7 +14,10 @@ level = "short"
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
-        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read/modify"
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read/modify",
     )
     subparser.add_argument(
         "--remote", action="store_true", help="list also compilers from registered buildcaches"

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -178,7 +178,7 @@ def _get_scope_and_section(args):
 
 
 def print_configuration(args, *, blame: bool) -> None:
-    if args.scope and args.scope not in spack.config.readable_scope_names():
+    if args.scope and args.scope not in spack.config.existing_scope_names():
         tty.die(f"the argument --scope={args.scope} must refer to an existing scope.")
     if args.scope and args.section is None:
         tty.die(f"the argument --scope={args.scope} requires specifying a section.")

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -178,6 +178,8 @@ def _get_scope_and_section(args):
 
 
 def print_configuration(args, *, blame: bool) -> None:
+    if args.scope and args.scope not in spack.config.readable_scope_names():
+        tty.die(f"the argument --scope={args.scope} must refer to an existing scope.")
     if args.scope and args.section is None:
         tty.die(f"the argument --scope={args.scope} requires specifying a section.")
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -48,7 +48,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     # List
     list_parser = sp.add_parser("list", aliases=["ls"], help=repo_list.__doc__)
     list_parser.add_argument(
-        "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
+        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read from"
     )
     output_group = list_parser.add_mutually_exclusive_group()
     output_group.add_argument("--names", action="store_true", help="show configuration names only")
@@ -83,6 +83,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     add_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
         default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -86,7 +86,6 @@ def setup_parser(subparser: argparse.ArgumentParser):
     add_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        type=arguments.config_scope_readable_validator,
         default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -48,7 +48,10 @@ def setup_parser(subparser: argparse.ArgumentParser):
     # List
     list_parser = sp.add_parser("list", aliases=["ls"], help=repo_list.__doc__)
     list_parser.add_argument(
-        "--scope", action=arguments.ConfigScope, type=arguments.config_scope_readable_validator, help="configuration scope to read from"
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read from",
     )
     output_group = list_parser.add_mutually_exclusive_group()
     output_group.add_argument("--names", action="store_true", help="show configuration names only")

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1032,15 +1032,16 @@ class OptionalInclude:
 
             config_name = f"{parent_scope.name}:{included_name}"
 
+        _, ext = os.path.splitext(config_path)
+        ext_is_yaml = ext == ".yaml" or ext == ".yml"
         is_dir = os.path.isdir(config_path)
         exists = os.path.exists(config_path)
-        is_file = config_path.endswith(".yaml") or config_path.endswith(".yml")
 
         if not exists and not self.optional:
             dest = f" at ({config_path})" if config_path != path else ""
             raise ValueError(f"Required path ({path}) does not exist{dest}")
 
-        if (not is_dir and exists) or is_file:
+        if (exists and not is_dir) or ext_is_yaml:
             # files are assumed to be SingleFileScopes
             tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
             return SingleFileScope(
@@ -1049,6 +1050,9 @@ class OptionalInclude:
                 spack.schema.merged.schema,
                 prefer_modify=self.prefer_modify,
             )
+
+        if ext:
+            raise ValueError(f"Attempting to create a config scope with invalid extension {ext}")
 
         # directories are treated as regular ConfigScopes
         # assign by "default"

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -174,7 +174,7 @@ class ConfigScope:
         return self._included_scopes
 
     @property
-    def readable(self) -> bool:
+    def exists(self) -> bool:
         """Whether the config object indicated by the scope can be read"""
         return True
 
@@ -226,7 +226,7 @@ class DirectoryConfigScope(ConfigScope):
         self.prefer_modify = prefer_modify
 
     @property
-    def readable(self) -> bool:
+    def exists(self) -> bool:
         return os.path.exists(self.path)
 
     def get_section_filename(self, section: str) -> str:
@@ -236,7 +236,7 @@ class DirectoryConfigScope(ConfigScope):
 
     def get_section(self, section: str) -> Optional[YamlConfigDict]:
         """Returns the data associated with a given section"""
-        if not self.readable:
+        if not self.exists:
             tty.debug(f"Attempting to read from missing scope: {self} at {self.path}")
             return {}
         if section not in self.sections:
@@ -304,7 +304,7 @@ class SingleFileScope(ConfigScope):
         self.yaml_path = yaml_path or []
 
     @property
-    def readable(self) -> bool:
+    def exists(self) -> bool:
         return os.path.exists(self.path)
 
     def get_section_filename(self, section) -> str:
@@ -337,7 +337,7 @@ class SingleFileScope(ConfigScope):
         #   }
         # }
 
-        if not self.readable:
+        if not self.exists:
             tty.debug(f"Attempting to read from missing scope: {self} at {self.path}")
             return {}
 
@@ -598,9 +598,10 @@ class Configuration:
         return (s for s in self.scopes.values() if s.writable)
 
     @property
-    def readable_scopes(self) -> Generator[ConfigScope, None, None]:
-        """Generator of readable scopes."""
-        return (s for s in self.scopes.values() if s.readable)
+    def existing_scopes(self) -> Generator[ConfigScope, None, None]:
+        """Generator of existing scopes. These are self.scopes where the
+        scope has a representation on the filesystem"""
+        return (s for s in self.scopes.values() if s.exists)
 
     def highest_precedence_scope(self) -> ConfigScope:
         """Writable scope with the highest precedence."""
@@ -1499,9 +1500,12 @@ def writable_scopes() -> List[ConfigScope]:
     return scopes
 
 
-def readable_scopes() -> List[ConfigScope]:
-    """Return list of readable scopes. Higher-priority scopes come first in the list."""
-    scopes = [x for x in CONFIG.scopes.values() if x.readable]
+def existing_scopes() -> List[ConfigScope]:
+    """Return list of existing scopes. Scopes where Spack is
+    aware of said scope, and the scope has a representation
+    on the filesystem.
+    Higher-priority scopes come first in the list."""
+    scopes = [x for x in CONFIG.scopes.values() if x.exists]
     scopes.reverse()
     return scopes
 
@@ -1510,8 +1514,8 @@ def writable_scope_names() -> List[str]:
     return list(x.name for x in writable_scopes())
 
 
-def readable_scope_names() -> List[str]:
-    return list(x.name for x in readable_scopes())
+def existing_scope_names() -> List[str]:
+    return list(x.name for x in existing_scopes())
 
 
 def matched_config(cfg_path: str) -> List[Tuple[str, Any]]:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1056,7 +1056,10 @@ class OptionalInclude:
             )
 
         if ext and not is_dir:
-            raise ValueError(f"Attempting to create a config scope with invalid extension {ext}")
+            raise ValueError(
+                f"File-based scope does not exist yet: should have a .yaml/.yml extension \
+for file scopes, or no extension for directory scopes (currently {ext})"
+            )
 
         # directories are treated as regular ConfigScopes
         # assign by "default"

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1011,6 +1011,10 @@ class OptionalInclude:
         Raises:
             ValueError: the required configuration path does not exist
         """
+        assert (
+            self._valid_parent_scope(parent_scope)
+        ), "Optional includes must have valid parent_scope object"
+
         # use specified name if there is one
         config_name = self.name
         if not config_name:
@@ -1058,6 +1062,16 @@ class OptionalInclude:
         # assign by "default"
         tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
         return DirectoryConfigScope(config_name, config_path, prefer_modify=self.prefer_modify)
+
+    def _valid_parent_scope(self, parent_scope: ConfigScope) -> bool:
+        """Validates that a parent scope is a valid configuration object"""
+        # enforced by type checking but those can always be # type: ignore'd
+        assert (
+            isinstance(parent_scope, ConfigScope)
+        ), f"Optional include must have valid parent scope,\
+ of type ConfigScope; Type:{type(parent_scope)} is not valid."
+        # naive check that parent scope name isn't empty or just whitespace
+        return bool(re.sub(r"\s", "", parent_scope.name))
 
     def evaluate_condition(self) -> bool:
         # circular dependencies

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1029,6 +1029,7 @@ class OptionalInclude:
 
         is_dir = os.path.isdir(config_path)
         exists = os.path.exists(config_path)
+        # notably naive
         is_file = config_path.endswith(".yaml") or config_path.endswith(".yml")
 
         if not exists and not self.optional:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -230,7 +230,7 @@ class DirectoryConfigScope(ConfigScope):
     def get_section(self, section: str) -> Optional[YamlConfigDict]:
         """Returns the data associated with a given section"""
         if not self.readable:
-            tty.debug(f"Attempting to read from missing scope {self}")
+            tty.warn(f"Attempting to read from missing scope: {self}")
             return {}
         if section not in self.sections:
             path = self.get_section_filename(section)
@@ -1032,7 +1032,6 @@ class OptionalInclude:
         tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
         return DirectoryConfigScope(config_name, config_path, readable=exists, prefer_modify=self.prefer_modify)
 
-
     def evaluate_condition(self) -> bool:
         # circular dependencies
         import spack.spec
@@ -1473,6 +1472,7 @@ def set(path: str, value: Any, scope: Optional[str] = None) -> None:
 def scopes() -> lang.PriorityOrderedMapping[str, ConfigScope]:
     """Convenience function to get list of configuration scopes."""
     return CONFIG.scopes
+
 
 def writable_scopes() -> List[ConfigScope]:
     """Return list of writable scopes. Higher-priority scopes come first in the list."""

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -214,7 +214,13 @@ class DirectoryConfigScope(ConfigScope):
     """Config scope backed by a directory containing one file per section."""
 
     def __init__(
-        self, name: str, path: str, *, writable: bool = True, readable: bool = True, prefer_modify: bool = True
+        self,
+        name: str,
+        path: str,
+        *,
+        writable: bool = True,
+        readable: bool = True,
+        prefer_modify: bool = True,
     ) -> None:
         super().__init__(name)
         self.path = path
@@ -590,7 +596,7 @@ class Configuration:
     def writable_scopes(self) -> Generator[ConfigScope, None, None]:
         """Generator of writable scopes with an associated file."""
         return (s for s in self.scopes.values() if s.writable)
-    
+
     @property
     def readable_scopes(self) -> Generator[ConfigScope, None, None]:
         """Generator of readable scopes."""
@@ -1032,12 +1038,20 @@ class OptionalInclude:
         if (not is_dir and exists) or is_file:
             # files are assumed to be SingleFileScopes
             tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
-            return SingleFileScope(config_name, config_path, spack.schema.merged.schema, readable=exists, prefer_modify=self.prefer_modify)
+            return SingleFileScope(
+                config_name,
+                config_path,
+                spack.schema.merged.schema,
+                readable=exists,
+                prefer_modify=self.prefer_modify,
+            )
 
         # directories are treated as regular ConfigScopes
         # assign by "default"
         tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
-        return DirectoryConfigScope(config_name, config_path, readable=exists, prefer_modify=self.prefer_modify)
+        return DirectoryConfigScope(
+            config_name, config_path, readable=exists, prefer_modify=self.prefer_modify
+        )
 
     def evaluate_condition(self) -> bool:
         # circular dependencies

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1011,8 +1011,8 @@ class OptionalInclude:
         Raises:
             ValueError: the required configuration path does not exist
         """
-        assert (
-            self._valid_parent_scope(parent_scope)
+        assert self._valid_parent_scope(
+            parent_scope
         ), "Optional includes must have valid parent_scope object"
 
         # use specified name if there is one
@@ -1066,8 +1066,8 @@ class OptionalInclude:
     def _valid_parent_scope(self, parent_scope: ConfigScope) -> bool:
         """Validates that a parent scope is a valid configuration object"""
         # enforced by type checking but those can always be # type: ignore'd
-        assert (
-            isinstance(parent_scope, ConfigScope)
+        assert isinstance(
+            parent_scope, ConfigScope
         ), f"Optional include must have valid parent scope,\
  of type ConfigScope; Type:{type(parent_scope)} is not valid."
         # naive check that parent scope name isn't empty or just whitespace

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -230,7 +230,9 @@ class DirectoryConfigScope(ConfigScope):
     def get_section(self, section: str) -> Optional[YamlConfigDict]:
         """Returns the data associated with a given section"""
         if not self.readable:
-            tty.warn(f"Attempting to read from missing scope: {self}")
+            # warn appears more reasonable but produces way too much output
+            # in a normal Spack run
+            tty.debug(f"Attempting to read from missing scope: {self}")
             return {}
         if section not in self.sections:
             path = self.get_section_filename(section)
@@ -588,6 +590,11 @@ class Configuration:
     def writable_scopes(self) -> Generator[ConfigScope, None, None]:
         """Generator of writable scopes with an associated file."""
         return (s for s in self.scopes.values() if s.writable)
+    
+    @property
+    def readable_scopes(self) -> Generator[ConfigScope, None, None]:
+        """Generator of readable scopes."""
+        return (s for s in self.scopes.values() if s.readable)
 
     def highest_precedence_scope(self) -> ConfigScope:
         """Writable scope with the highest precedence."""

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -604,7 +604,7 @@ class Configuration:
     @property
     def existing_scopes(self) -> Generator[ConfigScope, None, None]:
         """Generator of existing scopes. These are self.scopes where the
-        scope has a representation on the filesystem"""
+        scope has a representation on the filesystem or is internal"""
         return (s for s in self.scopes.values() if s.exists)
 
     def highest_precedence_scope(self) -> ConfigScope:
@@ -1525,7 +1525,7 @@ def writable_scopes() -> List[ConfigScope]:
 def existing_scopes() -> List[ConfigScope]:
     """Return list of existing scopes. Scopes where Spack is
     aware of said scope, and the scope has a representation
-    on the filesystem.
+    on the filesystem or are internal scopes.
     Higher-priority scopes come first in the list."""
     scopes = [x for x in CONFIG.scopes.values() if x.exists]
     scopes.reverse()

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -235,10 +235,14 @@ class DirectoryConfigScope(ConfigScope):
         return os.path.join(self.path, f"{section}.yaml")
 
     def get_section(self, section: str) -> Optional[YamlConfigDict]:
-        """Returns the data associated with a given section"""
+        """Returns the data associated with a given section if the scope exists"""
         if not self.exists:
             tty.debug(f"Attempting to read from missing scope: {self} at {self.path}")
             return {}
+        return self._get_section(section)
+
+    def _get_section(self, section: str) -> Optional[YamlConfigDict]:
+        """get_section but without the existence check"""
         if section not in self.sections:
             path = self.get_section_filename(section)
             schema = SECTION_SCHEMAS[section]
@@ -251,7 +255,7 @@ class DirectoryConfigScope(ConfigScope):
             raise spack.error.ConfigError(f"Cannot write to immutable scope {self}")
 
         filename = self.get_section_filename(section)
-        data = self.get_section(section)
+        data = self._get_section(section)
         if data is None:
             return
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -145,7 +145,6 @@ class ConfigScope:
     def __init__(self, name: str) -> None:
         self.name = name
         self.writable = False
-        self.readable = False
         self.sections = syaml.syaml_dict()
         self.prefer_modify = False
 
@@ -173,6 +172,11 @@ class ConfigScope:
                         self._included_scopes.append(included_scope)
 
         return self._included_scopes
+
+    @property
+    def readable(self) -> bool:
+        """Whether the config object indicated by the scope can be read"""
+        return True
 
     def override_include(self):
         """Whether the ``include::`` section of this scope should override lower scopes."""
@@ -214,19 +218,16 @@ class DirectoryConfigScope(ConfigScope):
     """Config scope backed by a directory containing one file per section."""
 
     def __init__(
-        self,
-        name: str,
-        path: str,
-        *,
-        writable: bool = True,
-        readable: bool = True,
-        prefer_modify: bool = True,
+        self, name: str, path: str, *, writable: bool = True, prefer_modify: bool = True
     ) -> None:
         super().__init__(name)
         self.path = path
         self.writable = writable
-        self.readable = readable
         self.prefer_modify = prefer_modify
+
+    @property
+    def readable(self) -> bool:
+        return os.path.exists(self.path)
 
     def get_section_filename(self, section: str) -> str:
         """Returns the filename associated with a given section"""
@@ -236,9 +237,7 @@ class DirectoryConfigScope(ConfigScope):
     def get_section(self, section: str) -> Optional[YamlConfigDict]:
         """Returns the data associated with a given section"""
         if not self.readable:
-            # warn appears more reasonable but produces way too much output
-            # in a normal Spack run
-            tty.debug(f"Attempting to read from missing scope: {self}")
+            tty.debug(f"Attempting to read from missing scope: {self} at {self.path}")
             return {}
         if section not in self.sections:
             path = self.get_section_filename(section)
@@ -262,7 +261,6 @@ class DirectoryConfigScope(ConfigScope):
             filesystem.mkdirp(self.path)
             with open(filename, "w", encoding="utf-8") as f:
                 syaml.dump_config(data, stream=f, default_flow_style=False)
-                self.readable = True
         except (syaml.SpackYAMLError, OSError) as e:
             raise ConfigFileError(f"cannot write to '{filename}'") from e
 
@@ -279,7 +277,6 @@ class SingleFileScope(ConfigScope):
         yaml_path: Optional[List[str]] = None,
         writable: bool = True,
         prefer_modify: bool = True,
-        readable: bool = True,
     ) -> None:
         """Similar to ``ConfigScope`` but can be embedded in another schema.
 
@@ -304,8 +301,11 @@ class SingleFileScope(ConfigScope):
         self.path = path
         self.writable = writable
         self.prefer_modify = prefer_modify
-        self.readable = readable
         self.yaml_path = yaml_path or []
+
+    @property
+    def readable(self) -> bool:
+        return os.path.exists(self.path)
 
     def get_section_filename(self, section) -> str:
         return self.path
@@ -338,6 +338,7 @@ class SingleFileScope(ConfigScope):
         # }
 
         if not self.readable:
+            tty.debug(f"Attempting to read from missing scope: {self} at {self.path}")
             return {}
 
         # This bit ensures we have read the file and have
@@ -400,7 +401,6 @@ class SingleFileScope(ConfigScope):
             tmp = os.path.join(parent, f".{os.path.basename(self.path)}.tmp")
             with open(tmp, "w", encoding="utf-8") as f:
                 syaml.dump_config(data_to_write, stream=f, default_flow_style=False)
-                self.readable = True
             filesystem.rename(tmp, self.path)
 
         except (syaml.SpackYAMLError, OSError) as e:
@@ -1029,7 +1029,6 @@ class OptionalInclude:
 
         is_dir = os.path.isdir(config_path)
         exists = os.path.exists(config_path)
-        # notably naive
         is_file = config_path.endswith(".yaml") or config_path.endswith(".yml")
 
         if not exists and not self.optional:
@@ -1043,16 +1042,13 @@ class OptionalInclude:
                 config_name,
                 config_path,
                 spack.schema.merged.schema,
-                readable=exists,
                 prefer_modify=self.prefer_modify,
             )
 
         # directories are treated as regular ConfigScopes
         # assign by "default"
         tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
-        return DirectoryConfigScope(
-            config_name, config_path, readable=exists, prefer_modify=self.prefer_modify
-        )
+        return DirectoryConfigScope(config_name, config_path, prefer_modify=self.prefer_modify)
 
     def evaluate_condition(self) -> bool:
         # circular dependencies

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -145,6 +145,7 @@ class ConfigScope:
     def __init__(self, name: str) -> None:
         self.name = name
         self.writable = False
+        self.readable = False
         self.sections = syaml.syaml_dict()
         self.prefer_modify = False
 
@@ -213,11 +214,12 @@ class DirectoryConfigScope(ConfigScope):
     """Config scope backed by a directory containing one file per section."""
 
     def __init__(
-        self, name: str, path: str, *, writable: bool = True, prefer_modify: bool = True
+        self, name: str, path: str, *, writable: bool = True, readable: bool = True, prefer_modify: bool = True
     ) -> None:
         super().__init__(name)
         self.path = path
         self.writable = writable
+        self.readable = readable
         self.prefer_modify = prefer_modify
 
     def get_section_filename(self, section: str) -> str:
@@ -227,6 +229,9 @@ class DirectoryConfigScope(ConfigScope):
 
     def get_section(self, section: str) -> Optional[YamlConfigDict]:
         """Returns the data associated with a given section"""
+        if not self.readable:
+            tty.debug(f"Attempting to read from missing scope {self}")
+            return {}
         if section not in self.sections:
             path = self.get_section_filename(section)
             schema = SECTION_SCHEMAS[section]
@@ -249,6 +254,7 @@ class DirectoryConfigScope(ConfigScope):
             filesystem.mkdirp(self.path)
             with open(filename, "w", encoding="utf-8") as f:
                 syaml.dump_config(data, stream=f, default_flow_style=False)
+                self.readable = True
         except (syaml.SpackYAMLError, OSError) as e:
             raise ConfigFileError(f"cannot write to '{filename}'") from e
 
@@ -265,6 +271,7 @@ class SingleFileScope(ConfigScope):
         yaml_path: Optional[List[str]] = None,
         writable: bool = True,
         prefer_modify: bool = True,
+        readable: bool = True,
     ) -> None:
         """Similar to ``ConfigScope`` but can be embedded in another schema.
 
@@ -289,6 +296,7 @@ class SingleFileScope(ConfigScope):
         self.path = path
         self.writable = writable
         self.prefer_modify = prefer_modify
+        self.readable = readable
         self.yaml_path = yaml_path or []
 
     def get_section_filename(self, section) -> str:
@@ -320,6 +328,9 @@ class SingleFileScope(ConfigScope):
         #      }
         #   }
         # }
+
+        if not self.readable:
+            return {}
 
         # This bit ensures we have read the file and have
         # the raw data in memory
@@ -381,6 +392,7 @@ class SingleFileScope(ConfigScope):
             tmp = os.path.join(parent, f".{os.path.basename(self.path)}.tmp")
             with open(tmp, "w", encoding="utf-8") as f:
                 syaml.dump_config(data_to_write, stream=f, default_flow_style=False)
+                self.readable = True
             filesystem.rename(tmp, self.path)
 
         except (syaml.SpackYAMLError, OSError) as e:
@@ -1002,26 +1014,24 @@ class OptionalInclude:
 
             config_name = f"{parent_scope.name}:{included_name}"
 
-        if os.path.isdir(config_path):
-            # directories are treated as regular ConfigScopes
-            tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
-            return DirectoryConfigScope(config_name, config_path, prefer_modify=self.prefer_modify)
+        is_dir = os.path.isdir(config_path)
+        exists = os.path.exists(config_path)
+        is_file = config_path.endswith(".yaml") or config_path.endswith(".yml")
 
-        if os.path.exists(config_path):
-            # files are assumed to be SingleFileScopes
-            tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
-            return SingleFileScope(
-                config_name,
-                config_path,
-                spack.schema.merged.schema,
-                prefer_modify=self.prefer_modify,
-            )
-
-        if not self.optional:
+        if not exists and not self.optional:
             dest = f" at ({config_path})" if config_path != path else ""
             raise ValueError(f"Required path ({path}) does not exist{dest}")
 
-        return None
+        if (not is_dir and exists) or is_file:
+            # files are assumed to be SingleFileScopes
+            tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
+            return SingleFileScope(config_name, config_path, spack.schema.merged.schema, readable=exists, prefer_modify=self.prefer_modify)
+
+        # directories are treated as regular ConfigScopes
+        # assign by "default"
+        tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
+        return DirectoryConfigScope(config_name, config_path, readable=exists, prefer_modify=self.prefer_modify)
+
 
     def evaluate_condition(self) -> bool:
         # circular dependencies
@@ -1464,7 +1474,6 @@ def scopes() -> lang.PriorityOrderedMapping[str, ConfigScope]:
     """Convenience function to get list of configuration scopes."""
     return CONFIG.scopes
 
-
 def writable_scopes() -> List[ConfigScope]:
     """Return list of writable scopes. Higher-priority scopes come first in the list."""
     scopes = [x for x in CONFIG.scopes.values() if x.writable]
@@ -1472,8 +1481,19 @@ def writable_scopes() -> List[ConfigScope]:
     return scopes
 
 
+def readable_scopes() -> List[ConfigScope]:
+    """Return list of readable scopes. Higher-priority scopes come first in the list."""
+    scopes = [x for x in CONFIG.scopes.values() if x.readable]
+    scopes.reverse()
+    return scopes
+
+
 def writable_scope_names() -> List[str]:
     return list(x.name for x in writable_scopes())
+
+
+def readable_scope_names() -> List[str]:
+    return list(x.name for x in readable_scopes())
 
 
 def matched_config(cfg_path: str) -> List[Tuple[str, Any]]:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1051,7 +1051,7 @@ class OptionalInclude:
                 prefer_modify=self.prefer_modify,
             )
 
-        if ext:
+        if ext and not is_dir:
             raise ValueError(f"Attempting to create a config scope with invalid extension {ext}")
 
         # directories are treated as regular ConfigScopes

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -153,3 +153,14 @@ def test_use_buildcache_type():
 
     with pytest.raises(argparse.ArgumentTypeError):
         assert arguments.use_buildcache("sometimes")
+
+def test_missing_config_scopes_are_valid_scope_arguments(mutable_config):
+    """Test that if an included scope does not have a directory or file,
+    we can still specify it as a scope as an argument"""
+
+
+
+def test_missing_config_scopes_not_valid_read_scope(mutable_config):
+    """Ensures that if a missing include scope is the subject of a read
+    operation, we fail at the argparse level"""
+

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -172,7 +172,7 @@ def test_missing_config_scopes_are_valid_scope_arguments(mock_missing_include_sc
 def test_missing_config_scopes_not_valid_read_scope(mock_missing_include_scopes):
     """Ensures that if a missing include scope is the subject of a read
     operation, we fail at the argparse level"""
-    a = argparse.ArgumentParser(exit_on_error=False)
+    a = argparse.ArgumentParser()
     a.add_argument(
         "--scope",
         action=arguments.ConfigScope,
@@ -180,5 +180,5 @@ def test_missing_config_scopes_not_valid_read_scope(mock_missing_include_scopes)
         default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )
-    with pytest.raises(argparse.ArgumentError):
+    with pytest.raises(SystemExit):
         a.parse_args(["--scope", "sub_base"])

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -154,13 +154,32 @@ def test_use_buildcache_type():
     with pytest.raises(argparse.ArgumentTypeError):
         assert arguments.use_buildcache("sometimes")
 
-def test_missing_config_scopes_are_valid_scope_arguments(mutable_config):
+
+def test_missing_config_scopes_are_valid_scope_arguments(mock_missing_include_scopes):
     """Test that if an included scope does not have a directory or file,
     we can still specify it as a scope as an argument"""
+    a = argparse.ArgumentParser()
+    a.add_argument(
+        "--scope",
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
+        help="configuration scope to modify",
+    )
+    namespace = a.parse_args(["--scope", "sub_base"])
+    assert namespace.scope == "sub_base"
 
 
 
-def test_missing_config_scopes_not_valid_read_scope(mutable_config):
+def test_missing_config_scopes_not_valid_read_scope(mock_missing_include_scopes):
     """Ensures that if a missing include scope is the subject of a read
     operation, we fail at the argparse level"""
-
+    a = argparse.ArgumentParser(exit_on_error=False)
+    a.add_argument(
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        default=lambda: spack.config.default_modify_scope(),
+        help="configuration scope to modify",
+    )
+    with pytest.raises(argparse.ArgumentError):
+        a.parse_args(["--scope", "sub_base"])

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -155,7 +155,7 @@ def test_use_buildcache_type():
         assert arguments.use_buildcache("sometimes")
 
 
-def test_missing_config_scopes_are_valid_scope_arguments(mock_missing_include_scopes):
+def test_missing_config_scopes_are_valid_scope_arguments(mock_missing_dir_include_scopes):
     """Test that if an included scope does not have a directory or file,
     we can still specify it as a scope as an argument"""
     a = argparse.ArgumentParser()
@@ -169,7 +169,7 @@ def test_missing_config_scopes_are_valid_scope_arguments(mock_missing_include_sc
     assert namespace.scope == "sub_base"
 
 
-def test_missing_config_scopes_not_valid_read_scope(mock_missing_include_scopes):
+def test_missing_config_scopes_not_valid_read_scope(mock_missing_dir_include_scopes):
     """Ensures that if a missing include scope is the subject of a read
     operation, we fail at the argparse level"""
     a = argparse.ArgumentParser()

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -169,7 +169,6 @@ def test_missing_config_scopes_are_valid_scope_arguments(mock_missing_include_sc
     assert namespace.scope == "sub_base"
 
 
-
 def test_missing_config_scopes_not_valid_read_scope(mock_missing_include_scopes):
     """Ensures that if a missing include scope is the subject of a read
     operation, we fail at the argparse level"""

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1866,8 +1866,9 @@ def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, mo
 def test_missing_include_scope_list(mock_missing_include_scopes):
     """Tests that an included scope with a non existent file/directory
     is still listed as a scope under spack.config.CONFIG.scopes"""
-    assert "sub_base" in list(spack.config.CONFIG.scopes), \
-        "Missing Optional Scope Missing from Config Scopes"
+    assert "sub_base" in list(
+        spack.config.CONFIG.scopes
+    ), "Missing Optional Scope Missing from Config Scopes"
 
 
 def test_missing_include_scope_writable_list(mock_missing_include_scopes):
@@ -1894,13 +1895,18 @@ def test_missing_include_scope_yaml_ext_is_file_scope(tmp_path):
     yaml extension is created as a file scope"""
     base_scope_dir = tmp_path / "base"
     scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
-    scope.sections["include"] = syaml.syaml_dict({"include" : [{
-            "name" : "sub_base",
-            "path" : str(tmp_path / "sub.yaml"),
-            "optional" : True,
-            "prefer_modify": True
-        }]
-    })
+    scope.sections["include"] = syaml.syaml_dict(
+        {
+            "include": [
+                {
+                    "name": "sub_base",
+                    "path": str(tmp_path / "sub.yaml"),
+                    "optional": True,
+                    "prefer_modify": True,
+                }
+            ]
+        }
+    )
     scope._write_section("include")
 
     with spack.config.use_configuration(scope):
@@ -1911,27 +1917,29 @@ def test_missing_include_scope_yaml_ext_is_file_scope(tmp_path):
 def test_missing_include_scope_writeable_not_readable(mock_missing_include_scopes):
     """Tests that an included scope with a non existent file/directory
     can be written to (and created)"""
-    assert spack.config.CONFIG.scopes["sub_base"].writable, \
-        "Missing Optional Scope should be writable"
-    assert not spack.config.CONFIG.scopes["sub_base"].readable, \
-        "Missing Optional Scope should be readable"
+    assert spack.config.CONFIG.scopes[
+        "sub_base"
+    ].writable, "Missing Optional Scope should be writable"
+    assert not spack.config.CONFIG.scopes[
+        "sub_base"
+    ].readable, "Missing Optional Scope should be readable"
 
 
 def test_missing_include_scope_empty_read(mock_missing_include_scopes):
     """Tests that an included scope with a non existent file/directory
     returns an empty dict on read and has "readable" set to false"""
-    assert spack.config.CONFIG.get("config", scope="sub_base") == {}, \
-        "Missing optional include scope does not return an empty value."
-    assert not os.path.exists(spack.config.CONFIG.scopes["sub_base"].path), \
-        "Missing optional include should not be created on read"
+    assert (
+        spack.config.CONFIG.get("config", scope="sub_base") == {}
+    ), "Missing optional include scope does not return an empty value."
+    assert not os.path.exists(
+        spack.config.CONFIG.scopes["sub_base"].path
+    ), "Missing optional include should not be created on read"
 
 
 def test_missing_include_scope_write_directory(mock_missing_include_scopes):
     """Tests that an include scope with a non existent directory
     creates said directory and the appropriate section file on write"""
-    install_tree = syaml.syaml_dict({"install_tree" : {
-        "root": "$spack/tmp/spack"
-    }})
+    install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})
     spack.config.CONFIG.set("config", install_tree, scope="sub_base")
     assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
     install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
@@ -1943,21 +1951,23 @@ def test_missing_include_scope_read_directory(tmp_path):
     with the appropriate section entry"""
     base_scope_dir = tmp_path / "base"
     scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
-    scope.sections["include"] = syaml.syaml_dict({"include" : [{
-            "name" : "sub_base",
-            "path" : str(tmp_path / "sub.yaml"),
-            "optional" : True,
-            "prefer_modify": True
-        }]
-    })
+    scope.sections["include"] = syaml.syaml_dict(
+        {
+            "include": [
+                {
+                    "name": "sub_base",
+                    "path": str(tmp_path / "sub.yaml"),
+                    "optional": True,
+                    "prefer_modify": True,
+                }
+            ]
+        }
+    )
     scope._write_section("include")
 
     with spack.config.use_configuration(scope):
-        install_tree = syaml.syaml_dict({"install_tree" : {
-            "root": "$spack/tmp/spack"
-        }})
+        install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})
         spack.config.CONFIG.set("config", install_tree, scope="sub_base")
         assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
         install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
         assert install_root == "$spack/tmp/spack"
-

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1664,10 +1664,12 @@ def test_included_path_string_no_parent_path(
     will be rooted in the current working directory (usually SPACK_ROOT)."""
     entry = {"path": "config.yaml", "optional": True}
     include = spack.config.included_path(entry)
-    FakeScope = collections.namedtuple("FakeScope", ["path", "name"])
-    parent_scope = FakeScope("", "")
-
-    assert include.scopes(parent_scope)  # type: ignore[arg-type]
+    parent_scope = spack.config.InternalConfigScope("parent-scope")
+    included_scopes = include.scopes(parent_scope)
+    # ensure scope is returned even if there is no parent path
+    assert len(included_scopes) == 1
+    # ensure scope for include is singlefile as it ends in .yaml
+    assert isinstance(included_scopes[0], spack.config.SingleFileScope)
     destination = include.destination
     curr_dir = os.getcwd()
     assert curr_dir == os.path.commonprefix([curr_dir, destination])  # type: ignore[list-item]

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1914,10 +1914,10 @@ def test_missing_include_scope_empty_read(mock_missing_dir_include_scopes):
     assert (
         spack.config.CONFIG.get("config", scope="sub_base") == {}
     ), "Missing optional include scope does not return an empty value."
-    assert (
-        not spack.config.CONFIG.scopes["sub_base"].exists
-    ), "Missing optional include should not be created on read"
-        
+    assert not spack.config.CONFIG.scopes[
+        "sub_base"
+    ].exists, "Missing optional include should not be created on read"
+
 
 def test_missing_include_scope_file_empty_read(mock_missing_file_include_scopes):
     """Tests that an include scope with a non existent file returns an empty
@@ -1925,9 +1925,9 @@ def test_missing_include_scope_file_empty_read(mock_missing_file_include_scopes)
     assert (
         spack.config.CONFIG.get("config", scope="sub_base") == {}
     ), "Missing optional include scope does not return an empty value."
-    assert (
-        not spack.config.CONFIG.scopes["sub_base"].exists
-    ), "Missing optional include should not be created on read"
+    assert not spack.config.CONFIG.scopes[
+        "sub_base"
+    ].exists, "Missing optional include should not be created on read"
 
 
 def test_missing_include_scope_write_directory(mock_missing_dir_include_scopes):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1861,3 +1861,22 @@ def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, mo
     include.branch = ""  # type: ignore[union-attr]
     with pytest.raises(spack.error.ConfigError, match="Missing or unsupported options"):
         include.scopes(parent_scope)
+
+
+def test_list_missing_include_scopes(mutable_config):
+    """Tests that an included scope with a non existent file/directory
+    is still listed as a scope under spack.config.CONFIG.scopes"""
+
+
+def test_missing_include_scope_writeable(mutable_config):
+    """Tests that an included scope with a non existent file/directory
+    can be written to (and created)"""
+
+
+def test_missing_include_scope_not_readable(mutable_config):
+    """"""
+
+
+def test_missing_include_scope_empty_read(mutable_config):
+    """Tests than an included scope with a non existent file/directory
+    returns an empty dict on read and has "readable" set to false"""

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1878,9 +1878,9 @@ def test_missing_include_scope_writable_list(mock_missing_dir_include_scopes):
 
 def test_missing_include_scope_not_readable_list(mock_missing_dir_include_scopes):
     """Tests that missing include scopes are not included in readable config lists"""
-    readable_scopes = [x for x in spack.config.CONFIG.readable_scopes if x.name != "sub_base"]
-    assert len(readable_scopes) == 1
-    assert readable_scopes[0].name != "sub_base"
+    existing_scopes = [x for x in spack.config.CONFIG.existing_scopes if x.name != "sub_base"]
+    assert len(existing_scopes) == 1
+    assert existing_scopes[0].name != "sub_base"
 
 
 def test_missing_include_scope_default_created_as_dir_scope(mock_missing_dir_include_scopes):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1863,20 +1863,101 @@ def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, mo
         include.scopes(parent_scope)
 
 
-def test_list_missing_include_scopes(mutable_config):
+def test_missing_include_scope_list(mock_missing_include_scopes):
     """Tests that an included scope with a non existent file/directory
     is still listed as a scope under spack.config.CONFIG.scopes"""
+    assert "sub_base" in list(spack.config.CONFIG.scopes), \
+        "Missing Optional Scope Missing from Config Scopes"
 
 
-def test_missing_include_scope_writeable(mutable_config):
+def test_missing_include_scope_writable_list(mock_missing_include_scopes):
+    """Tests that missing include scopes are included in writeable config lists"""
+    assert [x for x in spack.config.CONFIG.writable_scopes if x.name == "sub_base"]
+
+
+def test_missing_include_scope_not_readable_list(mock_missing_include_scopes):
+    """Tests that missing include scopes are not included in readable config lists"""
+    readable_scopes = [x for x in spack.config.CONFIG.readable_scopes if x.name != "sub_base"]
+    assert len(readable_scopes) == 1
+    assert readable_scopes[0].name != "sub_base"
+
+
+def test_missing_include_scope_default_created_as_dir_scope(mock_missing_include_scopes):
+    """Tests that an optional include with no existing file/directory and no yaml extention
+    is created as a directoryscope object"""
+    missing_inc_scope = spack.config.CONFIG.scopes["sub_base"]
+    assert isinstance(missing_inc_scope, spack.config.DirectoryConfigScope)
+
+
+def test_missing_include_scope_yaml_ext_is_file_scope(tmp_path):
+    """Tests that an optional include scope with no existing file/directory and a
+    yaml extension is created as a file scope"""
+    base_scope_dir = tmp_path / "base"
+    scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
+    scope.sections["include"] = syaml.syaml_dict({"include" : [{
+            "name" : "sub_base",
+            "path" : str(tmp_path / "sub.yaml"),
+            "optional" : True,
+            "prefer_modify": True
+        }]
+    })
+    scope._write_section("include")
+
+    with spack.config.use_configuration(scope):
+        missing_inc_scope = spack.config.CONFIG.scopes["sub_base"]
+        assert isinstance(missing_inc_scope, spack.config.SingleFileScope)
+
+
+def test_missing_include_scope_writeable_not_readable(mock_missing_include_scopes):
     """Tests that an included scope with a non existent file/directory
     can be written to (and created)"""
+    assert spack.config.CONFIG.scopes["sub_base"].writable, \
+        "Missing Optional Scope should be writable"
+    assert not spack.config.CONFIG.scopes["sub_base"].readable, \
+        "Missing Optional Scope should be readable"
 
 
-def test_missing_include_scope_not_readable(mutable_config):
-    """"""
-
-
-def test_missing_include_scope_empty_read(mutable_config):
-    """Tests than an included scope with a non existent file/directory
+def test_missing_include_scope_empty_read(mock_missing_include_scopes):
+    """Tests that an included scope with a non existent file/directory
     returns an empty dict on read and has "readable" set to false"""
+    assert spack.config.CONFIG.get("config", scope="sub_base") == {}, \
+        "Missing optional include scope does not return an empty value."
+    assert not os.path.exists(spack.config.CONFIG.scopes["sub_base"].path), \
+        "Missing optional include should not be created on read"
+
+
+def test_missing_include_scope_write_directory(mock_missing_include_scopes):
+    """Tests that an include scope with a non existent directory
+    creates said directory and the appropriate section file on write"""
+    install_tree = syaml.syaml_dict({"install_tree" : {
+        "root": "$spack/tmp/spack"
+    }})
+    spack.config.CONFIG.set("config", install_tree, scope="sub_base")
+    assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
+    install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
+    assert install_root == "$spack/tmp/spack"
+
+
+def test_missing_include_scope_read_directory(tmp_path):
+    """Tests that an include scope with a non existent file creates said file
+    with the appropriate section entry"""
+    base_scope_dir = tmp_path / "base"
+    scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
+    scope.sections["include"] = syaml.syaml_dict({"include" : [{
+            "name" : "sub_base",
+            "path" : str(tmp_path / "sub.yaml"),
+            "optional" : True,
+            "prefer_modify": True
+        }]
+    })
+    scope._write_section("include")
+
+    with spack.config.use_configuration(scope):
+        install_tree = syaml.syaml_dict({"install_tree" : {
+            "root": "$spack/tmp/spack"
+        }})
+        spack.config.CONFIG.set("config", install_tree, scope="sub_base")
+        assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
+        install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
+        assert install_root == "$spack/tmp/spack"
+

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1863,7 +1863,7 @@ def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, mo
         include.scopes(parent_scope)
 
 
-def test_missing_include_scope_list(mock_missing_include_scopes):
+def test_missing_include_scope_list(mock_missing_dir_include_scopes):
     """Tests that an included scope with a non existent file/directory
     is still listed as a scope under spack.config.CONFIG.scopes"""
     assert "sub_base" in list(
@@ -1871,50 +1871,33 @@ def test_missing_include_scope_list(mock_missing_include_scopes):
     ), "Missing Optional Scope Missing from Config Scopes"
 
 
-def test_missing_include_scope_writable_list(mock_missing_include_scopes):
+def test_missing_include_scope_writable_list(mock_missing_dir_include_scopes):
     """Tests that missing include scopes are included in writeable config lists"""
     assert [x for x in spack.config.CONFIG.writable_scopes if x.name == "sub_base"]
 
 
-def test_missing_include_scope_not_readable_list(mock_missing_include_scopes):
+def test_missing_include_scope_not_readable_list(mock_missing_dir_include_scopes):
     """Tests that missing include scopes are not included in readable config lists"""
     readable_scopes = [x for x in spack.config.CONFIG.readable_scopes if x.name != "sub_base"]
     assert len(readable_scopes) == 1
     assert readable_scopes[0].name != "sub_base"
 
 
-def test_missing_include_scope_default_created_as_dir_scope(mock_missing_include_scopes):
+def test_missing_include_scope_default_created_as_dir_scope(mock_missing_dir_include_scopes):
     """Tests that an optional include with no existing file/directory and no yaml extention
     is created as a directoryscope object"""
     missing_inc_scope = spack.config.CONFIG.scopes["sub_base"]
     assert isinstance(missing_inc_scope, spack.config.DirectoryConfigScope)
 
 
-def test_missing_include_scope_yaml_ext_is_file_scope(tmp_path):
+def test_missing_include_scope_yaml_ext_is_file_scope(mock_missing_file_include_scopes):
     """Tests that an optional include scope with no existing file/directory and a
     yaml extension is created as a file scope"""
-    base_scope_dir = tmp_path / "base"
-    scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
-    scope.sections["include"] = syaml.syaml_dict(
-        {
-            "include": [
-                {
-                    "name": "sub_base",
-                    "path": str(tmp_path / "sub.yaml"),
-                    "optional": True,
-                    "prefer_modify": True,
-                }
-            ]
-        }
-    )
-    scope._write_section("include")
-
-    with spack.config.use_configuration(scope):
-        missing_inc_scope = spack.config.CONFIG.scopes["sub_base"]
-        assert isinstance(missing_inc_scope, spack.config.SingleFileScope)
+    missing_inc_scope = spack.config.CONFIG.scopes["sub_base"]
+    assert isinstance(missing_inc_scope, spack.config.SingleFileScope)
 
 
-def test_missing_include_scope_writeable_not_readable(mock_missing_include_scopes):
+def test_missing_include_scope_writeable_not_readable(mock_missing_dir_include_scopes):
     """Tests that an included scope with a non existent file/directory
     can be written to (and created)"""
     assert spack.config.CONFIG.scopes[
@@ -1925,7 +1908,7 @@ def test_missing_include_scope_writeable_not_readable(mock_missing_include_scope
     ].readable, "Missing Optional Scope should be readable"
 
 
-def test_missing_include_scope_empty_read(mock_missing_include_scopes):
+def test_missing_include_scope_empty_read(mock_missing_dir_include_scopes):
     """Tests that an included scope with a non existent file/directory
     returns an empty dict on read and has "readable" set to false"""
     assert (
@@ -1936,7 +1919,7 @@ def test_missing_include_scope_empty_read(mock_missing_include_scopes):
     ), "Missing optional include should not be created on read"
 
 
-def test_missing_include_scope_write_directory(mock_missing_include_scopes):
+def test_missing_include_scope_write_directory(mock_missing_dir_include_scopes):
     """Tests that an include scope with a non existent directory
     creates said directory and the appropriate section file on write"""
     install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})
@@ -1946,28 +1929,11 @@ def test_missing_include_scope_write_directory(mock_missing_include_scopes):
     assert install_root == "$spack/tmp/spack"
 
 
-def test_missing_include_scope_read_directory(tmp_path):
+def test_missing_include_scope_read_directory(mock_missing_file_include_scopes):
     """Tests that an include scope with a non existent file creates said file
     with the appropriate section entry"""
-    base_scope_dir = tmp_path / "base"
-    scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
-    scope.sections["include"] = syaml.syaml_dict(
-        {
-            "include": [
-                {
-                    "name": "sub_base",
-                    "path": str(tmp_path / "sub.yaml"),
-                    "optional": True,
-                    "prefer_modify": True,
-                }
-            ]
-        }
-    )
-    scope._write_section("include")
-
-    with spack.config.use_configuration(scope):
-        install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})
-        spack.config.CONFIG.set("config", install_tree, scope="sub_base")
-        assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
-        install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
-        assert install_root == "$spack/tmp/spack"
+    install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})
+    spack.config.CONFIG.set("config", install_tree, scope="sub_base")
+    assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
+    install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
+    assert install_root == "$spack/tmp/spack"

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1667,7 +1667,7 @@ def test_included_path_string_no_parent_path(
     FakeScope = collections.namedtuple("FakeScope", ["path", "name"])
     parent_scope = FakeScope("", "")
 
-    assert not include.scopes(parent_scope)  # type: ignore[arg-type]
+    assert include.scopes(parent_scope)  # type: ignore[arg-type]
     destination = include.destination
     curr_dir = os.getcwd()
     assert curr_dir == os.path.commonprefix([curr_dir, destination])  # type: ignore[list-item]
@@ -1877,7 +1877,7 @@ def test_missing_include_scope_writable_list(mock_missing_dir_include_scopes):
 
 
 def test_missing_include_scope_not_readable_list(mock_missing_dir_include_scopes):
-    """Tests that missing include scopes are not included in readable config lists"""
+    """Tests that missing include scopes are not included in existing config lists"""
     existing_scopes = [x for x in spack.config.CONFIG.existing_scopes if x.name != "sub_base"]
     assert len(existing_scopes) == 1
     assert existing_scopes[0].name != "sub_base"
@@ -1905,17 +1905,28 @@ def test_missing_include_scope_writeable_not_readable(mock_missing_dir_include_s
     ].writable, "Missing Optional Scope should be writable"
     assert not spack.config.CONFIG.scopes[
         "sub_base"
-    ].readable, "Missing Optional Scope should be readable"
+    ].exists, "Missing Optional Scope should not exist"
 
 
 def test_missing_include_scope_empty_read(mock_missing_dir_include_scopes):
     """Tests that an included scope with a non existent file/directory
-    returns an empty dict on read and has "readable" set to false"""
+    returns an empty dict on read and has "exists" set to false"""
     assert (
         spack.config.CONFIG.get("config", scope="sub_base") == {}
     ), "Missing optional include scope does not return an empty value."
-    assert not os.path.exists(
-        spack.config.CONFIG.scopes["sub_base"].path
+    assert (
+        not spack.config.CONFIG.scopes["sub_base"].exists
+    ), "Missing optional include should not be created on read"
+        
+
+def test_missing_include_scope_file_empty_read(mock_missing_file_include_scopes):
+    """Tests that an include scope with a non existent file returns an empty
+    dict and has exists set to false"""
+    assert (
+        spack.config.CONFIG.get("config", scope="sub_base") == {}
+    ), "Missing optional include scope does not return an empty value."
+    assert (
+        not spack.config.CONFIG.scopes["sub_base"].exists
     ), "Missing optional include should not be created on read"
 
 
@@ -1929,7 +1940,7 @@ def test_missing_include_scope_write_directory(mock_missing_dir_include_scopes):
     assert install_root == "$spack/tmp/spack"
 
 
-def test_missing_include_scope_read_directory(mock_missing_file_include_scopes):
+def test_missing_include_scope_write_file(mock_missing_file_include_scopes):
     """Tests that an include scope with a non existent file creates said file
     with the appropriate section entry"""
     install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1039,6 +1039,15 @@ def mock_low_high_config(tmp_path: Path):
         yield config
 
 
+@pytest.fixture()
+def mock_missing_include_scopes(tmp_path: Path):
+    scope = spack.config.DirectoryConfigScope("", str(tmp_path / ""))
+
+    with spack.config.use_configuration(scope) as config:
+        yield config
+
+
+
 def _populate(mock_db):
     r"""Populate a mock database with packages.
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1039,16 +1039,17 @@ def mock_low_high_config(tmp_path: Path):
         yield config
 
 
-@pytest.fixture()
-def mock_missing_include_scopes(tmp_path: Path):
-    base_scope_dir = tmp_path / "base"
+def create_config_scope(path: Path, name: str) -> spack.config.DirectoryConfigScope:
+    """helper for creating config scopes with included file/directory scopes
+    that do not have existing representation on the filesystem"""
+    base_scope_dir = path / "base"
     scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
     scope.sections["include"] = syaml.syaml_dict(
         {
             "include": [
                 {
                     "name": "sub_base",
-                    "path": str(tmp_path / "sub"),
+                    "path": str(path / name),
                     "optional": True,
                     "prefer_modify": True,
                 }
@@ -1056,6 +1057,24 @@ def mock_missing_include_scopes(tmp_path: Path):
         }
     )
     scope._write_section("include")
+    return scope
+
+
+@pytest.fixture()
+def mock_missing_dir_include_scopes(tmp_path: Path):
+    """Mocks a config scope containing optional directory scope
+    includes that do not have represetation on the filesystem"""
+    scope = create_config_scope(tmp_path, "sub")
+
+    with spack.config.use_configuration(scope) as config:
+        yield config
+
+
+@pytest.fixture
+def mock_missing_file_include_scopes(tmp_path: Path):
+    """Mocks a config scope containing optional file scope
+    includes that do not have represetation on the filesystem"""
+    scope = create_config_scope(tmp_path, "sub.yaml")
 
     with spack.config.use_configuration(scope) as config:
         yield config

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1041,7 +1041,16 @@ def mock_low_high_config(tmp_path: Path):
 
 @pytest.fixture()
 def mock_missing_include_scopes(tmp_path: Path):
-    scope = spack.config.DirectoryConfigScope("", str(tmp_path / ""))
+    base_scope_dir = tmp_path / "base"
+    scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
+    scope.sections["include"] = syaml.syaml_dict({"include" : [{
+            "name" : "sub_base",
+            "path" : str(tmp_path / "sub"),
+            "optional" : True,
+            "prefer_modify": True
+        }]
+    })
+    scope._write_section("include")
 
     with spack.config.use_configuration(scope) as config:
         yield config

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1044,17 +1044,17 @@ def create_config_scope(path: Path, name: str) -> spack.config.DirectoryConfigSc
     that do not have existing representation on the filesystem"""
     base_scope_dir = path / "base"
     config_data = syaml.syaml_dict(
-            {
-                "include": [
-                    {
-                        "name": "sub_base",
-                        "path": str(path / name),
-                        "optional": True,
-                        "prefer_modify": True,
-                    }
-                ]
-            }
-        )
+        {
+            "include": [
+                {
+                    "name": "sub_base",
+                    "path": str(path / name),
+                    "optional": True,
+                    "prefer_modify": True,
+                }
+            ]
+        }
+    )
     base_scope_dir.mkdir()
     with open(str(base_scope_dir / "include.yaml"), "w+", encoding="utf-8") as f:
         syaml.dump_config(config_data, stream=f, default_flow_style=False)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1043,20 +1043,22 @@ def create_config_scope(path: Path, name: str) -> spack.config.DirectoryConfigSc
     """helper for creating config scopes with included file/directory scopes
     that do not have existing representation on the filesystem"""
     base_scope_dir = path / "base"
+    config_data = syaml.syaml_dict(
+            {
+                "include": [
+                    {
+                        "name": "sub_base",
+                        "path": str(path / name),
+                        "optional": True,
+                        "prefer_modify": True,
+                    }
+                ]
+            }
+        )
+    base_scope_dir.mkdir()
+    with open(str(base_scope_dir / "include.yaml"), "w+", encoding="utf-8") as f:
+        syaml.dump_config(config_data, stream=f, default_flow_style=False)
     scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
-    scope.sections["include"] = syaml.syaml_dict(
-        {
-            "include": [
-                {
-                    "name": "sub_base",
-                    "path": str(path / name),
-                    "optional": True,
-                    "prefer_modify": True,
-                }
-            ]
-        }
-    )
-    scope._write_section("include")
     return scope
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1043,18 +1043,22 @@ def mock_low_high_config(tmp_path: Path):
 def mock_missing_include_scopes(tmp_path: Path):
     base_scope_dir = tmp_path / "base"
     scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
-    scope.sections["include"] = syaml.syaml_dict({"include" : [{
-            "name" : "sub_base",
-            "path" : str(tmp_path / "sub"),
-            "optional" : True,
-            "prefer_modify": True
-        }]
-    })
+    scope.sections["include"] = syaml.syaml_dict(
+        {
+            "include": [
+                {
+                    "name": "sub_base",
+                    "path": str(tmp_path / "sub"),
+                    "optional": True,
+                    "prefer_modify": True,
+                }
+            ]
+        }
+    )
     scope._write_section("include")
 
     with spack.config.use_configuration(scope) as config:
         yield config
-
 
 
 def _populate(mock_db):

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -603,7 +603,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_enable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap enable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap disable
@@ -611,7 +611,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_disable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap disable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap reset
@@ -626,14 +626,14 @@ set -g __fish_spack_optspecs_spack_bootstrap_root h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap root' -f -a '(__fish_complete_directories)'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap list
 set -g __fish_spack_optspecs_spack_bootstrap_list h/help scope=
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap add
@@ -642,7 +642,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap add' -f -a '(__
 complete -c spack -n '__fish_spack_using_command_pos 1 bootstrap add' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -f -a trust
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -d 'enable the source immediately upon addition'
@@ -819,7 +819,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirro
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -d 'override any configured mirrors with this mirror URL'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -f -a output_file
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -d 'file where rebuild info should be written'
-complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -d 'configuration scope containing mirrors to check'
 
 # spack buildcache download
@@ -1097,7 +1097,7 @@ complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolcha
 complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1111,7 +1111,7 @@ complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchai
 complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1123,7 +1123,7 @@ complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -
 complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler rm
@@ -1133,14 +1133,14 @@ complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler list
 set -g __fish_spack_optspecs_spack_compiler_list h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'list also compilers from registered buildcaches'
@@ -1149,7 +1149,7 @@ complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'li
 set -g __fish_spack_optspecs_spack_compiler_ls h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -d 'list also compilers from registered buildcaches'
@@ -1159,14 +1159,14 @@ set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -d 'list also compilers from registered buildcaches'
@@ -1229,7 +1229,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a update -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a revert -d 'revert configuration files to their state before update'
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
@@ -1785,7 +1785,7 @@ complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -d 'one or more alternative search paths for finding externals'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
 complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
@@ -2375,7 +2375,7 @@ set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsig
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -f -a 'binary source'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -d 'specify the mirror type: for both binary and source use ``--type binary --type source`` (default)'
@@ -2409,7 +2409,7 @@ set -g __fish_spack_optspecs_spack_mirror_remove h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l all-scopes -f -a all_scopes
 complete -c spack -n '__fish_spack_using_command mirror remove' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching mirror)'
@@ -2419,7 +2419,7 @@ set -g __fish_spack_optspecs_spack_mirror_rm h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l all-scopes -f -a all_scopes
 complete -c spack -n '__fish_spack_using_command mirror rm' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching mirror)'
@@ -2433,7 +2433,7 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -f -a p
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -d 'set only the URL used for uploading'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -f -a fetch
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -d 'set only the URL used for downloading'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2475,7 +2475,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2500,14 +2500,14 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-var
 set -g __fish_spack_optspecs_spack_mirror_list h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -d 'configuration scope to read from'
 
 # spack mirror ls
 set -g __fish_spack_optspecs_spack_mirror_ls h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -d 'configuration scope to read from'
 
 # spack module
@@ -2820,7 +2820,7 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 set -g __fish_spack_optspecs_spack_repo_list h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo list' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo list' -l names -d 'show configuration names only'
@@ -2831,7 +2831,7 @@ complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -d 'sh
 set -g __fish_spack_optspecs_spack_repo_ls h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -d 'show configuration names only'
@@ -2847,7 +2847,7 @@ complete -c spack -n '__fish_spack_using_command repo add' -l name -r -f -a name
 complete -c spack -n '__fish_spack_using_command repo add' -l name -r -d 'config name for the package repository, defaults to the namespace of the repository'
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
 
 # spack repo set
@@ -2859,7 +2859,7 @@ complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -f 
 complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -d 'destination to clone git repository into'
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
@@ -2867,7 +2867,7 @@ set -g __fish_spack_optspecs_spack_repo_remove h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo remove' -l all-scopes -f -a all_scopes
 complete -c spack -n '__fish_spack_using_command repo remove' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching repo)'
@@ -2877,7 +2877,7 @@ set -g __fish_spack_optspecs_spack_repo_rm h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo rm' -l all-scopes -f -a all_scopes
 complete -c spack -n '__fish_spack_using_command repo rm' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching repo)'
@@ -2899,7 +2899,7 @@ complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -f -a remote
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -d 'name of remote to check for branches, tags, or commits'
-complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -f -a branch
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -d 'name of a branch to change to'


### PR DESCRIPTION
Previous efforts to add include scopes added behavior in `spack.config.OptionalInclude`, that, when including config scopes from a config scope being processed, checks for the existence of the file or directory of representing the included config scope. If the path does not exist, the included scope is skipped in the return of `OptionalInclude._scope`, which is used by the Config object to determine the available scopes for all of Spack.

Further, our argument parsing uses `spack.config.scopes().keys()` to determine the available scopes for `--scope` CLI arguments. If an included scope is skipped when building the available scopes, it will not be available as a valid scope option. 

This results in two issues:

1. We now cannot specify the scope in `spack.config.get|set` as the validation will fail. 
2. We cannot specify these scopes on the command line with the `--scope` argument.


This is particularly an issue for the `user` and `system` scopes, which were previously available by default, regardless of whether the directories to which they are assigned existed.
Currently in develop, `spack cmd --help` shows options for `--scope` arguments, of which, `user` and `system` are always listed. However, if their directories do not exist, they cannot be specified for CLI arguments.



Solution:

* Don't skip included configs if they don't exist, add them as either SingleFileConfigScope or DirectoryConfigScope (based on a heuristic, PTAL at that)
* Mark included scopes that don't have existing files/directories as `readable: False`
* Add a `readable_scopes` method to the config module and class.
* Missing scopes are now included in `spack.config.scopes` so they're allowed on the CLI again.
* Missing scopes can be written to as normal, once written to, `readable` is set to `True`
* Missing scopes can be "read" from, but the logic is short circuited and it just returns `{}`
* CLI arguments that are *read operations only* are given an argparse based type checker to determine if they're trying to read from a nonexistent scope, in that case, we throw

Note: Most writes are proceeded by a read, and in those cases, even with a missing configuration directory/file, the read write makes sense, even with an empty read, so we cannot just prevent all read operations on config scopes with no corresponding filesystem representation. 



Resolves https://github.com/spack/spack/issues/51564