### PR TITLE
variant.py: Sequence -> Iterable

### DIFF
--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -247,10 +247,10 @@ class Variant:
         )
 
 
-def _flatten(values) -> Collection:
+def _flatten(values) -> Tuple:
     """Flatten instances of _ConditionalVariantValues for internal representation"""
     if isinstance(values, DisjointSetsOfValues):
-        return values
+        return tuple(values)
 
     flattened: List = []
     for item in values:
@@ -511,9 +511,7 @@ class VariantValueRemoval(VariantValue):
         super().__init__(VariantType.INDICATOR, name, (None,))
 
 
-# The class below inherit from Sequence to disguise as a tuple and comply
-# with the semantic expected by the 'values' argument of the variant directive
-class DisjointSetsOfValues(collections.abc.Sequence):
+class DisjointSetsOfValues(collections.abc.Iterable):
     """Allows combinations from one of many mutually exclusive sets.
 
     The value ``('none',)`` is reserved to denote the empty set
@@ -597,11 +595,8 @@ class DisjointSetsOfValues(collections.abc.Sequence):
         )
         return object_without_empty_set
 
-    def __getitem__(self, idx):
-        return tuple(itertools.chain.from_iterable(self.sets))[idx]
-
-    def __len__(self):
-        return sum(len(x) for x in self.sets)
+    def __iter__(self):
+        return itertools.chain.from_iterable(self.sets)
 
     @property
     def validator(self):


### PR DESCRIPTION
Fix accidental quadratic complexity issue when iterating
DisjointSetsOfValues objects.

There's no efficient `__getindex__`, so stick to Iterable.