### PR TITLE
solver: improve the number of cache hits for triggers and effects

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1519,10 +1519,6 @@ class SpackSolverSetup:
 
         self.package_requirement_rules(pkg)
 
-        # trigger and effect tables
-        self.trigger_rules()
-        self.effect_rules()
-
     def trigger_rules(self):
         """Flushes all the trigger rules collected so far, and clears the cache."""
         if not self._trigger_cache:
@@ -3028,6 +3024,10 @@ class SpackSolverSetup:
             self.gen.h2(f"Package rules: {pkg}")
             self.pkg_rules(pkg, tests=self.tests)
             self.preferred_variants(pkg)
+
+        self.gen.h1("Condition Triggers and Imposed Effects")
+        self.trigger_rules()
+        self.effect_rules()
 
         self.gen.h1("Special variants")
         self.define_auto_variant("dev_path", multi=False)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -223,19 +223,19 @@ def identity_for_facts(
 # Caching because the returned function id is used as a cache key
 @functools.lru_cache(maxsize=None)
 def dependency_holds(
-    *, dependency_flags: dt.DepFlag, pkg: spack.package_base.PackageBase
+    *, dependency_flags: dt.DepFlag, pkg_cls: Type[spack.package_base.PackageBase]
 ) -> TransformFunction:
     def _transform_fn(
         name: str, input_spec: spack.spec.Spec, requirements: List[AspFunction]
     ) -> List[AspFunction]:
         result = remove_facts("node", "virtual_node")(name, input_spec, requirements) + [
-            fn.attr("dependency_holds", pkg.name, name, dt.flag_to_string(t))
+            fn.attr("dependency_holds", pkg_cls.name, name, dt.flag_to_string(t))
             for t in dt.ALL_FLAGS
             if t & dependency_flags
         ]
-        if name not in pkg.extendees:
+        if name not in pkg_cls.extendees:
             return result
-        return result + [fn.attr("extends", pkg.name, name)]
+        return result + [fn.attr("extends", pkg_cls.name, name)]
 
     return _transform_fn
 
@@ -1874,7 +1874,7 @@ class SpackSolverSetup:
                     pkg.name, ConstraintOrigin.DEPENDS_ON
                 )
                 context.transform_required = _track_dependencies
-                context.transform_imposed = dependency_holds(dependency_flags=depflag, pkg=pkg)
+                context.transform_imposed = dependency_holds(dependency_flags=depflag, pkg_cls=pkg)
                 self.condition(cond, dep.spec, required_name=pkg.name, msg=msg, context=context)
                 self.gen.newline()
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -209,7 +209,7 @@ def remove_facts(*to_be_removed: str) -> TransformFunction:
     """Returns a transformation function that removes facts from the input list of facts."""
 
     def _remove(name: str, spec: spack.spec.Spec, facts: List[AspFunction]) -> List[AspFunction]:
-        return list(filter(lambda x: x.args[0] not in to_be_removed, facts))
+        return [x for x in facts if x.args[0] not in to_be_removed]
 
     return _remove
 
@@ -218,6 +218,26 @@ def identity_for_facts(
     name: str, spec: spack.spec.Spec, facts: List[AspFunction]
 ) -> List[AspFunction]:
     return facts
+
+
+# Caching because the returned function id is used as a cache key
+@functools.lru_cache(maxsize=None)
+def dependency_holds(
+    *, dependency_flags: dt.DepFlag, pkg: spack.package_base.PackageBase
+) -> TransformFunction:
+    def _transform_fn(
+        name: str, input_spec: spack.spec.Spec, requirements: List[AspFunction]
+    ) -> List[AspFunction]:
+        result = remove_facts("node", "virtual_node")(name, input_spec, requirements) + [
+            fn.attr("dependency_holds", pkg.name, name, dt.flag_to_string(t))
+            for t in dt.ALL_FLAGS
+            if t & dependency_flags
+        ]
+        if name not in pkg.extendees:
+            return result
+        return result + [fn.attr("extends", pkg.name, name)]
+
+    return _transform_fn
 
 
 def dag_closure_by_deptype(
@@ -1830,26 +1850,6 @@ class SpackSolverSetup:
 
     def package_dependencies_rules(self, pkg):
         """Translate ``depends_on`` directives into ASP logic."""
-
-        # Caching because the returned function id is used as a cache key
-        @functools.lru_cache(maxsize=None)
-        def dependency_holds(
-            *, dependency_flags: dt.DepFlag
-        ) -> Callable[[str, spack.spec.Spec, List[AspFunction]], List[AspFunction]]:
-            def _transform_fn(
-                name: str, input_spec: spack.spec.Spec, requirements: List[AspFunction]
-            ) -> List[AspFunction]:
-                result = remove_facts("node", "virtual_node")(name, input_spec, requirements) + [
-                    fn.attr("dependency_holds", pkg.name, name, dt.flag_to_string(t))
-                    for t in dt.ALL_FLAGS
-                    if t & dependency_flags
-                ]
-                if name not in pkg.extendees:
-                    return result
-                return result + [fn.attr("extends", pkg.name, name)]
-
-            return _transform_fn
-
         for cond, deps_by_name in pkg.dependencies.items():
             cond_str = str(cond)
             cond_str_suffix = f" when {cond_str}" if cond_str else ""
@@ -1874,10 +1874,8 @@ class SpackSolverSetup:
                     pkg.name, ConstraintOrigin.DEPENDS_ON
                 )
                 context.transform_required = _track_dependencies
-                context.transform_imposed = dependency_holds(dependency_flags=depflag)
-
+                context.transform_imposed = dependency_holds(dependency_flags=depflag, pkg=pkg)
                 self.condition(cond, dep.spec, required_name=pkg.name, msg=msg, context=context)
-
                 self.gen.newline()
 
     def _gen_match_variant_splice_constraints(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -4,6 +4,7 @@
 import collections
 import collections.abc
 import enum
+import functools
 import gzip
 import io
 import itertools
@@ -202,6 +203,8 @@ def specify(spec):
     return spack.spec.Spec(spec)
 
 
+# Caching because the returned function id is used as a cache key
+@functools.lru_cache(maxsize=None)
 def remove_facts(*to_be_removed: str) -> TransformFunction:
     """Returns a transformation function that removes facts from the input list of facts."""
 
@@ -209,6 +212,12 @@ def remove_facts(*to_be_removed: str) -> TransformFunction:
         return list(filter(lambda x: x.args[0] not in to_be_removed, facts))
 
     return _remove
+
+
+def identity_for_facts(
+    name: str, spec: spack.spec.Spec, facts: List[AspFunction]
+) -> List[AspFunction]:
+    return facts
 
 
 def dag_closure_by_deptype(
@@ -1826,6 +1835,25 @@ class SpackSolverSetup:
     def package_dependencies_rules(self, pkg):
         """Translate ``depends_on`` directives into ASP logic."""
 
+        # Caching because the returned function id is used as a cache key
+        @functools.lru_cache(maxsize=None)
+        def dependency_holds(
+            *, dependency_flags: dt.DepFlag
+        ) -> Callable[[str, spack.spec.Spec, List[AspFunction]], List[AspFunction]]:
+            def _transform_fn(
+                name: str, input_spec: spack.spec.Spec, requirements: List[AspFunction]
+            ) -> List[AspFunction]:
+                result = remove_facts("node", "virtual_node")(name, input_spec, requirements) + [
+                    fn.attr("dependency_holds", pkg.name, name, dt.flag_to_string(t))
+                    for t in dt.ALL_FLAGS
+                    if t & dependency_flags
+                ]
+                if name not in pkg.extendees:
+                    return result
+                return result + [fn.attr("extends", pkg.name, name)]
+
+            return _transform_fn
+
         for cond, deps_by_name in pkg.dependencies.items():
             cond_str = str(cond)
             cond_str_suffix = f" when {cond_str}" if cond_str else ""
@@ -1845,32 +1873,12 @@ class SpackSolverSetup:
                     continue
 
                 msg = f"{pkg.name} depends on {dep.spec}{cond_str_suffix}"
-
-                def dependency_holds(
-                    name: str, input_spec: spack.spec.Spec, requirements: List[AspFunction]
-                ) -> List[AspFunction]:
-                    # TODO: `dependency_holds` is used as a cache key, and is a unique object in
-                    # every iteration of the loop. This prevents deduplication of identical
-                    # "effects" when unique when specs impose the same dependency. We cannot move
-                    # this out of the loop, because the effect cache is keyed only by a spec, and
-                    # not by the dependency type.
-                    result = remove_facts("node", "virtual_node")(
-                        name, input_spec, requirements
-                    ) + [
-                        fn.attr("dependency_holds", pkg.name, name, dt.flag_to_string(t))
-                        for t in dt.ALL_FLAGS
-                        if t & depflag
-                    ]
-                    if name not in pkg.extendees:
-                        return result
-                    return result + [fn.attr("extends", pkg.name, name)]
-
                 context = ConditionContext()
                 context.source = ConstraintOrigin.append_type_suffix(
                     pkg.name, ConstraintOrigin.DEPENDS_ON
                 )
                 context.transform_required = _track_dependencies
-                context.transform_imposed = dependency_holds
+                context.transform_imposed = dependency_holds(dependency_flags=depflag)
 
                 self.condition(cond, dep.spec, required_name=pkg.name, msg=msg, context=context)
 
@@ -3210,7 +3218,7 @@ class SpackSolverSetup:
             )
             # Default is to remove node-like attrs, override here
             context.transform_required = virtual_handler
-            context.transform_imposed = lambda x, y, z: z
+            context.transform_imposed = identity_for_facts
 
             try:
                 subcondition_id = self.condition(


### PR DESCRIPTION
Modifications:
- Use `functools.lru_cache` on a few functions returning transformation functions, so that they always return the same object whenever they are called with the same argument.
- Collect triggers and effects for all packages, and emit them at the end (instead of once per package)

**Before**:
```console
$ spack solve --show=asp trilinos | grep trigger_id | wc -l
18498
$ spack solve --show=asp trilinos | grep effect_id | wc -l
14603
```

**After**
```console
$ spack solve --show=asp trilinos | grep trigger_id | wc -l
18217
$ spack solve --show=asp trilinos | grep effect_id | wc -l
12443
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
