### PR TITLE
directives.py/asp.py: use literal/anonymous spec in when condition

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -497,12 +497,6 @@ def _execute_provides(pkg: PackageType, specs: Tuple[SpecType, ...], when: WhenT
     when_spec = _make_when_spec(when)
     if not when_spec:
         return
-    elif when_spec is EMPTY_SPEC:
-        when_spec = spack.spec.Spec()  # this function mutates, so can't use EMPTY_SPEC
-
-    # ``when`` specs for ``provides()`` need a name, as they are used
-    # to build the ProviderIndex.
-    when_spec.name = pkg.name
 
     spec_objs = [spack.spec.Spec(x) for x in specs]
     spec_names = [x.name for x in spec_objs]
@@ -511,10 +505,9 @@ def _execute_provides(pkg: PackageType, specs: Tuple[SpecType, ...], when: WhenT
 
     for provided_spec in spec_objs:
         if pkg.name == provided_spec.name:
-            raise CircularReferenceError("Package '%s' cannot provide itself." % pkg.name)
+            raise CircularReferenceError(f"Package '{pkg.name}' cannot provide itself.")
 
-        provided_set = pkg.provided.setdefault(when_spec, set())
-        provided_set.add(provided_spec)
+        pkg.provided.setdefault(when_spec, set()).add(provided_spec)
 
 
 @directive("splice_specs")

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1794,21 +1794,21 @@ class SpackSolverSetup:
 
         return condition_id
 
-    def package_provider_rules(self, pkg):
+    def package_provider_rules(self, pkg: Type[spack.package_base.PackageBase]) -> None:
         for vpkg_name in pkg.provided_virtual_names():
             if vpkg_name not in self.possible_virtuals:
                 continue
             self.gen.fact(fn.pkg_fact(pkg.name, fn.possible_provider(vpkg_name)))
 
         for when, provided in pkg.provided.items():
-            for vpkg in sorted(provided):
+            for vpkg in sorted(provided):  # type: ignore[type-var]
                 if vpkg.name not in self.possible_virtuals:
                     continue
 
-                msg = f"{pkg.name} provides {vpkg} when {when}"
+                msg = f"{pkg.name} provides {vpkg}{'' if when == EMPTY_SPEC else f' when {when}'}"
                 condition_id = self.condition(when, vpkg, required_name=pkg.name, msg=msg)
                 self.gen.fact(
-                    fn.pkg_fact(when.name, fn.provider_condition(condition_id, vpkg.name))
+                    fn.pkg_fact(pkg.name, fn.provider_condition(condition_id, vpkg.name))
                 )
             self.gen.newline()
 


### PR DESCRIPTION
`provides(... when=...)` was the only directive that mutates the `when` spec.

That was redundant, as the pkg name is available when emitting facts.

This also ensures trigger ids are reused better, resulting in shorter ASP (unlikely to be noticeable...):

```
grep 'trigger_id' before.lp  | wc -l
8219
grep 'trigger_id' after.lp  | wc -l
8199
```

The provider index remains the same, I've verified by diffing its normalized json before and after using:

```python
import json
import sys

with open(sys.argv[1], "r") as f:
    data = json.load(f)

def sort_all_lists(x):
    if isinstance(x, dict):
        for y in x.values():
            sort_all_lists(y)
    elif isinstance(x, list):
        x.sort(key=str)
        for y in x:
            sort_all_lists(y)

sort_all_lists(data)

json.dump(data, sys.stdout, indent=4, sort_keys=True)
```