### PR TITLE
tests: use direct pytest invocation on windows

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -261,7 +261,7 @@ jobs:
       env:
         COVERAGE_FILE: coverage/.coverage-windows
       run: |
-        spack unit-test -x --verbose --cov --cov-config=pyproject.toml
+        python -m pytest -x --verbose --cov --cov-config=pyproject.toml
         ./share/spack/qa/validate_last_exit.ps1
     - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
       with:


### PR DESCRIPTION
This may or may not help with installing a fault handler to troubleshoot
segfaults, which we may or may not be experiencing from clingo.

See

https://github.com/spack/spack/actions/runs/19775383230/job/56667215443
https://github.com/spack/spack/actions/runs/20106689843/job/57692712858
https://github.com/spack/spack/actions/runs/20131996129/job/57775628455

