### PR TITLE
solver: don't give a penalty for compiler reuse on compilers

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -652,10 +652,12 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
    not attr("virtual_on_build_edge", ParentNode, BuildDependency, Virtual).
 
-% Give a penalty if reuse introduces a node compiled with a compiler that is not used otherwise
+% Give a penalty if reuse introduces a node compiled with a compiler that is not used otherwise.
+% The only exception is if the current node is a compiler itself.
 compiler_from_reuse(Hash, DependencyPackage) :-
   attr("concrete_build_dependency", ParentNode, DependencyPackage, Hash),
   attr("virtual_on_build_edge", ParentNode, DependencyPackage, Virtual),
+  not node_compiler(_, ParentNode),
   language(Virtual).
 
 compiler_penalty_from_reuse(Hash) :-


### PR DESCRIPTION
In the solver we give a penalty if "reuse" introduces a node compiled with a compiler that is not used otherwise. This is to avoid that extraneous compilers are introduced in the DAG when reusing binaries.

Here we make an exception if such a node is a compiler itself.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
