### PR TITLE
Singleton instantiation: properly display AttributeError

### DIFF
--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -339,7 +339,7 @@ def test_fnmatch_multiple():
     assert not regex.match("libbaz.so")
 
 
-def _factory():
+def _attr_error_factory():
     raise AttributeError("Could not make something")
 
 
@@ -348,7 +348,7 @@ def test_singleton_instantiation_attr_failure():
     If an AttributeError occurs during the instantiation of a Singleton
     object, we want to see that error.
     """
-    x = Singleton(_factory)
+    x = Singleton(_attr_error_factory)
     with pytest.raises(SingletonInstantiationError) as last_exception:
         x.something
 

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -11,7 +11,14 @@ from datetime import datetime, timedelta
 import pytest
 
 import spack.llnl.util.lang
-from spack.llnl.util.lang import dedupe, match_predicate, memoized, pretty_date
+from spack.llnl.util.lang import (
+    Singleton,
+    SingletonInstantiationError,
+    dedupe,
+    match_predicate,
+    memoized,
+    pretty_date,
+)
 
 
 @pytest.fixture()
@@ -330,6 +337,26 @@ def test_fnmatch_multiple():
     assert not regex.match("libbar.so.1")
     assert not regex.match("libfoo.solibbar.so")
     assert not regex.match("libbaz.so")
+
+
+def _factory():
+    raise AttributeError("Could not make something")
+
+
+def test_singleton_instantiation_failure():
+    x = Singleton(_factory)
+    with pytest.raises(SingletonInstantiationError) as last_exception:
+        x.something
+
+    def follow_exceptions(e):
+        while e:
+            yield e
+            e = e.__cause__ or e.__context__
+
+    assert any(
+        "Could not make something" in str(e)
+        for e in follow_exceptions(last_exception.value)
+    )
 
 
 class TestPriorityOrderedMapping:

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -343,7 +343,11 @@ def _factory():
     raise AttributeError("Could not make something")
 
 
-def test_singleton_instantiation_failure():
+def test_singleton_instantiation_attr_failure():
+    """
+    If an AttributeError occurs during the instantiation of a Singleton
+    object, we want to see that error.
+    """
     x = Singleton(_factory)
     with pytest.raises(SingletonInstantiationError) as last_exception:
         x.something

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -358,8 +358,7 @@ def test_singleton_instantiation_attr_failure():
             e = e.__cause__ or e.__context__
 
     assert any(
-        "Could not make something" in str(e)
-        for e in follow_exceptions(last_exception.value)
+        "Could not make something" in str(e) for e in follow_exceptions(last_exception.value)
     )
 
 


### PR DESCRIPTION
If an `AttributeError` was generated when instantiating a `Singleton` object, that would be discarded and result in just

```
E           AttributeError: cannot create instance
```

Which makes it hard to figure out what error occurred in the first place.

(this is because when `.instance` fails with an `AttributeError`, Python then discards that and tries `__getattr__(..., "instance")`)