### PR TITLE
codecs.StreamReader -> io.TextIOWrapper

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import codecs
 import collections
 import concurrent.futures
 import contextlib
@@ -2522,7 +2521,7 @@ class IndexFetcher:
         """Read the response of the manifest request and return a BlobRecord"""
         cache_class = get_url_buildcache_class(CURRENT_BUILD_CACHE_LAYOUT_VERSION)
         try:
-            result = codecs.getreader("utf-8")(manifest_response).read()
+            result = io.TextIOWrapper(manifest_response, encoding="utf-8").read()
         except (ValueError, OSError) as e:
             raise FetchIndexError(f"Remote index {manifest_response.url} is invalid", e) from e
 
@@ -2600,7 +2599,7 @@ class DefaultIndexFetcherV2(IndexFetcher):
             raise FetchIndexError(f"Could not fetch index from {url_index}", e) from e
 
         try:
-            result = codecs.getreader("utf-8")(response).read()
+            result = io.TextIOWrapper(response, encoding="utf-8").read()
         except (ValueError, OSError) as e:
             raise FetchIndexError(f"Remote index {url_index} is invalid") from e
 
@@ -2652,7 +2651,7 @@ class EtagIndexFetcherV2(IndexFetcher):
             raise FetchIndexError(f"Could not fetch index {url}", e) from e
 
         try:
-            result = codecs.getreader("utf-8")(response).read()
+            result = io.TextIOWrapper(response, encoding="utf-8").read()
         except (ValueError, OSError) as e:
             raise FetchIndexError(f"Remote index {url} is invalid", e) from e
 
@@ -2710,7 +2709,7 @@ class OCIIndexFetcher(IndexFetcher):
                     headers={"Accept": "application/vnd.oci.image.layer.v1.tar+gzip"},
                 )
             )
-            result = codecs.getreader("utf-8")(response).read()
+            result = io.TextIOWrapper(response, encoding="utf-8").read()
         except (OSError, ValueError) as e:
             raise FetchIndexError(f"Remote index {url_manifest} is invalid", e) from e
 

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import codecs
+import io
 import json
 import os
 import pathlib
@@ -105,7 +105,7 @@ def _migrate_spec(
     for meta_url in v2_metadata_urls:
         try:
             _, _, meta_file = web_util.read_from_url(meta_url)
-            spec_contents = codecs.getreader("utf-8")(meta_file).read()
+            spec_contents = io.TextIOWrapper(meta_file, encoding="utf-8").read()
             v2_spec_url = meta_url
             break
         except (web_util.SpackWebError, OSError):
@@ -280,7 +280,7 @@ def migrate(
 
     try:
         _, _, index_file = web_util.read_from_url(index_url)
-        contents = codecs.getreader("utf-8")(index_file).read()
+        contents = io.TextIOWrapper(index_file, encoding="utf-8").read()
     except (web_util.SpackWebError, OSError):
         raise MigrationException("Buildcache migration requires a buildcache index")
 

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import base64
-import codecs
+import io
 import json
 import os
 import pathlib
@@ -1310,7 +1310,7 @@ def read_broken_spec(broken_spec_url):
         tty.warn(f"Unable to read broken spec from {broken_spec_url}")
         return None
 
-    broken_spec_contents = codecs.getreader("utf-8")(fs).read()
+    broken_spec_contents = io.TextIOWrapper(fs, encoding="utf-8").read()
     return syaml.load(broken_spec_contents)
 
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -1,9 +1,9 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import codecs
 import collections
 import hashlib
+import io
 import os
 import platform
 import posixpath
@@ -454,7 +454,7 @@ class CDash(Reporter):
             try:
                 response = web_util.urlopen(request, timeout=SPACK_CDASH_TIMEOUT)
                 if self.current_package_name not in self.buildIds:
-                    resp_value = codecs.getreader("utf-8")(response).read()
+                    resp_value = io.TextIOWrapper(response, encoding="utf-8").read()
                     match = self.buildid_regexp.search(resp_value)
                     if match:
                         buildid = match.group(1)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2403,6 +2403,9 @@ class MockHTTPResponse(io.IOBase):
         body = io.BytesIO(json.dumps(body).encode("utf-8"))
         return cls(status, reason, headers, body)
 
+    def readable(self):
+        return True
+
     def read(self, *args, **kwargs):
         return self._body.read(*args, **kwargs)
 

--- a/lib/spack/spack/test/util/unparse/unparse.py
+++ b/lib/spack/spack/test/util/unparse/unparse.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Python-2.0
 
 import ast
-import codecs
 import os
 import sys
 import tokenize
@@ -20,7 +19,7 @@ def read_pyfile(filename):
     string), taking into account the file encoding."""
     with open(filename, "rb") as pyfile:
         encoding = tokenize.detect_encoding(pyfile.readline)[0]
-    with codecs.open(filename, "r", encoding=encoding) as pyfile:
+    with open(filename, "r", encoding=encoding) as pyfile:
         source = pyfile.read()
     return source
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import codecs
 import enum
 import fnmatch
 import gzip
@@ -470,7 +469,7 @@ class URLBuildcacheEntry:
 
         try:
             _, _, manifest_file = web_util.read_from_url(manifest_url)
-            manifest_contents = codecs.getreader("utf-8")(manifest_file).read()
+            manifest_contents = io.TextIOWrapper(manifest_file, encoding="utf-8").read()
         except (web_util.SpackWebError, OSError) as e:
             raise BuildcacheEntryError(f"Error reading manifest at {manifest_url}") from e
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import codecs
 import email.message
 import errno
+import io
 import json
 import os
 import re
@@ -427,7 +427,7 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
         try:
             _, _, response = read_from_url(url)
 
-            output = codecs.getreader("utf-8")(response).read()
+            output = io.TextIOWrapper(response, encoding="utf-8").read()
             if output:
                 with working_dir(dest_dir, create=True):
                     with open(filename, "w", encoding="utf-8") as f:
@@ -745,7 +745,7 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
         if not response_url or not response:
             return pages, links, subcalls, _visited
 
-        page = codecs.getreader("utf-8")(response).read()
+        page = io.TextIOWrapper(response, encoding="utf-8").read()
         pages[response_url] = page
 
         # Parse out the include-fragments in the page
@@ -772,7 +772,7 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
             if not fragment_response_url or not fragment_response:
                 continue
 
-            fragment = codecs.getreader("utf-8")(fragment_response).read()
+            fragment = io.TextIOWrapper(fragment_response, encoding="utf-8").read()
             fragments.add(fragment)
 
             pages[fragment_response_url] = fragment


### PR DESCRIPTION
* `codecs.open` is deprecated (can just use `open()`)
* Anywhere else use `io.TextIOWrapper`, which is implemented in C, whereas
  `codecs` is a slow and sad module written in pure Python.