### PR TITLE
gha: dont run spack style with ancient black

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -158,7 +158,6 @@ jobs:
           source share/spack/setup-env.sh
           spack debug report
           spack -d bootstrap now --dev
-          spack -d style -t black
           pytest --verbose -x -n3 --dist loadfile -k 'not cvs and not svn and not hg'
   # Test for the clingo based solver (using clingo-cffi)
   clingo-cffi:


### PR DESCRIPTION
No point in running Black 22.8.0 from September 2022, which disagrees with latest black.

```diff

--- lib/spack/spack/solver/asp.py	2026-01-09 11:45:36.346600 +0000
+++ lib/spack/spack/solver/asp.py	2026-01-09 11:48:46.201360 +0000
@@ -1330,13 +1330,13 @@
         self.possible_virtuals: Set[str] = set()
 
         # pkg_name -> version -> list of possible origins (package.py, installed, etc.)
         self.possible_versions = collections.defaultdict(lambda: collections.defaultdict(list))
         self.versions_from_yaml: Dict[str, List[GitOrStandardVersion]] = {}
-        self.git_commit_versions: Dict[str, Dict[GitOrStandardVersion, str]] = (
-            collections.defaultdict(dict)
-        )
+        self.git_commit_versions: Dict[
+            str, Dict[GitOrStandardVersion, str]
+        ] = collections.defaultdict(dict)
         self.deprecated_versions: Dict[str, Set[GitOrStandardVersion]] = collections.defaultdict(
             set
         )
 
         self.possible_compilers: List[spack.spec.Spec] = []
@@ -4059,11 +4059,10 @@
         self.required = None
         self.constraint_type = None
 
 
 class OutputDoesNotSatisfyInputError(InternalConcretizerError):
-
     def __init__(
         self, input_to_output: List[Tuple[spack.spec.Spec, Optional[spack.spec.Spec]]]
     ) -> None:
         self.input_to_output = input_to_output
         super().__init__(
```