### PR TITLE
directives_meta.py: reduce iterations

### DIFF
--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -112,7 +112,7 @@ class DirectiveMeta(type):
             if isinstance(arg, (list, tuple)):
                 # Descend into args that are lists or tuples
                 DirectiveMeta._remove_directives(arg)
-            else:
+            elif callable(arg):
                 # Remove directives args from the exec queue
                 for directive in directives:
                     if arg is directive:

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -112,7 +112,7 @@ class DirectiveMeta(type):
             if isinstance(arg, (list, tuple)):
                 # Descend into args that are lists or tuples
                 DirectiveMeta._remove_directives(arg)
-            elif callable(arg):
+            elif callable(arg):  # directives are always callable, and very rare
                 # Remove directives args from the exec queue
                 for directive in directives:
                     if arg is directive:


### PR DESCRIPTION
A directive is callable, so that's a good way to avoid this loop.

Turns out, only 0.07% (no typo) of the time a callable is passed as
an argument to a directive, so this saves a whole lot of redundant
iterations over existing directives

