### PR TITLE
tests: fix Windows path related issues

### DIFF
--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import pathlib
-import sys
 
 import pytest
 
@@ -15,7 +14,6 @@ import spack.config
 import spack.environment as ev
 import spack.main
 import spack.spec
-from spack.llnl.path import convert_to_posix_path
 
 _bootstrap = spack.main.SpackCommand("bootstrap")
 
@@ -34,15 +32,13 @@ def test_enable_and_disable(mutable_config, scope):
 
 
 @pytest.mark.parametrize("scope", [None, "site", "system", "user"])
-def test_root_get_and_set(mutable_config, scope):
-    scope_args, path = [], "/scratch/spack/bootstrap"
+def test_root_get_and_set(mutable_config, tmp_path, scope):
+    scope_args, path = [], str(tmp_path)
     if scope:
         scope_args = ["--scope={0}".format(scope)]
 
     _bootstrap("root", path, *scope_args)
     out = _bootstrap("root", *scope_args)
-    if sys.platform == "win32":
-        out = convert_to_posix_path(out)
     assert out.strip() == path
 
 

--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -257,7 +257,7 @@ def test_path_manipulation(env):
     assert os.environ["PATH_LIST_WITH_DUPLICATES"].count(make_path("duplicate")) == 1
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Skip unix path tests on Windows")
+@pytest.mark.not_on_windows("Skip unix path tests on Windows")
 def test_unix_system_path_manipulation(env):
     """Tests manipulting paths that have special meaning as system paths on Unix"""
     env.deprioritize_system_paths("PATH_LIST_WITH_SYSTEM_PATHS")

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -9,6 +9,7 @@ static DSL metadata for packages.
 """
 
 import os
+import pathlib
 import shutil
 
 import pytest
@@ -225,14 +226,14 @@ def test_cache_extra_sources(install_mockery, spec, sources, extras, expect):
     shutil.rmtree(os.path.dirname(source_path))
 
 
-def test_cache_extra_sources_fails(install_mockery):
+def test_cache_extra_sources_fails(install_mockery, tmp_path: pathlib.Path):
     s = spack.concretize.concretize_one("pkg-a")
 
     with pytest.raises(InstallError) as exc_info:
-        spack.install_test.cache_extra_test_sources(s.package, ["/a/b", "no-such-file"])
+        spack.install_test.cache_extra_test_sources(s.package, [str(tmp_path), "no-such-file"])
 
     errors = str(exc_info.value)
-    assert "'/a/b') must be relative" in errors
+    assert f"'{tmp_path}') must be relative" in errors
     assert "'no-such-file') for the copy does not exist" in errors
 
 

--- a/lib/spack/spack/test/util/ld_so_conf.py
+++ b/lib/spack/spack/test/util/ld_so_conf.py
@@ -4,10 +4,14 @@
 
 import os
 import pathlib
+import sys
+
+import pytest
 
 import spack.util.ld_so_conf as ld_so_conf
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix path")
 def test_ld_so_conf_parsing(tmp_path: pathlib.Path):
     cwd = os.getcwd()
     (tmp_path / "subdir").mkdir()

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -9,7 +9,6 @@ import pytest
 
 import spack.config
 import spack.llnl.util.tty as tty
-import spack.paths
 import spack.util.path as sup
 
 #: Some lines with lots of placeholders
@@ -136,16 +135,17 @@ def test_path_debug_padded_filter(debug, monkeypatch):
         assert expected == sup.debug_padded_filter(string)
 
 
-@pytest.mark.parametrize(
-    "path,expected",
-    [
-        ("/home/spack/path/to/file.txt", "/home/spack/path/to/file.txt"),
-        ("file:///home/another/config.yaml", "/home/another/config.yaml"),
-        ("path/to.txt", os.path.join(spack.paths.spack_root, "path", "to.txt")),
-        (r"C:\Files (x86)\Windows\10", r"C:\Files (x86)\Windows\10"),
-        (r"E:/spack stage", "E:\\spack stage"),
-    ],
-)
-def test_canonicalize_file(path, expected):
-    """Confirm canonicalize path handles local files and file URLs."""
-    assert sup.canonicalize_path(path) == os.path.normpath(expected)
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix path")
+def test_canonicalize_file_unix():
+    assert sup.canonicalize_path("/home/spack/path/to/file.txt") == "/home/spack/path/to/file.txt"
+    assert sup.canonicalize_path("file:///home/another/config.yaml") == "/home/another/config.yaml"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows path")
+def test_canonicalize_file_windows():
+    assert sup.canonicalize_path(r"C:\Files (x86)\Windows\10") == r"C:\Files (x86)\Windows\10"
+    assert sup.canonicalize_path(r"E:/spack stage") == r"E:\spack stage"
+
+
+def test_canonicalize_file_relative():
+    assert sup.canonicalize_path("path/to.txt") == os.path.join(os.getcwd(), "path", "to.txt")

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -135,13 +135,13 @@ def test_path_debug_padded_filter(debug, monkeypatch):
         assert expected == sup.debug_padded_filter(string)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix path")
+@pytest.mark.not_on_windows("Unix path")
 def test_canonicalize_file_unix():
     assert sup.canonicalize_path("/home/spack/path/to/file.txt") == "/home/spack/path/to/file.txt"
     assert sup.canonicalize_path("file:///home/another/config.yaml") == "/home/another/config.yaml"
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows path")
+@pytest.mark.only_windows("Windows path")
 def test_canonicalize_file_windows():
     assert sup.canonicalize_path(r"C:\Files (x86)\Windows\10") == r"C:\Files (x86)\Windows\10"
     assert sup.canonicalize_path(r"E:/spack stage") == r"E:\spack stage"

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -9,7 +9,6 @@ import pytest
 
 import spack.config
 import spack.llnl.util.tty as tty
-import spack.paths
 import spack.util.remote_file_cache as rfc_util
 from spack.llnl.util.filesystem import join_path
 
@@ -29,21 +28,25 @@ def test_rfc_local_path_bad_scheme(path, err):
         _ = rfc_util.local_path(path, "")
 
 
-@pytest.mark.parametrize(
-    "path,expected",
-    [
-        ("/a/b/c/d/e/config.py", "/a/b/c/d/e/config.py"),
-        ("file:///this/is/a/file/url/include.yaml", "/this/is/a/file/url/include.yaml"),
-        (
-            "relative/packages.txt",
-            os.path.join(spack.paths.spack_root, "relative", "packages.txt"),
-        ),
-        (r"C:\Files (x86)\Windows\10", r"C:\Files (x86)\Windows\10"),
-        (r"D:/spack stage", "D:\\spack stage"),
-    ],
-)
-def test_rfc_local_file(path, expected):
-    assert rfc_util.local_path(path, "") == os.path.normpath(expected)
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix path")
+def test_rfc_local_file_unix():
+    assert rfc_util.local_path("/a/b/c/d/e/config.py", "") == "/a/b/c/d/e/config.py"
+    assert (
+        rfc_util.local_path("file:///this/is/a/file/url/include.yaml", "")
+        == "/this/is/a/file/url/include.yaml"
+    )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows path")
+def test_rfc_local_file_windows():
+    assert rfc_util.local_path(r"C:\Files (x86)\Windows\10", "") == r"C:\Files (x86)\Windows\10"
+    assert rfc_util.local_path(r"D:/spack stage", "") == r"D:\spack stage"
+
+
+def test_rfc_local_file_relative():
+    path = "relative/packages.txt"
+    expected = os.path.join(os.getcwd(), "relative", "packages.txt")
+    assert rfc_util.local_path(path, "") == expected
 
 
 def test_rfc_remote_local_path_no_dest():

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -28,7 +28,7 @@ def test_rfc_local_path_bad_scheme(path, err):
         _ = rfc_util.local_path(path, "")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix path")
+@pytest.mark.not_on_windows("Unix path")
 def test_rfc_local_file_unix():
     assert rfc_util.local_path("/a/b/c/d/e/config.py", "") == "/a/b/c/d/e/config.py"
     assert (
@@ -37,7 +37,7 @@ def test_rfc_local_file_unix():
     )
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows path")
+@pytest.mark.only_windows("Windows path")
 def test_rfc_local_file_windows():
     assert rfc_util.local_path(r"C:\Files (x86)\Windows\10", "") == r"C:\Files (x86)\Windows\10"
     assert rfc_util.local_path(r"D:/spack stage", "") == r"D:\spack stage"


### PR DESCRIPTION
Closes #51729

A few tests fail on Windows using Python 3.13 or higher, because

```
ntpath.isabs("/foo") is False
```

there.

The fix is mostly avoiding hard-coded posix paths in tests, and
sticking to platform-specific absolute paths.

- Remove usage of `os.sep + os.path.join(...)` which creates invalid
  paths on Windows or relies on Unix-style root.
- Use `tmp_path` fixture to create valid absolute paths for tests
  instead of hardcoded strings.
- Skip `test_substitute_config_variables` cases on Windows where
  `$spack` (an absolute path) is used in the middle of a path, which is
  invalid on Windows.
- Refactor `test_parse_install_tree` to use dynamic path via lambdas.
- Refactor `test_canonicalize_file` and `test_rfc_local_file` to split
  platform-specific tests.
- Fix `test_resolve_paths` in `stage.py` to handle platform differences
  correctly.
- Skip `test_ld_so_conf_parsing` on non-posix platforms.