### PR TITLE
conftest.py: less aggressive gc

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -8,6 +8,7 @@ import datetime
 import email.message
 import errno
 import functools
+import gc
 import inspect
 import io
 import itertools
@@ -81,6 +82,9 @@ from spack.llnl.util.filesystem import (
 from spack.main import SpackCommand
 from spack.util.pattern import Bunch
 from spack.util.remote_file_cache import raw_github_gitlab_url
+
+g0, g1, g2 = gc.get_threshold()
+gc.set_threshold(50000, g1, g2)
 
 mirror_cmd = SpackCommand("mirror")
 


### PR DESCRIPTION
Depending on the Python version, GC may run every 700 or 2000 allocations, but
in Spack, many cyclic objects cannot be freed during execution, and are only
freed when the process exits, because they are referenced by a Package type,
which is exists until end of execution.

So, try to run it less often.

