### PR TITLE
package_hash.py: do not copy input spec

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -606,7 +606,7 @@ def _ensure_packages_are_unparseable(pkgs, error_cls):
     errors = []
     for pkg_name in pkgs:
         try:
-            source = ph.canonical_source(pkg_name, filter_multimethods=False)
+            source = ph.canonical_source(spack.spec.Spec(pkg_name), filter_multimethods=False)
         except Exception as e:
             error_msg = "Package '{}' failed to unparse".format(pkg_name)
             details = ["{}".format(str(e))]

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -335,7 +335,7 @@ class ResolveMultiMethods(ast.NodeTransformer):
 
 
 def canonical_source(
-    spec, filter_multimethods: bool = True, source: Optional[bytes] = None
+    spec: spack.spec.Spec, filter_multimethods: bool = True, source: Optional[bytes] = None
 ) -> str:
     """Get canonical source for a spec's package.py by unparsing its AST.
 
@@ -347,7 +347,7 @@ def canonical_source(
     return unparse(package_ast(spec, filter_multimethods, source=source), py_ver_consistent=True)
 
 
-def package_hash(spec, source: Optional[bytes] = None) -> str:
+def package_hash(spec: spack.spec.Spec, source: Optional[bytes] = None) -> str:
     """Get a hash of a package's canonical source code.
 
     This function is used to determine whether a spec needs a rebuild when a
@@ -361,7 +361,9 @@ def package_hash(spec, source: Optional[bytes] = None) -> str:
     return spack.util.hash.b32_hash(source)
 
 
-def package_ast(spec, filter_multimethods: bool = True, source: Optional[bytes] = None) -> ast.AST:
+def package_ast(
+    spec: spack.spec.Spec, filter_multimethods: bool = True, source: Optional[bytes] = None
+) -> ast.AST:
     """Get the AST for the ``package.py`` file corresponding to ``spec``.
 
     Arguments:
@@ -369,8 +371,6 @@ def package_ast(spec, filter_multimethods: bool = True, source: Optional[bytes] 
             statically to be unused. Supply False to disable.
         source: Optionally provide a string to read python code from.
     """
-    spec = spack.spec.Spec(spec)
-
     if source is None:
         filename = spack.repo.PATH.filename_for_package_name(spec.name)
         with open(filename, "rb") as f:


### PR DESCRIPTION
It's guaranteed to be a Spec, and Spec(spec) copies unnecessarily. The
instance is only used to branch on `spec.satisfies(cond)`.

