### PR TITLE
spec: make compilers return a valid spec

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4509,9 +4509,8 @@ class Spec:
     @property
     def compilers(self):
         if self.original_spec_format() < 5:
-            # These specs don't have compilers as dependencies, return the
-            # specfile format and compiler
-            return f"[specfile v{self.original_spec_format()}] {self.compiler}"
+            # These specs don't have compilers as dependencies, return the compiler node attribute
+            return f" %{self.compiler}"
 
         # TODO: get rid of the space here and make formatting smarter
         return " " + self._format_dependencies(


### PR DESCRIPTION
fixes #51837

This makes spotting old specs harder, but gives a valid spec format.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
