### PR TITLE
Authentication schemes are case-insensitive (RFC 7235)

### DIFF
--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -14,7 +14,7 @@ import urllib.parse
 import urllib.request
 from enum import Enum, auto
 from http.client import HTTPResponse
-from typing import Callable, Dict, Iterable, List, Literal, NamedTuple, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple
 from urllib.request import Request
 
 import spack.config
@@ -97,7 +97,7 @@ class Challenge:
             and self.params == other.params
         )
 
-    def matches_scheme(self, scheme: Literal["Bearer", "Basic"]) -> bool:
+    def matches_scheme(self, scheme: str) -> bool:
         """Checks whether the challenge matches the given scheme, case-insensitive."""
         return self.scheme.lower() == scheme.lower()
 

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -101,6 +101,10 @@ class Challenge:
         """Checks whether the challenge matches the given scheme, case-insensitive."""
         return self.scheme == scheme.lower()
 
+    def get_param(self, key: str) -> str | None:
+        """Get the value of an auth param by key, or None if not found."""
+        return next((v for k, v in self.params if k == key.lower()), None)
+
 
 def parse_www_authenticate(input: str):
     """Very basic parsing of www-authenticate parsing (RFC7235 section 4.1)
@@ -123,7 +127,7 @@ def parse_www_authenticate(input: str):
 
     def extract_auth_param(input: str) -> Tuple[str, str]:
         key, value = input.split("=", 1)
-        key = key.rstrip()
+        key = key.rstrip().lower()
         value = value.lstrip()
         if value.startswith('"'):
             value = unquote(value)
@@ -216,9 +220,9 @@ def _get_bearer_challenge(challenges: List[Challenge]) -> Optional[RealmServiceS
         return None
 
     # Get realm / service / scope from challenge
-    realm = next((v for k, v in challenge.params if k == "realm"), None)
-    service = next((v for k, v in challenge.params if k == "service"), None)
-    scope = next((v for k, v in challenge.params if k == "scope"), None)
+    realm = challenge.get_param("realm")
+    service = challenge.get_param("service")
+    scope = challenge.get_param("scope")
 
     if realm is None or service is None or scope is None:
         return None
@@ -233,7 +237,7 @@ def _get_basic_challenge(challenges: List[Challenge]) -> Optional[str]:
     if challenge is None:
         return None
 
-    return next((v for k, v in challenge.params if k == "realm"), None)
+    return challenge.get_param("realm")
 
 
 class OCIAuthHandler(urllib.request.BaseHandler):

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -14,7 +14,7 @@ import urllib.parse
 import urllib.request
 from enum import Enum, auto
 from http.client import HTTPResponse
-from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Literal, NamedTuple, Optional, Tuple
 from urllib.request import Request
 
 import spack.config
@@ -97,6 +97,10 @@ class Challenge:
             and self.params == other.params
         )
 
+    def matches_scheme(self, scheme: Literal["Bearer", "Basic"]) -> bool:
+        """Checks whether the challenge matches the given scheme, case-insensitive."""
+        return self.scheme.lower() == scheme.lower()
+
 
 def parse_www_authenticate(input: str):
     """Very basic parsing of www-authenticate parsing (RFC7235 section 4.1)
@@ -132,7 +136,7 @@ def parse_www_authenticate(input: str):
             if token.kind == WwwAuthenticateTokens.EOF:
                 raise ValueError(token)
             elif token.kind == WwwAuthenticateTokens.TOKEN:
-                current_challenge.scheme = token.value.lower()
+                current_challenge.scheme = token.value
                 mode = State.AUTH_PARAM_LIST_START
             else:
                 raise ValueError(token)
@@ -206,7 +210,7 @@ class UsernamePassword(NamedTuple):
 
 def _get_bearer_challenge(challenges: List[Challenge]) -> Optional[RealmServiceScope]:
     """Return the realm/service/scope for a Bearer auth challenge, or None if not found."""
-    challenge = next((c for c in challenges if c.scheme.lower() == "bearer"), None)
+    challenge = next((c for c in challenges if c.matches_scheme("Bearer")), None)
 
     if challenge is None:
         return None
@@ -224,7 +228,7 @@ def _get_bearer_challenge(challenges: List[Challenge]) -> Optional[RealmServiceS
 
 def _get_basic_challenge(challenges: List[Challenge]) -> Optional[str]:
     """Return the realm for a Basic auth challenge, or None if not found."""
-    challenge = next((c for c in challenges if c.scheme.lower() == "basic"), None)
+    challenge = next((c for c in challenges if c.matches_scheme("Basic")), None)
 
     if challenge is None:
         return None

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -132,7 +132,7 @@ def parse_www_authenticate(input: str):
             if token.kind == WwwAuthenticateTokens.EOF:
                 raise ValueError(token)
             elif token.kind == WwwAuthenticateTokens.TOKEN:
-                current_challenge.scheme = token.value
+                current_challenge.scheme = token.value.lower()
                 mode = State.AUTH_PARAM_LIST_START
             else:
                 raise ValueError(token)

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -101,7 +101,7 @@ class Challenge:
         """Checks whether the challenge matches the given scheme, case-insensitive."""
         return self.scheme == scheme.lower()
 
-    def get_param(self, key: str):
+    def get_param(self, key: str) -> Optional[str]:
         """Get the value of an auth param by key, or None if not found."""
         return next((v for k, v in self.params if k == key.lower()), None)
 

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -206,7 +206,7 @@ class UsernamePassword(NamedTuple):
 
 def _get_bearer_challenge(challenges: List[Challenge]) -> Optional[RealmServiceScope]:
     """Return the realm/service/scope for a Bearer auth challenge, or None if not found."""
-    challenge = next((c for c in challenges if c.scheme == "Bearer"), None)
+    challenge = next((c for c in challenges if c.scheme.lower() == "bearer"), None)
 
     if challenge is None:
         return None
@@ -224,7 +224,7 @@ def _get_bearer_challenge(challenges: List[Challenge]) -> Optional[RealmServiceS
 
 def _get_basic_challenge(challenges: List[Challenge]) -> Optional[str]:
     """Return the realm for a Basic auth challenge, or None if not found."""
-    challenge = next((c for c in challenges if c.scheme == "Basic"), None)
+    challenge = next((c for c in challenges if c.scheme.lower() == "basic"), None)
 
     if challenge is None:
         return None

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -101,7 +101,7 @@ class Challenge:
         """Checks whether the challenge matches the given scheme, case-insensitive."""
         return self.scheme == scheme.lower()
 
-    def get_param(self, key: str) -> str | None:
+    def get_param(self, key: str):
         """Get the value of an auth param by key, or None if not found."""
         return next((v for k, v in self.params if k == key.lower()), None)
 

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -99,7 +99,7 @@ class Challenge:
 
     def matches_scheme(self, scheme: str) -> bool:
         """Checks whether the challenge matches the given scheme, case-insensitive."""
-        return self.scheme.lower() == scheme.lower()
+        return self.scheme == scheme.lower()
 
 
 def parse_www_authenticate(input: str):
@@ -136,7 +136,7 @@ def parse_www_authenticate(input: str):
             if token.kind == WwwAuthenticateTokens.EOF:
                 raise ValueError(token)
             elif token.kind == WwwAuthenticateTokens.TOKEN:
-                current_challenge.scheme = token.value
+                current_challenge.scheme = token.value.lower()
                 mode = State.AUTH_PARAM_LIST_START
             else:
                 raise ValueError(token)
@@ -180,7 +180,7 @@ def parse_www_authenticate(input: str):
                 raise ValueError(token)
             elif token.kind == WwwAuthenticateTokens.TOKEN:
                 challenges.append(current_challenge)
-                current_challenge = Challenge(token.value)
+                current_challenge = Challenge(token.value.lower())
                 mode = State.AUTH_PARAM_LIST_START
             elif token.kind == WwwAuthenticateTokens.AUTH_PARAM:
                 key, value = extract_auth_param(token.value)

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -54,7 +54,7 @@ def test_parse_www_authenticate():
     www_authenticate = 'Bearer realm="https://spack.io/authenticate",service="spack-registry",scope="repository:spack-registry:pull,push"'
     assert parse_www_authenticate(www_authenticate) == [
         Challenge(
-            "Bearer",
+            "bearer",
             [
                 ("realm", "https://spack.io/authenticate"),
                 ("service", "spack-registry"),
@@ -63,18 +63,18 @@ def test_parse_www_authenticate():
         )
     ]
 
-    assert parse_www_authenticate("Bearer") == [Challenge("Bearer")]
+    assert parse_www_authenticate("Bearer") == [Challenge("bearer")]
     assert parse_www_authenticate("MethodA, MethodB,MethodC") == [
-        Challenge("MethodA"),
-        Challenge("MethodB"),
-        Challenge("MethodC"),
+        Challenge("methoda"),
+        Challenge("methodb"),
+        Challenge("methodc"),
     ]
 
     assert parse_www_authenticate(
         'Digest realm="Digest Realm", nonce="1234567890", algorithm=MD5, qop="auth"'
     ) == [
         Challenge(
-            "Digest",
+            "digest",
             [
                 ("realm", "Digest Realm"),
                 ("nonce", "1234567890"),
@@ -87,12 +87,12 @@ def test_parse_www_authenticate():
     assert parse_www_authenticate(
         r'Newauth realm="apps", type=1, title="Login to \"apps\"", Basic realm="simple"'
     ) == [
-        Challenge("Newauth", [("realm", "apps"), ("type", "1"), ("title", 'Login to "apps"')]),
-        Challenge("Basic", [("realm", "simple")]),
+        Challenge("newauth", [("realm", "apps"), ("type", "1"), ("title", 'Login to "apps"')]),
+        Challenge("basic", [("realm", "simple")]),
     ]
 
     assert parse_www_authenticate(r'BASIC realm="simple"') == [
-        Challenge("BASIC", [("realm", "simple")])
+        Challenge("basic", [("realm", "simple")])
     ]
 
 
@@ -128,7 +128,7 @@ def test_get_basic_challenge():
         _get_basic_challenge(
             [
                 Challenge(
-                    "Bearer",
+                    "bearer",
                     [
                         ("realm", "https://spack.io/authenticate"),
                         ("service", "spack-registry"),
@@ -136,7 +136,7 @@ def test_get_basic_challenge():
                     ],
                 ),
                 Challenge(
-                    "Digest",
+                    "digest",
                     [
                         ("realm", "Digest Realm"),
                         ("nonce", "1234567890"),
@@ -154,16 +154,16 @@ def test_get_basic_challenge():
         _get_basic_challenge(
             [
                 Challenge(
-                    "Dummy",
+                    "dummy",
                     [
                         ("realm", "https://example.com/"),
                         ("service", "service"),
                         ("scope", "scope"),
                     ],
                 ),
-                Challenge("Basic", [("realm", "simple")]),
+                Challenge("basic", [("realm", "simple")]),
                 Challenge(
-                    "Bearer",
+                    "bearer",
                     [
                         ("realm", "https://spack.io/authenticate"),
                         ("service", "spack-registry"),
@@ -176,7 +176,7 @@ def test_get_basic_challenge():
     )
 
     # authentication scheme written in all-caps, should match nonetheless
-    assert _get_basic_challenge([Challenge("BASIC", [("realm", "simple")])]) == "simple"
+    assert _get_basic_challenge([Challenge("basic", [("realm", "simple")])]) == "simple"
 
 
 def test_get_bearer_challenge():
@@ -186,8 +186,8 @@ def test_get_bearer_challenge():
     assert (
         _get_bearer_challenge(
             [
-                Challenge("Bearer", [("realm", "https://spack.io/authenticate")]),
-                Challenge("Basic", [("realm", "simple")]),
+                Challenge("bearer", [("realm", "https://spack.io/authenticate")]),
+                Challenge("basic", [("realm", "simple")]),
                 Challenge(
                     "Digest",
                     [
@@ -206,11 +206,11 @@ def test_get_bearer_challenge():
     assert _get_bearer_challenge(
         [
             Challenge(
-                "Dummy",
+                "dummy",
                 [("realm", "https://example.com/"), ("service", "service"), ("scope", "scope")],
             ),
             Challenge(
-                "Bearer",
+                "bearer",
                 [
                     ("realm", "https://spack.io/authenticate"),
                     ("service", "spack-registry"),
@@ -226,7 +226,7 @@ def test_get_bearer_challenge():
     assert _get_bearer_challenge(
         [
             Challenge(
-                "BEARER",
+                "bearer",
                 [
                     ("realm", "https://spack.io/authenticate"),
                     ("service", "spack-registry"),

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -223,7 +223,20 @@ def test_get_bearer_challenge():
     )
 
     # authentication scheme written in all-caps, should match nonetheless
-    assert _get_basic_challenge([Challenge("BEARER", [("realm", "simple")])]) == "simple"
+    assert _get_bearer_challenge(
+        [
+            Challenge(
+                "BEARER",
+                [
+                    ("realm", "https://spack.io/authenticate"),
+                    ("service", "spack-registry"),
+                    ("scope", "repository:spack-registry:pull,push"),
+                ],
+            )
+        ]
+    ) == RealmServiceScope(
+        "https://spack.io/authenticate", "spack-registry", "repository:spack-registry:pull,push"
+    )
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -54,7 +54,7 @@ def test_parse_www_authenticate():
     www_authenticate = 'Bearer realm="https://spack.io/authenticate",service="spack-registry",scope="repository:spack-registry:pull,push"'
     assert parse_www_authenticate(www_authenticate) == [
         Challenge(
-            "bearer",
+            "Bearer",
             [
                 ("realm", "https://spack.io/authenticate"),
                 ("service", "spack-registry"),
@@ -63,18 +63,18 @@ def test_parse_www_authenticate():
         )
     ]
 
-    assert parse_www_authenticate("Bearer") == [Challenge("bearer")]
+    assert parse_www_authenticate("Bearer") == [Challenge("Bearer")]
     assert parse_www_authenticate("MethodA, MethodB,MethodC") == [
-        Challenge("methoda"),
-        Challenge("methodb"),
-        Challenge("methodc"),
+        Challenge("MethodA"),
+        Challenge("MethodB"),
+        Challenge("MethodC"),
     ]
 
     assert parse_www_authenticate(
         'Digest realm="Digest Realm", nonce="1234567890", algorithm=MD5, qop="auth"'
     ) == [
         Challenge(
-            "digest",
+            "Digest",
             [
                 ("realm", "Digest Realm"),
                 ("nonce", "1234567890"),
@@ -87,12 +87,12 @@ def test_parse_www_authenticate():
     assert parse_www_authenticate(
         r'Newauth realm="apps", type=1, title="Login to \"apps\"", Basic realm="simple"'
     ) == [
-        Challenge("newauth", [("realm", "apps"), ("type", "1"), ("title", 'Login to "apps"')]),
-        Challenge("basic", [("realm", "simple")]),
+        Challenge("Newauth", [("realm", "apps"), ("type", "1"), ("title", 'Login to "apps"')]),
+        Challenge("Basic", [("realm", "simple")]),
     ]
 
     assert parse_www_authenticate(r'BASIC realm="simple"') == [
-        Challenge("basic", [("realm", "simple")])
+        Challenge("BASIC", [("realm", "simple")])
     ]
 
 

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -54,7 +54,7 @@ def test_parse_www_authenticate():
     www_authenticate = 'Bearer realm="https://spack.io/authenticate",service="spack-registry",scope="repository:spack-registry:pull,push"'
     assert parse_www_authenticate(www_authenticate) == [
         Challenge(
-            "Bearer",
+            "bearer",
             [
                 ("realm", "https://spack.io/authenticate"),
                 ("service", "spack-registry"),
@@ -63,18 +63,18 @@ def test_parse_www_authenticate():
         )
     ]
 
-    assert parse_www_authenticate("Bearer") == [Challenge("Bearer")]
+    assert parse_www_authenticate("Bearer") == [Challenge("bearer")]
     assert parse_www_authenticate("MethodA, MethodB,MethodC") == [
-        Challenge("MethodA"),
-        Challenge("MethodB"),
-        Challenge("MethodC"),
+        Challenge("methoda"),
+        Challenge("methodb"),
+        Challenge("methodc"),
     ]
 
     assert parse_www_authenticate(
         'Digest realm="Digest Realm", nonce="1234567890", algorithm=MD5, qop="auth"'
     ) == [
         Challenge(
-            "Digest",
+            "digest",
             [
                 ("realm", "Digest Realm"),
                 ("nonce", "1234567890"),
@@ -87,8 +87,12 @@ def test_parse_www_authenticate():
     assert parse_www_authenticate(
         r'Newauth realm="apps", type=1, title="Login to \"apps\"", Basic realm="simple"'
     ) == [
-        Challenge("Newauth", [("realm", "apps"), ("type", "1"), ("title", 'Login to "apps"')]),
-        Challenge("Basic", [("realm", "simple")]),
+        Challenge("newauth", [("realm", "apps"), ("type", "1"), ("title", 'Login to "apps"')]),
+        Challenge("basic", [("realm", "simple")]),
+    ]
+
+    assert parse_www_authenticate(r'BASIC realm="simple"') == [
+        Challenge("basic", [("realm", "simple")])
     ]
 
 
@@ -171,6 +175,9 @@ def test_get_basic_challenge():
         == "simple"
     )
 
+    # authentication scheme written in all-caps, should match nonetheless
+    assert _get_basic_challenge([Challenge("BASIC", [("realm", "simple")])]) == "simple"
+
 
 def test_get_bearer_challenge():
     """Test extracting Bearer challenge from a list of challenges"""
@@ -214,6 +221,9 @@ def test_get_bearer_challenge():
     ) == RealmServiceScope(
         "https://spack.io/authenticate", "spack-registry", "repository:spack-registry:pull,push"
     )
+
+    # authentication scheme written in all-caps, should match nonetheless
+    assert _get_basic_challenge([Challenge("BEARER", [("realm", "simple")])]) == "simple"
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -91,7 +91,7 @@ def test_parse_www_authenticate():
         Challenge("basic", [("realm", "simple")]),
     ]
 
-    assert parse_www_authenticate(r'BASIC realm="simple"') == [
+    assert parse_www_authenticate(r'BASIC REALM="simple"') == [
         Challenge("basic", [("realm", "simple")])
     ]
 
@@ -175,9 +175,6 @@ def test_get_basic_challenge():
         == "simple"
     )
 
-    # authentication scheme written in all-caps, should match nonetheless
-    assert _get_basic_challenge([Challenge("basic", [("realm", "simple")])]) == "simple"
-
 
 def test_get_bearer_challenge():
     """Test extracting Bearer challenge from a list of challenges"""
@@ -217,22 +214,6 @@ def test_get_bearer_challenge():
                     ("scope", "repository:spack-registry:pull,push"),
                 ],
             ),
-        ]
-    ) == RealmServiceScope(
-        "https://spack.io/authenticate", "spack-registry", "repository:spack-registry:pull,push"
-    )
-
-    # authentication scheme written in all-caps, should match nonetheless
-    assert _get_bearer_challenge(
-        [
-            Challenge(
-                "bearer",
-                [
-                    ("realm", "https://spack.io/authenticate"),
-                    ("service", "spack-registry"),
-                    ("scope", "repository:spack-registry:pull,push"),
-                ],
-            )
         ]
     ) == RealmServiceScope(
         "https://spack.io/authenticate", "spack-registry", "repository:spack-registry:pull,push"


### PR DESCRIPTION
[RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235) specifies that HTTP 
> uses a case-insensitive token as a means to identify the authentication scheme

This PR modifies the authentication challenge matching logic to be case-insensitive for the authentication schemes "Bearer" and "Basic".