### PR TITLE
release docs: document version update before cherry-picked backports

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -865,6 +865,9 @@ The majority of the work is to cherry-pick the bug fixes, which ideally should b
 The backports pull request is always titled ``Backports vX.Y.Z`` and is labelled ``backports``.
 It is opened from a branch named ``backports/vX.Y.Z`` and targets the ``releases/vX.Y`` branch.
 
+The first commit on the ``backports/vX.Y.Z`` branch should update the Spack version to ``X.Y.Z.dev0``, and should have the commit message ``set version to X.Y.Z.dev0``.
+This ensures that if users check out an intermediate commit between two patch releases, Spack reports the version correctly.
+
 Whenever a pull request labelled ``vX.Y.Z`` is merged, cherry-pick the associated squashed commit on ``develop`` to the ``backports/vX.Y.Z`` branch.
 For pull requests that were rebased (or not squashed), cherry-pick each associated commit individually.
 Never force-push to the ``backports/vX.Y.Z`` branch.


### PR DESCRIPTION
@haampie correctly requested this behavior on https://github.com/spack/spack/pull/51835#discussion_r2692264926

This PR updates the release documentation to reflect that step of the process.