### PR TITLE
spec.py: fix SpecBuildInterface pickling issue

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4973,6 +4973,12 @@ class Spec:
         # As with to_dict, do not include dependents. This avoids serializing more than intended.
         state.pop("_dependents", None)
 
+        # Do not pickle attributes dynamically set by SpecBuildInterface
+        state.pop("wrapped_obj", None)
+        state.pop("token", None)
+        state.pop("last_query", None)
+        state.pop("indirect_spec", None)
+
         # Optimize variants and compiler_flags serialization
         variants = state.pop("variants", None)
         if variants:


### PR DESCRIPTION
Closes #51804

SpecBuildInterface acts as a proxy for Spec objects by sharing their `__dict__`
(it inherits from `ObjectWrapper`). Because of this, attributes specific to the
proxy (like `token`, `wrapped_obj`, etc.) are written directly into the Spec's
dictionary.

When pickling a SpecBuildInterface, it reduces to a reconstruction call using
the underlying Spec. However, since the Spec's `__getstate__` was serializing
its polluted `__dict__`, these proxy-specific attributes were included in the
pickle payload, creating a reference cycle and causing deserialization failures
in multiprocessing contexts.

This commit modifies `Spec.__getstate__` to explicitly remove these injected
attributes before pickling, ensuring a clean serialization of the Spec object.

---

I did not manage to extract a minimal reproducer where pickling actually fails
like in #51804, so no test is added.