### PR TITLE
schema/concretizer.py: remove enable_node_namespace

### DIFF
--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -99,10 +99,6 @@ properties: Dict[str, Any] = {
                     },
                 ],
             },
-            "enable_node_namespace": {
-                "type": "boolean",
-                "description": "Enable node namespace functionality in the concretizer",
-            },
             "targets": {
                 "type": "object",
                 "description": "Controls which target microarchitectures are considered "


### PR DESCRIPTION
This option was added for some ancient tutorial, and is not used.

