### PR TITLE
solver/core.py: refactor AspFunction

### DIFF
--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -47,12 +47,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
 
 
-def shift(asp_function):
+def shift(asp_function: asp.AspFunction) -> asp.AspFunction:
     """Transforms ``attr("foo", "bar")`` into ``foo("bar")``."""
-    if not asp_function.args:
+    args = asp_function.args
+    if not args:
         raise ValueError(f"Can't shift ASP function with no arguments: {str(asp_function)}")
-    first, *rest = asp_function.args
-    return asp.AspFunction(first, rest)
+    return asp.AspFunction(args[0], args[1:])
 
 
 def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):


### PR DESCRIPTION
Few changes to AspFunction:

* ensure the AspFunction arguments are tuples, use `()` instead of `None`
* inline `_id` in `__str__` for a minor perf improvement; apart from
   the extra function call, also eliminates another `str` call in
   `str(_id(...))`.
* order branches from most to least popular in practice
* use `type(...) is int` to remove a branch on bool that was only needed
  with `isinstance(..., int)`.
* remove redundant inheritance of `AspObject`

Also fix an existing issue in diff.py where a list was used for arguments
instead of the tuple the typehint suggests.

This seems to result in about 4-5% speedup of the `setup` phase, with or
without reuse enabled.

