### PR TITLE
Fix a few classes using `__slots__`

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -16,7 +16,6 @@ concurrency:
 
 
 jobs:
-  # Validate that the code can be run on all the Python versions supported by Spack
   validate:
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +26,7 @@ jobs:
     - name: Install Python Packages
       run: |
         pip install -r .github/workflows/requirements/style/requirements.txt
+    # Validate that the code can be run on all the Python versions supported by Spack
     - name: vermin
       run: |
         vermin --backport importlib \
@@ -37,6 +37,10 @@ jobs:
                -vvv \
                --exclude-regex lib/spack/spack/vendor \
                lib/spack/spack/ lib/spack/llnl/ bin/ var/spack/test_repos
+    # Check that __slots__ are used properly
+    - name: slotscheck
+      run: |
+        ./bin/spack python -m slotscheck --exclude-modules="spack.test|spack.vendor" lib/spack/spack/
 
   # Run style checks on the files that have been changed
   style:

--- a/.github/workflows/requirements/style/requirements.txt
+++ b/.github/workflows/requirements/style/requirements.txt
@@ -8,3 +8,4 @@ vermin==1.8.0
 pylint==4.0.4
 docutils==0.22.4
 ruamel.yaml==0.18.16
+slotscheck==0.19.1

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -31,6 +31,8 @@ ast_sym = _ast_getter("symbol", "term")
 class AspObject:
     """Object representing a piece of ASP code."""
 
+    __slots__ = ()
+
 
 def _id(thing: Any) -> Union[str, int, AspObject]:
     """Quote string if needed for it to be a valid identifier."""
@@ -51,6 +53,8 @@ class AspVar(AspObject):
     """Represents a variable in an ASP rule, allows for conditionally generating
     rules"""
 
+    __slots__ = ("name",)
+
     def __init__(self, name: str):
         self.name = name
 
@@ -62,7 +66,7 @@ class AspVar(AspObject):
 class AspFunction(AspObject):
     """A term in the ASP logic program"""
 
-    __slots__ = ["name", "args"]
+    __slots__ = ("name", "args")
 
     def __init__(self, name: str, args: Optional[Tuple[Any, ...]] = None) -> None:
         self.name = name

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -292,7 +292,7 @@ class NamePathModifier(NameValueModifier):
     """Base class for modifiers that modify the value of an environment variable
     that is a path."""
 
-    __slots__ = ("name", "value", "separator", "trace")
+    __slots__ = ()
 
     def __init__(
         self,

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -172,6 +172,8 @@ class VersionType(SupportsRichComparison):
 
     """
 
+    __slots__ = ()
+
     def intersection(self, other: "VersionType") -> "VersionType":
         """Any versions contained in both self and other, or empty VersionList if no overlap."""
         raise NotImplementedError
@@ -199,6 +201,8 @@ class VersionType(SupportsRichComparison):
 class ConcreteVersion(VersionType):
     """Base type for versions that represents a single (non-range or list) version."""
 
+    __slots__ = ()
+
 
 def _stringify_version(versions: VersionTuple, separators: Tuple[str, ...]) -> str:
     """Create a string representation from version components."""
@@ -217,7 +221,7 @@ def _stringify_version(versions: VersionTuple, separators: Tuple[str, ...]) -> s
 class StandardVersion(ConcreteVersion):
     """Class to represent versions"""
 
-    __slots__ = ["version", "_string", "separators"]
+    __slots__ = ("version", "_string", "separators")
 
     _string: str
     version: VersionTuple
@@ -552,7 +556,7 @@ class GitVersion(ConcreteVersion):
     sufficient.
     """
 
-    __slots__ = ["has_git_prefix", "commit_sha", "ref", "std_version", "_ref_lookup"]
+    __slots__ = ("has_git_prefix", "commit_sha", "ref", "is_commit", "std_version", "_ref_lookup")
 
     def __init__(self, string: str):
         # TODO will be required for concrete specs when commit lookup added


### PR DESCRIPTION
A few classes using slots inherit from base classes *not* using slots, or declare again the same slots in derived classes. This reduces the benefits of slots since:
- When we inherit from a base not using slots, a `__dict__` is always present in the object instance
- When we declare the same slot multiple times in a hierarchy, we may reserve multiple slots with the same name, but can access only one

In this PR we fix those issues and add a CI check to avoid them in the future.

Modifications:
- Added a CI job that fails when there are issues with `__slots__` (see [here](https://github.com/spack/spack/actions/runs/20570405128/job/59076372542))
- Fix `GitVersion`, `StandardVersion` and `AspFunction` base classes
- Fix `NamePathModifier` defining overlapping slots

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
