### PR TITLE
CI: Add an environment option for build cache index update behavior

### DIFF
--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -704,3 +704,15 @@ Optional.
 Only needed if you want ``spack ci rebuild`` to trust the key you store in this variable, in which case, it will subsequently be used to sign and verify binary packages (when installing or creating build caches).
 You could also have already trusted a key Spack knows about, or if no key is present anywhere, Spack will install specs using ``--no-check-signature`` and create build caches using ``-u`` (for unsigned binaries).
 
+``SPACK_CI_BUILDCACHE_VIEW``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Optional.
+Only needed when using a ``buildcache-destination`` mirror that points at a build cache view.
+This option affects the behavior the ``reindex`` job (:ref:`rebuild_index`) can have the values ``force`` or ``append`` which mirror behavior described by ref:`cmd-spack-buildcache-update-view`.
+The default option is ``append`` because that is what is used by the Spack build farm.
+
+.. warning::
+
+   Using the ``append`` option with build cache index views is a non-atomic operation.
+   It is up to the CI maintainer to ensure that concurrent writes to the build cache are handled appropriately.

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -255,7 +255,7 @@ def create_already_built_pruner(check_index_only: bool = True) -> PrunerCallback
         if not spec_locations:
             return RebuildDecision(True, "not found anywhere")
 
-        urls = ",".join(f"{loc.url}@v{loc.version}" for loc in spec_locations)
+        urls = ",".join(f"{loc:_url@v_version? (view: _view)}" for loc in spec_locations)
         message = f"up-to-date [{urls}]"
         return RebuildDecision(False, message)
 

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -617,12 +617,6 @@ class SpackCIConfig:
                         f"spack buildcache update-index --keys {' '.join(update_index_extra_args)} buildcache-destination"]
                 }
             },
-            # Cleanup script
-            {
-                "cleanup-job": {
-                    "script:": ["spack -d mirror destroy {mirror_prefix}/$CI_PIPELINE_ID"]
-                }
-            },
             # Add signing job tags
             {"signing-job": {"tags": ["aws", "protected", "notary"]}},
             # Remove reserved tags

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -583,10 +583,7 @@ class SpackCIConfig:
         defaults = [
             {
                 "build-job": {
-                    "script": [
-                        "spack env activate --without-view {env_dir}",
-                        "spack ci rebuild",
-                    ]
+                    "script": ["spack env activate --without-view {env_dir}", "spack ci rebuild"]
                 }
             },
             {"noop-job": {"script": ['echo "All specs already up to date, nothing to rebuild."']}},
@@ -600,7 +597,7 @@ class SpackCIConfig:
             option = os.environ.get("SPACK_CI_BUILDCACHE_VIEW", "append")
             if option == "append":
                 # For CI, we have to assume that this is fine
-                tty.warn("Using --append to update buildache-destination mirror index view")
+                tty.warn("Using --append to update buildcache-destination mirror index view")
                 update_index_extra_args.extend(["-y", "--append"])
             elif option == "force":
                 update_index_extra_args.append("--force")
@@ -614,7 +611,9 @@ class SpackCIConfig:
                 "reindex-job": {
                     "script:": [
                         "spack env activate --without-view {env_dir}",
-                        f"spack buildcache update-index --keys {' '.join(update_index_extra_args)} buildcache-destination"]
+                        "spack buildcache update-index --keys "
+                        + f"{' '.join(update_index_extra_args)} buildcache-destination",
+                    ]
                 }
             },
             # Add signing job tags

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -570,7 +570,12 @@ class SpackCIConfig:
 
     # Generate IR from the configs
     def generate_ir(self):
-        """Generate the IR from the Spack CI configurations."""
+        """Generate the IR from the Spack CI configurations.
+
+        Generate makes use of special strings that need to be expanded by python format.
+
+            env_dir: The concrete environment directory used in downstream jobs
+        """
 
         jobs = self.ir["jobs"]
 
@@ -579,8 +584,7 @@ class SpackCIConfig:
             {
                 "build-job": {
                     "script": [
-                        "cd {env_dir}",
-                        "spack env activate --without-view .",
+                        "spack env activate --without-view {env_dir}",
                         "spack ci rebuild",
                     ]
                 }
@@ -588,12 +592,29 @@ class SpackCIConfig:
             {"noop-job": {"script": ['echo "All specs already up to date, nothing to rebuild."']}},
         ]
 
+        pipeline_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True)
+        buildcache_destination = pipeline_mirrors["buildcache-destination"]
+        update_index_extra_args = []
+        if buildcache_destination.push_view:
+            update_index_extra_args.extend(["--name", buildcache_destination.push_view])
+            option = os.environ.get("SPACK_CI_BUILDCACHE_VIEW", "append")
+            if option == "append":
+                # For CI, we have to assume that this is fine
+                tty.warn("Using --append to update buildache-destination mirror index view")
+                update_index_extra_args.extend(["-y", "--append"])
+            elif option == "force":
+                update_index_extra_args.append("--force")
+            else:
+                raise SpackCIError(f"Unrecognized value: SPACK_CI_BUILDCACHE_VIEW={option}")
+
         # Job overrides
         overrides = [
             # Reindex script
             {
                 "reindex-job": {
-                    "script:": ["spack buildcache update-index --keys {index_target_mirror}"]
+                    "script:": [
+                        "spack env activate --without-view {env_dir}",
+                        f"spack buildcache update-index --keys {' '.join(update_index_extra_args)} buildcache-destination"]
                 }
             },
             # Cleanup script

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -596,7 +596,9 @@ class SpackCIConfig:
             update_index_extra_args.extend(["--name", buildcache_destination.push_view])
             option = os.environ.get("SPACK_CI_BUILDCACHE_VIEW", "append")
             if option == "append":
-                # For CI, we have to assume that this is fine
+                # Running this in CI relies on a guarentee from the calling context that there is
+                # only a single writter or the build cache view doesn't require a complete view
+                # after each append.
                 tty.warn("Using --append to update buildcache-destination mirror index view")
                 update_index_extra_args.extend(["-y", "--append"])
             elif option == "force":

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -396,10 +396,7 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             final_job = spack_ci_ir["jobs"]["reindex"]["attributes"]
 
             final_job["stage"] = "stage-rebuild-index"
-            final_job["script"] = unpack_script(
-                final_job["script"],
-                op=main_script_replacements,
-            )
+            final_job["script"] = unpack_script(final_job["script"], op=main_script_replacements)
 
             final_job["when"] = "always"
             final_job["retry"] = service_job_retries
@@ -408,7 +405,7 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             # it also needs to wait until all of the other stages complete.
             final_job["needs"] = [
                 {"job": generate_job_name, "pipeline": f"{generate_pipeline_id}"},
-                "wait-for-build-jobs"
+                "wait-for-build-jobs",
             ]
 
             output_object["rebuild-index"] = final_job

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -378,21 +378,38 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             output_object["sign-pkgs"] = signing_job
 
         if options.rebuild_index:
+            # Create a dummy job that runs as the stage before reindex.
+            # This job will be used to ensure reindex doesn't run until
+            # the other build jobs complete.
+            stage_names.append("stage-wait")
+            wait_job = spack_ci_ir["jobs"]["noop"]["attributes"]
+            wait_job["stage"] = "stage-wait"
+            wait_job["retry"] = 0
+            wait_job["when"] = "always"
+            wait_job["script"] = ["echo 'Open the pod bay doors HAL'"]
+            wait_job["dependencies"] = []
+
+            output_object["wait-for-build-jobs"] = wait_job
+
             # Add a final job to regenerate the index
             stage_names.append("stage-rebuild-index")
             final_job = spack_ci_ir["jobs"]["reindex"]["attributes"]
 
             final_job["stage"] = "stage-rebuild-index"
-            target_mirror = options.buildcache_destination.push_url
             final_job["script"] = unpack_script(
                 final_job["script"],
-                op=lambda cmd: cmd.replace("{index_target_mirror}", target_mirror),
+                op=main_script_replacements,
             )
 
             final_job["when"] = "always"
             final_job["retry"] = service_job_retries
             final_job["interruptible"] = True
-            final_job["dependencies"] = []
+            # update-index needs to download generate artifacts
+            # it also needs to wait until all of the other stages complete.
+            final_job["needs"] = [
+                {"job": generate_job_name, "pipeline": f"{generate_pipeline_id}"},
+                "wait-for-build-jobs"
+            ]
 
             output_object["rebuild-index"] = final_job
 

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1449,6 +1449,54 @@ def test_mirror_metadata():
         spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3@@4")
 
 
+def mirror_metadata_check_format(data, fmt, result):
+    assert fmt.format(data) == result.format(data)
+
+
+def test_mirror_metadata_format():
+    mirror_metadata = spack.binary_distribution.MirrorMetadata("https://dummy.io/__v3", 3)
+
+    # Check pass-through formatting
+    mirror_metadata_check_format(mirror_metadata, "{0:_url}", "{0.url}")
+    mirror_metadata_check_format(mirror_metadata, "{0:_version}", "{0.version}")
+    mirror_metadata_check_format(mirror_metadata, "{0:_view}", "{0.view}")
+
+    # Empty view
+    mirror_metadata_check_format(mirror_metadata, "{0:?_view}", "")
+    mirror_metadata_check_format(
+        mirror_metadata, "{0:_url?^_view^_version?^_version}", "{0.url}^{0.version}"
+    )
+    mirror_metadata_check_format(
+        mirror_metadata,
+        "{0:_url?^_view^_version?^_version?^_view^_version?^_url}",
+        "{0.url}^{0.version}^{0.url}",
+    )
+
+
+def test_mirror_metadata_format_with_view():
+    mirror_metadata = spack.binary_distribution.MirrorMetadata(
+        "https://dummy.io/__v3__@aview", 3, "aview"
+    )
+
+    # Check pass-through formatting
+    mirror_metadata_check_format(mirror_metadata, "{0:_url}", "{0.url}")
+    mirror_metadata_check_format(mirror_metadata, "{0:_version}", "{0.version}")
+    mirror_metadata_check_format(mirror_metadata, "{0:_view}", "{0.view}")
+
+    # View exists
+    mirror_metadata_check_format(mirror_metadata, "{0:?_view}", "{0.view}")
+    mirror_metadata_check_format(
+        mirror_metadata,
+        "{0:_url?^_view^_version?^_version}",
+        "{0.url}^{0.view}^{0.version}^{0.version}",
+    )
+    mirror_metadata_check_format(
+        mirror_metadata,
+        "{0:_url?^_view^_version?^_version?^_view^_version?^_url}",
+        "{0.url}^{0.view}^{0.version}^{0.version}^{0.view}^{0.version}^{0.url}",
+    )
+
+
 def test_mirror_metadata_with_view():
     mirror_metadata = spack.binary_distribution.MirrorMetadata(
         "https://dummy.io/__v3__@aview", 3, "aview"

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -193,14 +193,15 @@ spack:
     assert yaml_contents["workflow"]["rules"] == [{"when": "always"}]
 
     assert "stages" in yaml_contents
-    assert len(yaml_contents["stages"]) == 6
+    assert len(yaml_contents["stages"]) == 7
     assert yaml_contents["stages"][0] == "stage-0"
-    assert yaml_contents["stages"][5] == "stage-rebuild-index"
+    assert yaml_contents["stages"][5] == "stage-wait"
+    assert yaml_contents["stages"][6] == "stage-rebuild-index"
 
     assert "rebuild-index" in yaml_contents
     rebuild_job = yaml_contents["rebuild-index"]
     assert (
-        rebuild_job["script"][0] == f"spack buildcache update-index --keys {mirror_url.as_uri()}"
+        rebuild_job["script"][1] == "spack buildcache update-index --keys  buildcache-destination"
     )
     assert rebuild_job["custom_attribute"] == "custom!"
 
@@ -332,12 +333,11 @@ spack:
             "git checkout ${SPACK_REF}",
             "popd",
         ]
-        assert ci_obj["script"][1].startswith("cd ")
-        ci_obj["script"][1] = "cd ENV"
+        assert ci_obj["script"][1].startswith("spack env activate --without-view ")
+        ci_obj["script"][1] = "spack env activate --without-view ENV"
         assert ci_obj["script"] == [
             "spack -d ci rebuild",
-            "cd ENV",
-            "spack env activate --without-view .",
+            "spack env activate --without-view ENV",
             "spack ci rebuild",
         ]
         assert ci_obj["after_script"] == ["rm -rf /some/path/spack"]
@@ -1674,7 +1674,8 @@ spack:
     with open(tmp_path / ".gitlab-ci.yml", encoding="utf-8") as f:
         pipeline_doc = syaml.load(f)
         assert fst not in pipeline_doc["rebuild-index"]["script"][0]
-        assert snd in pipeline_doc["rebuild-index"]["script"][0]
+        assert "env activate" in pipeline_doc["rebuild-index"]["script"][0]
+        assert "buildcache-destination" in pipeline_doc["rebuild-index"]["script"][1]
 
 
 def dynamic_mapping_setup(tmp_path: pathlib.Path):
@@ -1855,11 +1856,13 @@ spack:
     # Make sure there are only two jobs and two stages
     stages = pipeline_doc["stages"]
     copy_stage = "copy"
+    wait_stage = "stage-wait"
     rebuild_index_stage = "stage-rebuild-index"
 
-    assert len(stages) == 2
+    assert len(stages) == 3
     assert stages[0] == copy_stage
-    assert stages[1] == rebuild_index_stage
+    assert stages[1] == wait_stage
+    assert stages[2] == rebuild_index_stage
 
     rebuild_index_job = pipeline_doc["rebuild-index"]
     assert rebuild_index_job["stage"] == rebuild_index_stage

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1365,10 +1365,7 @@ class MirrorMetadata:
         self.view = view
 
     def __str__(self):
-        s = f"{self.url}__v{self.version}"
-        if self.view:
-            s += f"__{self.view}"
-        return s
+        return f"{self:_url__v_version?___view}"
 
     def __eq__(self, other):
         if not isinstance(other, MirrorMetadata):
@@ -1377,6 +1374,37 @@ class MirrorMetadata:
 
     def __hash__(self):
         return hash((self.url, self.version, self.view))
+
+    def __format__(self, format_spec):
+        """Format the mirror metadata
+
+        Format Spec:
+            _url:     metadata.url
+            _version: metadata.version
+            _view:    metadata.view
+            ?:        delimiter to wrap conditional printing based on optional view
+
+        Example
+
+            f"{meta_data:_url?^_view?@v_version}"
+
+            Expansion without a view:
+                https://my-mirror.com/prefix@v3
+
+            Expansion with a view:
+                https://my-mirror.com/prefix^my-view@v3
+        """
+        if not format_spec:
+            format_spec = "_url@v3?-_view"
+            return
+        out = format_spec.replace("_url", self.url)
+        out = out.replace("_version", str(self.version))
+        out = out.replace("_view", str(self.view))
+        parts = out.split("?")
+        if self.view:
+            return "".join(parts)
+        else:
+            return "".join(parts[0::2])
 
     @classmethod
     def from_string(cls, s: str):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add support for build cache views to CI module.