### PR TITLE
solver: fix variant penalty for variants defined with a validator function

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1587,8 +1587,9 @@ class SpackSolverSetup:
 
         # Deal with variants that use validator functions
         if variant_def.values_defined_by_validator():
-            for value in default_values:
+            for penalty, value in enumerate(default_values, 1):
                 pkg_fact(fn.variant_possible_value(vid, value))
+                pkg_fact(fn.variant_penalty(vid, value, penalty))
             self.gen.newline()
             return
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1348,10 +1348,19 @@ variant_default_value(node(NodeID, Package), VariantName, Value) :-
     node_has_variant(node(NodeID, Package), VariantName, _),
     attr("variant_default_value_from_cli", node(min_dupe_id, Package), VariantName, Value).
 
+% Penalty from the variant definition
+possible_variant_penalty(VariantID, Value, Penalty) :- pkg_fact(Package, variant_penalty(VariantID, Value, Penalty)).
+
+% Use a very high penalty for variant values that are not defined in the package,
+% for instance those defined implicitly by a validator.
+possible_variant_penalty(VariantID, Value, 100) :-
+    pkg_fact(Package, variant_possible_value(VariantID, Value)),
+    not pkg_fact(Package, variant_penalty(VariantID, Value, _)).
+
 variant_penalty(node(NodeID, Package), Variant, Value, Penalty) :-
     node_has_variant(node(NodeID, Package), Variant, VariantID),
     attr("variant_value", node(NodeID, Package), Variant, Value),
-    pkg_fact(Package, variant_penalty(VariantID, Value, Penalty)),
+    possible_variant_penalty(VariantID, Value, Penalty),
     not variant_default_value(node(NodeID, Package), Variant, Value),
     % variants set explicitly from a directive don't count as non-default
     not attr("variant_set", node(NodeID, Package), Variant, _),

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4825,7 +4825,7 @@ def test_activating_variant_for_conditional_language_dependency(default_mock_con
 
 
 def test_imposed_spec_dependency_duplication(mock_packages: spack.repo.Repo):
-    """Tests that imposed dependenies triggered by identical conditions are grouped together,
+    """Tests that imposed dependencies triggered by identical conditions are grouped together,
     and that imposed dependencies that differ on a deptype are not grouped together."""
     # The trigger-and-effect-deps pkg has 4 conditions, 2 triggers, and 4 effects in total:
     # +x -> depends on pkg-a with deptype link
@@ -4846,3 +4846,23 @@ def test_imposed_spec_dependency_duplication(mock_packages: spack.repo.Repo):
     assert len([line for line in asp if re.search(r"trigger_id\(\d+\)", line)]) == 2
     # There should be 4 effects total
     assert len([line for line in asp if re.search(r"effect_id\(\d+\)", line)]) == 4
+
+
+@pytest.mark.regression("51842")
+@pytest.mark.parametrize(
+    "spec_str,expected",
+    [
+        ("variant-function-validator", "generator=make %adios2~bzip2"),
+        ("variant-function-validator generator=make", "generator=make %adios2~bzip2"),
+        ("variant-function-validator generator=ninja", "generator=ninja %adios2+bzip2"),
+        ("variant-function-validator generator=other", "generator=other %adios2+bzip2"),
+    ],
+)
+def test_penalties_for_variant_defined_by_function(
+    default_mock_concretization, spec_str, expected
+):
+    """Tests that we have penalties for variants defined by functions, and that variant values
+    are consistent with defaults and optimization rules.
+    """
+    s = default_mock_concretization(spec_str)
+    assert s.satisfies(expected)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/variant_function_validator/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/variant_function_validator/package.py
@@ -1,0 +1,27 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+def _allowed_values(x):
+    return x in {"make", "ninja", "other"}
+
+
+class VariantFunctionValidator(Package):
+    """This package has a variant with values defined by a function validator."""
+
+    homepage = "https://www.example.org"
+    url = "https://example.org/files/v3.4/cmake-3.4.3.tar.gz"
+
+    version("1.0", md5="4cb3ff35b2472aae70f542116d616e63")
+
+    variant("generator", default="make", values=_allowed_values, description="?")
+
+    # Create a situation where, if the penalty for the variant defined by a function
+    # is not taken into account, then we'll select the non-default value
+    depends_on("adios2")
+    conflicts("adios2+bzip2", when="generator=make")
+    conflicts("adios2~bzip2", when="generator=ninja")


### PR DESCRIPTION
fixes #51842

Variants defined with a validator function can have:
```
pkg_fact(Package, variant_possible_value(VariantID, Value))
```
that are not associated with a penalty and are not part of the variant definition. In this case set the penalty to a very high value to avoid selecting them accidentally.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
