### PR TITLE
`compiler_mixing:` config option applies per-language

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1716,8 +1716,9 @@ unification_set_compiler("root", node(CompilerHash, Compiler), Language) :-
 #defined allow_mixing/1.
 
 % You can't have >1 compiler for a given language if mixing is disabled
-error(100, "Compiler mixing is disabled") :-
-    #count { CompilerNode : unification_set_compiler("root", CompilerNode, Language) } > 1.
+error(100, "Compiler mixing is disabled for the {0} language", Language) :-
+    language(Language),
+	  #count { CompilerNode : unification_set_compiler("root", CompilerNode, Language) } > 1.
 
 %-----------------------------------------------------------------------------
 % Runtimes

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -497,6 +497,10 @@ class TestConcretize:
             with pytest.raises(spack.error.UnsatisfiableSpecError):
                 spack.concretize.concretize_one("dt-diamond%clang ^dt-diamond-bottom%gcc")
 
+    def test_disable_mixing_is_per_language(self):
+        with spack.config.override("concretizer", {"compiler_mixing": False}):
+            spack.concretize.concretize_one("openblas %c=llvm %fortran=gcc")
+
     def test_disable_mixing_override_by_package(self):
         with spack.config.override("concretizer", {"compiler_mixing": ["dt-diamond-bottom"]}):
             root = spack.concretize.concretize_one("dt-diamond%clang ^dt-diamond-bottom%gcc")


### PR DESCRIPTION
If you set

```
concretizer:
  compiler_mixing: false
```

then it should allow using different compilers for C and Fortran. As it was, https://github.com/spack/spack/pull/51135 was forcing all dependencies to use the same compiler for all languages.

This also updates the error generation to provide more info about which languages generated a mixing violation (when mixing is disallowed), and the compilers that were selected.