### PR TITLE
Revert "ci: disable PerfPowerServices process on macos (#51647)"

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -214,12 +214,6 @@ jobs:
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg kcov
-    # See https://github.com/actions/runner-images/issues/13358
-    - name: Unlock another CPU core on x86_64 MacOS
-      if: matrix.os == 'macos-15-intel'
-      run: |
-        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
-        sudo killall PerfPowerServices || true
     - name: Run unit tests
       env:
         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}


### PR DESCRIPTION
This reverts commit a6a383e14e8f9de0e87f9eb6c63d5a3a4aa614d5.

Seems to be part of the runner image now