### PR TITLE
includes overrides: do not remove hardcoded scopes

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -353,7 +353,7 @@ def mirror_add(args):
 def mirror_remove(args):
     """remove a mirror by name"""
     name = args.name
-    scopes = [args.scope] if args.scope else list(spack.config.CONFIG.scopes.keys())
+    scopes = [args.scope] if args.scope else reversed(list(spack.config.CONFIG.scopes.keys()))
 
     removed = False
     for scope in scopes:

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -258,7 +258,7 @@ def repo_add(args):
 
 def repo_remove(args):
     """remove a repository from Spack's configuration"""
-    scopes = [args.scope] if args.scope else list(spack.config.CONFIG.scopes.keys())
+    scopes = [args.scope] if args.scope else reversed(list(spack.config.CONFIG.scopes.keys()))
     found_and_removed = False
     for scope in scopes:
         found_and_removed |= _remove_repo(args.namespace_or_path, scope)

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -67,7 +67,7 @@ def test_config_scopes(path, types, mutable_mock_env_path):
         assert "command_line" in output
         assert "_builtin" in output
     if types:
-        if not any(i in ("all", "path") for i in types):
+        if not any(i in ("all", "path", "include") for i in types):
             assert "site" not in output
         if not any(i in ("all", "env", "include", "path") for i in types):
             assert not output or all(":" not in x for x in output)
@@ -133,21 +133,21 @@ def test_blame_override(mutable_config):
     # includes are present when section is specified
     output = config("blame", "include").strip()
     include_path = re.escape(os.path.join(mutable_config.scopes["site"].path, "include.yaml"))
-    assert re.search(rf"include:\n{include_path}:\d+\s+\- path: base", output)
+    assert re.search(rf"{include_path}:\d+\s+\- path: base", output)
 
     # includes are also present when section is NOT specified
     output = config("blame").strip()
-    assert re.search(rf"include:\n{include_path}:\d+\s+\- path: base", output)
+    assert re.search(rf"{include_path}:\d+\s+\- path: base", output)
 
     mutable_config.push_scope(spack.config.InternalConfigScope("override", {"include:": []}))
 
     # site includes are not present when overridden
     output = config("blame", "include").strip()
-    assert not re.search(rf"include:\n{include_path}:\d+\s+\- path: base", output)
+    assert not re.search(rf"{include_path}:\d+\s+\- path: base", output)
     assert "include: []" in output
 
     output = config("blame").strip()
-    assert not re.search(rf"include:\n{include_path}:\d+\s+\- path: base", output)
+    assert not re.search(rf"{include_path}:\d+\s+\- path: base", output)
     assert "include: []" in output
 
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -303,7 +303,7 @@ def test_mirror_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
     assert "mock" in system_output
 
     # Confirm that when the scope is not specified, it is removed from top scope
-    mirror("add", "--scope=site", "mock", str(tmp_path / "mockrepo"))
+    mirror("add", "--scope=site", "mock", str(tmp_path / "mock_mirror"))
     mirror("remove", "mock")
     site_output = mirror("list", "--scope=site")
     system_output = mirror("list", "--scope=system")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1002,6 +1002,10 @@ def mutable_config(tmp_path_factory: pytest.TempPathFactory, configuration_dir):
 
     scopes = _create_mock_configuration_scopes(mutable_dir)
     with spack.config.use_configuration(*scopes) as cfg:
+        for scope in cfg.scopes.values():
+            if hasattr(scope, "path"):
+                print(scope.path)
+        print("***")
         yield cfg
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1002,10 +1002,6 @@ def mutable_config(tmp_path_factory: pytest.TempPathFactory, configuration_dir):
 
     scopes = _create_mock_configuration_scopes(mutable_dir)
     with spack.config.use_configuration(*scopes) as cfg:
-        for scope in cfg.scopes.values():
-            if hasattr(scope, "path"):
-                print(scope.path)
-        print("***")
         yield cfg
 
 


### PR DESCRIPTION
Currently, the hardcoded `spack` scope is removed if a higher-priority scope specifies `include::`. This is incorrect behavior, as removing the `includes` from the `spack` scope should not remove the rest of its content.

This PR makes the following changes:
1. All `ConfigScope` objects track whether they were instantiated from an include
2. Only included scopes are dropped based on higher-priority `includes::` overrides
3. The `config` and `mutable_config` test scopes set up an include hierarchy analogous to that in `$spack/etc/spack/include.yaml` so that we test the way we actually run
4. Tests for include semantics are updated to get the correct semantics

Future work for a follow-on PR: We could simplify how default-priority includes are handled now that we have this.