### PR TITLE
solver: remove `attr("track_dependencies", ...)`

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1338,12 +1338,6 @@ class ConditionContext(SourceContext):
         return ctxt
 
 
-def _track_dependencies(
-    name: str, input_spec: spack.spec.Spec, requirements: List[AspFunction]
-) -> List[AspFunction]:
-    return requirements + [fn.attr("track_dependencies", name)]
-
-
 class SpackSolverSetup:
     """Class to set up and run a Spack concretization solve."""
 
@@ -1873,7 +1867,6 @@ class SpackSolverSetup:
                 context.source = ConstraintOrigin.append_type_suffix(
                     pkg.name, ConstraintOrigin.DEPENDS_ON
                 )
-                context.transform_required = _track_dependencies
                 context.transform_imposed = dependency_holds(dependency_flags=depflag, pkg_cls=pkg)
                 self.condition(cond, dep.spec, required_name=pkg.name, msg=msg, context=context)
                 self.gen.newline()
@@ -3444,7 +3437,6 @@ class SpecBuilder:
                 r"^dependency_holds$",
                 r"^package_hash$",
                 r"^root$",
-                r"^track_dependencies$",
                 r"^uses_virtual$",
                 r"^variant_default_value_from_cli$",
                 r"^virtual_node$",

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -839,9 +839,12 @@ concrete(PackageNode) :- attr("hash", PackageNode, _), attr("node", PackageNode)
 % Dependencies of any type imply that one package "depends on" another
 depends_on(PackageNode, DependencyNode) :- attr("depends_on", PackageNode, DependencyNode, _).
 
-% a dependency holds if its condition holds and if it is not concrete.
 % Dependencies of concrete specs don't need to be resolved -- they arise from the concrete specs themselves.
-attr("track_dependencies", Node) :- build(Node).
+do_not_impose(EffectID, node(X, Package)) :-
+     trigger_and_effect(Package, ConditionID, TriggerID, EffectID),
+     trigger_condition_holds(TriggerID, node(X, Package)),
+     imposed_constraint(EffectID, "dependency_holds", Package, _, _),
+     concrete(node(X, Package)).
 
 % If a dependency holds on a package node, there must be one and only one dependency node satisfying it
 1 { attr("depends_on", PackageNode, node(0..Y-1, Dependency), Type) : max_dupes(Dependency, Y) } 1

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -841,7 +841,7 @@ depends_on(PackageNode, DependencyNode) :- attr("depends_on", PackageNode, Depen
 
 % Dependencies of concrete specs don't need to be resolved -- they arise from the concrete specs themselves.
 do_not_impose(EffectID, node(X, Package)) :-
-     trigger_and_effect(Package, ConditionID, TriggerID, EffectID),
+     trigger_and_effect(Package, _, TriggerID, EffectID),
      trigger_condition_holds(TriggerID, node(X, Package)),
      imposed_constraint(EffectID, "dependency_holds", Package, _, _),
      concrete(node(X, Package)).


### PR DESCRIPTION
We gain some because:
```
# Develop
$ spack solve --show=asp trilinos | grep trigger_id |wc -l
18497
# This PR
$ spack solve --show=asp trilinos | grep trigger_id |wc -l
17515
```
We lose some because the rule to ground is more complex.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
