### PR TITLE
asp.py: partially revert #51626

### DIFF
--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/trigger_and_effect_deps/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/trigger_and_effect_deps/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class TriggerAndEffectDeps(Package):
+    """Package used to see if triggers and effects for dependencies are emitted correctly."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/patch-a-dependency-1.0.tar.gz"
+    version("1.0", sha256="0000000000000000000000000000000000000000000000000000000000000000")
+    variant("x", default=False, description="x")
+    variant("y", default=False, description="y")
+
+    with when("+x"):
+        depends_on("pkg-a", type="link")
+        depends_on("pkg-b", type="link")
+
+    with when("+y"):
+        depends_on("pkg-a", type="run")
+        depends_on("pkg-b", type="run")


### PR DESCRIPTION
Fixes the overly aggressive deps effect cache introduced in #51626.

The cache key didn't include the dependency type, only the dependency spec.
This caused distinct effects to be incorrectly deduplicated. For example:

```python
depends_on("java", type="build", when="+foo")
depends_on("java", type="link")
```

Both were keyed by "java", leading to incorrect deptypes in solutions.

Fix: move the effect function definition back into the loop. The
trigger function can remain at module level since it only depends on
the condition spec name, which is already part of the cache key.

The ASP problem size reduction from #51626 is mostly preserved since it's
common that one when condition triggers many dependencies, less so that
the same dependency is enabled under many distinct when conditions.