### PR TITLE
spec.py: VariantMap/FlagMap: drop backref to spec

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3305,7 +3305,7 @@ class Spec:
             if not self.versions.intersects(other.versions):
                 return False
 
-        if not self.variants.intersects(other.variants):
+        if not self._intersects_variants(other):
             return False
 
         if self.architecture and other.architecture:
@@ -3674,6 +3674,11 @@ class Spec:
                     return False
 
         return result
+
+    def _intersects_variants(self, other: "Spec") -> bool:
+        self_dict = self.variants.dict
+        other_dict = other.variants.dict
+        return all(self_dict[k].intersects(other_dict[k]) for k in other_dict if k in self_dict)
 
     def _constrain_variants(self, other: "Spec") -> bool:
         """Add all variants in other that aren't in self to self. Also constrain all multi-valued
@@ -5270,9 +5275,6 @@ class VariantMap(lang.HashableMap[str, vt.VariantValue]):
         non_prop = [x.name for x in non_prop]
         prop = [x.name for x in prop]
         return non_prop, prop
-
-    def intersects(self, other):
-        return all(self[k].intersects(other[k]) for k in other if k in self)
 
     def copy(self) -> "VariantMap":
         clone = VariantMap()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -928,11 +928,6 @@ def _shared_subset_pair_iterate(container1, container2):
 
 
 class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
-    __slots__ = ("spec",)
-
-    def __init__(self, spec):
-        super().__init__()
-        self.spec = spec
 
     def satisfies(self, other):
         return all(f in self and set(self[f]) >= set(other[f]) for f in other)
@@ -975,7 +970,7 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         return _valid_compiler_flags
 
     def copy(self):
-        clone = FlagMap(self.spec)
+        clone = FlagMap()
         for name, compiler_flag in self.items():
             clone[name] = compiler_flag
         return clone
@@ -1554,9 +1549,9 @@ class Spec:
         # init an empty spec that matches anything.
         self.name: str = ""
         self.versions = vn.VersionList.any()
-        self.variants = VariantMap(self)
+        self.variants = VariantMap()
         self.architecture = None
-        self.compiler_flags = FlagMap(self)
+        self.compiler_flags = FlagMap()
         self._dependents = {}
         self._dependencies = {}
         self.namespace = None
@@ -3156,7 +3151,7 @@ class Spec:
             changed = True
 
         changed |= self.versions.intersect(other.versions)
-        changed |= self.variants.constrain(other.variants)
+        changed |= self._constrain_variants(other)
 
         changed |= self.compiler_flags.constrain(other.compiler_flags)
 
@@ -3442,7 +3437,7 @@ class Spec:
         if not self.versions.satisfies(other.versions):
             return False
 
-        if not self.variants.satisfies(other.variants):
+        if not self._satisfies_variants(other):
             return False
 
         if self.architecture and other.architecture:
@@ -3618,6 +3613,89 @@ class Spec:
                 return False
 
         return True
+
+    def _satisfies_variants(self, other: "Spec") -> bool:
+        if self.concrete:
+            return self._satisfies_variants_when_self_concrete(other)
+        return self._satisfies_variants_when_self_abstract(other)
+
+    def _satisfies_variants_when_self_concrete(self, other: "Spec") -> bool:
+        non_propagating, propagating = other.variants.partition_variants()
+        result = all(
+            name in self.variants and self.variants[name].satisfies(other.variants[name])
+            for name in non_propagating
+        )
+        if not propagating:
+            return result
+
+        for node in self.traverse():
+            if not all(
+                node.variants[name].satisfies(other.variants[name])
+                for name in propagating
+                if name in node.variants
+            ):
+                return False
+        return result
+
+    def _satisfies_variants_when_self_abstract(self, other: "Spec") -> bool:
+        other_non_propagating, other_propagating = other.variants.partition_variants()
+        self_non_propagating, self_propagating = self.variants.partition_variants()
+
+        # First check variants without propagation set
+        result = all(
+            name in self_non_propagating
+            and (
+                self.variants[name].propagate
+                or self.variants[name].satisfies(other.variants[name])
+            )
+            for name in other_non_propagating
+        )
+        if result is False or (not other_propagating and not self_propagating):
+            return result
+
+        # Check that self doesn't contradict variants propagated by other
+        if other_propagating:
+            for node in self.traverse():
+                if not all(
+                    node.variants[name].satisfies(other.variants[name])
+                    for name in other_propagating
+                    if name in node.variants
+                ):
+                    return False
+
+        # Check that other doesn't contradict variants propagated by self
+        if self_propagating:
+            for node in other.traverse():
+                if not all(
+                    node.variants[name].satisfies(self.variants[name])
+                    for name in self_propagating
+                    if name in node.variants
+                ):
+                    return False
+
+        return result
+
+    def _constrain_variants(self, other: "Spec") -> bool:
+        """Add all variants in other that aren't in self to self. Also constrain all multi-valued
+        variants that are already present. Return True iff self changed"""
+        if other is not None and other._concrete:
+            for k in self.variants:
+                if k not in other.variants:
+                    raise vt.UnsatisfiableVariantSpecError(self.variants[k], "<absent>")
+
+        changed = False
+        for k in other.variants:
+            if k in self.variants:
+                if not self.variants[k].intersects(other.variants[k]):
+                    raise vt.UnsatisfiableVariantSpecError(self.variants[k], other.variants[k])
+                # If they are compatible merge them
+                changed |= self.variants[k].constrain(other.variants[k])
+            else:
+                # If it is not present copy it straight away
+                self.variants[k] = other.variants[k].copy()
+                changed = True
+
+        return changed
 
     @property  # type: ignore[misc] # decorated prop not supported in mypy
     def patches(self):
@@ -5115,8 +5193,8 @@ class Spec:
         self._package = None
 
         # Reconstruct variants and compiler_flags
-        self.variants = VariantMap(self)
-        self.compiler_flags = FlagMap(self)
+        self.variants = VariantMap()
+        self.compiler_flags = FlagMap()
         if variants_data is not None:
             self.variants.dict = variants_data
         if compiler_flags_data is not None:
@@ -5151,10 +5229,6 @@ class Spec:
 class VariantMap(lang.HashableMap[str, vt.VariantValue]):
     """Map containing variant instances. New values can be added only
     if the key is not already present."""
-
-    def __init__(self, spec: Spec):
-        super().__init__()
-        self.spec = spec
 
     def __setitem__(self, name, vspec):
         # Raise a TypeError if vspec is not of the right type
@@ -5197,90 +5271,11 @@ class VariantMap(lang.HashableMap[str, vt.VariantValue]):
         prop = [x.name for x in prop]
         return non_prop, prop
 
-    def satisfies(self, other: "VariantMap") -> bool:
-        if self.spec.concrete:
-            return self._satisfies_when_self_concrete(other)
-        return self._satisfies_when_self_abstract(other)
-
-    def _satisfies_when_self_concrete(self, other: "VariantMap") -> bool:
-        non_propagating, propagating = other.partition_variants()
-        result = all(
-            name in self and self[name].satisfies(other[name]) for name in non_propagating
-        )
-        if not propagating:
-            return result
-
-        for node in self.spec.traverse():
-            if not all(
-                node.variants[name].satisfies(other[name])
-                for name in propagating
-                if name in node.variants
-            ):
-                return False
-        return result
-
-    def _satisfies_when_self_abstract(self, other: "VariantMap") -> bool:
-        other_non_propagating, other_propagating = other.partition_variants()
-        self_non_propagating, self_propagating = self.partition_variants()
-
-        # First check variants without propagation set
-        result = all(
-            name in self_non_propagating
-            and (self[name].propagate or self[name].satisfies(other[name]))
-            for name in other_non_propagating
-        )
-        if result is False or (not other_propagating and not self_propagating):
-            return result
-
-        # Check that self doesn't contradict variants propagated by other
-        if other_propagating:
-            for node in self.spec.traverse():
-                if not all(
-                    node.variants[name].satisfies(other[name])
-                    for name in other_propagating
-                    if name in node.variants
-                ):
-                    return False
-
-        # Check that other doesn't contradict variants propagated by self
-        if self_propagating:
-            for node in other.spec.traverse():
-                if not all(
-                    node.variants[name].satisfies(self[name])
-                    for name in self_propagating
-                    if name in node.variants
-                ):
-                    return False
-
-        return result
-
     def intersects(self, other):
         return all(self[k].intersects(other[k]) for k in other if k in self)
 
-    def constrain(self, other: "VariantMap") -> bool:
-        """Add all variants in other that aren't in self to self. Also constrain all multi-valued
-        variants that are already present. Return True iff self changed"""
-        if other.spec is not None and other.spec._concrete:
-            for k in self:
-                if k not in other:
-                    raise vt.UnsatisfiableVariantSpecError(self[k], "<absent>")
-
-        changed = False
-        for k in other:
-            if k in self:
-                if not self[k].intersects(other[k]):
-                    raise vt.UnsatisfiableVariantSpecError(self[k], other[k])
-                # If they are compatible merge them
-                changed |= self[k].constrain(other[k])
-            else:
-                # If it is not present copy it straight away
-                self[k] = other[k].copy()
-                changed = True
-
-        return changed
-
     def copy(self) -> "VariantMap":
-        clone = VariantMap(self.spec)
+        clone = VariantMap()
         for name, variant in self.items():
             clone[name] = variant.copy()
         return clone

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -416,7 +416,7 @@ class TestVariant:
 class TestVariantMapTest:
     def test_invalid_values(self) -> None:
         # Value with invalid type
-        a = VariantMap(Spec())
+        a = VariantMap()
         with pytest.raises(TypeError):
             a["foo"] = 2
 
@@ -437,7 +437,7 @@ class TestVariantMapTest:
 
     def test_set_item(self) -> None:
         # Check that all the three types of variants are accepted
-        a = VariantMap(Spec())
+        a = VariantMap()
 
         a["foo"] = BoolValuedVariant("foo", True)
         a["bar"] = SingleValuedVariant("bar", "baz")
@@ -445,7 +445,7 @@ class TestVariantMapTest:
 
     def test_substitute(self) -> None:
         # Check substitution of a key that exists
-        a = VariantMap(Spec())
+        a = VariantMap()
         a["foo"] = BoolValuedVariant("foo", True)
         a.substitute(SingleValuedVariant("foo", "bar"))
 
@@ -456,34 +456,34 @@ class TestVariantMapTest:
 
     def test_satisfies_and_constrain(self) -> None:
         # foo=bar foobar=fee feebar=foo
-        a = VariantMap(Spec())
-        a["foo"] = MultiValuedVariant("foo", ("bar",))
-        a["foobar"] = SingleValuedVariant("foobar", "fee")
-        a["feebar"] = SingleValuedVariant("feebar", "foo")
+        a = Spec()
+        a.variants["foo"] = MultiValuedVariant("foo", ("bar",))
+        a.variants["foobar"] = SingleValuedVariant("foobar", "fee")
+        a.variants["feebar"] = SingleValuedVariant("feebar", "foo")
 
         # foo=bar,baz foobar=fee shared=True
-        b = VariantMap(Spec())
-        b["foo"] = MultiValuedVariant("foo", ("bar", "baz"))
-        b["foobar"] = SingleValuedVariant("foobar", "fee")
-        b["shared"] = BoolValuedVariant("shared", True)
+        b = Spec()
+        b.variants["foo"] = MultiValuedVariant("foo", ("bar", "baz"))
+        b.variants["foobar"] = SingleValuedVariant("foobar", "fee")
+        b.variants["shared"] = BoolValuedVariant("shared", True)
 
         # concrete, different values do not intersect / satisfy each other
         assert not a.intersects(b) and not b.intersects(a)
         assert not a.satisfies(b) and not b.satisfies(a)
 
         # foo=bar,baz foobar=fee feebar=foo shared=True
-        c = VariantMap(Spec())
-        c["foo"] = MultiValuedVariant("foo", ("bar", "baz"))
-        c["foobar"] = SingleValuedVariant("foobar", "fee")
-        c["feebar"] = SingleValuedVariant("feebar", "foo")
-        c["shared"] = BoolValuedVariant("shared", True)
+        c = Spec()
+        c.variants["foo"] = MultiValuedVariant("foo", ("bar", "baz"))
+        c.variants["foobar"] = SingleValuedVariant("foobar", "fee")
+        c.variants["feebar"] = SingleValuedVariant("feebar", "foo")
+        c.variants["shared"] = BoolValuedVariant("shared", True)
 
         # concrete values cannot be constrained
         with pytest.raises(spack.variant.UnsatisfiableVariantSpecError):
-            a.constrain(b)
+            a._constrain_variants(b)
 
     def test_copy(self) -> None:
-        a = VariantMap(Spec())
+        a = VariantMap()
         a["foo"] = BoolValuedVariant("foo", True)
         a["bar"] = SingleValuedVariant("bar", "baz")
         a["foobar"] = MultiValuedVariant("foobar", ("a", "b", "c", "d", "e"))
@@ -492,7 +492,7 @@ class TestVariantMapTest:
         assert a == c
 
     def test_str(self) -> None:
-        c = VariantMap(Spec())
+        c = VariantMap()
         c["foo"] = MultiValuedVariant("foo", ("bar", "baz"))
         c["foobar"] = SingleValuedVariant("foobar", "fee")
         c["feebar"] = SingleValuedVariant("feebar", "foo")


### PR DESCRIPTION
The many object cycles

1. `spec.variants.spec is spec`
2. `spec.compiler_flags.spec is spec`
3. `spec._dependencies[name][i].parent is spec`
4. `spec.package.spec is spec`

are problematic because they require a slow GC cycle to clean up Spec objects. Without cycles, refcounting is used and no GC is needed at all. (In practice, many GC cycles during execution are fruitless because the vast majority of the Specs we instantiate are referenced by package types, and only destroyed at the end of execution when the modules are unloaded...)

This commit breaks cycles (1) and (2), which makes a very large fraction of all Spec objects ever allocated acyclic, so they can be freed using refcounting, before a last slow GC cycle cleans up the remainder. This "very large fraction" is the many abstract specs like `+foo` used in directives.

1. VariantMap's satisfies/constrain logic depend so heavily on `VariantMap.spec` that it seems better as part of Spec anyways.
2. FlagMap's `.spec` property was unused

When loading all packages, this change speeds up exiting Python significantly:

```
for i in $(seq 5); do time python -c 'import time; s=time.perf_counter(); from spack.repo import PATH; x = list(PATH.all_package_classes()); print(time.perf_counter() - s)'; done
```

From a best of 5; before:

```
8.09s to the print statement, but time reports: real 0m11.118s
```

And after:

```
8.22s to the print statement, but time reports: real 0m10.578s
```

That's 540ms fewer spent on "exiting Python".