### PR TITLE
spec parser: ensure toolchains are expanded to different objects

### DIFF
--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -461,10 +461,11 @@ class SpecParser:
             toolchain = self._parse_toolchain(name)
             self.parsed_toolchains[name] = toolchain
 
-        toolchain = self.parsed_toolchains[name]
-        if propagation == PropagationPolicy.PREFERENCE:
-            toolchain = toolchain.copy(propagation=propagation)
-
+        propagation_arg = None if propagation != PropagationPolicy.PREFERENCE else propagation
+        # Here we need to copy because we want "foo %toolc ^bar %toolc" to generate different
+        # objects for the toolc attached to foo and bar, since the solver depends on that to
+        # generate facts
+        toolchain = self.parsed_toolchains[name].copy(propagation=propagation_arg)
         spec.constrain(toolchain)
 
     def _parse_toolchain(self, name: str) -> "spack.spec.Spec":


### PR DESCRIPTION
fixes #51606

If:
```
foo %gnu ^bar %gnu
```
has `%gnu` expanding to the same objects in memory, it may happen that some facts for the literal spec are not emitted correctly.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
