### PR TITLE
ci: fix an edge case where multiple versions share the same checksum

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -847,8 +847,8 @@ def ci_verify_versions(args):
             continue
 
         # Store versions checksums / commits for future loop
-        url_version_to_checksum: Dict[str, StandardVersion] = {}
-        git_version_to_checksum: Dict[str, StandardVersion] = {}
+        url_version_to_checksum: Dict[StandardVersion, str] = {}
+        git_version_to_checksum: Dict[StandardVersion, str] = {}
         for version in pkg.versions:
             # If the package version defines a sha256 we'll use that as the high entropy
             # string to detect which versions have been added between from_ref and to_ref

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -111,8 +111,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         action="store_true",
         dest="prune_externals",
         default=True,
-        help="skip external specs\n\n"
-        "do not generate jobs for specs that are marked as external",
+        help="skip external specs\n\ndo not generate jobs for specs that are marked as external",
     )
     prune_ext_group.add_argument(
         "--no-prune-externals",
@@ -472,7 +471,7 @@ def ci_rebuild(args):
         spack_cmd.append("-k")
 
     install_args = [
-        f'--use-buildcache={spack_ci.common.win_quote("package:never,dependencies:only")}'
+        f"--use-buildcache={spack_ci.common.win_quote('package:never,dependencies:only')}"
     ]
 
     can_verify = spack_ci.can_verify_binaries()
@@ -604,8 +603,8 @@ def ci_rebuild(args):
             if not result.success:
                 install_exit_code = FAILED_CREATE_BUILDCACHE_CODE
             (tty.msg if result.success else tty.error)(
-                f'{"Pushed" if result.success else "Failed to push"} '
-                f'{job_spec.format("{name}{@version}{/hash:7}", color=clr.get_color_when())} '
+                f"{'Pushed' if result.success else 'Failed to push'} "
+                f"{job_spec.format('{name}{@version}{/hash:7}', color=clr.get_color_when())} "
                 f"to {result.url}"
             )
 
@@ -848,33 +847,31 @@ def ci_verify_versions(args):
             continue
 
         # Store versions checksums / commits for future loop
-        checksum_to_url_version: Dict[str, StandardVersion] = {}
-        checksum_to_git_version: Dict[str, StandardVersion] = {}
+        url_version_to_checksum: Dict[str, StandardVersion] = {}
+        git_version_to_checksum: Dict[str, StandardVersion] = {}
         for version in pkg.versions:
             # If the package version defines a sha256 we'll use that as the high entropy
             # string to detect which versions have been added between from_ref and to_ref
             if "sha256" in pkg.versions[version]:
-                checksum_to_url_version[pkg.versions[version]["sha256"]] = version
+                url_version_to_checksum[version] = pkg.versions[version]["sha256"]
 
             # If a package version instead defines a commit we'll use that as a
             # high entropy string to detect new versions.
             elif "commit" in pkg.versions[version]:
-                checksum_to_git_version[pkg.versions[version]["commit"]] = version
+                git_version_to_checksum[version] = pkg.versions[version]["commit"]
 
             # TODO: enforce every version have a commit or a sha256 defined if not
             # an infinite version (there are a lot of packages where this doesn't work yet.)
 
-        def filter_added_versions(checksums: Dict[str, StandardVersion]) -> List[StandardVersion]:
-            return [
-                checksums[c]
-                for c in spack_ci.filter_added_checksums(
-                    checksums, path, from_ref=args.from_ref, to_ref=args.to_ref
-                )
-            ]
+        def filter_added_versions(versions: Dict[StandardVersion, str]) -> List[StandardVersion]:
+            added_checksums = spack_ci.filter_added_checksums(
+                versions.values(), path, from_ref=args.from_ref, to_ref=args.to_ref
+            )
+            return [v for v, c in versions.items() if c in added_checksums]
 
         with fs.working_dir(os.path.dirname(path)):
-            new_url_versions = filter_added_versions(checksum_to_url_version)
-            new_git_versions = filter_added_versions(checksum_to_git_version)
+            new_url_versions = filter_added_versions(url_version_to_checksum)
+            new_git_versions = filter_added_versions(git_version_to_checksum)
 
         if new_url_versions:
             success &= validate_standard_versions(pkg, new_url_versions)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -218,7 +218,7 @@ spack:
   specs:
     - archive-files
   mirrors:
-    buildcache-destination: {tmp_path / 'ci-mirror'}
+    buildcache-destination: {tmp_path / "ci-mirror"}
 """
     expect = "Environment does not have a `ci` configuration"
     with pytest.raises(ci.SpackCIError, match=expect):
@@ -355,7 +355,7 @@ spack:
   specs:
     - dependent-install
   mirrors:
-    buildcache-destination: {tmp_path / 'ci-mirror'}
+    buildcache-destination: {tmp_path / "ci-mirror"}
   ci:
     pipeline-gen:
     - submapping:
@@ -398,7 +398,7 @@ spack:
   specs:
     - dependent-install
   mirrors:
-    buildcache-destination: {tmp_path / 'ci-mirror'}
+    buildcache-destination: {tmp_path / "ci-mirror"}
   ci:
     pipeline-gen:
     - submapping:
@@ -1138,7 +1138,7 @@ spack:
     - pkg-a
     - pkg-d
   mirrors:
-    buildcache-destination: {tmp_path / 'ci-mirror'}
+    buildcache-destination: {tmp_path / "ci-mirror"}
   ci:
     pipeline-gen:
     - build-job:
@@ -2161,6 +2161,19 @@ def verify_standard_versions_invalid(monkeypatch):
 
 
 @pytest.fixture
+def verify_standard_versions_invalid_duplicates(monkeypatch):
+    def validate_standard_versions(pkg, versions):
+        for version in versions:
+            if str(version) == "2.1.7":
+                print(f"Validated {pkg.name}@{version}")
+            else:
+                print(f"Invalid checksum found {pkg.name}@{version}")
+        return False
+
+    monkeypatch.setattr(spack.cmd.ci, "validate_standard_versions", validate_standard_versions)
+
+
+@pytest.fixture
 def verify_git_versions_invalid(monkeypatch):
     def validate_git_versions(pkg, versions):
         for version in versions:
@@ -2200,6 +2213,23 @@ def test_ci_verify_versions_standard_invalid(
         out = ci_cmd("verify-versions", commits[-1], commits[-3], fail_on_error=False)
         assert "Invalid checksum found diff-test@2.1.5" in out
         assert "Invalid commit for diff-test@2.1.6" in out
+
+
+def test_ci_verify_versions_standard_duplicates(
+    monkeypatch,
+    mock_packages,
+    mock_git_package_changes,
+    verify_standard_versions_invalid_duplicates,
+    verify_git_versions_invalid,
+):
+    repo, _, commits = mock_git_package_changes
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
+
+        out = ci_cmd("verify-versions", commits[-3], commits[-4], fail_on_error=False)
+        print(f"'{out}'")
+        assert "Validated diff-test@2.1.7" in out
+        assert "Invalid checksum found diff-test@2.1.8" in out
 
 
 def test_ci_verify_versions_manual_package(monkeypatch, mock_packages, mock_git_package_changes):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2199,7 +2199,7 @@ def test_ci_verify_versions_valid(
         assert "Validated diff-test@2.1.6" in out
 
 
-def test_ci_verify_versions_standard_invalid(
+def test_ci_verify_versions_invalid(
     monkeypatch,
     mock_packages,
     mock_git_package_changes,
@@ -2220,7 +2220,6 @@ def test_ci_verify_versions_standard_duplicates(
     mock_packages,
     mock_git_package_changes,
     verify_standard_versions_invalid_duplicates,
-    verify_git_versions_invalid,
 ):
     repo, _, commits = mock_git_package_changes
     with spack.repo.use_repositories(repo):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -272,9 +272,11 @@ def mock_git_package_changes(git, tmp_path: Path, override_git_repos_cache_path,
 
     The structure of commits in this repo is as follows::
 
-       o diff-test: add v1.2 (from a git ref)
+       o diff-test: add v2.1.7 and v2.1.8 (invalid duplicated checksum)
        |
-       o diff-test: add v1.1 (from source tarball)
+       o diff-test: add v2.1.6 (from a git ref)
+       |
+       o diff-test: add v2.1.5 (from source tarball)
        |
        o diff-test: new package (testing multiple added versions)
 
@@ -317,22 +319,28 @@ def mock_git_package_changes(git, tmp_path: Path, override_git_repos_cache_path,
 
         os.makedirs(os.path.dirname(filename))
 
-        # add pkg-a as a new package to the repository
+        # add diff-test as a new package to the repository
         shutil.copy2(f"{spack.paths.test_path}/data/conftest/diff-test/package-0.txt", filename)
         git("add", filename)
         commit("diff-test: new package")
         commits.append(latest_commit())
 
-        # add v2.1.5 to pkg-a
+        # add v2.1.5 to diff-test
         shutil.copy2(f"{spack.paths.test_path}/data/conftest/diff-test/package-1.txt", filename)
         git("add", filename)
         commit("diff-test: add v2.1.5")
         commits.append(latest_commit())
 
-        # add v2.1.6 to pkg-a
+        # add v2.1.6 to diff-test
         shutil.copy2(f"{spack.paths.test_path}/data/conftest/diff-test/package-2.txt", filename)
         git("add", filename)
         commit("diff-test: add v2.1.6")
+        commits.append(latest_commit())
+
+        # add v2.1.7 and v2.1.8 to diff-test
+        shutil.copy2(f"{spack.paths.test_path}/data/conftest/diff-test/package-3.txt", filename)
+        git("add", filename)
+        commit("diff-test: add v2.1.7 and v2.1.8")
         commits.append(latest_commit())
 
         # The commits are ordered with the last commit first in the list

--- a/lib/spack/spack/test/data/conftest/diff-test/package-3.txt
+++ b/lib/spack/spack/test/data/conftest/diff-test/package-3.txt
@@ -1,0 +1,24 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package_base import PackageBase
+from spack.package import *
+
+
+class DiffTest(PackageBase):
+    """zlib replacement with optimizations for next generation systems."""
+
+    homepage = "https://github.com/zlib-ng/zlib-ng"
+    url = "https://github.com/zlib-ng/zlib-ng/archive/2.0.0.tar.gz"
+    git = "https://github.com/zlib-ng/zlib-ng.git"
+
+    license("Zlib")
+
+    version("2.1.8", sha256="59e68f67cbb16999842daeb517cdd86fc25b177b4affd335cd72b76ddc2a46d8")
+    version("2.1.7", sha256="59e68f67cbb16999842daeb517cdd86fc25b177b4affd335cd72b76ddc2a46d8")
+    version("2.1.6", tag="2.1.6", commit="74253725f884e2424a0dd8ae3f69896d5377f325")
+    version("2.1.5", sha256="3f6576971397b379d4205ae5451ff5a68edf6c103b2f03c4188ed7075fbb5f04")
+    version("2.1.4", sha256="a0293475e6a44a3f6c045229fe50f69dc0eebc62a42405a51f19d46a5541e77a")
+    version("2.0.7", sha256="6c0853bb27738b811f2b4d4af095323c3d5ce36ceed6b50e5f773204fb8f7200")
+    version("2.0.0", sha256="86993903527d9b12fc543335c19c1d33a93797b3d4d37648b5addae83679ecd8")


### PR DESCRIPTION
If someone accidentally submits a package with two versions with the same sha256 we might not catch it in the CI/CD checks depending on the version ordering. This is because the dictionary will squash two versions with the same checksum.

This PR adds a check to ensure versions are not squashed and we rightly report if two versions have identical checksums.

Thank you @tldahlgren for finding this!