### PR TITLE
Revert "externals: add a namespace before concretization"

### DIFF
--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -182,7 +182,6 @@ def spec_from_entry(entry):
     spec._hashes_final = True
     spec.external_path = entry["prefix"]
     spec.origin = "external-db"
-    spec.namespace = pkg_cls.namespace
     spack.spec.Spec.ensure_valid_variants(spec)
 
     return spec

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -87,7 +87,6 @@ def complete_architecture(node: spack.spec.Spec) -> None:
         node.constrain(spack.spec.Spec.default_arch())
         node.architecture.target = spack.archspec.HOST_TARGET_FAMILY
 
-    node.namespace = spack.repo.PATH.repo_for_pkg(node.name).namespace
     for flag_type in spack.spec.FlagMap.valid_compiler_flags():
         node.compiler_flags.setdefault(flag_type, [])
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5629,10 +5629,16 @@ def _inject_patches_variant(root: Spec) -> None:
     # since the Spec __hash__ will change as patches are added to them
     spec_to_patches: Dict[int, Set[spack.patch.Patch]] = {}
     for s in root.traverse():
-        assert s.namespace is not None, (
-            f"internal error: {s.name} has no namespace after concretization. "
-            f"Please report a bug at https://github.com/spack/spack/issues"
-        )
+        # After concretizing, assign namespaces to anything left.
+        # Note that this doesn't count as a "change".  The repository
+        # configuration is constant throughout a spack run, and
+        # normalize and concretize evaluate Packages using Repo.get(),
+        # which respects precedence.  So, a namespace assignment isn't
+        # changing how a package name would have been interpreted and
+        # we can do it as late as possible to allow as much
+        # compatibility across repositories as possible.
+        if s.namespace is None:
+            s.namespace = spack.repo.PATH.repo_for_pkg(s.name).namespace
 
         if s.concrete:
             continue

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -8,7 +8,6 @@ import pytest
 from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
-import spack.traverse
 from spack.externals import (
     DuplicateExternalError,
     ExternalDict,
@@ -278,10 +277,6 @@ def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expect
         assert len(result) == 1
         assert all(not result[0].satisfies(c) for c in not_expected_list)
 
-    # Assert all nodes have the namespace set
-    for node in spack.traverse.traverse_nodes(parser.all_specs()):
-        assert node.namespace is not None
-
 
 @pytest.mark.parametrize(
     "externals_dicts,expected_length,not_expected",
@@ -336,7 +331,3 @@ def test_external_node_completion(
         assert len(result) == 1
         for expected in expected_list:
             assert not result[0].satisfies(expected)
-
-    # Assert all nodes have the namespace set
-    for node in spack.traverse.traverse_nodes(parser.all_specs()):
-        assert node.namespace is not None


### PR DESCRIPTION
Reverts spack/spack#51708

That PR triggers a change to the DAG hash, noticed in https://github.com/spack/spack-packages/pull/2756.

Reverting it since it does not seem vital and gives @alalazo an opportunity to troubleshoot it.