### PR TITLE
gha: use python3 -m pytest and avoid spack-tmpconfig

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -222,16 +222,14 @@ jobs:
         sudo killall PerfPowerServices || true
     - name: Run unit tests
       env:
-        SPACK_TEST_PARALLEL: 4
         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
       run: |
         git --version
         . .github/workflows/bin/setup_git.sh
         . share/spack/setup-env.sh
-        $(which spack) bootstrap disable spack-install
-        $(which spack) solve zlib
-        common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
-        $(which spack) unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}"
+        spack bootstrap disable spack-install
+        spack solve zlib
+        python3 -m pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml --dist loadfile -x -n4
     - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
       with:
         name: coverage-${{ matrix.os }}-python${{ matrix.python-version }}

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -46,8 +46,8 @@ $coverage_run $(which spack) python -c "from spack_repo.builtin.packages.mpileak
 # Run unit tests with code coverage
 #-----------------------------------------------------------
 # Check if xdist is available
-if python -m pytest -VV 2>&1 | grep xdist; then
-  export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --dist loadfile --tx '${SPACK_TEST_PARALLEL:=3}*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python'"
+if python3 -m pytest -VV 2>&1 | grep xdist; then
+  export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --dist loadfile -n${SPACK_TEST_PARALLEL:=3}"
 fi
 
 # We are running pytest-cov after the addition of pytest-xdist, since it integrates
@@ -60,11 +60,10 @@ fi
 # where it seems that otherwise the configuration file might not be located by subprocesses
 # in some, not better specified, cases.
 if [[ "$UNIT_TEST_COVERAGE" == "true" ]]; then
-  "$(which spack)" unit-test -x --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml
-else
-  "$(which spack)" unit-test -x --verbose
+  export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml"
 fi
 
 
+python3 -m pytest -x --verbose
 
 bash "$QA_DIR/test-env-cfg.sh"


### PR DESCRIPTION
Invoke `python3 -m pytest` directly instead of running `spack unit-test`.

This has the advantage of getting coverage for Python code that runs during Spack module import.

Also it has the advantage that we're not running all these layers of indirection, making it easier to follow how tests actually run:

* `spack unit-test` imports and runs `pytest` with a mix of default flags and whatever is provided on the command line
* ... run with `--tx N*popen//python=spack-tmpconfig spack python`, invoking `spack` with a bunch of mysterious environment variables
* ... running `spack python` on xdist processes
* ... ultimately running yet another Python interpreter spawned by Spack

and avoids cloning `spack-packages` for each xdist process.

