### PR TITLE
conftest.py: nullify globals use empty config

### DIFF
--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -298,9 +298,7 @@ class SpecParser:
 
         # TODO: Move toolchains out of the parser, and expand them as a separate step
         self.toolchains = {}
-        configuration = getattr(spack.config, "CONFIG", None)
-        if configuration is not None:
-            self.toolchains = configuration.get_config("toolchains")
+        self.toolchains = spack.config.CONFIG.get_config("toolchains")
         self.parsed_toolchains: Dict[str, "spack.spec.Spec"] = {}
 
     def tokens(self) -> List[Token]:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2301,7 +2301,7 @@ def shell_as(shell):
 @pytest.fixture()
 def nullify_globals(request, monkeypatch):
     ensure_configuration_fixture_run_before(request)
-    monkeypatch.setattr(spack.config, "CONFIG", None)
+    monkeypatch.setattr(spack.config, "CONFIG", spack.config.Configuration())
     monkeypatch.setattr(spack.caches, "MISC_CACHE", None)
     monkeypatch.setattr(spack.caches, "FETCH_CACHE", None)
     monkeypatch.setattr(spack.repo, "PATH", None)


### PR DESCRIPTION
Since the introduction of toolchains, spack.config.CONFIG is needed
unconditionally by the parser.

