### PR TITLE
concretize.py: round down in progress

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -160,9 +160,9 @@ def concretize_separately(
         )
     ):
         ret.append((i, concrete))
-        percentage = (j + 1) / len(args) * 100
+        percentage = int((j + 1) / len(args) * 100)
         tty.verbose(
-            f"{duration:6.1f}s [{percentage:3.0f}%] {concrete.cformat('{hash:7}')} "
+            f"{duration:6.1f}s [{percentage:3d}%] {concrete.cformat('{hash:7}')} "
             f"{to_concretize[i].colored_str}"
         )
         sys.stdout.flush()


### PR DESCRIPTION
A bit of a trivial change, but personally I don't like it when I see

```
==>   20.2s [100%] zbtfyfl vtk-m ...
```

wait 10 seconds thinking Spack is stuck, just to see

```
==>   30.3s [100%] cwhz53z trilinos
```

another line with 100% show up.

Instead, round down so 100% appears exactly once at the end.

