### PR TITLE
Fix a typo with class definition in typing.py

### DIFF
--- a/lib/spack/spack/util/typing.py
+++ b/lib/spack/spack/util/typing.py
@@ -40,4 +40,4 @@ class SupportsRichComparison(Protocol):
 
 
 if not TYPE_CHECKING:
-    SupportRichComparison = object
+    SupportsRichComparison = object

--- a/lib/spack/spack/util/typing.py
+++ b/lib/spack/spack/util/typing.py
@@ -16,28 +16,28 @@ from typing import TYPE_CHECKING, Any
 
 from spack.vendor.typing_extensions import Protocol
 
+if TYPE_CHECKING:
 
-class SupportsRichComparison(Protocol):
-    """Objects that support =, !=, <, <=, >, and >=."""
+    class SupportsRichComparison(Protocol):
+        """Objects that support =, !=, <, <=, >, and >=."""
 
-    def __eq__(self, other: Any) -> bool:
-        raise NotImplementedError
+        def __eq__(self, other: Any) -> bool:
+            raise NotImplementedError
 
-    def __ne__(self, other: Any) -> bool:
-        raise NotImplementedError
+        def __ne__(self, other: Any) -> bool:
+            raise NotImplementedError
 
-    def __lt__(self, other: Any) -> bool:
-        raise NotImplementedError
+        def __lt__(self, other: Any) -> bool:
+            raise NotImplementedError
 
-    def __le__(self, other: Any) -> bool:
-        raise NotImplementedError
+        def __le__(self, other: Any) -> bool:
+            raise NotImplementedError
 
-    def __gt__(self, other: Any) -> bool:
-        raise NotImplementedError
+        def __gt__(self, other: Any) -> bool:
+            raise NotImplementedError
 
-    def __ge__(self, other: Any) -> bool:
-        raise NotImplementedError
+        def __ge__(self, other: Any) -> bool:
+            raise NotImplementedError
 
-
-if not TYPE_CHECKING:
-    SupportsRichComparison = object  # noqa: F811
+else:
+    SupportsRichComparison = object

--- a/lib/spack/spack/util/typing.py
+++ b/lib/spack/spack/util/typing.py
@@ -40,4 +40,4 @@ class SupportsRichComparison(Protocol):
 
 
 if not TYPE_CHECKING:
-    SupportsRichComparison = object
+    SupportsRichComparison = object  # noqa: F811


### PR DESCRIPTION
In #51781 the idea is to speed up common operations while not sacrificing type checking by using two different definitions of `SupportsRichComparison`.

There is a typo in the second definition that is fixed here

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
