### PR TITLE
input_analysis.py: optimize dependency analysis

### DIFF
--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -187,7 +187,7 @@ class NoStaticAnalysis(PossibleDependencyGraph):
                 if self.unreachable(pkg_name=pkg_name, when_spec=when_spec):
                     tty.debug(
                         f"[{__name__}] Skipping {', '.join(new_dependencies)} dependencies of "
-                        f"{pkg_name}, because conditions are not met"
+                        f"{pkg_name}, because {when_spec} is not met"
                     )
                     continue
 

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -185,6 +185,10 @@ class NoStaticAnalysis(PossibleDependencyGraph):
                     continue
 
                 if self.unreachable(pkg_name=pkg_name, when_spec=when_spec):
+                    tty.debug(
+                        f"[{__name__}] Skipping {', '.join(new_dependencies)} dependencies of "
+                        f"{pkg_name}, because conditions are not met"
+                    )
                     continue
 
                 for name in new_dependencies:


### PR DESCRIPTION
This commit improves the performance of the static analysis used to
determine possible dependencies in the solver setup phase.

1. Iterate directly over `PackageBase.dependencies` (keyed by
   `when_spec`) instead of using `dependencies_by_name`. This avoids the
   overhead of reconstructing the dependency dictionary, which involves
   allocating new structures and hashing abstract specs. It also ensures
   that `unreachable()` checks are performed once per condition group,
   rather than once per dependency name.

2. Skip reachability checks for conditional dependencies if the
   dependency is already present in the graph. If a package depends on
   `foo` unconditionally, subsequent conditional dependencies on `foo`
   (e.g. with different variants) no longer trigger an `unreachable()`
   check for that condition.

Results in about 4.8% reduction in "setup" time.

