### PR TITLE
git: fix locking issue in pull_checkout_branch

### DIFF
--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -202,7 +202,7 @@ def pull_checkout_branch(
             raise ValueError("depth must be a positive integer")
         fetch_args.append(f"--depth={depth}")
 
-    git_exe("fetch", *fetch_args, remote, f"{branch}:refs/remotes/{remote}/{branch}")
+    git_exe("fetch", *fetch_args, remote, f"refs/heads/{branch}:refs/remotes/{remote}/{branch}")
     git_exe("checkout", "--quiet", branch)
 
     try:


### PR DESCRIPTION
After https://github.com/spack/spack/pull/51779, I started experiencing git locking issues like the following when attempting to update my packages repository.

```console
> spack repo update
remote: Enumerating objects: 214, done.
remote: Counting objects: 100% (168/168), done.
remote: Compressing objects: 100% (70/70), done.
remote: Total 127 (delta 46), reused 84 (delta 18), pack-reused 0 (from 0)
error: cannot lock ref 'refs/remotes/upstream/develop': unable to resolve reference 'refs/remotes/upstream/develop'
```

Previously we'd used 

```python3
git fetch <remote> <branch>
```

which is shorthand for:

```
git fetch <remote> refs/heads/<branch>:refs/remotes/<remote>/<branch>
```

this was modified to the following to support RHEL7 (although we're unsure why this started creating the reference on old versions of git?)

```
git fetch <remote> <branch>:refs/remotes/<remote>/<branch>
```

This syntax bypasses a users configured refspecs and says "take whatever `<remote>` gives me for `<branch>` and write it directly to `refs/remotes/<remote>/<branch>` which causes locking errors with some user / repository git configurations. After updating the command syntax to be the explicit form of what we'd been using before I am no longer experiencing any issues.
