### PR TITLE
gha: use python 3.14 on windows for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
       with:
-        python-version: '3.11'
+        python-version: '3.14'
 
     - name: Install python dependencies
       run: pip install -r .github/workflows/requirements/coverage/requirements.txt

--- a/.github/workflows/requirements/coverage/requirements.txt
+++ b/.github/workflows/requirements/coverage/requirements.txt
@@ -1,1 +1,1 @@
-coverage==7.6.1
+coverage==7.11.0

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -248,10 +248,10 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
       with:
-        python-version: 3.9
+        python-version: '3.14'
     - name: Install Python packages
       run: |
-          python -m pip install --upgrade pip pywin32 pytest-cov clingo
+          python -m pip install --upgrade pip pywin32 pytest-cov clingo "coverage<=7.11.0"
     - name: Create local develop
       run: |
         ./.github/workflows/bin/setup_git.ps1


### PR DESCRIPTION
Use Python 3.14 with coverage 7.11.0 on Windows to make things run faster.

Also replace the floating point number `3.9` with the string `'3.14'` :melting_face:.

