### PR TITLE
spack find: group pre Spack v1.0 specs together by compiler

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4508,6 +4508,11 @@ class Spec:
 
     @property
     def compilers(self):
+        if self.original_spec_format() < 5:
+            # These specs don't have compilers as dependencies, return the
+            # specfile format and compiler
+            return f"[specfile v{self.original_spec_format()}] {self.compiler}"
+
         # TODO: get rid of the space here and make formatting smarter
         return " " + self._format_dependencies(
             "{name}{@version}",


### PR DESCRIPTION
Since #50909 the `spack find` command has been displaying specfile formats < 5 under the `no compilers` group.

This was likely due to the incomplete information we have on language / compiler associations for specs using these old formats. This PR refines how we display these specs and uses the annotated compiler spec _and_ the specfile format to group them.

**Before**
<img width="1603" height="594" alt="Screenshot from 2026-01-06 09-49-07" src="https://github.com/user-attachments/assets/efa1f78d-8ab3-49ab-b7ea-051fe46f7ee9" />

**After**
<img width="1534" height="641" alt="Screenshot from 2026-01-06 09-46-30" src="https://github.com/user-attachments/assets/f952c225-f499-4908-a0a2-d5e8c1ac72fb" />


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
