### PR TITLE
externals: add a namespace before concretization

### DIFF
--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -182,6 +182,7 @@ def spec_from_entry(entry):
     spec._hashes_final = True
     spec.external_path = entry["prefix"]
     spec.origin = "external-db"
+    spec.namespace = pkg_cls.namespace
     spack.spec.Spec.ensure_valid_variants(spec)
 
     return spec

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -87,6 +87,7 @@ def complete_architecture(node: spack.spec.Spec) -> None:
         node.constrain(spack.spec.Spec.default_arch())
         node.architecture.target = spack.archspec.HOST_TARGET_FAMILY
 
+    node.namespace = spack.repo.PATH.repo_for_pkg(node.name).namespace
     for flag_type in spack.spec.FlagMap.valid_compiler_flags():
         node.compiler_flags.setdefault(flag_type, [])
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5643,16 +5643,10 @@ def _inject_patches_variant(root: Spec) -> None:
     # since the Spec __hash__ will change as patches are added to them
     spec_to_patches: Dict[int, Set[spack.patch.Patch]] = {}
     for s in root.traverse():
-        # After concretizing, assign namespaces to anything left.
-        # Note that this doesn't count as a "change".  The repository
-        # configuration is constant throughout a spack run, and
-        # normalize and concretize evaluate Packages using Repo.get(),
-        # which respects precedence.  So, a namespace assignment isn't
-        # changing how a package name would have been interpreted and
-        # we can do it as late as possible to allow as much
-        # compatibility across repositories as possible.
-        if s.namespace is None:
-            s.namespace = spack.repo.PATH.repo_for_pkg(s.name).namespace
+        assert s.namespace is not None, (
+            f"internal error: {s.name} has no namespace after concretization. "
+            f"Please report a bug at https://github.com/spack/spack/issues"
+        )
 
         if s.concrete:
             continue

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -8,6 +8,7 @@ import pytest
 from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
+import spack.traverse
 from spack.externals import (
     DuplicateExternalError,
     ExternalDict,
@@ -277,6 +278,10 @@ def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expect
         assert len(result) == 1
         assert all(not result[0].satisfies(c) for c in not_expected_list)
 
+    # Assert all nodes have the namespace set
+    for node in spack.traverse.traverse_nodes(parser.all_specs()):
+        assert node.namespace is not None
+
 
 @pytest.mark.parametrize(
     "externals_dicts,expected_length,not_expected",
@@ -331,3 +336,7 @@ def test_external_node_completion(
         assert len(result) == 1
         for expected in expected_list:
             assert not result[0].satisfies(expected)
+
+    # Assert all nodes have the namespace set
+    for node in spack.traverse.traverse_nodes(parser.all_specs()):
+        assert node.namespace is not None


### PR DESCRIPTION
Currently, namespaces for externals are added after the ASP problem has been solved, as a by-product of building specs. This is wrong, because externals have their DAG hash assigned ahead of the solve, meaning that the solver mutates concrete specs, and these changes are not reflected in the DAG hash.

Therefore, move this _before_ the ASP problem is constructed, and just assert that all specs have namespaces after the ASP solve completed.