### PR TITLE
environment: consolidate a few attributes

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1557,15 +1557,14 @@ class Environment:
             self.write()
 
     def concretize(
-        self, force: Optional[bool] = None, tests: Union[bool, Sequence] = False
+        self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
     ) -> Sequence[SpecPair]:
         """Concretize user_specs in this environment.
 
-        Only concretizes specs that haven't been concretized yet unless
-        force is ``True``.
+        Only concretizes specs that haven't been concretized yet unless force is ``True``.
 
-        This only modifies the environment in memory. ``write()`` will
-        write out a lockfile containing concretized specs.
+        This only modifies the environment in memory. ``write()`` will write out a lockfile
+        containing concretized specs.
 
         Arguments:
             force: re-concretize ALL specs, even those that were already concretized;
@@ -1582,15 +1581,26 @@ class Environment:
 
         self._prepare_for_concretization(force=force)
 
+        # Exit early if the set of concretized specs is the set of user specs
+        new_user_specs, kept_user_specs, specs_to_concretize = self._get_specs_to_concretize()
+        if not new_user_specs:
+            return []
+
         # Pick the right concretization strategy
         if self.unify == "when_possible":
-            return self._concretize_together_where_possible(tests=tests)
+            return self._concretize_together_where_possible(
+                new_user_specs, kept_user_specs, specs_to_concretize, tests=tests
+            )
 
         if self.unify is True:
-            return self._concretize_together(tests=tests)
+            return self._concretize_together(
+                new_user_specs, kept_user_specs, specs_to_concretize, tests=tests
+            )
 
         if self.unify is False:
-            return self._concretize_separately(tests=tests)
+            return self._concretize_separately(
+                new_user_specs, kept_user_specs, specs_to_concretize, tests=tests
+            )
 
         msg = "concretization strategy not implemented [{0}]"
         raise SpackEnvironmentError(msg.format(self.unify))
@@ -1598,18 +1608,24 @@ class Environment:
     def _prepare_for_concretization(self, *, force: bool):
         """Reset the environment concrete state and ensure consistency with user specs."""
         if force:
-            # Clear previously concretized specs
-            self.concretized_roots = []
-            self.specs_by_hash = {}
-
-        # Remove concrete specs that no longer correlate to a user spec
-        to_deconcretize = [x.root for x in self.concretized_roots if x.root not in self.user_specs]
-        for spec in to_deconcretize:
-            self.deconcretize(spec, concrete=False)
+            self.clear_concretized_specs()
+        else:
+            self.sync_concretized_specs()
 
         # If a combined env, check updated spec is in the linked envs
         if self.included_concrete_envs:
             self.include_concrete_envs()
+
+    def sync_concretized_specs(self) -> None:
+        """Removes concrete specs that no longer correlate to a user spec"""
+        to_deconcretize = [x.root for x in self.concretized_roots if x.root not in self.user_specs]
+        for spec in to_deconcretize:
+            self.deconcretize(spec, concrete=False)
+
+    def clear_concretized_specs(self) -> None:
+        """Clears the currently concretized specs"""
+        self.concretized_roots = []
+        self.specs_by_hash = {}
 
     def deconcretize(self, spec: spack.spec.Spec, concrete: bool = True):
         """
@@ -1670,13 +1686,14 @@ class Environment:
         return new_user_specs, kept_user_specs, specs_to_concretize
 
     def _concretize_together_where_possible(
-        self, tests: Union[bool, Sequence] = False
+        self,
+        new_user_specs: List[Spec],
+        kept_user_specs: List[Spec],
+        specs_to_concretize: List[SpecPair],
+        *,
+        tests: Union[bool, Sequence] = False,
     ) -> Sequence[SpecPair]:
         # Exit early if the set of concretized specs is the set of user specs
-        new_user_specs, _, specs_to_concretize = self._get_specs_to_concretize()
-        if not new_user_specs:
-            return []
-
         result = spack.concretize.concretize_together_when_possible(
             specs_to_concretize, tests=tests
         )
@@ -1686,15 +1703,17 @@ class Environment:
 
         return result
 
-    def _concretize_together(self, tests: Union[bool, Sequence] = False) -> Sequence[SpecPair]:
+    def _concretize_together(
+        self,
+        new_user_specs: List[Spec],
+        kept_user_specs: List[Spec],
+        specs_to_concretize: List[SpecPair],
+        *,
+        tests: Union[bool, Sequence] = False,
+    ) -> Sequence[SpecPair]:
         """Concretization strategy that concretizes all the specs
         in the same DAG.
         """
-        # Exit early if the set of concretized specs is the set of user specs
-        new_user_specs, kept_user_specs, specs_to_concretize = self._get_specs_to_concretize()
-        if not new_user_specs:
-            return []
-
         try:
             concretized_specs = spack.concretize.concretize_together(
                 specs_to_concretize, tests=tests
@@ -1721,14 +1740,17 @@ class Environment:
             self._add_concrete_spec(abstract, concrete, new=True)
         return result
 
-    def _concretize_separately(self, tests: Union[bool, Sequence] = False):
+    def _concretize_separately(
+        self,
+        new_user_specs: List[Spec],
+        kept_user_specs: List[Spec],
+        specs_to_concretize: List[SpecPair],
+        *,
+        tests: Union[bool, Sequence] = False,
+    ):
         """Concretization strategy that concretizes separately one
         user spec after the other.
         """
-        # Exit early if the set of concretized specs is the set of user specs
-        new_user_specs, _, _ = self._get_specs_to_concretize()
-        if not new_user_specs:
-            return []
         to_concretize = [(root, None) for root in new_user_specs]
 
         concretized_specs = spack.concretize.concretize_separately(to_concretize, tests=tests)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1223,12 +1223,7 @@ class Environment:
         return spec_list
 
     def clear(self):
-        """Clear the contents of the environment
-
-        Arguments:
-            re_read: If ``True``, do not clear ``new_specs``. This value cannot be read from yaml,
-                and needs to be maintained when re-reading an existing environment.
-        """
+        """Clear the contents of the environment"""
         self.spec_lists = {}
         self._dev_specs = {}
         self.concretized_roots = []
@@ -1691,7 +1686,7 @@ class Environment:
         kept_user_specs: List[Spec],
         specs_to_concretize: List[SpecPair],
         *,
-        tests: Union[bool, Sequence] = False,
+        tests: Union[bool, Sequence[str]] = False,
     ) -> Sequence[SpecPair]:
         # Exit early if the set of concretized specs is the set of user specs
         result = spack.concretize.concretize_together_when_possible(
@@ -1709,7 +1704,7 @@ class Environment:
         kept_user_specs: List[Spec],
         specs_to_concretize: List[SpecPair],
         *,
-        tests: Union[bool, Sequence] = False,
+        tests: Union[bool, Sequence[str]] = False,
     ) -> Sequence[SpecPair]:
         """Concretization strategy that concretizes all the specs
         in the same DAG.
@@ -1746,7 +1741,7 @@ class Environment:
         kept_user_specs: List[Spec],
         specs_to_concretize: List[SpecPair],
         *,
-        tests: Union[bool, Sequence] = False,
+        tests: Union[bool, Sequence[str]] = False,
     ):
         """Concretization strategy that concretizes separately one
         user spec after the other.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1906,16 +1906,17 @@ class Environment:
 
         return env_mod
 
-    def _add_concrete_spec(self, spec, concrete, new=True):
+    def _add_concrete_spec(
+        self, spec: spack.spec.Spec, concrete: spack.spec.Spec, *, new: bool = True
+    ):
         """Called when a new concretized spec is added to the environment.
 
         This ensures that all internal data structures are kept in sync.
 
         Arguments:
-            spec (Spec): user spec that resulted in the concrete spec
-            concrete (Spec): spec concretized within this environment
-            new (bool): whether to write this spec's package to the env
-                repo on write()
+            spec: user spec that resulted in the concrete spec
+            concrete: spec concretized within this environment
+            new: whether to write this spec's package to the env repo on write()
         """
         assert concrete.concrete
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1568,19 +1568,7 @@ class Environment:
         if force is None:
             force = spack.config.get("concretizer:force")
 
-        if force:
-            # Clear previously concretized specs
-            self.concretized_user_specs = []
-            self.concretized_order = []
-            self.specs_by_hash = {}
-
-        # Remove concrete specs that no longer correlate to a user spec
-        for spec in set(self.concretized_user_specs) - set(self.user_specs):
-            self.deconcretize(spec, concrete=False)
-
-        # If a combined env, check updated spec is in the linked envs
-        if self.included_concrete_envs:
-            self.include_concrete_envs()
+        self._prepare_for_concretization(force=force)
 
         # Pick the right concretization strategy
         if self.unify == "when_possible":
@@ -1594,6 +1582,22 @@ class Environment:
 
         msg = "concretization strategy not implemented [{0}]"
         raise SpackEnvironmentError(msg.format(self.unify))
+
+    def _prepare_for_concretization(self, *, force: bool):
+        """Reset the environment concrete state and ensure consistency with user specs."""
+        if force:
+            # Clear previously concretized specs
+            self.concretized_user_specs = []
+            self.concretized_order = []
+            self.specs_by_hash = {}
+
+        # Remove concrete specs that no longer correlate to a user spec
+        for spec in set(self.concretized_user_specs) - set(self.user_specs):
+            self.deconcretize(spec, concrete=False)
+
+        # If a combined env, check updated spec is in the linked envs
+        if self.included_concrete_envs:
+            self.include_concrete_envs()
 
     def deconcretize(self, spec: spack.spec.Spec, concrete: bool = True):
         """

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -40,6 +40,7 @@ import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack import traverse
 from spack.llnl.util.filesystem import copy_tree, islink, readlink, symlink
+from spack.llnl.util.lang import stable_partition
 from spack.llnl.util.link_tree import ConflictingSpecsError
 from spack.schema.env import TOP_LEVEL_KEY
 from spack.spec import Spec
@@ -963,6 +964,20 @@ def env_subdir_path(manifest_dir: Union[str, pathlib.Path]) -> str:
     return os.path.join(str(manifest_dir), env_subdir_name)
 
 
+class ConcretizedRootInfo:
+    """Data on root specs that have been concretized"""
+
+    __slots__ = ("root", "hash", "new")
+
+    def __init__(self, *, root_spec: spack.spec.Spec, root_hash: str, new: bool = False):
+        self.root = root_spec
+        self.hash = root_hash
+        self.new = new
+
+    def __str__(self):
+        return f"{self.root} -> {self.hash} [new={self.new}]"
+
+
 class Environment:
     """A Spack environment, which bundles together configuration and a list of specs."""
 
@@ -980,17 +995,14 @@ class Environment:
         self.txlock = lk.Lock(self._transaction_lock_path)
 
         self._unify = None
-        self.new_specs: List[Spec] = []
         self.views: Dict[str, ViewDescriptor] = {}
 
         #: Parser for spec lists
         self._spec_lists_parser = SpecListParser()
         #: Specs from "spack.yaml"
         self.spec_lists: Dict[str, SpecList] = {}
-        #: User specs from the last concretization
-        self.concretized_user_specs: List[Spec] = []
-        #: Roots associated with the last concretization, in order
-        self.concretized_order: List[str] = []
+        #: Information on concretized roots
+        self.concretized_roots: List[ConcretizedRootInfo] = []
         #: Concretized specs by hash
         self.specs_by_hash: Dict[str, Spec] = {}
         #: Repository for this environment (memoized)
@@ -1046,7 +1058,7 @@ class Environment:
 
     def _re_read(self):
         """Reinitialize the environment object."""
-        self.clear(re_read=True)
+        self.clear()
         self._load_manifest_file()
 
     def _read(self):
@@ -1151,7 +1163,7 @@ class Environment:
     def all_concretized_user_specs(self) -> List[Spec]:
         """Returns all of the concretized user specs of the environment and
         its included environment(s)."""
-        concretized_user_specs = self.concretized_user_specs[:]
+        concretized_user_specs = self.concretized_user_specs
         for included_specs in self.included_concretized_user_specs.values():
             for included in included_specs:
                 # Don't duplicate included spec(s)
@@ -1163,7 +1175,7 @@ class Environment:
     def all_concretized_orders(self) -> List[str]:
         """Returns all of the concretized order of the environment and
         its included environment(s)."""
-        concretized_order = self.concretized_order[:]
+        concretized_order = [x.hash for x in self.concretized_roots]
         for included_concretized_order in self.included_concretized_order.values():
             for included in included_concretized_order:
                 # Don't duplicate included spec(s)
@@ -1210,7 +1222,7 @@ class Environment:
         add_root_specs(self.included_concrete_spec_data)
         return spec_list
 
-    def clear(self, re_read=False):
+    def clear(self):
         """Clear the contents of the environment
 
         Arguments:
@@ -1219,8 +1231,7 @@ class Environment:
         """
         self.spec_lists = {}
         self._dev_specs = {}
-        self.concretized_order = []  # roots of last concretize, in order
-        self.concretized_user_specs = []  # user specs from last concretize
+        self.concretized_roots = []
         self.specs_by_hash = {}  # concretized specs by hash
 
         self.included_concrete_spec_data = {}  # concretized specs from lockfile of included envs
@@ -1230,9 +1241,6 @@ class Environment:
 
         self.invalidate_repository_cache()
         self._previous_active = None  # previously active environment
-        if not re_read:
-            # things that cannot be recreated from file
-            self.new_specs = []  # write packages for these on write()
 
         self.manifest.clear()
 
@@ -1317,7 +1325,7 @@ class Environment:
             if transitive:
                 self.included_concrete_spec_data[env_path]["include_concrete"] = transitive
 
-        self._read_lockfile_dict(self._to_lockfile_dict())
+        self._unify_specs()
         self.write()
 
     def destroy(self):
@@ -1426,10 +1434,8 @@ class Environment:
             matches = [s for s in list_to_change if s.satisfies(query_spec)]
 
         else:
-            # concrete specs match against concrete specs in the env
-            # by dag hash.
-            specs_hashes = zip(self.concretized_user_specs, self.concretized_order)
-            matches = [s for s, h in specs_hashes if query_spec.dag_hash() == h]
+            # concrete specs match against concrete specs in the env by dag hash.
+            matches = [x.root for x in self.concretized_roots if query_spec.dag_hash() == x.hash]
 
         if not matches:
             raise SpackEnvironmentError(f"{err_msg_header}, no spec matches")
@@ -1458,14 +1464,13 @@ class Environment:
         new_specs = set(self.user_specs)
 
         # If 'force', update stale concretized specs
-        for spec in old_specs - new_specs:
-            if force and spec in self.concretized_user_specs:
-                i = self.concretized_user_specs.index(spec)
-                del self.concretized_user_specs[i]
-
-                dag_hash = self.concretized_order[i]
-                del self.concretized_order[i]
-                del self.specs_by_hash[dag_hash]
+        if force:
+            stale_specs = old_specs - new_specs
+            self.concretized_roots, removed = stable_partition(
+                self.concretized_roots, lambda x: x.root not in stale_specs
+            )
+            for x in removed:
+                del self.specs_by_hash[x.hash]
 
     def is_develop(self, spec):
         """Returns true when the spec is built from local sources"""
@@ -1535,11 +1540,18 @@ class Environment:
             parent.clear_caches()
 
         # Compute new hashes and update the env list of specs
+        hash_mutations = {}
         for root, old_hash in modified_roots:
+            # New hash must be computed after we finalize concretization
             root._finalize_concretization()
-            self.concretized_order[self.concretized_order.index(old_hash)] = root.dag_hash()
+            new_hash = root.dag_hash()
             self.specs_by_hash.pop(old_hash)
-            self.specs_by_hash[root.dag_hash()] = root
+            self.specs_by_hash[new_hash] = root
+            hash_mutations[old_hash] = new_hash
+
+        for x in self.concretized_roots:
+            if x.hash in hash_mutations:
+                x.hash = hash_mutations[x.hash]
 
         if modified_roots:
             self.write()
@@ -1587,12 +1599,12 @@ class Environment:
         """Reset the environment concrete state and ensure consistency with user specs."""
         if force:
             # Clear previously concretized specs
-            self.concretized_user_specs = []
-            self.concretized_order = []
+            self.concretized_roots = []
             self.specs_by_hash = {}
 
         # Remove concrete specs that no longer correlate to a user spec
-        for spec in set(self.concretized_user_specs) - set(self.user_specs):
+        to_deconcretize = [x.root for x in self.concretized_roots if x.root not in self.user_specs]
+        for spec in to_deconcretize:
             self.deconcretize(spec, concrete=False)
 
         # If a combined env, check updated spec is in the linked envs
@@ -1611,24 +1623,24 @@ class Environment:
         # spec has to be a root of the environment
         if concrete:
             dag_hash = spec.dag_hash()
-
-            pairs = zip(self.concretized_user_specs, self.concretized_order)
-            filtered = [(spec, h) for spec, h in pairs if h != dag_hash]
-            # Cannot use zip and unpack two values; it fails if filtered is empty
-            self.concretized_user_specs = [s for s, _ in filtered]
-            self.concretized_order = [h for _, h in filtered]
+            self.concretized_roots = [x for x in self.concretized_roots if x.hash != dag_hash]
         else:
-            index = self.concretized_user_specs.index(spec)
-            dag_hash = self.concretized_order.pop(index)
-
-            del self.concretized_user_specs[index]
+            self.concretized_roots, discarded = stable_partition(
+                self.concretized_roots, lambda x: x.root != spec
+            )
+            assert (
+                len({x.hash for x in discarded}) == 1
+            ), "More than one hash associated with a single user spec"
+            dag_hash = discarded[0].hash
 
         # If this was the only user spec that concretized to this concrete spec, remove it
-        if dag_hash not in self.concretized_order:
-            # if we deconcretized a dependency that doesn't correspond to a root, it
-            # won't be here.
-            if dag_hash in self.specs_by_hash:
-                del self.specs_by_hash[dag_hash]
+        if not self.user_spec_with_hash(dag_hash) and dag_hash in self.specs_by_hash:
+            # if we deconcretized a dependency that doesn't correspond to a root, it won't be here.
+            del self.specs_by_hash[dag_hash]
+
+    def user_spec_with_hash(self, dag_hash: str) -> bool:
+        """Returns True if any user spec is associated with a concrete spec with the given hash"""
+        return any(x.hash == dag_hash for x in self.concretized_roots)
 
     def _get_specs_to_concretize(
         self,
@@ -1642,8 +1654,10 @@ class Environment:
 
         """
         # Exit early if the set of concretized specs is the set of user specs
-        new_user_specs = list(set(self.user_specs) - set(self.concretized_user_specs))
-        kept_user_specs = list(set(self.user_specs) & set(self.concretized_user_specs))
+        concretized_user_specs = {x.root for x in self.concretized_roots}
+        kept_user_specs, new_user_specs = stable_partition(
+            self.user_specs, lambda x: x in concretized_user_specs
+        )
         kept_user_specs += self.included_user_specs
         if not new_user_specs:
             return new_user_specs, kept_user_specs, []
@@ -1663,24 +1677,14 @@ class Environment:
         if not new_user_specs:
             return []
 
-        self.concretized_user_specs = []
-        self.concretized_order = []
-        self.specs_by_hash = {}
-
-        ret = []
         result = spack.concretize.concretize_together_when_possible(
             specs_to_concretize, tests=tests
         )
+        result = [x for x in result if x[0] in new_user_specs]
         for abstract, concrete in result:
-            # Only add to the environment if it's from this environment (not included in)
-            if abstract in self.user_specs:
-                self._add_concrete_spec(abstract, concrete)
+            self._add_concrete_spec(abstract, concrete, new=True)
 
-            # Return only the new specs
-            if abstract in new_user_specs:
-                ret.append((abstract, concrete))
-
-        return ret
+        return result
 
     def _concretize_together(self, tests: Union[bool, Sequence] = False) -> Sequence[SpecPair]:
         """Concretization strategy that concretizes all the specs
@@ -1690,10 +1694,6 @@ class Environment:
         new_user_specs, kept_user_specs, specs_to_concretize = self._get_specs_to_concretize()
         if not new_user_specs:
             return []
-
-        self.concretized_user_specs = []
-        self.concretized_order = []
-        self.specs_by_hash = {}
 
         try:
             concretized_specs = spack.concretize.concretize_together(
@@ -1715,45 +1715,36 @@ class Environment:
                 )
             raise
 
-        for abstract, concrete in concretized_specs:
-            # Don't add if it's just included
-            if abstract in self.user_specs:
-                self._add_concrete_spec(abstract, concrete)
-
         # Return the portion of the return value that is new
-        return concretized_specs[: len(new_user_specs)]
+        result = concretized_specs[: len(new_user_specs)]
+        for abstract, concrete in result:
+            self._add_concrete_spec(abstract, concrete, new=True)
+        return result
 
     def _concretize_separately(self, tests: Union[bool, Sequence] = False):
         """Concretization strategy that concretizes separately one
         user spec after the other.
         """
-        # keep any concretized specs whose user specs are still in the manifest
-        old_concretized_user_specs = self.concretized_user_specs
-        old_concretized_order = self.concretized_order
-        old_specs_by_hash = self.specs_by_hash
+        # Exit early if the set of concretized specs is the set of user specs
+        new_user_specs, _, _ = self._get_specs_to_concretize()
+        if not new_user_specs:
+            return []
+        to_concretize = [(root, None) for root in new_user_specs]
 
-        self.concretized_user_specs = []
-        self.concretized_order = []
-        self.specs_by_hash = {}
-
-        for s, h in zip(old_concretized_user_specs, old_concretized_order):
-            if s in self.user_specs:
-                concrete = old_specs_by_hash[h]
-                self._add_concrete_spec(s, concrete, new=False)
-
-        to_concretize = [
-            (root, None) for root in self.user_specs if root not in old_concretized_user_specs
-        ]
         concretized_specs = spack.concretize.concretize_separately(to_concretize, tests=tests)
 
-        by_hash = {}
         for abstract, concrete in concretized_specs:
-            self._add_concrete_spec(abstract, concrete)
-            by_hash[concrete.dag_hash()] = concrete
+            self._add_concrete_spec(abstract, concrete, new=True)
 
         # Unify the specs objects, so we get correct references to all parents
-        self._read_lockfile_dict(self._to_lockfile_dict())
+        self._unify_specs()
         return concretized_specs
+
+    def _unify_specs(self) -> None:
+        # Keep the information on new specs by copying the concretized roots
+        old_concretized_roots = self.concretized_roots
+        self._read_lockfile_dict(self._to_lockfile_dict())
+        self.concretized_roots = old_concretized_roots
 
     @property
     def default_view(self):
@@ -1919,18 +1910,17 @@ class Environment:
             new: whether to write this spec's package to the env repo on write()
         """
         assert concrete.concrete
-
-        # when a spec is newly concretized, we need to make a note so
-        # that we can write its package to the env repo on write()
-        if new:
-            self.new_specs.append(concrete)
-
-        # update internal lists of specs
-        self.concretized_user_specs.append(spec)
-
         h = concrete.dag_hash()
-        self.concretized_order.append(h)
+        self.concretized_roots.append(ConcretizedRootInfo(root_spec=spec, root_hash=h, new=new))
         self.specs_by_hash[h] = concrete
+
+    @property
+    def concretized_order(self) -> List[str]:
+        return [x.hash for x in self.concretized_roots]
+
+    @property
+    def concretized_user_specs(self) -> List[Spec]:
+        return [x.root for x in self.concretized_roots]
 
     def _dev_specs_that_need_overwrite(self):
         """Return the hashes of all specs that need to be reinstalled due to source code change."""
@@ -2240,8 +2230,7 @@ class Environment:
         return concrete_specs
 
     def _concrete_roots_dict(self):
-        hash_spec_list = zip(self.concretized_order, self.concretized_user_specs)
-        return [{"hash": h, "spec": str(s)} for h, s in hash_spec_list]
+        return [{"hash": x.hash, "spec": str(x.root)} for x in self.concretized_roots]
 
     def _to_lockfile_dict(self):
         """Create a dictionary to store a lockfile for this environment."""
@@ -2329,8 +2318,12 @@ class Environment:
         self.included_concretized_order = {}
 
         roots = d["roots"]
-        self.concretized_user_specs = [Spec(r["spec"]) for r in roots]
-        self.concretized_order = [r["hash"] for r in roots]
+
+        self.concretized_roots = [
+            ConcretizedRootInfo(root_spec=Spec(r["spec"]), root_hash=r["hash"], new=False)
+            for r in roots
+        ]
+
         json_specs_by_hash = d["concrete_specs"]
         included_json_specs_by_hash = {}
 
@@ -2354,11 +2347,12 @@ class Environment:
                 msg += " You need to use a newer Spack version."
             raise SpackEnvironmentError(msg)
 
-        first_seen, self.concretized_order = self._filter_specs(
-            reader, json_specs_by_hash, self.concretized_order
+        concretized_order = [x.hash for x in self.concretized_roots]
+        first_seen, concretized_order = self._filter_specs(
+            reader, json_specs_by_hash, concretized_order
         )
-
-        for spec_dag_hash in self.concretized_order:
+        for idx, spec_dag_hash in enumerate(concretized_order):
+            self.concretized_roots[idx].hash = spec_dag_hash
             self.specs_by_hash[spec_dag_hash] = first_seen[spec_dag_hash]
 
         if any(self.included_concretized_order.values()):
@@ -2378,7 +2372,7 @@ class Environment:
                     )
 
     def _filter_specs(self, reader, json_specs_by_hash, order_concretized):
-        # Track specs by their lockfile key.  Currently spack uses the finest
+        # Track specs by their lockfile key.  Currently, spack uses the finest
         # grained hash as the lockfile key, while older formats used the build
         # hash or a previous incarnation of the DAG hash (one that did not
         # include build deps or package hash).
@@ -2460,7 +2454,8 @@ class Environment:
         if regenerate:
             self.regenerate_views()
 
-        self.new_specs.clear()
+        for x in self.concretized_roots:
+            x.new = False
 
     def update_lockfile(self) -> None:
         with fs.write_tmp_and_move(self.lock_path, encoding="utf-8") as f:
@@ -2478,7 +2473,8 @@ class Environment:
 
     def update_environment_repository(self) -> None:
         """Updates the repository associated with the environment."""
-        for spec in traverse.traverse_nodes(self.new_specs):
+        new_specs = [self.specs_by_hash[x.hash] for x in self.concretized_roots if x.new]
+        for spec in traverse.traverse_nodes(new_specs):
             if not spec.concrete:
                 raise ValueError("specs passed to environment.write() must be concrete!")
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2353,7 +2353,7 @@ class Environment:
                 msg += " You need to use a newer Spack version."
             raise SpackEnvironmentError(msg)
 
-        first_seen, self.concretized_order = self.filter_specs(
+        first_seen, self.concretized_order = self._filter_specs(
             reader, json_specs_by_hash, self.concretized_order
         )
 
@@ -2364,7 +2364,7 @@ class Environment:
             first_seen = {}
 
             for env_name, concretized_order in self.included_concretized_order.items():
-                filtered_spec, self.included_concretized_order[env_name] = self.filter_specs(
+                filtered_spec, self.included_concretized_order[env_name] = self._filter_specs(
                     reader, included_json_specs_by_hash, concretized_order
                 )
                 first_seen.update(filtered_spec)
@@ -2376,7 +2376,7 @@ class Environment:
                         {spec_dag_hash: first_seen[spec_dag_hash]}
                     )
 
-    def filter_specs(self, reader, json_specs_by_hash, order_concretized):
+    def _filter_specs(self, reader, json_specs_by_hash, order_concretized):
         # Track specs by their lockfile key.  Currently spack uses the finest
         # grained hash as the lockfile key, while older formats used the build
         # hash or a previous incarnation of the DAG hash (one that did not

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -59,10 +59,9 @@ def test_hash_change_no_rehash_concrete(tmp_path: pathlib.Path, config):
     env.concretize()
 
     # rewrite the hash
-    old_hash = env.concretized_order[0]
-    new_hash = "abc"
+    old_hash, new_hash = env.concretized_roots[0].hash, "abc"
     env.specs_by_hash[old_hash]._hash = new_hash  # type: ignore[attr-defined]
-    env.concretized_order[0] = new_hash
+    env.concretized_roots[0].hash = new_hash
     env.specs_by_hash[new_hash] = env.specs_by_hash[old_hash]
     del env.specs_by_hash[old_hash]
     env.write()
@@ -795,14 +794,15 @@ def test_env_with_include_def_missing(mutable_mock_env_path):
 
 
 @pytest.mark.regression("41292")
-def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path):
+@pytest.mark.parametrize("unify", ["true", "false", "when_possible"])
+def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unify):
     """Tests that, after having deconcretized a spec, we can reconcretize an environment which
     has 2 or more user specs mapping to the same concrete spec.
     """
     mutable_mock_env_path.mkdir()
     spack_yaml = mutable_mock_env_path / ev.manifest_name
     spack_yaml.write_text(
-        """spack:
+        f"""spack:
       specs:
       # These two specs concretize to the same hash
       - pkg-c
@@ -810,15 +810,30 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path):
       # Spec used to trigger the bug
       - pkg-a
       concretizer:
-        unify: true
+        unify: {unify}
     """
     )
     e = ev.Environment(mutable_mock_env_path)
+    # Initial state
+    assert len(e.user_specs) == 3
+    assert len(e.concretized_roots) == 0
+
     with e:
         e.concretize()
+        assert len(e.user_specs) == 3
+        assert len(e.concretized_roots) == 3
+        assert all(x.new for x in e.concretized_roots)
+
         e.deconcretize(spack.spec.Spec("pkg-a"), concrete=False)
+        assert len(e.user_specs) == 3
+        assert len(e.concretized_roots) == 2
+        assert all(x.new for x in e.concretized_roots)
+
         e.concretize()
-    assert len(e.concrete_roots()) == 3
+        assert len(e.user_specs) == 3
+        assert len(e.concretized_roots) == 3
+        assert all(x.new for x in e.concretized_roots)
+
     all_root_hashes = {x.dag_hash() for x in e.concrete_roots()}
     assert len(all_root_hashes) == 2
 


### PR DESCRIPTION
As I started working on #49097 I noticed that the mapping from user specs to concrete specs in environments is currently spread over 3 attributes:
- `new_specs`: specs that have not been persisted yet (must be in `concretized_user_specs`)
- `concretized_user_specs`: user specs that have been concretized
- `concretized_order`: list of hashes corresponding to `concretized_user_specs` (must have the same order)

These attributes are updated separately in different methods but have logical dependencies among them. This makes it easy to introduce bugs by creating accidental inconsistencies.

Here we consolidate the 3 attributes into a single one, which is a list of:
```python
class ConcretizedRootInfo:
    """Data on root specs that have been concretized"""

    __slots__ = ("root", "hash", "new")

    def __init__(self, *, root_spec: spack.spec.Spec, root_hash: str, new: bool = False):
        self.root = root_spec
        self.hash = root_hash
        self.new = new
```

This refactor is currently not conflicting with #50207 (or better, the two conflicts to be solved are trivial, and tests passes). Also, I didn't try to consolidate the attributes related to included concrete environments, because those would heavily conflict with #50207 - so we should do that refactor after #50207 is merged.

In light of #49097 using a data structure like the above makes it easy to also add a `group` information to concretized specs.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
