### PR TITLE
Backports: v1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,10 @@ spack-db.*
 *.out.log
 
 # Configuration: Ignore everything in /etc/spack,
-# except spack and site scopes that ship with spack
+# except defaults and site scopes that ship with spack
 /etc/spack/*
 !/etc/spack/defaults
-!/etc/spack/site
+!/etc/spack/site/README.md
 
 ###########################
 # Python-specific ignores #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+# v1.1.1 (2026-01-14)
+
+## Usability and performance enhancements
+
+* solver: do a precheck for non-existing and deprecated versions #51555
+* improvements to solver performance (PRs 51591, 51605, 51612, 51625)
+* python 3.14 support (PRs 51686, 51687, 51688, 51689, 51663)
+* display when conditions with dependencies in spack info #51588
+* spack repo remove: allow removing from unspecified scope #51563
+* spack compiler info: show non-external compilers too #51718
+
+## Improvements to the experimental new installer
+
+* support forkserver #51788 (for python 3.14 support)
+* support --dirty, --keep-stage, and `skip patch` arguments #51558
+* implement --use-buildcache, --cache-only, --use-cache and --only arguments #51593
+* implement overwrite, keep_prefix #51622
+* implement --dont-restage #51623
+* fix logging #51787
+
+## Bugfixes
+
+* repo.py: support rhel 7 #51617
+* solver: match glibc constraints by hash #51559
+* buildache list: list the component prefix not the root #51635
+* solver: fix issue with conditional language dependencies #51692
+* repo.py: fix checking out commits #51695
+* spec parser: ensure toolchains are expanded to different objects #51731
+* RHEL7 git 1.8.3.1 fix #51779
+* RewireTask.complete: return value from \_process\_binary\_cache\_tarball #51825
+
+## Documentation
+
+* docs: fix default projections setting discrepancy #51640
+
+
 # v1.1.0 (2025-11-14)
 
 `v1.1.0` features major improvements to **compiler handling** and **configuration management**, a significant refactoring of **externals**, and exciting new **experimental features** like a console UI for parallel installations and concretization caching.

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -38,7 +38,7 @@ By default, Spack installs all packages into a unique directory relative to the 
 
 .. code-block:: text
 
-   {architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}
+   {architecture.platform}-{architecture.target}/{name}-{version}-{hash}
 
 In very rare cases, it may be necessary to reduce the length of this path.
 For example, very old versions of the Intel compiler are known to segfault when input paths are too long:

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -10,7 +10,7 @@ import spack.paths
 import spack.util.git
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "1.1.1.dev0"
+__version__ = "1.1.1"
 spack_version = __version__
 
 #: The current Package API version implemented by this version of Spack. The Package API defines

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -10,7 +10,7 @@ import spack.paths
 import spack.util.git
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "1.1.0"
+__version__ = "1.1.1.dev0"
 spack_version = __version__
 
 #: The current Package API version implemented by this version of Spack. The Package API defines

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -914,11 +914,14 @@ def _linting_package_file(pkgs, error_cls):
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
+        homepage = pkg_cls.homepage
+        if not homepage:
+            continue
+
         # Does the homepage have http, and if so, does https work?
-        if pkg_cls.homepage.startswith("http://"):
-            https = re.sub("http", "https", pkg_cls.homepage, 1)
+        if homepage.startswith("http://"):
             try:
-                response = urlopen(https)
+                response = urlopen(f"https://{homepage[7:]}")
             except Exception as e:
                 msg = 'Error with attempting https for "{0}": '
                 errors.append(error_cls(msg.format(pkg_cls.name), [str(e)]))

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import codecs
 import collections
 import concurrent.futures
 import contextlib
@@ -2522,7 +2521,7 @@ class IndexFetcher:
         """Read the response of the manifest request and return a BlobRecord"""
         cache_class = get_url_buildcache_class(CURRENT_BUILD_CACHE_LAYOUT_VERSION)
         try:
-            result = codecs.getreader("utf-8")(manifest_response).read()
+            result = io.TextIOWrapper(manifest_response, encoding="utf-8").read()
         except (ValueError, OSError) as e:
             raise FetchIndexError(f"Remote index {manifest_response.url} is invalid", e) from e
 
@@ -2600,7 +2599,7 @@ class DefaultIndexFetcherV2(IndexFetcher):
             raise FetchIndexError(f"Could not fetch index from {url_index}", e) from e
 
         try:
-            result = codecs.getreader("utf-8")(response).read()
+            result = io.TextIOWrapper(response, encoding="utf-8").read()
         except (ValueError, OSError) as e:
             raise FetchIndexError(f"Remote index {url_index} is invalid") from e
 
@@ -2652,7 +2651,7 @@ class EtagIndexFetcherV2(IndexFetcher):
             raise FetchIndexError(f"Could not fetch index {url}", e) from e
 
         try:
-            result = codecs.getreader("utf-8")(response).read()
+            result = io.TextIOWrapper(response, encoding="utf-8").read()
         except (ValueError, OSError) as e:
             raise FetchIndexError(f"Remote index {url} is invalid", e) from e
 
@@ -2710,7 +2709,7 @@ class OCIIndexFetcher(IndexFetcher):
                     headers={"Accept": "application/vnd.oci.image.layer.v1.tar+gzip"},
                 )
             )
-            result = codecs.getreader("utf-8")(response).read()
+            result = io.TextIOWrapper(response, encoding="utf-8").read()
         except (OSError, ValueError) as e:
             raise FetchIndexError(f"Remote index {url_manifest} is invalid", e) from e
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1975,7 +1975,7 @@ def _tar_strip_component(tar: tarfile.TarFile, prefix: str):
 
 def extract_buildcache_tarball(tarfile_path: str, destination: str) -> None:
     with closing(tarfile.open(tarfile_path, "r")) as tar:
-        # Needed so that Python 3.14 and above don't error with AbsoluteLinkError
+        # For consistent behavior across all supported Python versions
         tar.extraction_filter = lambda member, path: member
         # Remove common prefix from tarball entries and directly extract them to the install dir.
         tar.extractall(

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -21,7 +21,6 @@ import spack.config
 import spack.package_base
 import spack.platforms
 import spack.repo
-import spack.solver.versions
 import spack.spec
 import spack.traverse
 import spack.version
@@ -34,14 +33,10 @@ def _select_best_version(
 ) -> None:
     """Try to attach the best known version to a node"""
     constraint = spack.version.from_string(valid_versions)
-    allowed_versions = [
-        (v, info) for v, info in pkg_cls.versions.items() if v.satisfies(constraint)
-    ]
+    allowed_versions = [v for v in pkg_cls.versions if v.satisfies(constraint)]
     try:
-        best_version, _ = max(
-            allowed_versions, key=spack.solver.versions.concretization_version_order
-        )
-    except (KeyError, ValueError):
+        best_version = spack.package_base.sort_by_pkg_preference(allowed_versions, pkg=pkg_cls)[0]
+    except (KeyError, ValueError, IndexError):
         return
     node.versions.versions = [spack.version.from_string(f"={best_version}")]
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -294,8 +294,8 @@ class SourceBootstrapper(Bootstrapper):
             PackageInstaller(
                 [concrete_spec.package],
                 fail_fast=True,
-                package_use_cache=False,
-                dependencies_use_cache=False,
+                root_policy="source_only",
+                dependencies_policy="source_only",
             ).install()
 
         if _try_import_from_store(module, query_spec=concrete_spec, query_info=info):

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import codecs
+import io
 import json
 import os
 import pathlib
@@ -105,7 +105,7 @@ def _migrate_spec(
     for meta_url in v2_metadata_urls:
         try:
             _, _, meta_file = web_util.read_from_url(meta_url)
-            spec_contents = codecs.getreader("utf-8")(meta_file).read()
+            spec_contents = io.TextIOWrapper(meta_file, encoding="utf-8").read()
             v2_spec_url = meta_url
             break
         except (web_util.SpackWebError, OSError):
@@ -280,7 +280,7 @@ def migrate(
 
     try:
         _, _, index_file = web_util.read_from_url(index_url)
-        contents = codecs.getreader("utf-8")(index_file).read()
+        contents = io.TextIOWrapper(index_file, encoding="utf-8").read()
     except (web_util.SpackWebError, OSError):
         raise MigrationException("Buildcache migration requires a buildcache index")
 

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -45,7 +45,7 @@ def _fetch_manifests(
              callable to read each manifest, and a list of blobs in the mirror.
     """
     manifest_file_to_mtime_mapping, read_fn = get_entries_from_cache(
-        url=mirror.fetch_url, tmpspecsdir=tmpspecsdir
+        mirror.fetch_url, tmpspecsdir, BuildcacheComponent.MANIFEST
     )
     url_to_list = url_util.join(
         mirror.fetch_url, spack.binary_distribution.buildcache_relative_blobs_path()
@@ -74,7 +74,9 @@ def _delete_manifests_from_cache_aws(
 
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
 
-    include_pattern = cache_class.get_buildcache_component_include_pattern()
+    include_pattern = cache_class.get_buildcache_component_include_pattern(
+        BuildcacheComponent.MANIFEST
+    )
 
     file_count_before_deletion = len(list(pathlib.Path(tmpspecsdir).rglob(include_pattern)))
 

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import base64
-import codecs
+import io
 import json
 import os
 import pathlib
@@ -1310,7 +1310,7 @@ def read_broken_spec(broken_spec_url):
         tty.warn(f"Unable to read broken spec from {broken_spec_url}")
         return None
 
-    broken_spec_contents = codecs.getreader("utf-8")(fs).read()
+    broken_spec_contents = io.TextIOWrapper(fs, encoding="utf-8").read()
     return syaml.load(broken_spec_contents)
 
 

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -111,7 +111,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
 
     list = sp.add_parser("list", help="list all the sources of software to bootstrap Spack")
-    _add_scope_option(list)
+    list.add_argument(
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read/modify",
+    )
 
     add = sp.add_parser("add", help="add a new source for bootstrapping")
     _add_scope_option(add)
@@ -188,6 +193,11 @@ def _reset(args):
 def _root(args):
     if args.path:
         spack.config.set("bootstrap:root", args.path, scope=args.scope)
+    elif args.scope:
+        if args.scope not in spack.config.existing_scope_names():
+            spack.llnl.util.tty.die(
+                f"The argument --scope={args.scope} must refer to an existing scope."
+            )
 
     root = spack.config.get("bootstrap:root", default=None, scope=args.scope)
     if root:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -192,6 +192,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     check.add_argument(
         "--scope",
         action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
         default=lambda: spack.config.default_modify_scope(),
         help="configuration scope containing mirrors to check",
     )

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -202,6 +202,15 @@ class ConfigScope(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
+def config_scope_readable_validator(value):
+    if value not in spack.config.existing_scope_names():
+        raise ValueError(
+            f"Invalid scope argument {value} "
+            "for config read operation, scope context does not exist"
+        )
+    return value
+
+
 def _cdash_reporter(namespace):
     """Helper function to create a CDash reporter. This function gets an early reference to the
     argparse namespace under construction, so it can later use it to create the object.

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -68,7 +68,10 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     # List
     list_parser = sp.add_parser("list", aliases=["ls"], help="list available compilers")
     list_parser.add_argument(
-        "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read from",
     )
     list_parser.add_argument(
         "--remote", action="store_true", help="list also compilers from registered buildcaches"
@@ -78,7 +81,10 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     info_parser = sp.add_parser("info", help="show compiler paths")
     info_parser.add_argument("compiler_spec")
     info_parser.add_argument(
-        "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read from",
     )
     info_parser.add_argument(
         "--remote", action="store_true", help="list also compilers from registered buildcaches"

--- a/lib/spack/spack/cmd/compilers.py
+++ b/lib/spack/spack/cmd/compilers.py
@@ -14,7 +14,10 @@ level = "short"
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
-        "--scope", action=arguments.ConfigScope, help="configuration scope to read/modify"
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read/modify",
     )
     subparser.add_argument(
         "--remote", action="store_true", help="list also compilers from registered buildcaches"

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -178,6 +178,8 @@ def _get_scope_and_section(args):
 
 
 def print_configuration(args, *, blame: bool) -> None:
+    if args.scope and args.scope not in spack.config.existing_scope_names():
+        tty.die(f"the argument --scope={args.scope} must refer to an existing scope.")
     if args.scope and args.section is None:
         tty.die(f"the argument --scope={args.scope} requires specifying a section.")
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -326,7 +326,7 @@ def print_tests(pkg: PackageBase, args: Namespace) -> None:
 
 def _fmt_when(when: "spack.spec.Spec", indent: int) -> str:
     return color.colorize(
-        f"{indent * ' '}@B{{when}} {color.cescape(when.format(color=color.get_color_when()))}"
+        f"{indent * ' '}@B{{when}} {color.cescape(when._long_spec(color=color.get_color_when()))}"
     )
 
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -48,7 +48,10 @@ def setup_parser(subparser: argparse.ArgumentParser):
     # List
     list_parser = sp.add_parser("list", aliases=["ls"], help=repo_list.__doc__)
     list_parser.add_argument(
-        "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        help="configuration scope to read from",
     )
     output_group = list_parser.add_mutually_exclusive_group()
     output_group.add_argument("--names", action="store_true", help="show configuration names only")

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """High-level functions to concretize list of specs"""
 import importlib
+import multiprocessing
 import sys
 import time
 from typing import Iterable, List, Optional, Sequence, Tuple, Union
@@ -142,7 +143,7 @@ def concretize_separately(
     num_procs = min(len(args), spack.config.determine_number_of_jobs(parallel=True))
 
     msg = "Starting concretization"
-    if sys.platform not in ("darwin", "win32") and num_procs > 1:
+    if multiprocessing.get_start_method() == "fork" and num_procs > 1:
         msg += f" pool with {num_procs} processes"
     tty.msg(msg)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -171,6 +171,11 @@ class ConfigScope:
 
         return self._included_scopes
 
+    @property
+    def exists(self) -> bool:
+        """Whether the config object indicated by the scope can be read"""
+        return True
+
     def override_include(self):
         """Whether the ``include::`` section of this scope should override lower scopes."""
         include = self.sections.get("include")
@@ -218,13 +223,24 @@ class DirectoryConfigScope(ConfigScope):
         self.writable = writable
         self.prefer_modify = prefer_modify
 
+    @property
+    def exists(self) -> bool:
+        return os.path.exists(self.path)
+
     def get_section_filename(self, section: str) -> str:
         """Returns the filename associated with a given section"""
         _validate_section_name(section)
         return os.path.join(self.path, f"{section}.yaml")
 
     def get_section(self, section: str) -> Optional[YamlConfigDict]:
-        """Returns the data associated with a given section"""
+        """Returns the data associated with a given section if the scope exists"""
+        if not self.exists:
+            tty.debug(f"Attempting to read from missing scope: {self} at {self.path}")
+            return {}
+        return self._get_section(section)
+
+    def _get_section(self, section: str) -> Optional[YamlConfigDict]:
+        """get_section but without the existence check"""
         if section not in self.sections:
             path = self.get_section_filename(section)
             schema = SECTION_SCHEMAS[section]
@@ -237,7 +253,7 @@ class DirectoryConfigScope(ConfigScope):
             raise spack.error.ConfigError(f"Cannot write to immutable scope {self}")
 
         filename = self.get_section_filename(section)
-        data = self.get_section(section)
+        data = self._get_section(section)
         if data is None:
             return
 
@@ -289,6 +305,10 @@ class SingleFileScope(ConfigScope):
         self.prefer_modify = prefer_modify
         self.yaml_path = yaml_path or []
 
+    @property
+    def exists(self) -> bool:
+        return os.path.exists(self.path)
+
     def get_section_filename(self, section) -> str:
         return self.path
 
@@ -318,6 +338,10 @@ class SingleFileScope(ConfigScope):
         #      }
         #   }
         # }
+
+        if not self.exists:
+            tty.debug(f"Attempting to read from missing scope: {self} at {self.path}")
+            return {}
 
         # This bit ensures we have read the file and have
         # the raw data in memory
@@ -574,6 +598,12 @@ class Configuration:
     def writable_scopes(self) -> Generator[ConfigScope, None, None]:
         """Generator of writable scopes with an associated file."""
         return (s for s in self.scopes.values() if s.writable)
+
+    @property
+    def existing_scopes(self) -> Generator[ConfigScope, None, None]:
+        """Generator of existing scopes. These are self.scopes where the
+        scope has a representation on the filesystem or is internal"""
+        return (s for s in self.scopes.values() if s.exists)
 
     def highest_precedence_scope(self) -> ConfigScope:
         """Writable scope with the highest precedence."""
@@ -979,6 +1009,10 @@ class OptionalInclude:
         Raises:
             ValueError: the required configuration path does not exist
         """
+        assert self._valid_parent_scope(
+            parent_scope
+        ), "Optional includes must have valid parent_scope object"
+
         # use specified name if there is one
         config_name = self.name
         if not config_name:
@@ -1000,12 +1034,16 @@ class OptionalInclude:
 
             config_name = f"{parent_scope.name}:{included_name}"
 
-        if os.path.isdir(config_path):
-            # directories are treated as regular ConfigScopes
-            tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
-            return DirectoryConfigScope(config_name, config_path, prefer_modify=self.prefer_modify)
+        _, ext = os.path.splitext(config_path)
+        ext_is_yaml = ext == ".yaml" or ext == ".yml"
+        is_dir = os.path.isdir(config_path)
+        exists = os.path.exists(config_path)
 
-        if os.path.exists(config_path):
+        if not exists and not self.optional:
+            dest = f" at ({config_path})" if config_path != path else ""
+            raise ValueError(f"Required path ({path}) does not exist{dest}")
+
+        if (exists and not is_dir) or ext_is_yaml:
             # files are assumed to be SingleFileScopes
             tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
             return SingleFileScope(
@@ -1015,11 +1053,26 @@ class OptionalInclude:
                 prefer_modify=self.prefer_modify,
             )
 
-        if not self.optional:
-            dest = f" at ({config_path})" if config_path != path else ""
-            raise ValueError(f"Required path ({path}) does not exist{dest}")
+        if ext and not is_dir:
+            raise ValueError(
+                f"File-based scope does not exist yet: should have a .yaml/.yml extension \
+for file scopes, or no extension for directory scopes (currently {ext})"
+            )
 
-        return None
+        # directories are treated as regular ConfigScopes
+        # assign by "default"
+        tty.debug(f"Creating DirectoryConfigScope {config_name} for '{config_path}'")
+        return DirectoryConfigScope(config_name, config_path, prefer_modify=self.prefer_modify)
+
+    def _valid_parent_scope(self, parent_scope: ConfigScope) -> bool:
+        """Validates that a parent scope is a valid configuration object"""
+        # enforced by type checking but those can always be # type: ignore'd
+        assert isinstance(
+            parent_scope, ConfigScope
+        ), f"Optional include must have valid parent scope,\
+ of type ConfigScope; Type:{type(parent_scope)} is not valid."
+        # naive check that parent scope name isn't empty or just whitespace
+        return bool(re.sub(r"\s", "", parent_scope.name))
 
     def evaluate_condition(self) -> bool:
         # circular dependencies
@@ -1470,8 +1523,22 @@ def writable_scopes() -> List[ConfigScope]:
     return scopes
 
 
+def existing_scopes() -> List[ConfigScope]:
+    """Return list of existing scopes. Scopes where Spack is
+    aware of said scope, and the scope has a representation
+    on the filesystem or are internal scopes.
+    Higher-priority scopes come first in the list."""
+    scopes = [x for x in CONFIG.scopes.values() if x.exists]
+    scopes.reverse()
+    return scopes
+
+
 def writable_scope_names() -> List[str]:
     return list(x.name for x in writable_scopes())
+
+
+def existing_scope_names() -> List[str]:
+    return list(x.name for x in existing_scopes())
 
 
 def matched_config(cfg_path: str) -> List[Tuple[str, Any]]:

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -182,6 +182,7 @@ def spec_from_entry(entry):
     spec._hashes_final = True
     spec.external_path = entry["prefix"]
     spec.origin = "external-db"
+    spec.namespace = pkg_cls.namespace
     spack.spec.Spec.ensure_valid_variants(spec)
 
     return spec

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -87,6 +87,7 @@ def complete_architecture(node: spack.spec.Spec) -> None:
         node.constrain(spack.spec.Spec.default_arch())
         node.architecture.target = spack.archspec.HOST_TARGET_FAMILY
 
+    node.namespace = spack.repo.PATH.repo_for_pkg(node.name).namespace
     for flag_type in spack.spec.FlagMap.valid_compiler_flags():
         node.compiler_flags.setdefault(flag_type, [])
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1432,7 +1432,18 @@ class RewireTask(Task):
             try:
                 install_args = self.request.install_args
                 unsigned = install_args.get("unsigned")
-                _process_binary_cache_tarball(self.pkg, explicit=self.explicit, unsigned=unsigned)
+                success = _process_binary_cache_tarball(
+                    self.pkg, explicit=self.explicit, unsigned=unsigned
+                )
+
+                if not success:
+                    tty.msg(
+                        "Failed to find binary for build spec, requeuing {self.pkg.spec} with"
+                        "dependency install task for its build spec"
+                    )
+                    self.status = oldstatus
+                    return ExecuteResult.MISSING_BUILD_SPEC
+
                 _print_installed_pkg(self.pkg.prefix)
                 self.record.succeed()
                 return ExecuteResult.SUCCESS

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1526,8 +1526,8 @@ class PackageInstaller:
             explicit = {pkg.spec.dag_hash() for pkg in packages} if explicit else set()
 
         if concurrent_packages is None:
-            concurrent_packages = spack.config.get("config:concurrent_packages", default=1)
-        self.concurrent_packages = concurrent_packages
+            concurrent_packages = int(spack.config.get("config:concurrent_packages", default=1))
+        self.concurrent_packages = max(1, concurrent_packages)
 
         install_args = {
             "dependencies_policy": dependencies_policy,

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -40,6 +40,8 @@ from collections import defaultdict
 from gzip import GzipFile
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
+from spack.vendor.typing_extensions import Literal
+
 import spack.binary_distribution as binary_distribution
 import spack.build_environment
 import spack.builder
@@ -75,6 +77,9 @@ from spack.util.executable import which
 _counter = itertools.count(0)
 
 _FAIL_FAST_ERR = "Terminating after first install failure"
+
+#: Type for specifying installation source modes
+InstallPolicy = Literal["auto", "cache_only", "source_only"]
 
 
 class BuildStatus(enum.Enum):
@@ -781,16 +786,14 @@ class BuildRequest:
         """Ensure standard install options are set to at least the default."""
         for arg, default in [
             ("context", "build"),  # installs *always* build
-            ("dependencies_cache_only", False),
-            ("dependencies_use_cache", True),
+            ("dependencies_policy", "auto"),
             ("dirty", False),
             ("fail_fast", False),
             ("fake", False),
             ("install_deps", True),
             ("install_package", True),
             ("install_source", False),
-            ("package_cache_only", False),
-            ("package_use_cache", True),
+            ("root_policy", "auto"),
             ("keep_prefix", False),
             ("keep_stage", False),
             ("restage", False),
@@ -814,14 +817,16 @@ class BuildRequest:
         include_build_deps = self.install_args.get("include_build_deps")
 
         if self.pkg_id == package_id(pkg.spec):
-            cache_only = self.install_args.get("package_cache_only")
+            policy = self.install_args.get("root_policy", "auto")
         else:
-            cache_only = self.install_args.get("dependencies_cache_only")
+            policy = self.install_args.get("dependencies_policy", "auto")
 
         # Include build dependencies if pkg is going to be built from sources, or
         # if build deps are explicitly requested.
         if include_build_deps or not (
-            cache_only or pkg.spec.installed and pkg.spec.dag_hash() not in self.overwrite
+            policy == "cache_only"
+            or pkg.spec.installed
+            and pkg.spec.dag_hash() not in self.overwrite
         ):
             depflag |= dt.BUILD
         if self.run_tests(pkg):
@@ -1164,20 +1169,11 @@ class Task:
         return self.pkg == self.request.pkg
 
     @property
-    def use_cache(self) -> bool:
-        _use_cache = True
+    def install_policy(self) -> InstallPolicy:
         if self.is_build_request:
-            return self.request.install_args.get("package_use_cache", _use_cache)
+            return self.request.install_args.get("root_policy", "auto")
         else:
-            return self.request.install_args.get("dependencies_use_cache", _use_cache)
-
-    @property
-    def cache_only(self) -> bool:
-        _cache_only = False
-        if self.is_build_request:
-            return self.request.install_args.get("package_cache_only", _cache_only)
-        else:
-            return self.request.install_args.get("dependencies_cache_only", _cache_only)
+            return self.request.install_args.get("dependencies_policy", "auto")
 
     @property
     def key(self) -> Tuple[int, int]:
@@ -1261,11 +1257,12 @@ class BuildTask(Task):
         # Use the binary cache to install if requested,
         # save result to be handled in BuildTask.complete()
         # TODO: change binary installs to occur in subprocesses rather than the main Spack process
-        if self.use_cache:
+        policy = self.install_policy
+        if policy != "source_only":
             if _install_from_cache(pkg, self.explicit, unsigned):
                 self.success_result = ExecuteResult.SUCCESS
                 return
-            elif self.cache_only:
+            elif policy == "cache_only":
                 self.error_result = spack.error.InstallError(
                     "No binary found when cache-only was specified", pkg=pkg
                 )
@@ -1472,9 +1469,6 @@ class PackageInstaller:
         self,
         packages: List["spack.package_base.PackageBase"],
         *,
-        cache_only: bool = False,
-        dependencies_cache_only: bool = False,
-        dependencies_use_cache: bool = True,
         dirty: bool = False,
         explicit: Union[Set[str], bool] = False,
         overwrite: Optional[Union[List[str], Set[str]]] = None,
@@ -1486,17 +1480,16 @@ class PackageInstaller:
         install_source: bool = False,
         keep_prefix: bool = False,
         keep_stage: bool = False,
-        package_cache_only: bool = False,
-        package_use_cache: bool = True,
         restage: bool = False,
         skip_patch: bool = False,
         stop_at: Optional[str] = None,
         stop_before: Optional[str] = None,
         tests: Union[bool, List[str], Set[str]] = False,
         unsigned: Optional[bool] = None,
-        use_cache: bool = False,
         verbose: bool = False,
         concurrent_packages: Optional[int] = None,
+        root_policy: InstallPolicy = "auto",
+        dependencies_policy: InstallPolicy = "auto",
     ) -> None:
         """
         Arguments:
@@ -1518,9 +1511,10 @@ class PackageInstaller:
             stop_at: last installation phase to be executed (or None)
             tests: False to run no tests, True to test all packages, or a list of package names to
                 run tests for some
-            use_cache: Install from binary package, if available.
             verbose: Display verbose build output (by default, suppresses it)
             concurrent_packages: Max packages to be built concurrently
+            root_policy: ``"auto"``, ``"cache_only"``, ``"source_only"``.
+            dependencies_policy: ``"auto"``, ``"cache_only"``, ``"source_only"``.
         """
         if sys.platform == "win32":
             # No locks on Windows, we should always use 1 process
@@ -1536,9 +1530,7 @@ class PackageInstaller:
         self.concurrent_packages = concurrent_packages
 
         install_args = {
-            "cache_only": cache_only,
-            "dependencies_cache_only": dependencies_cache_only,
-            "dependencies_use_cache": dependencies_use_cache,
+            "dependencies_policy": dependencies_policy,
             "dirty": dirty,
             "explicit": explicit,
             "fail_fast": fail_fast,
@@ -1550,15 +1542,13 @@ class PackageInstaller:
             "keep_prefix": keep_prefix,
             "keep_stage": keep_stage,
             "overwrite": overwrite or [],
-            "package_cache_only": package_cache_only,
-            "package_use_cache": package_use_cache,
+            "root_policy": root_policy,
             "restage": restage,
             "skip_patch": skip_patch,
             "stop_at": stop_at,
             "stop_before": stop_before,
             "tests": tests,
             "unsigned": unsigned,
-            "use_cache": use_cache,
             "verbose": verbose,
             "concurrent_packages": self.concurrent_packages,
         }
@@ -2385,7 +2375,7 @@ class PackageInstaller:
             raise
 
         except BuildcacheEntryError as exc:
-            if task.cache_only:
+            if task.install_policy == "cache_only":
                 raise
 
             # Checking hash on downloaded binary failed.
@@ -2394,7 +2384,7 @@ class PackageInstaller:
                 f"to {str(exc)}: Requeuing to install from source."
             )
             # this overrides a full method, which is ugly.
-            task.use_cache = False  # type: ignore[misc]
+            task.install_policy = "source_only"  # type: ignore[misc]
             self._requeue_task(task, install_status)
             return None
 

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -497,21 +497,27 @@ class nixlog:
         # Currently only used to save echo value between uses
         self.parent_pipe, child_pipe = multiprocessing.Pipe(duplex=False)
 
-        # Sets a daemon that writes to file what it reads from a pipe
+        stdin_fd = None
+        stdout_fd = None
         try:
             # need to pass this b/c multiprocessing closes stdin in child.
-            input_fd = None
             try:
                 if sys.stdin.isatty():
-                    input_fd = Connection(os.dup(sys.stdin.fileno()))
+                    stdin_fd = Connection(os.dup(sys.stdin.fileno()))
             except BaseException:
                 # just don't forward input if this fails
                 pass
 
+            # If our process has redirected stdout after the forkserver was started, we need to
+            # make the forked processes use the new file descriptors.
+            if multiprocessing.get_start_method() == "forkserver":
+                stdout_fd = Connection(os.dup(sys.stdout.fileno()))
+
             self.process = multiprocessing.Process(
                 target=_writer_daemon,
                 args=(
-                    input_fd,
+                    stdin_fd,
+                    stdout_fd,
                     read_fd,
                     self.write_fd,
                     self.echo,
@@ -524,8 +530,10 @@ class nixlog:
             self.process.start()
 
         finally:
-            if input_fd:
-                input_fd.close()
+            if stdin_fd:
+                stdin_fd.close()
+            if stdout_fd:
+                stdout_fd.close()
             read_fd.close()
 
         # Flush immediately before redirecting so that anything buffered
@@ -810,6 +818,7 @@ class winlog:
 
 def _writer_daemon(
     stdin_fd: Optional[Connection],
+    stdout_fd: Optional[Connection],
     read_fd: Connection,
     write_fd: Connection,
     echo: bool,
@@ -878,6 +887,10 @@ def _writer_daemon(
         stdin_file = os.fdopen(stdin_fd.fileno(), closefd=False)
     else:
         stdin_file = None
+
+    if stdout_fd:
+        os.dup2(stdout_fd.fileno(), sys.stdout.fileno())
+        stdout_fd.close()
 
     # list of streams to select from
     istreams = [read_file, stdin_file] if stdin_file else [read_file]

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -133,12 +133,9 @@ def remove(name, scope):
     if not mirrors:
         mirrors = syaml.syaml_dict()
 
-    if name not in mirrors:
-        tty.die("No mirror with name %s" % name)
-
-    mirrors.pop(name)
+    removed = mirrors.pop(name, False)
     spack.config.set("mirrors", mirrors, scope=scope)
-    tty.msg("Removed mirror %s." % name)
+    return bool(removed)
 
 
 class MirrorStatsForOneSpec:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -54,6 +54,7 @@ import spack.llnl.util.tty
 import spack.paths
 import spack.report
 import spack.spec
+import spack.stage
 import spack.store
 import spack.traverse
 import spack.url_buildcache
@@ -167,16 +168,13 @@ def tee(control_r: int, log_r: int, file_w: int, parent_w: int) -> None:
 
 class Tee:
     """Emulates ./build 2>&1 | tee build.log. The output is sent both to a log file and the parent
-    process (if echoing is enabled). The control_fd is used to enable/disable echoing. The initial
-    log file is /dev/null and can be changed later with set_output_file()."""
+    process (if echoing is enabled). The control_fd is used to enable/disable echoing."""
 
-    def __init__(self, control: Connection, parent: Connection) -> None:
+    def __init__(self, control: Connection, parent: Connection, log_fd: int) -> None:
         self.control = control
         self.parent = parent
-        dev_null_fd = os.open(os.devnull, os.O_WRONLY)
-        #: The file descriptor of the log file (initially /dev/null)
-        self.log_fd = os.dup(dev_null_fd)
-        os.close(dev_null_fd)
+        #: The file descriptor of the log file
+        self.log_fd = log_fd
         r, w = os.pipe()
         self.tee_thread = threading.Thread(
             target=tee,
@@ -188,15 +186,11 @@ class Tee:
         os.dup2(w, sys.stderr.fileno())
         os.close(w)
 
-    def set_output_file(self, path: str) -> None:
-        """Redirect output to the specified log file."""
-        log_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
-        os.dup2(log_fd, self.log_fd)
-        os.close(log_fd)
-
     def close(self) -> None:
         # Closing stdout and stderr should close the last reference to the write end of the pipe,
         # causing the tee thread to wake up, flush the last data, and exit.
+        sys.stdout.flush()
+        sys.stderr.flush()
         os.close(sys.stdout.fileno())
         os.close(sys.stderr.fileno())
         self.tee_thread.join()
@@ -366,12 +360,18 @@ def worker_function(
     if spec.external:
         return
 
-    tee = Tee(echo_control, parent)
-
     os.environ["MAKEFLAGS"] = makeflags
     spack.store.STORE = store
     spack.config.CONFIG = config
     spack.paths.set_working_dir()
+
+    # Create a log file in the root of the stage dir.
+    log_fd, log_path = tempfile.mkstemp(
+        prefix=f"spack-stage-{spec.name}-{spec.dag_hash()}-",
+        suffix=".log",
+        dir=spack.stage.get_stage_root(),
+    )
+    tee = Tee(echo_control, parent, log_fd)
 
     # Use closedfd=false because of the connection objects. Use line buffering.
     state_stream = os.fdopen(state.fileno(), "w", buffering=1, closefd=False)
@@ -390,7 +390,7 @@ def worker_function(
                 restage,
                 skip_patch,
                 state_stream,
-                tee,
+                log_path,
                 store,
             )
     except Exception:
@@ -399,6 +399,18 @@ def worker_function(
     finally:
         tee.close()
         state_stream.close()
+
+    if exit_code == 0 and not os.path.lexists(spec.package.install_log_path):
+        # Try to install the compressed log file
+        try:
+            with open(log_path, "rb") as f, open(spec.package.install_log_path, "wb") as g:
+                # Use GzipFile directly so we can omit filename / mtime in header
+                gzip_file = GzipFile(filename="", mode="wb", compresslevel=6, mtime=0, fileobj=g)
+                shutil.copyfileobj(f, gzip_file)
+                gzip_file.close()
+            os.unlink(log_path)
+        except Exception:
+            pass  # don't fail the build just because log compression failed
 
     sys.exit(exit_code)
 
@@ -414,7 +426,7 @@ def _install(
     restage: bool,
     skip_patch: bool,
     state_stream: io.TextIOWrapper,
-    tee: Tee,
+    log_path: str,
     store: spack.store.Store = spack.store.STORE,
 ) -> None:
     """Install a spec from build cache or source."""
@@ -444,8 +456,7 @@ def _install(
             stage.destroy()
         stage.create()
 
-        # Start collecting logs.
-        tee.set_output_file(pkg.log_path)
+        os.symlink(log_path, pkg.log_path)
 
         send_state("staging", state_stream)
 
@@ -461,13 +472,6 @@ def _install(
         for phase in spack.builder.create(pkg):
             send_state(phase.name, state_stream)
             phase.execute()
-
-        # Install source build logs
-        with open(pkg.log_path, "rb") as f, open(pkg.install_log_path, "wb") as g:
-            # Use GzipFile directly so we can omit filename / mtime in header
-            gzip_file = GzipFile(filename="", mode="wb", compresslevel=6, mtime=0, fileobj=g)
-            shutil.copyfileobj(f, gzip_file)
-            gzip_file.close()
 
         spack.hooks.post_install(spec, explicit)
 

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -39,6 +39,8 @@ from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
 from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Set, Tuple, Union
 
+from spack.vendor.typing_extensions import Literal
+
 import spack.binary_distribution
 import spack.build_environment
 import spack.builder
@@ -58,6 +60,9 @@ import spack.util.lock
 
 if TYPE_CHECKING:
     import spack.package_base
+
+#: Type for specifying installation source modes
+InstallPolicy = Literal["auto", "cache_only", "source_only"]
 
 #: How often to update a spinner in seconds
 SPINNER_INTERVAL = 0.1
@@ -952,9 +957,6 @@ class PackageInstaller:
         self,
         packages: List["spack.package_base.PackageBase"],
         *,
-        cache_only: bool = False,
-        dependencies_cache_only: bool = False,
-        dependencies_use_cache: bool = True,
         dirty: bool = False,
         explicit: Union[Set[str], bool] = False,
         overwrite: Optional[Union[List[str], Set[str]]] = None,
@@ -966,25 +968,22 @@ class PackageInstaller:
         install_source: bool = False,
         keep_prefix: bool = False,
         keep_stage: bool = False,
-        package_cache_only: bool = False,
-        package_use_cache: bool = True,
         restage: bool = True,
         skip_patch: bool = False,
         stop_at: Optional[str] = None,
         stop_before: Optional[str] = None,
         tests: Union[bool, List[str], Set[str]] = False,
         unsigned: Optional[bool] = None,
-        use_cache: bool = False,
         verbose: bool = False,
         concurrent_packages: Optional[int] = None,
+        root_policy: InstallPolicy = "auto",
+        dependencies_policy: InstallPolicy = "auto",
     ) -> None:
 
-        if cache_only:
+        if root_policy == "cache_only" or dependencies_policy == "cache_only":
             raise NotImplementedError("Cache-only installs are not implemented")
-        elif dependencies_cache_only:
-            raise NotImplementedError("Dependencies cache-only installs are not implemented")
-        elif not dependencies_use_cache:
-            raise NotImplementedError("Not using cache for dependencies is not implemented")
+        elif root_policy == "source_only" or dependencies_policy == "source_only":
+            raise NotImplementedError("Source-only installs are not implemented")
         elif dirty:
             raise NotImplementedError("Dirty installs are not implemented")
         elif overwrite:
@@ -1005,10 +1004,6 @@ class PackageInstaller:
             raise NotImplementedError("Keeping install prefixes is not implemented")
         elif keep_stage:
             raise NotImplementedError("Keeping build stages is not implemented")
-        elif package_cache_only:
-            raise NotImplementedError("Package cache only installs are not implemented")
-        elif not package_use_cache:
-            raise NotImplementedError("Not using package cache is not implemented")
         elif not restage:
             raise NotImplementedError("Restaging builds is not implemented")
         elif skip_patch:
@@ -1019,8 +1014,6 @@ class PackageInstaller:
             raise NotImplementedError("Stopping before an install phase is not implemented")
         elif tests is not False:
             raise NotImplementedError("Tests during install are not implemented")
-        elif use_cache:
-            raise NotImplementedError("Using cache only is not implemented")
         # verbose and concurrent_packages are not worth erroring out for
 
         specs = [pkg.spec for pkg in packages]

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -421,7 +421,6 @@ def _install(
 
     # Create the stage and log file before starting the tee thread.
     pkg = spec.package
-    spack.build_environment.setup_package(pkg, dirty=dirty)
 
     # Try to install from buildcache, unless user asked for source only
     if install_policy != "source_only":
@@ -433,6 +432,7 @@ def _install(
             send_state("no binary available", state_stream)
             raise spack.error.InstallError(f"No binary available for {spec}")
 
+    spack.build_environment.setup_package(pkg, dirty=dirty)
     store.layout.create_install_directory(spec)
 
     stage = pkg.stage

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -27,7 +27,6 @@ import os
 import re
 import selectors
 import shutil
-import signal
 import sys
 import tempfile
 import termios
@@ -70,18 +69,6 @@ CLEANUP_TIMEOUT = 2.0
 OUTPUT_BUFFER_SIZE = 4096
 
 
-def setup_signal_handling() -> int:
-    """Set up signal handling for SIGCHLD using a wakeup pipe."""
-    # A handler is still needed for set_wakeup_fd to work, but it can be a no-op.
-    signal.signal(signal.SIGCHLD, lambda signum, frame: None)
-    signal_r, signal_w = os.pipe()
-    os.set_blocking(signal_r, False)
-    os.set_blocking(signal_w, False)
-    # This will write the signal number to the pipe, waking up select().
-    signal.set_wakeup_fd(signal_w)
-    return signal_r
-
-
 class ChildInfo:
     """Information about a child process."""
 
@@ -112,6 +99,10 @@ class ChildInfo:
         try:
             selector.unregister(self.state_r_conn.fileno())
         except KeyError:
+            pass
+        try:
+            selector.unregister(self.proc.sentinel)
+        except (KeyError, ValueError):
             pass
         self.output_r_conn.close()
         self.state_r_conn.close()
@@ -470,23 +461,13 @@ def start_build(
     return ChildInfo(proc, spec, output_r_conn, state_r_conn, control_w_conn, explicit)
 
 
-def reap_children(
-    child_data: Dict[int, ChildInfo], selector: selectors.BaseSelector, jobserver: JobServer
-) -> List[int]:
-    """Reap terminated child processes"""
-    to_delete: List[int] = []
-    for pid, child in child_data.items():
-        if child.proc.is_alive():
-            continue
-        to_delete.append(pid)
-        jobserver.release()
-        child.cleanup(selector)
-    return to_delete
+def get_jobserver_config(makeflags: Optional[str] = None) -> Optional[Union[str, Tuple[int, int]]]:
+    """Parse MAKEFLAGS for jobserver. Either it's a FIFO or (r, w) pair of file descriptors.
 
-
-def get_jobserver_config() -> Optional[Union[str, Tuple[int, int]]]:
-    """Parse MAKEFLAGS for jobserver. Either it's a FIFO or (r, w) pair of file descriptors."""
-    makeflags = os.environ.get("MAKEFLAGS", "")
+    Args:
+        makeflags: MAKEFLAGS string to parse. If None, reads from os.environ.
+    """
+    makeflags = os.environ.get("MAKEFLAGS", "") if makeflags is None else makeflags
     if not makeflags:
         return None
     # We can have the following flags:
@@ -1106,9 +1087,6 @@ class PackageInstaller:
     def _installer(self) -> None:
         jobserver = JobServer(self.jobs)
 
-        # Set up signal handling
-        signal_r = setup_signal_handling()
-
         # Set stdin to non-blocking for key press detection
         if sys.stdin.isatty():
             old_stdin_settings = termios.tcgetattr(sys.stdin)
@@ -1117,7 +1095,6 @@ class PackageInstaller:
             old_stdin_settings = None
 
         selector = selectors.DefaultSelector()
-        selector.register(signal_r, selectors.EVENT_READ, "signal")
         selector.register(sys.stdin.fileno(), selectors.EVENT_READ, "stdin")
 
         # Setup the database write lock. TODO: clean this up
@@ -1142,11 +1119,12 @@ class PackageInstaller:
                 elif not self.pending_builds and jobserver.r in selector.get_map():
                     selector.unregister(jobserver.r)
 
-                children_have_finished = False
                 jobserver_token_available = False
                 stdin_ready = False
 
                 events = selector.select(timeout=SPINNER_INTERVAL)
+
+                finished_pids = []
 
                 for key, _ in events:
                     data = key.data
@@ -1157,27 +1135,23 @@ class PackageInstaller:
                             self._handle_child_logs(key.fd, child_info, selector)
                         elif data.name == "state":
                             self._handle_child_state(key.fd, child_info, selector)
-                    elif data == "signal":
-                        children_have_finished = True
+                        elif data.name == "sentinel":
+                            finished_pids.append(data.pid)
                     elif data == "jobserver":
                         jobserver_token_available = True
                     elif data == "stdin":
                         stdin_ready = True
 
-                if children_have_finished:
-                    try:
-                        # Clear the signal pipe
-                        os.read(signal_r, OUTPUT_BUFFER_SIZE)
-                    except BlockingIOError:
-                        pass
-                    for pid in reap_children(self.running_builds, selector, jobserver):
-                        build = self.running_builds.pop(pid)
-                        if build.proc.exitcode == 0:
-                            to_insert_in_database.append(build)
-                            self.build_status.update_state(build.spec.dag_hash(), "finished")
-                        else:
-                            failures.append(build.spec)
-                            self.build_status.update_state(build.spec.dag_hash(), "failed")
+                for pid in finished_pids:
+                    build = self.running_builds.pop(pid)
+                    jobserver.release()
+                    build.cleanup(selector)
+                    if build.proc.exitcode == 0:
+                        to_insert_in_database.append(build)
+                        self.build_status.update_state(build.spec.dag_hash(), "finished")
+                    else:
+                        failures.append(build.spec)
+                        self.build_status.update_state(build.spec.dag_hash(), "failed")
 
                 if stdin_ready:
                     try:
@@ -1236,9 +1210,6 @@ class PackageInstaller:
             self.build_status.update(finalize=True)
             selector.close()
             jobserver.close()
-            old_wakeup_fd = signal.set_wakeup_fd(-1)
-            os.close(old_wakeup_fd)
-            os.close(signal_r)
 
         if failures:
             lines = [f"{s}: {s.package.log_path}" for s in failures]
@@ -1275,6 +1246,7 @@ class PackageInstaller:
         selector.register(
             child_info.state_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "state")
         )
+        selector.register(child_info.proc.sentinel, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
         self.build_status.add_build(
             child_info.spec, explicit=explicit, control_w_conn=child_info.control_w_conn
         )

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -322,6 +322,7 @@ def worker_function(
     install_policy: InstallPolicy,
     dirty: bool,
     keep_stage: bool,
+    restage: bool,
     overwrite: bool,
     keep_prefix: bool,
     skip_patch: bool,
@@ -346,6 +347,7 @@ def worker_function(
         install_policy: ``"auto"``, ``"cache_only"``, or ``"source_only"``
         dirty: Whether to preserve user environment in the build environment
         keep_stage: Whether to keep the build stage after installation
+        restage: Whether to restage the source before building
         overwrite: Whether to overwrite the existing install prefix
         keep_prefix: Whether to keep a failed installation prefix
         skip_patch: Whether to skip the patch phase
@@ -384,6 +386,7 @@ def worker_function(
                 install_policy,
                 dirty,
                 keep_stage,
+                restage,
                 skip_patch,
                 state_stream,
                 tee,
@@ -407,6 +410,7 @@ def _install(
     install_policy: InstallPolicy,
     dirty: bool,
     keep_stage: bool,
+    restage: bool,
     skip_patch: bool,
     state_stream: io.TextIOWrapper,
     tee: Tee,
@@ -431,13 +435,12 @@ def _install(
     store.layout.create_install_directory(spec)
 
     stage = pkg.stage
+    stage.keep = keep_stage
 
     # Then try a source build.
     with stage:
-        # Set whether to keep the stage after installation
-        stage.keep = keep_stage
-
-        stage.destroy()
+        if restage:
+            stage.destroy()
         stage.create()
 
         # Start collecting logs.
@@ -561,6 +564,7 @@ def start_build(
     install_policy: InstallPolicy,
     dirty: bool,
     keep_stage: bool,
+    restage: bool,
     overwrite: bool,
     keep_prefix: bool,
     skip_patch: bool,
@@ -588,6 +592,7 @@ def start_build(
             install_policy,
             dirty,
             keep_stage,
+            restage,
             overwrite,
             keep_prefix,
             skip_patch,
@@ -1207,8 +1212,6 @@ class PackageInstaller:
             raise NotImplementedError("Fake installs are not implemented")
         elif install_source:
             raise NotImplementedError("Installing sources is not implemented")
-        elif not restage:
-            raise NotImplementedError("Restaging builds is not implemented")
         elif stop_at is not None:
             raise NotImplementedError("Stopping at an install phase is not implemented")
         elif stop_before is not None:
@@ -1249,6 +1252,7 @@ class PackageInstaller:
         }
         self.unsigned = unsigned
         self.dirty = dirty
+        self.restage = restage
         self.keep_stage = keep_stage
         self.skip_patch = skip_patch
 
@@ -1431,8 +1435,10 @@ class PackageInstaller:
     def _start(self, selector: selectors.BaseSelector, jobserver: JobServer) -> None:
         dag_hash = self.pending_builds.pop()
         explicit = dag_hash in self.explicit
+        spec = self.build_graph.nodes[dag_hash]
+        is_develop = spec.is_develop
         child_info = start_build(
-            self.build_graph.nodes[dag_hash],
+            spec,
             explicit=explicit,
             mirrors=self.binary_cache_for_spec[dag_hash],
             unsigned=self.unsigned,
@@ -1442,7 +1448,9 @@ class PackageInstaller:
                 else self.dependencies_policy
             ),
             dirty=self.dirty,
-            keep_stage=self.keep_stage,
+            # keep_stage/restage logic taken from installer.py
+            keep_stage=self.keep_stage or is_develop,
+            restage=self.restage and not is_develop,
             overwrite=dag_hash in self.overwrite,
             keep_prefix=self.keep_prefix,
             skip_patch=self.skip_patch,

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -55,6 +55,7 @@ import spack.paths
 import spack.report
 import spack.spec
 import spack.store
+import spack.traverse
 import spack.url_buildcache
 import spack.util.lock
 
@@ -1087,16 +1088,19 @@ class BuildGraph:
         ]
 
         with database.read_transaction():
+            # Set the install prefix for each spec based on the db record or store layout
+            for s in spack.traverse.traverse_nodes(specs):
+                _, record = database.query_by_spec_hash(s.dag_hash())
+                if record and record.path:
+                    s.set_prefix(record.path)
+                else:
+                    s.set_prefix(spack.store.STORE.layout.path_for_spec(s))
+
+            # Build the graph and determine which specs to prune
             while stack:
                 spec, install_policy = stack.pop()
                 key = spec.dag_hash()
                 _, record = database.query_by_spec_hash(key)
-
-                # Set the install prefix for each spec based on the db record or store layout
-                if record and record.path:
-                    spec.set_prefix(record.path)
-                else:
-                    spec.set_prefix(spack.store.STORE.layout.path_for_spec(spec))
 
                 # Conditionally include build dependencies
                 if record and record.installed and key not in overwrite_set:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -37,7 +37,7 @@ import tty
 from gzip import GzipFile
 from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
-from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, Generator, List, Optional, Set, Tuple, Union
 
 from spack.vendor.typing_extensions import Literal
 
@@ -591,7 +591,14 @@ class BuildInfo:
 class BuildStatus:
     """Tracks the build status display for terminal output."""
 
-    def __init__(self, total: int) -> None:
+    def __init__(
+        self,
+        total: int,
+        stdout: io.TextIOWrapper = sys.stdout,  # type: ignore[assignment]
+        get_terminal_size: Callable[[], Tuple[int, int]] = os.get_terminal_size,
+        get_time: Callable[[], float] = time.monotonic,
+        is_tty: Optional[bool] = None,
+    ) -> None:
         #: Ordered dict of build ID -> info
         self.total = total
         self.completed = 0
@@ -606,9 +613,13 @@ class BuildStatus:
         self.next_update = 0.0
         self.overview_mode = True  # Whether to draw the package overview
         self.tracked_build_id = ""  # identifier of the package whose logs we follow
-        self.is_tty = sys.stdout.isatty()  # Whether stdout is a terminal
         self.search_term = ""
         self.search_mode = False
+
+        self.stdout = stdout
+        self.get_terminal_size = get_terminal_size
+        self.get_time = get_time
+        self.is_tty = is_tty if is_tty is not None else self.stdout.isatty()
 
     def add_build(self, spec: spack.spec.Spec, explicit: bool, control_w_conn: Connection) -> None:
         """Add a new build to the display and mark the display as dirty."""
@@ -694,10 +705,10 @@ class BuildStatus:
         self.tracked_build_id = new_build_id
 
         # Tell the user we're following new logs, and instruct the child to start sending them.
-        print(
-            f"\n==> Following logs of {new_build.name}" f"\033[0;36m@{new_build.version}\033[0m",
-            flush=True,
+        self.stdout.write(
+            f"\n==> Following logs of {new_build.name}" f"\033[0;36m@{new_build.version}\033[0m\n"
         )
+        self.stdout.flush()
         try:
             os.write(new_build.control_w_conn.fileno(), b"1")
         except (KeyError, OSError):
@@ -711,7 +722,7 @@ class BuildStatus:
 
         if state in ("finished", "failed"):
             self.completed += 1
-            build_info.finished_time = time.monotonic() + CLEANUP_TIMEOUT
+            build_info.finished_time = self.get_time() + CLEANUP_TIMEOUT
 
             if build_id == self.tracked_build_id and not self.overview_mode:
                 self.toggle()
@@ -720,7 +731,10 @@ class BuildStatus:
 
         # For non-TTY output, print state changes immediately without colors
         if not self.is_tty:
-            print(f"{build_info.hash} {build_info.name}@{build_info.version}: {state}")
+            self.stdout.write(
+                f"{build_info.hash} {build_info.name}@{build_info.version}: {state}\n"
+            )
+            self.stdout.flush()
 
     def update_progress(self, build_id: str, current: int, total: int) -> None:
         """Update the progress of a package and mark the display as dirty."""
@@ -735,7 +749,7 @@ class BuildStatus:
         if not self.is_tty or not self.overview_mode:
             return
 
-        now = time.monotonic()
+        now = self.get_time()
 
         # Avoid excessive redraws
         if not finalize and now < self.next_update:
@@ -769,7 +783,7 @@ class BuildStatus:
         if self.active_area_rows > 0:
             buffer.write(f"\033[{self.active_area_rows}F")
 
-        max_width, max_height = os.get_terminal_size()
+        max_width, max_height = self.get_terminal_size()
 
         self.total_lines = 0
         total_finished = len(self.finished_builds)
@@ -817,8 +831,8 @@ class BuildStatus:
         buffer.write("\033[0J")
 
         # Print everything at once to avoid flickering
-        sys.stdout.write(buffer.getvalue())
-        sys.stdout.flush()
+        self.stdout.write(buffer.getvalue())
+        self.stdout.flush()
 
         # Update the number of lines drawn for next time. It reflects the number of active builds.
         self.active_area_rows = self.total_lines - total_finished
@@ -844,8 +858,8 @@ class BuildStatus:
         if self.overview_mode or build_id != self.tracked_build_id:
             return
         # TODO: drop initial bytes from data until first newline (?)
-        sys.stdout.buffer.write(data)
-        sys.stdout.flush()
+        self.stdout.buffer.write(data)
+        self.stdout.flush()
 
     def _render_build(self, build_info: BuildInfo, buffer: io.StringIO, max_width: int) -> None:
         line_width = 0

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -231,6 +231,9 @@ def worker_function(
     explicit: bool,
     mirrors: List[spack.url_buildcache.MirrorURLAndVersion],
     unsigned: Optional[bool],
+    dirty: bool,
+    keep_stage: bool,
+    skip_patch: bool,
     state: Connection,
     parent: Connection,
     echo_control: Connection,
@@ -249,6 +252,9 @@ def worker_function(
         explicit: Whether the spec was explicitly requested by the user
         mirrors: List of buildcache mirrors to try
         unsigned: Whether to allow unsigned buildcache entries
+        dirty: Whether to preserve user environment in the build environment
+        keep_stage: Whether to keep the build stage after installation
+        skip_patch: Whether to skip the patch phase
         state: Connection to send state updates to
         parent: Connection to send build output to
         echo_control: Connection to receive echo control messages from
@@ -273,7 +279,7 @@ def worker_function(
 
     # Create the stage and log file before starting the tee thread.
     pkg = spec.package
-    spack.build_environment.setup_package(pkg, dirty=False)
+    spack.build_environment.setup_package(pkg, dirty=dirty)
 
     # Use closedfd=false because of the connection objects. Use line buffering.
     state_stream = os.fdopen(state.fileno(), "w", buffering=1, closefd=False)
@@ -292,6 +298,9 @@ def worker_function(
 
     # Then try a source build.
     with stage:
+        # Set whether to keep the stage after installation
+        stage.keep = keep_stage
+
         stage.destroy()
         stage.create()
 
@@ -299,7 +308,10 @@ def worker_function(
         tee.set_output_file(pkg.log_path)
 
         send_state("staging", state_stream)
-        pkg.do_patch()
+        if not skip_patch:
+            pkg.do_patch()
+        else:
+            pkg.do_stage()
         os.chdir(stage.source_path)
 
         exit_code = 0
@@ -421,6 +433,9 @@ def start_build(
     explicit: bool,
     mirrors: List[spack.url_buildcache.MirrorURLAndVersion],
     unsigned: Optional[bool],
+    dirty: bool,
+    keep_stage: bool,
+    skip_patch: bool,
     jobserver: JobServer,
 ) -> ChildInfo:
     """Start a new build."""
@@ -442,6 +457,9 @@ def start_build(
             explicit,
             mirrors,
             unsigned,
+            dirty,
+            keep_stage,
+            skip_patch,
             state_w_conn,
             output_w_conn,
             control_r_conn,
@@ -984,8 +1002,6 @@ class PackageInstaller:
             raise NotImplementedError("Cache-only installs are not implemented")
         elif root_policy == "source_only" or dependencies_policy == "source_only":
             raise NotImplementedError("Source-only installs are not implemented")
-        elif dirty:
-            raise NotImplementedError("Dirty installs are not implemented")
         elif overwrite:
             raise NotImplementedError("Overwrite installs are not implemented")
         elif fail_fast:
@@ -1002,12 +1018,8 @@ class PackageInstaller:
             raise NotImplementedError("Installing sources is not implemented")
         elif keep_prefix:
             raise NotImplementedError("Keeping install prefixes is not implemented")
-        elif keep_stage:
-            raise NotImplementedError("Keeping build stages is not implemented")
         elif not restage:
             raise NotImplementedError("Restaging builds is not implemented")
-        elif skip_patch:
-            raise NotImplementedError("Skipping patches is not implemented")
         elif stop_at is not None:
             raise NotImplementedError("Stopping at an install phase is not implemented")
         elif stop_before is not None:
@@ -1032,6 +1044,9 @@ class PackageInstaller:
             for s in self.nodes.values()
         }
         self.unsigned = unsigned
+        self.dirty = dirty
+        self.keep_stage = keep_stage
+        self.skip_patch = skip_patch
 
         #: queue of packages ready to install (no children)
         self.pending_builds = [
@@ -1229,7 +1244,16 @@ class PackageInstaller:
         dag_hash = self.pending_builds.pop()
         explicit = dag_hash in self.explicit
         mirrors = self.binary_cache_for_spec[dag_hash]
-        child_info = start_build(self.nodes[dag_hash], explicit, mirrors, self.unsigned, jobserver)
+        child_info = start_build(
+            self.nodes[dag_hash],
+            explicit,
+            mirrors,
+            self.unsigned,
+            self.dirty,
+            self.keep_stage,
+            self.skip_patch,
+            jobserver,
+        )
         pid = child_info.proc.pid
         assert type(pid) is int
         self.running_builds[pid] = child_info

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -59,9 +59,8 @@ from spack.llnl.util.filesystem import (
     islink,
     symlink,
 )
-from spack.llnl.util.lang import ClassProperty, classproperty, memoized
+from spack.llnl.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.resource import Resource
-from spack.solver.versions import concretization_version_order
 from spack.util.package_hash import package_hash
 from spack.util.typing import SupportsRichComparison
 from spack.version import GitVersion, StandardVersion, VersionError, is_git_version
@@ -2584,6 +2583,33 @@ def preferred_version(pkg: Union[PackageBase, Type[PackageBase]]):
 
     version, _ = max(pkg.versions.items(), key=concretization_version_order)
     return version
+
+
+def sort_by_pkg_preference(
+    versions: Iterable[Union[GitVersion, StandardVersion]],
+    *,
+    pkg: Union[PackageBase, Type[PackageBase]],
+) -> List[Union[GitVersion, StandardVersion]]:
+    """Sorts the list of versions passed in input according to the preferences in the package. The
+    return value does not contain duplicate versions. Most preferred versions first.
+    """
+    s = [(v, pkg.versions.get(v, {})) for v in dedupe(versions)]
+    return [v for v, _ in sorted(s, reverse=True, key=concretization_version_order)]
+
+
+def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardVersion], dict]):
+    """Version order key for concretization, where preferred > not preferred,
+    not deprecated > deprecated, finite > any infinite component; only if all are
+    the same, do we use default version ordering."""
+    version, info = version_info
+    return (
+        info.get("preferred", False),
+        not info.get("deprecated", False),
+        not isinstance(version, GitVersion),
+        not version.isdevelop(),
+        not version.is_prerelease(),
+        version,
+    )
 
 
 class PackageStillNeededError(InstallError):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2574,14 +2574,21 @@ def deprecated_version(pkg: PackageBase, version: Union[str, StandardVersion]) -
 
 
 def preferred_version(pkg: Union[PackageBase, Type[PackageBase]]):
-    """
-    Returns a sorted list of the preferred versions of the package.
+    """Returns the preferred versions of the package according to package.py.
+
+    Accounts for version deprecation in the package recipe. Doesn't account for
+    any user configuration in packages.yaml.
 
     Arguments:
         pkg: The package whose versions are to be assessed.
     """
 
-    version, _ = max(pkg.versions.items(), key=concretization_version_order)
+    def _version_order(version_info):
+        version, info = version_info
+        deprecated_key = not info.get("deprecated", False)
+        return (deprecated_key, *concretization_version_order(version_info))
+
+    version, _ = max(pkg.versions.items(), key=_version_order)
     return version
 
 
@@ -2599,12 +2606,14 @@ def sort_by_pkg_preference(
 
 def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardVersion], dict]):
     """Version order key for concretization, where preferred > not preferred,
-    not deprecated > deprecated, finite > any infinite component; only if all are
-    the same, do we use default version ordering."""
+    finite > any infinite component; only if all are the same, do we use default version
+    ordering.
+
+    Version deprecation needs to be accounted for separately.
+    """
     version, info = version_info
     return (
         info.get("preferred", False),
-        not info.get("deprecated", False),
         not isinstance(version, GitVersion),
         not version.isdevelop(),
         not version.is_prerelease(),

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1730,11 +1730,13 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         remote = git("config", f"branch.{self.branch}.remote", output=str).strip()
 
                     if self.commit:
-                        spack.util.git.pull_checkout_commit(self.commit, git_exe=git)
+                        spack.util.git.pull_checkout_commit(
+                            self.commit, remote=remote, depth=depth, git_exe=git
+                        )
 
                     elif self.tag:
                         spack.util.git.pull_checkout_tag(
-                            self.tag, remote, depth=depth, git_exe=git
+                            self.tag, remote=remote, depth=depth, git_exe=git
                         )
 
                     elif self.branch:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -903,12 +903,6 @@ class RepoPath:
         """
         return any(repo.exists(pkg_name) for repo in self.repos)
 
-    def _have_name(self, pkg_name: str) -> bool:
-        have_name = pkg_name is not None
-        if have_name and not isinstance(pkg_name, str):
-            raise ValueError(f"is_virtual(): expected package name, got {type(pkg_name)}")
-        return have_name
-
     def is_virtual(self, pkg_name: str) -> bool:
         """Return True if the package with this name is virtual, False otherwise.
 
@@ -916,9 +910,9 @@ class RepoPath:
         is used to construct the provider index use the ``is_virtual_safe`` function.
 
         Args:
-            pkg_name (str): name of the package we want to check
+            pkg_name: name of the package we want to check
         """
-        have_name = self._have_name(pkg_name)
+        have_name = bool(pkg_name)
         return have_name and pkg_name in self.provider_index
 
     def is_virtual_safe(self, pkg_name: str) -> bool:
@@ -927,9 +921,9 @@ class RepoPath:
         This function doesn't use the provider index.
 
         Args:
-            pkg_name (str): name of the package we want to check
+            pkg_name: name of the package we want to check
         """
-        have_name = self._have_name(pkg_name)
+        have_name = bool(pkg_name)
         return have_name and (not self.exists(pkg_name) or self.get_pkg_class(pkg_name).virtual)
 
     def __contains__(self, pkg_name):

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -1,9 +1,9 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import codecs
 import collections
 import hashlib
+import io
 import os
 import platform
 import posixpath
@@ -454,7 +454,7 @@ class CDash(Reporter):
             try:
                 response = web_util.urlopen(request, timeout=SPACK_CDASH_TIMEOUT)
                 if self.current_package_name not in self.buildIds:
-                    resp_value = codecs.getreader("utf-8")(response).read()
+                    resp_value = io.TextIOWrapper(response, encoding="utf-8").read()
                     match = self.buildid_regexp.search(resp_value)
                     if match:
                         buildid = match.group(1)

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -70,7 +70,7 @@ properties: Dict[str, Any] = {
             "dirty": {"type": "boolean"},
             "build_language": {"type": "string"},
             "build_jobs": {"type": "integer", "minimum": 1},
-            "concurrent_packages": {"type": "integer", "minimum": 1},
+            "concurrent_packages": {"type": "integer", "minimum": 0},
             "ccache": {"type": "boolean"},
             "db_lock_timeout": {"type": "integer", "minimum": 1},
             "package_lock_timeout": {

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -15,7 +15,6 @@ import random
 import re
 import sys
 import time
-import typing
 import warnings
 from contextlib import contextmanager
 from typing import (
@@ -88,7 +87,7 @@ from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector
 from .runtimes import RuntimePropertyRecorder, all_libcs, external_config_with_implicit_externals
-from .versions import DeclaredVersion, Provenance, concretization_version_order
+from .versions import Provenance
 
 GitOrStandardVersion = Union[spack.version.GitVersion, spack.version.StandardVersion]
 
@@ -1448,6 +1447,7 @@ class SpackSolverSetup:
     """Class to set up and run a Spack concretization solve."""
 
     gen: "ProblemInstanceBuilder"
+    possible_versions: Dict[str, Dict[GitOrStandardVersion, List[Provenance]]]
 
     def __init__(self, tests: spack.concretize.TestsType = False):
         self.possible_graph = create_graph_analyzer()
@@ -1457,8 +1457,9 @@ class SpackSolverSetup:
         self.possible_virtuals: Set[str] = set()
 
         self.assumptions: List[Tuple["clingo.Symbol", bool]] = []  # type: ignore[name-defined]
-        self.declared_versions: Dict[str, List[DeclaredVersion]] = collections.defaultdict(list)
-        self.possible_versions: Dict[str, Set[GitOrStandardVersion]] = collections.defaultdict(set)
+        # pkg_name -> version -> list of possible origins (package.py, installed, etc.)
+        self.possible_versions = collections.defaultdict(lambda: collections.defaultdict(list))
+        self.versions_from_yaml: Dict[str, List[GitOrStandardVersion]] = {}
         self.git_commit_versions: Dict[str, Dict[GitOrStandardVersion, str]] = (
             collections.defaultdict(dict)
         )
@@ -1502,38 +1503,24 @@ class SpackSolverSetup:
         # If true, we have to load the code for synthesizing splices
         self.enable_splicing: bool = spack.config.CONFIG.get("concretizer:splice:automatic")
 
-    def pkg_version_rules(self, pkg):
-        """Output declared versions of a package.
-
-        This uses self.declared_versions so that we include any versions
-        that arise from a spec.
-        """
-
-        def key_fn(version):
-            # Origins are sorted by "provenance" first, see the Provenance enumeration above
-            return version.origin, version.idx
-
-        if isinstance(pkg, str):
-            pkg = self.pkg_class(pkg)
-
-        declared_versions = self.declared_versions[pkg.name]
-        partially_sorted_versions = sorted(set(declared_versions), key=key_fn)
-
-        most_to_least_preferred = []
-        for _, group in itertools.groupby(partially_sorted_versions, key=key_fn):
-            most_to_least_preferred.extend(
-                list(sorted(group, reverse=True, key=lambda x: vn.ver(x.version)))
+    def pkg_version_rules(self, pkg: Type[spack.package_base.PackageBase]) -> None:
+        """Declares known versions, their origins, and their weights."""
+        version_provenance = self.possible_versions[pkg.name]
+        ordered_versions = spack.package_base.sort_by_pkg_preference(
+            self.possible_versions[pkg.name], pkg=pkg
+        )
+        # Account for preferences in packages.yaml, if any
+        if pkg.name in self.versions_from_yaml:
+            ordered_versions = spack.llnl.util.lang.dedupe(
+                self.versions_from_yaml[pkg.name] + ordered_versions
             )
 
-        for weight, declared_version in enumerate(most_to_least_preferred):
-            self.gen.fact(
-                fn.pkg_fact(
-                    pkg.name,
-                    fn.version_declared(
-                        declared_version.version, weight, str(declared_version.origin)
-                    ),
+        for weight, declared_version in enumerate(ordered_versions):
+            self.gen.fact(fn.pkg_fact(pkg.name, fn.version_declared(declared_version, weight)))
+            for origin in version_provenance[declared_version]:
+                self.gen.fact(
+                    fn.pkg_fact(pkg.name, fn.version_origin(declared_version, str(origin)))
                 )
-            )
 
         for v in self.possible_versions[pkg.name]:
             if pkg.needs_commit(v):
@@ -2590,54 +2577,46 @@ class SpackSolverSetup:
             # All the versions from the corresponding package.py file. Since concepts
             # like being a "develop" version or being preferred exist only at a
             # package.py level, sort them in this partial list here
-            package_py_versions = sorted(
-                pkg_cls.versions.items(), key=concretization_version_order, reverse=True
-            )
+            from_package_py = list(pkg_cls.versions.items())
 
             if require_checksum and pkg_cls.has_code:
-                package_py_versions = [
-                    x for x in package_py_versions if _is_checksummed_version(x)
-                ]
+                from_package_py = [x for x in from_package_py if _is_checksummed_version(x)]
 
-            for idx, (v, version_info) in enumerate(package_py_versions):
+            for v, version_info in from_package_py:
                 if version_info.get("deprecated", False):
                     self.deprecated_versions[pkg_name].add(v)
                     if not allow_deprecated:
                         continue
 
-                self.possible_versions[pkg_name].add(v)
-                self.declared_versions[pkg_name].append(
-                    DeclaredVersion(version=v, idx=idx, origin=Provenance.PACKAGE_PY)
-                )
+                self.possible_versions[pkg_name][v].append(Provenance.PACKAGE_PY)
 
             if pkg_name not in packages_yaml or "version" not in packages_yaml[pkg_name]:
                 continue
 
             # TODO(psakiev) Need facts about versions
             # - requires_commit (associated with tag or branch)
-            version_defs: List[GitOrStandardVersion] = []
+            from_packages_yaml: List[GitOrStandardVersion] = []
 
             for vstr in packages_yaml[pkg_name]["version"]:
                 v = vn.ver(vstr)
 
                 if isinstance(v, vn.GitVersion):
                     if not require_checksum or v.is_commit:
-                        version_defs.append(v)
+                        from_packages_yaml.append(v)
                 else:
                     matches = [x for x in self.possible_versions[pkg_name] if x.satisfies(v)]
                     matches.sort(reverse=True)
                     if not matches:
                         raise spack.error.ConfigError(
                             f"Preference for version {v} does not match any known "
-                            f"version of {pkg_name} (in its package.py or any external)"
+                            f"version of {pkg_name}"
                         )
-                    version_defs.extend(matches)
+                    from_packages_yaml.extend(matches)
 
-            for weight, vdef in enumerate(spack.llnl.util.lang.dedupe(version_defs)):
-                self.declared_versions[pkg_name].append(
-                    DeclaredVersion(version=vdef, idx=weight, origin=Provenance.PACKAGES_YAML)
-                )
-                self.possible_versions[pkg_name].add(vdef)
+            from_packages_yaml = list(spack.llnl.util.lang.dedupe(from_packages_yaml))
+            for v in from_packages_yaml:
+                self.possible_versions[pkg_name][v].append(Provenance.PACKAGES_YAML)
+            self.versions_from_yaml[pkg_name] = from_packages_yaml
 
     def define_ad_hoc_versions_from_specs(
         self, specs, origin, *, allow_deprecated: bool, require_checksum: bool
@@ -2645,8 +2624,7 @@ class SpackSolverSetup:
         """Add concrete versions to possible versions from lists of CLI/dev specs."""
         for s in traverse.traverse_nodes(specs):
             # If there is a concrete version on the CLI *that we know nothing
-            # about*, add it to the known versions. Use idx=0, which is the
-            # best possible, so they're guaranteed to be used preferentially.
+            # about*, add it to the known versions.
             version = s.versions.concrete
 
             if version is None or (any((v == version) for v in self.possible_versions[s.name])):
@@ -2660,9 +2638,7 @@ class SpackSolverSetup:
             if not allow_deprecated and version in self.deprecated_versions[s.name]:
                 continue
 
-            declared = DeclaredVersion(version=version, idx=0, origin=origin)
-            self.declared_versions[s.name].append(declared)
-            self.possible_versions[s.name].add(version)
+            self.possible_versions[s.name][version].append(origin)
 
     def _supported_targets(self, compiler_name, compiler_version, targets):
         """Get a list of which targets are supported by the compiler.
@@ -2851,7 +2827,7 @@ class SpackSolverSetup:
         for pkg_name, versions in sorted(constraint_map.items()):
             possible_versions = set(sum([versions_for(v) for v in versions], []))
             for version in sorted(possible_versions):
-                self.possible_versions[pkg_name].add(version)
+                self.possible_versions[pkg_name][version].append(Provenance.VIRTUAL_CONSTRAINT)
 
     def define_compiler_version_constraints(self):
         for constraint in sorted(self.compiler_version_constraints):
@@ -2948,19 +2924,12 @@ class SpackSolverSetup:
             # - Add versions to possible versions
             # - Add OS to possible OS's
 
-            # is traverse deterministic?
             for dep in spec.traverse():
-                self.possible_versions[dep.name].add(dep.version)
+                provenance = Provenance.INSTALLED
                 if isinstance(dep.version, vn.GitVersion):
-                    self.declared_versions[dep.name].append(
-                        DeclaredVersion(
-                            version=dep.version, idx=0, origin=Provenance.INSTALLED_GIT_VERSION
-                        )
-                    )
-                else:
-                    self.declared_versions[dep.name].append(
-                        DeclaredVersion(version=dep.version, idx=0, origin=Provenance.INSTALLED)
-                    )
+                    provenance = Provenance.INSTALLED_GIT_VERSION
+
+                self.possible_versions[dep.name][dep.version].append(provenance)
                 self.possible_oses.add(dep.os)
 
     def define_concrete_input_specs(self, specs, possible):
@@ -3377,10 +3346,7 @@ class SpackSolverSetup:
                 # If concrete an not yet defined, conditionally define it, like we do for specs
                 # from the command line.
                 if not require_checksum or _is_checksummed_git_version(v):
-                    self.declared_versions[name].append(
-                        DeclaredVersion(version=v, idx=0, origin=Provenance.PACKAGE_REQUIREMENT)
-                    )
-                    self.possible_versions[name].add(v)
+                    self.possible_versions[name][v].append(Provenance.PACKAGE_REQUIREMENT)
 
     def _specs_from_requires(self, pkg_name, section):
         """Collect specs from a requirement rule"""
@@ -3404,7 +3370,7 @@ class SpackSolverSetup:
             for s in spec_group[key]:
                 yield _spec_with_default_name(s, pkg_name)
 
-    def pkg_class(self, pkg_name: str) -> typing.Type[spack.package_base.PackageBase]:
+    def pkg_class(self, pkg_name: str) -> Type[spack.package_base.PackageBase]:
         request = pkg_name
         if pkg_name in self.explicitly_required_namespaces:
             namespace = self.explicitly_required_namespaces[pkg_name]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -122,7 +122,7 @@ def default_clingo_control():
     control = clingo().Control()
     control.configuration.configuration = "tweety"
     control.configuration.solver.heuristic = "Domain"
-    control.configuration.solver.opt_strategy = "usc,one,1"
+    control.configuration.solver.opt_strategy = "usc"
     return control
 
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3821,15 +3821,11 @@ class SpecBuilder:
                 if spack.repo.PATH.is_virtual(pkg):
                     continue
 
-                # if we've already gotten a concrete spec for this pkg,
-                # do not bother calling actions on it except for node_flag_source,
-                # since node_flag_source is tracking information not in the spec itself
-                # we also need to keep track of splicing information.
+                # if we've already gotten a concrete spec for this pkg, we're done, unless
+                # we're splicing. `splice_at_hash()` is the only action we call on concrete specs.
                 spec = self._specs.get(node)
-                if spec and spec.concrete:
-                    do_not_ignore_attrs = ["node_flag_source", "splice_at_hash"]
-                    if name not in do_not_ignore_attrs:
-                        continue
+                if spec and spec.concrete and name != "splice_at_hash":
+                    continue
 
             action(*args)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3199,15 +3199,16 @@ class SpackSolverSetup:
                 # Inject default flags for compilers
                 recorder("*").default_flags(compiler)
 
-            # FIXME (compiler as nodes): think of using isinstance(compiler_cls, WrappedCompiler)
             # Add a dependency on the compiler wrapper
+            compiler_str = f"{compiler.name} /{compiler.dag_hash()}"
             for language in ("c", "cxx", "fortran"):
-                compiler_str = f"{compiler.name}@{compiler.versions}"
+                # Using compiler.name causes a bit of duplication, but that is taken care of by
+                # clingo during grounding.
                 recorder("*").depends_on(
                     "compiler-wrapper",
-                    when=f"%[deptypes=build virtuals={language}] {compiler_str}",
+                    when=f"%[deptypes=build virtuals={language}] {compiler.name}",
                     type="build",
-                    description=f"Add the compiler wrapper when using {compiler} for {language}",
+                    description=f"Add compiler wrapper when using {compiler.name} for {language}",
                 )
 
             if not using_libc_compatibility():
@@ -3225,9 +3226,9 @@ class SpackSolverSetup:
             if current_libc:
                 recorder("*").depends_on(
                     "libc",
-                    when=f"%[deptypes=build] {compiler_str}",
+                    when=f"%[deptypes=build] {compiler.name}",
                     type="link",
-                    description=f"Add libc when using {compiler}",
+                    description=f"Add libc when using {compiler.name}",
                 )
                 recorder("*").depends_on(
                     f"{current_libc.name}@={current_libc.version}",

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -24,13 +24,14 @@ duplicate_penalty(node(ID1, Package), 1, "version")
   :- attr("node", node(ID1, Package)), attr("node", node(ID2, Package)),
      version_weight(node(ID1, Package), Weight1), version_weight(node(ID2, Package), Weight2),
      multiple_unification_sets(Package),
-     ID1 < ID2, Weight2 < Weight1.
+     ID2 = ID1 + 1, Weight2 < Weight1,
+     max_dupes(Package, X), X > 1, ID2 < X.
 
 % We can enforce this, and hope the grounder generates fewer rules
 :- provider_weight(ProviderNode1, node(ID1, Virtual), Weight1),
    provider_weight(ProviderNode2, node(ID2, Virtual), Weight2),
-   ID1 < ID2, Weight2 < Weight1,
-   max_dupes(Virtual, X), X > 1.
+   ID2 = ID1 + 1, Weight2 < Weight1,
+   max_dupes(Virtual, X), X > 1, ID2 < X.
 
 % Integrity constraints on DAG nodes
 :- attr("root", PackageNode),
@@ -307,17 +308,19 @@ pkg_fact(Package, version_declared(Version)) :- pkg_fact(Package, version_declar
 % is not precisely one version chosen. Error facts are heavily optimized
 % against to ensure they cannot be inferred when a non-error solution is
 % possible
-{ choose_version(node(ID, Package), Version) : pkg_fact(Package, version_declared(Version)) }
- :- attr("node", node(ID, Package)).
+
+% Pick a single version among the possible ones
+1 { choose_version(node(ID, Package), Version) : pkg_fact(Package, version_declared(Version)) } 1 :- attr("node", node(ID, Package)).
+
+% To choose the "fake" version of virtual packages, we need a separate rule.
+% Note that a virtual node may or may not have a version, but cannot have more than one.
+{ choose_version(node(ID, Package), Version) : pkg_fact(Package, version_satisfies(Constraint, Version)) } 1
+  :- attr("node_version_satisfies", node(ID, Package), Constraint),
+     attr("virtual_node", node(ID, Package)).
 
 #defined compiler_package/1.
 
 attr("version", node(ID, Package), Version) :- choose_version(node(ID, Package), Version).
-
-% A virtual package may or may not have a version, but never has more than one
-error(100, "Cannot select a single version for virtual '{0}'", Virtual)
-  :- attr("virtual_node", node(ID, Virtual)),
-     2 { attr("version", node(ID, Virtual), Version) }.
 
 % If we select a deprecated version, mark the package as deprecated
 attr("deprecated", node(ID, Package), Version) :-
@@ -334,7 +337,7 @@ error(100, "Package '{0}' needs the deprecated version '{1}', and this is not al
 % we can't use a weight from an installed spec if we are building it
 % and vice-versa
 
-1 { allowed_versions(Version): pkg_fact(Package, version_origin(Version, Origin)),
+1 { allowed_origins(Origin): pkg_fact(Package, version_origin(Version, Origin)),
     Origin != "installed"}
   :- attr("version", node(ID, Package), Version),
      build(node(ID, Package)).
@@ -352,27 +355,12 @@ version_weight(node(ID, Package), Weight)
      pkg_fact(Package, version_declared(Version, Weight)),
      internal_error("version weights must exist and be unique").
 
-% node_version_satisfies implies that exactly one of the satisfying versions
-% is the package's version, and vice versa.
-% While this choice rule appears redundant with the initial choice rule for
-% versions, virtual nodes with version constraints require this rule to be
-% able to choose versions
-{ attr("version", node(ID, Package), Version) : pkg_fact(Package, version_satisfies(Constraint, Version)) }
-  :- attr("node_version_satisfies", node(ID, Package), Constraint).
-
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
 error(10000, "Cannot satisfy '{0}@{1}' 1({2})", Package, Constraint, Version)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
      attr("version", node(ID, Package), Version),
-     not pkg_fact(Package, version_satisfies(Constraint, Version)),
-     choose_version(node(ID, Package), Version).
-
-error(100, "Cannot satisfy '{0}@{1}' 2({2})", Package, Constraint, Version)
-  :- attr("node_version_satisfies", node(ID, Package), Constraint),
-     attr("version", node(ID, Package), Version),
-     not pkg_fact(Package, version_satisfies(Constraint, Version)),
-     not choose_version(node(ID, Package), _).
+     not pkg_fact(Package, version_satisfies(Constraint, Version)).
 
 error(10000, "Cannot satisfy '{0}@{1}'", Package, Constraint)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
@@ -435,11 +423,14 @@ trigger_real_node(ID, PackageNode) :- trigger_node(ID, PackageNode, _).
 % This is the requestor node, which may be a "real" or a "virtual" node
 trigger_requestor_node(ID, RequestorNode) :- trigger_node(ID, _, RequestorNode).
 
-condition_nodes(TriggerID, PackageNode, node(X, A1))
-  :- condition_packages(TriggerID, A1),
+trigger_package_requirement(TriggerNode, A1) :-
+  trigger_real_node(ID, TriggerNode),
+  condition_packages(ID, A1).
+
+condition_nodes(PackageNode, node(X, A1))
+  :- trigger_package_requirement(PackageNode, A1),
      condition_set(PackageNode, node(X, A1)),
-     not self_build_requirement(PackageNode, node(X, A1)),
-     trigger_real_node(TriggerID, PackageNode).
+     not self_build_requirement(PackageNode, node(X, A1)).
 
 cannot_hold(TriggerID, PackageNode)
   :- condition_packages(TriggerID, A1),
@@ -461,46 +452,40 @@ trigger_condition_holds(ID, RequestorNode) :-
 %%%%
 
 satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1)) :-
-  trigger_real_node(ID, PackageNode),
   attr(Name, node(X, A1)),
   condition_requirement(ID, Name, A1),
-  condition_nodes(ID, PackageNode, node(X, A1)).
+  condition_nodes(PackageNode, node(X, A1)).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2)) :-
-  trigger_real_node(ID, PackageNode),
   attr(Name, node(X, A1), A2),
   condition_requirement(ID, Name, A1, A2),
-  condition_nodes(ID, PackageNode, node(X, A1)).
+  condition_nodes(PackageNode, node(X, A1)).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3)) :-
-  trigger_real_node(ID, PackageNode),
   attr(Name, node(X, A1), A2, A3),
   condition_requirement(ID, Name, A1, A2, A3),
-  condition_nodes(ID, PackageNode, node(X, A1)),
+  condition_nodes(PackageNode, node(X, A1)),
   not node_attributes_with_custom_rules(Name).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3, A4)) :-
-  trigger_real_node(ID, PackageNode),
   attr(Name, node(X, A1), A2, A3, A4),
   condition_requirement(ID, Name, A1, A2, A3, A4),
-  condition_nodes(ID, PackageNode, node(X, A1)).
+  condition_nodes(PackageNode, node(X, A1)).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, "depends_on", A1, A2, A3)) :-
-  trigger_real_node(ID, PackageNode),
   attr("depends_on", node(X, A1), node(Y, A2), A3),
   condition_requirement(ID, "depends_on", A1, A2, A3),
-  condition_nodes(ID, PackageNode, node(X, A1)),
-  condition_nodes(ID, PackageNode, node(Y, A2)).
+  condition_nodes(PackageNode, node(X, A1)),
+  condition_nodes(PackageNode, node(Y, A2)).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, "concrete_variant_request", A1, A2, A3)) :-
-  trigger_real_node(ID, PackageNode),
   condition_requirement(ID, "concrete_variant_request", A1, A2, A3),
-  condition_nodes(ID, PackageNode, node(X, A1)).
+  condition_nodes(PackageNode, node(X, A1)).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, "closure", A1, A2, A3)) :-
   attr("closure", node(X, A1), node(_, A2), A3),
   condition_requirement(ID, "closure", A1, A2, A3),
-  condition_nodes(ID, PackageNode, node(X, A1)).
+  condition_nodes(PackageNode, node(X, A1)).
 
 %%%%
 % Conditions verified on pure build deps of reused nodes
@@ -547,13 +532,13 @@ cannot_hold(ID, PackageNode) :-
   not attr("variant_value", node(X, A1), Variant, Value),
   condition_with_concrete_variant(ID, A1, Variant),
   condition_requirement(ID, "concrete_variant_request", A1, Variant, Value),
-  condition_nodes(ID, PackageNode, node(X, A1)).
+  condition_nodes(PackageNode, node(X, A1)).
 
 cannot_hold(ID, PackageNode) :-
   attr("variant_value", node(X, A1), Variant, Value),
   condition_with_concrete_variant(ID, A1, Variant),
   not condition_requirement(ID, "concrete_variant_request", A1, Variant, Value),
-  condition_nodes(ID, PackageNode, node(X, A1)).
+  condition_nodes(PackageNode, node(X, A1)).
 
 condition_holds(ConditionID, node(X, Package))
   :- pkg_fact(Package, condition_trigger(ConditionID, TriggerID)),
@@ -952,15 +937,33 @@ error(100, "{0} and {1} must depend on the same {2}", ExtensionParent, Extension
 %-----------------------------------------------------------------------------
 % Conflicts
 %-----------------------------------------------------------------------------
-error(1, Msg)
-  :- attr("node", node(ID, Package)),
-     pkg_fact(Package, conflict(TriggerID, ConstraintID, Msg)),
-     % node(ID1, TriggerPackage) is node(ID2, Package) in most, but not all, cases
-     condition_holds(TriggerID, node(ID1, TriggerPackage)),
-     condition_holds(ConstraintID, node(ID2, Package)),
-     unification_set(X, node(ID2, Package)),
-     unification_set(X, node(ID1, TriggerPackage)),
-     build(node(ID, Package)).  % ignore conflicts for installed packages
+
+% Most conflicts are internal to the same package
+conflict_is_cross_package(Package, TriggerID) :-
+   pkg_fact(Package, conflict(TriggerID, _, _)),
+   pkg_fact(TriggerPackage, condition_trigger(TriggerID, _)),
+   TriggerPackage != Package.
+
+conflict_internal(Package, TriggerID, ConstraintID, Msg) :-
+   pkg_fact(Package, conflict(TriggerID, ConstraintID, Msg)),
+   not conflict_is_cross_package(Package, TriggerID).
+
+% Case 1: conflict is within the same package
+error(1, Msg) :-
+   conflict_internal(Package, TriggerID, ConstraintID, Msg),
+   condition_holds(TriggerID, node(ID, Package)),
+   condition_holds(ConstraintID, node(ID, Package)),
+   build(node(ID, Package)).  % ignore conflicts for installed packages
+
+% Case 2: Cross-package conflicts (Rare case - slower)
+error(1, Msg) :-
+   build(node(ID, Package)),
+   conflict_is_cross_package(Package, TriggerID),
+   pkg_fact(Package, conflict(TriggerID, ConstraintID, Msg)),
+   condition_holds(TriggerID, node(ID1, TriggerPackage)),
+   condition_holds(ConstraintID, node(ID, Package)),
+   unification_set(X, node(ID, Package)),
+   unification_set(X, node(ID1, TriggerPackage)).
 
 %-----------------------------------------------------------------------------
 % Virtual dependencies
@@ -1080,20 +1083,15 @@ do_not_impose(EffectID, node(X, Package))
 % Virtual dependency weights
 %-----------------------------------------------------------------------------
 
-% A provider has different possible weights depending on its preference. This rule ensures that
-% we select the weight, among the possible ones, that minimizes the overall objective function.
-1 { provider_weight(DependencyNode, VirtualNode, Weight) :
-    possible_provider_weight(DependencyNode, VirtualNode, Weight, _) } 1
- :- provider(DependencyNode, VirtualNode), internal_error("Package provider weights must be unique").
-
 % Any configured provider has a weight based on index in the preference list
-possible_provider_weight(node(ProviderID, Provider), node(VirtualID, Virtual), Weight, "default")
+provider_weight(node(ProviderID, Provider), node(VirtualID, Virtual), Weight)
   :- provider(node(ProviderID, Provider), node(VirtualID, Virtual)),
      provider_weight_from_config(Virtual, Provider, Weight).
 
 % Any non-configured provider has a default weight of 100
-possible_provider_weight(node(ProviderID, Provider), VirtualNode, 100, "fallback")
-  :- provider(node(ProviderID, Provider), VirtualNode).
+provider_weight(node(ProviderID, Provider), node(VirtualID, Virtual), 100)
+  :- provider(node(ProviderID, Provider), node(VirtualID, Virtual)),
+     not provider_weight_from_config(Virtual, Provider, _).
 
 % do not warn if generated program contains none of these.
 #defined virtual/1.
@@ -1392,7 +1390,8 @@ variant_value_from_disjoint_sets(node(NodeID, Package), VariantName, Value1, Set
 % -- Associate definition's arity with the node
 variant_single_value(node(NodeID, Package), VariantName) :-
   node_has_variant(node(NodeID, Package), VariantName, VariantID),
-  not variant_type(VariantID, "multi").
+  variant_type(VariantID, VariantType),
+  VariantType != "multi".
 
 % C: Determining variant values on each node
 
@@ -1406,14 +1405,13 @@ attr("variant_selected", node(ID, Package), Variant, Value, VariantType, Variant
   build(node(ID, Package)).
 
 % we can choose variant values from all the possible values for the node
-{
-  attr("variant_selected", node(ID, Package), Variant, Value, VariantType, VariantID)
-  : variant_possible_value(node(ID, Package), Variant, Value)
+1 {
+  attr("variant_selected", PackageNode, Variant, Value, VariantType, VariantID)
+  : variant_possible_value(PackageNode, Variant, Value)
 } :-
-  attr("node", node(ID, Package)),
-  node_has_variant(node(ID, Package), Variant, VariantID),
+  node_has_variant(PackageNode, Variant, VariantID),
   variant_type(VariantID, VariantType),
-  build(node(ID, Package)).
+  build(PackageNode).
 
 % variant_selected is only needed for reconstruction on the python side, so we can ignore it here
 attr("variant_value", PackageNode, Variant, Value) :-
@@ -1530,7 +1528,8 @@ node_has_variant(PackageNode, Variant, VariantID)
 variant_single_value(PackageNode, Variant)
   :- node_has_variant(PackageNode, Variant, VariantID),
      auto_variant(Variant, VariantID),
-     not variant_type(VariantID, "multi").
+     variant_type(VariantID, VariantType),
+     VariantType != "multi".
 
 % to respect requirements/preferences we need to define that an auto_variant is set
 { attr("variant_set", node(ID, Package), Variant, VariantValue)}

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -338,7 +338,7 @@ error(100, "Package '{0}' needs the deprecated version '{1}', and this is not al
 % and vice-versa
 
 1 { allowed_origins(Origin): pkg_fact(Package, version_origin(Version, Origin)),
-    Origin != "installed"}
+    Origin != "installed", Origin != "packages_yaml"}
   :- attr("version", node(ID, Package), Version),
      build(node(ID, Package)).
 
@@ -354,6 +354,13 @@ version_weight(node(ID, Package), Weight)
      attr("node", node(ID, Package)),
      pkg_fact(Package, version_declared(Version, Weight)),
      internal_error("version weights must exist and be unique").
+
+version_deprecation_penalty(node(ID, Package), Penalty)
+  :- pkg_fact(Package, deprecated_version(Version)),
+     pkg_fact(Package, version_deprecation_penalty(Penalty)),
+     attr("node", node(ID, Package)),
+     attr("version", node(ID, Package), Version),
+     not external(node(ID, Package)).
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
@@ -2094,6 +2101,12 @@ opt_criterion(70, "version badness (roots)").
       version_weight(PackageNode, Weight),
       build_priority(PackageNode, Priority)
 }.
+#minimize {
+    Penalty@70+Priority,PackageNode
+    : attr("root", PackageNode),
+      version_deprecation_penalty(PackageNode, Penalty),
+      build_priority(PackageNode, Priority)
+}.
 
 opt_criterion(65, "number of non-default variants (roots)").
 #minimize{ 0@265: #true }.
@@ -2198,6 +2211,14 @@ opt_criterion(25, "version badness (non roots)").
       not attr("root", node(X, Package)),
       not runtime(Package)
 }.
+#minimize {
+    Penalty@25+Priority,node(X, Package)
+    : version_deprecation_penalty(node(X, Package), Penalty),
+      build_priority(node(X, Package), Priority),
+      not attr("root", node(X, Package)),
+      not runtime(Package)
+}.
+
 
 % Try to use all the default values of variants
 opt_criterion(20, "default values of variants not being used (non-roots)").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -808,10 +808,22 @@ attr("hash", node(X, BuildDependency), BuildHash) :-
   attr("direct_dependency", ParentNode, node_requirement("hash", BuildDependency, BuildHash)),
   build_requirement(ParentNode, node(X, BuildDependency)).
 
-
+% For a spec like `hdf5 %cxx=gcc` we need to ensure that
+% 1. gcc is a provider for cxx
+% 2. hdf5 depends on that provider for cxx
 1 { attr("provider_set", node(X, BuildDependency), node(0..Y-1, Virtual)) : max_dupes(Virtual, Y) } 1 :-
   attr("direct_dependency", ParentNode, node_requirement("provider_set", BuildDependency, Virtual)),
   direct_dependency(ParentNode, node(X, BuildDependency)).
+
+error(10, "{0} cannot have a dependency on {1}", Package, Virtual)
+  :- attr("direct_dependency", node(ID, Package), node_requirement("provider_set", BuildDependency, Virtual)),
+     direct_dependency(node(ID, Package), node(X, BuildDependency)),
+     not attr("virtual_on_edge", node(ID, Package), node(X, BuildDependency), Virtual).
+
+% For a spec like `hdf5 %cxx` we need to ensure that the virtual is needed on a direct edge
+error(10, "{0} cannot have a dependency on {1}", Package, Virtual)
+  :- attr("direct_dependency", node(ID, Package), node_requirement("virtual_node", Virtual)),
+     not attr("virtual_on_edge", node(ID, Package), _, Virtual).
 
 % Reconstruct virtual dependencies for reused specs
 attr("virtual_on_edge", node(X, A1), node(Y, A2), Virtual)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -438,12 +438,13 @@ cannot_hold(TriggerID, PackageNode)
      trigger_real_node(TriggerID, PackageNode),
      attr("node", PackageNode).
 
+% Aggregates generic condition requirements with TriggerID, to see if a condition holds
 trigger_condition_holds(ID, RequestorNode) :-
   trigger_node(ID, PackageNode, RequestorNode);
-  satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1))         : condition_requirement(ID, Name, A1);
-  satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2))     : condition_requirement(ID, Name, A1, A2);
-  satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3)) : condition_requirement(ID, Name, A1, A2, A3);
-  satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3, A4)) : condition_requirement(ID, Name, A1, A2, A3, A4);
+  satisfied(trigger(PackageNode), condition_requirement(Name, A1))         : condition_requirement(ID, Name, A1);
+  satisfied(trigger(PackageNode), condition_requirement(Name, A1, A2))     : condition_requirement(ID, Name, A1, A2);
+  satisfied(trigger(PackageNode), condition_requirement(Name, A1, A2, A3)) : condition_requirement(ID, Name, A1, A2, A3);
+  satisfied(trigger(PackageNode), condition_requirement(Name, A1, A2, A3, A4)) : condition_requirement(ID, Name, A1, A2, A3, A4);
   not cannot_hold(ID, PackageNode).
 
 
@@ -451,75 +452,83 @@ trigger_condition_holds(ID, RequestorNode) :-
 % Conditions verified on actual nodes in the DAG
 %%%%
 
-satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1)) :-
+% Here we project out the trigger ID from condition requirements, so that we can reduce the space
+% of satisfied facts below. All we care about below is if a condition is met (e.g. a node exists
+% in the DAG), we don't care instead about *which* rule is requesting that.
+generic_condition_requirement(Name, A1)             :- condition_requirement(ID, Name, A1).
+generic_condition_requirement(Name, A1, A2)         :- condition_requirement(ID, Name, A1, A2).
+generic_condition_requirement(Name, A1, A2, A3)     :- condition_requirement(ID, Name, A1, A2, A3).
+generic_condition_requirement(Name, A1, A2, A3, A4) :- condition_requirement(ID, Name, A1, A2, A3, A4).
+
+satisfied(trigger(PackageNode), condition_requirement(Name, A1)) :-
   attr(Name, node(X, A1)),
-  condition_requirement(ID, Name, A1),
+  generic_condition_requirement(Name, A1),
   condition_nodes(PackageNode, node(X, A1)).
 
-satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2)) :-
+satisfied(trigger(PackageNode), condition_requirement(Name, A1, A2)) :-
   attr(Name, node(X, A1), A2),
-  condition_requirement(ID, Name, A1, A2),
+  generic_condition_requirement(Name, A1, A2),
   condition_nodes(PackageNode, node(X, A1)).
 
-satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3)) :-
+satisfied(trigger(PackageNode), condition_requirement(Name, A1, A2, A3)) :-
   attr(Name, node(X, A1), A2, A3),
-  condition_requirement(ID, Name, A1, A2, A3),
+  generic_condition_requirement(Name, A1, A2, A3),
   condition_nodes(PackageNode, node(X, A1)),
   not node_attributes_with_custom_rules(Name).
 
-satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3, A4)) :-
+satisfied(trigger(PackageNode), condition_requirement(Name, A1, A2, A3, A4)) :-
   attr(Name, node(X, A1), A2, A3, A4),
-  condition_requirement(ID, Name, A1, A2, A3, A4),
+  generic_condition_requirement(Name, A1, A2, A3, A4),
   condition_nodes(PackageNode, node(X, A1)).
 
-satisfied(trigger(PackageNode), condition_requirement(ID, "depends_on", A1, A2, A3)) :-
+satisfied(trigger(PackageNode), condition_requirement("depends_on", A1, A2, A3)) :-
   attr("depends_on", node(X, A1), node(Y, A2), A3),
-  condition_requirement(ID, "depends_on", A1, A2, A3),
+  generic_condition_requirement("depends_on", A1, A2, A3),
   condition_nodes(PackageNode, node(X, A1)),
   condition_nodes(PackageNode, node(Y, A2)).
 
-satisfied(trigger(PackageNode), condition_requirement(ID, "concrete_variant_request", A1, A2, A3)) :-
-  condition_requirement(ID, "concrete_variant_request", A1, A2, A3),
+satisfied(trigger(PackageNode), condition_requirement("concrete_variant_request", A1, A2, A3)) :-
+  generic_condition_requirement("concrete_variant_request", A1, A2, A3),
   condition_nodes(PackageNode, node(X, A1)).
 
-satisfied(trigger(PackageNode), condition_requirement(ID, "closure", A1, A2, A3)) :-
+satisfied(trigger(PackageNode), condition_requirement("closure", A1, A2, A3)) :-
   attr("closure", node(X, A1), node(_, A2), A3),
-  condition_requirement(ID, "closure", A1, A2, A3),
+  generic_condition_requirement("closure", A1, A2, A3),
   condition_nodes(PackageNode, node(X, A1)).
 
 %%%%
 % Conditions verified on pure build deps of reused nodes
 %%%%
 
-satisfied(trigger(PackageNode), condition_requirement(ID, "node", A1)) :-
+satisfied(trigger(PackageNode), condition_requirement("node", A1)) :-
   trigger_real_node(ID, PackageNode),
   reused_provider(PackageNode, _),
   condition_requirement(ID, "node", A1).
 
-satisfied(trigger(PackageNode), condition_requirement(ID, "virtual_node", A1)) :-
+satisfied(trigger(PackageNode), condition_requirement("virtual_node", A1)) :-
   trigger_real_node(ID, PackageNode),
   reused_provider(PackageNode, node(_, A1)),
   condition_requirement(ID, "virtual_node", A1).
 
-satisfied(trigger(PackageNode), condition_requirement(ID, "virtual_on_incoming_edges", A1, A2)) :-
+satisfied(trigger(PackageNode), condition_requirement("virtual_on_incoming_edges", A1, A2)) :-
   trigger_real_node(ID, PackageNode),
   reused_provider(node(Hash, A1), node(Hash, A2)),
   condition_requirement(ID, "virtual_on_incoming_edges", A1, A2).
 
-satisfied(trigger(node(Hash, Package)), condition_requirement(ID, Name, Package, A1)) :-
+satisfied(trigger(node(Hash, Package)), condition_requirement(Name, Package, A1)) :-
   trigger_real_node(ID, node(Hash, Package)),
   reused_provider(node(Hash, Package), node(Hash, Language)),
   hash_attr(Hash, Name, Package, A1),
   condition_requirement(ID, Name, Package, A1).
 
-satisfied(trigger(node(Hash, Package)), condition_requirement(ID, "node_version_satisfies", Package, VersionConstraint)) :-
+satisfied(trigger(node(Hash, Package)), condition_requirement("node_version_satisfies", Package, VersionConstraint)) :-
   trigger_real_node(ID, node(Hash, Package)),
   reused_provider(node(Hash, Package), node(Hash, Language)),
   hash_attr(Hash, "version", Package, Version),
   condition_requirement(ID, "node_version_satisfies", Package, VersionConstraint),
   pkg_fact(Package, version_satisfies(VersionConstraint, Version)).
 
-satisfied(trigger(node(Hash, Package)), condition_requirement(ID, Name, Package, A1, A2)) :-
+satisfied(trigger(node(Hash, Package)), condition_requirement(Name, Package, A1, A2)) :-
   trigger_real_node(ID, node(Hash, Package)),
   reused_provider(node(Hash, Package), node(Hash, Language)),
   hash_attr(Hash, Name, Package, A1, A2),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -429,16 +429,22 @@ condition_packages(ID, A1) :- condition_requirement(ID, _, A1, _, _, _).
 trigger_node(ID, node(PackageID, Package), node(PackageID, Package)) :- pkg_fact(Package, trigger_id(ID)), attr("node", node(PackageID, Package)).
 trigger_node(ID, node(PackageID, Package), node(VirtualID, Virtual)) :- pkg_fact(Virtual, trigger_id(ID)), provider(node(PackageID, Package), node(VirtualID, Virtual)).
 
+% This is the "real node" that triggers the request, e.g. if the request started from "mpi" this is the mpi provider
+trigger_real_node(ID, PackageNode) :- trigger_node(ID, PackageNode, _).
+
+% This is the requestor node, which may be a "real" or a "virtual" node
+trigger_requestor_node(ID, RequestorNode) :- trigger_node(ID, _, RequestorNode).
+
 condition_nodes(TriggerID, PackageNode, node(X, A1))
   :- condition_packages(TriggerID, A1),
      condition_set(PackageNode, node(X, A1)),
      not self_build_requirement(PackageNode, node(X, A1)),
-     trigger_node(TriggerID, PackageNode, _).
+     trigger_real_node(TriggerID, PackageNode).
 
 cannot_hold(TriggerID, PackageNode)
   :- condition_packages(TriggerID, A1),
      not condition_set(PackageNode, node(_, A1)),
-     trigger_node(TriggerID, PackageNode, _),
+     trigger_real_node(TriggerID, PackageNode),
      attr("node", PackageNode).
 
 trigger_condition_holds(ID, RequestorNode) :-
@@ -455,39 +461,39 @@ trigger_condition_holds(ID, RequestorNode) :-
 %%%%
 
 satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1)) :-
-  trigger_node(ID, PackageNode, _),
+  trigger_real_node(ID, PackageNode),
   attr(Name, node(X, A1)),
   condition_requirement(ID, Name, A1),
   condition_nodes(ID, PackageNode, node(X, A1)).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2)) :-
-  trigger_node(ID, PackageNode, _),
+  trigger_real_node(ID, PackageNode),
   attr(Name, node(X, A1), A2),
   condition_requirement(ID, Name, A1, A2),
   condition_nodes(ID, PackageNode, node(X, A1)).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3)) :-
-  trigger_node(ID, PackageNode, _),
+  trigger_real_node(ID, PackageNode),
   attr(Name, node(X, A1), A2, A3),
   condition_requirement(ID, Name, A1, A2, A3),
   condition_nodes(ID, PackageNode, node(X, A1)),
   not node_attributes_with_custom_rules(Name).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, Name, A1, A2, A3, A4)) :-
-  trigger_node(ID, PackageNode, _),
+  trigger_real_node(ID, PackageNode),
   attr(Name, node(X, A1), A2, A3, A4),
   condition_requirement(ID, Name, A1, A2, A3, A4),
   condition_nodes(ID, PackageNode, node(X, A1)).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, "depends_on", A1, A2, A3)) :-
-  trigger_node(ID, PackageNode, _),
+  trigger_real_node(ID, PackageNode),
   attr("depends_on", node(X, A1), node(Y, A2), A3),
   condition_requirement(ID, "depends_on", A1, A2, A3),
   condition_nodes(ID, PackageNode, node(X, A1)),
   condition_nodes(ID, PackageNode, node(Y, A2)).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, "concrete_variant_request", A1, A2, A3)) :-
-  trigger_node(ID, PackageNode, _),
+  trigger_real_node(ID, PackageNode),
   condition_requirement(ID, "concrete_variant_request", A1, A2, A3),
   condition_nodes(ID, PackageNode, node(X, A1)).
 
@@ -501,35 +507,35 @@ satisfied(trigger(PackageNode), condition_requirement(ID, "closure", A1, A2, A3)
 %%%%
 
 satisfied(trigger(PackageNode), condition_requirement(ID, "node", A1)) :-
-  trigger_node(ID, PackageNode, _),
+  trigger_real_node(ID, PackageNode),
   reused_provider(PackageNode, _),
   condition_requirement(ID, "node", A1).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, "virtual_node", A1)) :-
-  trigger_node(ID, PackageNode, _),
+  trigger_real_node(ID, PackageNode),
   reused_provider(PackageNode, node(_, A1)),
   condition_requirement(ID, "virtual_node", A1).
 
 satisfied(trigger(PackageNode), condition_requirement(ID, "virtual_on_incoming_edges", A1, A2)) :-
-  trigger_node(ID, PackageNode, _),
+  trigger_real_node(ID, PackageNode),
   reused_provider(node(Hash, A1), node(Hash, A2)),
   condition_requirement(ID, "virtual_on_incoming_edges", A1, A2).
 
 satisfied(trigger(node(Hash, Package)), condition_requirement(ID, Name, Package, A1)) :-
-  trigger_node(ID, node(Hash, Package), _),
+  trigger_real_node(ID, node(Hash, Package)),
   reused_provider(node(Hash, Package), node(Hash, Language)),
   hash_attr(Hash, Name, Package, A1),
   condition_requirement(ID, Name, Package, A1).
 
 satisfied(trigger(node(Hash, Package)), condition_requirement(ID, "node_version_satisfies", Package, VersionConstraint)) :-
-  trigger_node(ID, node(Hash, Package), _),
+  trigger_real_node(ID, node(Hash, Package)),
   reused_provider(node(Hash, Package), node(Hash, Language)),
   hash_attr(Hash, "version", Package, Version),
   condition_requirement(ID, "node_version_satisfies", Package, VersionConstraint),
   pkg_fact(Package, version_satisfies(VersionConstraint, Version)).
 
 satisfied(trigger(node(Hash, Package)), condition_requirement(ID, Name, Package, A1, A2)) :-
-  trigger_node(ID, node(Hash, Package), _),
+  trigger_real_node(ID, node(Hash, Package)),
   reused_provider(node(Hash, Package), node(Hash, Language)),
   hash_attr(Hash, Name, Package, A1, A2),
   condition_requirement(ID, Name, Package, A1, A2).
@@ -566,7 +572,7 @@ trigger_and_effect(Package, TriggerID, EffectID) :- trigger_and_effect(Package, 
 impose(EffectID, node(X, Package))
   :- not subcondition(ConditionID, _),
      trigger_and_effect(Package, ConditionID, TriggerID, EffectID),
-     trigger_node(TriggerID, _, node(X, Package)),
+     trigger_requestor_node(TriggerID, node(X, Package)),
      trigger_condition_holds(TriggerID, node(X, Package)),
      not do_not_impose(EffectID, node(X, Package)).
 
@@ -577,7 +583,7 @@ impose(EffectID, node(X, Package))
      condition_holds(ConditionID, ConditionNode),
      condition_set(ConditionNode, node(X, Package)),
      trigger_and_effect(Package, SubconditionID, TriggerID, EffectID),
-     trigger_node(TriggerID, _, node(X, Package)),
+     trigger_requestor_node(TriggerID, node(X, Package)),
      trigger_condition_holds(TriggerID, node(X, Package)),
      not do_not_impose(EffectID, node(X, Package)).
 
@@ -591,7 +597,7 @@ imposed_nodes(EffectID, node(NodeID, Package), node(X, A1))
   :- trigger_and_effect(Package, TriggerID, EffectID),
      imposed_packages(EffectID, A1),
      condition_set(node(NodeID, Package), node(X, A1)),
-     trigger_node(TriggerID, _, node(NodeID, Package)),
+     trigger_requestor_node(TriggerID, node(NodeID, Package)),
      % We don't want to add build requirements to imposed nodes, to avoid
      % unsat problems when we deal with self-dependencies: gcc@14 %gcc@10
      not self_build_requirement(node(NodeID, Package), node(X, A1)).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -298,23 +298,6 @@ error(100, multiple_values_error, Attribute, Package)
 % Version semantics
 %-----------------------------------------------------------------------------
 
-% Versions are declared with a weight and an origin, which indicates where the
-% version was declared (e.g. "package_py" or "external").
-pkg_fact(Package, version_declared(Version, Weight)) :- pkg_fact(Package, version_declared(Version, Weight, _)).
-
-% We can't emit the same version **with the same weight** from two different sources
-:- pkg_fact(Package, version_declared(Version, Weight, Origin1)),
-   pkg_fact(Package, version_declared(Version, Weight, Origin2)),
-   Origin1 < Origin2,
-   internal_error("Two versions with identical weights").
-
-% We cannot use a version declared for an installed package if we end up building it
-:- pkg_fact(Package, version_declared(Version, Weight, "installed")),
-   attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   not attr("hash", node(ID, Package), _),
-   internal_error("Reuse version weight used for built package").
-
 % versions are declared w/priority -- declared with priority implies declared
 pkg_fact(Package, version_declared(Version)) :- pkg_fact(Package, version_declared(Version, _)).
 
@@ -350,22 +333,23 @@ error(100, "Package '{0}' needs the deprecated version '{1}', and this is not al
 
 % we can't use a weight from an installed spec if we are building it
 % and vice-versa
-:- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   pkg_fact(Package, version_declared(Version, Weight, "installed")),
-   build(node(ID, Package)),
-   internal_error("Reuse version weight used for build package").
 
-:- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   not pkg_fact(Package, version_declared(Version, Weight, "installed")),
-   not pkg_fact(Package, version_declared(Version, Weight, "installed_git_version")),
+1 { allowed_versions(Version): pkg_fact(Package, version_origin(Version, Origin)),
+    Origin != "installed"}
+  :- attr("version", node(ID, Package), Version),
+     build(node(ID, Package)).
+
+% We cannot use a version declared for an installed package if we end up building it
+:- not pkg_fact(Package, version_origin(Version, "installed")),
+   not pkg_fact(Package, version_origin(Version, "installed_git_version")),
+   attr("version", node(ID, Package), Version),
    concrete(node(ID, Package)),
-   internal_error("Build version weight used for reused package").
+   internal_error("Reuse version weight used for built package").
 
-1 { version_weight(node(ID, Package), Weight) : pkg_fact(Package, version_declared(Version, Weight)) } 1
+version_weight(node(ID, Package), Weight)
   :- attr("version", node(ID, Package), Version),
      attr("node", node(ID, Package)),
+     pkg_fact(Package, version_declared(Version, Weight)),
      internal_error("version weights must exist and be unique").
 
 % node_version_satisfies implies that exactly one of the satisfying versions
@@ -2022,23 +2006,6 @@ treat_node_as_concrete(node(X, Package)) :- attr("node", node(X, Package)), runt
 build_priority(PackageNode, 200) :- build(PackageNode), attr("node", PackageNode), not treat_node_as_concrete(PackageNode).
 build_priority(PackageNode, 0)   :- build(PackageNode), attr("node", PackageNode), treat_node_as_concrete(PackageNode).
 build_priority(PackageNode, 0)   :- concrete(PackageNode), attr("node", PackageNode).
-
-% don't assign versions from installed packages unless reuse is enabled
-% NOTE: that "installed" means the declared version was only included because
-% that package happens to be installed, NOT because it was asked for on the
-% command line.  If the user specifies a hash, the origin will be "spec".
-%
-% TODO: There's a slight inconsistency with this: if the user concretizes
-% and installs `foo ^bar`, for some build dependency `bar`, and then later
-% does a `spack install --fresh foo ^bar/abcde` (i.e.,the hash of `bar`, it
-% currently *won't* force versions for `bar`'s build dependencies -- `--fresh`
-% will instead build the latest bar. When we actually include transitive
-% build deps in the solve, consider using them as a preference to resolve this.
-:- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   pkg_fact(Package, version_declared(Version, Weight, "installed")),
-   not optimize_for_reuse().
-
 
 % This statement, which is a hidden feature of clingo, let us avoid cycles in the DAG
 #edge (A, B) : depends_on(A, B).

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -44,7 +44,7 @@
 #show trigger_and_effect/3.
 #show unification_set/2.
 #show provider/2.
-#show condition_nodes/3.
+#show condition_nodes/2.
 #show trigger_node/3.
 #show imposed_nodes/3.
 #show variant_single_value/2.

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -25,7 +25,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package),
-  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  condition_nodes(TriggerNode, node(ID, Package)),
   trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
@@ -36,7 +36,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1),
-  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  condition_nodes(TriggerNode, node(ID, Package)),
   trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
@@ -47,7 +47,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1, A2),
-  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  condition_nodes(TriggerNode, node(ID, Package)),
   trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
@@ -58,7 +58,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1, A2, A3),
-  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  condition_nodes(TriggerNode, node(ID, Package)),
   trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
@@ -72,7 +72,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, "node", Package),
-  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  condition_nodes(TriggerNode, node(ID, Package)),
   trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
@@ -194,7 +194,7 @@ error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
 #defined imposed_constraint/5.
 #defined imposed_constraint/6.
 #defined condition_cause/4.
-#defined condition_nodes/3.
+#defined condition_nodes/2.
 #defined condition_requirement/3.
 #defined condition_requirement/4.
 #defined condition_requirement/5.

--- a/lib/spack/spack/solver/heuristic.lp
+++ b/lib/spack/spack/solver/heuristic.lp
@@ -6,46 +6,35 @@
 % Heuristic to speed-up solves
 %=============================================================================
 
-#heuristic node_compiler(ParentNode, CompilerNode). [1200, init]
-#heuristic node_compiler(ParentNode, CompilerNode). [  6, factor]
-#heuristic node_compiler(ParentNode, CompilerNode). [ -1, sign]
-#heuristic node_compiler(ParentNode, CompilerNode) : attr("depends_on", ParentNode, CompilerNode, "build"), provider_weight(CompilerNode, Language, 0), language(Language). [1@2, sign]
+% Decide about DAG atoms, before trying to guess facts used only in
+% the internal representation
+#heuristic attr("virtual_node", node(X, Virtual)). [80, level]
+#heuristic attr("node", PackageNode). [80, level]
+#heuristic attr("version", node(PackageID, Package), Version). [80, level]
+#heuristic attr("variant_value", PackageNode, Variant, Value). [80, level]
+#heuristic attr("node_target", node(PackageID, Package), Target). [80, level]
 
 #heuristic attr("virtual_node", node(X, Virtual)). [600, init]
 #heuristic attr("virtual_node", node(X, Virtual)). [-1, sign]
 #heuristic attr("virtual_node", node(0, Virtual)) : node_depends_on_virtual(PackageNode, Virtual). [1@2, sign]
 #heuristic attr("virtual_node", node(0, "c")).     [1@3, sign]
 #heuristic attr("virtual_node", node(0, "cxx")).   [1@3, sign]
-
-#heuristic unification_set(SetID, Node). [400, init]
-#heuristic unification_set(SetID, Node). [  4, factor]
-#heuristic unification_set(SetID, Node). [  -1, sign]
-#heuristic unification_set("root", node(0, "libc")). [  1@2, sign]
+#heuristic attr("virtual_node", node(0, "libc")).   [1@3, sign]
 
 #heuristic attr("node", PackageNode). [300, init]
 #heuristic attr("node", PackageNode). [  4, factor]
 #heuristic attr("node", PackageNode). [ -1, sign]
 #heuristic attr("node", node(0, Dependency)) : attr("dependency_holds", ParentNode, Dependency, Type), not virtual(Dependency). [1@2, sign]
 
-#heuristic attr("depends_on", ParentNode, ChildNode, Type). [100, init]
-#heuristic attr("depends_on", ParentNode, ChildNode, Type). [4,  factor]
-#heuristic attr("depends_on", ParentNode, ChildNode, Type). [-1, sign]
-#heuristic attr("depends_on", ParentNode, node(0, Dependency), Type) : attr("dependency_holds", ParentNode, Dependency, Type), not virtual(Dependency). [1@2, sign]
-#heuristic attr("depends_on", ParentNode, ProviderNode       , Type) : node_depends_on_virtual(ParentNode, Virtual, Type), provider(ProviderNode, node(VirtualID, Virtual)). [1@2, sign]
-
 #heuristic attr("version", node(PackageID, Package), Version). [30, init]
 #heuristic attr("version", node(PackageID, Package), Version). [-1, sign]
 #heuristic attr("version", node(PackageID, Package), Version) : pkg_fact(Package, version_declared(Version, 0)), attr("node", node(PackageID, Package)). [ 1@2, sign]
 
-#heuristic version_weight(node(PackageID, Package), Weight).                                          [30, init]
-#heuristic version_weight(node(PackageID, Package), Weight).                                          [-1  , sign]
-#heuristic version_weight(node(PackageID, Package), 0     ) : attr("node", node(PackageID, Package)). [ 1@2, sign]
+% Use default targets
+#heuristic attr("node_target", node(PackageID, Package), Target). [-1, sign]
+#heuristic attr("node_target", node(PackageID, Package), Target) : target_weight(Target, 0), attr("node", node(PackageID, Package)). [1@2, sign]
 
 % Use default variants
 #heuristic attr("variant_value", PackageNode, Variant, Value). [30, init]
 #heuristic attr("variant_value", PackageNode, Variant, Value). [-1, sign]
 #heuristic attr("variant_value", PackageNode, Variant, Value) : variant_default_value(PackageNode, Variant, Value), attr("node", PackageNode). [1@2, sign]
-
-% Use default targets
-#heuristic attr("node_target", node(PackageID, Package), Target). [-1, sign]
-#heuristic attr("node_target", node(PackageID, Package), Target) : target_weight(Target, 0), attr("node", node(PackageID, Package)). [1@2, sign]

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -13,7 +13,7 @@ import spack.util.libc
 import spack.version
 
 from .core import SourceContext, fn, using_libc_compatibility
-from .versions import DeclaredVersion, Provenance
+from .versions import Provenance
 
 
 class RuntimePropertyRecorder:
@@ -174,10 +174,7 @@ class RuntimePropertyRecorder:
         for s in (imposed_spec, when_spec):
             if not s.versions.concrete:
                 continue
-            self._setup.possible_versions[s.name].add(s.version)
-            self._setup.declared_versions[s.name].append(
-                DeclaredVersion(version=s.version, idx=0, origin=Provenance.RUNTIME)
-            )
+            self._setup.possible_versions[s.name][s.version].append(Provenance.RUNTIME)
 
         self.runtime_conditions.add((imposed_spec, when_spec))
         self.reset()

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -143,6 +143,12 @@ class RuntimePropertyRecorder:
                 # (avoid adding virtuals everywhere, if a single edge needs it)
                 _, provider, virtual = clause.args
                 clause.args = "virtual_on_edge", node_placeholder, provider, virtual
+
+        # Check for abstract hashes in the body
+        for s in when_spec.traverse(root=False):
+            if s.abstract_hash:
+                body_clauses.append(fn.attr("hash", s.name, s.abstract_hash))
+
         body_str = ",\n".join(f"  {x}" for x in body_clauses)
         body_str = body_str.replace(f'"{node_placeholder}"', f"{node_variable}")
         for old, replacement in when_substitutions.items():

--- a/lib/spack/spack/solver/versions.py
+++ b/lib/spack/spack/solver/versions.py
@@ -13,6 +13,8 @@ class Provenance(enum.IntEnum):
     DEV_SPEC = enum.auto()
     # The 'packages' section of the configuration
     PACKAGES_YAML = enum.auto()
+    # A git version in the 'packages' section of the configuration
+    PACKAGES_YAML_GIT_VERSION = enum.auto()
     # A package requirement
     PACKAGE_REQUIREMENT = enum.auto()
     # A 'package.py' file

--- a/lib/spack/spack/solver/versions.py
+++ b/lib/spack/spack/solver/versions.py
@@ -2,23 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
-from typing import NamedTuple, Tuple, Union
-
-from spack.version import GitVersion, StandardVersion
-
-
-def concretization_version_order(version_info: Tuple[Union[GitVersion, StandardVersion], dict]):
-    """Version order key for concretization, where preferred > not preferred,
-    not deprecated > deprecated, finite > any infinite component; only if all are
-    the same, do we use default version ordering."""
-    version, info = version_info
-    return (
-        info.get("preferred", False),
-        not info.get("deprecated", False),
-        not version.isdevelop(),
-        not version.is_prerelease(),
-        version,
-    )
 
 
 class Provenance(enum.IntEnum):
@@ -36,23 +19,12 @@ class Provenance(enum.IntEnum):
     PACKAGE_PY = enum.auto()
     # An installed spec
     INSTALLED = enum.auto()
-    # An external spec declaration
-    EXTERNAL = enum.auto()
     # lower provenance for installed git refs so concretizer prefers StandardVersion installs
     INSTALLED_GIT_VERSION = enum.auto()
+    # Synthetic versions for virtual packages
+    VIRTUAL_CONSTRAINT = enum.auto()
     # A runtime injected from another package (e.g. a compiler)
     RUNTIME = enum.auto()
 
     def __str__(self):
         return f"{self._name_.lower()}"
-
-
-class DeclaredVersion(NamedTuple):
-    """Data class to contain information on declared versions used in the solve"""
-
-    #: String representation of the version
-    version: str
-    #: Unique index assigned to this version
-    idx: int
-    #: Provenance of the version
-    origin: Provenance

--- a/lib/spack/spack/solver/when_possible.lp
+++ b/lib/spack/spack/solver/when_possible.lp
@@ -27,7 +27,7 @@ do_not_impose(EffectID, node(X, Package)) :-
   subcondition(SubconditionID, ParentConditionID),
   pkg_fact(Package, condition_effect(SubconditionID, EffectID)),
   trigger_and_effect(_, TriggerID, EffectID),
-  trigger_node(TriggerID, _, node(X, Package)).
+  trigger_requestor_node(TriggerID, node(X, Package)).
 
 opt_criterion(320, "number of input specs not concretized").
 #minimize{ 0@320: #true }.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5580,16 +5580,10 @@ def _inject_patches_variant(root: Spec) -> None:
     # since the Spec __hash__ will change as patches are added to them
     spec_to_patches: Dict[int, Set[spack.patch.Patch]] = {}
     for s in root.traverse():
-        # After concretizing, assign namespaces to anything left.
-        # Note that this doesn't count as a "change".  The repository
-        # configuration is constant throughout a spack run, and
-        # normalize and concretize evaluate Packages using Repo.get(),
-        # which respects precedence.  So, a namespace assignment isn't
-        # changing how a package name would have been interpreted and
-        # we can do it as late as possible to allow as much
-        # compatibility across repositories as possible.
-        if s.namespace is None:
-            s.namespace = spack.repo.PATH.repo_for_pkg(s.name).namespace
+        assert s.namespace is not None, (
+            f"internal error: {s.name} has no namespace after concretization. "
+            f"Please report a bug at https://github.com/spack/spack/issues"
+        )
 
         if s.concrete:
             continue

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -461,10 +461,11 @@ class SpecParser:
             toolchain = self._parse_toolchain(name)
             self.parsed_toolchains[name] = toolchain
 
-        toolchain = self.parsed_toolchains[name]
-        if propagation == PropagationPolicy.PREFERENCE:
-            toolchain = toolchain.copy(propagation=propagation)
-
+        propagation_arg = None if propagation != PropagationPolicy.PREFERENCE else propagation
+        # Here we need to copy because we want "foo %toolc ^bar %toolc" to generate different
+        # objects for the toolc attached to foo and bar, since the solver depends on that to
+        # generate facts
+        toolchain = self.parsed_toolchains[name].copy(propagation=propagation_arg)
         spec.constrain(toolchain)
 
     def _parse_toolchain(self, name: str) -> "spack.spec.Spec":

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -851,6 +851,9 @@ def test_tarball_common_prefix(dummy_prefix, tmp_path: pathlib.Path):
             common_prefix = spack.binary_distribution._ensure_common_prefix(tar)
             assert common_prefix == expected_prefix
 
+            # For consistent behavior across all supported Python versions
+            tar.extraction_filter = lambda member, path: member
+
             # Extract into prefix2
             tar.extractall(
                 path="prefix2",

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -372,7 +372,9 @@ def test_update_sbang(tmp_path: pathlib.Path, temporary_mirror, mock_fetch, inst
         new_prefix, new_sbang_shebang = s.prefix, sbang.sbang_shebang_line()
         assert old_prefix != new_prefix
         assert old_sbang_shebang != new_sbang_shebang
-        PackageInstaller([s.package], cache_only=True, unsigned=True).install()
+        PackageInstaller(
+            [s.package], root_policy="cache_only", dependencies_policy="cache_only", unsigned=True
+        ).install()
 
         # Check that the sbang line refers to the new install tree
         new_contents = f"""\

--- a/lib/spack/spack/test/buildrequest.py
+++ b/lib/spack/spack/test/buildrequest.py
@@ -56,29 +56,21 @@ def test_build_request_strings(install_mockery):
 
 
 @pytest.mark.parametrize(
-    "package_cache_only,dependencies_cache_only,package_deptypes,dependencies_deptypes",
+    "root_policy,dependencies_policy,package_deptypes,dependencies_deptypes",
     [
-        (False, False, dt.BUILD | dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
-        (True, False, dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
-        (False, True, dt.BUILD | dt.LINK | dt.RUN, dt.LINK | dt.RUN),
-        (True, True, dt.LINK | dt.RUN, dt.LINK | dt.RUN),
+        ("auto", "auto", dt.BUILD | dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
+        ("cache_only", "auto", dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
+        ("auto", "cache_only", dt.BUILD | dt.LINK | dt.RUN, dt.LINK | dt.RUN),
+        ("cache_only", "cache_only", dt.LINK | dt.RUN, dt.LINK | dt.RUN),
     ],
 )
 def test_build_request_deptypes(
-    install_mockery,
-    package_cache_only,
-    dependencies_cache_only,
-    package_deptypes,
-    dependencies_deptypes,
+    install_mockery, root_policy, dependencies_policy, package_deptypes, dependencies_deptypes
 ):
     s = spack.concretize.concretize_one("dependent-install")
 
     build_request = inst.BuildRequest(
-        s.package,
-        {
-            "package_cache_only": package_cache_only,
-            "dependencies_cache_only": dependencies_cache_only,
-        },
+        s.package, {"root_policy": root_policy, "dependencies_policy": dependencies_policy}
     )
 
     actual_package_deptypes = build_request.get_depflags(s.package)

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -472,7 +472,11 @@ def test_push_and_install_with_mirror_marked_unsigned_does_not_require_extra_fla
 
     spec.package.do_uninstall(force=True)
     PackageInstaller(
-        [spec.package], explicit=True, cache_only=True, unsigned=True if signed else None
+        [spec.package],
+        explicit=True,
+        root_policy="cache_only",
+        dependencies_policy="cache_only",
+        unsigned=True if signed else None,
     ).install()
 
 

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -153,3 +153,32 @@ def test_use_buildcache_type():
 
     with pytest.raises(argparse.ArgumentTypeError):
         assert arguments.use_buildcache("sometimes")
+
+
+def test_missing_config_scopes_are_valid_scope_arguments(mock_missing_dir_include_scopes):
+    """Test that if an included scope does not have a directory or file,
+    we can still specify it as a scope as an argument"""
+    a = argparse.ArgumentParser()
+    a.add_argument(
+        "--scope",
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
+        help="configuration scope to modify",
+    )
+    namespace = a.parse_args(["--scope", "sub_base"])
+    assert namespace.scope == "sub_base"
+
+
+def test_missing_config_scopes_not_valid_read_scope(mock_missing_dir_include_scopes):
+    """Ensures that if a missing include scope is the subject of a read
+    operation, we fail at the argparse level"""
+    a = argparse.ArgumentParser()
+    a.add_argument(
+        "--scope",
+        action=arguments.ConfigScope,
+        type=arguments.config_scope_readable_validator,
+        default=lambda: spack.config.default_modify_scope(),
+        help="configuration scope to modify",
+    )
+    with pytest.raises(SystemExit):
+        a.parse_args(["--scope", "sub_base"])

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -70,7 +70,7 @@ def test_transitive_installed_dependents(mock_packages, database):
     with color_when(False):
         out = dependents("--installed", "--transitive", "fake")
 
-    lines = [li for li in out.strip().split("\n") if not li.startswith("--")]
+    lines = [li for li in out.strip().split("\n") if li and not li.startswith("--")]
     hashes = set([re.split(r"\s+", li)[0] for li in lines])
 
     expected = set(

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -128,6 +128,17 @@ def test_info_fields(pkg_query, extra_args):
             [r"when\s*build_system=cmake"],
             [r"when\s*build_system=autotools"],
         ),
+        (
+            ["optional-dep-test"],
+            [
+                r"when \^pkg-g",
+                r"when \%intel",
+                r"when \%intel\@64\.1",
+                r"when \%clang@34\:40",
+                r"when \^pkg\-f",
+            ],
+            [],
+        ),
     ],
 )
 @pytest.mark.parametrize("by_name", [True, False])

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2014,7 +2014,7 @@ spack:
                 else:
                     weights["built"] = x.value
 
-            assert weights["reused"] == 1 and weights["built"] == 0
+            assert weights["reused"] == 3 and weights["built"] == 0
 
             result_spec = result.specs[0]
             assert result_spec.satisfies("^pkg-b@1.0")
@@ -3128,11 +3128,11 @@ def test_concretization_version_order():
     ]
     assert result == [
         Version("0.9"),  # preferred
+        Version("2.0"),  # deprecation is accounted for separately
         Version("1.1"),  # latest non-deprecated final version
         Version("1.0"),  # latest non-deprecated final version
         Version("1.1alpha1"),  # prereleases
         Version("develop"),  # likely development version
-        Version("2.0"),  # deprecated
     ]
 
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4698,3 +4698,17 @@ packages:
     mpileaks = spack.concretize.concretize_one("mpileaks %c=gcc@12")
 
     assert mpileaks.satisfies("%c=gcc@12")
+
+
+@pytest.mark.regression("51683")
+def test_activating_variant_for_conditional_language_dependency(default_mock_concretization):
+    """Tests that a dependency on a conditional language can be concretized, and that the solver
+    turn on the correct variant to enable the language dependency
+    """
+    # To trigger the bug, we need at least another node needing fortran, in this case mpich
+    s = default_mock_concretization("mpileaks %fortran=gcc %mpi=mpich")
+    assert s.satisfies("+fortran")
+
+    # Try just asking for fortran, without the provider
+    s = default_mock_concretization("mpileaks %fortran %mpi=mpich")
+    assert s.satisfies("+fortran")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -35,7 +35,6 @@ import spack.solver.asp
 import spack.solver.core
 import spack.solver.reuse
 import spack.solver.runtimes
-import spack.solver.versions
 import spack.spec
 import spack.test.conftest
 import spack.util.file_cache
@@ -2001,10 +2000,13 @@ spack:
             # Version badness should be > 0 only for reused specs. For instance, for pkg-b
             # the version provenance is:
             #
-            # version_declared("pkg-b","1.0",0,"package_py").
-            # version_declared("pkg-b","0.9",1,"package_py").
-            # version_declared("pkg-b","1.0",2,"installed").
-            # version_declared("pkg-b","0.9",3,"installed").
+            # pkg_fact("pkg-b", version_declared("1.0", 0)).
+            # pkg_fact("pkg-b", version_origin("1.0", "installed")).
+            # pkg_fact("pkg-b", version_origin("1.0", "package_py")).
+            # pkg_fact("pkg-b", version_declared("0.9", 1)).
+            # pkg_fact("pkg-b", version_origin("0.9", "installed")).
+            # pkg_fact("pkg-b", version_origin("0.9", "package_py")).
+
             weights = {}
             for x in [x for x in result.criteria if x.name == "version badness (non roots)"]:
                 if x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
@@ -2012,7 +2014,7 @@ spack:
                 else:
                     weights["built"] = x.value
 
-            assert weights["reused"] > 2 and weights["built"] == 0
+            assert weights["reused"] == 1 and weights["built"] == 0
 
             result_spec = result.specs[0]
             assert result_spec.satisfies("^pkg-b@1.0")
@@ -3121,7 +3123,7 @@ def test_concretization_version_order():
     result = [
         v
         for v, _ in sorted(
-            versions, key=spack.solver.versions.concretization_version_order, reverse=True
+            versions, key=spack.package_base.concretization_version_order, reverse=True
         )
     ]
     assert result == [

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -827,7 +827,7 @@ spack:
 
     def test_no_matching_compiler_specs(self):
         s = Spec("pkg-a %gcc@0.0.0")
-        with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
+        with pytest.raises(spack.solver.asp.InvalidVersionError):
             spack.concretize.concretize_one(s)
 
     def test_no_compilers_for_arch(self):

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -59,6 +59,25 @@ def test_error_messages(error_messages, config_set, spec, mock_packages, mutable
         assert em in str(e.value), str(e.value)
 
 
+@pytest.mark.parametrize(
+    "spec", ["deprecated-versions@1.1.0", "deprecated-client ^deprecated-versions@1.1.0"]
+)
+def test_deprecated_version_error(spec, mock_packages, mutable_config):
+    with pytest.raises(spack.solver.asp.DeprecatedVersionError, match="deprecated-versions@1.1.0"):
+        _ = spack.concretize.concretize_one(spec)
+
+    spack.config.set("config:deprecated", True)
+    spack.concretize.concretize_one(spec)
+
+
+@pytest.mark.parametrize(
+    "spec", ["deprecated-versions@99.9", "deprecated-client ^deprecated-versions@99.9"]
+)
+def test_nonexistent_version_error(spec, mock_packages, mutable_config):
+    with pytest.raises(spack.solver.asp.InvalidVersionError, match="deprecated-versions@99.9"):
+        _ = spack.concretize.concretize_one(spec)
+
+
 def test_internal_error_handling_formatting(tmp_path: pathlib.Path):
     log = StringIO()
     input_to_output = [

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2334,6 +2334,9 @@ class MockHTTPResponse(io.IOBase):
         body = io.BytesIO(json.dumps(body).encode("utf-8"))
         return cls(status, reason, headers, body)
 
+    def readable(self):
+        return True
+
     def read(self, *args, **kwargs):
         return self._body.read(*args, **kwargs)
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1209,32 +1209,11 @@ def install_mockery(temporary_store: spack.store.Store, mutable_config, mock_pac
     temporary_store.failure_tracker.clear_all()
 
 
-@pytest.fixture(scope="module")
-def temporary_mirror_dir(tmp_path_factory: pytest.TempPathFactory):
-    dir = tmp_path_factory.mktemp("mirror")
-    yield str(dir)
-
-
 @pytest.fixture(scope="function")
-def temporary_mirror(temporary_mirror_dir):
-    mirror_url = url_util.path_to_file_url(temporary_mirror_dir)
-    mirror_cmd("add", "--scope", "site", "test-mirror-func", mirror_url)
-    yield temporary_mirror_dir
-    mirror_cmd("rm", "--scope=site", "test-mirror-func")
-
-
-@pytest.fixture(scope="function")
-def mutable_temporary_mirror_dir(tmp_path_factory: pytest.TempPathFactory):
-    dir = tmp_path_factory.mktemp("mirror")
-    yield str(dir)
-
-
-@pytest.fixture(scope="function")
-def mutable_temporary_mirror(mutable_temporary_mirror_dir):
-    mirror_url = url_util.path_to_file_url(mutable_temporary_mirror_dir)
-    mirror_cmd("add", "--scope", "site", "test-mirror-func", mirror_url)
-    yield mutable_temporary_mirror_dir
-    mirror_cmd("rm", "--scope=site", "test-mirror-func")
+def temporary_mirror(mutable_config, tmp_path_factory):
+    mirror_dir = tmp_path_factory.mktemp("mirror")
+    mirror_cmd("add", "test-mirror-func", mirror_dir.as_uri())
+    yield str(mirror_dir)
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1043,6 +1043,49 @@ def mock_low_high_config(tmp_path: Path):
         yield config
 
 
+def create_config_scope(path: Path, name: str) -> spack.config.DirectoryConfigScope:
+    """helper for creating config scopes with included file/directory scopes
+    that do not have existing representation on the filesystem"""
+    base_scope_dir = path / "base"
+    config_data = syaml.syaml_dict(
+        {
+            "include": [
+                {
+                    "name": "sub_base",
+                    "path": str(path / name),
+                    "optional": True,
+                    "prefer_modify": True,
+                }
+            ]
+        }
+    )
+    base_scope_dir.mkdir()
+    with open(str(base_scope_dir / "include.yaml"), "w+", encoding="utf-8") as f:
+        syaml.dump_config(config_data, stream=f, default_flow_style=False)
+    scope = spack.config.DirectoryConfigScope("base", str(base_scope_dir))
+    return scope
+
+
+@pytest.fixture()
+def mock_missing_dir_include_scopes(tmp_path: Path):
+    """Mocks a config scope containing optional directory scope
+    includes that do not have represetation on the filesystem"""
+    scope = create_config_scope(tmp_path, "sub")
+
+    with spack.config.use_configuration(scope) as config:
+        yield config
+
+
+@pytest.fixture
+def mock_missing_file_include_scopes(tmp_path: Path):
+    """Mocks a config scope containing optional file scope
+    includes that do not have represetation on the filesystem"""
+    scope = create_config_scope(tmp_path, "sub.yaml")
+
+    with spack.config.use_configuration(scope) as config:
+        yield config
+
+
 def _populate(mock_db):
     r"""Populate a mock database with packages.
 

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -8,6 +8,7 @@ import pytest
 from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
+import spack.traverse
 from spack.externals import (
     DuplicateExternalError,
     ExternalDict,
@@ -277,6 +278,10 @@ def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expect
         assert len(result) == 1
         assert all(not result[0].satisfies(c) for c in not_expected_list)
 
+    # Assert all nodes have the namespace set
+    for node in spack.traverse.traverse_nodes(parser.all_specs()):
+        assert node.namespace is not None
+
 
 @pytest.mark.parametrize(
     "externals_dicts,expected_length,not_expected",
@@ -331,3 +336,7 @@ def test_external_node_completion(
         assert len(result) == 1
         for expected in expected_list:
             assert not result[0].satisfies(expected)
+
+    # Assert all nodes have the namespace set
+    for node in spack.traverse.traverse_nodes(parser.all_specs()):
+        assert node.namespace is not None

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -594,8 +594,8 @@ def test_install_from_binary_with_missing_patch_succeeds(
     PackageInstaller(
         [s.package],
         explicit=True,
-        package_cache_only=True,
-        dependencies_cache_only=True,
+        root_policy="cache_only",
+        dependencies_policy="cache_only",
         unsigned=True,
     ).install()
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -25,6 +25,7 @@ import spack.llnl.util.tty as tty
 import spack.package_base
 import spack.package_prefs as prefs
 import spack.repo
+import spack.report
 import spack.spec
 import spack.store
 import spack.test.conftest
@@ -644,6 +645,22 @@ def test_installer_init_requests(install_mockery):
     assert len(installer.build_requests) == 1
     request = installer.build_requests[0]
     assert request.pkg.name == spec_name
+
+
+def false(*args, **kwargs):
+    return False
+
+
+def test_rewire_task_no_tarball(monkeypatch, mock_packages):
+    spec = spack.concretize.concretize_one("splice-t")
+    dep = spack.concretize.concretize_one("splice-h+foo")
+    out = spec.splice(dep)
+
+    rewire_task = inst.RewireTask(out.package, inst.BuildRequest(out.package, {}))
+    monkeypatch.setattr(inst, "_process_binary_cache_tarball", false)
+    monkeypatch.setattr(spack.report.InstallRecord, "succeed", lambda x: None)
+
+    assert rewire_task.complete() == inst.ExecuteResult.MISSING_BUILD_SPEC
 
 
 @pytest.mark.parametrize("transitive", [True, False])

--- a/lib/spack/spack/test/installer_build_graph.py
+++ b/lib/spack/spack/test/installer_build_graph.py
@@ -1,0 +1,552 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Tests for BuildGraph class in new_installer"""
+import sys
+from typing import Dict, List, Tuple, Union
+
+import pytest
+
+if sys.platform == "win32":
+    pytest.skip("Skipping new installer tests on Windows", allow_module_level=True)
+
+import spack.deptypes as dt
+import spack.error
+from spack.new_installer import BuildGraph
+from spack.spec import Spec
+from spack.store import Store
+
+
+def create_dag(
+    nodes: List[str], edges: List[Tuple[str, str, Union[dt.DepType, Tuple[dt.DepType, ...]]]]
+) -> Dict[str, Spec]:
+    """
+    Create a DAG of concrete specs, as a mapping from package name to Spec.
+
+    Arguments:
+        nodes: list of unique package names
+        edges: list of tuples (parent, child, deptype)
+    """
+    specs = {name: Spec(name) for name in nodes}
+    for parent, child, deptypes in edges:
+        depflag = deptypes if isinstance(deptypes, dt.DepFlag) else dt.canonicalize(deptypes)
+        specs[parent].add_dependency_edge(specs[child], depflag=depflag, virtuals=())
+
+    # Mark all specs as concrete
+    for spec in specs.values():
+        spec._mark_concrete()
+
+    return specs
+
+
+def install_spec_in_db(spec: Spec, store: Store):
+    """Helper to install a spec in the database for testing."""
+    prefix = store.layout.path_for_spec(spec)
+    spec.set_prefix(prefix)
+    # Use the layout to create a proper installation directory structure
+    store.layout.create_install_directory(spec)
+    store.db.add(spec, explicit=False)
+
+
+@pytest.fixture
+def mock_specs():
+    """Create a set of mock specs for testing.
+
+    DAG structure:
+        root -> dep1 -> dep2
+        root -> dep3
+    """
+    return create_dag(
+        nodes=["root", "dep1", "dep2", "dep3"],
+        edges=[
+            ("root", "dep1", ("build", "link")),
+            ("root", "dep3", ("build", "link")),
+            ("dep1", "dep2", ("build", "link")),
+        ],
+    )
+
+
+@pytest.fixture
+def diamond_dag():
+    """Create a diamond-shaped DAG to test shared dependencies.
+
+    DAG structure:
+        root -> dep1 -> shared
+        root -> dep2 -> shared
+    """
+    return create_dag(
+        nodes=["root", "dep1", "dep2", "shared"],
+        edges=[
+            ("root", "dep1", ("build", "link")),
+            ("root", "dep2", ("build", "link")),
+            ("dep1", "shared", ("build", "link")),
+            ("dep2", "shared", ("build", "link")),
+        ],
+    )
+
+
+@pytest.fixture
+def specs_with_build_deps():
+    """Create specs with different dependency types for testing build dep filtering.
+
+    DAG structure:
+        root -> link_dep (link only)
+        root -> build_dep (build only)
+        root -> all_dep (build, link, run)
+    """
+    return create_dag(
+        nodes=["root", "link_dep", "build_dep", "all_dep"],
+        edges=[
+            ("root", "link_dep", "link"),
+            ("root", "build_dep", "build"),
+            ("root", "all_dep", ("build", "link", "run")),
+        ],
+    )
+
+
+@pytest.fixture
+def complex_pruning_dag():
+    """Create a complex DAG for testing re-parenting logic.
+
+    DAG structure:
+        parent1 -> middle -> child1
+        parent2 -> middle -> child2
+
+    When 'middle' is installed and pruned, both parent1 and parent2 should
+    become direct parents of both child1 and child2 (full Cartesian product).
+    """
+    return create_dag(
+        nodes=["parent1", "parent2", "middle", "child1", "child2"],
+        edges=[
+            ("parent1", "middle", ("build", "link")),
+            ("parent2", "middle", ("build", "link")),
+            ("middle", "child1", ("build", "link")),
+            ("middle", "child2", ("build", "link")),
+        ],
+    )
+
+
+class TestBuildGraph:
+    """Tests for the BuildGraph class."""
+
+    def test_basic_graph_construction(self, mock_specs: Dict[str, Spec], temporary_store: Store):
+        """Test basic graph construction with all specs to be installed."""
+        graph = BuildGraph(
+            specs=[mock_specs["root"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Root should be in roots set
+        assert mock_specs["root"].dag_hash() in graph.roots
+        # All uninstalled specs should be in nodes
+        assert len(graph.nodes) == 4  # root, dep1, dep2, dep3
+        # Root should have 2 children (dep1, dep3)
+        assert len(graph.parent_to_child[mock_specs["root"].dag_hash()]) == 2
+
+    def test_install_package_only_mode(self, mock_specs: Dict[str, Spec], temporary_store: Store):
+        """Test that install_package=False removes root specs from graph."""
+        graph = BuildGraph(
+            specs=[mock_specs["root"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=False,  # Only install dependencies
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Root should NOT be in nodes when install_package=False
+        assert mock_specs["root"].dag_hash() not in graph.nodes
+        # But its dependencies should be
+        assert mock_specs["dep1"].dag_hash() in graph.nodes
+
+    def test_install_deps_false_with_uninstalled_deps(
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test that install_deps=False raises error when dependencies are not installed."""
+        # Should raise error because dependencies are not installed
+        with pytest.raises(
+            spack.error.InstallError, match="package only mode.*dependency.*not installed"
+        ):
+            BuildGraph(
+                specs=[mock_specs["root"]],
+                root_policy="auto",
+                dependencies_policy="auto",
+                include_build_deps=False,
+                install_package=True,
+                install_deps=False,  # Don't install dependencies
+                database=temporary_store.db,
+            )
+
+    def test_multiple_roots(self, mock_specs: Dict[str, Spec], temporary_store: Store):
+        """Test graph construction with multiple root specs."""
+        graph = BuildGraph(
+            specs=[mock_specs["root"], mock_specs["dep1"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Both should be in roots
+        assert mock_specs["root"].dag_hash() in graph.roots
+        assert mock_specs["dep1"].dag_hash() in graph.roots
+
+    def test_parent_child_mappings(self, mock_specs: Dict[str, Spec], temporary_store: Store):
+        """Test that parent-child mappings are correctly constructed."""
+        spec_root = mock_specs["root"]
+        graph = BuildGraph(
+            specs=[spec_root],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Verify parent_to_child and child_to_parent are inverse mappings
+        for parent, children in graph.parent_to_child.items():
+            for child in children:
+                assert child in graph.child_to_parent
+                assert parent in graph.child_to_parent[child]
+
+    def test_diamond_dag_with_shared_dependency(
+        self, diamond_dag: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test graph construction with a diamond DAG where a dependency has multiple parents."""
+        graph = BuildGraph(
+            specs=[diamond_dag["root"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Shared dependency should have two parents
+        shared_hash = diamond_dag["shared"].dag_hash()
+        assert len(graph.child_to_parent[shared_hash]) == 2
+        # Both dep1 and dep2 should be parents of shared
+        assert diamond_dag["dep1"].dag_hash() in graph.child_to_parent[shared_hash]
+        assert diamond_dag["dep2"].dag_hash() in graph.child_to_parent[shared_hash]
+
+    def test_pruning_installed_specs(self, mock_specs: Dict[str, Spec], temporary_store: Store):
+        """Test that installed specs are correctly pruned from the graph."""
+        # Install dep2 in the database
+        dep2 = mock_specs["dep2"]
+        install_spec_in_db(dep2, temporary_store)
+
+        graph = BuildGraph(
+            specs=[mock_specs["root"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # dep2 should be pruned since it's installed
+        assert dep2.dag_hash() not in graph.nodes
+        # But dep1 (its parent) should still be in the graph
+        assert mock_specs["dep1"].dag_hash() in graph.nodes
+        # And dep1 should have no children (since dep2 was pruned)
+        assert len(graph.parent_to_child[mock_specs["dep1"].dag_hash()]) == 0
+
+    def test_pruning_with_shared_dependency_partially_installed(
+        self, diamond_dag: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test that pruning a shared dependency correctly updates all parents."""
+        # Install the shared dependency
+        shared = diamond_dag["shared"]
+        install_spec_in_db(shared, temporary_store)
+        graph = BuildGraph(
+            specs=[diamond_dag["root"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Shared should be pruned
+        assert shared.dag_hash() not in graph.nodes
+        # Both dep1 and dep2 should have no children
+        assert len(graph.parent_to_child[diamond_dag["dep1"].dag_hash()]) == 0
+        assert len(graph.parent_to_child[diamond_dag["dep2"].dag_hash()]) == 0
+
+    def test_installed_root_excludes_build_deps_even_when_requested(
+        self, specs_with_build_deps: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test that installed root specs never include build deps, even with
+        include_build_deps=True."""
+        root = specs_with_build_deps["root"]
+        install_spec_in_db(root, temporary_store)
+
+        graph = BuildGraph(
+            specs=[root],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=True,  # Should be ignored for installed root
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # build_dep should NOT be in the graph (installed root never needs build deps)
+        assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes
+        # link_dep and all_dep should be in the graph (link/run deps)
+        assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
+
+    def test_cache_only_excludes_build_deps(
+        self, specs_with_build_deps: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test that cache_only policy excludes build deps when include_build_deps=False."""
+        graph = BuildGraph(
+            specs=[specs_with_build_deps["root"]],
+            root_policy="cache_only",
+            dependencies_policy="auto",
+            include_build_deps=False,  # exclude build deps when possible
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes
+        assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
+
+    def test_cache_only_includes_build_deps_when_requested(
+        self, specs_with_build_deps: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test that cache_only policy includes build deps when include_build_deps=True."""
+        graph = BuildGraph(
+            specs=[specs_with_build_deps["root"]],
+            root_policy="cache_only",
+            dependencies_policy="cache_only",
+            include_build_deps=True,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # All dependencies should be in the graph, including build_dep
+        assert specs_with_build_deps["build_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["link_dep"].dag_hash() in graph.nodes
+        assert specs_with_build_deps["all_dep"].dag_hash() in graph.nodes
+
+    def test_install_deps_false_with_all_deps_installed(
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test successful package-only install when all dependencies are already installed."""
+        # Install all dependencies
+        for dep_name in ["dep1", "dep2", "dep3"]:
+            install_spec_in_db(mock_specs[dep_name], temporary_store)
+
+        # Should succeed since all dependencies are installed
+        graph = BuildGraph(
+            specs=[mock_specs["root"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=False,
+            database=temporary_store.db,
+        )
+
+        # Only the root should be in the graph
+        assert len(graph.nodes) == 1
+        assert mock_specs["root"].dag_hash() in graph.nodes
+        # Root should have no children (all deps pruned)
+        assert len(graph.parent_to_child.get(mock_specs["root"].dag_hash(), [])) == 0
+
+    def test_pruning_creates_cartesian_product_of_connections(
+        self, complex_pruning_dag: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test that pruning creates full Cartesian product of parent-child connections.
+
+        When a node with multiple parents and multiple children is pruned,
+        all parents should be connected to all children (parents x children).
+
+        DAG structure:
+            parent1 -> middle -> child1
+            parent2 -> middle -> child2
+
+        After pruning 'middle':
+            parent1 -> child1
+            parent1 -> child2
+            parent2 -> child1
+            parent2 -> child2
+        """
+        # Install the middle node
+        middle = complex_pruning_dag["middle"]
+        install_spec_in_db(middle, temporary_store)
+
+        # Use parent1 as the root to build the graph
+        graph = BuildGraph(
+            specs=[complex_pruning_dag["parent1"], complex_pruning_dag["parent2"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        parent1_hash = complex_pruning_dag["parent1"].dag_hash()
+        parent2_hash = complex_pruning_dag["parent2"].dag_hash()
+        middle_hash = middle.dag_hash()
+        child1_hash = complex_pruning_dag["child1"].dag_hash()
+        child2_hash = complex_pruning_dag["child2"].dag_hash()
+
+        # middle should be pruned since it's installed
+        assert middle_hash not in graph.nodes
+
+        # All other nodes should be in the graph
+        assert parent1_hash in graph.nodes
+        assert parent2_hash in graph.nodes
+        assert child1_hash in graph.nodes
+        assert child2_hash in graph.nodes
+
+        # Verify full Cartesian product: each parent should be connected to each child
+        # parent1 -> child1, child2
+        assert child1_hash in graph.parent_to_child[parent1_hash]
+        assert child2_hash in graph.parent_to_child[parent1_hash]
+
+        # parent2 -> child1, child2
+        assert child1_hash in graph.parent_to_child[parent2_hash]
+        assert child2_hash in graph.parent_to_child[parent2_hash]
+
+        # Verify reverse mapping: each child should have both parents
+        # child1 <- parent1, parent2
+        assert parent1_hash in graph.child_to_parent[child1_hash]
+        assert parent2_hash in graph.child_to_parent[child1_hash]
+
+        # child2 <- parent1, parent2
+        assert parent1_hash in graph.child_to_parent[child2_hash]
+        assert parent2_hash in graph.child_to_parent[child2_hash]
+
+        # middle should not appear in any parent-child relationships
+        assert middle_hash not in graph.parent_to_child
+        assert middle_hash not in graph.child_to_parent
+
+    def test_empty_graph_all_specs_installed(
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test that the graph is empty when all specs are already installed."""
+        # Install all specs in the DAG
+        for spec_name in ["root", "dep1", "dep2", "dep3"]:
+            install_spec_in_db(mock_specs[spec_name], temporary_store)
+
+        graph = BuildGraph(
+            specs=[mock_specs["root"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # All nodes should be pruned, resulting in an empty graph
+        assert len(graph.nodes) == 0
+        assert len(graph.parent_to_child) == 0
+        assert len(graph.child_to_parent) == 0
+
+    def test_empty_graph_install_package_false_all_deps_installed(
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test empty graph when install_package=False and all dependencies are installed."""
+        # Install all dependencies (but not the root)
+        for dep_name in ["dep1", "dep2", "dep3"]:
+            install_spec_in_db(mock_specs[dep_name], temporary_store)
+
+        graph = BuildGraph(
+            specs=[mock_specs["root"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=False,  # Don't install the root
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        # Root is pruned because install_package=False
+        # Dependencies are pruned because they're installed
+        # Result: empty graph
+        assert len(graph.nodes) == 0
+        assert len(graph.parent_to_child) == 0
+        assert len(graph.child_to_parent) == 0
+
+    def test_pruning_leaf_node(self, mock_specs: Dict[str, Spec], temporary_store: Store):
+        """Test that pruning a leaf node (no children) works correctly.
+
+        This ensures the pruning logic handles the boundary condition where
+        a node has no children to re-wire.
+        """
+        # Install dep2, which is a leaf node (no children)
+        dep2 = mock_specs["dep2"]
+        install_spec_in_db(dep2, temporary_store)
+
+        graph = BuildGraph(
+            specs=[mock_specs["root"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        dep2_hash = dep2.dag_hash()
+        dep1_hash = mock_specs["dep1"].dag_hash()
+
+        # dep2 should be pruned
+        assert dep2_hash not in graph.nodes
+        # dep1 (parent of dep2) should have no children now
+        assert len(graph.parent_to_child[dep1_hash]) == 0
+        # dep2 should not appear in any mappings
+        assert dep2_hash not in graph.parent_to_child
+        assert dep2_hash not in graph.child_to_parent
+
+    def test_pruning_root_node_with_install_package_false(
+        self, mock_specs: Dict[str, Spec], temporary_store: Store
+    ):
+        """Test that pruning a root node (no parents in the context) works correctly.
+
+        When install_package=False, root nodes are marked for pruning. This ensures
+        the pruning logic handles the boundary condition where a node has no parents.
+        """
+        graph = BuildGraph(
+            specs=[mock_specs["dep1"]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=False,  # Prune the root
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+        dep1_hash = mock_specs["dep1"].dag_hash()
+        dep2_hash = mock_specs["dep2"].dag_hash()
+
+        # dep1 should be pruned (it's the root and install_package=False)
+        assert dep1_hash not in graph.nodes
+        # dep2 (child of dep1) should still be in the graph
+        assert dep2_hash in graph.nodes
+        # dep2 should have no parents now (its only parent was pruned)
+        assert not graph.child_to_parent.get(dep2_hash)
+        # dep1 should not appear in any mappings
+        assert dep1_hash not in graph.parent_to_child
+        assert dep1_hash not in graph.child_to_parent

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -1,0 +1,1082 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Tests for the BuildStatus terminal UI in new_installer.py"""
+
+import io
+import os
+import sys
+from typing import List, Optional, Tuple
+
+import pytest
+
+if sys.platform == "win32":
+    pytest.skip("No Windows support", allow_module_level=True)
+
+import spack.new_installer as inst
+from spack.new_installer import BuildStatus
+
+
+class MockConnection:
+    """Mock multiprocessing.Connection for testing"""
+
+    def fileno(self):
+        return -1
+
+
+class MockSpec:
+    """Minimal mock for spack.spec.Spec"""
+
+    def __init__(
+        self, name: str, version: str = "1.0", external: bool = False, prefix: Optional[str] = None
+    ) -> None:
+        self.name = name
+        self.version = version
+        self.external = external
+        self.prefix = prefix or f"/fake/prefix/{name}"
+        self._hash = name  # Simple hash based on name
+
+    def dag_hash(self, length: Optional[int] = None) -> str:
+        if length:
+            return self._hash[:length]
+        return self._hash
+
+
+class SimpleTextIOWrapper(io.TextIOWrapper):
+    """TextIOWrapper around a BytesIO buffer for testing of stdout behavior"""
+
+    def __init__(self, tty: bool) -> None:
+        self._buffer = io.BytesIO()
+        self._tty = tty
+        super().__init__(self._buffer, encoding="utf-8", line_buffering=True)
+
+    def isatty(self) -> bool:
+        return self._tty
+
+    def getvalue(self) -> str:
+        self.flush()
+        return self._buffer.getvalue().decode("utf-8")
+
+    def clear(self):
+        self.flush()
+        self._buffer.truncate(0)
+        self._buffer.seek(0)
+
+
+def create_build_status(
+    is_tty: bool = True, terminal_cols: int = 80, terminal_rows: int = 24, total: int = 0
+) -> Tuple[BuildStatus, List[float], SimpleTextIOWrapper]:
+    """Helper function to create BuildStatus with mocked dependencies"""
+    fake_stdout = SimpleTextIOWrapper(tty=is_tty)
+    # Easy way to set the current time in tests before running UI updates
+    time_values = [0.0]
+
+    def mock_get_time():
+        return time_values[-1]
+
+    def mock_get_terminal_size():
+        return os.terminal_size((terminal_cols, terminal_rows))
+
+    status = BuildStatus(
+        total=total,
+        stdout=fake_stdout,
+        get_terminal_size=mock_get_terminal_size,
+        get_time=mock_get_time,
+        is_tty=is_tty,
+    )
+
+    return status, time_values, fake_stdout
+
+
+def add_mock_builds(status: BuildStatus, count: int) -> List[MockSpec]:
+    """Helper function to add builds to a BuildStatus instance"""
+    specs = [MockSpec(f"pkg{i}", f"{i}.0") for i in range(count)]
+    for spec in specs:
+        status.add_build(spec, explicit=True, control_w_conn=MockConnection())  # type: ignore
+    return specs
+
+
+class TestBasicStateManagement:
+    """Test basic state management operations"""
+
+    def test_add_build(self):
+        """Test that add_build adds builds correctly"""
+        status, _, _ = create_build_status(total=2)
+        spec1 = MockSpec("pkg1", "1.0")
+        spec2 = MockSpec("pkg2", "2.0")
+
+        status.add_build(spec1, explicit=True, control_w_conn=MockConnection())
+        assert len(status.builds) == 1
+        assert spec1.dag_hash() in status.builds
+        assert status.builds[spec1.dag_hash()].name == "pkg1"
+        assert status.builds[spec1.dag_hash()].explicit is True
+        assert status.dirty is True
+
+        status.add_build(spec2, explicit=False, control_w_conn=MockConnection())
+        assert len(status.builds) == 2
+        assert spec2.dag_hash() in status.builds
+        assert status.builds[spec2.dag_hash()].explicit is False
+
+    def test_update_state_transitions(self):
+        """Test that update_state transitions states properly"""
+        status, fake_time, _ = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        # Update to 'building' state
+        status.update_state(build_id, "building")
+        assert status.builds[build_id].state == "building"
+        assert status.builds[build_id].progress_percent is None
+        assert status.completed == 0
+
+        # Update to 'finished' state
+        status.update_state(build_id, "finished")
+        assert status.builds[build_id].state == "finished"
+        assert status.completed == 1
+        assert status.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
+
+    def test_update_state_failed(self):
+        """Test that failed state increments completed counter"""
+        status, fake_time, _ = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        status.update_state(build_id, "failed")
+        assert status.builds[build_id].state == "failed"
+        assert status.completed == 1
+        assert status.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
+
+    def test_update_progress(self):
+        """Test that update_progress updates percentages"""
+        status, _, _ = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        # Update progress
+        status.update_progress(build_id, 50, 100)
+        assert status.builds[build_id].progress_percent == 50
+        assert status.dirty is True
+
+        # Same percentage shouldn't mark dirty again
+        status.dirty = False
+        status.update_progress(build_id, 50, 100)
+        assert status.dirty is False
+
+        # Different percentage should mark dirty
+        status.update_progress(build_id, 75, 100)
+        assert status.builds[build_id].progress_percent == 75
+        assert status.dirty is True
+
+    def test_completion_counter(self):
+        """Test that completion counter increments correctly"""
+        status, _, _ = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        assert status.completed == 0
+
+        status.update_state(specs[0].dag_hash(), "finished")
+        assert status.completed == 1
+
+        status.update_state(specs[1].dag_hash(), "failed")
+        assert status.completed == 2
+
+        status.update_state(specs[2].dag_hash(), "finished")
+        assert status.completed == 3
+
+
+class TestOutputRendering:
+    """Test output rendering for TTY and non-TTY modes"""
+
+    def test_non_tty_output(self):
+        """Test that non-TTY mode prints simple state changes"""
+        status, _, fake_stdout = create_build_status(is_tty=False)
+        spec = MockSpec("mypackage", "1.0")
+
+        status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+        build_id = spec.dag_hash()
+
+        status.update_state(build_id, "finished")
+
+        output = fake_stdout.getvalue()
+        assert "mypackage" in output
+        assert "1.0" in output
+        assert "finished" in output
+        # Non-TTY output should not contain ANSI escape codes
+        assert "\033[" not in output
+
+    def test_tty_output_contains_ansi(self):
+        """Test that TTY mode produces ANSI codes"""
+        status, _, fake_stdout = create_build_status()
+        add_mock_builds(status, 1)
+
+        # Call update to render
+        status.update()
+
+        output = fake_stdout.getvalue()
+        # Should contain ANSI escape sequences
+        assert "\033[" in output
+        # Should contain progress header
+        assert "Progress:" in output
+
+    def test_no_output_when_not_dirty(self):
+        """Test that update() skips rendering when not dirty"""
+        status, _, fake_stdout = create_build_status()
+        add_mock_builds(status, 1)
+        status.update()
+
+        # Clear stdout and mark not dirty
+        fake_stdout.clear()
+        status.dirty = False
+
+        # Update should not produce output
+        status.update()
+        assert fake_stdout.getvalue() == ""
+
+    def test_update_throttling(self):
+        """Test that update() throttles redraws"""
+        status, fake_time, fake_stdout = create_build_status()
+        add_mock_builds(status, 1)
+
+        # First update at time 0
+        fake_time[0] = 0.0
+        status.update()
+        first_output = fake_stdout.getvalue()
+        assert first_output != ""
+
+        # Mark dirty and try to update immediately
+        fake_stdout.clear()
+        status.dirty = True
+        fake_time[0] = 0.01  # Very small time advance
+
+        # Should be throttled (next_update not reached)
+        status.update()
+        assert fake_stdout.getvalue() == ""
+
+        # Advance time past throttle and try again
+        fake_time[0] = 1.0
+        status.update()
+        assert fake_stdout.getvalue() != ""
+
+    def test_cursor_movement_vs_newlines(self):
+        """Test that finished builds get newlines, active builds get cursor movements"""
+        status, fake_time, fake_stdout = create_build_status(total=5)
+        specs = add_mock_builds(status, 3)
+
+        # First update renders 3 active builds
+        fake_time[0] = 0.0
+        status.update()
+        output1 = fake_stdout.getvalue()
+
+        # Count newlines (\n) and cursor movements (\033[1E = move down 1 line)
+        newlines1 = output1.count("\n")
+        cursor_moves1 = output1.count("\033[1E")
+
+        # Initially all lines should be newlines (nothing in history yet)
+        assert newlines1 > 0
+        assert cursor_moves1 == 0
+
+        # Now finish 2 builds and add 2 more
+        fake_stdout.clear()
+        fake_time[0] = inst.CLEANUP_TIMEOUT + 0.1
+        status.update_state(specs[0].dag_hash(), "finished")
+        status.update_state(specs[1].dag_hash(), "finished")
+
+        spec4 = MockSpec("pkg3", "3.0")
+        spec5 = MockSpec("pkg4", "4.0")
+        status.add_build(spec4, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec5, explicit=True, control_w_conn=MockConnection())
+
+        # Second update: finished builds persist (newlines), active area updates (cursor moves)
+        status.update()
+        output2 = fake_stdout.getvalue()
+
+        newlines2 = output2.count("\n")
+        cursor_moves2 = output2.count("\033[1E")
+
+        # Should have newlines for the 2 finished builds persisted to history
+        # and cursor movements for the active area (header + 3 active builds)
+        assert newlines2 > 0, "Should have newlines for finished builds"
+        assert cursor_moves2 > 0, "Should have cursor movements for active area"
+
+        # Finished builds should be printed with newlines
+        assert "pkg0" in output2
+        assert "pkg1" in output2
+
+
+class TestTimeBasedBehavior:
+    """Test time-based behaviors like spinner and cleanup"""
+
+    def test_spinner_updates(self):
+        """Test that spinner advances over time"""
+        status, fake_time, _ = create_build_status()
+        add_mock_builds(status, 1)
+
+        # Initial spinner index
+        initial_index = status.spinner_index
+
+        # Advance time past spinner interval
+        fake_time[0] = inst.SPINNER_INTERVAL + 0.01
+        status.update()
+
+        # Spinner should have advanced
+        assert status.spinner_index == (initial_index + 1) % len(status.spinner_chars)
+
+    def test_finished_package_cleanup(self):
+        """Test that finished packages are cleaned up after timeout"""
+        status, fake_time, _ = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        # Mark as finished
+        fake_time[0] = 0.0
+        status.update_state(build_id, "finished")
+
+        # Build should still be in active builds
+        assert build_id in status.builds
+        assert len(status.finished_builds) == 0
+
+        # Advance time past cleanup timeout
+        fake_time[0] = inst.CLEANUP_TIMEOUT + 0.01
+        status.update()
+
+        # Build should now be moved to finished_builds and removed from active
+        assert build_id not in status.builds
+        # Note: finished_builds is cleared after rendering, so check it happened via side effects
+        assert status.dirty or build_id not in status.builds
+
+    def test_failed_packages_not_cleaned_up(self):
+        """Test that failed packages stay in active builds"""
+        status, fake_time, _ = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        # Mark as failed
+        fake_time[0] = 0.0
+        status.update_state(build_id, "failed")
+
+        # Advance time past cleanup timeout
+        fake_time[0] = inst.CLEANUP_TIMEOUT + 0.01
+        status.update()
+
+        # Failed build should remain in active builds
+        assert build_id in status.builds
+
+
+class TestSearchAndFilter:
+    """Test search mode and filtering"""
+
+    def test_enter_search_mode(self):
+        """Test that enter_search enables search mode"""
+        status, _, _ = create_build_status()
+        assert status.search_mode is False
+
+        status.enter_search()
+        assert status.search_mode is True
+        assert status.dirty is True
+
+    def test_search_input_printable(self):
+        """Test that printable characters are added to search term"""
+        status, _, _ = create_build_status()
+        status.enter_search()
+
+        status.search_input("a")
+        assert status.search_term == "a"
+
+        status.search_input("b")
+        assert status.search_term == "ab"
+
+        status.search_input("c")
+        assert status.search_term == "abc"
+
+    def test_search_input_backspace(self):
+        """Test that backspace removes characters"""
+        status, _, _ = create_build_status()
+        status.enter_search()
+
+        status.search_input("a")
+        status.search_input("b")
+        status.search_input("c")
+        assert status.search_term == "abc"
+
+        status.search_input("\x7f")  # Backspace
+        assert status.search_term == "ab"
+
+        status.search_input("\b")  # Alternative backspace
+        assert status.search_term == "a"
+
+    def test_search_input_escape(self):
+        """Test that escape exits search mode"""
+        status, _, _ = create_build_status()
+        status.enter_search()
+        status.search_input("test")
+
+        status.search_input("\x1b")  # Escape
+        assert status.search_mode is False
+        assert status.search_term == ""
+
+    def test_is_displayed_filters_by_name(self):
+        """Test that _is_displayed filters by package name"""
+        status, _, _ = create_build_status(total=3)
+
+        spec1 = MockSpec("package-foo", "1.0")
+        spec2 = MockSpec("package-bar", "1.0")
+        spec3 = MockSpec("other", "1.0")
+
+        status.add_build(spec1, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec2, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec3, explicit=True, control_w_conn=MockConnection())
+
+        build1 = status.builds[spec1.dag_hash()]
+        build2 = status.builds[spec2.dag_hash()]
+        build3 = status.builds[spec3.dag_hash()]
+
+        # No search term: all displayed
+        status.search_term = ""
+        assert status._is_displayed(build1)
+        assert status._is_displayed(build2)
+        assert status._is_displayed(build3)
+
+        # Search for "package"
+        status.search_term = "package"
+        assert status._is_displayed(build1)
+        assert status._is_displayed(build2)
+        assert not status._is_displayed(build3)
+
+        # Search for "foo"
+        status.search_term = "foo"
+        assert status._is_displayed(build1)
+        assert not status._is_displayed(build2)
+        assert not status._is_displayed(build3)
+
+    def test_is_displayed_filters_by_hash(self):
+        """Test that _is_displayed filters by hash prefix"""
+        status, _, _ = create_build_status(total=2)
+
+        spec1 = MockSpec("pkg1", "1.0")
+        spec1._hash = "abc123"
+        spec2 = MockSpec("pkg2", "1.0")
+        spec2._hash = "def456"
+
+        status.add_build(spec1, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec2, explicit=True, control_w_conn=MockConnection())
+
+        build1 = status.builds[spec1.dag_hash()]
+        build2 = status.builds[spec2.dag_hash()]
+
+        # Search by hash prefix
+        status.search_term = "abc"
+        assert status._is_displayed(build1)
+        assert not status._is_displayed(build2)
+
+        status.search_term = "def"
+        assert not status._is_displayed(build1)
+        assert status._is_displayed(build2)
+
+
+class TestNavigation:
+    """Test navigation between builds"""
+
+    def test_get_next_basic(self):
+        """Test basic next/previous navigation"""
+        status, _, _ = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        # Get first build
+        first_id = status._get_next(1)
+        assert first_id == specs[0].dag_hash()
+
+        # Set tracked and get next
+        status.tracked_build_id = first_id
+        next_id = status._get_next(1)
+        assert next_id == specs[1].dag_hash()
+
+        # Get next again
+        status.tracked_build_id = next_id
+        next_id = status._get_next(1)
+        assert next_id == specs[2].dag_hash()
+
+        # Wrap around
+        status.tracked_build_id = next_id
+        next_id = status._get_next(1)
+        assert next_id == specs[0].dag_hash()
+
+    def test_get_next_previous(self):
+        """Test backward navigation"""
+        status, _, _ = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        # Start at second build
+        status.tracked_build_id = specs[1].dag_hash()
+
+        # Go backward
+        prev_id = status._get_next(-1)
+        assert prev_id == specs[0].dag_hash()
+
+        # Go backward again (wrap around)
+        status.tracked_build_id = prev_id
+        prev_id = status._get_next(-1)
+        assert prev_id == specs[2].dag_hash()
+
+    def test_get_next_with_filter(self):
+        """Test navigation respects search filter"""
+        status, _, _ = create_build_status(total=4)
+
+        specs = [
+            MockSpec("package-a", "1.0"),
+            MockSpec("package-b", "1.0"),
+            MockSpec("other-c", "1.0"),
+            MockSpec("package-d", "1.0"),
+        ]
+        for spec in specs:
+            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+
+        # Filter to only "package-*"
+        status.search_term = "package"
+
+        # Should only navigate through matching builds
+        first_id = status._get_next(1)
+        assert first_id and first_id == specs[0].dag_hash()
+
+        status.tracked_build_id = first_id
+        next_id = status._get_next(1)
+        assert next_id and next_id == specs[1].dag_hash()
+
+        status.tracked_build_id = next_id
+        next_id = status._get_next(1)
+        # Should skip "other-c" and go to "package-d"
+        assert next_id and next_id == specs[3].dag_hash()
+
+    def test_get_next_skips_finished(self):
+        """Test that navigation skips finished builds"""
+        status, _, _ = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        # Mark middle build as finished
+        status.update_state(specs[1].dag_hash(), "finished")
+
+        # Navigate from first
+        status.tracked_build_id = specs[0].dag_hash()
+        next_id = status._get_next(1)
+        # Should skip finished build and go to third
+        assert next_id == specs[2].dag_hash()
+
+    def test_get_next_no_matching(self):
+        """Test that _get_next returns None when no builds match"""
+        status, _, _ = create_build_status(total=2)
+        specs = add_mock_builds(status, 2)
+
+        # Mark both as finished
+        for spec in specs:
+            status.update_state(spec.dag_hash(), "finished")
+
+        # Should return None since no unfinished builds
+        result = status._get_next(1)
+        assert result is None
+
+    def test_get_next_fallback_when_tracked_filtered_out(self):
+        """Test that _get_next falls back correctly when tracked build no longer matches filter"""
+        status, _, _ = create_build_status(total=3)
+
+        specs = [
+            MockSpec("package-a", "1.0"),
+            MockSpec("package-b", "1.0"),
+            MockSpec("other-c", "1.0"),
+        ]
+        for spec in specs:
+            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+
+        # Start tracking "other-c"
+        status.tracked_build_id = specs[2].dag_hash()
+
+        # Now apply a filter that excludes the tracked build
+        status.search_term = "package"
+
+        # _get_next should fall back to first matching build (forward)
+        next_id = status._get_next(1)
+        assert next_id == specs[0].dag_hash()
+
+        # Test backward direction, should fall back to last matching build
+        status.tracked_build_id = specs[2].dag_hash()  # Reset to filtered-out build
+        prev_id = status._get_next(-1)
+        assert prev_id == specs[1].dag_hash()
+
+
+class TestTerminalSizes:
+    """Test behavior with different terminal sizes"""
+
+    def test_small_terminal_truncation(self):
+        """Test that output is truncated for small terminals"""
+        status, _, fake_stdout = create_build_status(total=10, terminal_cols=80, terminal_rows=10)
+
+        # Add more builds than can fit on screen
+        add_mock_builds(status, 10)
+
+        status.update()
+        output = fake_stdout.getvalue()
+
+        # Should contain "more..." message indicating truncation
+        assert "more..." in output
+
+    def test_large_terminal_no_truncation(self):
+        """Test that all builds shown on large terminal"""
+        status, _, fake_stdout = create_build_status(total=3, terminal_cols=120)
+        add_mock_builds(status, 3)
+
+        status.update()
+        output = fake_stdout.getvalue()
+
+        # Should not contain truncation message
+        assert "more..." not in output
+        # Should contain all package names
+        for i in range(3):
+            assert f"pkg{i}" in output
+
+    def test_narrow_terminal_short_header(self):
+        """Test that narrow terminals get shortened header"""
+        status, _, fake_stdout = create_build_status(total=1, terminal_cols=40)
+        add_mock_builds(status, 1)
+
+        status.update()
+        output = fake_stdout.getvalue()
+
+        # Should not contain the full header with hints
+        assert "filter" not in output
+        # But should contain progress
+        assert "Progress:" in output
+
+
+class TestBuildInfo:
+    """Test the BuildInfo dataclass"""
+
+    def test_build_info_creation(self):
+        """Test that BuildInfo is created correctly"""
+        spec = MockSpec("mypackage", "1.0")
+
+        build_info = inst.BuildInfo(spec, explicit=True, control_w_conn=MockConnection())
+
+        assert build_info.name == "mypackage"
+        assert build_info.version == "1.0"
+        assert build_info.explicit is True
+        assert build_info.external is False
+        assert build_info.state == "starting"
+        assert build_info.finished_time is None
+        assert build_info.progress_percent is None
+
+    def test_build_info_external_package(self):
+        """Test BuildInfo for external package"""
+        spec = MockSpec("external-pkg", "1.0", external=True)
+
+        build_info = inst.BuildInfo(spec, explicit=False, control_w_conn=MockConnection())
+
+        assert build_info.external is True
+
+
+class TestLogFollowing:
+    """Test log following and print_logs functionality"""
+
+    def test_print_logs_when_following(self):
+        """Test that logs are printed when following a specific build"""
+        status, _, fake_stdout = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        # Switch to log-following mode
+        status.overview_mode = False
+        status.tracked_build_id = build_id
+
+        # Send some log data
+        log_data = b"Building package...\nRunning tests...\n"
+        status.print_logs(build_id, log_data)
+
+        # Check that logs were echoed to stdout
+        assert fake_stdout._buffer.getvalue() == log_data
+
+    def test_print_logs_discarded_when_in_overview_mode(self):
+        """Test that logs are discarded when in overview mode"""
+        status, _, fake_stdout = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        # Stay in overview mode
+        assert status.overview_mode is True
+
+        # Try to print logs
+        log_data = b"Should not be printed\n"
+        status.print_logs(build_id, log_data)
+
+        # Nothing should be printed
+        assert fake_stdout.getvalue() == ""
+
+    def test_print_logs_discarded_when_not_tracked(self):
+        """Test that logs from non-tracked builds are discarded"""
+        status, _, fake_stdout = create_build_status(total=2)
+        spec1, spec2 = add_mock_builds(status, 2)
+
+        # Switch to log-following mode for spec1
+        status.overview_mode = False
+        status.tracked_build_id = spec1.dag_hash()
+
+        # Try to print logs from spec2 (not tracked)
+        log_data = b"Logs from pkg2\n"
+        status.print_logs(spec2.dag_hash(), log_data)
+
+        # Nothing should be printed since we're tracking pkg1, not pkg2
+        assert fake_stdout.getvalue() == ""
+
+    def test_cannot_follow_failed_build(self):
+        """Test that navigation skips failed builds"""
+        status, _, _ = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        # Mark the middle build as failed
+        status.update_state(specs[1].dag_hash(), "failed")
+
+        # The failed build should have finished_time set
+        assert status.builds[specs[1].dag_hash()].finished_time is not None
+
+        # Try to get next build, should skip the failed one
+        status.tracked_build_id = specs[0].dag_hash()
+        next_id = status._get_next(1)
+
+        # Should skip pkg1 (failed) and return pkg2
+        assert next_id == specs[2].dag_hash()
+
+
+class TestNavigationIntegration:
+    """Test the next() method and navigation between builds"""
+
+    def test_next_switches_from_overview_to_logs(self):
+        """Test that next() switches from overview mode to log-following mode"""
+        status, _, fake_stdout = create_build_status(total=2)
+        specs = add_mock_builds(status, 2)
+
+        # Start in overview mode
+        assert status.overview_mode is True
+        assert status.tracked_build_id == ""
+
+        # Call next() to start following first build
+        status.next()
+
+        # Should have switched to log-following mode
+        assert status.overview_mode is False
+        assert status.tracked_build_id == specs[0].dag_hash()
+
+        # Should have printed "Following logs" message
+        output = fake_stdout.getvalue()
+        assert "Following logs of" in output
+        assert "pkg0" in output
+
+    def test_next_cycles_through_builds(self):
+        """Test that next() cycles through multiple builds"""
+        status, _, fake_stdout = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        # Start following first build
+        status.next()
+        assert status.tracked_build_id == specs[0].dag_hash()
+
+        fake_stdout.clear()
+
+        # Navigate to next
+        status.next(1)
+        assert status.tracked_build_id == specs[1].dag_hash()
+        assert "pkg1" in fake_stdout.getvalue()
+
+        fake_stdout.clear()
+
+        # Navigate to next (third build)
+        status.next(1)
+        assert status.tracked_build_id == specs[2].dag_hash()
+        assert "pkg2" in fake_stdout.getvalue()
+
+        fake_stdout.clear()
+
+        # Navigate to next (should wrap to first)
+        status.next(1)
+        assert status.tracked_build_id == specs[0].dag_hash()
+        assert "pkg0" in fake_stdout.getvalue()
+
+    def test_next_backward_navigation(self):
+        """Test that next(-1) navigates backward"""
+        status, _, _ = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        # Start at first build
+        status.next()
+        assert status.tracked_build_id == specs[0].dag_hash()
+
+        # Go backward (should wrap to last)
+        status.next(-1)
+        assert status.tracked_build_id == specs[2].dag_hash()
+
+        # Go backward again
+        status.next(-1)
+        assert status.tracked_build_id == specs[1].dag_hash()
+
+    def test_next_does_nothing_when_no_builds(self):
+        """Test that next() does nothing when no unfinished builds exist"""
+        status, _, _ = create_build_status(total=1)
+        (spec,) = add_mock_builds(status, 1)
+
+        # Mark as finished
+        status.update_state(spec.dag_hash(), "finished")
+
+        # Try to navigate
+        initial_mode = status.overview_mode
+        initial_tracked = status.tracked_build_id
+
+        status.next()
+
+        # Nothing should change
+        assert status.overview_mode == initial_mode
+        assert status.tracked_build_id == initial_tracked
+
+    def test_next_does_nothing_when_same_build(self):
+        """Test that next() doesn't re-print when already on the same build"""
+        status, _, fake_stdout = create_build_status(total=1)
+        (spec,) = add_mock_builds(status, 1)
+
+        # Start following
+        status.next()
+        assert status.tracked_build_id == spec.dag_hash()
+
+        # Clear output
+        fake_stdout.clear()
+
+        # Try to navigate to "next" (which is the same build)
+        status.next()
+
+        # Should not print anything
+        assert fake_stdout.getvalue() == ""
+
+
+class TestToggle:
+    """Test toggle() method for switching between overview and log-following modes"""
+
+    def test_toggle_from_overview_calls_next(self):
+        """Test that toggle() from overview mode calls next()"""
+        status, _, fake_stdout = create_build_status(total=2)
+        add_mock_builds(status, 2)
+
+        # Start in overview mode
+        assert status.overview_mode is True
+
+        # Toggle should call next()
+        status.toggle()
+
+        # Should now be following logs
+        assert status.overview_mode is False
+        assert status.tracked_build_id != ""
+        assert "Following logs of" in fake_stdout.getvalue()
+
+    def test_toggle_from_logs_returns_to_overview(self):
+        """Test that toggle() from log-following mode returns to overview"""
+        status, _, _ = create_build_status(total=2)
+        add_mock_builds(status, 2)
+
+        # Switch to log-following mode first
+        status.next()
+        assert status.overview_mode is False
+        tracked_id = status.tracked_build_id
+        assert tracked_id != ""
+
+        # Set some search state to verify cleanup
+        status.search_term = "test"
+        status.search_mode = True
+        status.active_area_rows = 5
+
+        # Toggle back to overview
+        status.toggle()
+
+        # Should be back in overview mode with cleaned state
+        assert status.overview_mode is True
+        assert status.tracked_build_id == ""
+        assert status.search_term == ""
+        assert status.search_mode is False
+        assert status.active_area_rows == 0
+        assert status.dirty is True
+
+    def test_update_state_finished_triggers_toggle_when_tracking(self):
+        """Test that finishing a tracked build triggers toggle back to overview"""
+        status, _, _ = create_build_status(total=2)
+        specs = add_mock_builds(status, 2)
+
+        # Start tracking first build
+        status.next()
+        assert status.overview_mode is False
+        assert status.tracked_build_id == specs[0].dag_hash()
+
+        # Mark the tracked build as finished
+        status.update_state(specs[0].dag_hash(), "finished")
+
+        # Should have toggled back to overview mode
+        assert status.overview_mode is True
+        assert status.tracked_build_id == ""
+
+
+class TestSearchFilteringIntegration:
+    """Test search mode with display filtering"""
+
+    def test_search_mode_filters_displayed_builds(self):
+        """Test that search mode actually filters what's displayed"""
+        status, _, fake_stdout = create_build_status(total=4)
+
+        specs = [
+            MockSpec("package-foo", "1.0"),
+            MockSpec("package-bar", "2.0"),
+            MockSpec("other-thing", "3.0"),
+            MockSpec("package-baz", "4.0"),
+        ]
+        for spec in specs:
+            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+
+        # Enter search mode and search for "package"
+        status.enter_search()
+        assert status.search_mode is True
+
+        for character in "package":
+            status.search_input(character)
+
+        assert status.search_term == "package"
+
+        # Update to render
+        status.update()
+        output = fake_stdout.getvalue()
+
+        # Should contain filtered builds
+        assert "package-foo" in output
+        assert "package-bar" in output
+        assert "package-baz" in output
+        # Should not contain the filtered-out build
+        assert "other-thing" not in output
+
+        # Should show filter prompt
+        assert "filter>" in output
+        assert status.search_term in output
+
+    def test_search_mode_with_navigation(self):
+        """Test that navigation respects search filter"""
+        status, _, _ = create_build_status(total=4)
+
+        specs = [
+            MockSpec("package-a", "1.0"),
+            MockSpec("other-b", "2.0"),
+            MockSpec("package-c", "3.0"),
+            MockSpec("other-d", "4.0"),
+        ]
+        for spec in specs:
+            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+
+        # Set search term to filter for "package"
+        status.search_term = "package"
+
+        # Start navigating,  should only go through "package-a" and "package-c"
+        status.next()
+        assert status.tracked_build_id == specs[0].dag_hash()  # package-a
+
+        status.next(1)
+        # Should skip other-b and go to package-c
+        assert status.tracked_build_id == specs[2].dag_hash()  # package-c
+
+        status.next(1)
+        # Should wrap around to package-a
+        assert status.tracked_build_id == specs[0].dag_hash()  # package-a
+
+    def test_search_input_enter_navigates_to_next(self):
+        """Test that pressing enter in search mode navigates to next match"""
+        status, _, _ = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        # Enter search mode
+        status.enter_search()
+        for character in "pkg":
+            status.search_input(character)
+
+        # Press enter (should navigate to first match)
+        status.search_input("\r")
+
+        # Should have started following first matching build
+        assert status.overview_mode is False
+        assert status.tracked_build_id == specs[0].dag_hash()
+
+    def test_clearing_search_shows_all_builds(self):
+        """Test that clearing search term shows all builds again"""
+        status, _, fake_stdout = create_build_status(total=3)
+
+        specs = [
+            MockSpec("package-a", "1.0"),
+            MockSpec("other-b", "2.0"),
+            MockSpec("package-c", "3.0"),
+        ]
+        for spec in specs:
+            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+
+        # Enter search and type something
+        status.enter_search()
+        status.search_input("p")
+        status.search_input("a")
+        status.search_input("c")
+        assert status.search_term == "pac"
+
+        # Clear it with backspace
+        status.search_input("\x7f")  # backspace
+        status.search_input("\x7f")  # backspace
+        status.search_input("\x7f")  # backspace
+        assert status.search_term == ""
+
+        # Update to render
+        status.update()
+        output = fake_stdout.getvalue()
+
+        # All builds should be visible now
+        assert "package-a" in output
+        assert "other-b" in output
+        assert "package-c" in output
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions"""
+
+    def test_empty_build_list(self):
+        """Test update with no builds"""
+        status, _, fake_stdout = create_build_status(total=0)
+
+        status.update()
+        output = fake_stdout.getvalue()
+
+        # Should render header but no builds
+        assert "Progress:" in output
+        assert "0/0" in output
+
+    def test_all_builds_finished(self):
+        """Test when all builds are finished"""
+        status, fake_time, _ = create_build_status(total=2)
+        specs = add_mock_builds(status, 2)
+
+        # Mark all as finished
+        for spec in specs:
+            status.update_state(spec.dag_hash(), "finished")
+
+        # Advance time and update
+        fake_time[0] = inst.CLEANUP_TIMEOUT + 0.01
+        status.update()
+
+        # All should be cleaned up
+        assert len(status.builds) == 0
+        assert status.completed == 2
+
+    def test_update_progress_rounds_correctly(self):
+        """Test that progress percentage rounding works"""
+        status, _, _ = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        # Test rounding
+        status.update_progress(build_id, 1, 3)
+        assert status.builds[build_id].progress_percent == 33  # int(100/3)
+
+        status.update_progress(build_id, 2, 3)
+        assert status.builds[build_id].progress_percent == 66  # int(200/3)
+
+        status.update_progress(build_id, 3, 3)
+        assert status.builds[build_id].progress_percent == 100

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -1,0 +1,201 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Tests for the new_installer.py module"""
+
+import pathlib as pathlb
+import sys
+
+import pytest
+
+if sys.platform == "win32":
+    pytest.skip("No Windows support", allow_module_level=True)
+
+import spack.error
+from spack.new_installer import OVERWRITE_GARBAGE_SUFFIX, PrefixPivoter
+
+
+@pytest.fixture
+def existing_prefix(tmp_path: pathlb.Path) -> pathlb.Path:
+    """Creates a standard existing prefix with content."""
+    prefix = tmp_path / "existing_prefix"
+    prefix.mkdir()
+    (prefix / "old_file").write_text("old content")
+    return prefix
+
+
+class TestPrefixPivoter:
+    """Tests for the PrefixPivoter class."""
+
+    def test_no_existing_prefix(self, tmp_path: pathlb.Path):
+        """Test installation when prefix doesn't exist yet."""
+        prefix = tmp_path / "new_prefix"
+
+        with PrefixPivoter(str(prefix), overwrite=False):
+            prefix.mkdir()
+            (prefix / "installed_file").write_text("content")
+
+        assert prefix.exists()
+        assert (prefix / "installed_file").read_text() == "content"
+
+    def test_existing_prefix_no_overwrite_raises(self, existing_prefix: pathlb.Path):
+        """Test that existing prefix raises error when overwrite=False."""
+        with pytest.raises(spack.error.InstallError, match="already exists"):
+            with PrefixPivoter(str(existing_prefix), overwrite=False):
+                pass
+
+    def test_overwrite_success_cleans_up_old_prefix(
+        self, tmp_path: pathlb.Path, existing_prefix: pathlb.Path
+    ):
+        """Test that overwrite=True moves old prefix and cleans it up on success."""
+        with PrefixPivoter(str(existing_prefix), overwrite=True):
+            assert not existing_prefix.exists()
+            existing_prefix.mkdir()
+            (existing_prefix / "new_file").write_text("new content")
+
+        assert existing_prefix.exists()
+        assert (existing_prefix / "new_file").exists()
+        assert not (existing_prefix / "old_file").exists()
+        # Only the existing_prefix directory should remain
+        assert len(list(tmp_path.iterdir())) == 1
+
+    def test_overwrite_failure_restores_original_prefix(
+        self, tmp_path: pathlb.Path, existing_prefix: pathlb.Path
+    ):
+        """Test that original prefix is restored when installation fails.
+
+        Note: keep_prefix=True is passed but should be ignored since overwrite=True
+        takes precedence."""
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            with PrefixPivoter(str(existing_prefix), overwrite=True, keep_prefix=True):
+                existing_prefix.mkdir()
+                (existing_prefix / "partial_file").write_text("partial")
+                raise RuntimeError("simulated failure")
+
+        assert existing_prefix.exists()
+        assert (existing_prefix / "old_file").read_text() == "old content"
+        assert not (existing_prefix / "partial_file").exists()
+        # Only the existing_prefix directory should remain
+        assert len(list(tmp_path.iterdir())) == 1
+
+    def test_overwrite_failure_no_partial_prefix_created(self, existing_prefix: pathlb.Path):
+        """Test restoration when failure occurs before any prefix is created."""
+        with pytest.raises(RuntimeError, match="early failure"):
+            with PrefixPivoter(str(existing_prefix), overwrite=True):
+                raise RuntimeError("early failure")
+
+        assert existing_prefix.exists()
+        assert (existing_prefix / "old_file").read_text() == "old content"
+
+    def test_overwrite_true_no_existing_prefix(self, tmp_path: pathlb.Path):
+        """Test that overwrite=True works fine when prefix doesn't exist."""
+        prefix = tmp_path / "new_prefix"
+        with PrefixPivoter(str(prefix), overwrite=True):
+            prefix.mkdir()
+            (prefix / "installed_file").write_text("content")
+
+        assert prefix.exists()
+        # Only the new_prefix directory should remain
+        assert len(list(tmp_path.iterdir())) == 1
+
+    def test_keep_prefix_true_leaves_failed_install(self, tmp_path: pathlb.Path):
+        """Test that keep_prefix=True preserves the failed installation."""
+        prefix = tmp_path / "new_prefix"
+
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            with PrefixPivoter(str(prefix), overwrite=False, keep_prefix=True):
+                prefix.mkdir()
+                (prefix / "partial_file").write_text("partial content")
+                raise RuntimeError("simulated failure")
+
+        # Failed prefix should still exist
+        assert prefix.exists()
+        assert (prefix / "partial_file").exists()
+        assert (prefix / "partial_file").read_text() == "partial content"
+        # Only the failed prefix should remain
+        assert len(list(tmp_path.iterdir())) == 1
+
+    def test_keep_prefix_false_removes_failed_install(self, tmp_path: pathlb.Path):
+        """Test that keep_prefix=False removes the failed installation."""
+        prefix = tmp_path / "new_prefix"
+
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            with PrefixPivoter(str(prefix), overwrite=False, keep_prefix=False):
+                prefix.mkdir()
+                (prefix / "partial_file").write_text("partial content")
+                raise RuntimeError("simulated failure")
+
+        # Failed prefix should be removed
+        assert not prefix.exists()
+        # Nothing should remain
+        assert len(list(tmp_path.iterdir())) == 0
+
+
+class FailingPrefixPivoter(PrefixPivoter):
+    """Test subclass that can simulate filesystem failures."""
+
+    def __init__(
+        self,
+        prefix: str,
+        overwrite: bool,
+        keep_prefix: bool = False,
+        fail_on_restore: bool = False,
+        fail_on_move_garbage: bool = False,
+    ):
+        super().__init__(prefix, overwrite, keep_prefix)
+        self.fail_on_restore = fail_on_restore
+        self.fail_on_move_garbage = fail_on_move_garbage
+        self.restore_rename_count = 0
+
+    def _rename(self, src: str, dst: str) -> None:
+        if (
+            self.fail_on_restore
+            and self.tmp_prefix
+            and src == self.tmp_prefix
+            and dst == self.prefix
+        ):
+            self.restore_rename_count += 1
+            raise OSError("Simulated rename failure during restore")
+
+        if self.fail_on_move_garbage and dst.endswith(OVERWRITE_GARBAGE_SUFFIX):
+            raise OSError("Simulated rename failure moving to garbage")
+
+        super()._rename(src, dst)
+
+
+class TestPrefixPivoterFailureRecovery:
+    """Tests for edge cases and failure recovery in PrefixPivoter."""
+
+    def test_restore_failure_leaves_backup(
+        self, tmp_path: pathlb.Path, existing_prefix: pathlb.Path
+    ):
+        """Test that if restoration fails, the backup is not deleted."""
+        pivoter = FailingPrefixPivoter(str(existing_prefix), overwrite=True, fail_on_restore=True)
+
+        with pytest.raises(OSError, match="Simulated rename failure during restore"):
+            with pivoter:
+                existing_prefix.mkdir()
+                (existing_prefix / "partial_file").write_text("partial")
+                raise RuntimeError("simulated failure")
+
+        assert pivoter.restore_rename_count > 0
+        # Backup directory should still exist (plus the failed prefix)
+        assert len(list(tmp_path.iterdir())) == 2
+
+    def test_garbage_move_failure_leaves_backup(
+        self, tmp_path: pathlb.Path, existing_prefix: pathlb.Path
+    ):
+        """Test that if moving the failed install to garbage fails, the backup is preserved."""
+        pivoter = FailingPrefixPivoter(
+            str(existing_prefix), overwrite=True, fail_on_move_garbage=True
+        )
+
+        with pytest.raises(OSError, match="Simulated rename failure moving to garbage"):
+            with pivoter:
+                existing_prefix.mkdir()
+                (existing_prefix / "partial_file").write_text("partial")
+                raise RuntimeError("simulated failure")
+
+        assert (existing_prefix / "partial_file").exists()
+        # Backup directory, failed prefix, and empty garbage directory should exist
+        assert len(list(tmp_path.iterdir())) == 3

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -26,6 +26,7 @@ import spack.subprocess_context
 from spack.error import InstallError
 from spack.package_base import PackageBase
 from spack.solver.input_analysis import NoStaticAnalysis, StaticAnalysis
+from spack.version import Version
 
 
 @pytest.fixture(scope="module")
@@ -385,3 +386,20 @@ def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, 
     captured = capsys.readouterr()
     assert "commit" not in spec.variants
     assert "Warning: Unable to resolve the git commit" in captured.err
+
+
+@pytest.mark.parametrize(
+    "pkg_name,preferred_version",
+    [
+        # This package has a deprecated v1.1.0 which should not be the preferred
+        ("deprecated_versions", "1.0.0"),
+        # Python has v2.7.11 marked as preferred and newer v3 versions
+        ("python", "2.7.11"),
+        # This package has various versions, some deprecated, plus "main" and "develop"
+        ("git-ref-package", "3.0.1"),
+    ],
+)
+def test_package_preferred_version(mock_packages, config, pkg_name, preferred_version):
+    """Tests retrieving the preferred version of a package."""
+    pkg_cls = mock_packages.get_pkg_class(pkg_name)
+    assert spack.package_base.preferred_version(pkg_cls) == Version(preferred_version)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -716,7 +716,11 @@ def test_repo_descriptors_construct(tmp_path: pathlib.Path):
             action = args[0]
 
             if action == "ls-remote":
-                return "refs/heads/develop"
+                return """\
+a8eff4da7aab59bbf5996ac1720954bf82443247        HEAD
+165c479984b94051c982a6be1bd850f8bae02858        refs/heads/feature-branch
+a8eff4da7aab59bbf5996ac1720954bf82443247        refs/heads/develop
+3bd0276ab0491552247fa055921a23d2ffd9443c        refs/heads/releases/v0.20"""
 
             elif action == "rev-parse":
                 return "develop"
@@ -750,6 +754,8 @@ repo_index:
     assert len(errors_1) == 1
     assert all("No repo.yaml" in str(err) for err in errors_1.values()), errors_1
     assert descriptors_1["foo"].relative_paths == ["spack_repo/foo"]
+    # Verify that the default branch was detected from ls-remote
+    assert descriptors_1["foo"].branch == "develop"
 
     # Do the same test with another instance: it should *not* clone a second time.
     repo_path_2, errors_2 = repos_2.construct(cache=cache, find_git=MockGit)
@@ -804,7 +810,11 @@ def test_repo_descriptors_update(tmp_path: pathlib.Path):
             action = args[0]
 
             if action == "ls-remote":
-                return "refs/heads/develop"
+                return """\
+a8eff4da7aab59bbf5996ac1720954bf82443247        HEAD
+165c479984b94051c982a6be1bd850f8bae02858        refs/heads/feature-branch
+a8eff4da7aab59bbf5996ac1720954bf82443247        refs/heads/develop
+3bd0276ab0491552247fa055921a23d2ffd9443c        refs/heads/releases/v0.20"""
 
             elif action == "rev-parse":
                 return "develop"
@@ -892,7 +902,10 @@ def test_repo_descriptors_update_invalid(tmp_path: pathlib.Path):
             action = args[0]
 
             if action == "ls-remote":
-                return "bad string"
+                # HEAD ref exists, but no default branch (i.e. no refs/heads/*)
+                return "a8eff4da7aab59bbf5996ac1720954bf82443247        HEAD"
+
+            return ""
 
     class MockGitFailed(spack.util.executable.Executable):
         def __init__(self):

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -11,6 +11,7 @@ import spack.deptypes as dt
 import spack.error
 import spack.installer
 import spack.repo
+import spack.solver.asp
 import spack.test.conftest
 import spack.util.hash as hashutil
 import spack.version
@@ -457,9 +458,9 @@ class TestSpecDag:
     @pytest.mark.parametrize(
         "constraint_str,spec_str",
         [
-            ("mpich@1.0", "mpileaks ^mpich@2.0"),
+            ("mpich@1.0", "mpileaks ^mpich@3.0"),
             ("mpich%gcc", "mpileaks ^mpich%intel"),
-            ("mpich%gcc@4.6", "mpileaks ^mpich%gcc@4.5"),
+            ("mpich%gcc@2.0", "mpileaks ^mpich%gcc@3.0"),
         ],
     )
     def test_unsatisfiable_cases(self, set_dependency, constraint_str, spec_str):
@@ -475,7 +476,7 @@ class TestSpecDag:
     )
     def test_invalid_dep(self, spec_str):
         spec = Spec(spec_str)
-        with pytest.raises(spack.error.SpecError):
+        with pytest.raises(spack.solver.asp.InvalidDependencyError):
             spack.concretize.concretize_one(spec)
 
     def test_equal(self):

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -35,7 +35,7 @@ def test_modified_files(mock_git_package_changes):
 
 def test_init_git_repo(git, tmp_path: pathlib.Path):
     repo_url = "https://github.com/spack/spack.git"
-    destination = tmp_path / "test_git_init"
+    destination = str(tmp_path / "test_git_init")
 
     with working_dir(destination, create=True):
         spack.util.git.init_git_repo(repo_url)
@@ -43,9 +43,9 @@ def test_init_git_repo(git, tmp_path: pathlib.Path):
         assert "No commits yet" in git("status", output=str)
 
 
-def test_pull_checkout_commit(git, tmp_path: pathlib.Path, mock_git_version_info):
+def test_pull_checkout_commit_any_remote(git, tmp_path: pathlib.Path, mock_git_version_info):
     repo, _, commits = mock_git_version_info
-    destination = tmp_path / "test_git_checkout_commit"
+    destination = str(tmp_path / "test_git_checkout_commit")
 
     with working_dir(destination, create=True):
         spack.util.git.init_git_repo(repo)
@@ -54,9 +54,21 @@ def test_pull_checkout_commit(git, tmp_path: pathlib.Path, mock_git_version_info
         assert commits[0] in git("rev-parse", "HEAD", output=str)
 
 
+def test_pull_checkout_commit_specific_remote(git, tmp_path: pathlib.Path, mock_git_version_info):
+    """Test fetching a specific commit from a specific remote."""
+    repo, _, commits = mock_git_version_info
+    destination = str(tmp_path / "test_git_checkout_commit_from_remote")
+
+    with working_dir(destination, create=True):
+        spack.util.git.init_git_repo(repo)
+        spack.util.git.pull_checkout_commit(commits[0], remote="origin", depth=1)
+
+        assert commits[0] in git("rev-parse", "HEAD", output=str)
+
+
 def test_pull_checkout_tag(git, tmp_path: pathlib.Path, mock_git_version_info):
     repo, _, _ = mock_git_version_info
-    destination = tmp_path / "test_git_checkout_tag"
+    destination = str(tmp_path / "test_git_checkout_tag")
 
     with working_dir(destination, create=True):
         spack.util.git.init_git_repo(repo)
@@ -67,7 +79,7 @@ def test_pull_checkout_tag(git, tmp_path: pathlib.Path, mock_git_version_info):
 
 def test_pull_checkout_branch(git, tmp_path: pathlib.Path, mock_git_version_info):
     repo, _, _ = mock_git_version_info
-    destination = tmp_path / "test_git_checkout_branch"
+    destination = str(tmp_path / "test_git_checkout_branch")
 
     with working_dir(destination, create=True):
         spack.util.git.init_git_repo(repo)

--- a/lib/spack/spack/test/util/unparse/unparse.py
+++ b/lib/spack/spack/test/util/unparse/unparse.py
@@ -555,6 +555,20 @@ def test_match_literal(literal):
     check_ast_roundtrip(literal)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="Not supported < 3.14")
+def test_tstrings():
+    check_ast_roundtrip("t'foo'")
+    check_ast_roundtrip("t'foo {bar}'")
+    check_ast_roundtrip("t'foo {bar!s:.2f}'")
+    check_ast_roundtrip("t'{a +    b}'")
+    check_ast_roundtrip("t'{a +    b:x}'")
+    check_ast_roundtrip("t'{a +    b!s}'")
+    check_ast_roundtrip("t'{ {a}}'")
+    check_ast_roundtrip("t'{ {a}=}'")
+    check_ast_roundtrip("t'{{a}}'")
+    check_ast_roundtrip("t''")
+
+
 def test_subscript_with_tuple():
     """Test change in visit_Subscript/visit_Index is_non_empty_tuple."""
     check_ast_roundtrip("a[()]")

--- a/lib/spack/spack/test/util/unparse/unparse.py
+++ b/lib/spack/spack/test/util/unparse/unparse.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Python-2.0
 
 import ast
-import codecs
 import os
 import sys
 import tokenize
@@ -20,7 +19,7 @@ def read_pyfile(filename):
     string), taking into account the file encoding."""
     with open(filename, "rb") as pyfile:
         encoding = tokenize.detect_encoding(pyfile.readline)[0]
-    with codecs.open(filename, "r", encoding=encoding) as pyfile:
+    with open(filename, "r", encoding=encoding) as pyfile:
         source = pyfile.read()
     return source
 

--- a/lib/spack/spack/test/util/util_url.py
+++ b/lib/spack/spack/test/util/util_url.py
@@ -20,6 +20,8 @@ def test_url_local_file_path(tmp_path: pathlib.Path):
     with open(path, "wb") as f:
         f.write(b"hello world")
 
+    assert url_util.path_to_file_url(path).startswith("file://")
+
     # Go from path -> url -> path.
     roundtrip = url_util.local_file_path(url_util.path_to_file_url(path))
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import codecs
 import enum
 import fnmatch
 import gzip
@@ -470,7 +469,7 @@ class URLBuildcacheEntry:
 
         try:
             _, _, manifest_file = web_util.read_from_url(manifest_url)
-            manifest_contents = codecs.getreader("utf-8")(manifest_file).read()
+            manifest_contents = io.TextIOWrapper(manifest_file, encoding="utf-8").read()
         except (web_util.SpackWebError, OSError) as e:
             raise BuildcacheEntryError(f"Error reading manifest at {manifest_url}") from e
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -67,12 +67,39 @@ def init_git_repo(
     git_exe("config", "feature.manyFiles", "true", ignore_errors=True)
 
 
-def pull_checkout_commit(commit: str, git_exe: Optional[exe.Executable] = None):
-    """Fetch all remotes and checkout the specified commit."""
+def pull_checkout_commit(
+    commit: str,
+    remote: Optional[str] = None,
+    depth: Optional[int] = None,
+    git_exe: Optional[exe.Executable] = None,
+):
+    """Checkout the specified commit (fetched if necessary)."""
     git_exe = git_exe or git(required=True)
 
-    git_exe("fetch", "--quiet", "--progress", "--all")
-    git_exe("checkout", commit)
+    # Do not do any fetching if the commit is already present.
+    try:
+        git_exe("checkout", "--quiet", commit, error=os.devnull)
+        return
+    except exe.ProcessError:
+        pass
+
+    # First try to fetch the specific commit from a specific remote. This allows fixed depth, but
+    # the server needs to support it.
+    if remote is not None:
+        try:
+            flags = [] if depth is None else [f"--depth={depth}"]
+            git_exe("fetch", "--quiet", "--progress", *flags, remote, commit, error=os.devnull)
+            git_exe("checkout", "--quiet", commit)
+            return
+        except exe.ProcessError:
+            pass
+
+    # Fall back to fetching all while unshallowing, to guarantee we get the commit. The depth flag
+    # is equivalent to --unshallow, and needed cause git can pedantically error with
+    # "--unshallow on a complete repository does not make sense".
+    remote_flag = "--all" if remote is None else remote
+    git_exe("fetch", "--quiet", "--progress", "--depth=2147483647", remote_flag)
+    git_exe("checkout", "--quiet", commit)
 
 
 def pull_checkout_tag(

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -136,7 +136,7 @@ def pull_checkout_branch(
             raise ValueError("depth must be a positive integer")
         fetch_args.append(f"--depth={depth}")
 
-    git_exe("fetch", *fetch_args, remote, branch)
+    git_exe("fetch", *fetch_args, remote, f"{branch}:refs/remotes/{remote}/{branch}")
     git_exe("checkout", "--quiet", branch)
 
     try:

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -73,11 +73,12 @@ def imap_unordered(
     Raises:
         RuntimeError: if any error occurred in the worker processes
     """
-    from spack.subprocess_context import GlobalStateMarshaler
 
-    if sys.platform in ("darwin", "win32") or len(list_of_args) == 1:
+    if multiprocessing.get_start_method() != "fork" or len(list_of_args) == 1:
         yield from map(f, list_of_args)
         return
+
+    from spack.subprocess_context import GlobalStateMarshaler
 
     marshaler = GlobalStateMarshaler()
     with multiprocessing.Pool(

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -652,25 +652,11 @@ class Unparser(NodeVisitor):
         def visit_Ellipsis(self, node):
             self.write("...")
 
-    def visit_JoinedStr(self, node):
-        self.write("f")
-        # Python 3.12 added support for backslashes inside format parts.
-        # We need to keep adding backslashes for python < 3.11 compat.
-        if self._avoid_backslashes:
-            with self.buffered() as buffer:
-                self._write_fstring_inner(node)
-            return self._write_str_avoiding_backslashes("".join(buffer))
-
-        fstring_parts = []
-        for value in node.values:
-            with self.buffered() as buffer:
-                self._write_fstring_inner(value)
-            fstring_parts.append(("".join(buffer), _is_str_literal(value)))
-
-        new_fstring_parts = []
+    def _ftstring_helper(self, parts):
+        new_parts = []
         quote_types = list(_ALL_QUOTES)
         fallback_to_repr = False
-        for value, is_constant in fstring_parts:
+        for value, is_constant in parts:
             # Python 3.12 allows `f'{''}'`.
             # But we unparse to `f'{""}'` for < 3.12 compat.
             if True:
@@ -684,14 +670,14 @@ class Unparser(NodeVisitor):
             elif "\n" in value:
                 quote_types = [q for q in quote_types if q in _MULTI_QUOTES]
                 assert quote_types
-            new_fstring_parts.append(value)
+            new_parts.append(value)
 
         if fallback_to_repr:
             # If we weren't able to find a quote type that works for all parts
             # of the JoinedStr, fallback to using repr and triple single quotes.
             quote_types = ["'''"]
-            new_fstring_parts.clear()
-            for value, is_constant in fstring_parts:
+            new_parts.clear()
+            for value, is_constant in parts:
                 # Python 3.12 allows `f'{''}'`.
                 # We need to unparse to `f'{""}'` for < 3.12 compat.
                 if True:
@@ -699,19 +685,42 @@ class Unparser(NodeVisitor):
                     expected_prefix = "'\""
                     assert value.startswith(expected_prefix), repr(value)
                     value = value[len(expected_prefix) : -1]
-                new_fstring_parts.append(value)
+                new_parts.append(value)
 
-        value = "".join(new_fstring_parts)
+        value = "".join(new_parts)
         quote_type = quote_types[0]
         self.write(f"{quote_type}{value}{quote_type}")
 
-    def _write_fstring_inner(self, node, is_format_spec=False):
+    def _write_ftstring(self, node, prefix):
+        self.write(prefix)
+        # Python 3.12 added support for backslashes inside format parts.
+        # We need to keep adding backslashes for python < 3.11 compat.
+        if self._avoid_backslashes:
+            with self.buffered() as buffer:
+                self._write_ftstring_inner(node)
+            return self._write_str_avoiding_backslashes("".join(buffer))
+        fstring_parts = []
+        for value in node.values:
+            with self.buffered() as buffer:
+                self._write_ftstring_inner(value)
+            fstring_parts.append(("".join(buffer), _is_str_literal(value)))
+        self._ftstring_helper(fstring_parts)
+
+    def visit_JoinedStr(self, node):
+        self._write_ftstring(node, "f")
+
+    def visit_TemplateStr(self, node):
+        self._write_ftstring(node, "t")
+
+    def _write_ftstring_inner(self, node, is_format_spec=False):
         if isinstance(node, JoinedStr):
             # for both the f-string itself, and format_spec
             for value in node.values:
-                self._write_fstring_inner(value, is_format_spec=is_format_spec)
+                self._write_ftstring_inner(value, is_format_spec=is_format_spec)
         elif isinstance(node, FormattedValue):
             self.visit_FormattedValue(node)
+        elif _is_interpolation(node):
+            self.visit_Interpolation(node)
         else:  # str literal
             maybe_string = _get_str_literal_value(node)
             if maybe_string is None:
@@ -726,15 +735,18 @@ class Unparser(NodeVisitor):
                 value = value.replace("\n", "\\n")
             self.write(value)
 
-    def visit_FormattedValue(self, node):
-        def unparse_inner(inner):
-            # Python <= 3.11 does not support backslashes inside format parts
-            unparser = type(self)(_avoid_backslashes=True)
-            unparser.set_precedence(_Precedence.TEST.next(), inner)
-            return unparser.visit(inner)
+    def _unparse_interpolation_value(self, inner):
+        # Python <= 3.11 does not support backslashes inside format parts
+        unparser = type(self)(_avoid_backslashes=True)
+        unparser.set_precedence(_Precedence.TEST.next(), inner)
+        return unparser.visit(inner)
 
+    def _write_interpolation(self, node, use_str_attr=False):
         with self.delimit("{", "}"):
-            expr = unparse_inner(node.value)
+            if use_str_attr:
+                expr = node.str
+            else:
+                expr = self._unparse_interpolation_value(node.value)
             # Python <= 3.11 does not support backslash in formats part
             if "\\" in expr:
                 raise ValueError(
@@ -748,7 +760,14 @@ class Unparser(NodeVisitor):
                 self.write(f"!{chr(node.conversion)}")
             if node.format_spec:
                 self.write(":")
-                self._write_fstring_inner(node.format_spec, is_format_spec=True)
+                self._write_ftstring_inner(node.format_spec, is_format_spec=True)
+
+    def visit_FormattedValue(self, node):
+        self._write_interpolation(node)
+
+    def visit_Interpolation(self, node):
+        # If `str` is set to `None`, use the `value` to generate the source code.
+        self._write_interpolation(node, use_str_attr=node.str is not None)
 
     def visit_Name(self, node):
         self.write(node.id)
@@ -1282,3 +1301,16 @@ else:
     def _get_str_literal_value(node: ast.AST) -> Optional[str]:
         """Get the string value of a literal str node."""
         return node.s if isinstance(node, ast.Str) else None
+
+
+if sys.version_info >= (3, 14):
+
+    def _is_interpolation(node: ast.AST) -> bool:
+        """Check if a node represents a template string literal."""
+        return isinstance(node, ast.Interpolation)
+
+else:
+
+    def _is_interpolation(node: ast.AST) -> bool:
+        """Check if a node represents a template string literal."""
+        return False

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -6,11 +6,11 @@
 Utility functions for parsing, formatting, and manipulating URLs.
 """
 
-import os
 import posixpath
 import re
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Optional
 
 from spack.util.path import sanitize_filename
@@ -40,9 +40,7 @@ def local_file_path(url):
 
 
 def path_to_file_url(path):
-    if not os.path.isabs(path):
-        path = os.path.abspath(path)
-    return urllib.parse.urljoin("file:", urllib.request.pathname2url(path))
+    return Path(path).absolute().as_uri()
 
 
 def file_url_string_to_path(url):

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import codecs
 import email.message
 import errno
+import io
 import json
 import os
 import re
@@ -427,7 +427,7 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
         try:
             _, _, response = read_from_url(url)
 
-            output = codecs.getreader("utf-8")(response).read()
+            output = io.TextIOWrapper(response, encoding="utf-8").read()
             if output:
                 with working_dir(dest_dir, create=True):
                     with open(filename, "w", encoding="utf-8") as f:
@@ -745,7 +745,7 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
         if not response_url or not response:
             return pages, links, subcalls, _visited
 
-        page = codecs.getreader("utf-8")(response).read()
+        page = io.TextIOWrapper(response, encoding="utf-8").read()
         pages[response_url] = page
 
         # Parse out the include-fragments in the page
@@ -772,7 +772,7 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
             if not fragment_response_url or not fragment_response:
                 continue
 
-            fragment = codecs.getreader("utf-8")(fragment_response).read()
+            fragment = io.TextIOWrapper(fragment_response, encoding="utf-8").read()
             fragments.add(fragment)
 
             pages[fragment_response_url] = fragment

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1486,7 +1486,7 @@ _spack_mirror_add() {
 _spack_mirror_remove() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --all-scopes"
     else
         _mirrors
     fi
@@ -1495,7 +1495,7 @@ _spack_mirror_remove() {
 _spack_mirror_rm() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --all-scopes"
     else
         _mirrors
     fi
@@ -1839,7 +1839,7 @@ _spack_repo_set() {
 _spack_repo_remove() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --all-scopes"
     else
         _repos
     fi
@@ -1848,7 +1848,7 @@ _spack_repo_remove() {
 _spack_repo_rm() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --all-scopes"
     else
         _repos
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -809,7 +809,7 @@ _spack_compiler_ls() {
 _spack_compiler_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --remote"
     else
         _installed_compilers
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2403,20 +2403,24 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password-var
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password-variable -r -d 'environment variable containing password to use to connect to this OCI mirror'
 
 # spack mirror remove
-set -g __fish_spack_optspecs_spack_mirror_remove h/help scope=
+set -g __fish_spack_optspecs_spack_mirror_remove h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l all-scopes -f -a all_scopes
+complete -c spack -n '__fish_spack_using_command mirror remove' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching mirror)'
 
 # spack mirror rm
-set -g __fish_spack_optspecs_spack_mirror_rm h/help scope=
+set -g __fish_spack_optspecs_spack_mirror_rm h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l all-scopes -f -a all_scopes
+complete -c spack -n '__fish_spack_using_command mirror rm' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching mirror)'
 
 # spack mirror set-url
 set -g __fish_spack_optspecs_spack_mirror_set_url h/help push fetch scope= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
@@ -2857,20 +2861,24 @@ complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_b
 complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
-set -g __fish_spack_optspecs_spack_repo_remove h/help scope=
+set -g __fish_spack_optspecs_spack_repo_remove h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command repo remove' -l all-scopes -f -a all_scopes
+complete -c spack -n '__fish_spack_using_command repo remove' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching repo)'
 
 # spack repo rm
-set -g __fish_spack_optspecs_spack_repo_rm h/help scope=
+set -g __fish_spack_optspecs_spack_repo_rm h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command repo rm' -l all-scopes -f -a all_scopes
+complete -c spack -n '__fish_spack_using_command repo rm' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching repo)'
 
 # spack repo migrate
 set -g __fish_spack_optspecs_spack_repo_migrate h/help dry-run fix

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1153,12 +1153,14 @@ complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -f -a re
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -d 'list also compilers from registered buildcaches'
 
 # spack compiler info
-set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
+set -g __fish_spack_optspecs_spack_compiler_info h/help scope= remote
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
+complete -c spack -n '__fish_spack_using_command compiler info' -l remote -f -a remote
+complete -c spack -n '__fish_spack_using_command compiler info' -l remote -d 'list also compilers from registered buildcaches'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope= remote

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -601,7 +601,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_enable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap enable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap enable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap disable
@@ -609,7 +609,7 @@ set -g __fish_spack_optspecs_spack_bootstrap_disable h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap disable' -f -a '(__fish_spack_bootstrap_names)'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap disable' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap reset
@@ -624,14 +624,14 @@ set -g __fish_spack_optspecs_spack_bootstrap_root h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap root' -f -a '(__fish_complete_directories)'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap root' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap root' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap list
 set -g __fish_spack_optspecs_spack_bootstrap_list h/help scope=
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap list' -l scope -r -d 'configuration scope to read/modify'
 
 # spack bootstrap add
@@ -640,7 +640,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 bootstrap add' -f -a '(__
 complete -c spack -n '__fish_spack_using_command_pos 1 bootstrap add' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command bootstrap add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -f -a trust
 complete -c spack -n '__fish_spack_using_command bootstrap add' -l trust -d 'enable the source immediately upon addition'
@@ -817,7 +817,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirro
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -d 'override any configured mirrors with this mirror URL'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -f -a output_file
 complete -c spack -n '__fish_spack_using_command buildcache check' -s o -l output-file -r -d 'file where rebuild info should be written'
-complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command buildcache check' -l scope -r -d 'configuration scope containing mirrors to check'
 
 # spack buildcache download
@@ -1095,7 +1095,7 @@ complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolcha
 complete -c spack -n '__fish_spack_using_command compiler find' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler find' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1109,7 +1109,7 @@ complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchai
 complete -c spack -n '__fish_spack_using_command compiler add' -l mixed-toolchain -d '(DEPRECATED) Allow mixed toolchains (for example: clang, clang++, gfortran)'
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -f -a mixed_toolchain
 complete -c spack -n '__fish_spack_using_command compiler add' -l no-mixed-toolchain -d '(DEPRECATED) Do not allow mixed toolchains (for example: clang, clang++, gfortran)'
-complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command compiler add' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
@@ -1121,7 +1121,7 @@ complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -
 complete -c spack -n '__fish_spack_using_command compiler remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler remove' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler remove' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler rm
@@ -1131,14 +1131,14 @@ complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command compiler rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command compiler rm' -s a -l all -d 'remove ALL compilers that match spec'
-complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler rm' -l scope -r -d 'configuration scope to modify'
 
 # spack compiler list
 set -g __fish_spack_optspecs_spack_compiler_list h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'list also compilers from registered buildcaches'
@@ -1147,7 +1147,7 @@ complete -c spack -n '__fish_spack_using_command compiler list' -l remote -d 'li
 set -g __fish_spack_optspecs_spack_compiler_ls h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler ls' -l remote -d 'list also compilers from registered buildcaches'
@@ -1157,7 +1157,7 @@ set -g __fish_spack_optspecs_spack_compiler_info h/help scope= remote
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command compiler info' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compiler info' -l remote -d 'list also compilers from registered buildcaches'
@@ -1166,7 +1166,7 @@ complete -c spack -n '__fish_spack_using_command compiler info' -l remote -d 'li
 set -g __fish_spack_optspecs_spack_compilers h/help scope= remote
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compilers' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command compilers' -l scope -r -d 'configuration scope to read/modify'
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command compilers' -l remote -d 'list also compilers from registered buildcaches'
@@ -1229,7 +1229,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a update -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a revert -d 'revert configuration files to their state before update'
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
@@ -1785,7 +1785,7 @@ complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -d 'one or more alternative search paths for finding externals'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
 complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
@@ -2375,7 +2375,7 @@ set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsig
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror add' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -f -a 'binary source'
 complete -c spack -n '__fish_spack_using_command mirror add' -l type -r -d 'specify the mirror type: for both binary and source use ``--type binary --type source`` (default)'
@@ -2409,7 +2409,7 @@ set -g __fish_spack_optspecs_spack_mirror_remove h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror remove' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror remove' -l all-scopes -f -a all_scopes
 complete -c spack -n '__fish_spack_using_command mirror remove' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching mirror)'
@@ -2419,7 +2419,7 @@ set -g __fish_spack_optspecs_spack_mirror_rm h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror rm' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror rm' -l all-scopes -f -a all_scopes
 complete -c spack -n '__fish_spack_using_command mirror rm' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching mirror)'
@@ -2433,7 +2433,7 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -f -a p
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l push -d 'set only the URL used for uploading'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -f -a fetch
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l fetch -d 'set only the URL used for downloading'
-complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2475,7 +2475,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror set' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
@@ -2500,14 +2500,14 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-var
 set -g __fish_spack_optspecs_spack_mirror_list h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror list' -l scope -r -d 'configuration scope to read from'
 
 # spack mirror ls
 set -g __fish_spack_optspecs_spack_mirror_ls h/help scope=
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror ls' -l scope -r -d 'configuration scope to read from'
 
 # spack module
@@ -2820,7 +2820,7 @@ complete -c spack -n '__fish_spack_using_command repo create' -s d -l subdirecto
 set -g __fish_spack_optspecs_spack_repo_list h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo list' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo list' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo list' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo list' -l names -d 'show configuration names only'
@@ -2831,7 +2831,7 @@ complete -c spack -n '__fish_spack_using_command repo list' -l namespaces -d 'sh
 set -g __fish_spack_optspecs_spack_repo_ls h/help scope= names namespaces
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo ls' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo ls' -l scope -r -d 'configuration scope to read from'
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -f -a names
 complete -c spack -n '__fish_spack_using_command repo ls' -l names -d 'show configuration names only'
@@ -2847,7 +2847,7 @@ complete -c spack -n '__fish_spack_using_command repo add' -l name -r -f -a name
 complete -c spack -n '__fish_spack_using_command repo add' -l name -r -d 'config name for the package repository, defaults to the namespace of the repository'
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo add' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo add' -l scope -r -d 'configuration scope to modify'
 
 # spack repo set
@@ -2859,7 +2859,7 @@ complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -f 
 complete -c spack -n '__fish_spack_using_command repo set' -l destination -r -d 'destination to clone git repository into'
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command repo set' -l path -r -d 'relative path to the Spack package repository inside a git repository. Can be repeated to add multiple package repositories in case of a monorepo'
-complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo set' -l scope -r -d 'configuration scope to modify'
 
 # spack repo remove
@@ -2867,7 +2867,7 @@ set -g __fish_spack_optspecs_spack_repo_remove h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 repo remove' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo remove' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo remove' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo remove' -l all-scopes -f -a all_scopes
 complete -c spack -n '__fish_spack_using_command repo remove' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching repo)'
@@ -2877,7 +2877,7 @@ set -g __fish_spack_optspecs_spack_repo_rm h/help scope= all-scopes
 complete -c spack -n '__fish_spack_using_command_pos 0 repo rm' $__fish_spack_force_files -a '(__fish_spack_repos)'
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo rm' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo rm' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo rm' -l all-scopes -f -a all_scopes
 complete -c spack -n '__fish_spack_using_command repo rm' -l all-scopes -d 'remove from all config scopes (default: highest scope with matching repo)'
@@ -2899,7 +2899,7 @@ complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -f -a remote
 complete -c spack -n '__fish_spack_using_command repo update' -l remote -s r -r -d 'name of remote to check for branches, tags, or commits'
-complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults site user spack command_line'
+complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -f -a branch
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -d 'name of a branch to change to'

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/callpath/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/callpath/package.py
@@ -16,6 +16,7 @@ class Callpath(Package):
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("dyninst")
     depends_on("mpi")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
@@ -15,10 +15,18 @@ class Gcc(CompilerPackage, Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/gcc-1.0.tar.gz"
 
+    version("14.0.1", md5="abcdef0123456789abcdef0123456789")
     version("14.0", md5="abcdef0123456789abcdef0123456789")
+    version("12.1.0", md5="abcdef0123456789abcdef0123456789")
+    version("10.2.1", md5="abcdef0123456789abcdef0123456789")
+    version("9.4.1", md5="abcdef0123456789abcdef0123456789")
+    version("9.4.0", md5="abcdef0123456789abcdef0123456789")
     version("3.0", md5="def0123456789abcdef0123456789abc")
     version("2.0", md5="abcdef0123456789abcdef0123456789")
     version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    with default_args(deprecated=True):
+        version("12.4.0", md5="abcdef0123456789abcdef0123456789")
 
     variant(
         "languages",

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/mpileaks/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/mpileaks/package.py
@@ -22,11 +22,14 @@ class Mpileaks(Package):
     variant("opt", default=False, description="Optimized variant")
     variant("shared", default=True, description="Build shared library")
     variant("static", default=True, description="Build static library")
+    variant("fortran", default=False, description="Enable fortran API")
 
     depends_on("mpi")
     depends_on("callpath")
 
     depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="+fortran")
 
     # Will be used to try raising an exception
     libs = None


### PR DESCRIPTION
All PRs listed in the order they were backported.

PRs in this backport branch:

- #51559 
- #51588
- #51617 
- #51563 
- #51640 
- #51636 
- #51635 
- #51669 
- #51686 
- #51692 
- #51687 
- #51688 
- #51689 
- #51663 
- #51718 
- #51720 
- #51695 
- #51735 
- #51731 
- #51708 
- #51779 
- #51767 
- #51825
- #51788 
- #51591 (not tagged for 1.1.1, but needed as dependency of 51612)
- #51605 (not tagged for 1.1.1, but needed as dependency of 51612)
- #51612
- #51625 
- #51561 (not tagged for 1.1.1, but added as dependency of 51787)
- #51558 (not tagged for 1.1.1, but added as dependency of 51787)
- #51570 (not tagged for 1.1.1, but added as dependency of 51787)
- #51593 (not tagged for 1.1.1, but added as dependency of 51787)
- #51622 (not tagged for 1.1.1, but added as dependency of 51787)
- #51623 (not tagged for 1.1.1, but added as dependency of 51787)
- #51769 (not tagged for 1.1.1, but added as dependency of 51787)
- #51776 (not tagged for 1.1.1, but added as dependency of 51787)
- #51787 

PRs manually merged after cherry-pick did not apply cleanly
- #51555 (depends on #50950, which is not being backported. The conflict was a single import resolved manually)

TODO:
- [x] #51840
- [x] #51764