### PR TITLE
checksum cmd: render URL if found via web spider

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -154,7 +154,10 @@ def checksum(parser, args):
         tty.die(f"Could not find any remote versions for {pkg.name}")
     elif len(url_dict) > 1 and not args.batch and sys.stdin.isatty():
         filtered_url_dict = spack.stage.interactive_version_filter(
-            url_dict, pkg.versions, url_overrides=url_overrides, initial_verion_filter=spec.versions
+            url_dict,
+            pkg.versions,
+            url_overrides=url_overrides,
+            initial_verion_filter=spec.versions,
         )
         if not filtered_url_dict:
             exit(0)
@@ -207,13 +210,8 @@ def print_checksum_status(pkg: PackageBase, version_hashes: dict, url_dict: dict
             msg = "No previous checksum"
             status = "-"
 
-        elif version not in url_dict:
-            msg = "URL not found"
-            status = "x"
-            failed = True
-
         elif url_dict[version] not in pkg.all_urls_for_version(version):
-            msg = "URL for version does not exist"
+            msg = "URL for version not found"
             status = "x"
             failed = True
 

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -212,7 +212,7 @@ def print_checksum_status(pkg: PackageBase, version_hashes: dict, url_dict: dict
             msg = "No previous checksum"
             status = "-"
 
-        if url_dict[version] not in pkg.all_urls_for_version(version):
+        elif url_dict[version] not in pkg.all_urls_for_version(version):
             msg = "URL for version does not exist"
             status = "x"
             failed = True

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -170,11 +170,14 @@ def checksum(parser, args):
     )
 
     if args.verify:
-        print_checksum_status(pkg, version_hashes)
+        print_checksum_status(pkg, version_hashes, url_dict)
         sys.exit(0)
 
     # convert dict into package.py version statements
-    version_lines = get_version_lines(version_hashes)
+    version_lines = get_version_lines(
+        version_hashes,
+        url_changed_for_version={v: url_dict.get(v) for v in url_changed_for_version},
+    )
     print()
     print(version_lines)
     print()
@@ -187,7 +190,7 @@ def checksum(parser, args):
             editor(path)
 
 
-def print_checksum_status(pkg: PackageBase, version_hashes: dict):
+def print_checksum_status(pkg: PackageBase, version_hashes: dict, url_dict: dict):
     """
     Verify checksums present in version_hashes against those present
     in the package's instructions.
@@ -208,6 +211,11 @@ def print_checksum_status(pkg: PackageBase, version_hashes: dict):
         if version not in pkg.versions:
             msg = "No previous checksum"
             status = "-"
+
+        if url_dict[version] not in pkg.all_urls_for_version(version):
+            msg = "URL for version does not exist"
+            status = "x"
+            failed = True
 
         elif sha == pkg.versions[version]["sha256"]:
             msg = "Correct"

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -139,7 +139,7 @@ def checksum(parser, args):
     # We wanna ensure that `spack checksum` and `spack install` ultimately use the same URL, so
     # here we check whether the crawled and computed URLs disagree, and if so, prioritize the
     # former if that URL exists (just sending a HEAD request that is).
-    url_changed_for_version = set()
+    url_overrides: Dict[StandardVersion, str] = {}
     for version, url in url_dict.items():
         possible_urls = pkg.all_urls_for_version(version)
         if url not in possible_urls:
@@ -148,16 +148,13 @@ def checksum(parser, args):
                     url_dict[version] = possible_url
                     break
             else:
-                url_changed_for_version.add(version)
+                url_overrides[version] = url
 
     if not url_dict:
         tty.die(f"Could not find any remote versions for {pkg.name}")
     elif len(url_dict) > 1 and not args.batch and sys.stdin.isatty():
         filtered_url_dict = spack.stage.interactive_version_filter(
-            url_dict,
-            pkg.versions,
-            url_changes=url_changed_for_version,
-            initial_verion_filter=spec.versions,
+            url_dict, pkg.versions, url_overrides=url_overrides, initial_verion_filter=spec.versions
         )
         if not filtered_url_dict:
             exit(0)
@@ -174,10 +171,7 @@ def checksum(parser, args):
         sys.exit(0)
 
     # convert dict into package.py version statements
-    version_lines = get_version_lines(
-        version_hashes,
-        url_changed_for_version={v: url_dict.get(v) for v in url_changed_for_version},
-    )
+    version_lines = get_version_lines(version_hashes, url_overrides=url_overrides)
     print()
     print(version_lines)
     print()
@@ -198,6 +192,7 @@ def print_checksum_status(pkg: PackageBase, version_hashes: dict, url_dict: dict
     Args:
         pkg (spack.package_base.PackageBase): A package class for a given package in Spack.
         version_hashes (dict): A dictionary of the form: version -> checksum.
+        url_dict (dict): A dictionary of the form: version -> url.
 
     """
     results = []
@@ -211,6 +206,11 @@ def print_checksum_status(pkg: PackageBase, version_hashes: dict, url_dict: dict
         if version not in pkg.versions:
             msg = "No previous checksum"
             status = "-"
+
+        elif version not in url_dict:
+            msg = "URL not found"
+            status = "x"
+            failed = True
 
         elif url_dict[version] not in pkg.all_urls_for_version(version):
             msg = "URL for version does not exist"

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -1056,7 +1056,7 @@ def interactive_version_filter(
     known_versions: Iterable[StandardVersion] = (),
     *,
     initial_verion_filter: Optional[VersionList] = None,
-    url_changes: Set[StandardVersion] = set(),
+    url_overrides: Dict[StandardVersion, str] = {},
     input: Callable[..., str] = input,
 ) -> Optional[Dict[StandardVersion, str]]:
     """Interactively filter the list of spidered versions.
@@ -1098,7 +1098,7 @@ def interactive_version_filter(
             version_with_url = [
                 colorize(
                     f"{VERSION_COLOR}{str(v):{max_len}}@.  {url_dict[v]}"
-                    f"{'  @K{# NOTE: change of URL}' if v in url_changes else ''}"
+                    f"{'  @K{# NOTE: change of URL}' if v in url_overrides else ''}"
                 )
                 for v in sorted_and_filtered
             ]

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -11,7 +11,7 @@ import shutil
 import stat
 import sys
 import tempfile
-from typing import TYPE_CHECKING, Callable, Dict, Generator, Iterable, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Callable, Dict, Generator, Iterable, List, Optional, Union
 
 import spack.caches
 import spack.config

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -314,8 +314,9 @@ def test_checksum_verification_fails(default_mock_concretization, capfd, can_fet
     pkg = spec.package
     versions = list(pkg.versions.keys())
     version_hashes = {versions[0]: "abadhash", Version("0.1"): "123456789"}
+    url_dict = {versions[0]: pkg.versions[versions[0]]}
     with pytest.raises(SystemExit):
-        spack.cmd.checksum.print_checksum_status(pkg, version_hashes)
+        spack.cmd.checksum.print_checksum_status(pkg, version_hashes, url_dict)
     out = str(capfd.readouterr())
     assert out.count("Correct") == 0
     assert "No previous checksum" in out

--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -8,7 +8,7 @@ INDENT = " " * 4
 
 
 def get_version_lines(
-    version_hashes_dict: Mapping, url_changed_for_version: Optional[Mapping] = None
+    version_hashes_dict: Mapping, url_overrides: Optional[Mapping] = None
 ) -> str:
     """
     Renders out a set of versions like those found in a package's
@@ -16,18 +16,18 @@ def get_version_lines(
 
     Args:
         version_hashes_dict: A dictionary of the form: version -> checksum.
-        url_changed_for_version: A dictionary of the form: version -> url.
+        url_overrides: A dictionary of the form: version -> url.
 
     Returns: Rendered version lines.
     """
-    url_overrides = url_changed_for_version or {}
+    url_overrides = url_overrides or {}
     version_lines = []
 
     for version in sorted(version_hashes_dict):
         checksum = version_hashes_dict[version]
 
         url = url_overrides.get(version)
-        url_parameter = f', url="{url}"' if url is not None else ""
+        url_parameter = f', url={repr(url)}' if url is not None else ""
 
         line = f'{INDENT}version("{version}", sha256="{checksum}"{url_parameter})'
         version_lines.append(line)

--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -27,7 +27,7 @@ def get_version_lines(
         checksum = version_hashes_dict[version]
 
         url = url_overrides.get(version)
-        url_parameter = f', url={repr(url)}' if url is not None else ""
+        url_parameter = f", url={repr(url)}" if url is not None else ""
 
         line = f'{INDENT}version("{version}", sha256="{checksum}"{url_parameter})'
         version_lines.append(line)

--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -2,20 +2,34 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from typing import Mapping, Optional
 
-def get_version_lines(version_hashes_dict: dict) -> str:
+INDENT = " " * 4
+
+
+def get_version_lines(
+    version_hashes_dict: Mapping, url_changed_for_version: Optional[Mapping] = None
+) -> str:
     """
     Renders out a set of versions like those found in a package's
     package.py file for a given set of versions and hashes.
 
     Args:
         version_hashes_dict: A dictionary of the form: version -> checksum.
+        url_changed_for_version: A dictionary of the form: version -> url.
 
     Returns: Rendered version lines.
     """
+    url_overrides = url_changed_for_version or {}
     version_lines = []
 
-    for v, h in version_hashes_dict.items():
-        version_lines.append(f'    version("{v}", sha256="{h}")')
+    for version in sorted(version_hashes_dict):
+        checksum = version_hashes_dict[version]
+
+        url = url_overrides.get(version)
+        url_parameter = f', url="{url}"' if url is not None else ""
+
+        line = f'{INDENT}version("{version}", sha256="{checksum}"{url_parameter})'
+        version_lines.append(line)
 
     return "\n".join(version_lines)


### PR DESCRIPTION
This PR improves the output behavior of Spack's `checksum` command when it has to fall back to the web spider to discover URLs for new versions.

Today, if Spack cannot interpolate a URL from the package for a given version, it uses the web spider to find a candidate tarball, computes a checksum, and then renders a `version()` directive. However, that rendered `version()` directive does **not** include the spider-discovered URL. This can lead to a situation where:

1. `spack checksum` appears to work and yields a new `version()` line, but  
2. `spack install` later fails, because the URL interpolation logic cannot reproduce the same URL the spider found.

This PR fixes that, and also tightens checksum verification behavior under `--verify`.

---

**Current behavior**

Spack spiders the web to find a tarball for, say, version `1.2.3`, but the rendered package only contains the version and checksum, and still relies on URL interpolation:

```python
class Foo(Package):
    homepage = "https://example.com/foo"
    url      = "https://example.com/foo/foo-1.0.0.tar.gz"

    version("1.2.3", sha256="abc123...")  # URL discovered via spider, but not recorded
```

If the URL pattern for `1.2.3` does not match the base `url` interpolation, `spack install foo@1.2.3` will later fail.

**New behavior**

If the URL is discovered via spider, we include it directly in the `version` line:

```python
class Foo(Package):
    homepage = "https://example.com/foo"
    url      = "https://example.com/foo/foo-1.0.0.tar.gz"

    # URL was discovered via spider and is now persisted
    version("1.2.3", sha256="abc123...", url="https://example.com/releases/foo-1.2.3.tar.gz",)
```