### PR TITLE
stage: use effective uid's username; fix tests under `unshare -r`

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import abc
 import errno
-import getpass
 import glob
 import hashlib
 import io
@@ -82,7 +81,7 @@ def create_stage_root(path: str) -> None:
     user_uid = getuid()
 
     # Obtain lists of ancestor and descendant paths of the $user node, if any.
-    group_paths, user_node, user_paths = partition_path(path, getpass.getuser())
+    group_paths, user_node, user_paths = partition_path(path, sup.get_user())
 
     for p in group_paths:
         if not os.path.exists(p):
@@ -162,7 +161,7 @@ def _resolve_paths(candidates):
     $user and appending $user if it is not present in the path.
     """
     temp_path = sup.canonicalize_path("$tempdir")
-    user = getpass.getuser()
+    user = sup.get_user()
     tmp_has_usr = user in temp_path.split(os.path.sep)
 
     paths = []

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -26,7 +26,7 @@ import spack.spec
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.installer import PackageInstaller
-from spack.llnl.util.filesystem import copy_tree, find
+from spack.llnl.util.filesystem import copy_tree, find, getuid
 from spack.paths import test_path
 from spack.url_buildcache import (
     BuildcacheComponent,
@@ -116,6 +116,7 @@ def test_buildcache_create_fails_on_noargs(tmp_path: pathlib.Path):
         buildcache("push", "--unsigned", str(tmp_path))
 
 
+@pytest.mark.skipif(getuid() == 0, reason="user is root")
 def test_buildcache_create_fail_on_perm_denied(
     install_mockery, mock_fetch, monkeypatch, tmp_path: pathlib.Path
 ):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import collections
-import getpass
 import io
 import os
 import pathlib
@@ -36,7 +35,7 @@ import spack.util.git
 import spack.util.path as spack_path
 import spack.util.spack_yaml as syaml
 from spack.enums import ConfigScopePriority
-from spack.llnl.util.filesystem import join_path, touch
+from spack.llnl.util.filesystem import getuid, join_path, touch
 from spack.util.spack_yaml import DictWithLineInfo
 
 # sample config data
@@ -437,7 +436,7 @@ def test_merge_with_defaults(mock_low_high_config, write_config_file):
 
 
 def test_substitute_user(mock_low_high_config):
-    user = getpass.getuser()
+    user = spack_path.get_user()
     assert os.sep + os.path.join(
         "foo", "bar"
     ) + os.sep + user + os.sep + "baz" == spack_path.canonicalize_path(
@@ -1462,6 +1461,7 @@ def test_config_file_dir_failure(tmp_path: pathlib.Path, mutable_empty_config):
 
 
 @pytest.mark.not_on_windows("chmod not supported on Windows")
+@pytest.mark.skipif(getuid() == 0, reason="user is root")
 def test_config_file_read_perms_failure(tmp_path: pathlib.Path, mutable_empty_config):
     """Test reading a configuration file without permissions to ensure
     ConfigFileError is raised."""

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -509,6 +509,7 @@ def test_clear_failures_success(tmp_path: pathlib.Path):
 
 
 @pytest.mark.not_on_windows("chmod does not prevent removal on Win")
+@pytest.mark.skipif(fs.getuid() == 0, reason="user is root")
 def test_clear_failures_errs(tmp_path: pathlib.Path, capfd):
     """Test the clear_failures exception paths."""
     failures = spack.database.FailureTracker(str(tmp_path), default_timeout=0.1)

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -663,6 +663,7 @@ def test_upgrade_read_to_write(private_lock_path):
     assert lock._file is None
 
 
+@pytest.mark.skipif(getuid() == 0, reason="user is root")
 def test_upgrade_read_to_write_fails_with_readonly_file(private_lock_path):
     """Test that read-only file can be read-locked but not write-locked."""
     # ensure lock file exists the first time

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -83,6 +83,7 @@ def test_write_and_remove_cache_file(file_cache):
 
 
 @pytest.mark.not_on_windows("Not supported on Windows (yet)")
+@pytest.mark.skipif(fs.getuid() == 0, reason="user is root")
 def test_cache_init_entry_fails(file_cache):
     """Test init_entry failures."""
     relpath = fs.join_path("test-dir", "read-only-file.txt")
@@ -106,6 +107,7 @@ def test_cache_init_entry_fails(file_cache):
         file_cache.init_entry(relpath)
 
 
+@pytest.mark.skipif(fs.getuid() == 0, reason="user is root")
 def test_cache_write_readonly_cache_fails(file_cache):
     """Test writing a read-only cached file."""
     filename = "read-only-file.txt"

--- a/lib/spack/spack/test/util/spack_lock_wrapper.py
+++ b/lib/spack/spack/test/util/spack_lock_wrapper.py
@@ -33,6 +33,7 @@ def test_disable_locking(tmp_path: pathlib.Path):
 
 # "Disable" mock_stage fixture to avoid subdir permissions issues on cleanup.
 @pytest.mark.nomockstage
+@pytest.mark.skipif(getuid() == 0, reason="user is root")
 def test_lock_checks_user(tmp_path: pathlib.Path):
     """Ensure lock checks work with a self-owned, self-group repo."""
     uid = getuid()


### PR DESCRIPTION
* Use `spack.util.path.get_user()` instead of `getpass.getuser()` to allow
  mocking and support effective UIDs on Linux.
* Use monkeypatch in tests to avoid that tests fail depending on the
  current username.
* Fix `test_stage_purge` so it works independently of the username, for
  example when running under `unshare -r pytest`.
* Skip tests that rely on permission denial when running as root.
  When running as root (or via `unshare -r`), file permissions are ignored,
  causing tests that expect `PermissionError` or `OSError` on read-only
  files to fail.