### PR TITLE
style.py: improve redundant/missing imports check

### DIFF
--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -553,7 +553,7 @@ class SpackCIConfig:
                 if _spec_matches(spec, match_string):
                     matched = True
                     if "build-job-remove" in match_attrs:
-                        spack.config.remove_yaml(dest, attrs["build-job-remove"])
+                        cfg.remove_yaml(dest, attrs["build-job-remove"])
                     if "build-job" in match_attrs:
                         spack.schema.merge_yaml(dest, attrs["build-job"])
                     break
@@ -624,7 +624,7 @@ class SpackCIConfig:
 
                 def _apply_section(dest, src):
                     if do_remove:
-                        dest = spack.config.remove_yaml(dest, src[remove_job_name])
+                        dest = cfg.remove_yaml(dest, src[remove_job_name])
                     if do_merge:
                         dest = copy.copy(spack.schema.merge_yaml(dest, src[merge_job_name]))
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -371,7 +371,7 @@ def _print_definition(
     formatted_name_and_values = f"{indent * ' '}{name_field}"
     if values_field:
         formatted_values = "\n".join(
-            spack.llnl.util.tty.color.cwrap(
+            color.cwrap(
                 values_field,
                 width=cols - 2,
                 initial_indent=value_indent,
@@ -591,7 +591,7 @@ def print_versions(pkg: PackageBase, args: Namespace) -> None:
         def get_url(version: spack.version.VersionType) -> str:
             try:
                 return str(fs.for_package_version(pkg, version))
-            except spack.fetch_strategy.InvalidArgsError:
+            except fs.InvalidArgsError:
                 return "No URL"
 
         url = get_url(preferred) if pkg.has_code else ""

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -38,7 +38,7 @@ import tempfile
 import time
 from collections import defaultdict
 from gzip import GzipFile
-from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from spack.vendor.typing_extensions import Literal
 
@@ -59,7 +59,6 @@ import spack.package_prefs as prefs
 import spack.repo
 import spack.report
 import spack.rewiring
-import spack.spec
 import spack.store
 import spack.util.path
 import spack.util.timer as timer
@@ -70,6 +69,9 @@ from spack.llnl.util.tty.log import log_output, preserve_terminal_settings
 from spack.url_buildcache import BuildcacheEntryError
 from spack.util.environment import EnvironmentModifications, dump_environment
 from spack.util.executable import which
+
+if TYPE_CHECKING:
+    import spack.spec
 
 #: Counter to support unique spec sequencing that is used to ensure packages
 #: with the same priority are (initially) processed in the order in which they

--- a/lib/spack/spack/mirrors/layout.py
+++ b/lib/spack/spack/mirrors/layout.py
@@ -2,15 +2,17 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import spack.fetch_strategy
 import spack.llnl.url
 import spack.oci.image
 import spack.repo
-import spack.spec
 from spack.error import MirrorError
 from spack.llnl.util.filesystem import mkdirp, symlink
+
+if TYPE_CHECKING:
+    import spack.spec
 
 
 class MirrorLayout:

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -7,7 +7,6 @@ from collections import Counter
 
 import spack.caches
 import spack.config
-import spack.error
 import spack.llnl.util.tty as tty
 import spack.repo
 import spack.spec

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -89,7 +89,7 @@ from .reuse import ReusableSpecsSelector, create_external_parser
 from .runtimes import RuntimePropertyRecorder, all_libcs, external_config_with_implicit_externals
 from .versions import Provenance
 
-GitOrStandardVersion = Union[spack.version.GitVersion, spack.version.StandardVersion]
+GitOrStandardVersion = Union[vn.GitVersion, vn.StandardVersion]
 
 TransformFunction = Callable[[spack.spec.Spec, List[AspFunction]], List[AspFunction]]
 
@@ -847,7 +847,7 @@ def _is_checksummed_git_version(v):
 def _is_checksummed_version(version_info: Tuple[GitOrStandardVersion, dict]):
     """Returns true iff the version is not a moving target"""
     version, info = version_info
-    if isinstance(version, spack.version.StandardVersion):
+    if isinstance(version, vn.StandardVersion):
         if any(h in info for h in spack.util.crypto.hashes.keys()) or "checksum" in info:
             return True
         return "commit" in info and len(info["commit"]) == 40
@@ -3334,7 +3334,7 @@ class SpackSolverSetup:
             for s in traverse.traverse_nodes(self._specs_from_requires(pkg_name, d["require"])):
                 name, versions = s.name, s.versions
 
-                if name not in self.pkgs or versions == spack.version.any_version:
+                if name not in self.pkgs or versions == vn.any_version:
                     continue
 
                 s.attach_git_version_lookup()
@@ -3911,7 +3911,7 @@ def _specs_with_commits(spec):
     if not pkg_class.needs_commit(spec.version):
         return
 
-    if isinstance(spec.version, spack.version.GitVersion):
+    if isinstance(spec.version, vn.GitVersion):
         if "commit" not in spec.variants and spec.version.commit_sha:
             spec.variants["commit"] = vt.SingleValuedVariant("commit", spec.version.commit_sha)
 

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -14,7 +14,7 @@ import spack.concretize
 import spack.environment as ev
 import spack.error
 import spack.llnl.util.filesystem as fs
-import spack.paths as spack_paths
+import spack.paths
 import spack.repo as repo
 import spack.util.git
 from spack.spec import Spec
@@ -190,7 +190,7 @@ def test_pipeline_dag(config, repo_builder: RepoBuilder):
 
 @pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_import_signing_key(mock_gnupghome):
-    signing_key_dir = spack_paths.mock_gpg_keys_path
+    signing_key_dir = spack.paths.mock_gpg_keys_path
     signing_key_path = os.path.join(signing_key_dir, "package-signing-key")
     with open(signing_key_path, encoding="utf-8") as fd:
         signing_key = fd.read()
@@ -205,7 +205,7 @@ def test_download_and_extract_artifacts(tmp_path: pathlib.Path, monkeypatch):
     url = "https://www.nosuchurlexists.itsfake/artifacts.zip"
     working_dir = tmp_path / "repro"
     test_artifacts_path = os.path.join(
-        spack_paths.test_path, "data", "ci", "gitlab", "artifacts.zip"
+        spack.paths.test_path, "data", "ci", "gitlab", "artifacts.zip"
     )
 
     def _urlopen_OK(*args, **kwargs):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -19,7 +19,7 @@ import spack.concretize
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.main
-import spack.paths as spack_paths
+import spack.paths
 import spack.repo
 import spack.spec
 import spack.stage
@@ -474,7 +474,7 @@ def test_ci_rebuild_missing_config(tmp_path: pathlib.Path, working_env, mutable_
 
 
 def _signing_key():
-    signing_key_path = pathlib.Path(spack_paths.mock_gpg_keys_path) / "package-signing-key"
+    signing_key_path = pathlib.Path(spack.paths.mock_gpg_keys_path) / "package-signing-key"
     return signing_key_path.read_text()
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -31,10 +31,8 @@ import spack.package_base
 import spack.paths
 import spack.repo
 import spack.solver.asp
-import spack.spec
 import spack.stage
 import spack.store
-import spack.test.conftest
 import spack.util.environment
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml
@@ -602,7 +600,7 @@ def test_env_modifications_error_on_activate(install_mockery, mock_fetch, monkey
     pkg = spack.repo.PATH.get_pkg_class("cmake-client")
     monkeypatch.setattr(pkg, "setup_run_environment", setup_error)
 
-    spack.environment.shell.activate(e)
+    ev.shell.activate(e)
 
     _, err = capfd.readouterr()
     assert "cmake-client had issues!" in err
@@ -3769,7 +3767,7 @@ spack:
     )
     current_store_root = str(spack.store.STORE.root)
     assert str(current_store_root) != str(install_root)
-    with spack.environment.Environment(str(tmp_path)):
+    with ev.Environment(str(tmp_path)):
         assert str(spack.store.STORE.root) == str(install_root)
     assert str(spack.store.STORE.root) == current_store_root
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -9,7 +9,7 @@ import pathlib
 
 import pytest
 
-import spack.cmd as cmd
+import spack.cmd
 import spack.cmd.find
 import spack.concretize
 import spack.environment as ev
@@ -190,11 +190,11 @@ def test_display_json(database, capfd):
         for s in ["mpileaks ^zmpi", "mpileaks ^mpich", "mpileaks ^mpich2"]
     ]
 
-    cmd.display_specs_as_json(specs)
+    spack.cmd.display_specs_as_json(specs)
     spec_list = json.loads(capfd.readouterr()[0])
     _check_json_output(spec_list)
 
-    cmd.display_specs_as_json(specs + specs + specs)
+    spack.cmd.display_specs_as_json(specs + specs + specs)
     spec_list = json.loads(capfd.readouterr()[0])
     _check_json_output(spec_list)
 
@@ -206,11 +206,11 @@ def test_display_json_deps(database, capfd):
         for s in ["mpileaks ^zmpi", "mpileaks ^mpich", "mpileaks ^mpich2"]
     ]
 
-    cmd.display_specs_as_json(specs, deps=True)
+    spack.cmd.display_specs_as_json(specs, deps=True)
     spec_list = json.loads(capfd.readouterr()[0])
     _check_json_output_deps(spec_list)
 
-    cmd.display_specs_as_json(specs + specs + specs, deps=True)
+    spack.cmd.display_specs_as_json(specs + specs + specs, deps=True)
     spec_list = json.loads(capfd.readouterr()[0])
     _check_json_output_deps(spec_list)
 

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -9,7 +9,6 @@ import pytest
 
 import spack.binary_distribution
 import spack.llnl.util.filesystem as fs
-import spack.util.executable
 import spack.util.gpg
 from spack.main import SpackCommand
 from spack.paths import mock_gpg_data_path, mock_gpg_keys_path

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -13,7 +13,6 @@ import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.error
-import spack.mirrors.utils
 import spack.package_base
 import spack.spec
 import spack.util.git

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -326,6 +326,12 @@ def foo(config: "spack.error.SpackError"):
     spack.util.executable.Executable("example")
     print(spack.__version__)
     print(spack.repo_utils.__file__)
+
+import spack.enums
+from spack.enums import ConfigScopePriority
+
+import spack.util.url as url_util
+def something(y: spack.util.url.Url): ...
 '''
     file.write_text(contents)
     root = str(tmp_path)
@@ -343,8 +349,10 @@ def foo(config: "spack.error.SpackError"):
     assert "issues.py: redundant import: spack.cmd" in output
     assert "issues.py: redundant import: spack.repo" in output
     assert "issues.py: redundant import: spack.config" not in output  # comment prevents removal
+    assert "issues.py: redundant import: spack.enums" in output  # imported via from-import
     assert "issues.py: missing import: spack" in output  # used by spack.__version__
     assert "issues.py: missing import: spack.util.executable" in output
+    assert "issues.py: missing import: spack.util.url" in output  # used in type hint
     assert "issues.py: missing import: spack.error" not in output  # not directly used
     assert exit_code == 1
     assert file.read_text() == contents  # fix=False should not change the file
@@ -362,8 +370,10 @@ def foo(config: "spack.error.SpackError"):
     output = output_buf.getvalue()
     assert exit_code == 1
     assert "issues.py: redundant import: spack.cmd" in output
+    assert "issues.py: redundant import: spack.enums" in output
     assert "issues.py: missing import: spack" in output
     assert "issues.py: missing import: spack.util.executable" in output
+    assert "issues.py: missing import: spack.util.url" in output
 
     # after fix a second fix is idempotent
     output_buf = io.StringIO()
@@ -382,8 +392,10 @@ def foo(config: "spack.error.SpackError"):
     # check that the file was fixed
     new_contents = file.read_text()
     assert "import spack.cmd" not in new_contents
+    assert "import spack.enums" not in new_contents
     assert "import spack\n" in new_contents
     assert "import spack.util.executable\n" in new_contents
+    assert "import spack.util.url\n" in new_contents
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires Python 3.9+")

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -13,7 +13,6 @@ import spack.cmd.test
 import spack.concretize
 import spack.config
 import spack.install_test
-import spack.main
 import spack.paths
 from spack.install_test import TestStatus
 from spack.llnl.util.filesystem import copy_tree, working_dir

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -37,7 +37,6 @@ import spack.solver.core
 import spack.solver.reuse
 import spack.solver.runtimes
 import spack.spec
-import spack.test.conftest
 import spack.util.file_cache
 import spack.util.hash
 import spack.util.spack_yaml as syaml
@@ -4246,10 +4245,10 @@ def test_commit_variant_enters_the_hash(mutable_config, mock_packages, monkeypat
 
     def _mock_resolve(spec) -> None:
         if first_call:
-            spec.variants["commit"] = spack.variant.SingleValuedVariant("commit", f"{'b' * 40}")
+            spec.variants["commit"] = vt.SingleValuedVariant("commit", f"{'b' * 40}")
             return
 
-        spec.variants["commit"] = spack.variant.SingleValuedVariant("commit", f"{'a' * 40}")
+        spec.variants["commit"] = vt.SingleValuedVariant("commit", f"{'a' * 40}")
 
     monkeypatch.setattr(spack.package_base.PackageBase, "_resolve_git_provenance", _mock_resolve)
 

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -11,7 +11,6 @@ import spack.concretize
 import spack.config
 import spack.package_prefs
 import spack.repo
-import spack.spec
 import spack.util.module_cmd
 import spack.util.spack_yaml as syaml
 from spack.error import ConfigError

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -15,7 +15,6 @@ import spack.concretize
 import spack.hash_types
 import spack.paths
 import spack.repo
-import spack.spec
 import spack.util.file_cache
 from spack.directory_layout import DirectoryLayout, InvalidDirectoryLayoutParametersError
 from spack.llnl.path import path_to_os_path

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -140,7 +140,7 @@ def test_env_change_spec_in_matrix_raises_error(tmp_path: pathlib.Path, mutable_
     e.concretize()
     e.write()
 
-    with pytest.raises(spack.environment.SpackEnvironmentError) as error:
+    with pytest.raises(ev.SpackEnvironmentError) as error:
         e.change_existing_spec(spack.spec.Spec("mpileaks@2.2"))
     assert "Cannot directly change specs in matrices" in str(error)
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -1346,7 +1346,7 @@ def test_print_install_test_log_skipped(install_mockery, mock_packages, capfd, r
     pkg = s.package
 
     pkg.run_tests = run_tests
-    spack.installer.print_install_test_log(pkg)
+    inst.print_install_test_log(pkg)
     out = capfd.readouterr()[0]
     assert out == ""
 
@@ -1363,12 +1363,12 @@ def test_print_install_test_log_failures(
     pkg.run_tests = True
     pkg.tester.test_log_file = str(tmp_path / "test-log.txt")
     pkg.tester.add_failure(AssertionError("test"), "test-failure")
-    spack.installer.print_install_test_log(pkg)
+    inst.print_install_test_log(pkg)
     err = capfd.readouterr()[1]
     assert "no test log file" in err
 
     # Having test log results in path being output
     fs.touch(pkg.tester.test_log_file)
-    spack.installer.print_install_test_log(pkg)
+    inst.print_install_test_log(pkg)
     out = capfd.readouterr()[0]
     assert "See test results at" in out

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -18,7 +18,6 @@ import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.patch
 import spack.stage
-import spack.util.executable
 import spack.util.spack_json as sjson
 import spack.util.url as url_util
 from spack.cmd.common.arguments import mirror_name_or_url

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -11,7 +11,6 @@ import spack.deptypes as dt
 import spack.error
 import spack.installer
 import spack.repo
-import spack.test.conftest
 import spack.util.hash as hashutil
 import spack.version
 from spack.dependency import Dependency

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -9,7 +9,6 @@ import pytest
 import spack.concretize
 import spack.deptypes as dt
 import spack.directives
-import spack.error
 import spack.llnl.util.lang
 import spack.package_base
 import spack.paths

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -26,7 +26,6 @@ import spack.hash_types as ht
 import spack.paths
 import spack.repo
 import spack.spec
-import spack.test.conftest
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 from spack.spec import Spec, save_dependency_specfiles

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -18,7 +18,6 @@ import spack.fetch_strategy as fs
 import spack.llnl.util.tty as tty
 import spack.url
 import spack.util.crypto as crypto
-import spack.util.executable
 import spack.util.web as web_util
 import spack.version
 from spack.llnl.util.filesystem import is_exe, working_dir

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -253,7 +253,7 @@ def get_commit_sha(path: str, ref: str) -> Optional[str]:
 
             if query:
                 return query.strip().split()[0]
-        except spack.util.executable.ProcessError:
+        except exe.ProcessError:
             continue
 
     return None


### PR DESCRIPTION
With this commit, when you have

```python
import foo
from foo import x
```

and never refer to `foo`, then `import foo` is considered redundant.

And when you have

```python
import foo.bar as baz

def func(lol: foo.bar.something): ...
```

then `import foo.bar` is considered missing.

The previous regexes did not capture this.

---

Second part fixes dozens of issues found. It's a small miracle anything worked at all.