### PR TITLE
docs: use `autodoc_preserve_defaults = True`

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -342,6 +342,7 @@ exclude_patterns = ["_build", "_spack_root", ".spack-env", ".spack", ".venv"]
 
 autodoc_mock_imports = ["llnl"]
 autodoc_default_options = {"no-value": True}
+autodoc_preserve_defaults = True
 
 nitpicky = True
 nitpick_ignore = [
@@ -359,6 +360,7 @@ nitpick_ignore = [
     ("py:class", "hashlib._Hash"),
     ("py:class", "concurrent.futures._base.Executor"),
     ("py:class", "multiprocessing.context.Process"),
+    ("py:class", "posix.DirEntry"),
     ("py:class", "spack.vendor.jinja2.Environment"),
     # Spack classes that are private and we don't want to expose
     ("py:class", "spack.repo._PrependFileLoader"),

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -36,9 +36,11 @@ if sys.platform == "win32":
         "C:\\ProgramData",
     ]
     SUFFIXES = []
+    DEFAULT_SHELL = os.environ.get("SPACK_SHELL", "bat")
 else:
     SYSTEM_PATHS = ["/", "/usr", "/usr/local"]
     SUFFIXES = ["bin", "bin64", "include", "lib", "lib64"]
+    DEFAULT_SHELL = "sh"
 
 SYSTEM_DIRS = [os.path.join(p, s) for s in SUFFIXES for p in SYSTEM_PATHS] + SYSTEM_PATHS
 
@@ -776,7 +778,7 @@ class EnvironmentModifications:
 
     def shell_modifications(
         self,
-        shell: str = "sh" if sys.platform != "win32" else os.environ.get("SPACK_SHELL", "bat"),
+        shell: str = DEFAULT_SHELL,
         explicit: bool = False,
         env: Optional[MutableMapping[str, str]] = None,
     ) -> str:


### PR DESCRIPTION
Similar to #51272. When documenting default argument values, document the
expression instead of the stringified value.

This fixes various issues such as environment leakage, semantic loss, and uninformative object representations:

* `depflag = 15` -> `depflag = dt.ALL`
* `shell = "sh"` but the value is platform-dependent
* `remove_file=<function remove_link>` -> `remove_file=remove_link`
* `out=<_io.TextIOWrapper ...>` -> `out=sys.stdout`
* `SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)` -> `ht.dag_hash`
* `16` -> `cpus_available()`
* `511` -> `0o777`

and so on and so forth.

The downside of doing this is that Sphinx works on the AST level and no longer knows how things resolve, to in the above `ht.dag_hash` is not linked to the relevant variable in the `spack.hash_types` module, but I think that's minor.

<details>

<summary>Full diff on word level, with HTML tags removed:</summary>

```diff
--- a/package_api.html
+++ b/package_api.html
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-shell:
+shell:
-str
+str = "sh" if sys.platform != "win32"
-=
+else
-'sh',
+os.environ.get("SPACK_SHELL",
-explicit:
+"bat"), explicit:
-bool
+bool
-=
+=
-
-env:
+env:
-MutableMapping[str, str]
+~typing.MutableMapping[str, str]
-| None
+| None
-=
+=
-
-dest_root, ignore_conflicts: bool = False, ignore: ~typing.Callable[[str], bool] | None = None, link: ~typing.Callable = &lt;built-in function symlink&gt;,
+dest_root, ignore_conflicts:
-relative:
+bool = False, ignore:
-bool
+Callable[[str], bool] | None = None, link:
-=
+Callable = fs.symlink, relative:
-False
+bool = False
-ignore=None,
+ignore=None,
-remove_file=&lt;function remove_link&gt;
+remove_file=remove_link
-default=&lt;object object&gt;
+default=NO_DEFAULT
-'{name}{@versions}{compiler_flags}{variants}{ namespace=namespace_if_anonymous}{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}{/abstract_hash}'
+DEFAULT_FORMAT
-15,
+dt.ALL,
-15
+dt.ALL
-15,
+dt.ALL,
-15,
+dt.ALL,
-'{name}{@versions}{compiler_flags}{variants}{ namespace=namespace_if_anonymous}{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}{/abstract_hash}',
+DEFAULT_FORMAT,
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-*, root: bool = True, order: ~typing.Literal['pre', 'post', 'breadth', 'topo'] = 'pre', cover: ~typing.Literal['nodes', 'edges', 'paths']
+*, root:
-=
+bool
-'nodes',
+=
-direction:
+True, order:
-~typing.Literal['children',
+Literal['pre',
-'parents']
+'post',
-=
+'breadth',
-'children',
+'topo']
-deptype:
+=
-int
+'pre', cover:
-|
+Literal['nodes',
-str
+'edges',
-|
+'paths']
-~typing.List[str]
+=
-|
+'nodes', direction:
-~typing.Tuple[str,
+Literal['children',
-...]
+'parents']
-=
+=
-'all',
+'children', deptype:
-depth:
+int
-bool
+| str
-=
+| List[str]
-False,
+| Tuple[str,
-key:
+...]
-~typing.Callable[[~spack.spec.Spec],
+=
-~typing.Any]
+'all', depth:
-=
+bool
-&lt;built-in
+=
-function
+False, key:
-id&gt;,
+Callable[[Spec], Any]
-visited:
+=
-~typing.Set[~typing.Any]
+id, visited:
-|
+Set[Any]
-None
+| None
-=
+=
-None
+None
-*, root: bool = True, order: ~typing.Literal['pre', 'post', 'breadth', 'topo'] = 'pre', cover: ~typing.Literal['nodes', 'edges', 'paths'] = 'nodes', direction: ~typing.Literal['children', 'parents'] = 'children', deptype: int | str | ~typing.List[str] | ~typing.Tuple[str, ...] = 'all', depth: bool = False, key: ~typing.Callable[[~spack.spec.Spec], ~typing.Any]
+*, root:
-=
+bool = True, order:
-&lt;built-in
+Literal['pre', 'post', 'breadth', 'topo'] = 'pre', cover:
-function
+Literal['nodes', 'edges', 'paths'] = 'nodes', direction:
-id&gt;,
+Literal['children', 'parents'] = 'children', deptype:
-visited:
+int | str | List[str] | Tuple[str, ...] = 'all', depth:
-~typing.Set[~typing.Any]
+bool = False, key:
-|
+Callable[[Spec], Any] = id, visited:
-None
+Set[Any] | None
-=
+=
-None
+None
-*, color: bool | None = None, depth: bool = False, hashes: bool = False, hashlen: int | None = None, cover: ~typing.Literal['nodes', 'edges', 'paths'] = 'nodes', indent: int = 0, format: str = '{name}{@versions}{compiler_flags}{variants}{ namespace=namespace_if_anonymous}{ platform=architecture.platform}{
+*, color:
-os=architecture.os}{
+bool
-target=architecture.target}{/abstract_hash}',
+| None
-deptypes:
+=
-str
+None, depth:
-|
+bool
-~typing.List[str]
+=
-|
+False, hashes:
-~typing.Tuple[str,
+bool
-...]
+=
-|
+False, hashlen:
-int
+int
-=
+| None
-15,
+=
-show_types:
+None, cover:
-bool
+Literal['nodes', 'edges', 'paths'] = 'nodes', indent:
-=
+int
-False,
+=
-depth_first:
+0, format:
-bool
+str
-=
+=
-False,
+DEFAULT_FORMAT, deptypes:
-recurse_dependencies:
+str
-bool
+| List[str]
-=
+| Tuple[str, ...] | int
-True,
+=
-status_fn:
+dt.ALL, show_types:
-~typing.Callable[[~spack.spec.Spec],
+bool
-~spack.spec.InstallStatus]
+=
-|
+False, depth_first:
-None
+bool
-=
+=
-None,
+False, recurse_dependencies:
-prefix:
+bool
-~typing.Callable[[~spack.spec.Spec],
+=
-str]
+True, status_fn:
-|
+Callable[[Spec], InstallStatus] | None
-None
+=
-=
+None, prefix:
-None,
+Callable[[Spec], str]
-key=&lt;built-in
+| None
-function
+=
-id&gt;
+None, key=id
-root_key=&lt;spack.util.windows_registry._HKEY_CONSTANT object&gt;
+root_key=HKEY.HKEY_CURRENT_USER
-('build', 'link'),
+dt.DEFAULT_TYPES,
-16,
+cpus_available(),
-copy_function=&lt;function copy2&gt;
+copy_function=copy2
--- a/spack.ci.html
+++ b/spack.ci.html
-op=&lt;function _noop&gt;
+op=_noop
--- a/spack.cmd.html
+++ b/spack.cmd.html
-prog:
+prog:
-str,
+str,
-out: ~typing.IO =
+out:
-&lt;_io.TextIOWrapper name='&lt;stdout&gt;'
+IO
-mode='w'
+=
-encoding='utf-8'&gt;,
+sys.stdout,
-aliases:
+aliases:
-bool
+bool
-=
+=
+
-prog:
+prog:
-str,
+str,
-out: ~typing.IO =
+out:
-&lt;_io.TextIOWrapper name='&lt;stdout&gt;'
+IO
-mode='w'
+=
-encoding='utf-8'&gt;,
+sys.stdout,
-aliases:
+aliases:
-bool
+bool
-=
+=
+
-prog:
+prog:
-str, out: ~typing.IO = &lt;_io.TextIOWrapper name='&lt;stdout&gt;' mode='w' encoding='utf-8'&gt;, aliases: bool = False, documented_commands: ~typing.Set[str] = {},
+str, out:
-rst_levels:
+IO = sys.stdout, aliases:
-~typing.Sequence[str]
+bool = False, documented_commands:
-=
+Set[str] = set(), rst_levels:
+Sequence[str] = 
-'`']
+'`']
-prog:
+prog:
-str,
+str,
-out: ~typing.IO =
+out:
-&lt;_io.TextIOWrapper name='&lt;stdout&gt;'
+IO
-mode='w'
+=
-encoding='utf-8'&gt;,
+sys.stdout,
-aliases:
+aliases:
-bool
+bool
-=
+=
+
--- a/spack.cmd.modules.html
+++ b/spack.cmd.modules.html
-callbacks={'find': &lt;function find&gt;, 'loads': &lt;function loads&gt;, 'refresh': &lt;function refresh&gt;, 'rm': &lt;function rm&gt;}
+callbacks=callbacks
--- a/spack.environment.html
+++ b/spack.environment.html
-'specs'
+user_speclist_name
-'specs',
+user_speclist_name,
-'specs',
+user_speclist_name,
-'specs'
+user_speclist_name
-'specs',
+user_speclist_name,
-'specs',
+user_speclist_name,
-'all',
+default_view_link,
--- a/spack.html
+++ b/spack.html
-url_and_version:
+url_and_version:
-~spack.url_buildcache.MirrorURLAndVersion,
+MirrorURLAndVersion,
-urlopen=&lt;function _urlopen.&lt;locals&gt;.dispatch_open&gt;
+urlopen=web_util.urlopen
-urlopen=&lt;function _urlopen.&lt;locals&gt;.dispatch_open&gt;
+urlopen=web_util.urlopen
-url_and_version:
+url_and_version:
-~spack.url_buildcache.MirrorURLAndVersion,
+MirrorURLAndVersion,
-urlopen=&lt;function _urlopen.&lt;locals&gt;.dispatch_open&gt;
+urlopen=web_util.urlopen
-urlopen=&lt;function _urlopen.&lt;locals&gt;.dispatch_open&gt;
+urlopen=web_util.urlopen
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
-tarball_stage:
+tarball_stage:
-~spack.stage.Stage,
+Stage,
-force=False,
+force=False,
-timer=&lt;spack.util.timer.NullTimer object&gt;
+timer=timer.NULL_TIMER
-16,
+cpus_available(),
-(True, 120, None),
+DEFAULT_LOCK_CFG,
-dag_hash:
+dag_hash:
-str,
+str,
-default: ~typing.List[~spack.spec.Spec]
+default:
-|
+List[Spec]
-None
+| None
-=
+=
+
-installed: bool |
+installed:
-~spack.enums.InstallRecordStatus
+bool
-=
+| InstallRecordStatus
-&lt;InstallRecordStatus.ANY:
+=
-7&gt;
+InstallRecordStatus.ANY
-dag_hash:
+dag_hash:
-str,
+str,
-default: ~typing.List[~spack.spec.Spec]
+default:
-|
+List[Spec]
-None
+| None
-=
+=
+
-installed: bool |
+installed:
-~spack.enums.InstallRecordStatus
+bool
-=
+| InstallRecordStatus
-&lt;InstallRecordStatus.ANY:
+=
-7&gt;
+InstallRecordStatus.ANY
-3
+dt.LINK | dt.RUN
-('spec', 'ref_count', 'path', 'installed', 'explicit', 'installation_time', 'deprecated_for')
+DEFAULT_INSTALL_RECORD_FIELDS
-5
+dt.DEFAULT
-('build', 'link'),
+dt.DEFAULT_TYPES,
-external_dicts:
+external_dicts:
-~typing.List[~spack.externals.ExternalDict], *, complete_node: ~typing.Callable[[~spack.spec.Spec], None] =
+List[ExternalDict], *, complete_node:
-&lt;function
+Callable[[Spec], None]
-complete_variants_and_architecture&gt;,
+=
-allow_nonexisting:
+complete_variants_and_architecture, allow_nonexisting:
-bool
+bool
-=
+=
-True
+True
-total_bytes:
+total_bytes:
-int |
+int
-None
+| None
-=
+=
+
-enabled:
+enabled:
-bool
+bool
-=
+=
+
-get_time:
+get_time:
-~typing.Callable[[], float] = &lt;built-in
+Callable[[], float]
-function
+=
-time&gt;
+time.time
-num_bytes:
+num_bytes:
-int,
+int,
-out=&lt;_io.TextIOWrapper name='&lt;stdout&gt;' mode='w' encoding='utf-8'&gt;
+out=sys.stdout
-headers:
+headers:
-~typing.Mapping[str, str], enabled: bool = True, get_time:
+Mapping[str, str], enabled:
-~typing.Callable[[],
+bool
-float]
+=
-=
+True, get_time:
-&lt;built-in
+Callable[[], float]
-function
+=
-time&gt;
+time.time
-final:
+final:
-bool
+bool
-=
+=
+
-out=&lt;_io.TextIOWrapper name='&lt;stdout&gt;' mode='w' encoding='utf-8'&gt;
+out=sys.stdout
-15
+dt.ALL
-15,
+dt.ALL,
-15,
+dt.ALL,
-{}
+set()
-{}
+set()
-{}
+set()
-{}
+set()
-prog=None,
+prog=None,
-usage=None,
+usage=None,
-description=None,
+description=None,
-epilog=None,
+epilog=None,
-parents=[],
+parents=[],
-formatter_class=&lt;class 'argparse.HelpFormatter'&gt;,
+formatter_class=HelpFormatter,
-prefix_chars='-',
+prefix_chars='-',
-fromfile_prefix_chars=None,
+fromfile_prefix_chars=None,
-argument_default=None,
+argument_default=None,
-conflict_handler='error',
+conflict_handler='error',
-add_help=True,
+add_help=True,
-allow_abbrev=True,
+allow_abbrev=True,
-exit_on_error=True
+exit_on_error=True
-total:
+total:
-int, stdout: ~io.TextIOWrapper = &lt;_io.TextIOWrapper name='&lt;stdout&gt;' mode='w' encoding='utf-8'&gt;, get_terminal_size: ~typing.Callable[[], ~typing.Tuple[int,
+int,
-int]]
+stdout:
-= &lt;built-in function get_terminal_size&gt;,
+TextIOWrapper = sys.stdout,
-get_time:
+get_terminal_size:
-~typing.Callable[[],
+Callable[[], Tuple[int, int]] = os.get_terminal_size,
-float] =
+get_time:
-&lt;built-in function monotonic&gt;,
+Callable[[], float] = time.monotonic,
-is_tty:
+is_tty:
-bool | None
+bool | None
-=
+=
+
-default=&lt;object object&gt;
+default=NO_DEFAULT
-cache:
+cache:
-~spack.util.file_cache.FileCache,
+FileCache,
-fetch:
+fetch:
-bool
+bool
-=
+=
+
-find_git: ~typing.Callable[[], ~spack.util.executable.Executable
+find_git:
-|
+Callable[[], Executable
-None]
+| None]
-=
+=
-&lt;function
+lambda
-RepoDescriptors.&lt;lambda&gt;&gt;, overrides:
+:
-~typing.Dict[str,
+...,
-~typing.Any]
+overrides:
-|
+Dict[str, Any]
-None
+| None
-=
+=
+
-repo:
+repo:
-~spack.repo.Repo | ~spack.repo.RepoPath |
+Repo
-str
+| RepoPath
-|
+| str
-None
+| None
-=
+=
+
-*,
+*,
-get_close_matches=&lt;function get_close_matches&gt;
+get_close_matches=difflib.get_close_matches
-(2, 4)
+spack.package_api_version
-'packages',
+packages_dir_name,
-(2, 4)
+spack.package_api_version
-repo:
+repo:
-~spack.repo.Repo,
+Repo,
-*,
+*,
-patch_file:
+patch_file:
-~typing.IO[bytes] |
+IO[bytes]
-None,
+| None,
-err: ~typing.IO[str] = &lt;_io.TextIOWrapper
+err:
-name='&lt;stderr&gt;'
+IO[str]
-mode='w'
+=
-encoding='utf-8'&gt;
+sys.stderr
-packages_dir:
+packages_dir:
-str,
+str,
-root:
+root:
-str,
+str,
-patch_file:
+patch_file:
-~typing.IO[bytes] |
+IO[bytes]
-None,
+| None,
-err: ~typing.IO[str] =
+err:
-&lt;_io.TextIOWrapper name='&lt;stderr&gt;'
+IO[str]
-mode='w'
+=
-encoding='utf-8'&gt;
+sys.stderr
-'{name}{@versions}{compiler_flags}{variants}{ namespace=namespace_if_anonymous}{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}{/abstract_hash}'
+DEFAULT_FORMAT
-15,
+dt.ALL,
-15
+dt.ALL
-15,
+dt.ALL,
-15,
+dt.ALL,
-'{name}{@versions}{compiler_flags}{variants}{ namespace=namespace_if_anonymous}{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}{/abstract_hash}',
+DEFAULT_FORMAT,
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-SpecHashDescriptor(depflag=15, package_hash=True, name='hash', override=None)
+ht.dag_hash
-*, root: bool = True, order: ~typing.Literal['pre', 'post', 'breadth', 'topo'] = 'pre', cover: ~typing.Literal['nodes', 'edges', 'paths']
+*, root:
-=
+bool
-'nodes',
+=
-direction:
+True, order:
-~typing.Literal['children',
+Literal['pre',
-'parents']
+'post',
-=
+'breadth',
-'children',
+'topo']
-deptype:
+=
-int
+'pre', cover:
-|
+Literal['nodes',
-str
+'edges',
-|
+'paths']
-~typing.List[str]
+=
-|
+'nodes', direction:
-~typing.Tuple[str,
+Literal['children',
-...]
+'parents']
-=
+=
-'all',
+'children', deptype:
-depth:
+int
-~typing.Literal[False]
+| str
-=
+| List[str]
-False,
+| Tuple[str,
-key:
+...]
-~typing.Callable[[~spack.spec.Spec],
+=
-~typing.Any]
+'all', depth:
-=
+Literal[False]
-&lt;built-in
+=
-function
+False, key:
-id&gt;,
+Callable[[Spec], Any]
-visited:
+=
-~typing.Set[~typing.Any]
+id, visited:
-|
+Set[Any]
-None
+| None
-=
+=
-None
+None
-*, root: bool = True, order: ~typing.Literal['pre', 'post', 'breadth', 'topo'] = 'pre', cover: ~typing.Literal['nodes', 'edges', 'paths']
+*, root:
-=
+bool
-'nodes',
+=
-direction:
+True, order:
-~typing.Literal['children',
+Literal['pre',
-'parents']
+'post',
-=
+'breadth',
-'children',
+'topo']
-deptype:
+=
-int
+'pre', cover:
-|
+Literal['nodes',
-str
+'edges',
-|
+'paths']
-~typing.List[str]
+=
-|
+'nodes', direction:
-~typing.Tuple[str,
+Literal['children',
-...]
+'parents']
-=
+=
-'all',
+'children', deptype:
-depth:
+int
-~typing.Literal[True],
+| str
-key:
+| List[str]
-~typing.Callable[[~spack.spec.Spec],
+| Tuple[str,
-~typing.Any]
+...]
-=
+=
-&lt;built-in
+'all', depth:
-function
+Literal[True], key:
-id&gt;,
+Callable[[Spec], Any]
-visited:
+=
-~typing.Set[~typing.Any]
+id, visited:
-|
+Set[Any]
-None
+| None
-=
+=
-None
+None
-*, root: bool = True, order: ~typing.Literal['pre', 'post', 'breadth', 'topo'] = 'pre', cover: ~typing.Literal['nodes', 'edges', 'paths']
+*, root:
-=
+bool
-'nodes',
+=
-direction:
+True, order:
-~typing.Literal['children',
+Literal['pre',
-'parents']
+'post',
-=
+'breadth',
-'children',
+'topo']
-deptype:
+=
-int
+'pre', cover:
-|
+Literal['nodes',
-str
+'edges',
-|
+'paths']
-~typing.List[str]
+=
-|
+'nodes', direction:
-~typing.Tuple[str,
+Literal['children',
-...]
+'parents']
-=
+=
-'all',
+'children', deptype:
-depth:
+int
-~typing.Literal[False]
+| str
-=
+| List[str]
-False,
+| Tuple[str,
-key:
+...]
-~typing.Callable[[~spack.spec.Spec],
+=
-~typing.Any]
+'all', depth:
-=
+Literal[False]
-&lt;built-in
+=
-function
+False, key:
-id&gt;,
+Callable[[Spec], Any]
-visited:
+=
-~typing.Set[~typing.Any]
+id, visited:
-|
+Set[Any]
-None
+| None
-=
+=
-None
+None
-*, root: bool = True, order: ~typing.Literal['pre', 'post', 'breadth', 'topo'] = 'pre', cover: ~typing.Literal['nodes', 'edges', 'paths']
+*, root:
-=
+bool
-'nodes',
+=
-direction:
+True, order:
-~typing.Literal['children',
+Literal['pre',
-'parents']
+'post',
-=
+'breadth',
-'children',
+'topo']
-deptype:
+=
-int
+'pre', cover:
-|
+Literal['nodes',
-str
+'edges',
-|
+'paths']
-~typing.List[str]
+=
-|
+'nodes', direction:
-~typing.Tuple[str,
+Literal['children',
-...]
+'parents']
-=
+=
-'all',
+'children', deptype:
-depth:
+int
-~typing.Literal[True],
+| str
-key:
+| List[str]
-~typing.Callable[[~spack.spec.Spec],
+| Tuple[str,
-~typing.Any]
+...]
-=
+=
-&lt;built-in
+'all', depth:
-function
+Literal[True], key:
-id&gt;,
+Callable[[Spec], Any]
-visited:
+=
-~typing.Set[~typing.Any]
+id, visited:
-|
+Set[Any]
-None
+| None
-=
+=
-None
+None
-*, color: bool | None = None, depth: bool = False, hashes: bool = False, hashlen: int | None = None, cover: ~typing.Literal['nodes', 'edges', 'paths'] = 'nodes', indent: int = 0, format: str = '{name}{@versions}{compiler_flags}{variants}{ namespace=namespace_if_anonymous}{ platform=architecture.platform}{
+*, color:
-os=architecture.os}{
+bool
-target=architecture.target}{/abstract_hash}',
+| None
-deptypes:
+=
-str
+None, depth:
-|
+bool
-~typing.List[str]
+=
-|
+False, hashes:
-~typing.Tuple[str,
+bool
-...]
+=
-|
+False, hashlen:
-int
+int
-=
+| None
-15,
+=
-show_types:
+None, cover:
-bool
+Literal['nodes', 'edges', 'paths'] = 'nodes', indent:
-=
+int
-False,
+=
-depth_first:
+0, format:
-bool
+str
-=
+=
-False,
+DEFAULT_FORMAT, deptypes:
-recurse_dependencies:
+str
-bool
+| List[str]
-=
+| Tuple[str, ...] | int
-True,
+=
-status_fn:
+dt.ALL, show_types:
-~typing.Callable[[~spack.spec.Spec],
+bool
-~spack.spec.InstallStatus]
+=
-|
+False, depth_first:
-None
+bool
-=
+=
-None,
+False, recurse_dependencies:
-prefix:
+bool
-~typing.Callable[[~spack.spec.Spec],
+=
-str]
+True, status_fn:
-|
+Callable[[Spec], InstallStatus] | None
-None
+=
-=
+None, prefix:
-None,
+Callable[[Spec], str]
-key=&lt;built-in
+| None
-function
+=
-id&gt;
+None, key=id
-token=&lt;class 'spack.tokenize.Token'&gt;
+token=Token
-url_dict:
+url_dict:
-~typing.Dict[~spack.version.version_types.StandardVersion, str], known_versions: ~typing.Iterable[~spack.version.version_types.StandardVersion] = (), *, initial_verion_filter: ~spack.version.version_types.VersionList | None = None, url_changes: ~typing.Set[~spack.version.version_types.StandardVersion] =
+Dict[StandardVersion, str], known_versions:
-{},
+Iterable[StandardVersion] = (), *, initial_verion_filter:
-input:
+VersionList | None
-~typing.Callable[[...],
+=
-str]
+None, url_changes:
-=
+Set[StandardVersion] = set(), input:
-&lt;built-in
+Callable[[...], str]
-function
+=
-input&gt;
+input
-(False, None, None)
+spack.database.NO_LOCK
-specs: ~typing.Sequence[spack.spec.Spec], cover: ~typing.Literal['nodes', 'edges', 'paths'] = 'nodes', deptype: int | str | ~typing.List[str] | ~typing.Tuple[str, ...] = 'all', key: ~typing.Callable[[spack.spec.Spec], ~typing.Any] = &lt;built-in function id&gt;, depth_first: bool = True
+specs: Sequence[spack.spec.Spec], cover: Literal['nodes', 'edges', 'paths'] = 'nodes', deptype: int | str | List[str] | Tuple[str, ...] = 'all', key: Callable[[spack.spec.Spec], Any] = id, depth_first: bool = True
-3
+CURRENT_BUILD_CACHE_LAYOUT_VERSION
--- a/spack.llnl.html
+++ b/spack.llnl.html
-0
+Path.unix
--- a/spack.llnl.util.html
+++ b/spack.llnl.util.html
-prog:
+prog:
-str, out: ~typing.IO = &lt;_io.TextIOWrapper name='&lt;stdout&gt;' mode='w' encoding='utf-8'&gt;, aliases: bool = False, rst_levels: ~typing.Sequence[str] = ['=', '-', '^',
+str, out:
-'~',
+IO = sys.stdout, aliases:
-':',
+bool = False, rst_levels:
-'`']
+Sequence[str] = _rst_levels
-prog:
+prog:
-str,
+str,
-out: ~typing.IO =
+out:
-&lt;_io.TextIOWrapper name='&lt;stdout&gt;'
+IO
-mode='w'
+=
-encoding='utf-8'&gt;,
+sys.stdout,
-aliases:
+aliases:
-bool
+bool
-=
+=
+
-context:
+context:
-str,
+str,
-base: type =
+base:
-&lt;class 'BaseException'&gt;
+type = BaseException
-dest_root, ignore_conflicts: bool = False, ignore: ~typing.Callable[[str], bool] | None = None, link: ~typing.Callable = &lt;built-in function symlink&gt;,
+dest_root, ignore_conflicts:
-relative:
+bool = False, ignore:
-bool
+Callable[[str], bool] | None = None, link:
-=
+Callable = fs.symlink, relative:
-False
+bool = False
-ignore=None,
+ignore=None,
-remove_file=&lt;function remove_link&gt;
+remove_file=remove_link
--- a/spack.solver.html
+++ b/spack.solver.html
-pkg_name:
+pkg_name:
-str,
+str,
-constraint:
+constraint:
-~spack.spec.Spec,
+Spec,
-condition:
+condition:
-~spack.spec.Spec
+Spec =
-=,
+spack.spec.Spec(),
-origin:
+origin:
-~spack.solver.requirements.RequirementOrigin
+RequirementOrigin
-=
+=
+
-kind:
+kind:
-~spack.solver.requirements.RequirementKind
+RequirementKind
-=
+=
+
-message: str
+message:
-| None
+str | None
-=
+=
+
-pkg_name:
+pkg_name:
-str,
+str,
-constraint:
+constraint:
-~spack.spec.Spec,
+Spec,
-condition:
+condition:
-~spack.spec.Spec
+Spec =
-=,
+spack.spec.Spec(),
-origin:
+origin:
-~spack.solver.requirements.RequirementOrigin
+RequirementOrigin
-=
+=
+
-kind:
+kind:
-~spack.solver.requirements.RequirementKind
+RequirementKind
-=
+=
+
-message: str
+message:
-| None
+str | None
-=
+=
+
--- a/spack.util.html
+++ b/spack.util.html
-algorithm=&lt;built-in function openssl_sha256&gt;
+algorithm=hashlib.sha256
-0
+io.SEEK_SET
-tar:
+tar:
-~tarfile.TarFile, prefix: str, *, include_parent_directories: bool = False, skip: ~typing.Callable[[~posix.DirEntry], bool] = &lt;function &lt;lambda&gt;&gt;, path_to_name: ~typing.Callable[[str], str] = &lt;function default_path_to_name&gt;, add_file: ~typing.Callable[[~tarfile.TarFile, ~tarfile.TarInfo,
+TarFile, prefix:
-str],
+str, *, include_parent_directories:
-None]
+bool
-=
+=
-&lt;function
+False, skip:
-default_add_file&gt;,
+Callable[[DirEntry], bool]
-add_symlink:
+=
-~typing.Callable[[~tarfile.TarFile,
+lambda
-~tarfile.TarInfo,
+entry:
-str],
+..., path_to_name:
-None]
+Callable[[str], str]
-=
+=
-&lt;function
+default_path_to_name, add_file:
-default_add_link&gt;,
+Callable[[TarFile, TarInfo, str], None]
-add_hardlink:
+=
-~typing.Callable[[~tarfile.TarFile,
+default_add_file, add_symlink:
-~tarfile.TarInfo,
+Callable[[TarFile, TarInfo, str], None]
-str],
+=
-None]
+default_add_link, add_hardlink:
-=
+Callable[[TarFile, TarInfo, str], None]
-&lt;function
+=
-default_add_link&gt;
+default_add_link
-1048576
+2**20
-1048576
+2**20
-*args:
+*args:
-str, exec_fn: ~typing.Callable[[str, ~typing.List[str]], int] =
+str, exec_fn:
-&lt;built-in
+Callable[[str, List[str]], int]
-function
+=
-execv&gt;
+os.execv
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-':'
+os.pathsep
-shell:
+shell:
-str
+str = "sh" if sys.platform != "win32"
-=
+else
-'sh',
+os.environ.get("SPACK_SHELL",
-explicit:
+"bat"), explicit:
-bool
+bool
-=
+=
-
-env:
+env:
-MutableMapping[str, str]
+~typing.MutableMapping[str, str]
-| None
+| None
-=
+=
-
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-':',
+os.pathsep,
-out=&lt;_io.TextIOWrapper name='&lt;stdout&gt;' mode='w' encoding='utf-8'&gt;
+out=sys.stdout
-out=&lt;_io.TextIOWrapper name='&lt;stdout&gt;' mode='w' encoding='utf-8'&gt;
+out=sys.stdout
-now:
+now:
-~typing.Callable[[], float] = &lt;built-in
+Callable[[], float]
-function
+=
-time&gt;
+time.time
-'_global'
+global_timer_name
-'_global'
+global_timer_name
-'_global'
+global_timer_name
-out=&lt;_io.TextIOWrapper name='&lt;stdout&gt;' mode='w' encoding='utf-8'&gt;,
+out=sys.stdout,
-extra_attributes={}
+extra_attributes={}
-out=&lt;_io.TextIOWrapper name='&lt;stdout&gt;' mode='w' encoding='utf-8'&gt;
+out=sys.stdout
-root_key=&lt;spack.util.windows_registry._HKEY_CONSTANT object&gt;
+root_key=HKEY.HKEY_CURRENT_USER
```
</details>

