### PR TITLE
version_types.py: cache `ClosedOpenRange` `__str__` and `__hash__`

### DIFF
--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -17,6 +17,7 @@ import spack.spec
 import spack.version
 from spack.llnl.util.filesystem import working_dir
 from spack.version import (
+    ClosedOpenRange,
     EmptyRangeError,
     GitVersion,
     StandardVersion,
@@ -596,6 +597,22 @@ def test_repr_and_str():
     check_repr_and_str("1.2.3")
     check_repr_and_str("R2016a")
     check_repr_and_str("R2016a.2-3_4")
+
+
+def test_str_and_hash_version_range():
+    """Test that precomputed string and hash values are consistent with computed ones."""
+    x = ver("1.2:3.4")
+    assert isinstance(x, ClosedOpenRange)
+    # Test that precomputed str() and hash() are assigned
+    assert x._string is not None and x._hash is not None
+    _str = str(x)
+    _hash = hash(x)
+    assert x._string == _str and x._hash == _hash
+    # Ensure computed values match precomputed ones
+    x._string = None
+    x._hash = None
+    assert _str == str(x)
+    assert _hash == hash(x)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Since `ClosedOpenRange` is immutable we can cache its string
and hash value in the named constructor, before the internal
representation of `hi = _next_version(hi)` is computed.

That saves the expensive, allocating `_prev_version` call in
`__str__` and reduces "setup time" by 7.4%.

Should be the best of both worlds: the internal `_next_version`
representation allowed us to do non-allocating, fast range inclusion
checks as tuple comparsion, while this change ensures that `__str__`
doesn't have to compute the original `hi` from the input.

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/b99b4264-8e77-4604-9555-3860d54059c3" />

