### PR TITLE
new_installer.py: delay "setup_package" until after install from binary cache

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -430,7 +430,6 @@ def _install(
 
     # Create the stage and log file before starting the tee thread.
     pkg = spec.package
-    spack.build_environment.setup_package(pkg, dirty=dirty)
 
     # Try to install from buildcache, unless user asked for source only
     if install_policy != "source_only":
@@ -442,6 +441,7 @@ def _install(
             send_state("no binary available", state_stream)
             raise spack.error.InstallError(f"No binary available for {spec}")
 
+    spack.build_environment.setup_package(pkg, dirty=dirty)
     store.layout.create_install_directory(spec)
 
     stage = pkg.stage


### PR DESCRIPTION
Shouldn't be necessary to define all environment variables and module
globals when installing from a binary cache. It's probably sometimes
somewhat time consuming to do so, so avoid it.

