### PR TITLE
solver: account for variant penalties correctly when only one of multiple values is "set"

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1363,9 +1363,9 @@ variant_penalty(node(NodeID, Package), Variant, Value, Penalty) :-
     possible_variant_penalty(VariantID, Value, Penalty),
     not variant_default_value(node(NodeID, Package), Variant, Value),
     % variants set explicitly from a directive don't count as non-default
-    not attr("variant_set", node(NodeID, Package), Variant, _),
+    not attr("variant_set", node(NodeID, Package), Variant, Value),
     % variant values forced by propagation don't count as non-default
-    not propagate(node(NodeID, Package), variant_value(Variant, _, _)).
+    not propagate(node(NodeID, Package), variant_value(Variant, Value, _)).
 
 % -- Associate the definition's possible values with the node
 variant_possible_value(node(NodeID, Package), VariantName, Value) :-


### PR DESCRIPTION
Before, for a pattern like:
```python
variant(
    "io",
    values=any_combination_of(
        "adios2", "cgns", "exodusii", "ffmpeg", "fides", "ioss", "netcdf", "xdmf"
    ).with_default("cgns,exodusii,ioss,netcdf"),
    description="Enable IO modules",
)
requires("io=adios2", when="io=fides")
```
the fact that `io=adios2` was "set" was causing the penalty on `fides` to be disregarded, due to the projection on values.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
