### PR TITLE
solver: fix a small issue computing penalties for default values not being used

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1484,9 +1484,9 @@ variant_default_not_used(node(ID, Package), Variant, Value)
      node_has_variant(node(ID, Package), Variant, VariantID),
      variant_type(VariantID, VariantType), VariantType == "multi",
      not attr("variant_value", node(ID, Package), Variant, Value),
-     not propagate(node(ID, Package), variant_value(Variant, _, _)),
+     not propagate(node(ID, Package), variant_value(Variant, Value, _)),
      % variant set explicitly don't count for this metric
-     not attr("variant_set", node(ID, Package), Variant, _),
+     not attr("variant_set", node(ID, Package), Variant, Value),
      attr("node", node(ID, Package)).
 
 % Treat 'none' in a special way - it cannot be combined with other

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4866,3 +4866,12 @@ def test_penalties_for_variant_defined_by_function(
     """
     s = default_mock_concretization(spec_str)
     assert s.satisfies(expected)
+
+
+def test_default_values_used_if_subset_required_by_dependent(mock_packages):
+    """If a dependent requires *at least* a subset of default values of a multi-valued variant of
+    a dependency, that should not influence concretization; the default values should be used."""
+    # multivalue-variant-multi-defaults-dependent requires myvariant=bar without baz.
+    a = spack.concretize.concretize_one("multivalue-variant-multi-defaults-dependent")
+    # we still end up using baz, and we don't drop it to avoid an extra dependency.
+    assert a.satisfies("%multivalue-variant-multi-defaults myvariant=bar,baz")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/multivalue_variant_multi_defaults/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/multivalue_variant_multi_defaults/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class MultivalueVariantMultiDefaults(Package):
+    homepage = "http://www.spack.llnl.gov"
+    url = "http://www.spack.llnl.gov/mpileaks-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    variant(
+        "myvariant",
+        default="bar,baz",
+        values=("bar", "baz"),
+        multi=True,
+        description="Type of libraries to install",
+    )
+
+    # conditional dep to incur a cost for packages to build when myvariant includes baz
+    depends_on("trivial-install-test-package", when="myvariant=baz")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/multivalue_variant_multi_defaults_dependent/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/multivalue_variant_multi_defaults_dependent/package.py
@@ -1,0 +1,18 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class MultivalueVariantMultiDefaultsDependent(Package):
+    homepage = "http://www.spack.llnl.gov"
+    url = "http://www.spack.llnl.gov/mpileaks-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    # includes a subset of the default values `bar,baz`; we expect the request for myvariant=bar
+    # not to override the default myvariant=bar,baz
+    depends_on("multivalue-variant-multi-defaults myvariant=bar")


### PR DESCRIPTION
Currently, the rule is:
```
Don't give a penalty to <value> if there's any value set in this variant
or if any value is propagated.
```
with the PR it becomes:
```
Don't give a penalty to <value> if <value> is set in this variant
or if <value> is propagated.
```

This should slightly change optimization in a few edge cases, but seems more correct.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
