### PR TITLE
config: relax concurrent_packages to minimum 0

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1528,8 +1528,8 @@ class PackageInstaller:
             explicit = {pkg.spec.dag_hash() for pkg in packages} if explicit else set()
 
         if concurrent_packages is None:
-            concurrent_packages = spack.config.get("config:concurrent_packages", default=1)
-        self.concurrent_packages = concurrent_packages
+            concurrent_packages = int(spack.config.get("config:concurrent_packages", default=1))
+        self.concurrent_packages = max(1, concurrent_packages)
 
         install_args = {
             "dependencies_policy": dependencies_policy,

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -176,7 +176,7 @@ properties: Dict[str, Any] = {
             },
             "concurrent_packages": {
                 "type": "integer",
-                "minimum": 1,
+                "minimum": 0,
                 "description": "The maximum number of concurrent package builds a single Spack "
                 "instance will run",
             },


### PR DESCRIPTION
In the new installer, the number of concurrent packages is bound by
`build_jobs`, and users don't have to bother setting
`concurrent_packages` too. As a result, the new installer currently
ignores `concurrent_packages`.

In Spack v1.2 however, the new installer *will* respect
`concurrent_packages` as an upper limit on the number of concurrent
package installs. That makes the default value of `1` in config
problematic.

The suggestion is to use a default value of `0` from Spack v1.2 onwards,
and make that mean "default settings". For the old installer that is "no
package parallelism", for the new installer that is "at most `build_jobs`".

This commit allows the value `0` in config, and is primarily meant to be
backported to ensure forward compatibilty with newer config files in
older Spack version.

