### PR TITLE
solver: exclude externals from deprecation penalties

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2597,7 +2597,8 @@ def sort_by_pkg_preference(
     """Sorts the list of versions passed in input according to the preferences in the package. The
     return value does not contain duplicate versions. Most preferred versions first.
     """
-    s = [(v, pkg.versions.get(v, {})) for v in dedupe(versions)]
+    # For safety, consider versions we don't know about as "deprecated"
+    s = [(v, pkg.versions.get(v, {"deprecated": True})) for v in dedupe(versions)]
     return [v for v, _ in sorted(s, reverse=True, key=concretization_version_order)]
 
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2578,14 +2578,21 @@ def deprecated_version(pkg: PackageBase, version: Union[str, StandardVersion]) -
 
 
 def preferred_version(pkg: Union[PackageBase, Type[PackageBase]]):
-    """
-    Returns a sorted list of the preferred versions of the package.
+    """Returns the preferred versions of the package according to package.py.
+
+    Accounts for version deprecation in the package recipe. Doesn't account for
+    any user configuration in packages.yaml.
 
     Arguments:
         pkg: The package whose versions are to be assessed.
     """
 
-    version, _ = max(pkg.versions.items(), key=concretization_version_order)
+    def _version_order(version_info):
+        version, info = version_info
+        deprecated_key = not info.get("deprecated", False)
+        return (deprecated_key, *concretization_version_order(version_info))
+
+    version, _ = max(pkg.versions.items(), key=_version_order)
     return version
 
 
@@ -2603,8 +2610,11 @@ def sort_by_pkg_preference(
 
 def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardVersion], dict]):
     """Version order key for concretization, where preferred > not preferred,
-    not deprecated > deprecated, finite > any infinite component; only if all are
-    the same, do we use default version ordering."""
+    finite > any infinite component; only if all are the same, do we use default version
+    ordering.
+
+    Version deprecation needs to be accounted for separately.
+    """
     version, info = version_info
     return (
         info.get("preferred", False),

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2597,8 +2597,7 @@ def sort_by_pkg_preference(
     """Sorts the list of versions passed in input according to the preferences in the package. The
     return value does not contain duplicate versions. Most preferred versions first.
     """
-    # For safety, consider versions we don't know about as "deprecated"
-    s = [(v, pkg.versions.get(v, {"deprecated": True})) for v in dedupe(versions)]
+    s = [(v, pkg.versions.get(v, {})) for v in dedupe(versions)]
     return [v for v, _ in sorted(s, reverse=True, key=concretization_version_order)]
 
 
@@ -2609,7 +2608,6 @@ def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardV
     version, info = version_info
     return (
         info.get("preferred", False),
-        not info.get("deprecated", False),
         not isinstance(version, GitVersion),
         not version.isdevelop(),
         not version.is_prerelease(),

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1513,9 +1513,13 @@ class SpackSolverSetup:
         )
         # Account for preferences in packages.yaml, if any
         if pkg.name in self.versions_from_yaml:
-            ordered_versions = spack.llnl.util.lang.dedupe(
-                self.versions_from_yaml[pkg.name] + ordered_versions
+            ordered_versions = list(
+                spack.llnl.util.lang.dedupe(self.versions_from_yaml[pkg.name] + ordered_versions)
             )
+
+        # Set the deprecation penalty, according to the package. This should be enough to move the
+        # first version last if deprecated.
+        self.gen.fact(fn.pkg_fact(pkg.name, fn.version_deprecation_penalty(len(ordered_versions))))
 
         for weight, declared_version in enumerate(ordered_versions):
             self.gen.fact(fn.pkg_fact(pkg.name, fn.version_declared(declared_version, weight)))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2617,7 +2617,10 @@ class SpackSolverSetup:
 
             from_packages_yaml = list(spack.llnl.util.lang.dedupe(from_packages_yaml))
             for v in from_packages_yaml:
-                self.possible_versions[pkg_name][v].append(Provenance.PACKAGES_YAML)
+                provenance = Provenance.PACKAGES_YAML
+                if isinstance(v, vn.GitVersion):
+                    provenance = Provenance.PACKAGES_YAML_GIT_VERSION
+                self.possible_versions[pkg_name][v].append(provenance)
             self.versions_from_yaml[pkg_name] = from_packages_yaml
 
     def define_ad_hoc_versions_from_specs(

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -338,7 +338,7 @@ error(100, "Package '{0}' needs the deprecated version '{1}', and this is not al
 % and vice-versa
 
 1 { allowed_origins(Origin): pkg_fact(Package, version_origin(Version, Origin)),
-    Origin != "installed"}
+    Origin != "installed", Origin != "packages_yaml"}
   :- attr("version", node(ID, Package), Version),
      build(node(ID, Package)).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -355,6 +355,13 @@ version_weight(node(ID, Package), Weight)
      pkg_fact(Package, version_declared(Version, Weight)),
      internal_error("version weights must exist and be unique").
 
+version_deprecation_penalty(node(ID, Package), Penalty)
+  :- pkg_fact(Package, deprecated_version(Version)),
+     pkg_fact(Package, version_deprecation_penalty(Penalty)),
+     attr("node", node(ID, Package)),
+     attr("version", node(ID, Package), Version),
+     not external(node(ID, Package)).
+
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
 error(10000, "Cannot satisfy '{0}@{1}' 1({2})", Package, Constraint, Version)
@@ -2091,6 +2098,12 @@ opt_criterion(70, "version badness (roots)").
       version_weight(PackageNode, Weight),
       build_priority(PackageNode, Priority)
 }.
+#minimize {
+    Penalty@70+Priority,PackageNode
+    : attr("root", PackageNode),
+      version_deprecation_penalty(PackageNode, Penalty),
+      build_priority(PackageNode, Priority)
+}.
 
 opt_criterion(65, "number of non-default variants (roots)").
 #minimize{ 0@265: #true }.
@@ -2195,6 +2208,14 @@ opt_criterion(25, "version badness (non roots)").
       not attr("root", node(X, Package)),
       not runtime(Package)
 }.
+#minimize {
+    Penalty@25+Priority,node(X, Package)
+    : version_deprecation_penalty(node(X, Package), Penalty),
+      build_priority(node(X, Package), Priority),
+      not attr("root", node(X, Package)),
+      not runtime(Package)
+}.
+
 
 % Try to use all the default values of variants
 opt_criterion(20, "default values of variants not being used (non-roots)").

--- a/lib/spack/spack/solver/versions.py
+++ b/lib/spack/spack/solver/versions.py
@@ -13,6 +13,8 @@ class Provenance(enum.IntEnum):
     DEV_SPEC = enum.auto()
     # The 'packages' section of the configuration
     PACKAGES_YAML = enum.auto()
+    # A git version in the 'packages' section of the configuration
+    PACKAGES_YAML_GIT_VERSION = enum.auto()
     # A package requirement
     PACKAGE_REQUIREMENT = enum.auto()
     # A 'package.py' file

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3144,11 +3144,11 @@ def test_concretization_version_order():
     ]
     assert result == [
         Version("0.9"),  # preferred
+        Version("2.0"),  # deprecation is accounted for separately
         Version("1.1"),  # latest non-deprecated final version
         Version("1.0"),  # latest non-deprecated final version
         Version("1.1alpha1"),  # prereleases
         Version("develop"),  # likely development version
-        Version("2.0"),  # deprecated
     ]
 
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1410,7 +1410,7 @@ spack:
             # This external package is buildable, has a custom version
             # in packages.yaml that is greater than the ones in package.py
             # and specifies a variant
-            ("external-buildable-with-variant@1: +baz", True, "@1.1.special +baz"),
+            ("external-buildable-with-variant +baz", True, "@1.1.special +baz"),
             ("external-buildable-with-variant ~baz", False, "@1.0 ~baz"),
             ("external-buildable-with-variant@1.0: ~baz", False, "@1.0 ~baz"),
             # This uses an external version that meets the condition for

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1410,7 +1410,7 @@ spack:
             # This external package is buildable, has a custom version
             # in packages.yaml that is greater than the ones in package.py
             # and specifies a variant
-            ("external-buildable-with-variant +baz", True, "@1.1.special +baz"),
+            ("external-buildable-with-variant@1: +baz", True, "@1.1.special +baz"),
             ("external-buildable-with-variant ~baz", False, "@1.0 ~baz"),
             ("external-buildable-with-variant@1.0: ~baz", False, "@1.0 ~baz"),
             # This uses an external version that meets the condition for
@@ -2025,7 +2025,7 @@ spack:
                 else:
                     weights["built"] = x.value
 
-            assert weights["reused"] == 1 and weights["built"] == 0
+            assert weights["reused"] == 3 and weights["built"] == 0
 
             result_spec = result.specs[0]
             assert result_spec.satisfies("^pkg-b@1.0")

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -39,6 +39,7 @@ packages:
       prefix: /usr
   'external-buildable-with-variant':
     buildable: True
+    version: ["1.1.special"]
     externals:
       - spec: external-buildable-with-variant@1.1.special +baz
         prefix: /usr

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -39,7 +39,6 @@ packages:
       prefix: /usr
   'external-buildable-with-variant':
     buildable: True
-    version: ["1.1.special"]
     externals:
       - spec: external-buildable-with-variant@1.1.special +baz
         prefix: /usr

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -26,6 +26,7 @@ import spack.subprocess_context
 from spack.error import InstallError
 from spack.package_base import PackageBase
 from spack.solver.input_analysis import NoStaticAnalysis, StaticAnalysis
+from spack.version import Version
 
 
 @pytest.fixture(scope="module")
@@ -387,3 +388,20 @@ def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, 
     captured = capfd.readouterr()
     assert "commit" not in spec.variants
     assert "Warning: Unable to resolve the git commit" in captured.err
+
+
+@pytest.mark.parametrize(
+    "pkg_name,preferred_version",
+    [
+        # This package has a deprecated v1.1.0 which should not be the preferred
+        ("deprecated_versions", "1.0.0"),
+        # Python has v2.7.11 marked as preferred and newer v3 versions
+        ("python", "2.7.11"),
+        # This package has various versions, some deprecated, plus "main" and "develop"
+        ("git-ref-package", "3.0.1"),
+    ],
+)
+def test_package_preferred_version(mock_packages, config, pkg_name, preferred_version):
+    """Tests retrieving the preferred version of a package."""
+    pkg_cls = mock_packages.get_pkg_class(pkg_name)
+    assert spack.package_base.preferred_version(pkg_cls) == Version(preferred_version)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
@@ -20,6 +20,9 @@ class Gcc(CompilerPackage, Package):
     version("2.0", md5="abcdef0123456789abcdef0123456789")
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
+    with default_args(deprecated=True):
+        version("12.4.0", md5="abcdef0123456789abcdef0123456789")
+
     variant(
         "languages",
         default="c,c++,fortran",

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
@@ -15,7 +15,12 @@ class Gcc(CompilerPackage, Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/gcc-1.0.tar.gz"
 
+    version("14.0.1", md5="abcdef0123456789abcdef0123456789")
     version("14.0", md5="abcdef0123456789abcdef0123456789")
+    version("12.1.0", md5="abcdef0123456789abcdef0123456789")
+    version("10.2.1", md5="abcdef0123456789abcdef0123456789")
+    version("9.4.1", md5="abcdef0123456789abcdef0123456789")
+    version("9.4.0", md5="abcdef0123456789abcdef0123456789")
     version("3.0", md5="def0123456789abcdef0123456789abc")
     version("2.0", md5="abcdef0123456789abcdef0123456789")
     version("1.0", md5="0123456789abcdef0123456789abcdef")


### PR DESCRIPTION
#51591 started applying deprecation penalties also to external specs. Here we restore  the previous semantics and exclude externals from taking a deprecation penalty.

This is done applying a separate:
```prolog
deprecation_penalty(PackageNode, Penalty).
```
in the ASP problem, according to certain rules. This makes it easier to debug whether a penalty for deprecation was taken, and to add or modify behavior around deprecation  in following PRs.

**Benchmarks**

* **Spack:** 1.2.0.dev0 (https://github.com/spack/spack/commit/3fbfb1cfd60f7f31ea9952c099f3ab9449162c2d)
* **Builtin repo:** https://github.com/spack/spack-packages/commit/647259fdbd472ef18f9b992bb88ce77a360acb5c
* **Python:** 3.13.2
* **Platform:** linux-ubuntu20.04-icelake

[radiuss.develop.csv](https://github.com/user-attachments/files/24184845/radiuss.develop.csv)
[radiuss.pr.csv](https://github.com/user-attachments/files/24184846/radiuss.pr.csv)

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/19f3b962-3b85-4edd-9ee8-0bddff4d80d1" />


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
