### PR TITLE
use tuple([...]) in a few places

### DIFF
--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -211,7 +211,7 @@ done = object()
 
 def tuplify(seq):
     """Helper for lazy_lexicographic_ordering()."""
-    return tuple((tuplify(x) if callable(x) else x) for x in seq())
+    return tuple([(tuplify(x) if callable(x) else x) for x in seq()])
 
 
 def lazy_eq(lseq, rseq):
@@ -456,7 +456,7 @@ class HashableMap(typing.MutableMapping[K, V]):
         del self.dict[key]
 
     def _cmp_iter(self):
-        for _, v in sorted(self.items()):
+        for _, v in sorted(self.dict.items()):
             yield v
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -992,7 +992,7 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         return flag_type, [str(flag) for flag in self[flag_type]]
 
     def _cmp_iter(self):
-        for k, v in sorted(self.items()):
+        for k, v in sorted(self.dict.items()):
             yield k
 
             def flags():

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -131,7 +131,7 @@ def parse_string_components(string: str) -> Tuple[VersionTuple, SeparatorTuple]:
         raise ValueError("Bad characters in version string: %s" % string)
 
     segments = SEGMENT_REGEX.findall(string)
-    separators: Tuple[str] = tuple(m[2] for m in segments)
+    separators: Tuple[str] = tuple([m[2] for m in segments])
     prerelease: Tuple[int, ...]
 
     # <version>(alpha|beta|rc)<number>
@@ -149,7 +149,7 @@ def parse_string_components(string: str) -> Tuple[VersionTuple, SeparatorTuple]:
         prerelease = (FINAL,)
 
     release: VersionComponentTuple = tuple(
-        int(m[0]) if m[0] else VersionStrComponent.from_string(m[1]) for m in segments
+        [int(m[0]) if m[0] else VersionStrComponent.from_string(m[1]) for m in segments]
     )
 
     return (release, prerelease), separators
@@ -245,7 +245,8 @@ class StandardVersion(ConcreteVersion):
 
     @staticmethod
     def from_string(string: str) -> "StandardVersion":
-        return StandardVersion(string, *parse_string_components(string))
+        version, separators = parse_string_components(string)
+        return StandardVersion(string, version, separators)
 
     @staticmethod
     def typemin() -> "StandardVersion":


### PR DESCRIPTION
Extracted from #51836 

In Python 3.11+ it's better to do `tuple([...])` instead of `tuple(...)`. For
older Python it doesn't matter much.

The reason is that `tuple(x for x in xs)` creates a generator function
where cpythonn needs another stack frame, whereas `tuple([x for x in xs])`
is native iteration equivalent to `lst = []; for x in xs: lst.append(x); tuple(lst)`,
except that `append` is not a function call but an intrinsic.

Further, remove the indirection of the `HashableMap.__iter__` function
call, and do not use splatting in `StandardVersion.from_string`.

Before:

```
$ python -m timeit -s 'from spack.spec import Spec; s = Spec("pkg@1.2.3 foo=bar")' 'hash(s)'
100000 loops, best of 5: 2.66 usec per loop
$ python -m timeit -s 'from spack.version import ver' 'ver("1.2.3")'
200000 loops, best of 5: 1.82 usec per loop
```

After:

```
$ python -m timeit -s 'from spack.spec import Spec; s = Spec("pkg@1.2.3 foo=bar")' 'hash(s)'
200000 loops, best of 5: 1.58 usec per loop
$ python -m timeit -s 'from spack.version import ver' 'ver("1.2.3")'
200000 loops, best of 5: 1.54 usec per loop
```

On my macbook it gives small (4.8%) reduction in package load time.
