### PR TITLE
solver: use penalties for variant values

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1590,7 +1590,7 @@ class SpackSolverSetup:
         if variant_def.sticky:
             pkg_fact(fn.variant_sticky(vid))
 
-        # define defaults for this variant definition
+        # Get the default values for this variant definition as a tuple
         default_values: Tuple[Union[bool, str], ...] = (variant_def.default,)
         if variant_def.multi:
             default_values = variant_def.make_default().values
@@ -1598,39 +1598,34 @@ class SpackSolverSetup:
         for val in default_values:
             pkg_fact(fn.variant_default_value_from_package_py(vid, val))
 
-        if variant_def.values is not None:
-            # Put default values first, otherwise keep the order
-            penalty = 1
-            for v in default_values:
-                pkg_fact(fn.variant_penalty(vid, v, penalty))
-                penalty += 1
+        # Deal with variants that use validator functions
+        if variant_def.values_defined_by_validator():
+            for value in default_values:
+                pkg_fact(fn.variant_possible_value(vid, value))
+            self.gen.newline()
+            return
 
-            for v in variant_def.values:
-                if v not in default_values:
-                    pkg_fact(fn.variant_penalty(vid, v, penalty))
-                    penalty += 1
+        values = variant_def.values or default_values
 
-        # define possible values for this variant definition
-        values = variant_def.values
-        if values is None:
-            values = []
-
-        elif isinstance(values, vt.DisjointSetsOfValues):
-            union: Set[str] = set()
+        # If we deal with disjoint sets of values, define the sets
+        if isinstance(values, vt.DisjointSetsOfValues):
             for sid, s in enumerate(values.sets):
                 for value in s:
                     pkg_fact(fn.variant_value_from_disjoint_sets(vid, value, sid))
-                union.update(s)
-            values = union
 
-        # ensure that every variant has at least one possible value.
-        if not values:
-            values = [variant_def.default]
+        # Define penalties. Put default values first, otherwise keep the order
+        penalty = 1
+        for v in default_values:
+            pkg_fact(fn.variant_penalty(vid, v, penalty))
+            penalty += 1
 
-        for value in sorted(values):
-            pkg_fact(fn.variant_possible_value(vid, value))
+        for v in values:
+            if v not in default_values:
+                pkg_fact(fn.variant_penalty(vid, v, penalty))
+                penalty += 1
 
-            # we're done here for unconditional values
+        # Deal with conditional values
+        for value in values:
             if not isinstance(value, vt.ConditionalValue):
                 continue
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1591,11 +1591,17 @@ class SpackSolverSetup:
             pkg_fact(fn.variant_sticky(vid))
 
         # define defaults for this variant definition
+        default_values: Tuple[Union[bool, str], ...] = (variant_def.default,)
         if variant_def.multi:
-            for val in sorted(variant_def.make_default().values):
-                pkg_fact(fn.variant_default_value_from_package_py(vid, val))
-        else:
-            pkg_fact(fn.variant_default_value_from_package_py(vid, variant_def.default))
+            default_values = variant_def.make_default().values
+
+        for val in default_values:
+            pkg_fact(fn.variant_default_value_from_package_py(vid, val))
+
+        if variant_def.values is not None:
+            current_values = sorted(variant_def.values, key=lambda v: (v not in default_values, v))
+            for penalty, v in enumerate(current_values, 1):
+                pkg_fact(fn.variant_penalty(vid, v, penalty))
 
         # define possible values for this variant definition
         values = variant_def.values

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1599,10 +1599,16 @@ class SpackSolverSetup:
             pkg_fact(fn.variant_default_value_from_package_py(vid, val))
 
         if variant_def.values is not None:
-            # Put default values first, otherwise keep the order since sort is stable
-            current_values = sorted(variant_def.values, key=lambda v: v not in default_values)
-            for penalty, v in enumerate(current_values, 1):
+            # Put default values first, otherwise keep the order
+            penalty = 1
+            for v in default_values:
                 pkg_fact(fn.variant_penalty(vid, v, penalty))
+                penalty += 1
+
+            for v in variant_def.values:
+                if v not in default_values:
+                    pkg_fact(fn.variant_penalty(vid, v, penalty))
+                    penalty += 1
 
         # define possible values for this variant definition
         values = variant_def.values

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1599,7 +1599,8 @@ class SpackSolverSetup:
             pkg_fact(fn.variant_default_value_from_package_py(vid, val))
 
         if variant_def.values is not None:
-            current_values = sorted(variant_def.values, key=lambda v: (v not in default_values, v))
+            # Put default values first, otherwise keep the order since sort is stable
+            current_values = sorted(variant_def.values, key=lambda v: v not in default_values)
             for penalty, v in enumerate(current_values, 1):
                 pkg_fact(fn.variant_penalty(vid, v, penalty))
 
@@ -1609,9 +1610,9 @@ class SpackSolverSetup:
             values = []
 
         elif isinstance(values, vt.DisjointSetsOfValues):
-            union = set()
-            for sid, s in enumerate(sorted(values.sets)):
-                for value in sorted(s):
+            union: Set[str] = set()
+            for sid, s in enumerate(values.sets):
+                for value in s:
                     pkg_fact(fn.variant_value_from_disjoint_sets(vid, value, sid))
                 union.update(s)
             values = union

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1348,6 +1348,16 @@ variant_default_value(node(NodeID, Package), VariantName, Value) :-
     node_has_variant(node(NodeID, Package), VariantName, _),
     attr("variant_default_value_from_cli", node(min_dupe_id, Package), VariantName, Value).
 
+variant_penalty(node(NodeID, Package), Variant, Value, Penalty) :-
+    node_has_variant(node(NodeID, Package), Variant, VariantID),
+    attr("variant_value", node(NodeID, Package), Variant, Value),
+    pkg_fact(Package, variant_penalty(VariantID, Value, Penalty)),
+    not variant_default_value(node(NodeID, Package), Variant, Value),
+    % variants set explicitly on the CLI don't count as non-default
+    not attr("variant_set", node(NodeID, Package), Variant, Value),
+    % variant values forced by propagation don't count as non-default
+    not propagate(node(NodeID, Package), variant_value(Variant, Value, _)).
+
 % -- Associate the definition's possible values with the node
 variant_possible_value(node(NodeID, Package), VariantName, Value) :-
   node_has_variant(node(NodeID, Package), VariantName, VariantID),
@@ -1455,22 +1465,11 @@ error(100, "{0} variant '{1}' cannot have values '{2}' and '{3}' as they come fr
 :- attr("variant_set", node(ID, Package), Variant, Value),
    not attr("variant_value", node(ID, Package), Variant, Value).
 
-% The rules below allow us to prefer default values for variants
-% whenever possible. If a variant is set in a spec, or if it is
-% specified in an external, we score it as if it was a default value.
-variant_not_default(node(ID, Package), Variant, Value)
- :- attr("variant_value", node(ID, Package), Variant, Value),
-    not variant_default_value(node(ID, Package), Variant, Value),
-    % variants set explicitly on the CLI don't count as non-default
-    not attr("variant_set", node(ID, Package), Variant, Value),
-    % variant values forced by propagation don't count as non-default
-    not propagate(node(ID, Package), variant_value(Variant, Value, _)),
-    attr("node", node(ID, Package)).
-
-% A default variant value that is not used
+% A default variant value that is not used, makes sense only for multi valued variants
 variant_default_not_used(node(ID, Package), Variant, Value)
   :- variant_default_value(node(ID, Package), Variant, Value),
-     node_has_variant(node(ID, Package), Variant, _),
+     node_has_variant(node(ID, Package), Variant, VariantID),
+     variant_type(VariantID, VariantType), VariantType == "multi",
      not attr("variant_value", node(ID, Package), Variant, Value),
      not propagate(node(ID, Package), variant_value(Variant, _, _)),
      % variant set explicitly don't count for this metric
@@ -2060,12 +2059,12 @@ opt_criterion(70, "version badness (roots)").
       build_priority(PackageNode, Priority)
 }.
 
-opt_criterion(65, "number of non-default variants (roots)").
+opt_criterion(65, "variant penalty (roots)").
 #minimize{ 0@265: #true }.
 #minimize{ 0@65: #true }.
 #minimize {
-    1@65+Priority,PackageNode,Variant,Value
-    : variant_not_default(PackageNode, Variant, Value),
+    Penalty@65+Priority,PackageNode,Variant,Value
+    : variant_penalty(PackageNode, Variant, Value, Penalty),
       attr("root", PackageNode),
       build_priority(PackageNode, Priority)
 }.
@@ -2091,12 +2090,12 @@ opt_criterion(55, "default values of variants not being used (roots)").
 }.
 
 % Try to use default variants or variants that have been set
-opt_criterion(50, "number of non-default variants (non-roots)").
+opt_criterion(50, "variant penalty (non-roots)").
 #minimize{ 0@250: #true }.
 #minimize{ 0@50: #true }.
 #minimize {
-    1@50+Priority,PackageNode,Variant,Value
-    : variant_not_default(PackageNode, Variant, Value),
+    Penalty@50+Priority,PackageNode,Variant,Value
+    : variant_penalty(PackageNode, Variant, Value, Penalty),
       not attr("root", PackageNode),
       build_priority(PackageNode, Priority)
 }.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1353,10 +1353,10 @@ variant_penalty(node(NodeID, Package), Variant, Value, Penalty) :-
     attr("variant_value", node(NodeID, Package), Variant, Value),
     pkg_fact(Package, variant_penalty(VariantID, Value, Penalty)),
     not variant_default_value(node(NodeID, Package), Variant, Value),
-    % variants set explicitly on the CLI don't count as non-default
-    not attr("variant_set", node(NodeID, Package), Variant, Value),
+    % variants set explicitly from a directive don't count as non-default
+    not attr("variant_set", node(NodeID, Package), Variant, _),
     % variant values forced by propagation don't count as non-default
-    not propagate(node(NodeID, Package), variant_value(Variant, Value, _)).
+    not propagate(node(NodeID, Package), variant_value(Variant, _, _)).
 
 % -- Associate the definition's possible values with the node
 variant_possible_value(node(NodeID, Package), VariantName, Value) :-

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1363,6 +1363,10 @@ variant_possible_value(node(NodeID, Package), VariantName, Value) :-
   node_has_variant(node(NodeID, Package), VariantName, VariantID),
   pkg_fact(Package, variant_possible_value(VariantID, Value)).
 
+variant_possible_value(node(NodeID, Package), VariantName, Value) :-
+  node_has_variant(node(NodeID, Package), VariantName, VariantID),
+  pkg_fact(Package, variant_penalty(VariantID, Value, _)).
+
 variant_value_from_disjoint_sets(node(NodeID, Package), VariantName, Value1, Set1) :-
   node_has_variant(node(NodeID, Package), VariantName, VariantID),
   pkg_fact(Package, variant_value_from_disjoint_sets(VariantID, Value1, Set1)).

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2083,6 +2083,21 @@ spack:
         trilinos = result.specs[0]
         assert trilinos.satisfies("cxxstd=20")
 
+        # Test a disjoint set of values to ensure declared package order is respected
+        result, _, _ = solver.driver.solve(setup, [Spec("mvapich2")], reuse=external_specs)
+
+        weights = weights_from_result(result, name="variant penalty (roots)")
+        assert weights["reused"] == 0 and weights["built"] == 0
+        mvapich2 = result.specs[0]
+        assert mvapich2.satisfies("file_systems=auto")
+
+        result, _, _ = solver.driver.solve(setup, [Spec("mvapich2+noauto")], reuse=external_specs)
+
+        weights = weights_from_result(result, name="variant penalty (roots)")
+        assert weights["reused"] == 0 and weights["built"] == 2
+        mvapich2 = result.specs[0]
+        assert mvapich2.satisfies("file_systems=lustre")
+
     @pytest.mark.regression("51267")
     @pytest.mark.parametrize(
         "packages_config,expected",

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -316,10 +316,10 @@ def gcc11_with_flags(compiler_factory):
 
 def weights_from_result(result: Result, *, name: str) -> Dict[str, int]:
     weights = {}
-    for x in [x for x in result.criteria if x.name == name]:
-        if x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
+    for x in result.criteria:
+        if x.name == name and x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
             weights["reused"] = x.value
-        else:
+        elif x.name == name and x.kind == spack.solver.asp.OptimizationKind.BUILD:
             weights["built"] = x.value
     return weights
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -43,6 +43,7 @@ import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack.externals import ExternalDependencyError
 from spack.installer import PackageInstaller
+from spack.solver.asp import Result
 from spack.solver.reuse import SpecFilter, create_external_parser
 from spack.solver.runtimes import external_config_with_implicit_externals
 from spack.spec import Spec
@@ -311,6 +312,16 @@ def gcc11_with_flags(compiler_factory):
     c = compiler_factory(spec="gcc@11.1.0 languages:=c,c++,fortran os=redhat6")
     c["extra_attributes"]["flags"] = {"cflags": "-O0 -g", "cxxflags": "-O0 -g", "fflags": "-O0 -g"}
     return c
+
+
+def weights_from_result(result: Result, *, name: str) -> Dict[str, int]:
+    weights = {}
+    for x in [x for x in result.criteria if x.name == name]:
+        if x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
+            weights["reused"] = x.value
+        else:
+            weights["built"] = x.value
+    return weights
 
 
 # This must use the mutable_config fixture because the test
@@ -2017,18 +2028,60 @@ spack:
             # pkg_fact("pkg-b", version_origin("0.9", "installed")).
             # pkg_fact("pkg-b", version_origin("0.9", "package_py")).
 
-            weights = {}
-            for x in [x for x in result.criteria if x.name == "version badness (non roots)"]:
-                if x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
-                    weights["reused"] = x.value
-                else:
-                    weights["built"] = x.value
-
+            weights = weights_from_result(result, name="version badness (non roots)")
             assert weights["reused"] == 3 and weights["built"] == 0
 
             result_spec = result.specs[0]
             assert result_spec.satisfies("^pkg-b@1.0")
             assert result_spec["pkg-b"].dag_hash() == reusable_specs[1].dag_hash()
+
+    @pytest.mark.regression("51112")
+    def test_variant_penalty(self, mutable_config):
+        """Test package preferences during concretization."""
+        packages_with_externals = external_config_with_implicit_externals(mutable_config)
+        completion_mode = mutable_config.get("concretizer:externals:completion")
+        external_specs = SpecFilter.from_packages_yaml(
+            external_parser=create_external_parser(packages_with_externals, completion_mode),
+            packages_with_externals=packages_with_externals,
+            include=[],
+            exclude=[],
+        ).selected_specs()
+
+        # The variant definition is similar to
+        #
+        # % Variant cxxstd in package trilinos
+        # pkg_fact("trilinos",variant_definition("cxxstd",195)).
+        # variant_type(195,"single").
+        # pkg_fact("trilinos",variant_default_value_from_package_py(195,"14")).
+        # pkg_fact("trilinos",variant_penalty(195,"14",1)).
+        # pkg_fact("trilinos",variant_penalty(195,"17",2)).
+        # pkg_fact("trilinos",variant_penalty(195,"20",3)).
+        # pkg_fact("trilinos",variant_possible_value(195,"14")).
+        # pkg_fact("trilinos",variant_possible_value(195,"17")).
+        # pkg_fact("trilinos",variant_possible_value(195,"20")).
+
+        solver = spack.solver.asp.Solver()
+        setup = spack.solver.asp.SpackSolverSetup()
+
+        # Ensure that since the default value of 14 cannot be taken, we select "17"
+        result, _, _ = solver.driver.solve(setup, [Spec("trilinos")], reuse=external_specs)
+
+        weights = weights_from_result(result, name="variant penalty (roots)")
+        assert weights["reused"] == 0 and weights["built"] == 2
+
+        trilinos = result.specs[0]
+        assert trilinos.satisfies("cxxstd=17")
+
+        # If we disable "17", then "20" is next, and the penalty is higher
+        result, _, _ = solver.driver.solve(
+            setup, [Spec("trilinos+disable17")], reuse=external_specs
+        )
+
+        weights = weights_from_result(result, name="variant penalty (roots)")
+        assert weights["reused"] == 0 and weights["built"] == 3
+
+        trilinos = result.specs[0]
+        assert trilinos.satisfies("cxxstd=20")
 
     @pytest.mark.regression("51267")
     @pytest.mark.parametrize(

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -519,20 +519,20 @@ def test_disjoint_set_initialization():
 
     assert d.default == "none"
     assert d.multi is True
-    assert set(x for x in d) == set(["none", "a", "b", "c", "e", "f"])
+    assert list(d) == ["none", "a", "b", "c", "e", "f"]
 
 
 def test_disjoint_set_fluent_methods():
     # Construct an object without the empty set
     d = disjoint_sets(("a",), ("b", "c"), ("e", "f")).prohibit_empty_set()
-    assert set(("none",)) not in d.sets
+    assert ("none",) not in d.sets
 
     # Call this 2 times to check that no matter whether
     # the empty set was allowed or not before, the state
     # returned is consistent.
     for _ in range(2):
         d = d.allow_empty_set()
-        assert set(("none",)) in d.sets
+        assert ("none",) in d.sets
         assert "none" in d
         assert "none" in [x for x in d]
         assert "none" in d.feature_values
@@ -550,7 +550,7 @@ def test_disjoint_set_fluent_methods():
     # returned is consistent.
     for _ in range(2):
         d = d.prohibit_empty_set()
-        assert set(("none",)) not in d.sets
+        assert ("none",) not in d.sets
         assert "none" not in d
         assert "none" not in [x for x in d]
         assert "none" not in d.feature_values

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -18,6 +18,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Set,
     Tuple,
     Type,
     Union,
@@ -519,23 +520,28 @@ class DisjointSetsOfValues(collections.abc.Sequence):
         *sets (list): mutually exclusive sets of values
     """
 
-    _empty_set = {"none"}
+    _empty_set = ("none",)
 
     def __init__(self, *sets: Tuple[str, ...]) -> None:
-        self.sets = [set(_flatten(x)) for x in sets]
+        self.sets = [tuple(_flatten(x)) for x in sets]
 
-        # 'none' is a special value and can appear only in a set of
-        # a single element
-        if any("none" in s and s != {"none"} for s in self.sets):
+        # 'none' is a special value and can appear only in a set of a single element
+        if any("none" in s and s != self._empty_set for s in self.sets):
             raise spack.error.SpecError(
-                "The value 'none' represents the empty set,"
-                " and must appear alone in a set. Use the "
-                "method 'allow_empty_set' to add it."
+                "The value 'none' represents the empty set, and must appear alone in a set. "
+                "Use the method 'allow_empty_set' to add it."
             )
 
         # Sets should not intersect with each other
-        if any(s1 & s2 for s1, s2 in itertools.combinations(self.sets, 2)):
-            raise spack.error.SpecError("sets in input must be disjoint")
+        cumulated: Set[str] = set()
+        for current_set in self.sets:
+            intersection = cumulated.intersection(set(current_set))
+            if intersection:
+                raise spack.error.SpecError(
+                    f"sets in input must be disjoint, but {', '.join(sorted(intersection))} "
+                    f"appeared more than once"
+                )
+            cumulated.update(current_set)
 
         #: Attribute used to track values which correspond to
         #: features which can be enabled or disabled as understood by the

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -153,6 +153,9 @@ class Variant:
         self.sticky = sticky
         self.precedence = precedence
 
+    def values_defined_by_validator(self) -> bool:
+        return self.values is None
+
     def validate_or_raise(self, vspec: "VariantValue", pkg_name: str):
         """Validate a variant spec against this package variant. Raises an
         exception if any error is found.
@@ -599,7 +602,7 @@ class DisjointSetsOfValues(collections.abc.Sequence):
         return tuple(itertools.chain.from_iterable(self.sets))[idx]
 
     def __len__(self):
-        return len(itertools.chain.from_iterable(self.sets))
+        return len(tuple(itertools.chain.from_iterable(self.sets)))
 
     @property
     def validator(self):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -601,7 +601,7 @@ class DisjointSetsOfValues(collections.abc.Sequence):
         return tuple(itertools.chain.from_iterable(self.sets))[idx]
 
     def __len__(self):
-        return len(tuple(itertools.chain.from_iterable(self.sets)))
+        return sum(len(x) for x in self.sets)
 
     @property
     def validator(self):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -538,11 +538,10 @@ class DisjointSetsOfValues(collections.abc.Sequence):
         # Sets should not intersect with each other
         cumulated: Set[str] = set()
         for current_set in self.sets:
-            intersection = cumulated.intersection(set(current_set))
-            if intersection:
+            if not cumulated.isdisjoint(current_set):
+                duplicates = ", ".join(sorted(cumulated.intersection(current_set)))
                 raise spack.error.SpecError(
-                    f"sets in input must be disjoint, but {', '.join(sorted(intersection))} "
-                    f"appeared more than once"
+                    f"sets in input must be disjoint, but {duplicates} appeared more than once"
                 )
             cumulated.update(current_set)
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/mvapich2/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/mvapich2/package.py
@@ -17,3 +17,6 @@ class Mvapich2(Package):
         description="List of the ROMIO file systems to activate",
         values=auto_or_any_combination_of("lustre", "gpfs", "nfs", "ufs"),
     )
+    variant("noauto", default=False, description="Adds a conflict with 'auto' for tests")
+
+    conflicts("file_systems=auto", when="+noauto")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/trilinos/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/trilinos/package.py
@@ -21,3 +21,15 @@ class Trilinos(Package):
 
     depends_on("mpi")
     depends_on("callpath")
+
+    # The variant default value cannot be taken by the default version of the package
+    variant("disable17", default=False, description="Disable support for C++17")
+    variant(
+        "cxxstd",
+        default="14",
+        description="C++ standard",
+        values=["14", "17", "20", "23"],
+        multi=False,
+    )
+    conflicts("cxxstd=14", when="@16:")
+    conflicts("cxxstd=17", when="+disable17")


### PR DESCRIPTION
fixes #51112

On develop nodes in a DAG get a penalty of 1 when a variant value is not the default. This might lead to cases of non-determinism, due to having multiple optimal solutions.

Here we give different penalties to different non-default values, thereby reducing the non-determinism in concretization.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
