### PR TITLE
spec: fix issue with `%<virtual>` satisfying itself

### DIFF
--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -205,3 +205,18 @@ class TestSpecList:
         # Ensure that only mpich~debug is selected, and that the assembled spec remains abstract.
         assert len(result.specs) == 1
         assert result.specs[0] == Spec(f"mpileaks ^callpath ^mpich/{mpich_2.dag_hash(5)}")
+
+    @pytest.mark.regression("51703")
+    def test_exclusion_with_conditional_dependencies(self):
+        """Tests that we can exclude some spec using conditional dependencies in the exclusion."""
+        parser = SpecListParser()
+        result = parser.parse_user_specs(
+            name="specs",
+            yaml_list=[
+                {
+                    "matrix": [["libunwind"], ["%[when=%c]c=gcc", "%[when=%c]c=llvm"]],
+                    "exclude": ["libunwind %[when=%c]c=gcc"],
+                }
+            ],
+        )
+        assert len(result.specs) == 1

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2464,3 +2464,12 @@ def test_attribute_existence_in_satisfies(spec_str, assertions, mock_packages, c
     s = Spec(spec_str)
     for test, expected in assertions:
         assert s.satisfies(test) is expected
+
+
+@pytest.mark.regression("51768")
+@pytest.mark.parametrize("spec_str", ["mpi", "%mpi", "^mpi", "%foo", "%c=gcc", "%[when=%c]c=gcc"])
+def test_specs_semantics_on_self(spec_str, mock_packages, config):
+    """Tests that an abstract spec satisfies and intersects with itself."""
+    s = Spec(spec_str)
+    assert s.satisfies(s)
+    assert s.intersects(s)


### PR DESCRIPTION
fixes #51703
fixes #51768
closes #51668

This commit adds logic to treat cases like:
```
(%mpi).satisfies(%mpi)
(^mpi).satisfies(^mpi)
```
correctly. As a consequence, it fixes an issue with matrix expansion related to the bug.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
