### PR TITLE
test: skip cmd/unit_test.py tests

### DIFF
--- a/lib/spack/spack/test/cmd/unit_test.py
+++ b/lib/spack/spack/test/cmd/unit_test.py
@@ -4,7 +4,11 @@
 
 import os
 
+import pytest
+
 from spack.main import SpackCommand
+
+pytest.skip("Recursive pytest is brittle", allow_module_level=True)
 
 spack_test = SpackCommand("unit-test")
 cmd_test_py = os.path.join("lib", "spack", "spack", "test", "cmd", "unit_test.py")


### PR DESCRIPTION
On develop I noticed `test/cmd/unit_test.py` taking 30min+ under certain conditions.

Given that 

1. it executes `pytest.main` in the process already running from `pytest.main`, I think this is generally a bad idea, also considering `pytest-xdist` locking etc.
2. we changed from `spack unit-test` to simply `python3 -m pytest` in GitHub Actions

it sounds like a good idea to stop "meta-testing".

Edit, upon further investigation, it is indeed problematic to do nested pytest with xdist and coverage:

```
INTERNALERROR> def worker_internal_error(
INTERNALERROR>         self, node: WorkerController, formatted_error: str
INTERNALERROR>     ) -> None:
INTERNALERROR>         """
INTERNALERROR>         pytest_internalerror() was called on the worker.
INTERNALERROR>     
INTERNALERROR>         pytest_internalerror() arguments are an excinfo and an excrepr, which can't
INTERNALERROR>         be serialized, so we go with a poor man's solution of raising an exception
INTERNALERROR>         here ourselves using the formatted message.
INTERNALERROR>         """
INTERNALERROR>         self._active_nodes.remove(node)
INTERNALERROR>         try:
INTERNALERROR> >           assert False, formatted_error
INTERNALERROR> E           AssertionError: Traceback (most recent call last):
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/_pytest/main.py", line 318, in wrap_session
INTERNALERROR> E                 session.exitstatus = doit(config, session) or 0
INTERNALERROR> E                                      ~~~~^^^^^^^^^^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/_pytest/main.py", line 372, in _main
INTERNALERROR> E                 config.hook.pytest_runtestloop(session=session)
INTERNALERROR> E                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
INTERNALERROR> E                 return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR> E                        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR> E                 return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR> E                        ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/pluggy/_callers.py", line 167, in _multicall
INTERNALERROR> E                 raise exception
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR> E                 teardown.throw(exception)
INTERNALERROR> E                 ~~~~~~~~~~~~~~^^^^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/_pytest/logging.py", line 801, in pytest_runtestloop
INTERNALERROR> E                 return (yield)  # Run all the tests.
INTERNALERROR> E                         ^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR> E                 teardown.throw(exception)
INTERNALERROR> E                 ~~~~~~~~~~~~~~^^^^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/_pytest/terminal.py", line 707, in pytest_runtestloop
INTERNALERROR> E                 result = yield
INTERNALERROR> E                          ^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/pluggy/_callers.py", line 152, in _multicall
INTERNALERROR> E                 teardown.send(result)
INTERNALERROR> E                 ~~~~~~~~~~~~~^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/pytest_cov/plugin.py", line 349, in pytest_runtestloop
INTERNALERROR> E                 self.cov_controller.finish()
INTERNALERROR> E                 ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/pytest_cov/engine.py", line 55, in ensure_topdir_wrapper
INTERNALERROR> E                 return meth(self, *args, **kwargs)
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/pytest_cov/engine.py", line 430, in finish
INTERNALERROR> E                 self.cov.stop()
INTERNALERROR> E                 ~~~~~~~~~~~~~^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/coverage/control.py", line 720, in stop
INTERNALERROR> E                 self._collector.stop()
INTERNALERROR> E                 ~~~~~~~~~~~~~~~~~~~~^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/coverage/collector.py", line 358, in stop
INTERNALERROR> E                 assert self._collectors[-1] is self, (
INTERNALERROR> E                     f"Expected current collector to be {self!r}, but it's {self._collectors[-1]!r}"
INTERNALERROR> E                 )
INTERNALERROR> E             AssertionError: Expected current collector to be <Collector at 0x7fc037d8d1d0: SysMonitor>, but it's <Collector at 0x7fbfd727e250: SysMonitor>
INTERNALERROR> E             assert <Collector at 0x7fbfd727e250: SysMonitor> is <Collector at 0x7fc037d8d1d0: SysMonitor>
INTERNALERROR> E           assert False
INTERNALERROR> 
INTERNALERROR> /opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/xdist/dsession.py:232: AssertionError
```
