### PR TITLE
spec.py: add return type for `package`

### DIFF
--- a/lib/spack/spack/archspec.py
+++ b/lib/spack/spack/archspec.py
@@ -54,7 +54,9 @@ def microarchitecture_flags_from_target(
         compiler.version.dotted_numeric_string
     )
     try:
-        return target.optimization_flags(compiler.package.archspec_name(), version_number)
+        return target.optimization_flags(
+            compiler.package.archspec_name(), version_number  # type: ignore[attr-defined]
+        )
     except ValueError:
         return ""
 

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -67,9 +67,11 @@ def _try_import_from_store(
 
         # if python is installed, ask it for the layout
         if python.installed:
+            purelib = python.package.purelib  # type: ignore[attr-defined]
+            platlib = python.package.platlib  # type: ignore[attr-defined]
             module_paths = [
-                os.path.join(candidate_spec.prefix, python.package.purelib),
-                os.path.join(candidate_spec.prefix, python.package.platlib),
+                os.path.join(candidate_spec.prefix, purelib),
+                os.path.join(candidate_spec.prefix, platlib),
             ]
         # otherwise search for the site-packages directory
         # (clingo from binaries with truncated python-venv runtime)

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -71,7 +71,10 @@ class BootstrapEnvironment(spack.environment.Environment):
 
     def python_dirs(self) -> Iterable[pathlib.Path]:
         python = next(s for s in self.all_specs_generator() if s.name == "python-venv").package
-        return {self.view_root().joinpath(p) for p in (python.platlib, python.purelib)}
+        return {
+            self.view_root().joinpath(p)
+            for p in (python.platlib, python.purelib)  # type: ignore[attr-defined]
+        }
 
     @classmethod
     def spack_yaml(cls) -> pathlib.Path:

--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -44,34 +44,38 @@ class CompilerAdaptor:
     @property
     def cc_rpath_arg(self) -> str:
         self._lang_exists_or_raise("cc_rpath_arg", lang=Languages.C)
-        return self.compilers[Languages.C].package.rpath_arg
+        return self.compilers[Languages.C].package.rpath_arg  # type: ignore[attr-defined]
 
     @property
     def cxx_rpath_arg(self) -> str:
         self._lang_exists_or_raise("cxx_rpath_arg", lang=Languages.CXX)
-        return self.compilers[Languages.CXX].package.rpath_arg
+        return self.compilers[Languages.CXX].package.rpath_arg  # type: ignore[attr-defined]
 
     @property
     def fc_rpath_arg(self) -> str:
         self._lang_exists_or_raise("fc_rpath_arg", lang=Languages.FORTRAN)
-        return self.compilers[Languages.FORTRAN].package.rpath_arg
+        return self.compilers[Languages.FORTRAN].package.rpath_arg  # type: ignore[attr-defined]
 
     @property
     def f77_rpath_arg(self) -> str:
         self._lang_exists_or_raise("f77_rpath_arg", lang=Languages.FORTRAN)
-        return self.compilers[Languages.FORTRAN].package.rpath_arg
+        return self.compilers[Languages.FORTRAN].package.rpath_arg  # type: ignore[attr-defined]
 
     @property
     def linker_arg(self) -> str:
         return self._maybe_return_attribute("linker_arg", lang=Languages.C)
 
     @property
+    def _first_compiler(self) -> spack.spec.Spec:
+        return next(iter(self.compilers.values()))
+
+    @property
     def name(self):
-        return next(iter(self.compilers.values())).name
+        return self._first_compiler.name
 
     @property
     def version(self):
-        return next(iter(self.compilers.values())).version
+        return self._first_compiler.version
 
     def implicit_rpaths(self) -> List[str]:
         result, seen = [], set()
@@ -84,104 +88,103 @@ class CompilerAdaptor:
 
     @property
     def opt_flags(self) -> List[str]:
-        return next(iter(self.compilers.values())).package.opt_flags
+        return self._first_compiler.package.opt_flags  # type: ignore[attr-defined]
 
     @property
     def debug_flags(self) -> List[str]:
-        return next(iter(self.compilers.values())).package.debug_flags
+        return self._first_compiler.package.debug_flags  # type: ignore[attr-defined]
 
     @property
     def openmp_flag(self) -> str:
-        return next(iter(self.compilers.values())).package.openmp_flag
+        return self._first_compiler.package.openmp_flag  # type: ignore[attr-defined]
 
     @property
     def cxx98_flag(self) -> str:
-        return self.compilers[Languages.CXX].package.standard_flag(
+        return self.compilers[Languages.CXX].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.CXX.value, standard="98"
         )
 
     @property
     def cxx11_flag(self) -> str:
-        return self.compilers[Languages.CXX].package.standard_flag(
+        return self.compilers[Languages.CXX].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.CXX.value, standard="11"
         )
 
     @property
     def cxx14_flag(self) -> str:
-        return self.compilers[Languages.CXX].package.standard_flag(
+        return self.compilers[Languages.CXX].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.CXX.value, standard="14"
         )
 
     @property
     def cxx17_flag(self) -> str:
-        return self.compilers[Languages.CXX].package.standard_flag(
+        return self.compilers[Languages.CXX].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.CXX.value, standard="17"
         )
 
     @property
     def cxx20_flag(self) -> str:
-        return self.compilers[Languages.CXX].package.standard_flag(
+        return self.compilers[Languages.CXX].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.CXX.value, standard="20"
         )
 
     @property
     def cxx23_flag(self) -> str:
-        return self.compilers[Languages.CXX].package.standard_flag(
+        return self.compilers[Languages.CXX].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.CXX.value, standard="23"
         )
 
     @property
     def c99_flag(self) -> str:
-        return self.compilers[Languages.C].package.standard_flag(
+        return self.compilers[Languages.C].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.C.value, standard="99"
         )
 
     @property
     def c11_flag(self) -> str:
-        return self.compilers[Languages.C].package.standard_flag(
+        return self.compilers[Languages.C].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.C.value, standard="11"
         )
 
     @property
     def c17_flag(self) -> str:
-        return self.compilers[Languages.C].package.standard_flag(
+        return self.compilers[Languages.C].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.C.value, standard="17"
         )
 
     @property
     def c23_flag(self) -> str:
-        return self.compilers[Languages.C].package.standard_flag(
+        return self.compilers[Languages.C].package.standard_flag(  # type: ignore[attr-defined]
             language=Languages.C.value, standard="23"
         )
 
     @property
     def cc_pic_flag(self) -> str:
         self._lang_exists_or_raise("cc_pic_flag", lang=Languages.C)
-        return self.compilers[Languages.C].package.pic_flag
+        return self.compilers[Languages.C].package.pic_flag  # type: ignore[attr-defined]
 
     @property
     def cxx_pic_flag(self) -> str:
         self._lang_exists_or_raise("cxx_pic_flag", lang=Languages.CXX)
-        return self.compilers[Languages.CXX].package.pic_flag
+        return self.compilers[Languages.CXX].package.pic_flag  # type: ignore[attr-defined]
 
     @property
     def fc_pic_flag(self) -> str:
         self._lang_exists_or_raise("fc_pic_flag", lang=Languages.FORTRAN)
-        return self.compilers[Languages.FORTRAN].package.pic_flag
+        return self.compilers[Languages.FORTRAN].package.pic_flag  # type: ignore[attr-defined]
 
     @property
     def f77_pic_flag(self) -> str:
         self._lang_exists_or_raise("f77_pic_flag", lang=Languages.FORTRAN)
-        return self.compilers[Languages.FORTRAN].package.pic_flag
+        return self.compilers[Languages.FORTRAN].package.pic_flag  # type: ignore[attr-defined]
 
     @property
     def prefix(self) -> str:
-        return next(iter(self.compilers.values())).prefix
+        return self._first_compiler.prefix
 
     @property
     def extra_rpaths(self) -> List[str]:
-        compiler = next(iter(self.compilers.values()))
-        return getattr(compiler, "extra_attributes", {}).get("extra_rpaths", [])
+        return getattr(self._first_compiler, "extra_attributes", {}).get("extra_rpaths", [])
 
     @property
     def cc(self):
@@ -194,12 +197,12 @@ class CompilerAdaptor:
     @property
     def fc(self):
         self._lang_exists_or_raise("fc", lang=Languages.FORTRAN)
-        return self.compilers[Languages.FORTRAN].package.fortran
+        return self.compilers[Languages.FORTRAN].package.fortran  # type: ignore[attr-defined]
 
     @property
     def f77(self):
         self._lang_exists_or_raise("f77", lang=Languages.FORTRAN)
-        return self.compilers[Languages.FORTRAN].package.fortran
+        return self.compilers[Languages.FORTRAN].package.fortran  # type: ignore[attr-defined]
 
     @property
     def stdcxx_libs(self):

--- a/lib/spack/spack/compilers/libraries.py
+++ b/lib/spack/spack/compilers/libraries.py
@@ -180,13 +180,13 @@ class CompilerPropertyDetector:
     def _compile_dummy_c_source(self) -> Optional[str]:
         compiler_pkg = self.spec.package
         if getattr(compiler_pkg, "cc"):
-            cc = compiler_pkg.cc
+            cc = compiler_pkg.cc  # type: ignore[attr-defined]
             ext = "c"
         else:
-            cc = compiler_pkg.cxx
+            cc = compiler_pkg.cxx  # type: ignore[attr-defined]
             ext = "cc"
 
-        if not cc or not self.spec.package.verbose_flags:
+        if not cc or not self.spec.package.verbose_flags:  # type: ignore[attr-defined]
             return None
 
         try:
@@ -202,11 +202,8 @@ class CompilerPropertyDetector:
 
             if self.spec.external:
                 compiler_flags = self.spec.extra_attributes.get("flags", {})
-                for flag_type in [
-                    "cflags" if cc == compiler_pkg.cc else "cxxflags",
-                    "cppflags",
-                    "ldflags",
-                ]:
+                is_cc = cc == compiler_pkg.cc  # type: ignore[attr-defined]
+                for flag_type in ["cflags" if is_cc else "cxxflags", "cppflags", "ldflags"]:
                     current_flags = compiler_flags.get(flag_type, "").strip()
                     if current_flags:
                         cc_exe.add_default_arg(*current_flags.split(" "))
@@ -254,11 +251,9 @@ class CompilerPropertyDetector:
             return []
 
         link_dirs = parse_non_system_link_dirs(output)
-        all_required_libs = list(self.spec.package.implicit_rpath_libs) + [
-            "libc",
-            "libc++",
-            "libstdc++",
-        ]
+        all_required_libs = list(
+            self.spec.package.implicit_rpath_libs  # type: ignore[attr-defined]
+        ) + ["libc", "libc++", "libstdc++"]
         dynamic_linker = self.default_dynamic_linker()
         result = DefaultDynamicLinkerFilter(dynamic_linker)(
             paths_containing_libs(link_dirs, all_required_libs)

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -73,7 +73,7 @@ def guess_core_compilers(name, store=False) -> List[spack.spec.Spec]:
     core_compilers = []
     for compiler in spack.compilers.config.all_compilers(init_config=False):
         try:
-            cc_dir = pathlib.Path(compiler.package.cc).parent
+            cc_dir = pathlib.Path(compiler.package.cc).parent  # type: ignore[attr-defined]
             is_system_compiler = str(cc_dir) in spack.util.environment.SYSTEM_DIRS
             if is_system_compiler:
                 core_compilers.append(compiler)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -47,7 +47,6 @@ line is a spec for a particular installation of the mpileaks package.
 6. The architecture to build with.
 """
 import collections
-import collections.abc
 import enum
 import io
 import itertools
@@ -59,6 +58,7 @@ import re
 import socket
 import warnings
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -104,6 +104,9 @@ import spack.version as vn
 import spack.version.git_ref_lookup
 
 from .enums import InstallRecordStatus, PropagationPolicy
+
+if TYPE_CHECKING:
+    import spack.package_base
 
 __all__ = [
     "CompilerSpec",
@@ -1979,16 +1982,14 @@ class Spec:
         return edges_by_package[0].parent.root
 
     @property
-    def package(self):
-        assert self.concrete, "{0}: Spec.package can only be called on concrete specs".format(
-            self.name
-        )
+    def package(self) -> "spack.package_base.PackageBase":
+        assert self.concrete, f"{self.name}: Spec.package can only be called on concrete specs"
         if not self._package:
             self._package = spack.repo.PATH.get(self)
         return self._package
 
     @property
-    def concrete(self):
+    def concrete(self) -> bool:
         """A spec is concrete if it describes a single build of a package.
 
         More formally, a spec is concrete if concretize() has been called
@@ -2002,14 +2003,14 @@ class Spec:
         return self._concrete
 
     @property
-    def spliced(self):
+    def spliced(self) -> bool:
         """Returns whether or not this Spec is being deployed as built i.e.
         whether or not this Spec has ever been spliced.
         """
         return any(s.build_spec is not s for s in self.traverse(root=True))
 
     @property
-    def installed(self):
+    def installed(self) -> bool:
         """Installation status of a package.
 
         Returns:
@@ -2030,7 +2031,7 @@ class Spec:
             return False
 
     @property
-    def installed_upstream(self):
+    def installed_upstream(self) -> bool:
         """Whether the spec is installed in an upstream repository.
 
         Returns:
@@ -2042,7 +2043,7 @@ class Spec:
         from spack.store import STORE
 
         upstream, record = STORE.db.query_by_spec_hash(self.dag_hash())
-        return upstream and record and record.installed
+        return upstream and record is not None and record.installed
 
     @overload
     def traverse(

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -32,14 +32,18 @@ def test_dev_build_basics(tmp_path: pathlib.Path, install_mockery):
     assert "dev_path" in spec.variants
 
     with fs.working_dir(str(tmp_path)):
-        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore
-            f.write(spec.package.original_string)  # type: ignore
+        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            f.write(spec.package.original_string)  # type: ignore[attr-defined]
 
         dev_build("dev-build-test-install@0.0.0")
 
-    assert spec.package.filename in os.listdir(spec.prefix)
-    with open(os.path.join(spec.prefix, spec.package.filename), "r", encoding="utf-8") as f:
-        assert f.read() == spec.package.replacement_string
+    assert spec.package.filename in os.listdir(spec.prefix)  # type: ignore[attr-defined]
+    with open(
+        os.path.join(spec.prefix, spec.package.filename),  # type: ignore[attr-defined]
+        "r",
+        encoding="utf-8",
+    ) as f:
+        assert f.read() == spec.package.replacement_string  # type: ignore[attr-defined]
 
     assert os.path.exists(str(tmp_path))
 
@@ -50,14 +54,14 @@ def test_dev_build_before(tmp_path: pathlib.Path, install_mockery):
     )
 
     with fs.working_dir(str(tmp_path)):
-        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore
-            f.write(spec.package.original_string)  # type: ignore
+        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            f.write(spec.package.original_string)  # type: ignore[attr-defined]
 
         dev_build("-b", "edit", "dev-build-test-install@0.0.0")
 
-        assert spec.package.filename in os.listdir(os.getcwd())  # type: ignore
-        with open(spec.package.filename, "r", encoding="utf-8") as f:  # type: ignore
-            assert f.read() == spec.package.original_string  # type: ignore
+        assert spec.package.filename in os.listdir(os.getcwd())  # type: ignore[attr-defined]
+        with open(spec.package.filename, "r", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            assert f.read() == spec.package.original_string  # type: ignore[attr-defined]
 
     assert not os.path.exists(spec.prefix)
 
@@ -88,14 +92,14 @@ def test_dev_build_until_last_phase(tmp_path: pathlib.Path, install_mockery):
     )
 
     with fs.working_dir(str(tmp_path)):
-        with open(spec.package.filename, "w", encoding="utf-8") as f:
-            f.write(spec.package.original_string)
+        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            f.write(spec.package.original_string)  # type: ignore[attr-defined]
 
         dev_build("-u", "install", "dev-build-test-install@0.0.0")
 
-        assert spec.package.filename in os.listdir(os.getcwd())
-        with open(spec.package.filename, "r", encoding="utf-8") as f:
-            assert f.read() == spec.package.replacement_string
+        assert spec.package.filename in os.listdir(os.getcwd())  # type: ignore[attr-defined]
+        with open(spec.package.filename, "r", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            assert f.read() == spec.package.replacement_string  # type: ignore[attr-defined]
 
     assert os.path.exists(spec.prefix)
     assert spack.store.STORE.db.query(spec, installed=True)
@@ -108,8 +112,8 @@ def test_dev_build_before_until(tmp_path: pathlib.Path, install_mockery):
     )
 
     with fs.working_dir(str(tmp_path)):
-        with open(spec.package.filename, "w", encoding="utf-8") as f:
-            f.write(spec.package.original_string)
+        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            f.write(spec.package.original_string)  # type: ignore[attr-defined]
 
         with pytest.raises(spack.main.SpackCommandError):
             dev_build("-u", "edit", "-b", "edit", "dev-build-test-install@0.0.0")
@@ -147,8 +151,8 @@ def test_dev_build_fails_already_installed(tmp_path: pathlib.Path, install_mocke
     )
 
     with fs.working_dir(str(tmp_path)):
-        with open(spec.package.filename, "w", encoding="utf-8") as f:
-            f.write(spec.package.original_string)
+        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            f.write(spec.package.original_string)  # type: ignore[attr-defined]
 
         dev_build("dev-build-test-install@0.0.0")
         output = dev_build("dev-build-test-install@0.0.0", fail_on_error=False)
@@ -190,10 +194,10 @@ def test_dev_build_can_parse_path_with_at_symbol(tmp_path: pathlib.Path, install
     )
 
     with fs.working_dir(str(special_char_dir)):
-        with open(spec.package.filename, "w", encoding="utf-8") as f:
-            f.write(spec.package.original_string)
+        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            f.write(spec.package.original_string)  # type: ignore[attr-defined]
         dev_build("dev-build-test-install@0.0.0")
-    assert spec.package.filename in os.listdir(spec.prefix)
+    assert spec.package.filename in os.listdir(spec.prefix)  # type: ignore[attr-defined]
 
 
 def test_dev_build_env(tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path):
@@ -206,8 +210,8 @@ def test_dev_build_env(tmp_path: pathlib.Path, install_mockery, mutable_mock_env
     )
 
     with fs.working_dir(str(build_dir)):
-        with open(spec.package.filename, "w", encoding="utf-8") as f:
-            f.write(spec.package.original_string)
+        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            f.write(spec.package.original_string)  # type: ignore[attr-defined]
 
     # setup environment
     envdir = tmp_path / "env"
@@ -230,9 +234,13 @@ spack:
         with ev.read("test"):
             install()
 
-    assert spec.package.filename in os.listdir(spec.prefix)
-    with open(os.path.join(spec.prefix, spec.package.filename), "r", encoding="utf-8") as f:
-        assert f.read() == spec.package.replacement_string
+    assert spec.package.filename in os.listdir(spec.prefix)  # type: ignore[attr-defined]
+    with open(
+        os.path.join(spec.prefix, spec.package.filename),  # type: ignore[attr-defined]
+        "r",
+        encoding="utf-8",
+    ) as f:
+        assert f.read() == spec.package.replacement_string  # type: ignore[attr-defined]
 
 
 def test_dev_build_env_with_vars(
@@ -249,8 +257,10 @@ def test_dev_build_env_with_vars(
     # store the build path in an environment variable that will be used in the environment
     monkeypatch.setenv("CUSTOM_BUILD_PATH", str(build_dir))
 
-    with fs.working_dir(str(build_dir)), open(spec.package.filename, "w", encoding="utf-8") as f:
-        f.write(spec.package.original_string)
+    with fs.working_dir(str(build_dir)), open(
+        spec.package.filename, "w", encoding="utf-8"  # type: ignore[attr-defined]
+    ) as f:
+        f.write(spec.package.original_string)  # type: ignore[attr-defined]
 
     # setup environment
     envdir = tmp_path / "env"
@@ -273,9 +283,13 @@ spack:
         with ev.read("test"):
             install()
 
-    assert spec.package.filename in os.listdir(spec.prefix)
-    with open(os.path.join(spec.prefix, spec.package.filename), "r", encoding="utf-8") as f:
-        assert f.read() == spec.package.replacement_string
+    assert spec.package.filename in os.listdir(spec.prefix)  # type: ignore[attr-defined]
+    with open(
+        os.path.join(spec.prefix, spec.package.filename),  # type: ignore[attr-defined]
+        "r",
+        encoding="utf-8",
+    ) as f:
+        assert f.read() == spec.package.replacement_string  # type: ignore[attr-defined]
 
 
 def test_dev_build_env_version_mismatch(
@@ -290,8 +304,8 @@ def test_dev_build_env_version_mismatch(
     )
 
     with fs.working_dir(str(build_dir)):
-        with open(spec.package.filename, "w", encoding="utf-8") as f:
-            f.write(spec.package.original_string)
+        with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore[attr-defined]
+            f.write(spec.package.original_string)  # type: ignore[attr-defined]
 
     # setup environment
     envdir = tmp_path / "env"
@@ -383,7 +397,7 @@ spack:
         filename = spec.package.filename  # type: ignore
         assert filename in os.listdir(spec.prefix)
         with open(os.path.join(spec.prefix, filename), "r", encoding="utf-8") as f:
-            assert f.read() == spec.package.replacement_string
+            assert f.read() == spec.package.replacement_string  # type: ignore[attr-defined]
 
 
 def test_dev_build_env_dependency(
@@ -430,7 +444,7 @@ spack:
             install()
 
     # Ensure that both specs installed properly
-    assert dep_spec.package.filename in os.listdir(dep_spec.prefix)
+    assert dep_spec.package.filename in os.listdir(dep_spec.prefix)  # type: ignore[attr-defined]
     assert os.path.exists(spec.prefix)
 
     # Ensure variants set properly; ensure build_dir is absolute and normalized

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -190,9 +190,9 @@ def test_mirror_spec_from_env(
 @pytest.fixture
 def source_for_pkg_with_hash(mock_packages, tmp_path: pathlib.Path):
     s = spack.concretize.concretize_one("trivial-pkg-with-valid-hash")
-    local_url_basename = os.path.basename(s.package.url)
+    local_url_basename = os.path.basename(s.package.url)  # type: ignore[attr-defined]
     local_path = tmp_path / local_url_basename
-    local_path.write_text(s.package.hashed_content, encoding="utf-8")
+    local_path.write_text(s.package.hashed_content, encoding="utf-8")  # type: ignore[attr-defined]
     local_url = url_util.path_to_file_url(str(local_path))
     s.package.versions[spack.version.Version("1.0")]["url"] = local_url
 

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -219,7 +219,7 @@ def test_view_files_not_ignored(
     spec = spack.concretize.concretize_one("view-not-ignored")
     pkg = spec.package
     PackageInstaller([pkg], explicit=True).install()
-    pkg.assert_installed(spec.prefix)
+    pkg.assert_installed(spec.prefix)  # type: ignore[attr-defined]
 
     install("view-file")  # Arbitrary package to add noise
 
@@ -237,7 +237,7 @@ def test_view_files_not_ignored(
         args = []
 
     view(cmd, *(args + [viewpath, "view-not-ignored", "view-file"]))
-    pkg.assert_installed(prefix_in_view)
+    pkg.assert_installed(prefix_in_view)  # type: ignore[attr-defined]
 
     view("remove", viewpath, "view-not-ignored")
-    pkg.assert_not_installed(prefix_in_view)
+    pkg.assert_not_installed(prefix_in_view)  # type: ignore[attr-defined]

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -60,7 +60,7 @@ def test_view_with_spec_not_contributing_files(mock_packages, tmp_path: pathlib.
     def pkg_a_add_files_to_view(view, merge_map, skip_if_exists=True):
         assert False, "There shouldn't be files to add"
 
-    a.package.add_files_to_view = pkg_a_add_files_to_view
+    setattr(a.package, "add_files_to_view", pkg_a_add_files_to_view)
 
     # Create view and see if files are linked.
     view.add_specs(a, b)


### PR DESCRIPTION
Make `Spec.package` return `PackageBase`.

Of course the actual return type is more specific and not tractable (... unless we generate a bunch of `@overload`s mapping literal package names to package classes), but I think it's still important to add this bit of typing.