### PR TITLE
spec.py: add EMPTY_SPEC

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -59,6 +59,7 @@ import spack.variant
 from spack.dependency import Dependency
 from spack.directives_meta import DirectiveError, DirectiveMeta
 from spack.resource import Resource
+from spack.spec import EMPTY_SPEC
 from spack.version import (
     GitVersion,
     Version,
@@ -136,7 +137,7 @@ def _make_when_spec(value: WhenType) -> Optional[spack.spec.Spec]:
     # represent this by returning the unconstrained `Spec()`, which is
     # always satisfied.
     if value is None or value is True:
-        return spack.spec.EMPTY_SPEC
+        return EMPTY_SPEC
 
     # This is conditional on the spec
     return spack.spec.Spec(value)
@@ -496,7 +497,7 @@ def _execute_provides(pkg: PackageType, specs: Tuple[SpecType, ...], when: WhenT
     when_spec = _make_when_spec(when)
     if not when_spec:
         return
-    elif when_spec is spack.spec.EMPTY_SPEC:
+    elif when_spec is EMPTY_SPEC:
         when_spec = spack.spec.Spec()  # this function mutates, so can't use EMPTY_SPEC
 
     # ``when`` specs for ``provides()`` need a name, as they are used
@@ -941,10 +942,10 @@ def _execute_license(pkg: PackageType, license_identifier: str, when: Optional[U
     for other_when_spec in pkg.licenses:
         if when_spec.intersects(other_when_spec):
             when_message = ""
-            if when_spec != spack.spec.EMPTY_SPEC:
+            if when_spec != EMPTY_SPEC:
                 when_message = f"when {when_spec}"
             other_when_message = ""
-            if other_when_spec != spack.spec.EMPTY_SPEC:
+            if other_when_spec != EMPTY_SPEC:
                 other_when_message = f"when {other_when_spec}"
             err_msg = (
                 f"{pkg.name} is specified as being licensed as {license_identifier} "

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -136,7 +136,7 @@ def _make_when_spec(value: WhenType) -> Optional[spack.spec.Spec]:
     # represent this by returning the unconstrained `Spec()`, which is
     # always satisfied.
     if value is None or value is True:
-        return spack.spec.Spec()
+        return spack.spec.EMPTY_SPEC
 
     # This is conditional on the spec
     return spack.spec.Spec(value)
@@ -496,6 +496,8 @@ def _execute_provides(pkg: PackageType, specs: Tuple[SpecType, ...], when: WhenT
     when_spec = _make_when_spec(when)
     if not when_spec:
         return
+    elif when_spec is spack.spec.EMPTY_SPEC:
+        when_spec = spack.spec.Spec()  # this function mutates, so can't use EMPTY_SPEC
 
     # ``when`` specs for ``provides()`` need a name, as they are used
     # to build the ProviderIndex.
@@ -939,10 +941,10 @@ def _execute_license(pkg: PackageType, license_identifier: str, when: Optional[U
     for other_when_spec in pkg.licenses:
         if when_spec.intersects(other_when_spec):
             when_message = ""
-            if when_spec != _make_when_spec(None):
+            if when_spec != spack.spec.EMPTY_SPEC:
                 when_message = f"when {when_spec}"
             other_when_message = ""
-            if other_when_spec != _make_when_spec(None):
+            if other_when_spec != spack.spec.EMPTY_SPEC:
                 other_when_message = f"when {other_when_spec}"
             err_msg = (
                 f"{pkg.name} is specified as being licensed as {license_identifier} "

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -65,6 +65,7 @@ import spack.version.git_ref_lookup
 from spack import traverse
 from spack.compilers.libraries import CompilerPropertyDetector
 from spack.llnl.util.lang import elide_list
+from spack.spec import EMPTY_SPEC
 from spack.util.compression import GZipFileType
 
 from .core import (
@@ -86,8 +87,6 @@ from .versions import Provenance
 GitOrStandardVersion = Union[vn.GitVersion, vn.StandardVersion]
 
 TransformFunction = Callable[[str, spack.spec.Spec, List[AspFunction]], List[AspFunction]]
-
-EMPTY_SPEC = spack.spec.EMPTY_SPEC
 
 
 class OutputConfiguration(NamedTuple):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -87,7 +87,7 @@ GitOrStandardVersion = Union[vn.GitVersion, vn.StandardVersion]
 
 TransformFunction = Callable[[str, spack.spec.Spec, List[AspFunction]], List[AspFunction]]
 
-EMPTY_SPEC = spack.spec.Spec()
+EMPTY_SPEC = spack.spec.EMPTY_SPEC
 
 
 class OutputConfiguration(NamedTuple):

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -17,6 +17,7 @@ import spack.spec
 import spack.store
 from spack.error import SpackError
 from spack.llnl.util import lang, tty
+from spack.spec import EMPTY_SPEC
 
 
 class PossibleGraph(NamedTuple):
@@ -85,10 +86,9 @@ class NoStaticAnalysis(PossibleDependencyGraph):
     def is_allowed_on_this_platform(self, *, pkg_name: str) -> bool:
         """Returns true if a package is allowed on the current host"""
         pkg_cls = self.repo.get_pkg_class(pkg_name)
-        no_condition = spack.spec.EMPTY_SPEC
         for when_spec, conditions in pkg_cls.requirements.items():
             # Restrict analysis to unconditional requirements
-            if when_spec != no_condition:
+            if when_spec != EMPTY_SPEC:
                 continue
             for requirements, _, _ in conditions:
                 if not any(x.intersects(self._platform_condition) for x in requirements):

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -85,7 +85,7 @@ class NoStaticAnalysis(PossibleDependencyGraph):
     def is_allowed_on_this_platform(self, *, pkg_name: str) -> bool:
         """Returns true if a package is allowed on the current host"""
         pkg_cls = self.repo.get_pkg_class(pkg_name)
-        no_condition = spack.spec.Spec()
+        no_condition = spack.spec.EMPTY_SPEC
         for when_spec, conditions in pkg_cls.requirements.items():
             # Restrict analysis to unconditional requirements
             if when_spec != no_condition:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -758,7 +758,7 @@ class DependencySpec:
         self.virtuals = tuple(sorted(set(virtuals)))
         self.direct = direct
         self.propagation = propagation
-        self.when = when or Spec()
+        self.when = when or EMPTY_SPEC
 
     def update_deptypes(self, depflag: dt.DepFlag) -> bool:
         """Update the current dependency types"""
@@ -1843,7 +1843,7 @@ class Spec:
             when: optional condition under which dependency holds
         """
         if when is None:
-            when = Spec()
+            when = EMPTY_SPEC
 
         if spec.name not in self._dependencies or not spec.name:
             self.add_dependency_edge(
@@ -1914,7 +1914,7 @@ class Spec:
             when: if non-None, condition under which dependency holds
         """
         if when is None:
-            when = Spec()
+            when = EMPTY_SPEC
 
         # Check if we need to update edges that are already present
         selected = self._dependencies.get(dependency_spec.name, [])
@@ -3083,7 +3083,7 @@ class Spec:
         # If we are trying to constrain a concrete spec, either the spec
         # already satisfies the constraint (and the method returns False)
         # or it raises an exception
-        if self.concrete:
+        if self.concrete or self is EMPTY_SPEC:
             if self._satisfies(other, resolve_virtuals=resolve_virtuals):
                 return False
             else:
@@ -3222,6 +3222,8 @@ class Spec:
     def _intersects(
         self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
     ) -> bool:
+        if other is EMPTY_SPEC:
+            return True
         other = self._autospec(other)
 
         if other.concrete and self.concrete:
@@ -3358,6 +3360,7 @@ class Spec:
             other: spec to be satisfied
             deps: if True, descend to dependencies, otherwise only check root node
         """
+
         return self._satisfies(other=other, deps=deps, resolve_virtuals=True)
 
     def _satisfies(
@@ -3371,6 +3374,8 @@ class Spec:
             resolve_virtuals: if True, resolve virtuals in self and other. This requires a
                 repository to be available.
         """
+        if other is EMPTY_SPEC:
+            return True
         other = self._autospec(other)
 
         if other.concrete:
@@ -4393,7 +4398,7 @@ class Spec:
             if deptypes and dep.depflag
             else ""
         )
-        when_str = f"when='{(dep.when)}'" if dep.when != Spec() else ""
+        when_str = f"when='{(dep.when)}'" if dep.when != EMPTY_SPEC else ""
         virtuals_str = f"virtuals={','.join(dep.virtuals)}" if virtuals and dep.virtuals else ""
 
         attrs = " ".join(s for s in (when_str, deptypes_str, virtuals_str) if s)
@@ -4437,7 +4442,7 @@ class Spec:
 
             edge_attributes = (
                 self._format_edge_attributes(edge, deptypes=deptypes, virtuals=False)
-                if edge.depflag or edge.when != Spec()
+                if edge.depflag or edge.when != EMPTY_SPEC
                 else ""
             )
             virtuals = f"{','.join(edge.virtuals)}=" if edge.virtuals else ""
@@ -6009,3 +6014,7 @@ class InvalidEdgeError(spack.error.SpecError):
 
 class SpecMutationError(spack.error.SpecError):
     """Raised when a mutation is attempted with invalid attributes."""
+
+
+#: Global empty spec, immutable by convention. Used for fast comparisons and reducing memory usage.
+EMPTY_SPEC = Spec()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3083,7 +3083,7 @@ class Spec:
         # If we are trying to constrain a concrete spec, either the spec
         # already satisfies the constraint (and the method returns False)
         # or it raises an exception
-        if self.concrete or self is EMPTY_SPEC:
+        if self.concrete:
             if self._satisfies(other, resolve_virtuals=resolve_virtuals):
                 return False
             else:
@@ -3360,7 +3360,6 @@ class Spec:
             other: spec to be satisfied
             deps: if True, descend to dependencies, otherwise only check root node
         """
-
         return self._satisfies(other=other, deps=deps, resolve_virtuals=True)
 
     def _satisfies(
@@ -6016,5 +6015,35 @@ class SpecMutationError(spack.error.SpecError):
     """Raised when a mutation is attempted with invalid attributes."""
 
 
-#: Global empty spec, immutable by convention. Used for fast comparisons and reducing memory usage.
-EMPTY_SPEC = Spec()
+class _EmptySpec(Spec):
+    """An immutable empty Spec that prevents a class of accidental mutations."""
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "_mutable", True)
+        super().__init__()
+        object.__delattr__(self, "_mutable")
+
+    def __setstate__(self, state) -> None:
+        object.__setattr__(self, "_mutable", True)
+        super().__setstate__(state)
+        object.__delattr__(self, "_mutable")
+
+    def constrain(self, *args, **kwargs) -> bool:
+        raise TypeError("EmptySpec is immutable and cannot be modified")
+
+    def add_dependency_edge(self, *args, **kwargs):
+        raise TypeError("EmptySpec is immutable and cannot be modified")
+
+    def __setattr__(self, name, value) -> None:
+        if not getattr(self, "_mutable", False):
+            raise TypeError("EmptySpec is immutable and cannot be modified")
+        super().__setattr__(name, value)
+
+    def __delattr__(self, name) -> None:
+        if name != "_mutable":
+            raise TypeError("EmptySpec is immutable and cannot be modified")
+        object.__delattr__(self, name)
+
+
+#: Immutable empty spec, for fast comparisons and reduced memory usage.
+EMPTY_SPEC = _EmptySpec()

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -447,12 +447,15 @@ class SpecParser:
                 when = entry.get("when", "")
                 self._ensure_all_direct_edges(toolchain_part)
 
-                # Conditions are applied to every edge in the constraint
-                for edge in toolchain_part.traverse_edges():
-                    # EMPTY_SPEC is immutable by convention, so create a mutable instance.
-                    if edge.when is EMPTY_SPEC:
-                        edge.when = Spec()
-                    edge.when.constrain(when)
+                # Apply global "when" to all edges in toolchain part
+                if when:
+                    when_spec = Spec(when)
+                    for edge in toolchain_part.traverse_edges():
+                        # EMPTY_SPEC is immutable by convention, so create a mutable instance.
+                        if edge.when is EMPTY_SPEC:
+                            edge.when = when_spec.copy()
+                        else:
+                            edge.when.constrain(when_spec)
                 toolchain.constrain(toolchain_part)
         return toolchain
 

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -439,7 +439,7 @@ class SpecParser:
             toolchain = parse_one_or_raise(toolchain_config)
             self._ensure_all_direct_edges(toolchain)
         else:
-            from spack.spec import Spec
+            from spack.spec import EMPTY_SPEC, Spec
 
             toolchain = Spec()
             for entry in toolchain_config:
@@ -449,6 +449,9 @@ class SpecParser:
 
                 # Conditions are applied to every edge in the constraint
                 for edge in toolchain_part.traverse_edges():
+                    # EMPTY_SPEC is immutable by convention, so create a mutable instance.
+                    if edge.when is EMPTY_SPEC:
+                        edge.when = Spec()
                     edge.when.constrain(when)
                 toolchain.constrain(toolchain_part)
         return toolchain


### PR DESCRIPTION
Conditional dependencies are the exception, but all unconditional
dependencies allocate a `when=Spec()` object after the introduction
of toolchains. Trivial specs are also common in package metadata,
since almost all directives are now dictionaries keyed by `when`
condition, where the unconditional `Spec()` is popular as well.

tracemalloc analysis shows that during `spack spec zlib`, 61% of all
`Spec` objects that are *garbage collected* (by the cyclic garbage
collector, which are all specs ever) are trivial/empty.

This commit introduced a singleton `spack.spec.EMPTY_SPEC = Spec()`,
which is "immutable by convention", used in the hot spots.

Setup time reduces by 12.7%.

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/63afa884-5542-4bf8-a40e-5d96e2ce3f4c" />

Some other nice results, using the E4S environment's lock file of 2.9MB, comparing against fe438347f69e05a4da9546f07c3a73c554aae62d

Pickle size of `list(e.roots())`

* before: 5.0MB
* after: 3.0M (-40.0%)

Pickle and unpickle speed:

* before: 0.1830s
* after: 0.0703s (-61.6%)

Database and Environment loading speed:

* before: 0.1853s
* after: 0.1471 (-20.64%)

Spawned subprocess startup speed, passing the environment as arg

* before: 0.5066s
* after: 0.2227s (-56.0%)

To reproduce, see [envbench.tar.gz](https://github.com/user-attachments/files/24474060/envbench.tar.gz)

---


Before this commit:

```
Total Spec objects: 85803
Trivial (empty) Spec objects: 52878

Top 20 allocation sites for trivial (empty) Spec objects:
   COUNT | LOCATION
-------------------------------------------------------------------------------------
   26666 | $spack/lib/spack/spack/spec.py:1846
    8930 | $spack/lib/spack/spack/spec.py:1917
    7535 | $spack/lib/spack/spack/spec.py:761
    5210 | $spack/lib/spack/spack/spec.py:4440
    3904 | $spack/lib/spack/spack/directives.py:129
     532 | $spack/lib/spack/spack/solver/input_analysis.py:88
      77 | $spack/lib/spack/spack/spec.py:3771
      18 | $spack/lib/spack/spack/spec.py:4396
       1 | $spack/lib/spack/spack/solver/requirements.py:203
       1 | $spack/lib/spack/spack/solver/requirements.py:67
       1 | $spack/bin/spack:110
```

After this commit:

```
Total Spec objects: 33020
Trivial (empty) Spec objects: 99

Top 20 allocation sites for trivial (empty) Spec objects:
   COUNT | LOCATION
-------------------------------------------------------------------------------------
      77 | $spack/lib/spack/spack/spec.py:3771
      16 | $spack/lib/spack/spack/spec.py:4396
       1 | $spack/lib/spack/spack/solver/requirements.py:203
       1 | $spack/lib/spack/spack/solver/requirements.py:67
       1 | $spack/bin/spack:110
```

