### PR TITLE
bugfix: db records for build_specs

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -766,6 +766,7 @@ class Database:
             # old format
             spec_node_dict = spec_node_dict[spec.name]
         if "build_spec" in spec_node_dict:
+            assert isinstance(spec_reader, spack.spec.SpecfileV2)  # later inherit from it
             _, bhash, _ = spec_reader.extract_build_spec_info_from_node_dict(spec_node_dict)
             build_spec = self.query_by_spec_hash(bhash, data=data)
             spec._build_spec = build_spec

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -766,7 +766,7 @@ class Database:
             # old format
             spec_node_dict = spec_node_dict[spec.name]
         if "build_spec" in spec_node_dict:
-            assert isinstance(spec_reader, spack.spec.SpecfileV2)  # later inherit from it
+            assert issubclass(spec_reader, spack.spec.SpecfileV2)  # later ones inherit from it
             _, bhash, _ = spec_reader.extract_build_spec_info_from_node_dict(spec_node_dict)
             build_spec = self.query_by_spec_hash(bhash, data=data)
             spec._build_spec = build_spec

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -766,7 +766,7 @@ class Database:
             # old format
             spec_node_dict = spec_node_dict[spec.name]
         if "build_spec" in spec_node_dict:
-            assert issubclass(spec_reader, spack.spec.SpecfileV2)  # later ones inherit from it
+            assert spec_reader.SPEC_VERSION >= 2, "SpecfileV1 spec cannot have build_spec"
             _, bhash, _ = spec_reader.extract_build_spec_info_from_node_dict(spec_node_dict)
             build_spec = self.query_by_spec_hash(bhash, data=data)
             spec._build_spec = build_spec

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -16,6 +16,7 @@ as the authoritative database of packages in Spack.  This module
 provides a cache and a sanity checking mechanism for what is in the
 filesystem.
 """
+
 import contextlib
 import datetime
 import os
@@ -768,8 +769,9 @@ class Database:
         if "build_spec" in spec_node_dict:
             assert spec_reader.SPEC_VERSION >= 2, "SpecfileV1 spec cannot have build_spec"
             _, bhash, _ = spec_reader.extract_build_spec_info_from_node_dict(spec_node_dict)
-            build_spec = self.query_by_spec_hash(bhash, data=data)
-            spec._build_spec = build_spec
+            _, build_spec = self.query_by_spec_hash(bhash, data=data)
+            assert build_spec is not None, f"build_spec with hash {bhash} not found in database"
+            spec._build_spec = build_spec.spec
 
     def _assign_dependencies(
         self,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5445,6 +5445,10 @@ class SpecfileReaderBase:
         return hash_dict[root_spec_hash]["node_spec"]
 
     @classmethod
+    def extract_build_spec_info_from_node_dict(cls, node, hash_type=ht.dag_hash.name):
+        raise NotImplementedError("Subclasses must implement this method.")
+
+    @classmethod
     def read_specfile_dep_specs(cls, deps, hash_type=ht.dag_hash.name):
         raise NotImplementedError("Subclasses must implement this method.")
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5301,6 +5301,8 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
 
 
 class SpecfileReaderBase:
+    SPEC_VERSION: int
+
     @classmethod
     def from_node_dict(cls, node):
         spec = Spec()

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -592,6 +592,20 @@ def test_015_write_and_read(mutable_database):
         assert new_rec.installed == rec.installed
 
 
+def test_016_roundtrip_spliced_spec(mutable_database):
+    build_spec = spack.concretize.concretize_one("splice-t")
+    replacement = spack.concretize.concretize_one("splice-h+foo")
+    spec = build_spec.splice(replacement)
+
+    spack.store.STORE.db.add(spec)
+    _, spec_record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
+    _, buildspec_record = spack.store.STORE.db.query_by_spec_hash(spec.build_spec.dag_hash())
+
+    assert spec_record.spec == spec
+    assert spec_record.spec.build_spec == spec.build_spec
+    assert buildspec_record  # buildspec needs to be recorded in db
+
+
 def test_017_write_and_read_without_uuid(mutable_database, monkeypatch):
     monkeypatch.setattr(spack.database, "_use_uuid", False)
     # write and read DB

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -598,6 +598,8 @@ def test_016_roundtrip_spliced_spec(mutable_database):
     spec = build_spec.splice(replacement)
 
     spack.store.STORE.db.add(spec)
+    spack.store.STORE.db._state_is_inconsistent = True  # force re-read
+
     _, spec_record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
     _, buildspec_record = spack.store.STORE.db.query_by_spec_hash(spec.build_spec.dag_hash())
 


### PR DESCRIPTION
Currently, the spack database doesn't record build specs for spliced installed specs. In the case that the build_spec was never installed (the spliced spec was installed directly from a buildcache of the build_spec), this leads to the build_spec being absent in the database, and the downstream effect is that the `Spec.build_spec` property erroneously reports the spec as its own build_spec.

This PR fixes this by reading/writing build_specs from the database.