### PR TITLE
spack compiler info: show non-external compilers too

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -153,14 +153,28 @@ def compiler_info(args):
     if not compilers:
         tty.die(f"No compilers match spec {query.cformat()}")
 
+    compilers.sort(key=lambda x: (not x.external, x.name, x.version))
+
     for c in compilers:
-        print(f"{c.cformat()}:")
+        exes = {
+            cname: getattr(c.package, cname)
+            for cname in ("cc", "cxx", "fortran")
+            if hasattr(c.package, cname)
+        }
+        if not exes:
+            tty.debug(
+                f"{__name__}: skipping {c.format()} from compiler list, "
+                f"since it has no executables"
+            )
+            continue
+
+        print(f"{c.tree(recurse_dependencies=False, status_fn=spack.spec.Spec.install_status)}")
         print(f"  prefix: {c.prefix}")
+        print("  compilers:")
+        for language, exe in exes.items():
+            print(f"    {language}: {exe}")
+
         extra_attributes = getattr(c, "extra_attributes", {})
-        if "compilers" in extra_attributes:
-            print("  compilers:")
-            for language, exe in extra_attributes.get("compilers", {}).items():
-                print(f"    {language}: {exe}")
         if "flags" in extra_attributes:
             print("  flags:")
             for flag, flag_value in extra_attributes["flags"].items():

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -5,7 +5,7 @@
 import argparse
 import sys
 import warnings
-from typing import List
+from typing import List, Optional
 
 import spack.binary_distribution
 import spack.compilers.config
@@ -146,7 +146,7 @@ def compiler_remove(args):
 
 def compiler_info(args):
     """Print info about all compilers matching a spec."""
-    all_compilers = _all_available_compilers(args)
+    all_compilers = _all_available_compilers(scope=args.scope, remote=args.remote)
     query = spack.spec.Spec(args.compiler_spec)
     compilers = [x for x in all_compilers if x.satisfies(query)]
 
@@ -198,7 +198,7 @@ def compiler_info(args):
 
 
 def compiler_list(args):
-    compilers = _all_available_compilers(args)
+    compilers = _all_available_compilers(scope=args.scope, remote=args.remote)
 
     # If there are no compilers in any scope, and we're outputting to a tty, give a
     # hint to the user.
@@ -239,17 +239,17 @@ def compiler_list(args):
         colify(reversed(sorted(result)))
 
 
-def _all_available_compilers(args: argparse.Namespace) -> List[Spec]:
+def _all_available_compilers(scope: Optional[str], remote: bool) -> List[Spec]:
     supported_compilers = spack.compilers.config.supported_compilers()
 
     def _is_compiler(x):
         return x.name in supported_compilers and x.package.supported_languages and not x.external
 
     compilers_from_store = [x for x in spack.store.STORE.db.query() if _is_compiler(x)]
-    compilers_from_yaml = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
+    compilers_from_yaml = spack.compilers.config.all_compilers(scope=scope, init_config=False)
     compilers = compilers_from_yaml + compilers_from_store
 
-    if args.remote:
+    if remote:
         compilers.extend(
             [x for x in spack.binary_distribution.update_cache_and_get_specs() if _is_compiler(x)]
         )

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -5,6 +5,7 @@
 import argparse
 import sys
 import warnings
+from typing import List
 
 import spack.binary_distribution
 import spack.compilers.config
@@ -16,6 +17,7 @@ from spack.cmd.common import arguments
 from spack.llnl.util.lang import index_by
 from spack.llnl.util.tty.colify import colify
 from spack.llnl.util.tty.color import colorize
+from spack.spec import Spec
 
 description = "manage compilers"
 section = "config"
@@ -84,6 +86,9 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         type=arguments.config_scope_readable_validator,
         help="configuration scope to read from",
     )
+    info_parser.add_argument(
+        "--remote", action="store_true", help="list also compilers from registered buildcaches"
+    )
 
 
 def compiler_find(args):
@@ -141,58 +146,45 @@ def compiler_remove(args):
 
 def compiler_info(args):
     """Print info about all compilers matching a spec."""
+    all_compilers = _all_available_compilers(args)
     query = spack.spec.Spec(args.compiler_spec)
-    all_compilers = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
-
     compilers = [x for x in all_compilers if x.satisfies(query)]
 
     if not compilers:
         tty.die(f"No compilers match spec {query.cformat()}")
-    else:
-        for c in compilers:
-            print(f"{c.cformat()}:")
-            print(f"  prefix: {c.external_path}")
-            extra_attributes = getattr(c, "extra_attributes", {})
-            if "compilers" in extra_attributes:
-                print("  compilers:")
-                for language, exe in extra_attributes.get("compilers", {}).items():
-                    print(f"    {language}: {exe}")
-            if "flags" in extra_attributes:
-                print("  flags:")
-                for flag, flag_value in extra_attributes["flags"].items():
-                    print(f"    {flag} = {flag_value}")
-            if "environment" in extra_attributes:
-                environment = extra_attributes["environment"]
-                if len(environment.get("set", {})) != 0:
-                    print("\tenvironment:")
-                    print("\t    set:")
-                    for key, value in environment["set"].items():
-                        print(f"\t        {key} = {value}")
-            if "extra_rpaths" in extra_attributes:
-                print("  extra rpaths:")
-                for extra_rpath in extra_attributes["extra_rpaths"]:
-                    print(f"    {extra_rpath}")
-            if getattr(c, "external_modules", []):
-                print("  modules: ")
-                for module in c.external_modules:
-                    print(f"    {module}")
-            print()
+
+    for c in compilers:
+        print(f"{c.cformat()}:")
+        print(f"  prefix: {c.prefix}")
+        extra_attributes = getattr(c, "extra_attributes", {})
+        if "compilers" in extra_attributes:
+            print("  compilers:")
+            for language, exe in extra_attributes.get("compilers", {}).items():
+                print(f"    {language}: {exe}")
+        if "flags" in extra_attributes:
+            print("  flags:")
+            for flag, flag_value in extra_attributes["flags"].items():
+                print(f"    {flag} = {flag_value}")
+        if "environment" in extra_attributes:
+            environment = extra_attributes["environment"]
+            if len(environment.get("set", {})) != 0:
+                print("\tenvironment:")
+                print("\t    set:")
+                for key, value in environment["set"].items():
+                    print(f"\t        {key} = {value}")
+        if "extra_rpaths" in extra_attributes:
+            print("  extra rpaths:")
+            for extra_rpath in extra_attributes["extra_rpaths"]:
+                print(f"    {extra_rpath}")
+        if getattr(c, "external_modules", []):
+            print("  modules: ")
+            for module in c.external_modules:
+                print(f"    {module}")
+        print()
 
 
 def compiler_list(args):
-    supported_compilers = spack.compilers.config.supported_compilers()
-
-    def _is_compiler(x):
-        return x.name in supported_compilers and x.package.supported_languages and not x.external
-
-    compilers_from_store = [x for x in spack.store.STORE.db.query() if _is_compiler(x)]
-    compilers_from_yaml = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
-    compilers = compilers_from_yaml + compilers_from_store
-
-    if args.remote:
-        compilers.extend(
-            [x for x in spack.binary_distribution.update_cache_and_get_specs() if _is_compiler(x)]
-        )
+    compilers = _all_available_compilers(args)
 
     # If there are no compilers in any scope, and we're outputting to a tty, give a
     # hint to the user.
@@ -231,6 +223,23 @@ def compiler_list(args):
             colorize(c.install_status().value) + c.format("{name}@{version}") for c in compilers
         }
         colify(reversed(sorted(result)))
+
+
+def _all_available_compilers(args: argparse.Namespace) -> List[Spec]:
+    supported_compilers = spack.compilers.config.supported_compilers()
+
+    def _is_compiler(x):
+        return x.name in supported_compilers and x.package.supported_languages and not x.external
+
+    compilers_from_store = [x for x in spack.store.STORE.db.query() if _is_compiler(x)]
+    compilers_from_yaml = spack.compilers.config.all_compilers(scope=args.scope, init_config=False)
+    compilers = compilers_from_yaml + compilers_from_store
+
+    if args.remote:
+        compilers.extend(
+            [x for x in spack.binary_distribution.update_cache_and_get_specs() if _is_compiler(x)]
+        )
+    return compilers
 
 
 def compiler(parser, args):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -809,7 +809,7 @@ _spack_compiler_ls() {
 _spack_compiler_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --remote"
     else
         _installed_compilers
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1155,12 +1155,14 @@ complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -f -a re
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -d 'list also compilers from registered buildcaches'
 
 # spack compiler info
-set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
+set -g __fish_spack_optspecs_spack_compiler_info h/help scope= remote
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
+complete -c spack -n '__fish_spack_using_command compiler info' -l remote -f -a remote
+complete -c spack -n '__fish_spack_using_command compiler info' -l remote -d 'list also compilers from registered buildcaches'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope= remote


### PR DESCRIPTION
fixes #51681

After this change, `spack compiler info` will start showing installed compilers and, on demand, compilers from buildcaches.

**Before**
```console
$ spack compiler list
==> Available compilers
-- gcc ubuntu20.04-x86_64 ---------------------------------------
[e]  gcc@9.4.0  [e]  gcc@8.4.0  [e]  gcc@10.5.0  [+]  gcc@15.2.0

-- llvm ubuntu20.04-x86_64 --------------------------------------
[e]  llvm@12.0.0  [e]  llvm@11.0.0  [e]  llvm@10.0.0

$ spack compiler info gcc@10:
gcc@=10.5.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=ubuntu20.04 target=x86_64:
  prefix: /usr
  compilers:
    c: /usr/bin/gcc-10
    cxx: /usr/bin/g++-10
    fortran: /usr/bin/gfortran-10
```
**After**
```console
$ spack compiler list
==> Available compilers
-- gcc ubuntu20.04-x86_64 ---------------------------------------
[e]  gcc@9.4.0  [e]  gcc@8.4.0  [e]  gcc@10.5.0  [+]  gcc@15.2.0

-- llvm ubuntu20.04-x86_64 --------------------------------------
[e]  llvm@12.0.0  [e]  llvm@11.0.0  [e]  llvm@10.0.0

$ spack compiler info gcc@10:
[e]  gcc@=10.5.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=ubuntu20.04 target=x86_64

  prefix: /usr
  compilers:
    cc: /usr/bin/gcc-10
    cxx: /usr/bin/g++-10
    fortran: /usr/bin/gfortran-10

[+]  gcc@=15.2.0~binutils+bootstrap~graphite~mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=ubuntu20.04 target=icelake

  prefix: /home/culpo/.local/spack/opt/linux-icelake/gcc-15.2.0-hf5qmg2xdqgxhnfhlqpn7djhjrat6max
  compilers:
    cc: /home/culpo/.local/spack/opt/linux-icelake/gcc-15.2.0-hf5qmg2xdqgxhnfhlqpn7djhjrat6max/bin/gcc
    cxx: /home/culpo/.local/spack/opt/linux-icelake/gcc-15.2.0-hf5qmg2xdqgxhnfhlqpn7djhjrat6max/bin/g++
    fortran: /home/culpo/.local/spack/opt/linux-icelake/gcc-15.2.0-hf5qmg2xdqgxhnfhlqpn7djhjrat6max/bin/gfortran
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
