### PR TITLE
Remove use of `spack unit-test` in `clingo-cffi` job

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -173,7 +173,7 @@ jobs:
           sudo apt-get -y install coreutils gfortran graphviz gnupg2
     - name: Install Python packages
       run: |
-          pip install --upgrade pip pytest coverage[toml] pytest-cov clingo
+          pip install --upgrade pip pytest coverage[toml] pytest-cov clingo pytest-xdist
           pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
     - name: Run unit tests (full suite with coverage)
       env:
@@ -186,7 +186,7 @@ jobs:
         spack bootstrap disable github-actions-v2
         spack bootstrap status
         spack solve zlib
-        spack unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml lib/spack/spack/test/concretization/core.py
+        pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 lib/spack/spack/test/concretization/core.py
     - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
       with:
         name: coverage-clingo-cffi

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -147,16 +147,19 @@ jobs:
           git config --global --add safe.directory '*'
           git fetch --unshallow
           . .github/workflows/bin/setup_git.sh
-          useradd spack-test
-          chown -R spack-test .
-    - name: Bootstrap Spack development environment and run unit tests
-      shell: runuser -u spack-test -- bash {0}
+    - name: Setup a virtual environment with platform-python
       run: |
+          /usr/libexec/platform-python -m venv ~/platform-spack 
+          source ~/platform-spack/bin/activate
+          pip install --upgrade pip pytest coverage[toml] pytest-xdist
+    - name: Bootstrap Spack development environment and run unit tests
+      run: |
+          source ~/platform-spack/bin/activate
           source share/spack/setup-env.sh
           spack debug report
           spack -d bootstrap now --dev
           spack -d style -t black
-          spack unit-test -k 'not cvs and not svn and not hg' -x --verbose
+          pytest --verbose -x -n3 --dist loadfile -k 'not cvs and not svn and not hg'
   # Test for the clingo based solver (using clingo-cffi)
   clingo-cffi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Modifications:
- Remove all the uses of `spack unit-test` in CI in favor of `pytest`
- Make `rhel8-*` job run in parallel using xdist (runtime is approximately halved) 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
