### PR TITLE
spec.py: optimize constructor

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1533,7 +1533,7 @@ class Spec:
 
         # init an empty spec that matches anything.
         self.name: str = ""
-        self.versions = vn.VersionList(":")
+        self.versions = vn.VersionList.any()
         self.variants = VariantMap(self)
         self.architecture = None
         self.compiler_flags = FlagMap(self)

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -513,13 +513,6 @@ class StandardVersion(ConcreteVersion):
         return self.up_to(3)
 
 
-_STANDARD_VERSION_TYPEMIN = StandardVersion("", ((), (ALPHA,)), ("",))
-
-_STANDARD_VERSION_TYPEMAX = StandardVersion(
-    "infinity", ((VersionStrComponent(len(infinity_versions)),), (FINAL,)), ("",)
-)
-
-
 class GitVersion(ConcreteVersion):
     """Class to represent versions interpreted from git refs.
 
@@ -781,6 +774,8 @@ class GitVersion(ConcreteVersion):
 
 
 class ClosedOpenRange(VersionType):
+    __slots__ = ("lo", "hi")
+
     def __init__(self, lo: StandardVersion, hi: StandardVersion):
         if hi < lo:
             raise EmptyRangeError(f"{lo}..{hi} is an empty range")
@@ -1074,6 +1069,13 @@ class VersionList(VersionType):
             return VersionList([Version(dictionary["version"])])
         raise ValueError("Dict must have 'version' or 'versions' in it.")
 
+    @classmethod
+    def any(cls) -> "VersionList":
+        """Return a VersionList that matches any version."""
+        version_list = cls.__new__(cls)
+        version_list.versions = [_UNBOUNDED_RANGE]
+        return version_list
+
     def update(self, other: "VersionList") -> None:
         self.add(other)
 
@@ -1332,3 +1334,14 @@ def ver(obj: Union[VersionType, str, list, tuple, int, float]) -> VersionType:
         return from_string(str(obj))
     else:
         raise TypeError("ver() can't convert %s to version!" % type(obj))
+
+
+_STANDARD_VERSION_TYPEMIN = StandardVersion("", ((), (ALPHA,)), ("",))
+
+_STANDARD_VERSION_TYPEMAX = StandardVersion(
+    "infinity", ((VersionStrComponent(len(infinity_versions)),), (FINAL,)), ("",)
+)
+
+_UNBOUNDED_RANGE = ClosedOpenRange.from_version_range(
+    _STANDARD_VERSION_TYPEMIN, _STANDARD_VERSION_TYPEMAX
+)


### PR DESCRIPTION
Running `Spec()` triggers the parser to run on a single byte `":"`, which then
triggers slow construction of a version range object.

Given that the parser itself runs `Spec()` a lot when parsing dependencies, there's
a curious unintended recursion worth fixing.

Using timeit the constructor goes from 3.25us -> 1.90us. Package load time
improves from 27.3s -> 24.1s, or about 11% reduction.


```
time python3 -c 'import spack.repo; x = list(spack.repo.PATH.all_package_classes())'
```
