### PR TITLE
directives_meta.py: more use of immutable specs

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -57,7 +57,7 @@ import spack.spec
 import spack.util.crypto
 import spack.variant
 from spack.dependency import Dependency
-from spack.directives_meta import DirectiveError, DirectiveMeta, get_spec
+from spack.directives_meta import DirectiveError, directive, get_spec
 from spack.resource import Resource
 from spack.spec import EMPTY_SPEC
 from spack.version import (
@@ -144,10 +144,9 @@ def _make_when_spec(value: WhenType) -> Optional[spack.spec.Spec]:
 
 
 SubmoduleCallback = Callable[[spack.package_base.PackageBase], Union[str, List[str], bool]]
-directive = DirectiveMeta.directive
 
 
-@directive("versions")
+@directive("versions", supports_when=False)
 def version(
     ver: Union[str, int],
     # this positional argument is deprecated, use sha256=... instead

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -45,7 +45,7 @@ import os
 import re
 import warnings
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, List, Optional, Tuple, Type, Union
 
 import spack.deptypes as dt
 import spack.error
@@ -57,7 +57,7 @@ import spack.spec
 import spack.util.crypto
 import spack.variant
 from spack.dependency import Dependency
-from spack.directives_meta import DirectiveError, DirectiveMeta
+from spack.directives_meta import DirectiveError, DirectiveMeta, get_spec
 from spack.resource import Resource
 from spack.spec import EMPTY_SPEC
 from spack.version import (
@@ -96,15 +96,6 @@ WhenType = Optional[Union[spack.spec.Spec, str, bool]]
 PackageType = Type[spack.package_base.PackageBase]
 Patcher = Callable[[Union[PackageType, Dependency]], None]
 PatchesType = Union[Patcher, str, List[Union[Patcher, str]]]
-
-SPEC_CACHE: Dict[str, spack.spec.Spec] = {}
-
-
-def get_spec(spec_str: str) -> spack.spec.Spec:
-    """Get a spec from the cache, or create it if not present."""
-    if spec_str not in SPEC_CACHE:
-        SPEC_CACHE[spec_str] = spack.spec._ImmutableSpec(spec_str)
-    return SPEC_CACHE[spec_str]
 
 
 def _make_when_spec(value: WhenType) -> Optional[spack.spec.Spec]:

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -134,20 +134,24 @@ class DirectiveMeta(type):
 
 def _combine_when(
     when: Optional[str] = None,
-    context: List[spack.spec.Spec] = DirectiveMeta._when_constraints_stack,
+    when_stack: List[spack.spec.Spec] = DirectiveMeta._when_constraints_stack,
 ) -> spack.spec.Spec:
-    """Compute the combined when constraints from context and argument."""
+    """Compute the combined when constraints from the context and the directive keyword argument.
 
-    if len(context) == 1 and not when:
-        # In case of a single when constraint, avoid allocating a new spec
-        return context[0]
+    Arguments:
+        when: The when constraint from the directive's keyword argument as a raw string (if any).
+        when_stack: The stack of parsed when constraints from ``with when(...)`` context managers.
+    """
+    # In the following case
+    #     with when("+foo"):     # single constraint on the stack
+    #         depends_on("foo")  # unconditional directive
+    # avoid creating a new spec and just return the one from the stack
+    if len(when_stack) == 1 and not when:
+        return when_stack[0]
 
     # Otherwise, combine all when constraints by mutating a new spec
-    if when:
-        when_spec = spack.spec.Spec(when)
-    else:
-        when_spec = spack.spec.Spec()
-    for current in context:
+    when_spec = spack.spec.Spec(when)
+    for current in when_stack:
         when_spec._constrain_symbolically(current, deps=True)
     return when_spec
 

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -15,6 +15,15 @@ import spack.spec
 #: Some directives leverage others and in that case are not automatically added.
 directive_names = ["build_system"]
 
+SPEC_CACHE: Dict[str, spack.spec.Spec] = {}
+
+
+def get_spec(spec_str: str) -> spack.spec.Spec:
+    """Get a spec from the cache, or create it if not present."""
+    if spec_str not in SPEC_CACHE:
+        SPEC_CACHE[spec_str] = spack.spec._ImmutableSpec(spec_str)
+    return SPEC_CACHE[spec_str]
+
 
 class DirectiveMeta(type):
     """Flushes the directives that were temporarily stored in the staging
@@ -180,48 +189,44 @@ class DirectiveMeta(type):
             @functools.wraps(decorated_function)
             def _wrapper(*args, **_kwargs):
                 # First merge default args with kwargs
-                kwargs = dict()
-                for default_args in DirectiveMeta._default_args:
-                    kwargs.update(default_args)
-                kwargs.update(_kwargs)
+                if DirectiveMeta._default_args:
+                    kwargs = {}
+                    for default_args in DirectiveMeta._default_args:
+                        kwargs.update(default_args)
+                    kwargs.update(_kwargs)
+                else:
+                    kwargs = _kwargs
 
                 # Inject when arguments from the context
                 if DirectiveMeta._when_constraints_from_context:
+                    when_constraints = DirectiveMeta._when_constraints_from_context
                     # Check that directives not yet supporting the when= argument
                     # are not used inside the context manager
                     if decorated_function.__name__ == "version":
-                        msg = (
-                            'directive "{0}" cannot be used within a "when"'
-                            ' context since it does not support a "when=" '
-                            "argument"
+                        raise DirectiveError(
+                            f'directive "{decorated_function.__name__}" cannot be used within a '
+                            '"when" context since it does not support a "when=" argument'
                         )
-                        msg = msg.format(decorated_function.__name__)
-                        raise DirectiveError(msg)
 
-                    when_constraints = [
-                        spack.spec.Spec(x) for x in DirectiveMeta._when_constraints_from_context
-                    ]
-                    if kwargs.get("when"):
-                        when_constraints.append(spack.spec.Spec(kwargs["when"]))
-
-                    when_spec = spack.spec.Spec()
-                    for current in when_constraints:
-                        when_spec._constrain_symbolically(current, deps=True)
-                    kwargs["when"] = when_spec
+                    if len(when_constraints) == 1 and not kwargs.get("when"):
+                        # In case of a single when constraint, avoid allocating a new spec
+                        kwargs["when"] = when_constraints[0]
+                    else:
+                        # Otherwise, combine all when constraints by mutating a new spec
+                        if kwargs.get("when"):
+                            when_spec = spack.spec.Spec(kwargs["when"])
+                        else:
+                            when_spec = spack.spec.Spec()
+                        for current in when_constraints:
+                            when_spec._constrain_symbolically(current, deps=True)
+                        kwargs["when"] = when_spec
 
                 DirectiveMeta._remove_directives(args)
                 DirectiveMeta._remove_directives(list(kwargs.values()))
 
-                # A directive returns either something that is callable on a
-                # package or a sequence of them
                 result = decorated_function(*args, **kwargs)
 
-                # ...so if it is not a sequence make it so
-                values = result
-                if not isinstance(values, collections.abc.Sequence):
-                    values = (values,)
-
-                DirectiveMeta._directives_to_be_executed.extend(values)
+                DirectiveMeta._directives_to_be_executed.append(result)
 
                 # wrapped function returns same result as original so
                 # that we can nest directives

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import collections.abc
 import functools
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Type, Union
+import itertools
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import spack.error
 import spack.llnl.util.lang
@@ -30,11 +30,14 @@ class DirectiveMeta(type):
     area into the package.
     """
 
-    # Set of all known directives
+    #: Set of all known directive dictionary names from `@directive(dicts=...)`
     _directive_dict_names: Set[str] = set()
+    #: List of directives to be executed at class initialization time
     _directives_to_be_executed: List[Callable] = []
-    _when_constraints_from_context: List[spack.spec.Spec] = []
-    _default_args: List[dict] = []
+    #: Stack of when constraints from `with when(...)` context managers
+    _when_constraints_stack: List[spack.spec.Spec] = []
+    #: Stack of default args from `with default_args(...)` context managers
+    _default_args_stack: List[dict] = []
 
     def __new__(
         cls: Type["DirectiveMeta"], name: str, bases: tuple, attr_dict: dict
@@ -90,24 +93,24 @@ class DirectiveMeta(type):
         super(DirectiveMeta, cls).__init__(name, bases, attr_dict)
 
     @staticmethod
-    def push_to_context(when_spec: spack.spec.Spec) -> None:
+    def push_when_constraint(when_spec: spack.spec.Spec) -> None:
         """Add a spec to the context constraints."""
-        DirectiveMeta._when_constraints_from_context.append(when_spec)
+        DirectiveMeta._when_constraints_stack.append(when_spec)
 
     @staticmethod
-    def pop_from_context() -> spack.spec.Spec:
+    def pop_when_constraint() -> spack.spec.Spec:
         """Pop the last constraint from the context"""
-        return DirectiveMeta._when_constraints_from_context.pop()
+        return DirectiveMeta._when_constraints_stack.pop()
 
     @staticmethod
     def push_default_args(default_args: Dict[str, Any]) -> None:
         """Push default arguments"""
-        DirectiveMeta._default_args.append(default_args)
+        DirectiveMeta._default_args_stack.append(default_args)
 
     @staticmethod
     def pop_default_args() -> dict:
         """Pop default arguments"""
-        return DirectiveMeta._default_args.pop()
+        return DirectiveMeta._default_args_stack.pop()
 
     @staticmethod
     def _remove_directives(args):
@@ -128,113 +131,110 @@ class DirectiveMeta(type):
                         directives.remove(directive)  # iterations ends, so mutation is fine
                         break
 
-    @staticmethod
-    def directive(dicts: Optional[Union[Sequence[str], str]] = None) -> Callable:
+
+def _combine_when(
+    when: Optional[str] = None,
+    context: List[spack.spec.Spec] = DirectiveMeta._when_constraints_stack,
+) -> spack.spec.Spec:
+    """Compute the combined when constraints from context and argument."""
+
+    if len(context) == 1 and not when:
+        # In case of a single when constraint, avoid allocating a new spec
+        return context[0]
+
+    # Otherwise, combine all when constraints by mutating a new spec
+    if when:
+        when_spec = spack.spec.Spec(when)
+    else:
+        when_spec = spack.spec.Spec()
+    for current in context:
+        when_spec._constrain_symbolically(current, deps=True)
+    return when_spec
+
+
+class directive:
+    def __init__(
+        self, dicts: Union[Tuple[str, ...], str] = (), supports_when: bool = True
+    ) -> None:
         """Decorator for Spack directives.
 
-        Spack directives allow you to modify a package while it is being
-        defined, e.g. to add version or dependency information.  Directives
-        are one of the key pieces of Spack's package "language", which is
-        embedded in python.
+        Spack directives allow you to modify a package while it is being defined, e.g. to add
+        version or dependency information.  Directives are one of the key pieces of Spack's
+        package "language", which is embedded in python.
 
-        Here's an example directive:
-
-        .. code-block:: python
+        Here's an example directive::
 
             @directive(dicts="versions")
             def version(pkg, ...):
                 ...
 
-        This directive allows you write:
-
-        .. code-block:: python
+        This directive allows you write::
 
             class Foo(Package):
                 version(...)
 
         The ``@directive`` decorator handles a couple things for you:
 
-        1. Adds the class scope (pkg) as an initial parameter when
-           called, like a class method would.  This allows you to modify
-           a package from within a directive, while the package is still
-           being defined.
+        1. Adds the class scope (pkg) as an initial parameter when called, like a class method
+           would. This allows you to modify a package from within a directive, while the package is
+           still being defined.
 
-        2. It automatically adds a dictionary called ``versions`` to the
-           package so that you can refer to pkg.versions.
+        2. It automatically adds a dictionary called ``versions`` to the package so that you can
+           refer to pkg.versions.
 
-        The ``(dicts="versions")`` part ensures that ALL packages in Spack
-        will have a ``versions`` attribute after they're constructed, and
-        that if no directive actually modified it, it will just be an
-        empty dict.
-
-        This is just a modular way to add storage attributes to the
-        Package class, and it's how Spack gets information from the
-        packages to the core.
+        Arguments:
+            dicts: A list of names of dictionaries to add to the package class if they don't
+                already exist.
+            supports_when: If True, the directive can be used within a ``with when(...)`` context
+                manager. (To be removed when all directives support ``when=`` arguments.)
         """
 
         if isinstance(dicts, str):
             dicts = (dicts,)
 
-        if not isinstance(dicts, collections.abc.Sequence):
-            message = "dicts arg must be list, tuple, or string. Found {0}"
-            raise TypeError(message.format(type(dicts)))
-
         # Add the dictionary names if not already there
-        DirectiveMeta._directive_dict_names |= set(dicts)
+        DirectiveMeta._directive_dict_names.update(dicts)
 
-        # This decorator just returns the directive functions
-        def _decorator(decorated_function: Callable) -> Callable:
-            directive_names.append(decorated_function.__name__)
+        self.supports_when = supports_when
 
-            @functools.wraps(decorated_function)
-            def _wrapper(*args, **_kwargs):
-                # First merge default args with kwargs
-                if DirectiveMeta._default_args:
-                    kwargs = {}
-                    for default_args in DirectiveMeta._default_args:
-                        kwargs.update(default_args)
-                    kwargs.update(_kwargs)
-                else:
-                    kwargs = _kwargs
+    def __call__(self, decorated_function: Callable) -> Callable:
+        directive_names.append(decorated_function.__name__)
 
-                # Inject when arguments from the context
-                if DirectiveMeta._when_constraints_from_context:
-                    when_constraints = DirectiveMeta._when_constraints_from_context
-                    # Check that directives not yet supporting the when= argument
-                    # are not used inside the context manager
-                    if decorated_function.__name__ == "version":
-                        raise DirectiveError(
-                            f'directive "{decorated_function.__name__}" cannot be used within a '
-                            '"when" context since it does not support a "when=" argument'
-                        )
+        # Do not capture `self` in the wrapper
+        supports_when = self.supports_when
 
-                    if len(when_constraints) == 1 and not kwargs.get("when"):
-                        # In case of a single when constraint, avoid allocating a new spec
-                        kwargs["when"] = when_constraints[0]
-                    else:
-                        # Otherwise, combine all when constraints by mutating a new spec
-                        if kwargs.get("when"):
-                            when_spec = spack.spec.Spec(kwargs["when"])
-                        else:
-                            when_spec = spack.spec.Spec()
-                        for current in when_constraints:
-                            when_spec._constrain_symbolically(current, deps=True)
-                        kwargs["when"] = when_spec
+        @functools.wraps(decorated_function)
+        def _wrapper(*args, **_kwargs):
+            # First merge default args with kwargs
+            if DirectiveMeta._default_args_stack:
+                kwargs = {}
+                for default_args in DirectiveMeta._default_args_stack:
+                    kwargs.update(default_args)
+                kwargs.update(_kwargs)
+            else:
+                kwargs = _kwargs
 
-                DirectiveMeta._remove_directives(args)
-                DirectiveMeta._remove_directives(list(kwargs.values()))
+            # Inject when arguments from the context
+            if DirectiveMeta._when_constraints_stack:
+                if not supports_when:
+                    raise DirectiveError(
+                        f'directive "{decorated_function.__name__}" cannot be used within a '
+                        '"when" context since it does not support a "when=" argument'
+                    )
+                kwargs["when"] = _combine_when(kwargs.get("when"))
 
-                result = decorated_function(*args, **kwargs)
+            # Remove directives passed as arguments, so they are not executed as part of this
+            # class's directive execution, but handled by the called directive instead
+            DirectiveMeta._remove_directives(itertools.chain(args, kwargs.values()))
 
-                DirectiveMeta._directives_to_be_executed.append(result)
+            result = decorated_function(*args, **kwargs)
 
-                # wrapped function returns same result as original so
-                # that we can nest directives
-                return result
+            DirectiveMeta._directives_to_be_executed.append(result)
 
-            return _wrapper
+            # wrapped function returns same result as original so that we can nest directives
+            return result
 
-        return _decorator
+        return _wrapper
 
 
 class DirectiveError(spack.error.SpackError):

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -25,7 +25,7 @@ so package authors should use their judgement.
 """
 import functools
 from contextlib import contextmanager
-from typing import Union
+from typing import Optional, Union
 
 import spack.directives_meta
 import spack.error
@@ -237,6 +237,8 @@ class when:
     override all of the decorated versions. This is a limitation of the Python language.
     """
 
+    spec: Optional[spack.spec.Spec]
+
     def __init__(self, condition: Union[str, bool]):
         """Can be used both as a decorator, for multimethods, or as a context
         manager to group ``when=`` arguments together.
@@ -246,9 +248,9 @@ class when:
             condition (str): condition to be met
         """
         if isinstance(condition, bool):
-            self.spec = spack.spec.Spec() if condition else None
+            self.spec = spack.spec.EMPTY_SPEC if condition else None
         else:
-            self.spec = spack.spec.Spec(condition)
+            self.spec = spack.directives_meta.get_spec(condition)
 
     def __call__(self, method):
         assert (
@@ -266,10 +268,12 @@ class when:
         return original_method
 
     def __enter__(self):
-        spack.directives_meta.DirectiveMeta.push_to_context(str(self.spec))
+        if self.spec is not None:
+            spack.directives_meta.DirectiveMeta.push_to_context(self.spec)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        spack.directives_meta.DirectiveMeta.pop_from_context()
+        if self.spec is not None:
+            spack.directives_meta.DirectiveMeta.pop_from_context()
 
 
 @contextmanager

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -269,11 +269,11 @@ class when:
 
     def __enter__(self):
         if self.spec is not None:
-            spack.directives_meta.DirectiveMeta.push_to_context(self.spec)
+            spack.directives_meta.DirectiveMeta.push_when_constraint(self.spec)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.spec is not None:
-            spack.directives_meta.DirectiveMeta.pop_from_context()
+            spack.directives_meta.DirectiveMeta.pop_when_constraint()
 
 
 @contextmanager

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -10,6 +10,8 @@ import spack.directives
 import spack.repo
 import spack.spec
 import spack.version
+from spack.directives_meta import _combine_when
+from spack.spec import Spec
 
 
 def test_false_directives_do_not_exist(mock_packages):
@@ -212,3 +214,19 @@ def test_direct_dependencies_from_when_context_are_retained(mock_packages):
     assert spack.spec.Spec("%pkg-c") in pkg_cls.dependencies
     # Nested ^foo followed by ^foo %gcc
     assert spack.spec.Spec("^pkg-c %gcc") in pkg_cls.dependencies
+
+
+def test_directives_meta_combine_when():
+    x, y = Spec("+x ^dep +a"), Spec("+y ^dep +b")
+
+    # Check that specs are combined, and do not mutate inputs
+    assert _combine_when("+z", [x, y]) == Spec("+x +y +z ^dep +a +b")
+    assert x == Spec("+x ^dep +a")
+    assert y == Spec("+y ^dep +b")
+
+    assert _combine_when(None, [x, y]) == Spec("+x +y ^dep +a +b")
+    assert x == Spec("+x ^dep +a")
+    assert y == Spec("+y ^dep +b")
+
+    # Check the optimization for single stack with no when
+    assert _combine_when(None, [x]) is x


### PR DESCRIPTION
Move the Spec cache from `directives.py` to `directives_meta.py`

* Both `@when(...)` and `with when(...)` now use immutable Specs
* Avoid the `Spec -> str -> Spec` conversion between `when` and
  `directives_meta`
* Avoid copy of `kwargs` in the common case where there is no
  `default_args` set
* Remove vestigial `if isinstance(result, Sequence)` check on the return
  value of a directive -- it's always a callable.
* Replace closure-in-closure pattern with class + `__call__` to make it
   a bit more readable.

The cache hits are not spectacular (only 444 new hits when loading all
packages, about ~1% more). But there is a speedup in package loading
nonetheless thanks to the other changes:

* 11.2s -> 10.5s (about 6%)