### PR TITLE
extract_git_version_str: resolve issue with mac git error

### DIFF
--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -84,7 +84,12 @@ def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info
 
 @pytest.mark.parametrize(
     "input,answer",
-    (["git version 1.7.1", (1, 7, 1)], ["git version 2.34.1.windows.2", (2, 34, 1, 2)]),
+    (
+        ["git version 1.7.1", (1, 7, 1)],
+        ["git version 2.34.1.windows.2", (2, 34, 1)],
+        ["git version 2.50.1 (Apple Git-155)", (2, 50, 1)],
+        ["git version 1.2.3.4.150.abcd10", (1, 2, 3, 4, 150)],
+    ),
 )
 def test_extract_git_version(mock_util_executable, input, answer):
     _, _, registered_responses = mock_util_executable

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -30,8 +30,8 @@ def _find_git() -> Optional[str]:
 
 
 def extract_git_version_str(git_exe):
-    v_str = git_exe("--version", output=str).strip().split()[-1].replace("windows.", "")
-    return v_str
+    v_str = re.sub(r"\(.*", "", git_exe("--version", output=str)).strip().split()[-1]
+    return v_str.replace("windows.", "")
 
 
 class GitExecutable(exe.Executable):

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -18,8 +18,8 @@ import spack.util.executable as exe
 # regex for a commit version
 COMMIT_VERSION = re.compile(r"^[a-f0-9]{40}$")
 
-# regex for (git) version
-GIT_VERSION = re.compile(r"(\d+(?:\.\d+)*(?:[-+a-zA-Z0-9.]*))")
+# regex for a git version to extract only the numeric parts
+GIT_VERSION = re.compile(r"(\d+(?:\.\d+)*(?:[0-9]*))")
 
 
 def is_git_commit_sha(string: str) -> bool:
@@ -34,7 +34,7 @@ def _find_git() -> Optional[str]:
 
 def extract_git_version_str(git_exe):
     match = re.search(GIT_VERSION, git_exe("--version", output=str))
-    return match.group(1).replace("windows.", "") if match else None
+    return match.group(1) if match else None
 
 
 class GitExecutable(exe.Executable):

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -32,9 +32,9 @@ def _find_git() -> Optional[str]:
     return exe.which_string("git", required=False)
 
 
-def extract_git_version_str(git_exe):
+def extract_git_version_str(git_exe: exe.Executable) -> str:
     match = re.search(GIT_VERSION, git_exe("--version", output=str))
-    return match.group(1) if match else None
+    return match.group(1) if match else ""
 
 
 class GitExecutable(exe.Executable):

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -19,7 +19,7 @@ import spack.util.executable as exe
 COMMIT_VERSION = re.compile(r"^[a-f0-9]{40}$")
 
 # regex for a git version to extract only the numeric parts
-GIT_VERSION = re.compile(r"(\d+(?:\.\d+)*(?:[0-9]*))")
+GIT_VERSION = re.compile(r"(\d+(?:\.\d+)*)")
 
 
 def is_git_commit_sha(string: str) -> bool:

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -18,6 +18,9 @@ import spack.util.executable as exe
 # regex for a commit version
 COMMIT_VERSION = re.compile(r"^[a-f0-9]{40}$")
 
+# regex for (git) version
+GIT_VERSION = re.compile(r"(\d+(?:\.\d+)*(?:[-+a-zA-Z0-9.]*))")
+
 
 def is_git_commit_sha(string: str) -> bool:
     return len(string) == 40 and bool(COMMIT_VERSION.match(string))
@@ -30,8 +33,8 @@ def _find_git() -> Optional[str]:
 
 
 def extract_git_version_str(git_exe):
-    v_str = re.sub(r"\(.*", "", git_exe("--version", output=str)).strip().split()[-1]
-    return v_str.replace("windows.", "")
+    match = re.search(GIT_VERSION, git_exe("--version", output=str))
+    return match.group(1).replace("windows.", "") if match else None
 
 
 class GitExecutable(exe.Executable):


### PR DESCRIPTION
Fixes #51722 

There are on the order of 40 unit tests that fail on a Mac whose 'git' is formatted as follows:

```
$ git --version
git version 2.50.1 (Apple Git-155)
```

This PR drops any text from "(" on before conducting the split.