### PR TITLE
Windows: Disable parallel concretization

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -149,7 +149,8 @@ def concretize_separately(
     num_procs = min(len(args), spack.config.determine_number_of_jobs(parallel=True))
 
     msg = "Starting concretization"
-    if num_procs > 1:
+    # no parallel conc on Windows
+    if not sys.platform == "win32" and num_procs > 1:
         msg += f" pool with {num_procs} processes"
     tty.msg(msg)
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3319,6 +3319,7 @@ def test_spec_unification(unify, mutable_config, mock_packages):
         _ = spack.cmd.parse_specs([a_restricted, b], concretize=True)
 
 
+@pytest.mark.not_on_windows("parallelism unsupported on Windows")
 @pytest.mark.enable_parallelism
 def test_parallel_concretization(mutable_config, mock_packages):
     """Test whether parallel unify-false style concretization works."""

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -77,7 +77,7 @@ def imap_unordered(
         RuntimeError: if any error occurred in the worker processes
     """
 
-    if not ENABLE_PARALLELISM or len(list_of_args) <= 1:
+    if not ENABLE_PARALLELISM or len(list_of_args) <= 1 or sys.platform == "win32":
         yield from map(f, list_of_args)
         return
 
@@ -118,6 +118,7 @@ def make_concurrent_executor(
         not ENABLE_PARALLELISM
         or (require_fork and multiprocessing.get_start_method() != "fork")
         or sys.version_info[:2] == (3, 6)
+        or sys.platform == "win32"
     ):
         return SequentialExecutor()
 

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -11,7 +11,7 @@ from typing import Optional
 import spack.config
 
 #: Used in tests to disable parallelism, as tests themselves are parallelized
-ENABLE_PARALLELISM = True
+ENABLE_PARALLELISM = sys.platform != "win32"
 
 
 class ErrorFromWorker:
@@ -77,7 +77,7 @@ def imap_unordered(
         RuntimeError: if any error occurred in the worker processes
     """
 
-    if not ENABLE_PARALLELISM or len(list_of_args) <= 1 or sys.platform == "win32":
+    if not ENABLE_PARALLELISM or len(list_of_args) <= 1:
         yield from map(f, list_of_args)
         return
 
@@ -118,7 +118,6 @@ def make_concurrent_executor(
         not ENABLE_PARALLELISM
         or (require_fork and multiprocessing.get_start_method() != "fork")
         or sys.version_info[:2] == (3, 6)
-        or sys.platform == "win32"
     ):
         return SequentialExecutor()
 


### PR DESCRIPTION
Parallel concretization on Windows is error prone and will take substantial effort to fix. Disable for now.

I think this should be sufficient to disable the parallelism (trying to concretize an env with multiple specs and unify: false does not spin up multiple processes) but let me know if I missed a spot.