### PR TITLE
spack compiler: remove deprecated --mixed-toolchain option

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -4,7 +4,6 @@
 
 import argparse
 import sys
-import warnings
 from typing import List, Optional
 
 import spack.binary_distribution
@@ -32,19 +31,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "find",
         aliases=["add"],
         help="search the system for compilers to add to Spack configuration",
-    )
-    mixed_toolchain_group = find_parser.add_mutually_exclusive_group()
-    mixed_toolchain_group.add_argument(
-        "--mixed-toolchain",
-        action="store_true",
-        default=False,
-        help="(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)",
-    )
-    mixed_toolchain_group.add_argument(
-        "--no-mixed-toolchain",
-        action="store_false",
-        dest="mixed_toolchain",
-        help="(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)",
     )
     find_parser.add_argument("add_paths", nargs=argparse.REMAINDER)
     find_parser.add_argument(
@@ -95,12 +81,6 @@ def compiler_find(args):
     """Search either $PATH or a list of paths OR MODULES for compilers and
     add them to Spack's configuration.
     """
-    if args.mixed_toolchain:
-        warnings.warn(
-            "The '--mixed-toolchain' option has been deprecated in Spack v0.23, and currently "
-            "has no effect. The option will be removed in Spack v1.1"
-        )
-
     paths = args.add_paths or None
     new_compilers = spack.compilers.config.find_compilers(
         path_hints=paths, scope=args.scope, max_workers=args.jobs

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -765,7 +765,7 @@ _spack_compiler() {
 _spack_compiler_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --mixed-toolchain --no-mixed-toolchain --scope -j --jobs"
+        SPACK_COMPREPLY="-h --help --scope -j --jobs"
     else
         SPACK_COMPREPLY=""
     fi
@@ -774,7 +774,7 @@ _spack_compiler_find() {
 _spack_compiler_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --mixed-toolchain --no-mixed-toolchain --scope -j --jobs"
+        SPACK_COMPREPLY="-h --help --scope -j --jobs"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1089,28 +1089,20 @@ complete -c spack -n '__fish_spack_using_command compiler' -s h -l help -f -a he
 complete -c spack -n '__fish_spack_using_command compiler' -s h -l help -d 'show this help message and exit'
 
 # spack compiler find
-set -g __fish_spack_optspecs_spack_compiler_find h/help mixed-toolchain no-mixed-toolchain scope= j/jobs=
+set -g __fish_spack_optspecs_spack_compiler_find h/help scope= j/jobs=
 
 complete -c spack -n '__fish_spack_using_command compiler find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler find' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -f -a mixed_toolchain
-complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -f -a mixed_toolchain
-complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 
 # spack compiler add
-set -g __fish_spack_optspecs_spack_compiler_add h/help mixed-toolchain no-mixed-toolchain scope= j/jobs=
+set -g __fish_spack_optspecs_spack_compiler_add h/help scope= j/jobs=
 
 complete -c spack -n '__fish_spack_using_command compiler add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -f -a mixed_toolchain
-complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -f -a mixed_toolchain
-complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -f -a jobs


### PR DESCRIPTION
This option was slated for removal in v1.1, but it seems it will be removed in v1.2 :slightly_smiling_face: 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
