### PR TITLE
Fix package name suggestions

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -103,6 +103,25 @@ def namespace_from_fullname(fullname: str) -> str:
     return fullname
 
 
+def name_from_fullname(fullname: str) -> str:
+    """Return the package name for the full module name.
+
+    For instance::
+
+        name_from_fullname("spack.pkg.builtin.hdf5") == "hdf5"
+        name_from_fullname("spack_repo.x.y.z.packages.pkg_name.package") == "pkg_name"
+
+    Args:
+        fullname: full name for the Python module
+    """
+    if fullname.startswith(PKG_MODULE_PREFIX_V1):
+        _, _, pkg_module = fullname.rpartition(".")
+        return pkg_module
+    elif fullname.startswith(PKG_MODULE_PREFIX_V2) and fullname.endswith(".package"):
+        return fullname.rsplit(".", 2)[-2]
+    return fullname
+
+
 class _PrependFileLoader(importlib.machinery.SourceFileLoader):
     def __init__(self, fullname: str, repo: "Repo", package_name: str) -> None:
         self.repo = repo
@@ -2136,9 +2155,9 @@ class UnknownPackageError(UnknownEntityError):
                     repo = PATH.ensure_unwrapped()
 
                 # We need to compare the base package name
-                pkg_name = name.rsplit(".", 1)[-1]
+                pkg_name = name_from_fullname(name)
                 similar = []
-                if isinstance(repo, RepoPath):
+                if isinstance(repo, (Repo, RepoPath)):
                     try:
                         similar = get_close_matches(pkg_name, repo.all_package_names())
                     except Exception:

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -7,10 +7,17 @@ import re
 import pytest
 
 from spack.main import SpackCommand, SpackCommandError
+from spack.repo import UnknownPackageError
 
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
 
 info = SpackCommand("info")
+
+
+def test_package_suggestion():
+    with pytest.raises(UnknownPackageError) as exc_info:
+        info("vtk")
+    assert "Did you mean one of the following packages?" in str(exc_info.value)
 
 
 def test_deprecated_option_warns():


### PR DESCRIPTION
This fixes the suggestions when mistyping package names:
```
$ spack info jula
==> Error: Package 'spack_repo.builtin.packages.jula.package' not found in repository '/root/.spack/package_repos/fncqgg4/repos/spack_repo/builtin'
Use 'spack create' to create a new package.

Did you mean one of the following packages?
  julia
  julea
  tauola
```