### PR TITLE
Compiler mixing: always allow for externals

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1702,6 +1702,7 @@ unification_set_compiler("root", CompilerNode, Language) :-
     node_compiler(node(ID, Package), CompilerNode, Language),
     no_compiler_mixing(Language),
     not allow_mixing(Package),
+    not external(node(ID, Package)),
     unification_set("root", node(ID, Package)).
 
 % Compiler for a reused node
@@ -1731,6 +1732,7 @@ unification_set_compiler("root", CompilerNode, Language) :-
     attr("hash", CompilerNode, CompilerHash),
     no_compiler_mixing(Language),
     not allow_mixing(Package),
+    not external(node(ID, Package)),
     unification_set("root", node(ID, Package)).
 
 % Compiler-unmixing: 3rd rule
@@ -1742,6 +1744,7 @@ unification_set_compiler("root", node(CompilerHash, Compiler), Language) :-
     not attr("hash", _, CompilerHash),
     no_compiler_mixing(Language),
     not allow_mixing(Package),
+    not external(node(ID, Package)),
     unification_set("root", node(ID, Package)).
 
 #defined no_compiler_mixing/1.

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -580,19 +580,16 @@ spack:
                     assert root["dt-diamond-left"].satisfies("%llvm")
                     assert root["dt-diamond-bottom"].satisfies("%llvm")
 
-    def test_disable_mixing_externals(
-        self, mutable_config
-    ):
+    def test_disable_mixing_externals(self, mutable_config):
         mutable_config.set(
             "packages",
             {
                 "dt-diamond-bottom": {
                     "buildable": False,
-                    "externals": [{
-                        "prefix": "/fake/prefix/",
-                        "spec": "dt-diamond-bottom@1.0%gcc@9.4.1"
-                    }]
-                },
+                    "externals": [
+                        {"prefix": "/fake/prefix/", "spec": "dt-diamond-bottom@1.0%gcc@9.4.1"}
+                    ],
+                }
             },
         )
         # Sanity check, make sure the external is usable in least-constrained context

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -599,8 +599,9 @@ spack:
         spack.concretize.concretize_one("dt-diamond")
         with spack.config.override("concretizer", {"compiler_mixing": False}):
             x = spack.concretize.concretize_one("dt-diamond%clang")
-            import pdb; pdb.set_trace()
-            print('hi')
+            assert x["dt-diamond-bottom"].external
+            assert x["dt-diamond-bottom"].satisfies("%gcc")
+            assert x.satisfies("%clang")
 
     def test_compiler_inherited_upwards(self):
         spec = spack.concretize.concretize_one("dt-diamond ^dt-diamond-bottom%clang")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -580,6 +580,28 @@ spack:
                     assert root["dt-diamond-left"].satisfies("%llvm")
                     assert root["dt-diamond-bottom"].satisfies("%llvm")
 
+    def test_disable_mixing_externals(
+        self, mutable_config
+    ):
+        mutable_config.set(
+            "packages",
+            {
+                "dt-diamond-bottom": {
+                    "buildable": False,
+                    "externals": [{
+                        "prefix": "/fake/prefix/",
+                        "spec": "dt-diamond-bottom@1.0%gcc@9.4.1"
+                    }]
+                },
+            },
+        )
+        # Sanity check, make sure the external is usable in least-constrained context
+        spack.concretize.concretize_one("dt-diamond")
+        with spack.config.override("concretizer", {"compiler_mixing": False}):
+            x = spack.concretize.concretize_one("dt-diamond%clang")
+            import pdb; pdb.set_trace()
+            print('hi')
+
     def test_compiler_inherited_upwards(self):
         spec = spack.concretize.concretize_one("dt-diamond ^dt-diamond-bottom%clang")
         for x in spec.traverse(deptype=("link", "run")):


### PR DESCRIPTION
https://github.com/spack/spack/pull/51135 added

```
concretizer:
  compiler_mixing: false
```

which tells spack not to mix compilers between link/run dependencies. That PR also applied to externals (accidentally): this amends the logic so that even when `compiler_mixing: false`, externals can specify whatever compiler they want.