### PR TITLE
solver: improve version encoding

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2663,7 +2663,7 @@ class SpackSolverSetup:
 
         sorted_versions = {}
         for pkg_name in self.possible_versions:
-            possible_versions = [x for x in self.possible_versions[pkg_name]]
+            possible_versions = list(self.possible_versions[pkg_name])
             possible_versions.sort()
             sorted_versions[pkg_name] = possible_versions
             for idx, v in enumerate(possible_versions):
@@ -2689,18 +2689,12 @@ class SpackSolverSetup:
                         start_idx = current_idx
                 elif start_idx is not None:
                     # End of a contiguous satisfying range found
-                    self.gen.fact(
-                        fn.pkg_fact(
-                            pkg_name, fn.version_range(versions, start_idx, current_idx - 1)
-                        )
-                    )
+                    version_range = fn.version_range(versions, start_idx, current_idx - 1)
+                    self.gen.fact(fn.pkg_fact(pkg_name, version_range))
                     start_idx = None
             if start_idx is not None:
-                self.gen.fact(
-                    fn.pkg_fact(
-                        pkg_name, fn.version_range(versions, start_idx, len(possible_versions) - 1)
-                    )
-                )
+                version_range = fn.version_range(versions, start_idx, len(possible_versions) - 1)
+                self.gen.fact(fn.pkg_fact(pkg_name, version_range))
             self.gen.newline()
 
     def collect_virtual_constraints(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2681,14 +2681,26 @@ class SpackSolverSetup:
             possible_versions = sorted_versions.get(pkg_name)
             if possible_versions is None:
                 continue
-            satisfies = [v.satisfies(versions) for v in possible_versions]
-            for key, group in itertools.groupby(enumerate(satisfies), lambda x: x[1]):
-                if key is True:
-                    indexes = [idx for idx, _ in group]
-                    min_idx, max_idx = indexes[0], indexes[-1]
+            # Look for contiguous ranges of versions that satisfy the constraint
+            start_idx = None
+            for current_idx, v in enumerate(possible_versions):
+                if v.satisfies(versions):
+                    if start_idx is None:
+                        start_idx = current_idx
+                elif start_idx is not None:
+                    # End of a contiguous satisfying range found
                     self.gen.fact(
-                        fn.pkg_fact(pkg_name, fn.version_range(versions, min_idx, max_idx))
+                        fn.pkg_fact(
+                            pkg_name, fn.version_range(versions, start_idx, current_idx - 1)
+                        )
                     )
+                    start_idx = None
+            if start_idx is not None:
+                self.gen.fact(
+                    fn.pkg_fact(
+                        pkg_name, fn.version_range(versions, start_idx, len(possible_versions) - 1)
+                    )
+                )
             self.gen.newline()
 
     def collect_virtual_constraints(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2678,7 +2678,9 @@ class SpackSolverSetup:
         self.gen.newline()
 
         for pkg_name, versions in self.version_constraints:
-            possible_versions = sorted_versions.get(pkg_name, [])
+            possible_versions = sorted_versions.get(pkg_name)
+            if possible_versions is None:
+                continue
             satisfies = [v.satisfies(versions) for v in possible_versions]
             for key, group in itertools.groupby(enumerate(satisfies), lambda x: x[1]):
                 if key is True:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2661,22 +2661,32 @@ class SpackSolverSetup:
     def define_version_constraints(self):
         """Define what version_satisfies(...) means in ASP logic."""
 
-        for pkg_name, versions in self.possible_versions.items():
-            for v in versions:
+        sorted_versions = {}
+        for pkg_name in self.possible_versions:
+            possible_versions = [x for x in self.possible_versions[pkg_name]]
+            possible_versions.sort()
+            sorted_versions[pkg_name] = possible_versions
+            for idx, v in enumerate(possible_versions):
+                self.gen.fact(fn.pkg_fact(pkg_name, fn.version_order(v, idx)))
                 if v in self.git_commit_versions[pkg_name]:
                     sha = self.git_commit_versions[pkg_name].get(v)
                     if sha:
                         self.gen.fact(fn.pkg_fact(pkg_name, fn.version_has_commit(v, sha)))
                     else:
                         self.gen.fact(fn.pkg_fact(pkg_name, fn.version_needs_commit(v)))
+            self.gen.newline()
         self.gen.newline()
 
         for pkg_name, versions in self.version_constraints:
-            # generate facts for each package constraint and the version
-            # that satisfies it
-            for v in self.possible_versions[pkg_name]:
-                if v.satisfies(versions):
-                    self.gen.fact(fn.pkg_fact(pkg_name, fn.version_satisfies(versions, v)))
+            possible_versions = sorted_versions.get(pkg_name, [])
+            satisfies = [v.satisfies(versions) for v in possible_versions]
+            for key, group in itertools.groupby(enumerate(satisfies), lambda x: x[1]):
+                if key is True:
+                    indexes = [idx for idx, _ in group]
+                    min_idx, max_idx = indexes[0], indexes[-1]
+                    self.gen.fact(
+                        fn.pkg_fact(pkg_name, fn.version_range(versions, min_idx, max_idx))
+                    )
             self.gen.newline()
 
     def collect_virtual_constraints(self):

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -268,8 +268,7 @@ error(100, multiple_values_error, Attribute, Package)
 % Version semantics
 %-----------------------------------------------------------------------------
 
-% versions are declared w/priority -- declared with priority implies declared
-pkg_fact(Package, version_declared(Version)) :- pkg_fact(Package, version_declared(Version, _)).
+version_declared(Package, Version) :- pkg_fact(Package, version_order(Version, _)).
 
 % If something is a package, it has only one version and that must be a
 % declared version.
@@ -278,14 +277,20 @@ pkg_fact(Package, version_declared(Version)) :- pkg_fact(Package, version_declar
 % against to ensure they cannot be inferred when a non-error solution is
 % possible
 
+version_constraint_satisfied(node(ID,Package), Constraint) :-
+    attr("version", node(ID,Package), Version),
+    pkg_fact(Package, version_order(Version, VersionIdx)),
+    pkg_fact(Package, version_range(Constraint, MinIdx, MaxIdx)),
+    VersionIdx >= MinIdx, VersionIdx <= MaxIdx.
+
 % Pick a single version among the possible ones
-1 { choose_version(node(ID, Package), Version) : pkg_fact(Package, version_declared(Version)) } 1 :- attr("node", node(ID, Package)).
+1 { choose_version(node(ID, Package), Version) : version_declared(Package, Version) } 1 :- attr("node", node(ID, Package)).
 
 % To choose the "fake" version of virtual packages, we need a separate rule.
 % Note that a virtual node may or may not have a version, but cannot have more than one.
-{ choose_version(node(ID, Package), Version) : pkg_fact(Package, version_satisfies(Constraint, Version)) } 1
-  :- attr("node_version_satisfies", node(ID, Package), Constraint),
-     attr("virtual_node", node(ID, Package)).
+{ choose_version(node(ID, Package), Version) : version_declared(Package, Version) } 1
+  :- attr("virtual_node", node(ID, Package)),
+     virtual(Package).
 
 #defined compiler_package/1.
 
@@ -331,18 +336,16 @@ version_deprecation_penalty(node(ID, Package), Penalty)
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
-error(10000, "Cannot satisfy '{0}@{1}' 1({2})", Package, Constraint, Version)
-  :- attr("node_version_satisfies", node(ID, Package), Constraint),
-     attr("version", node(ID, Package), Version),
-     not pkg_fact(Package, version_satisfies(Constraint, Version)).
-
 error(10000, "Cannot satisfy '{0}@{1}'", Package, Constraint)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
-     not attr("version", node(ID, Package), _).
+     not version_constraint_satisfied(node(ID,Package), Constraint).
 
 attr("node_version_satisfies", node(ID, Package), Constraint)
   :- attr("version", node(ID, Package), Version),
-     pkg_fact(Package, version_satisfies(Constraint, Version)).
+     pkg_fact(Package, version_order(Version, VersionIdx)),
+     pkg_fact(Package, version_range(Constraint, MinIdx, MaxIdx)),
+     VersionIdx >= MinIdx, VersionIdx <= MaxIdx.
+
 
 % if a version needs a commit or has one it can use the commit variant
 can_accept_commit(Package, Version) :- pkg_fact(Package, version_needs_commit(Version)).
@@ -500,7 +503,9 @@ satisfied(trigger(node(Hash, Package)), condition_requirement("node_version_sati
   reused_provider(node(Hash, Package), node(Hash, Language)),
   hash_attr(Hash, "version", Package, Version),
   condition_requirement(ID, "node_version_satisfies", Package, VersionConstraint),
-  pkg_fact(Package, version_satisfies(VersionConstraint, Version)).
+  pkg_fact(Package, version_order(Version, VersionIdx)),
+  pkg_fact(Package, version_range(VersionConstraint, MinIdx, MaxIdx)),
+  VersionIdx >= MinIdx, VersionIdx <= MaxIdx.
 
 satisfied(trigger(node(Hash, Package)), condition_requirement(Name, Package, A1, A2)) :-
   trigger_real_node(ID, node(Hash, Package)),
@@ -636,7 +641,7 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
 :- attr("direct_dependency", ParentNode, node_requirement("node_version_satisfies", BuildDependency, Constraint)),
    concrete_build_requirement(ParentNode, BuildDependency),
    attr("concrete_build_dependency", ParentNode, BuildDependency, BuildDependencyHash),
-   not 1 { pkg_fact(BuildDependency, version_satisfies(Constraint, Version)) : hash_attr(BuildDependencyHash, "version", BuildDependency, Version) } 1.
+   not hash_attr(BuildDependencyHash, "node_version_satisfies", BuildDependency, Constraint).
 
 :- attr("direct_dependency", ParentNode, node_requirement("provider_set", BuildDependency, Virtual)),
    concrete_build_requirement(ParentNode, BuildDependency),
@@ -1911,7 +1916,9 @@ error(100, "Cannot set multiple {0} values for {1} from cli", FlagType, Package)
 % hash_attrs are versions, but can_splice_attr are usually node_version_satisfies
 hash_attr(Hash, "node_version_satisfies", PackageName, Constraint) :-
   hash_attr(Hash, "version", PackageName, Version),
-  pkg_fact(PackageName, version_satisfies(Constraint, Version)).
+  pkg_fact(PackageName, version_order(Version, VersionIdx)),
+  pkg_fact(PackageName, version_range(Constraint, MinIdx, MaxIdx)),
+  VersionIdx >= MinIdx, VersionIdx <= MaxIdx.
 
 % This recovers the exact semantics for hash reuse hash and depends_on are where
 % splices are decided, and virtual_on_edge can result in name-changes, which is

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -158,6 +158,11 @@ error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
      unification_set(X, node(ID1, TriggerPackage)),
      build(node(ID, Package)).  % ignore conflicts for concrete packages
 
+pkg_fact(Package, version_satisfies(Constraint, Version)) :-
+    pkg_fact(Package, version_order(Version, VersionIdx)),
+    pkg_fact(Package, version_range(Constraint, MinIdx, MaxIdx)),
+    VersionIdx >= MinIdx, VersionIdx <= MaxIdx.
+
 % variables to show
 #show error/2.
 #show error/3.


### PR DESCRIPTION
Previously we encoded version constraints with a table:
```
pkg_fact(Package, version_satisfies(Constraint, Version))
```
This gives a number of facts equal to
```
Package x Version x Constraint on Package
```

Now we encode version ordering like:
```
pkg_fact("zlib-ng",version_order("2.0.0",0)).
...
pkg_fact("zlib-ng",version_order("2.2.5",10)).
pkg_fact("zlib-ng",version_order("2.3.2",11)).
```
and constraints like:
```
pkg_fact("zlib-ng",version_range("2.1.0:",2,11)).
```

This allows us to reduce the number of a few grounded rules.




<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
