### PR TITLE
repo.py: fast path without overrides

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1424,6 +1424,14 @@ class Repo:
         if not isinstance(cls, type):
             tty.die(f"{pkg_name}.{class_name} is not a class")
 
+        # Early exit if no overrides to apply or undo
+        if (
+            not self.overrides.get(pkg_name)
+            and not hasattr(cls, "overridden_attrs")
+            and not hasattr(cls, "attrs_exclusively_from_config")
+        ):
+            return cls
+
         def defining_class(myclass, name):
             return next((c for c in myclass.__mro__ if name in c.__dict__), None)
 


### PR DESCRIPTION
Simpler than #51862

Package class overrides are almost never used, so add an early exit in `get_pkg_class`
