### PR TITLE
git: pull_checkout_branch RHEL7 git 1.8.3.1 fix

### DIFF
--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -202,7 +202,7 @@ def pull_checkout_branch(
             raise ValueError("depth must be a positive integer")
         fetch_args.append(f"--depth={depth}")
 
-    git_exe("fetch", *fetch_args, remote, branch)
+    git_exe("fetch", *fetch_args, remote, f"{branch}:refs/remotes/{remote}/{branch}")
     git_exe("checkout", "--quiet", branch)
 
     try:


### PR DESCRIPTION
Closes #51750

Currently Spack is unusable on RHEL7 because `git fetch origin develop`
does not create `refs/remotes/origin/develop`. Don't ask me why.

Solution is to use

```
git fetch origin develop:refs/remotes/origin/develop
```

explicitly.
