### PR TITLE
Developer Docs: Add section on debugging GHA Unit Tests

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -406,7 +406,7 @@ Debugging Unit Tests in CI
 
 Spack runs its CI for unit tests via Github Actions from the Spack repo.
 The unit tests are run for each platform Spack supports, Windows, Linux, and MacOS.
-It may be the case that a unit test fails or passes on one of these platforms.
+It may be the case that a unit test fails or passes on just one of these platforms.
 When the platform is one the PR author does not have access to, it can be difficult to reproduce, diagnose, and fix a CI failure.
 Thankfully, PR authors can take advantage of a Github Actions Action to gain temporary access to the failing platform from the context of their PRs.
 Simply copy the following Github actions yaml stanza into `the GHA workflow file <https://github.com/spack/spack/blob/develop/.github/workflows/unit_tests.yaml>`__ in the `steps` section of whatever unit test needs debugging.
@@ -456,8 +456,8 @@ As the action runs, you should observe output similar to:
    ssh 5RjFs7LPdtwGG8cwSPkGrdMNg@sfo2.tmate.io
    https://tmate.io/t/5RjFs7LPdtwGG8cwSPkGrdMNg
 
-The first line is the ssh command neccesary to connect to the server, the second line is a tmate web-ui that also provides access to the ssh server on the runner. .. note:: the UI has occasionally been unresponsive.
-If it does not respond within ~10s, you'll need to use your local ssh utility.
+The first line is the ssh command neccesary to connect to the server, the second line is a tmate web-ui that also provides access to the ssh server on the runner. 
+.. note:: the UI has occasionally been unresponsive. If it does not respond within ~10s, you'll need to use your local ssh utility.
 
 Once connected via SSH, you have the same level of access to the machine that the CI job's user does.
 Spack's source should be available already (depending on where the step was inserted).

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -461,8 +461,14 @@ Spack's source should be available already (depending on where the step was inse
 
 .. note:: If you are on Windows you'll be dropped into an MSYS shell, Spack is not supported inside MSYS, so it is strongly recommended to drop into a CMD or powershell prompt.
 
+You will have access to this ssh session for as long as Github allows a job to be alive.
 
 Once you have finished debugging, remove this action from the Github actions workflow.
+
+If you want to continue a workflow and you are inside a session, just create a empty file with the name continue either in the root directory or in the project directory.
+
+This action has a few option to configure behavior like ssh key handling, tmate server, detached mode, etc.
+For more on how to use those options, see the actions docs at https://github.com/mxschmitt/action-tmate
 
 Developer environment
 ---------------------

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -404,58 +404,61 @@ Unit testing
 Debugging Unit Tests in CI
 -----------------------
 
-Spack runs its CI for unit tests via Github Actions from the Spack repo. The unit tests are run for each platform Spack supports, Windows, Linux, and MacOS.
-It may be the case that a unit test fails or passes on one of these platforms. When the platform is one the PR author does not have access to, it can be difficult to reproduce, diagnose, and fix a CI failure.
+Spack runs its CI for unit tests via Github Actions from the Spack repo.
+The unit tests are run for each platform Spack supports, Windows, Linux, and MacOS.
+It may be the case that a unit test fails or passes on one of these platforms.
+When the platform is one the PR author does not have access to, it can be difficult to reproduce, diagnose, and fix a CI failure.
 Thankfully, PR authors can take advantage of a Github Actions Action to gain temporary access to the failing platform from the context of their PRs.
 Simply copy the following Github actions yaml stanza into the `<spack_root>/.github/workflows/unit_tests.yaml` GHA workflow file in the `steps` section of whatever unit test needs debugging.
 
-```yaml
-- name: Setup tmate session
-  uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
-```
+.. code-block:: yaml
+   - name: Setup tmate session
+   uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
 
 Ideally this would be inserted somewhere after GHA checks out Spack and does any setup, but before the unit tests themselves are run.
 You can of course put this stanza after the unit-tests, but then you'll be stuck waiting for the unit tests to complete (potentially up to ~30m) and will need to add additional logic to the yaml in the case where the unit tests fail.
 
 For example, if you were to add this step to the Linux unit test CI, it would look something like:
 
-```yaml
-    - name: Bootstrap clingo
-      if: ${{ matrix.concretizer == 'clingo' }}
-      env:
-          SPACK_PYTHON: python
-      run: |
-          . share/spack/setup-env.sh
-          spack bootstrap disable spack-install
-          spack bootstrap now
-          spack -v solve zlib
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
-    - name: Run unit tests
-      env:
-          SPACK_PYTHON: python
-          SPACK_TEST_PARALLEL: 4
-          COVERAGE: true
-          COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
-          UNIT_TEST_COVERAGE: ${{ matrix.python-version == '3.14' }}
-      run: |
-          share/spack/qa/run-unit-tests
-```
+.. code-block:: yaml
+   - name: Bootstrap clingo
+   if: ${{ matrix.concretizer == 'clingo' }}
+   env:
+         SPACK_PYTHON: python
+   run: |
+         . share/spack/setup-env.sh
+         spack bootstrap disable spack-install
+         spack bootstrap now
+         spack -v solve zlib
+   - name: Setup tmate session
+   uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+   - name: Run unit tests
+   env:
+         SPACK_PYTHON: python
+         SPACK_TEST_PARALLEL: 4
+         COVERAGE: true
+         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
+         UNIT_TEST_COVERAGE: ${{ matrix.python-version == '3.14' }}
+   run: |
+         share/spack/qa/run-unit-tests
+
 
 Note that the ssh session comes after Spack does its setup but before it runs the unit tests.
 
 Once this step is present in the job definition, it will be triggered for each CI run.
-This action provides access to an SSH server running on the GHA runner that is hosting a given CI run. As the action runs, you should observe output similar to:
+This action provides access to an SSH server running on the GHA runner that is hosting a given CI run.
+As the action runs, you should observe output similar to:
 
-```bash
-ssh 5RjFs7LPdtwGG8cwSPkGrdMNg@sfo2.tmate.io
-https://tmate.io/t/5RjFs7LPdtwGG8cwSPkGrdMNg
-```
-The first line is the ssh command neccesary to connect to the server, the second line is a tmate web-ui that also provides access to the ssh server on the runner.
-.. note:: the UI has occasionally been unresponsive. If it does not respond within ~10s, you'll need to use your local ssh utility.
+.. code-block:: bash
+   ssh 5RjFs7LPdtwGG8cwSPkGrdMNg@sfo2.tmate.io
+   https://tmate.io/t/5RjFs7LPdtwGG8cwSPkGrdMNg
+
+The first line is the ssh command neccesary to connect to the server, the second line is a tmate web-ui that also provides access to the ssh server on the runner. .. note:: the UI has occasionally been unresponsive.
+If it does not respond within ~10s, you'll need to use your local ssh utility.
 
 Once connected via SSH, you have the same level of access to the machine that the CI job's user does.
-Spack's source should be available already (depending on where the step was inserted). So you can just setup the shell to run Spack via the setup scripts and then debug as needed.
+Spack's source should be available already (depending on where the step was inserted).
+So you can just setup the shell to run Spack via the setup scripts and then debug as needed.
 
 .. note:: If you have configured your Github profile with SSH keys, the action will be aware of this and require those keys to access the SSH session.
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -456,8 +456,9 @@ As the action runs, you should observe output similar to:
    ssh 5RjFs7LPdtwGG8cwSPkGrdMNg@sfo2.tmate.io
    https://tmate.io/t/5RjFs7LPdtwGG8cwSPkGrdMNg
 
-The first line is the ssh command neccesary to connect to the server, the second line is a tmate web-ui that also provides access to the ssh server on the runner. 
-.. note:: the UI has occasionally been unresponsive. If it does not respond within ~10s, you'll need to use your local ssh utility.
+The first line is the ssh command neccesary to connect to the server, the second line is a tmate web-ui that also provides access to the ssh server on the runner.
+
+.. note:: The web UI has occasionally been unresponsive, if it does not respond within ~10s, you'll need to use your local ssh utility.
 
 Once connected via SSH, you have the same level of access to the machine that the CI job's user does.
 Spack's source should be available already (depending on where the step was inserted).

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -414,7 +414,7 @@ Simply copy the following Github actions yaml stanza into the `<spack_root>/.git
 .. code-block:: yaml
 
    - name: Setup tmate session
-   uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+     uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
 
 Ideally this would be inserted somewhere after GHA checks out Spack and does any setup, but before the unit tests themselves are run.
 You can of course put this stanza after the unit-tests, but then you'll be stuck waiting for the unit tests to complete (potentially up to ~30m) and will need to add additional logic to the yaml in the case where the unit tests fail.
@@ -424,25 +424,25 @@ For example, if you were to add this step to the Linux unit test CI, it would lo
 .. code-block:: yaml
 
    - name: Bootstrap clingo
-   if: ${{ matrix.concretizer == 'clingo' }}
-   env:
-         SPACK_PYTHON: python
-   run: |
-         . share/spack/setup-env.sh
-         spack bootstrap disable spack-install
-         spack bootstrap now
-         spack -v solve zlib
+     if: ${{ matrix.concretizer == 'clingo' }}
+     env:
+       SPACK_PYTHON: python
+     run: |
+       . share/spack/setup-env.sh
+       spack bootstrap disable spack-install
+       spack bootstrap now
+       spack -v solve zlib
    - name: Setup tmate session
-   uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+     uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
    - name: Run unit tests
-   env:
-         SPACK_PYTHON: python
-         SPACK_TEST_PARALLEL: 4
-         COVERAGE: true
-         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
-         UNIT_TEST_COVERAGE: ${{ matrix.python-version == '3.14' }}
-   run: |
-         share/spack/qa/run-unit-tests
+     env:
+       SPACK_PYTHON: python
+       SPACK_TEST_PARALLEL: 4
+       COVERAGE: true
+       COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
+       UNIT_TEST_COVERAGE: ${{ matrix.python-version == '3.14' }}
+     run: |-
+       share/spack/qa/run-unit-tests
 
 
 Note that the ssh session comes after Spack does its setup but before it runs the unit tests.

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -462,6 +462,8 @@ Spack's source should be available already (depending on where the step was inse
 .. note:: If you are on Windows you'll be dropped into an MSYS shell, Spack is not supported inside MSYS, so it is strongly recommended to drop into a CMD or powershell prompt.
 
 
+Once you have finished debugging, remove this action from the Github actions workflow.
+
 Developer environment
 ---------------------
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -402,7 +402,7 @@ Unit testing
 ------------
 
 Debugging Unit Tests in CI
------------------------
+--------------------------
 
 Spack runs its CI for unit tests via Github Actions from the Spack repo.
 The unit tests are run for each platform Spack supports, Windows, Linux, and MacOS.
@@ -412,6 +412,7 @@ Thankfully, PR authors can take advantage of a Github Actions Action to gain tem
 Simply copy the following Github actions yaml stanza into the `<spack_root>/.github/workflows/unit_tests.yaml` GHA workflow file in the `steps` section of whatever unit test needs debugging.
 
 .. code-block:: yaml
+
    - name: Setup tmate session
    uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
 
@@ -421,6 +422,7 @@ You can of course put this stanza after the unit-tests, but then you'll be stuck
 For example, if you were to add this step to the Linux unit test CI, it would look something like:
 
 .. code-block:: yaml
+
    - name: Bootstrap clingo
    if: ${{ matrix.concretizer == 'clingo' }}
    env:
@@ -450,6 +452,7 @@ This action provides access to an SSH server running on the GHA runner that is h
 As the action runs, you should observe output similar to:
 
 .. code-block:: bash
+
    ssh 5RjFs7LPdtwGG8cwSPkGrdMNg@sfo2.tmate.io
    https://tmate.io/t/5RjFs7LPdtwGG8cwSPkGrdMNg
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -401,6 +401,67 @@ Unit tests
 Unit testing
 ------------
 
+Debugging Unit Tests in CI
+-----------------------
+
+Spack runs its CI for unit tests via Github Actions from the Spack repo. The unit tests are run for each platform Spack supports, Windows, Linux, and MacOS.
+It may be the case that a unit test fails or passes on one of these platforms. When the platform is one the PR author does not have access to, it can be difficult to reproduce, diagnose, and fix a CI failure.
+Thankfully, PR authors can take advantage of a Github Actions Action to gain temporary access to the failing platform from the context of their PRs.
+Simply copy the following Github actions yaml stanza into the `<spack_root>/.github/workflows/unit_tests.yaml` GHA workflow file in the `steps` section of whatever unit test needs debugging.
+
+```yaml
+- name: Setup tmate session
+  uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+```
+
+Ideally this would be inserted somewhere after GHA checks out Spack and does any setup, but before the unit tests themselves are run.
+You can of course put this stanza after the unit-tests, but then you'll be stuck waiting for the unit tests to complete (potentially up to ~30m) and will need to add additional logic to the yaml in the case where the unit tests fail.
+
+For example, if you were to add this step to the Linux unit test CI, it would look something like:
+
+```yaml
+    - name: Bootstrap clingo
+      if: ${{ matrix.concretizer == 'clingo' }}
+      env:
+          SPACK_PYTHON: python
+      run: |
+          . share/spack/setup-env.sh
+          spack bootstrap disable spack-install
+          spack bootstrap now
+          spack -v solve zlib
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+    - name: Run unit tests
+      env:
+          SPACK_PYTHON: python
+          SPACK_TEST_PARALLEL: 4
+          COVERAGE: true
+          COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
+          UNIT_TEST_COVERAGE: ${{ matrix.python-version == '3.14' }}
+      run: |
+          share/spack/qa/run-unit-tests
+```
+
+Note that the ssh session comes after Spack does its setup but before it runs the unit tests.
+
+Once this step is present in the job definition, it will be triggered for each CI run.
+This action provides access to an SSH server running on the GHA runner that is hosting a given CI run. As the action runs, you should observe output similar to:
+
+```bash
+ssh 5RjFs7LPdtwGG8cwSPkGrdMNg@sfo2.tmate.io
+https://tmate.io/t/5RjFs7LPdtwGG8cwSPkGrdMNg
+```
+The first line is the ssh command neccesary to connect to the server, the second line is a tmate web-ui that also provides access to the ssh server on the runner.
+.. note:: the UI has occasionally been unresponsive. If it does not respond within ~10s, you'll need to use your local ssh utility.
+
+Once connected via SSH, you have the same level of access to the machine that the CI job's user does.
+Spack's source should be available already (depending on where the step was inserted). So you can just setup the shell to run Spack via the setup scripts and then debug as needed.
+
+.. note:: If you have configured your Github profile with SSH keys, the action will be aware of this and require those keys to access the SSH session.
+
+.. note:: If you are on Windows you'll be dropped into an MSYS shell, Spack is not supported inside MSYS, so it is strongly recommended to drop into a CMD or powershell prompt.
+
+
 Developer environment
 ---------------------
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -409,7 +409,7 @@ The unit tests are run for each platform Spack supports, Windows, Linux, and Mac
 It may be the case that a unit test fails or passes on one of these platforms.
 When the platform is one the PR author does not have access to, it can be difficult to reproduce, diagnose, and fix a CI failure.
 Thankfully, PR authors can take advantage of a Github Actions Action to gain temporary access to the failing platform from the context of their PRs.
-Simply copy the following Github actions yaml stanza into the `<spack_root>/.github/workflows/unit_tests.yaml` GHA workflow file in the `steps` section of whatever unit test needs debugging.
+Simply copy the following Github actions yaml stanza into `the GHA workflow file <https://github.com/spack/spack/blob/develop/.github/workflows/unit_tests.yaml>`__ in the `steps` section of whatever unit test needs debugging.
 
 .. code-block:: yaml
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -451,7 +451,7 @@ Once this step is present in the job definition, it will be triggered for each C
 This action provides access to an SSH server running on the GHA runner that is hosting a given CI run.
 As the action runs, you should observe output similar to:
 
-.. code-block:: bash
+.. code-block:: console
 
    ssh 5RjFs7LPdtwGG8cwSPkGrdMNg@sfo2.tmate.io
    https://tmate.io/t/5RjFs7LPdtwGG8cwSPkGrdMNg


### PR DESCRIPTION
Spack runs unit tests on many platforms, not all devs have access to all platforms. This PR provides instructions on using GHA to get temporary access to all supported platforms.

Basic steps:
* Copy yaml stanza from docs into GHA workflow for relevant unit test run
* Run unit tests
* Connect to created SSH server
* Debug unit tests
* Profit

Questions:
* Do we want to provide a basic workflow that is not available by default, but folks can just move into the workflows directory that provides similar functionality but doesn't require folks to modify the unit tests workflow yaml?
* Do we want to provide an `on_dispatch` triggered version of this that will just checkout Spack and drop into an ssh session (I'm leaning no, but figured I'd pose the question)?
* Do we want some of the action's options enabled from our example?
