### PR TITLE
directives: lazy execution for package metadata

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -435,6 +435,22 @@ def _check_build_test_callbacks(pkgs, error_cls):
 
 
 @package_directives
+def _directives_can_be_evaluated(pkgs, error_cls):
+    """Ensure that all directives in a package can be evaluated."""
+    errors = []
+    for pkg_name in pkgs:
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        for attr in pkg_cls._dict_to_directives:
+            try:
+                getattr(pkg_cls, attr)
+            except Exception as e:
+                error_msg = f"Package '{pkg_name}' has invalid directive '{attr}'"
+                details = [str(e)]
+                errors.append(error_cls(error_msg, details))
+    return errors
+
+
+@package_directives
 def _check_patch_urls(pkgs, error_cls):
     """Ensure that patches fetched from GitHub and GitLab have stable sha256
     hashes."""

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -295,11 +295,12 @@ def _execute_conflicts(pkg: PackageType, conflict_spec, when, msg):
     conflict_spec_list.append((get_spec(conflict_spec), msg_with_name))
 
 
-@directive("dependencies")
+@directive("dependencies", can_patch_dependencies=True)
 def depends_on(
     spec: SpecType,
     when: WhenType = None,
     type: DepType = dt.DEFAULT_TYPES,
+    *,
     patches: Optional[PatchesType] = None,
 ):
     """Declare a dependency on another package.
@@ -316,18 +317,18 @@ def depends_on(
         patches: single result of :py:func:`patch` directive, a
             ``str`` to be passed to ``patch``, or a list of these
     """
-    dep_spec = get_spec(spec)
-    return partial(_execute_depends_on, spec=dep_spec, when=when, type=type, patches=patches)
+    return partial(_execute_depends_on, spec=spec, when=when, type=type, patches=patches)
 
 
 def _execute_depends_on(
     pkg: PackageType,
-    spec: spack.spec.Spec,
+    spec: Union[SpecType, spack.spec.Spec],
     *,
     when: WhenType = None,
     type: DepType = dt.DEFAULT_TYPES,
     patches: Optional[PatchesType] = None,
 ):
+    spec = get_spec(spec) if isinstance(spec, str) else spec
     when_spec = _make_when_spec(when)
     if not when_spec:
         return
@@ -362,10 +363,6 @@ def _execute_depends_on(
     elif not isinstance(patches, (list, tuple)):
         patches = [patches]
 
-    # auto-call patch() directive on any strings in patch list
-    patches = [patch(p) if isinstance(p, str) else p for p in patches]
-    assert all(callable(p) for p in patches)
-
     # this is where we actually add the dependency to this package
     deps_by_name = pkg.dependencies.setdefault(when_spec, {})
     dependency = deps_by_name.get(spec.name)
@@ -388,8 +385,12 @@ def _execute_depends_on(
         dependency.depflag |= depflag
 
     # apply patches to the dependency
-    for execute_patch in patches:
-        execute_patch(dependency)
+    for patch in patches:
+        if isinstance(patch, str):
+            _execute_patch(dependency, url_or_filename=patch)
+        else:
+            assert callable(patch), f"Invalid patch argument: {patch!r}"
+            patch(dependency)
 
 
 @directive("disable_redistribute")
@@ -440,11 +441,12 @@ def _execute_redistribute(
         )
 
 
-@directive(("extendees", "dependencies"))
+@directive(("extendees", "dependencies"), can_patch_dependencies=True)
 def extends(
     spec: str,
     when: WhenType = None,
     type: DepType = ("build", "run"),
+    *,
     patches: Optional[PatchesType] = None,
 ):
     """Same as :func:`depends_on`, but also adds this package to the extendee list.
@@ -472,7 +474,7 @@ def _execute_extends(
     # When extending python, also add a dependency on python-venv. This is done so that
     # Spack environment views are Python virtual environments.
     if dep_spec.name == "python" and not pkg.name == "python-venv":
-        _execute_depends_on(pkg, get_spec("python-venv"), when=when, type=("build", "run"))
+        _execute_depends_on(pkg, "python-venv", when=when, type=("build", "run"))
 
     pkg.extendees[dep_spec.name] = (dep_spec, when_spec)
 
@@ -591,12 +593,12 @@ def patch(
 def _execute_patch(
     pkg_or_dep: Union[PackageType, Dependency],
     url_or_filename: str,
-    level: int,
-    when: WhenType,
-    working_dir: str,
-    reverse: bool,
-    sha256: Optional[str],
-    archive_sha256: Optional[str],
+    level: int = 1,
+    when: WhenType = None,
+    working_dir: str = ".",
+    reverse: bool = False,
+    sha256: Optional[str] = None,
+    archive_sha256: Optional[str] = None,
 ) -> None:
     pkg = pkg_or_dep.pkg if isinstance(pkg_or_dep, Dependency) else pkg_or_dep
 
@@ -901,7 +903,7 @@ def maintainers(*names: str):
 
 
 def _execute_maintainer(pkg: PackageType, names: Tuple[str, ...]):
-    maintainers = set(getattr(pkg, "maintainers", []))
+    maintainers = set(pkg.maintainers)
     maintainers.update(names)
     pkg.maintainers = sorted(maintainers)
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -322,7 +322,7 @@ def depends_on(
 
 def _execute_depends_on(
     pkg: PackageType,
-    spec: Union[SpecType, spack.spec.Spec],
+    spec: Union[str, spack.spec.Spec],
     *,
     when: WhenType = None,
     type: DepType = dt.DEFAULT_TYPES,

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -38,13 +38,18 @@ class DirectiveMeta(type):
     _descriptor_cache: Dict[str, "DirectiveDictDescriptor"] = {}
     #: Set of all known directive dictionary names from `@directive(dicts=...)`
     _directive_dict_names: Set[str] = set()
-    #: List of directives to be executed at class initialization time
+    #: Lists of directives to be executed for the class being defined, grouped by directive
+    #: function name (e.g. "depends_on", "version", etc.)
     _directives_to_be_executed: Dict[str, List[Callable]] = collections.defaultdict(list)
     #: Stack of when constraints from `with when(...)` context managers
     _when_constraints_stack: List[spack.spec.Spec] = []
     #: Stack of default args from `with default_args(...)` context managers
     _default_args_stack: List[dict] = []
-    #: Whether the package being defined patches dependencies
+    #: This property is set *automatically* during class definition as directives are invoked,
+    #: if any ``depends_on`` or ``extends`` calls include patches for dependencies. This flag can
+    #: be used as an optimization to detect whether a package provides patches for dependencies,
+    #: without triggering the expensive deferred execution of those directives (without populating
+    #: the ``dependencies`` dictionary).
     _patches_dependencies: bool = False
 
     def __new__(
@@ -126,7 +131,7 @@ class DirectiveMeta(type):
     @staticmethod
     def _remove_kwarg_value_directives_from_queue(value) -> None:
         """Remove directives found in a kwarg value from the execution queue."""
-        # Certain keyword argument values of directives may themselve be (lists of) directives. An
+        # Certain keyword argument values of directives may themselves be (lists of) directives. An
         # example of this is ``depends_on(..., patches=[patch(...), ...])``. In that case, we
         # should not execute those directives as part of the current package, but let the called
         # directive handle them. This function removes such directives from the execution queue.

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import collections
 import functools
-import itertools
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import spack.error
-import spack.llnl.util.lang
 import spack.repo
 import spack.spec
+from spack.llnl.util.lang import dedupe
 
 #: Names of possible directives. This list is mostly populated using the @directive decorator.
 #: Some directives leverage others and in that case are not automatically added.
@@ -30,67 +30,78 @@ class DirectiveMeta(type):
     area into the package.
     """
 
+    #: Registry of {directive_name: [list_of_dicts_it_modifies]} populated by @directive
+    _directive_to_dicts: Dict[str, Tuple[str, ...]] = {}
+    #: Inverted index of {dict_name: [list_of_directives_modifying_it]}
+    _dict_to_directives: Dict[str, List[str]] = collections.defaultdict(list)
+    #: Maps dictionary name to its descriptor instance
+    _descriptor_cache: Dict[str, "DirectiveDictDescriptor"] = {}
     #: Set of all known directive dictionary names from `@directive(dicts=...)`
     _directive_dict_names: Set[str] = set()
     #: List of directives to be executed at class initialization time
-    _directives_to_be_executed: List[Callable] = []
+    _directives_to_be_executed: Dict[str, List[Callable]] = collections.defaultdict(list)
     #: Stack of when constraints from `with when(...)` context managers
     _when_constraints_stack: List[spack.spec.Spec] = []
     #: Stack of default args from `with default_args(...)` context managers
     _default_args_stack: List[dict] = []
+    #: Whether the package being defined patches dependencies
+    _patches_dependencies: bool = False
 
     def __new__(
         cls: Type["DirectiveMeta"], name: str, bases: tuple, attr_dict: dict
     ) -> "DirectiveMeta":
-        # Initialize the attribute containing the list of directives
-        # to be executed. Here we go reversed because we want to execute
-        # commands:
-        # 1. in the order they were defined
-        # 2. following the MRO
-        attr_dict["_directives_to_be_executed"] = []
-        for base in reversed(bases):
-            try:
-                directive_from_base = base._directives_to_be_executed
-                attr_dict["_directives_to_be_executed"].extend(directive_from_base)
-            except AttributeError:
-                # The base class didn't have the required attribute.
-                # Continue searching
-                pass
+        attr_dict["_patches_dependencies"] = DirectiveMeta._patches_dependencies
+        # Initialize the attribute containing the list of directives to be executed. Here we go
+        # reversed because we want to execute commands in the order they were defined, following
+        # the MRO.
+        merged: Dict[str, List[Callable]] = {}
+        sources = [getattr(b, "_directives_to_be_executed", None) or {} for b in reversed(bases)]
+        for source in sources:
+            for key, directive_list in source.items():
+                merged.setdefault(key, []).extend(directive_list)
 
-        # De-duplicates directives from base classes
-        attr_dict["_directives_to_be_executed"] = [
-            x for x in spack.llnl.util.lang.dedupe(attr_dict["_directives_to_be_executed"])
-        ]
+        merged = {key: list(dedupe(directive_list)) for key, directive_list in merged.items()}
 
-        # Move things to be executed from module scope (where they
-        # are collected first) to class scope
-        if DirectiveMeta._directives_to_be_executed:
-            attr_dict["_directives_to_be_executed"].extend(
-                DirectiveMeta._directives_to_be_executed
-            )
-            DirectiveMeta._directives_to_be_executed = []
+        # Add current class's directives (no deduplication needed here)
+        for key, directive_list in DirectiveMeta._directives_to_be_executed.items():
+            merged.setdefault(key, []).extend(directive_list)
+
+        attr_dict["_directives_to_be_executed"] = merged
+
+        DirectiveMeta._directives_to_be_executed.clear()
+        DirectiveMeta._patches_dependencies = False
+
+        # Add descriptors for all known directive dictionaries
+        for dict_name in DirectiveMeta._directive_dict_names:
+            # Where the actual data will be stored
+            attr_dict[f"_{dict_name}"] = None
+            # Descriptor to lazily initialize and populate the dictionary
+            attr_dict[dict_name] = DirectiveMeta._get_descriptor(dict_name)
 
         return super(DirectiveMeta, cls).__new__(cls, name, bases, attr_dict)
 
     def __init__(cls: "DirectiveMeta", name: str, bases: tuple, attr_dict: dict):
-        # The instance is being initialized: if it is a package we must ensure
-        # that the directives are called to set it up.
-
         if spack.repo.is_package_module(cls.__module__):
-            # Ensure the presence of the dictionaries associated with the directives.
-            # All dictionaries are defaultdicts that create lists for missing keys.
-            for d in DirectiveMeta._directive_dict_names:
-                setattr(cls, d, {})
-
-            # Lazily execute directives
-            for directive in cls._directives_to_be_executed:
+            # Historically, maintainers was not a directive. They were simply set as class
+            # attributes `maintainers = ["alice", "bob"]`. Therefore, we execute these directives
+            # eagerly.
+            for directive in cls._directives_to_be_executed.get("maintainers", ()):
                 directive(cls)
-
-            # Ignore any directives executed *within* top-level
-            # directives by clearing out the queue they're appended to
-            DirectiveMeta._directives_to_be_executed = []
-
         super(DirectiveMeta, cls).__init__(name, bases, attr_dict)
+
+    @staticmethod
+    def register_directive(name: str, dicts: Tuple[str, ...]) -> None:
+        """Called by @directive to register relationships."""
+        DirectiveMeta._directive_to_dicts[name] = dicts
+        for d in dicts:
+            DirectiveMeta._dict_to_directives[d].append(name)
+
+    @staticmethod
+    def _get_descriptor(name: str) -> "DirectiveDictDescriptor":
+        """Returns a singleton descriptor for the given dictionary name."""
+        if name not in DirectiveMeta._descriptor_cache:
+            DirectiveMeta._descriptor_cache[name] = DirectiveDictDescriptor(name)
+        return DirectiveMeta._descriptor_cache[name]
 
     @staticmethod
     def push_when_constraint(when_spec: spack.spec.Spec) -> None:
@@ -113,23 +124,73 @@ class DirectiveMeta(type):
         return DirectiveMeta._default_args_stack.pop()
 
     @staticmethod
-    def _remove_directives(args):
-        # If any of the arguments are executors returned by a directive passed as an argument,
-        # don't execute them lazily. Instead, let the called directive handle them. This allows
-        # nested directive calls in packages.  The caller can return the directive if it should be
-        # queued. Nasty, but it's the best way I can think of to avoid side effects if directive
-        # results are passed as args
-        directives = DirectiveMeta._directives_to_be_executed
-        for arg in args:
-            if isinstance(arg, (list, tuple)):
-                # Descend into args that are lists or tuples
-                DirectiveMeta._remove_directives(arg)
-            elif callable(arg):  # directives are always callable, and very rare
-                # Remove directives args from the exec queue
-                for directive in directives:
-                    if arg is directive:
-                        directives.remove(directive)  # iterations ends, so mutation is fine
+    def _remove_kwarg_value_directives_from_queue(value) -> None:
+        """Remove directives found in a kwarg value from the execution queue."""
+        # Certain keyword argument values of directives may themselve be (lists of) directives. An
+        # example of this is ``depends_on(..., patches=[patch(...), ...])``. In that case, we
+        # should not execute those directives as part of the current package, but let the called
+        # directive handle them. This function removes such directives from the execution queue.
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                DirectiveMeta._remove_kwarg_value_directives_from_queue(item)
+        elif callable(value):  # directives are always callable
+            # Remove directives args from the exec queue
+            for lst in DirectiveMeta._directives_to_be_executed.values():
+                for directive in lst:
+                    if value is directive:
+                        lst.remove(directive)  # iterations ends, so mutation is fine
                         break
+
+    @staticmethod
+    def _get_execution_plan(target_dict: str) -> Tuple[List[str], List[str]]:
+        """Calculates the closure of dicts and directives needed to populate target_dict."""
+        dicts_involved = {target_dict}
+        directives_involved = set()
+        stack = [target_dict]
+
+        while stack:
+            current_dict = stack.pop()
+
+            for directive_name in DirectiveMeta._dict_to_directives.get(current_dict, ()):
+                if directive_name in directives_involved:
+                    continue
+
+                directives_involved.add(directive_name)
+
+                for other_dict in DirectiveMeta._directive_to_dicts[directive_name]:
+                    if other_dict not in dicts_involved:
+                        dicts_involved.add(other_dict)
+                        stack.append(other_dict)
+
+        return sorted(dicts_involved), sorted(directives_involved)
+
+
+class DirectiveDictDescriptor:
+    """A descriptor that lazily executes directives on first access."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.private_name = f"_{name}"
+        self.dicts_to_init, self.directives_to_run = DirectiveMeta._get_execution_plan(name)
+
+    def __get__(self, obj, objtype=None):
+        val = getattr(objtype, self.private_name)
+        if val is not None:
+            return val
+
+        # The None value is a sentinel for "not yet initialized".
+        for dictionary in self.dicts_to_init:
+            if getattr(objtype, f"_{dictionary}") is None:
+                setattr(objtype, f"_{dictionary}", {})
+
+        # Populate these dictionaries by running all directives that modify them
+        for directive_name in self.directives_to_run:
+            directives = objtype._directives_to_be_executed.get(directive_name)
+            if directives:
+                for directive in directives:
+                    directive(objtype)
+
+        return getattr(objtype, self.private_name)
 
 
 def _combine_when(
@@ -158,7 +219,10 @@ def _combine_when(
 
 class directive:
     def __init__(
-        self, dicts: Union[Tuple[str, ...], str] = (), supports_when: bool = True
+        self,
+        dicts: Union[Tuple[str, ...], str] = (),
+        supports_when: bool = True,
+        can_patch_dependencies: bool = False,
     ) -> None:
         """Decorator for Spack directives.
 
@@ -187,10 +251,13 @@ class directive:
            refer to pkg.versions.
 
         Arguments:
-            dicts: A list of names of dictionaries to add to the package class if they don't
+            dicts: A tuple of names of dictionaries to add to the package class if they don't
                 already exist.
             supports_when: If True, the directive can be used within a ``with when(...)`` context
                 manager. (To be removed when all directives support ``when=`` arguments.)
+            can_patch_dependencies: If True, the directive can patch dependencies. This is used to
+                identify nested directives so they can be removed from the execution queue, and to
+                mark the package as patching dependencies.
         """
 
         if isinstance(dicts, str):
@@ -200,12 +267,12 @@ class directive:
         DirectiveMeta._directive_dict_names.update(dicts)
 
         self.supports_when = supports_when
+        self.can_patch_dependencies = can_patch_dependencies
+        self.dicts = tuple(dicts)
 
     def __call__(self, decorated_function: Callable) -> Callable:
         directive_names.append(decorated_function.__name__)
-
-        # Do not capture `self` in the wrapper
-        supports_when = self.supports_when
+        DirectiveMeta.register_directive(decorated_function.__name__, self.dicts)
 
         @functools.wraps(decorated_function)
         def _wrapper(*args, **_kwargs):
@@ -220,7 +287,7 @@ class directive:
 
             # Inject when arguments from the context
             if DirectiveMeta._when_constraints_stack:
-                if not supports_when:
+                if not self.supports_when:
                     raise DirectiveError(
                         f'directive "{decorated_function.__name__}" cannot be used within a '
                         '"when" context since it does not support a "when=" argument'
@@ -229,11 +296,13 @@ class directive:
 
             # Remove directives passed as arguments, so they are not executed as part of this
             # class's directive execution, but handled by the called directive instead
-            DirectiveMeta._remove_directives(itertools.chain(args, kwargs.values()))
+            if self.can_patch_dependencies and "patches" in kwargs:
+                DirectiveMeta._remove_kwarg_value_directives_from_queue(kwargs["patches"])
+                DirectiveMeta._patches_dependencies = True
 
             result = decorated_function(*args, **kwargs)
 
-            DirectiveMeta._directives_to_be_executed.append(result)
+            DirectiveMeta._directives_to_be_executed[decorated_function.__name__].append(result)
 
             # wrapped function returns same result as original so that we can nest directives
             return result

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -546,6 +546,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     compiler = DeprecatedCompiler()
 
+    #: Set to true when this package has directives that specify patches on dependencies. Can be
+    #: used as an optimization to avoid execution of :func:`~spack.directives.depends_on` and
+    #: :func:`~spack.directives.extends` directives when looking for all patches defined by this
+    #: package.
+    _patches_dependencies: bool = False
     #: Class level dictionary populated by :func:`~spack.directives.version` directives
     versions: dict
     #: Class level dictionary populated by :func:`~spack.directives.resource` directives

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -546,11 +546,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     compiler = DeprecatedCompiler()
 
-    #: Set to true when this package has directives that specify patches on dependencies. Can be
-    #: used as an optimization to avoid execution of :func:`~spack.directives.depends_on` and
-    #: :func:`~spack.directives.extends` directives when looking for all patches defined by this
-    #: package.
-    _patches_dependencies: bool = False
     #: Class level dictionary populated by :func:`~spack.directives.version` directives
     versions: dict
     #: Class level dictionary populated by :func:`~spack.directives.resource` directives

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -520,6 +520,9 @@ class PatchCache:
                 patch_dict.pop("sha256")  # save some space
                 index[patch.sha256] = {pkg_class.fullname: patch_dict}
 
+        if not pkg_class._patches_dependencies:
+            return index
+
         for deps_by_name in pkg_class.dependencies.values():
             for dependency in deps_by_name.values():
                 for patch_list in dependency.patches.values():

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2016,7 +2016,7 @@ def clear_directive_functions():
     # Make sure any directive functions overidden by tests are cleared before
     # proceeding with subsequent tests that may depend on the original
     # functions.
-    spack.directives_meta.DirectiveMeta._directives_to_be_executed = []
+    spack.directives_meta.DirectiveMeta._directives_to_be_executed.clear()
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -10,7 +10,7 @@ import spack.directives
 import spack.repo
 import spack.spec
 import spack.version
-from spack.directives_meta import _combine_when
+from spack.directives_meta import DirectiveDictDescriptor, _combine_when
 from spack.spec import Spec
 
 
@@ -230,3 +230,33 @@ def test_directives_meta_combine_when():
 
     # Check the optimization for single stack with no when
     assert _combine_when(None, [x]) is x
+
+
+def test_directive_descriptor_init():
+    # when `pkg.variants` is initialized, only the `variant` directive should run
+    variants = DirectiveDictDescriptor("variants")
+    assert variants.directives_to_run == ["variant"]
+    assert variants.dicts_to_init == ["variants"]
+
+    # when `pkg.dependencies` is initialized, `depends_on` and `extends` should run, and also
+    # `pkg.extendees` should be initialized
+    dependencies = DirectiveDictDescriptor("dependencies")
+    assert dependencies.directives_to_run == ["depends_on", "extends"]
+    assert dependencies.dicts_to_init == ["dependencies", "extendees"]
+
+    # when `pkg.provided` is initialized, so should `pkg.provided_together`, and only the
+    # provides directive should run
+    provided = DirectiveDictDescriptor("provided")
+    assert provided.directives_to_run == ["provides"]
+    assert provided.dicts_to_init == ["provided", "provided_together"]
+
+    # idem for `pkg.provided_together`
+    provided_together = DirectiveDictDescriptor("provided_together")
+    assert provided_together.directives_to_run == ["provides"]
+    assert provided_together.dicts_to_init == ["provided", "provided_together"]
+
+    # when specifying patches on dependencies with `depends_on` and `extends`, the `pkg.patches`
+    # dict is not affects -- they are stored on a Dependency object.
+    patches = DirectiveDictDescriptor("patches")
+    assert patches.directives_to_run == ["patch"]
+    assert patches.dicts_to_init == ["patches"]

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -10,7 +10,8 @@ import spack.directives
 import spack.repo
 import spack.spec
 import spack.version
-from spack.directives_meta import DirectiveDictDescriptor, _combine_when
+from spack.directives import depends_on, extends, patch
+from spack.directives_meta import DirectiveDictDescriptor, DirectiveMeta, _combine_when
 from spack.spec import Spec
 
 
@@ -260,3 +261,45 @@ def test_directive_descriptor_init():
     patches = DirectiveDictDescriptor("patches")
     assert patches.directives_to_run == ["patch"]
     assert patches.dicts_to_init == ["patches"]
+
+
+def test_directive_laziness():
+    class ExamplePackage(metaclass=DirectiveMeta):
+        name = "example-package"
+        depends_on("foo")
+        extends("bar", when="+bar")
+
+    # Initially, no directive dicts are initialized
+    assert ExamplePackage._dependencies is None  # type: ignore
+    assert ExamplePackage._extendees is None  # type: ignore
+    assert ExamplePackage._variants is None  # type: ignore
+
+    # Only when we access the dependencies descriptor, the relevant dicts (dependencies, extendees)
+    # are initialized, while others remain None
+    dependencies = ExamplePackage.dependencies  # type: ignore
+    assert type(ExamplePackage._dependencies) is dict  # type: ignore
+    assert type(ExamplePackage._extendees) is dict  # type: ignore
+    assert ExamplePackage._variants is None  # type: ignore
+
+    # The dependencies dict is populated with the expected entries
+    assert "foo" in dependencies[spack.spec.Spec()]
+    assert "bar" in dependencies[spack.spec.Spec("+bar")]
+
+
+def test_patched_dependencies_sets_class_attribute():
+    sha256 = "a" * 64
+
+    class PatchesDependencies(metaclass=DirectiveMeta):
+        name = "patches-dependencies"
+        depends_on("dependency", patches=patch("https://example.com/diff.patch", sha256=sha256))
+
+    assert PatchesDependencies._patches_dependencies is True
+    assert not PatchesDependencies.patches  # type: ignore
+
+    class DoesNotPatchDependencies(metaclass=DirectiveMeta):
+        name = "does-not-patch-dependencies"
+        fullname = "does-not-patch-dependencies"
+        patch("https://example.com/diff.patch", sha256=sha256)
+
+    assert DoesNotPatchDependencies._patches_dependencies is False
+    assert DoesNotPatchDependencies.patches  # type: ignore


### PR DESCRIPTION
This refactors the directive system to execute directives lazily.  Directives
are now queued during class definition and only executed when the corresponding
dictionary on the package class is accessed (e.g., `pkg.dependencies`,
`pkg.versions`). This reduces overhead during cache population, and in non-forking
build sub-processes where `spec.package` is used and metadata isn't needed.

- `DirectiveDictDescriptor` is a singleton descriptor shared across package
  classes. It handles the lazy initialization of package attributes.
- For each dictionary, the set of directives affecting it is computed
  automatically. For example, accessing `pkg.extendees` automatically triggers
  the execution of both `extends` and `depends_on` directives.
- The actual dictionary is now stored at `pkg._dependencies` and so on. It is
   initially set to `None` to indicate the directives have not run yet.
- `_execute_depends_on` now applies nested patches immediately via
  `_execute_patch` instead of going through `patch(...)` internally. This prevents
  state corruption in the global directive queue when `depends_on` is evaluated
  lazily.
- `maintainers` directives remain eager to ensure backward compatibility with
  packages that define maintainers as a simple class-level list.
- `PackageBase._patches_dependencies = True/False` is set without evaluation of
   `depends_on` and `extends` directives. This allows us to optimize patch indexing by
  avoiding evaluation of these directives if none of them produce patches.

In the current form, the PR has two "breaking" changes:

1. `patches=...` is kwarg-only in the `depends_on` and `extends` directives.
   Previously this was a positional argument.
2. Nested directives are only deleted from the `patches` kwarg of `depends_on`
   and `extends`. Previously all args and kwarg values where searched for nested
   directives.

In principle (1) is a breaking change to the package API, but pragmatically speaking,
I would argue (a) it was an oversight from us to keep `patches` as a positional argument,
and (b) it's not breaking in practice for all packages in `spack/spack-packages`. If it
breaks an internal repo, the change of adding `patches=[...]` is trivial.

The descriptor indirection does not seem to impact the "setup" phase of the
solver.

The first use of Spack is significantly faster. Below are results from a best of 3.

Before (855e07abce5c0a7609ed722bd378ff8381a7f357):

```
$ spack clean -m && time spack list
0m15.371s
```

After (5ee3706c0d072bedd9402476df2176a49d489226):

```
$ spack clean -m && time spack list
0m8.452s
```

The `list(spack.repo.PATH.all_package_classes())` benchmark is now useless. With
a few other PRs combined (#51875, #51836, #51879, #48771), the first-use time reduces
further to under 5 seconds, or 3x faster than reference.

 