### PR TITLE
Pin the packages hash to the latest green packages CI

### DIFF
--- a/.ci/gitlab-ci.yml
+++ b/.ci/gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - packages
 
 variables:
-  SPACK_PACKAGES_CHECKOUT_VERSION: 546fccb9d13b92c8cd633cc3af1a479f5c977826
+  SPACK_PACKAGES_CHECKOUT_VERSION: 3afe089ae050f502c5b49d69c2546dfc91681089
 
 .clone_packages: &clone_packages
   - mkdir -p ${REPO_DESTINATION}

--- a/.ci/gitlab-ci.yml
+++ b/.ci/gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - packages
 
 variables:
-  SPACK_PACKAGES_CHECKOUT_VERSION: develop
+  SPACK_PACKAGES_CHECKOUT_VERSION: 546fccb9d13b92c8cd633cc3af1a479f5c977826
 
 .clone_packages: &clone_packages
   - mkdir -p ${REPO_DESTINATION}


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Pin this so that failures should be a result of Spack core changes and not due to running on a floating develop.