### PR TITLE
Revert "solver: simplify encoding of versions (#51591)"

### DIFF
--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -21,6 +21,7 @@ import spack.config
 import spack.package_base
 import spack.platforms
 import spack.repo
+import spack.solver.versions
 import spack.spec
 import spack.traverse
 import spack.version
@@ -33,10 +34,14 @@ def _select_best_version(
 ) -> None:
     """Try to attach the best known version to a node"""
     constraint = spack.version.from_string(valid_versions)
-    allowed_versions = [v for v in pkg_cls.versions if v.satisfies(constraint)]
+    allowed_versions = [
+        (v, info) for v, info in pkg_cls.versions.items() if v.satisfies(constraint)
+    ]
     try:
-        best_version = spack.package_base.sort_by_pkg_preference(allowed_versions, pkg=pkg_cls)[0]
-    except (KeyError, ValueError, IndexError):
+        best_version, _ = max(
+            allowed_versions, key=spack.solver.versions.concretization_version_order
+        )
+    except (KeyError, ValueError):
         return
     node.versions.versions = [spack.version.from_string(f"={best_version}")]
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -59,8 +59,9 @@ from spack.llnl.util.filesystem import (
     islink,
     symlink,
 )
-from spack.llnl.util.lang import ClassProperty, classproperty, dedupe, memoized
+from spack.llnl.util.lang import ClassProperty, classproperty, memoized
 from spack.resource import Resource
+from spack.solver.versions import concretization_version_order
 from spack.util.package_hash import package_hash
 from spack.util.typing import SupportsRichComparison
 from spack.version import GitVersion, StandardVersion, VersionError, is_git_version
@@ -2587,33 +2588,6 @@ def preferred_version(pkg: Union[PackageBase, Type[PackageBase]]):
 
     version, _ = max(pkg.versions.items(), key=concretization_version_order)
     return version
-
-
-def sort_by_pkg_preference(
-    versions: Iterable[Union[GitVersion, StandardVersion]],
-    *,
-    pkg: Union[PackageBase, Type[PackageBase]],
-) -> List[Union[GitVersion, StandardVersion]]:
-    """Sorts the list of versions passed in input according to the preferences in the package. The
-    return value does not contain duplicate versions. Most preferred versions first.
-    """
-    s = [(v, pkg.versions.get(v, {})) for v in dedupe(versions)]
-    return [v for v, _ in sorted(s, reverse=True, key=concretization_version_order)]
-
-
-def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardVersion], dict]):
-    """Version order key for concretization, where preferred > not preferred,
-    not deprecated > deprecated, finite > any infinite component; only if all are
-    the same, do we use default version ordering."""
-    version, info = version_info
-    return (
-        info.get("preferred", False),
-        not info.get("deprecated", False),
-        not isinstance(version, GitVersion),
-        not version.isdevelop(),
-        not version.is_prerelease(),
-        version,
-    )
 
 
 class PackageStillNeededError(InstallError):

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -299,6 +299,23 @@ error(100, multiple_values_error, Attribute, Package)
 % Version semantics
 %-----------------------------------------------------------------------------
 
+% Versions are declared with a weight and an origin, which indicates where the
+% version was declared (e.g. "package_py" or "external").
+pkg_fact(Package, version_declared(Version, Weight)) :- pkg_fact(Package, version_declared(Version, Weight, _)).
+
+% We can't emit the same version **with the same weight** from two different sources
+:- pkg_fact(Package, version_declared(Version, Weight, Origin1)),
+   pkg_fact(Package, version_declared(Version, Weight, Origin2)),
+   Origin1 < Origin2,
+   internal_error("Two versions with identical weights").
+
+% We cannot use a version declared for an installed package if we end up building it
+:- pkg_fact(Package, version_declared(Version, Weight, "installed")),
+   attr("version", node(ID, Package), Version),
+   version_weight(node(ID, Package), Weight),
+   not attr("hash", node(ID, Package), _),
+   internal_error("Reuse version weight used for built package").
+
 % versions are declared w/priority -- declared with priority implies declared
 pkg_fact(Package, version_declared(Version)) :- pkg_fact(Package, version_declared(Version, _)).
 
@@ -336,23 +353,22 @@ error(100, "Package '{0}' needs the deprecated version '{1}', and this is not al
 
 % we can't use a weight from an installed spec if we are building it
 % and vice-versa
+:- attr("version", node(ID, Package), Version),
+   version_weight(node(ID, Package), Weight),
+   pkg_fact(Package, version_declared(Version, Weight, "installed")),
+   build(node(ID, Package)),
+   internal_error("Reuse version weight used for build package").
 
-1 { allowed_origins(Origin): pkg_fact(Package, version_origin(Version, Origin)),
-    Origin != "installed"}
-  :- attr("version", node(ID, Package), Version),
-     build(node(ID, Package)).
-
-% We cannot use a version declared for an installed package if we end up building it
-:- not pkg_fact(Package, version_origin(Version, "installed")),
-   not pkg_fact(Package, version_origin(Version, "installed_git_version")),
-   attr("version", node(ID, Package), Version),
+:- attr("version", node(ID, Package), Version),
+   version_weight(node(ID, Package), Weight),
+   not pkg_fact(Package, version_declared(Version, Weight, "installed")),
+   not pkg_fact(Package, version_declared(Version, Weight, "installed_git_version")),
    concrete(node(ID, Package)),
-   internal_error("Reuse version weight used for built package").
+   internal_error("Build version weight used for reused package").
 
-version_weight(node(ID, Package), Weight)
+1 { version_weight(node(ID, Package), Weight) : pkg_fact(Package, version_declared(Version, Weight)) } 1
   :- attr("version", node(ID, Package), Version),
      attr("node", node(ID, Package)),
-     pkg_fact(Package, version_declared(Version, Weight)),
      internal_error("version weights must exist and be unique").
 
 % More specific error message if the version cannot satisfy some constraint
@@ -2017,6 +2033,23 @@ treat_node_as_concrete(node(X, Package)) :- attr("node", node(X, Package)), runt
 build_priority(PackageNode, 200) :- build(PackageNode), attr("node", PackageNode), not treat_node_as_concrete(PackageNode).
 build_priority(PackageNode, 0)   :- build(PackageNode), attr("node", PackageNode), treat_node_as_concrete(PackageNode).
 build_priority(PackageNode, 0)   :- concrete(PackageNode), attr("node", PackageNode).
+
+% don't assign versions from installed packages unless reuse is enabled
+% NOTE: that "installed" means the declared version was only included because
+% that package happens to be installed, NOT because it was asked for on the
+% command line.  If the user specifies a hash, the origin will be "spec".
+%
+% TODO: There's a slight inconsistency with this: if the user concretizes
+% and installs `foo ^bar`, for some build dependency `bar`, and then later
+% does a `spack install --fresh foo ^bar/abcde` (i.e.,the hash of `bar`, it
+% currently *won't* force versions for `bar`'s build dependencies -- `--fresh`
+% will instead build the latest bar. When we actually include transitive
+% build deps in the solve, consider using them as a preference to resolve this.
+:- attr("version", node(ID, Package), Version),
+   version_weight(node(ID, Package), Weight),
+   pkg_fact(Package, version_declared(Version, Weight, "installed")),
+   not optimize_for_reuse().
+
 
 % This statement, which is a hidden feature of clingo, let us avoid cycles in the DAG
 #edge (A, B) : depends_on(A, B).

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -13,7 +13,7 @@ import spack.util.libc
 import spack.version
 
 from .core import SourceContext, fn, using_libc_compatibility
-from .versions import Provenance
+from .versions import DeclaredVersion, Provenance
 
 
 class RuntimePropertyRecorder:
@@ -174,7 +174,10 @@ class RuntimePropertyRecorder:
         for s in (imposed_spec, when_spec):
             if not s.versions.concrete:
                 continue
-            self._setup.possible_versions[s.name][s.version].append(Provenance.RUNTIME)
+            self._setup.possible_versions[s.name].add(s.version)
+            self._setup.declared_versions[s.name].append(
+                DeclaredVersion(version=s.version, idx=0, origin=Provenance.RUNTIME)
+            )
 
         self.runtime_conditions.add((imposed_spec, when_spec))
         self.reset()

--- a/lib/spack/spack/solver/versions.py
+++ b/lib/spack/spack/solver/versions.py
@@ -2,6 +2,23 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
+from typing import NamedTuple, Tuple, Union
+
+from spack.version import GitVersion, StandardVersion
+
+
+def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardVersion], dict]):
+    """Version order key for concretization, where preferred > not preferred,
+    not deprecated > deprecated, finite > any infinite component; only if all are
+    the same, do we use default version ordering."""
+    version, info = version_info
+    return (
+        info.get("preferred", False),
+        not info.get("deprecated", False),
+        not version.isdevelop(),
+        not version.is_prerelease(),
+        version,
+    )
 
 
 class Provenance(enum.IntEnum):
@@ -19,12 +36,23 @@ class Provenance(enum.IntEnum):
     PACKAGE_PY = enum.auto()
     # An installed spec
     INSTALLED = enum.auto()
+    # An external spec declaration
+    EXTERNAL = enum.auto()
     # lower provenance for installed git refs so concretizer prefers StandardVersion installs
     INSTALLED_GIT_VERSION = enum.auto()
-    # Synthetic versions for virtual packages
-    VIRTUAL_CONSTRAINT = enum.auto()
     # A runtime injected from another package (e.g. a compiler)
     RUNTIME = enum.auto()
 
     def __str__(self):
         return f"{self._name_.lower()}"
+
+
+class DeclaredVersion(NamedTuple):
+    """Data class to contain information on declared versions used in the solve"""
+
+    #: String representation of the version
+    version: str
+    #: Unique index assigned to this version
+    idx: int
+    #: Provenance of the version
+    origin: Provenance

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -36,6 +36,7 @@ import spack.solver.asp
 import spack.solver.core
 import spack.solver.reuse
 import spack.solver.runtimes
+import spack.solver.versions
 import spack.spec
 import spack.test.conftest
 import spack.util.file_cache
@@ -2011,13 +2012,10 @@ spack:
             # Version badness should be > 0 only for reused specs. For instance, for pkg-b
             # the version provenance is:
             #
-            # pkg_fact("pkg-b", version_declared("1.0", 0)).
-            # pkg_fact("pkg-b", version_origin("1.0", "installed")).
-            # pkg_fact("pkg-b", version_origin("1.0", "package_py")).
-            # pkg_fact("pkg-b", version_declared("0.9", 1)).
-            # pkg_fact("pkg-b", version_origin("0.9", "installed")).
-            # pkg_fact("pkg-b", version_origin("0.9", "package_py")).
-
+            # version_declared("pkg-b","1.0",0,"package_py").
+            # version_declared("pkg-b","0.9",1,"package_py").
+            # version_declared("pkg-b","1.0",2,"installed").
+            # version_declared("pkg-b","0.9",3,"installed").
             weights = {}
             for x in [x for x in result.criteria if x.name == "version badness (non roots)"]:
                 if x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
@@ -2025,7 +2023,7 @@ spack:
                 else:
                     weights["built"] = x.value
 
-            assert weights["reused"] == 1 and weights["built"] == 0
+            assert weights["reused"] > 2 and weights["built"] == 0
 
             result_spec = result.specs[0]
             assert result_spec.satisfies("^pkg-b@1.0")
@@ -3139,7 +3137,7 @@ def test_concretization_version_order():
     result = [
         v
         for v, _ in sorted(
-            versions, key=spack.package_base.concretization_version_order, reverse=True
+            versions, key=spack.solver.versions.concretization_version_order, reverse=True
         )
     ]
     assert result == [


### PR DESCRIPTION
This reverts commit 7a06883c454e93632907e0e9d5be6b05c573c3dc.

For testing in spack-packages, while @alalazo submits a fix in parallel.
