### PR TITLE
tests: avoid networking with git

### DIFF
--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -378,8 +378,10 @@ def test_git_provenance_find_commit_ls_remote(
 
 @pytest.mark.require_provenance
 @pytest.mark.disable_clean_stage_check
-def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, capfd):
+def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, capfd, tmp_path):
     """Fail all attempts to resolve git commits"""
+    repo_path = str(tmp_path / "non_existent")
+    monkeypatch.setattr(spack.package_base.PackageBase, "git", repo_path, raising=False)
     monkeypatch.setattr(spack.package_base.PackageBase, "do_fetch", lambda *args, **kwargs: None)
     spec = spack.concretize.concretize_one("git-ref-package@develop")
     captured = capfd.readouterr()

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -33,13 +33,14 @@ def test_modified_files(mock_git_package_changes):
         assert files[0] == filename
 
 
-def test_init_git_repo(git, tmp_path: pathlib.Path):
-    repo_url = "https://github.com/spack/spack.git"
-    destination = str(tmp_path / "test_git_init")
+def test_init_git_repo(git, mock_git_version_info, tmp_path: pathlib.Path):
+    """Test that init_git_repo creates a new repo with remote but doesn't checkout."""
+    repo, _, _ = mock_git_version_info
 
-    with working_dir(destination, create=True):
-        spack.util.git.init_git_repo(repo_url)
+    with working_dir(str(tmp_path / "test_git_init_repo"), create=True):
+        spack.util.git.init_git_repo(repo)
 
+        # Verify repo was initialized but no commits checked out yet
         assert "No commits yet" in git("status", output=str)
 
 


### PR DESCRIPTION
When running from vscode, these tests trigger an interactive login request.