### PR TITLE
fix: conditionnal remove of <view>/lib/site-packages in PYTHONPATH

### DIFF
--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -118,11 +118,14 @@ def environment_modifications_for_specs(
 
         # we don't want to set PYTHONPATH to the default search path in virtual environments
         view_python_pattern = re.compile(
-                r"^" + re.escape(os.path.join(view.root, "lib")) + r"/python[^/]+/site-packages$"
+            r"^" + re.escape(os.path.join(view.root, "lib")) + r"/python[^/]+/site-packages$"
         )
 
         for mod in env.env_modifications:
-            if (isinstance(mod, environment.PrependPath) and mod.name == "PYTHONPATH" and
-                view_python_pattern.match(mod.value)):
+            if (
+                isinstance(mod, environment.PrependPath)
+                and mod.name == "PYTHONPATH"
+                and view_python_pattern.match(mod.value)
+            ):
                 env.remove_path("PYTHONPATH", mod.value)
     return env

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -118,11 +118,19 @@ def environment_modifications_for_specs(
 
         # we don't want to set PYTHONPATH to the default search path in virtual environments
         view_python_pattern = re.compile(
-                r"^" + re.escape(os.path.join(view.root, "lib")) + r"/python[^/]+/site-packages$"
+            r"^" + re.escape(os.path.join(view.root, "lib")) + r"/python[^/]+/site-packages$"
         )
 
-        for mod in env.env_modifications:
-            if (isinstance(mod, environment.PrependPath) and mod.name == "PYTHONPATH" and
-                view_python_pattern.match(mod.value)):
-                env.remove_path("PYTHONPATH", mod.value)
+        mods = [
+            mod.value
+            for mod in env.env_modifications
+            if (
+                isinstance(mod, environment.PrependPath)
+                and mod.name == "PYTHONPATH"
+                and view_python_pattern.match(mod.value)
+            )
+        ]
+
+        for modif in mods:
+            env.remove_path("PYTHONPATH", modif)
     return env

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -116,4 +116,13 @@ def environment_modifications_for_specs(
     if view:
         project_env_mods(*topo_ordered, view=view, env=env)
 
+        # we don't want to set PYTHONPATH to the default search path in virtual environments
+        view_python_pattern = re.compile(
+                r"^" + re.escape(os.path.join(view.root, "lib")) + r"/python[^/]+/site-packages$"
+        )
+
+        for mod in env.env_modifications:
+            if (isinstance(mod, environment.PrependPath) and mod.name == "PYTHONPATH" and
+                view_python_pattern.match(mod.value)):
+                env.remove_path("PYTHONPATH", mod.value)
     return env


### PR DESCRIPTION
Following the discussion with @haampie on the spack slack : https://spackpm.slack.com/archives/C08Q62S7XEX/p1765462706754369?thread_ts=1765441985.287519&cid=C08Q62S7XEX
<view>/lib/site-packages is removed from the PYTHONPATH if we are in a view since its redundant.