### PR TITLE
Revert "repo: memoized pkg_class construction (#51649)"

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1392,7 +1392,6 @@ class Repo:
         """
         return not self.exists(pkg_name) or self.get_pkg_class(pkg_name).virtual
 
-    @spack.llnl.util.lang.memoized
     def get_pkg_class(self, pkg_name: str) -> Type["spack.package_base.PackageBase"]:
         """Get the class for the package out of its module.
 


### PR DESCRIPTION
From commit 6a15cf2e35d15e93b6f416946fb9d41b88679fe6 onward, GitHub actions on macOS started to take significantly longer. This is due to `memoized` of a class method. The cache is like a static variable, and keys by all function arguments including `self`, which is unique for each `Repo` instance, of which we create a lot during tests, resulting in 50k references to package classes.

From a post test hook:

```
Repo.get_pkg_class: CacheInfo(hits=465728, misses=50042, maxsize=None, currsize=50018)
```

Oops.

<img width="1236" height="480" alt="Figure_1" src="https://github.com/user-attachments/assets/56561962-9376-4211-9079-62cb4ae8144f" />

