### PR TITLE
A pass over the docs to fix spelling/consistency

### DIFF
--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -150,8 +150,8 @@ Build Cache Index Views
 Build caches can quickly become large and inefficient to search as binaries are added over time.
 A common work around to this problem is to break the build cache into stacks that target specific applications or workflows.
 This allows for curation of binaries as smaller collections of packages that push to their own mirrors that each maintain a smaller search area.
-However, this approach comes with the tradeoff of requiring much larger storage and computational footprints due to duplication of common dependencies between stacks.
-Splitting build caches can also reduce direct fetch hits by reducing the breadth of binaries availabe in a single mirror.
+However, this approach comes with the trade off of requiring much larger storage and computational footprints due to duplication of common dependencies between stacks.
+Splitting build caches can also reduce direct fetch hits by reducing the breadth of binaries available in a single mirror.
 
 To better address the issues with large search areas, build cache index views (or just "views" in this section) were introduced.
 A view is a named index which provides a curated view into a larger build cache.
@@ -167,7 +167,7 @@ View indices are stored similarly to the top level build cache index, but use an
 Creating a Build Cache Index View
 """""""""""""""""""""""""""""""""
 
-Here is an example of creating a view using an active environent.
+Here is an example of creating a view using an active environment.
 
 .. code-block:: console
 
@@ -188,7 +188,7 @@ If a list of environments is passed while inside of an active environment, the a
 Updating a Build Cache Index View
 """""""""""""""""""""""""""""""""
 
-To prevent accidently overwriting an existing view, it is required to specify how a view should be updated.
+To prevent accidentally overwriting an existing view, it is required to specify how a view should be updated.
 It is possible to use one of two options for updating a view index: ``--force`` or ``--append``.
 Using the ``--force`` option will replace the index as if the previous one did not exist.
 The ``--append`` option will first read the existing index, and then add the new specs to it.
@@ -332,13 +332,13 @@ Automatic Push to a Build Cache
 ---------------------------------
 
 Sometimes it is convenient to push packages to a build cache immediately after they are installed.
-Spack can do this by setting the autopush flag when adding a mirror:
+Spack can do this by setting the ``--autopush`` flag when adding a mirror:
 
 .. code-block:: console
 
     $ spack mirror add --autopush <name> <url or path>
 
-Or the autopush flag can be set for an existing mirror:
+Or the ``--autopush`` flag can be set for an existing mirror:
 
 .. code-block:: console
 

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -66,7 +66,7 @@ From lowest to highest precedence:
 
 #. **system**: Stored in ``/etc/spack/``.
    These are settings for this machine or for all machines on which this file system is mounted.
-   The systm scope overrides the defaults scope.
+   The system scope overrides the defaults scope.
    It can be used for settings idiosyncratic to a particular machine, such as the locations of compilers or external packages.
    Be careful when modifying this scope, as changes here affect all Spack users on a machine.
    Before putting configuration here, instead consider using the ``site`` scope, which only affects the spack instance it's part of.
@@ -85,7 +85,7 @@ From lowest to highest precedence:
 #. **spack**: Stored in ``$(prefix)/etc/spack/``.
    Settings here affect only *this instance* of Spack, and they override ``user`` and lower configuration scopes.
    This is intended for project-specific or single-user spack installations.
-   This is the the topmost built-in spack scope, and modifying it gives you full control over configuration scopes.
+   This is the topmost built-in spack scope, and modifying it gives you full control over configuration scopes.
    For example, it defines the ``user``, ``site``, and ``system`` scopes, so you can use it to remove them completely if you want.
 
 #. **environment**: When using Spack :ref:`environments`, Spack reads additional configuration from the environment file.
@@ -102,7 +102,7 @@ When configurations conflict, settings from higher-precedence scopes override lo
 
 All of these except ``spack`` and ``defaults`` are initially empty, so you don't have to think about the others unless you need them.
 The most commonly used scopes are ``environment``, ``user``, and ``spack``.
-If you forget, you can always see the available configuration scopes in order of precedece wiht the ``spack config scopes`` command::
+If you forget, you can always see the available configuration scopes in order of precedence with the ``spack config scopes`` command::
 
     > spack config scopes -p
     Scope            Path

--- a/lib/spack/docs/configuring_compilers.rst
+++ b/lib/spack/docs/configuring_compilers.rst
@@ -17,7 +17,7 @@ Compilers can be made available to Spack by:
 
 1. Specifying them as externals in ``packages.yaml``, or
 2. Having them installed in the current Spack store, or
-3. Having them available as binaries in a buildcache
+3. Having them available as binaries in a build cache
 
 For convenience, Spack will automatically detect compilers as externals the first time it needs them, if no compiler is available.
 
@@ -36,7 +36,7 @@ You can see which compilers are available to Spack by running ``spack compiler l
    [e]  gcc@10.5.0  [+]  gcc@15.1.0  [+]  gcc@14.3.0
 
 Compilers marked with an ``[e]`` are system compilers (externals), and those marked with a ``[+]`` have been installed by Spack.
-Compilers from remote buildcaches are marked as ``-``, but are not shown by default.
+Compilers from remote build caches are marked as ``-``, but are not shown by default.
 To see them you need a specific option:
 
 .. code-block:: console

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -61,7 +61,7 @@ Exporting Spack installations as Container Images
 The command
 
 .. code-block:: text
-  
+
    spack buildcache push [--base-image BASE_IMAGE] [--tag TAG] mirror [specs...]
 
 creates and pushes a container image to an OCI-compatible container registry, with the ``mirror`` argument specifying a registry (see below).
@@ -72,7 +72,7 @@ Container images created this way are **minimal**: they contain only runtime dep
 Spack itself is *not* included in the resulting image.
 
 The arguments are as follows:
-  
+
 ``--base-image BASE_IMAGE``
    Specifies the base image to use for the container.
    This should be a minimal Linux distribution with a libc that is compatible with the host system.
@@ -253,7 +253,7 @@ Since recipes need a little more boilerplate than:
    RUN spack -e /environment install
 
 Spack provides a command to generate customizable recipes for container images.
-Customizations include minimizing the size of the image, installing packages in the base image using the system package manager, and setting up a proper entrypoint to run the image.
+Customizations include minimizing the size of the image, installing packages in the base image using the system package manager, and setting up a proper entry point to run the image.
 
 .. _cmd-spack-containerize:
 

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -282,7 +282,7 @@ Spack uses GitLab CI for managing the orchestration of build jobs.
 GitLab Entry Point
 ~~~~~~~~~~~~~~~~~~
 
-Add a stack entrypoint to ``share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml``.
+Add a stack entry point to ``share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml``.
 There are two stages required for each new stack: the generation stage and the build stage.
 
 The generate stage is defined using the job template ``.generate`` configured with environment variables defining the name of the stack in ``SPACK_CI_STACK_NAME``, the platform (``SPACK_TARGET_PLATFORM``) and architecture (``SPACK_TARGET_ARCH``) configuration, and the tags associated with the class of runners to build on.

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -456,7 +456,7 @@ As the action runs, you should observe output similar to:
    ssh 5RjFs7LPdtwGG8cwSPkGrdMNg@sfo2.tmate.io
    https://tmate.io/t/5RjFs7LPdtwGG8cwSPkGrdMNg
 
-The first line is the ssh command neccesary to connect to the server, the second line is a tmate web-ui that also provides access to the ssh server on the runner.
+The first line is the ssh command necessary to connect to the server, the second line is a tmate web UI that also provides access to the ssh server on the runner.
 
 .. note:: The web UI has occasionally been unresponsive, if it does not respond within ~10s, you'll need to use your local ssh utility.
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -636,7 +636,7 @@ For example, a ``spack.yaml`` manifest file containing some package preference c
            mpi: [openmpi]
      # ...
 
-This configuration sets the default mpi provider to be openmpi.
+This configuration sets the default ``mpi`` provider to be ``openmpi``.
 
 Included configurations
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -876,7 +876,7 @@ The valid variables for a ``when`` clause are:
    The platform string of the default Spack architecture on the system.
 
 #. ``os``.
-   The os string of the default Spack architecture on the system.
+   The OS string of the default Spack architecture on the system.
 
 #. ``target``.
    The target string of the default Spack architecture on the system.
@@ -1222,7 +1222,7 @@ Adding post-install hooks
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Another advanced use-case of generated ``Makefile``\s is running a post-install command for each package.
-These "hooks" could be anything from printing a post-install message, running tests, or pushing just-built binaries to a buildcache.
+These "hooks" could be anything from printing a post-install message, running tests, or pushing just-built binaries to a build cache.
 
 This can be accomplished through the generated ``[<prefix>/]SPACK_PACKAGE_IDS`` variable.
 Assuming we have an active and concrete environment, we generate the associated ``Makefile`` with a prefix ``example``:
@@ -1235,7 +1235,7 @@ And we now include it in a different ``Makefile``, in which we create a target `
 This target depends on the particular package installation.
 In this target we automatically have the target-specific ``HASH`` and ``SPEC`` variables at our disposal.
 They are respectively the spec hash (excluding leading ``/``), and a human-readable spec.
-Finally, we have an entry point target ``push`` that will update the buildcache index once every package is pushed.
+Finally, we have an entry point target ``push`` that will update the build cache index once every package is pushed.
 Note how this target uses the generated ``example/SPACK_PACKAGE_IDS`` variable to define its prerequisites.
 
 .. code-block:: Makefile

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -89,7 +89,7 @@ If the search was successful, you can now list known compilers, and get an outpu
 If no compilers were found, you need to either:
 
 * Install further prerequisites, see :ref:`verify-spack-prerequisites`, and repeat the search above.
-* Register a buildcache that provides a compiler already available as a binary
+* Register a build cache that provides a compiler already available as a binary
 
 Once a compiler is available, you can proceed installing your first package:
 

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -112,7 +112,7 @@ Scopes can tell Spack to prefer to edit their included scopes instead, using ``p
      path: /path/to/scope/we/want-to-write
      prefer_modify: true
 
-Now, if the including scope is the highest precedence scope and would otherwise be selected automatically by one fo these commands, they will instead prefer to edit ``preferred``.
+Now, if the including scope is the highest precedence scope and would otherwise be selected automatically by one of these commands, they will instead prefer to edit ``preferred``.
 The including scope can still be modified by using the ``--scope`` argument (e.g., ``spack compiler find --scope NAME``).
 
 .. warning::

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -399,7 +399,7 @@ For instance, the following config options,
 
 will add a ``python3.12`` to module names of packages compiled with Python 3.12, and similarly for all specs depending on ``python@3``.
 This is useful to know which version of Python a set of Python extensions is associated with.
-Likewise, the ``openblas`` string is attached to any program that has openblas in the spec, most likely via the ``+blas`` variant specification.
+Likewise, the ``openblas`` string is attached to any program that has ``openblas`` in the spec, most likely via the ``+blas`` variant specification.
 
 The most heavyweight solution to module naming is to change the entire naming convention for module files.
 This uses the projections format covered in :ref:`view_projections`.
@@ -413,7 +413,7 @@ This uses the projections format covered in :ref:`view_projections`.
            all: "{name}/{version}-{compiler.name}-{compiler.version}-module"
            ^mpi: "{name}/{version}-{^mpi.name}-{^mpi.version}-{compiler.name}-{compiler.version}-module"
 
-will create module files that are nested in directories by package name, contain the version and compiler name and version, and have the word ``module`` before the hash for all specs that do not depend on mpi, and will have the same information plus the MPI implementation name and version for all packages that depend on mpi.
+will create module files that are nested in directories by package name, contain the version and compiler name and version, and have the word ``module`` before the hash for all specs that do not depend on ``mpi``, and will have the same information plus the MPI implementation name and version for all packages that depend on ``mpi``.
 
 When specifying module names by projection for Lmod modules, we recommend NOT including names of dependencies (e.g., MPI, compilers) that are already in the Lmod hierarchy.
 

--- a/lib/spack/docs/package_fundamentals.rst
+++ b/lib/spack/docs/package_fundamentals.rst
@@ -176,7 +176,7 @@ We'll talk more about how you can use them to customize an installation in :ref:
 Reusing installed dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, when you run ``spack install``, Spack tries hard to reuse existing installations as dependencies, either from a local store or from remote buildcaches, if configured.
+By default, when you run ``spack install``, Spack tries hard to reuse existing installations as dependencies, either from a local store or from remote build caches, if configured.
 This minimizes unwanted rebuilds of common dependencies, in particular if you update Spack frequently.
 
 In case you want the latest versions and configurations to be installed instead, you can add the ``--fresh`` option:
@@ -539,7 +539,7 @@ If you want to find only libelf versions greater than version 0.8.12, you could 
    -- linux-debian7-x86_64 / gcc@4.4.7 --------------------------------
        libelf@0.8.12  libelf@0.8.13
 
-Finding just the versions of libdwarf built with a particular version of libelf would look like this:
+Finding just the versions of ``libdwarf`` built with a particular version of libelf would look like this:
 
 .. code-block:: spec
 
@@ -549,7 +549,7 @@ Finding just the versions of libdwarf built with a particular version of libelf 
    libdwarf@20130729-d9b90962
 
 We can also search for packages that have a certain attribute.
-For example, ``spack find libdwarf +debug`` will show only installations of libdwarf with the 'debug' compile-time option enabled.
+For example, ``spack find libdwarf +debug`` will show only installations of ``libdwarf`` with the 'debug' compile-time option enabled.
 
 The full spec syntax is discussed in detail in :ref:`sec-specs`.
 
@@ -656,7 +656,7 @@ You can use this with tools like `jq <https://jqlang.org/>`_ to quickly create J
 ^^^^^^^^^^^^^^
 
 It's often the case that you have two versions of a spec that you need to disambiguate.
-Let's say that we've installed two variants of zlib, one with and one without the optimize variant:
+Let's say that we've installed two variants of ``zlib``, one with and one without the optimize variant:
 
 .. code-block:: spec
 
@@ -690,7 +690,7 @@ We run the command and quickly encounter a problem because two versions are inst
         c) use `spack uninstall --all` to uninstall ALL matching specs.
 
 Oh no!
-We can see from the above that we have two different versions of zlib installed, and the only difference between the two is the hash.
+We can see from the above that we have two different versions of ``zlib`` installed, and the only difference between the two is the hash.
 This is a good use case for ``spack diff``, which can easily show us the "diff" or set difference between properties for two packages.
 Let's try it out.
 Because the only difference we see in the ``spack find`` view is the hash, let's use ``spack diff`` to look for more detail.
@@ -721,7 +721,7 @@ Here is an example:
 
 Awesome!
 Now let's read the diff.
-It tells us that our first zlib was built with ``~optimize`` (``False``) and the second was built with ``+optimize`` (``True``).
+It tells us that our first ``zlib`` was built with ``~optimize`` (``False``) and the second was built with ``+optimize`` (``True``).
 You can't see it in the docs here, but the output above is also colored based on the content being an addition (+) or subtraction (-).
 
 This is a small example, but you will be able to see differences for any attributes on the installation spec.
@@ -808,7 +808,7 @@ For example, this will add the ``mpich`` package built with ``gcc`` to your path
    ~/spack/opt/linux-debian7-x86_64/gcc@4.4.7/mpich@3.0.4/bin/mpicc
 
 These commands will add appropriate directories to your ``PATH`` and ``MANPATH`` according to the :ref:`prefix inspections <customize-env-modifications>` defined in your modules configuration.
-When you no longer want to use a package, you can type unload or unuse similarly:
+When you no longer want to use a package, you can type ``spack unload``:
 
 .. code-block:: spec
 

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -129,7 +129,7 @@ This commonly happens with Python packages.
 For example, the case of one or more letters in the package name may change at some point (e.g., `py-sphinx <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_sphinx/package.py>`_).
 Also, dashes may be replaced with underscores (e.g., `py-scikit-build <https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/py_scikit_build/package.py>`_).
 In some cases, both changes can occur for the same package.
-As these examples illlustrate, it is sometimes possible to add a ``url_for_version`` method to override the default derived URL to ensure the correct one is returned.
+As these examples illustrate, it is sometimes possible to add a ``url_for_version`` method to override the default derived URL to ensure the correct one is returned.
 
 If older versions are no longer available and there is a chance someone has the package in a build cache, the usual approach is to first suggest :ref:`deprecating <deprecate>` them in the package.
 

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -62,7 +62,7 @@ If Spack is asked to build a package that uses one of these MPIs as a dependency
 Note that the specified path is the top-level install prefix, not the ``bin`` subdirectory.
 
 ``packages.yaml`` can also be used to specify modules to load instead of the installation prefixes.
-The following example says that module ``CMake/3.7.2`` provides cmake version 3.7.2.
+The following example says that module ``CMake/3.7.2`` provides CMake version 3.7.2.
 
 .. code-block:: yaml
 
@@ -155,7 +155,7 @@ Spack can be configured with every MPI provider not buildable individually, but 
 
 Spack can then use any of the listed external implementations of MPI to satisfy a dependency, and will choose among them depending on the compiler and architecture.
 
-In cases where the concretizer is configured to reuse specs, and other ``mpi`` providers (available via stores or buildcaches) are not desirable, Spack can be configured to require specs matching only the available externals:
+In cases where the concretizer is configured to reuse specs, and other ``mpi`` providers (available via stores or build caches) are not desirable, Spack can be configured to require specs matching only the available externals:
 
 .. code-block:: yaml
 
@@ -173,7 +173,7 @@ In cases where the concretizer is configured to reuse specs, and other ``mpi`` p
        - spec: "openmpi@1.4.3+debug"
          prefix: /opt/openmpi-1.4.3-debug
 
-This configuration prevents any spec using MPI and originating from stores or buildcaches to be reused, unless it matches the requirements under ``packages:mpi:require``.
+This configuration prevents any spec using MPI and originating from stores or build caches to be reused, unless it matches the requirements under ``packages:mpi:require``.
 For more information on requirements see :ref:`package-requirements`.
 
 Specifying dependencies among external packages

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -85,7 +85,7 @@ From simplest to most complex, the following are the most common ways to customi
    For example, for ``AutotoolsPackage`` you can specify the command line arguments for ``./configure`` by implementing ``configure_args``:
 
    .. code-block:: python
-   
+
       class MyPkg(AutotoolsPackage):
           def configure_args(self):
               # FIXME: Add arguments other than --prefix
@@ -96,7 +96,7 @@ From simplest to most complex, the following are the most common ways to customi
    Similarly for ``CMakePackage`` you can influence how ``cmake`` is invoked by implementing ``cmake_args``:
 
    .. code-block:: python
-   
+
       class MyPkg(CMakePackage):
           def cmake_args(self):
               # FIXME: Add arguments other than
@@ -113,7 +113,7 @@ From simplest to most complex, the following are the most common ways to customi
    You can set these variables by overriding the ``setup_build_environment`` method in your package class:
 
    .. code-block:: python
-   
+
       def setup_build_environment(self, env):
           env.set("MY_ENV_VAR", "value")
 
@@ -126,7 +126,7 @@ From simplest to most complex, the following are the most common ways to customi
    This is useful for installing additional files missed by the build system, or for running custom scripts.
 
    .. code-block:: python
-   
+
       @run_after("install")
       def install_missing_files(self):
           install_tree("extra_files", self.prefix.bin)
@@ -147,9 +147,9 @@ In any of the functions above, you can
 
       if self.spec.satisfies("+variant_name"):
           ...
-   
+
    to check if a variant is enabled, or
-   
+
    .. code-block:: python
 
       self.spec["dependency_name"].prefix
@@ -363,7 +363,7 @@ This example adds a flag when the C compiler is from GCC version 8 or higher.
 The ``%c=gcc`` syntax technically means that ``gcc`` is the provider for the ``c`` language virtual.
 
 .. tip::
-   
+
     Historically, many packages have been written using ``^dep`` to refer to a dependency.
     Modern Spack packages should consider using ``%dep`` instead, which is more precise: it can only match direct dependencies, which are listed in the ``depends_on`` statements.
 
@@ -456,20 +456,20 @@ We can get the provider's (e.g. OpenBLAS or Intel MKL) prefixes like this:
                 f"--with-lapack={self.spec['lapack'].prefix}",
             ]
 
-Many build systems struggle to locate the ``blas`` and ``lapack`` libraries during configure, either because they do not know the exact names of the libraries, or because the libraries are not in typical locations --- they may not even know whether blas and lapack are a single or separate libraries.
+Many build systems struggle to locate the ``blas`` and ``lapack`` libraries during configure, either because they do not know the exact names of the libraries, or because the libraries are not in typical locations --- they may not even know whether ``blas`` and ``lapack`` are a single or separate libraries.
 In those cases, the build system could use some help, for which we give a few examples below:
 
 1. Space separated list of full paths
 
    .. code-block:: python
-   
+
       lapack_blas = spec["lapack"].libs + spec["blas"].libs
       args.append(f"--with-blas-lapack-lib={lapack_blas.joined()}")
 
 2. Names of libraries and directories which contain them
 
    .. code-block:: python
-   
+
       lapack_blas = spec["lapack"].libs + spec["blas"].libs
       args.extend(
           [
@@ -481,7 +481,7 @@ In those cases, the build system could use some help, for which we give a few ex
 3. Search and link flags
 
    .. code-block:: python
-   
+
       lapack_blas = spec["lapack"].libs + spec["blas"].libs
       args.append(f"-DMATH_LIBS={lapack_blas.ld_flags}")
 
@@ -610,7 +610,7 @@ Not all dependencies set up such variables for dependent packages, in which case
 
 1. Use the ``command`` attribute of the dependency.
    This is a good option, since it refers to an executable provided by a specific dependency.
-   
+
    .. code-block:: python
 
       def install(self, spec: Spec, prefix: Prefix) -> None:
@@ -619,7 +619,7 @@ Not all dependencies set up such variables for dependent packages, in which case
 
 2. Use the ``which`` function (from the ``spack.package`` module).
    Do note that this function relies on the order of the ``PATH`` environment variable, which may be less reliable than the first option.
-   
+
    .. code-block:: python
 
       def install(self, spec: Spec, prefix: Prefix) -> None:
@@ -1151,7 +1151,7 @@ The ``compiler-wrapper`` package has several responsibilities:
 * It sets the ``CC``, ``CXX``, and ``FC`` environment variables in the :ref:`build environment <environment-variables>`.
   These variables point to a wrapper executable in the ``compiler-wrapper``'s bin directory, which is a shell script that ultimately invokes the actual, underlying compiler executable.
 * It ensures that three kinds of compiler flags are passed to the compiler when it is invoked:
-  
+
   1. Flags requested by the user and package author (see :ref:`compiler flags <compiler_flags>`)
   2. Flags needed to locate headers and libraries (during the build as well as at runtime)
   3. Target specific flags, like ``-march=x86-64-v3``, translated from the spec's ``target=<target>`` variant.
@@ -1198,7 +1198,7 @@ Spack heavily makes use of `RPATHs <http://en.wikipedia.org/wiki/Rpath>`_ on Lin
 Executables are able to find their needed libraries *without* any of the infamous environment variables such as ``LD_LIBRARY_PATH`` on Linux or ``DYLD_LIBRARY_PATH`` on macOS.
 
 The :ref:`compiler wrapper <compiler-wrappers>` is the main component that ensures that all binaries built by Spack have the correct RPATHs set.
-As a package author, you rarely need to worry about RPATHs: the relevant compiler flags are automatically injected through the compiler wrappers, and the build system is blisfully unaware of them.
+As a package author, you rarely need to worry about RPATHs: the relevant compiler flags are automatically injected through the compiler wrappers, and the build system is blissfully unaware of them.
 
 This works for most packages and build systems, with the notable exception of CMake, which has its own RPATH handling.
 CMake has its own RPATH handling, and distinguishes between build and install RPATHs.
@@ -1260,7 +1260,7 @@ Loosely, there are three types of MPI builds:
 3. CMake's ``FindMPI`` needs the compiler wrappers, but it uses them to extract ``-I`` / ``-L`` / ``-D`` arguments, then treats MPI like a regular library.
 
 Note that some CMake builds fall into case 2 because they either don't know about or don't like CMake's ``FindMPI`` support -- they just assume an MPI compiler.
-Also, some autotools builds fall into case 3 (e.g., `here is an autotools version of CMake's FindMPI <https://github.com/tgamblin/libra/blob/master/m4/lx_find_mpi.m4>`_).
+Also, some Autotools builds fall into case 3 (e.g., `here is an autotools version of CMake's FindMPI <https://github.com/tgamblin/libra/blob/master/m4/lx_find_mpi.m4>`_).
 
 Given all of this, we leave the use of the wrappers up to the packager.
 Spack will support all three ways of building MPI packages.
@@ -1298,11 +1298,11 @@ So using the MPI wrappers should really be as simple as the code above.
 ``spec["mpi"]``
 ^^^^^^^^^^^^^^^^^^^^^
 
-Ok, so how does all this work?
+Okay, so how does all this work?
 
 If your package has a virtual dependency like ``mpi``, then referring to ``spec["mpi"]`` within ``install()`` will get you the concrete ``mpi`` implementation in your dependency DAG.
 That is a spec object just like the one passed to install, only the MPI implementations all set some additional properties on it to help you out.
-E.g., in openmpi, you'll find this:
+E.g., in ``openmpi``, you'll find this:
 
 .. literalinclude:: .spack/spack-packages/repos/spack_repo/builtin/packages/openmpi/package.py
    :pyobject: Openmpi.setup_dependent_package
@@ -1318,13 +1318,13 @@ Wrapping wrappers
 Spack likes to use its own compiler wrappers to make it easy to add ``RPATHs`` to builds, and to try hard to ensure that your builds use the right dependencies.
 This doesn't play nicely by default with MPI, so we have to do a couple of tricks.
 
-1. If we build MPI with Spack's wrappers, mpicc and friends will be installed with hard-coded paths to Spack's wrappers, and using them from outside of Spack will fail because they only work within Spack.
-   To fix this, we patch mpicc and friends to use the regular compilers.
-   Look at the filter_compilers method in mpich, openmpi, or mvapich2 for details.
+1. If we build MPI with Spack's wrappers, ``mpicc`` and friends will be installed with hard-coded paths to Spack's wrappers, and using them from outside of Spack will fail because they only work within Spack.
+   To fix this, we patch ``mpicc`` and friends to use the regular compilers.
+   Look at the filter_compilers method in ``mpich``, ``openmpi``, or ``mvapich2`` for details.
 
-2. We still want to use the Spack compiler wrappers when Spack is calling mpicc.
-   Luckily, wrappers in all mainstream MPI implementations provide environment variables that allow us to dynamically set the compiler to be used by mpicc, mpicxx, etc.
-   Spack's build environment sets ``MPICC``, ``MPICXX``, etc. for mpich derivatives and ``OMPI_CC``, ``OMPI_CXX``, etc. for OpenMPI.
+2. We still want to use the Spack compiler wrappers when Spack is calling ``mpicc``.
+   Luckily, wrappers in all mainstream MPI implementations provide environment variables that allow us to dynamically set the compiler to be used by ``mpicc``, ``mpicxx``, etc.
+   Spack's build environment sets ``MPICC``, ``MPICXX``, etc. for MPICH derivatives and ``OMPI_CC``, ``OMPI_CXX``, etc. for OpenMPI.
    This makes the MPI compiler wrappers use the Spack compiler wrappers so that your dependencies still get proper RPATHs even if you use the MPI wrappers.
 
 MPI on Cray machines

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1660,7 +1660,7 @@ Let's take a look at the ``libdwarf`` package to see how it's done:
 ^^^^^^^^^^^^^^^^
 
 The highlighted ``depends_on("libelf")`` call tells Spack that it needs to build and install the ``libelf`` package before it builds ``libdwarf``.
-This means that in your ``install()`` method, you are guaranteed that ``libelf`` has been built and installed successfully, so you can rely on it for your libdwarf build.
+This means that in your ``install()`` method, you are guaranteed that ``libelf`` has been built and installed successfully, so you can rely on it for your ``libdwarf`` build.
 
 .. _dependency_specs:
 
@@ -2294,7 +2294,7 @@ Only needed for patches fetched from URLs.
 
 If supplied, this is a spec that tells Spack when to apply the patch.
 If the installed package spec matches this spec, the patch will be applied.
-In our example above, the patch is applied when mvapich is at version ``1.9`` or higher.
+In our example above, the patch is applied when ``mvapich`` is at version ``1.9`` or higher.
 
 ``level``
 """""""""
@@ -2325,7 +2325,7 @@ Lines 1-2 show paths with synthetic ``a/`` and ``b/`` prefixes.
 These are placeholders for the two ``mvapich2`` source directories that ``diff`` compared when it created the patch file.
 This is git's default behavior when creating patch files, but other programs may behave differently.
 
-``-p1`` strips off the first level of the prefix in both paths, allowing the patch to be applied from the root of an expanded mvapich2 archive.
+``-p1`` strips off the first level of the prefix in both paths, allowing the patch to be applied from the root of an expanded ``mvapich2`` archive.
 If you set level to ``2``, it would strip off ``src``, and so on.
 
 It's generally easier to just structure your patch file so that it applies cleanly with ``-p1``, but if you're using a patch you didn't create yourself, ``level`` can be handy.
@@ -2482,7 +2482,7 @@ This ensures that Python in a view can always locate its Python packages, even w
 
 A package can only extend one other package at a time.
 To support packages that may extend one of a list of other packages, Spack supports multiple ``extends`` directives as long as at most one of them is selected as a dependency during concretization.
-For example, a lua package could extend either lua or luajit, but not both:
+For example, a lua package could extend either ``lua`` or ``lua-luajit``, but not both:
 
 .. code-block:: python
 
@@ -2493,7 +2493,7 @@ For example, a lua package could extend either lua or luajit, but not both:
        extends("lua-luajit", when="~use_lua")
        ...
 
-Now, a user can install, and activate, the ``lua-lpeg`` package for either lua or luajit.
+Now, a user can install, and activate, the ``lua-lpeg`` package for either lua or ``lua-luajit``.
 
 Adding additional constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/packaging_guide_testing.rst
+++ b/lib/spack/docs/packaging_guide_testing.rst
@@ -49,7 +49,7 @@ Success is assumed if anything (e.g., a file or directory) is written after ``in
 Otherwise, the build is assumed to have failed.
 However, the presence of install prefix contents is not a sufficient indicator of success so Spack supports the addition of tests that can be performed during `spack install` processing.
 
-Consider a simple autotools build using the following commands:
+Consider a simple Autotools build using the following commands:
 
 .. code-block:: console
 

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -87,7 +87,7 @@ Here's the ``.gitlab-ci.yml`` file from that example that builds and runs the pi
        job: generate-pipeline
 
 
-The key thing to note above is that there are two jobs: The first job to run, ``generate-pipeline``, runs the ``spack ci generate`` command to generate a dynamic child pipeline and write it to a yaml file, which is then picked up by the second job, ``build-jobs``, and used to trigger the downstream pipeline.
+The key thing to note above is that there are two jobs: The first job to run, ``generate-pipeline``, runs the ``spack ci generate`` command to generate a dynamic child pipeline and write it to a YAML file, which is then picked up by the second job, ``build-jobs``, and used to trigger the downstream pipeline.
 
 And here's the Spack environment built by the pipeline represented as a ``spack.yaml`` file:
 
@@ -161,7 +161,7 @@ This file, ``mirrors.yaml`` looks like this:
 
 
 Note the name of the mirror is ``buildcache-destination``, which is required as of Spack 0.23 (see below for more information).
-The mirror url simply points to the container registry associated with the project, while ``id_variable`` and ``secret_variable`` refer to environment variables containing the access credentials for the mirror.
+The mirror URL simply points to the container registry associated with the project, while ``id_variable`` and ``secret_variable`` refer to environment variables containing the access credentials for the mirror.
 
 When Spack builds packages for this example project, they will be pushed to the project container registry, where they will be available for subsequent jobs to install as dependencies or for other pipelines to use to build runnable container images.
 
@@ -184,9 +184,8 @@ Super-command for functionality related to generating pipelines and executing pi
 ^^^^^^^^^^^^^^^^^^^^^
 
 Throughout this documentation, references to the "mirror" mean the target mirror which is checked for the presence of up-to-date specs, and where any scheduled jobs should push built binary packages.
-In the past, this defaulted to the mirror at index 0 in the mirror configs, and could be overridden using the ``--buildcache-destination`` argument.
-Starting with Spack 0.23, ``spack ci generate`` will require you to identify this mirror by the name "buildcache-destination".
-While you can configure any number of mirrors as sources for your pipelines, you will need to identify the destination mirror by name.
+When running ``spack ci generate`` it is required to configure a mirror named ``buildcache-destination`` to be used as the target mirror.
+It is permitted to configure any number of other mirrors as sources for your pipelines, but only the ``buildcache-destination`` mirror will be used as the destination mirror.
 
 Concretizes the specs in the active environment, stages them (as described in :ref:`staging_algorithm`), and writes the resulting ``.gitlab-ci.yml`` to disk.
 During concretization of the environment, ``spack ci generate`` also writes a ``spack.lock`` file which is then provided to generated child jobs and made available in all generated job artifacts to aid in reproducing failed builds in a local environment.
@@ -197,9 +196,9 @@ In the :ref:`functional_example` section, we only mentioned one path in the ``ar
 Using ``--prune-dag`` or ``--no-prune-dag`` configures whether or not jobs are generated for specs that are already up to date on the mirror.
 If enabling DAG pruning using ``--prune-dag``, more information may be required in your ``spack.yaml`` file, see the :ref:`noop_jobs` section below regarding ``noop-job``.
 
-The optional ``--check-index-only`` argument can be used to speed up pipeline generation by telling Spack to consider only remote buildcache indices when checking the remote mirror to determine if each spec in the DAG is up to date or not.
+The optional ``--check-index-only`` argument can be used to speed up pipeline generation by telling Spack to consider only remote build cache indices when checking the remote mirror to determine if each spec in the DAG is up to date or not.
 The default behavior is for Spack to fetch the index and check it, but if the spec is not found in the index, it also performs a direct check for the spec on the mirror.
-If the remote buildcache index is out of date, which can easily happen if it is not updated frequently, this behavior ensures that Spack has a way to know for certain about the status of any concrete spec on the remote mirror, but can slow down pipeline generation significantly.
+If the remote build cache index is out of date, which can easily happen if it is not updated frequently, this behavior ensures that Spack has a way to know for certain about the status of any concrete spec on the remote mirror, but can slow down pipeline generation significantly.
 
 The optional ``--output-file`` argument should be an absolute path (including file name) to the generated pipeline, and if not given, the default is ``./.gitlab-ci.yml``.
 
@@ -264,7 +263,7 @@ You can find them under Spack's `stacks <https://github.com/spack/spack/tree/dev
 ``spack ci rebuild-index``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This is a convenience command to rebuild the buildcache index associated with the mirror in the active, GitLab-enabled environment (specifying the mirror URL or name is not required).
+This is a convenience command to rebuild the build cache index associated with the mirror in the active, GitLab-enabled environment (specifying the mirror URL or name is not required).
 
 .. _cmd-spack-ci-reproduce-build:
 
@@ -298,12 +297,12 @@ The default script does three main steps: change directories to the pipelines co
 Update Index (reindex)
 ^^^^^^^^^^^^^^^^^^^^^^
 
-By default, while a pipeline job may rebuild a package, create a buildcache entry, and push it to the mirror, it does not automatically re-generate the mirror's buildcache index afterward.
+By default, while a pipeline job may rebuild a package, create a build cache entry, and push it to the mirror, it does not automatically re-generate the mirror's build cache index afterward.
 Because the index is not needed by the default rebuild jobs in the pipeline, not updating the index at the end of each job avoids possible race conditions between simultaneous jobs, and it avoids the computational expense of regenerating the index.
 This potentially saves minutes per job, depending on the number of binary packages in the mirror.
-As a result, the default is that the mirror's buildcache index may not correctly reflect the mirror's contents at the end of a pipeline.
+As a result, the default is that the mirror's build cache index may not correctly reflect the mirror's contents at the end of a pipeline.
 
-To make sure the buildcache index is up to date at the end of your pipeline, Spack generates a job to update the buildcache index of the target mirror at the end of each pipeline by default.
+To make sure the build cache index is up to date at the end of your pipeline, Spack generates a job to update the build cache index of the target mirror at the end of each pipeline by default.
 You can disable this behavior by adding ``rebuild-index: False`` inside the ``ci`` section of your Spack environment.
 
 Reindex jobs do not allow modifying the ``script`` attribute since it is automatically generated using the target mirror listed in the ``mirrors::mirror`` configuration.
@@ -516,7 +515,7 @@ All the jobs generated from this environment will belong to a "build group" with
 As the release progresses, this build group may have jobs added or removed.
 The URL, project, and site are used to specify the CDash instance to which build results should be reported.
 
-Take a look at the `schema <https://github.com/spack/spack/blob/develop/lib/spack/spack/schema/ci.py>`_ for the ci section of the Spack environment file, to see precisely what syntax is allowed there.
+Take a look at the `schema <https://github.com/spack/spack/blob/develop/lib/spack/spack/schema/ci.py>`_ for the ``ci`` section of the Spack environment file, to see precisely what syntax is allowed there.
 
 .. _reserved_tags:
 
@@ -702,6 +701,6 @@ Only needed to report build groups to CDash.
 ^^^^^^^^^^^^^^^^^^^^^
 
 Optional.
-Only needed if you want ``spack ci rebuild`` to trust the key you store in this variable, in which case, it will subsequently be used to sign and verify binary packages (when installing or creating buildcaches).
-You could also have already trusted a key Spack knows about, or if no key is present anywhere, Spack will install specs using ``--no-check-signature`` and create buildcaches using ``-u`` (for unsigned binaries).
+Only needed if you want ``spack ci rebuild`` to trust the key you store in this variable, in which case, it will subsequently be used to sign and verify binary packages (when installing or creating build caches).
+You could also have already trusted a key Spack knows about, or if no key is present anywhere, Spack will install specs using ``--no-check-signature`` and create build caches using ``-u`` (for unsigned binaries).
 

--- a/lib/spack/docs/signing.rst
+++ b/lib/spack/docs/signing.rst
@@ -217,7 +217,7 @@ Procedurally the ``spack-intermediate-ci-signing-key`` secret is used in the fol
 
 1. A ``large-arm-prot`` or ``large-x86-prot`` protected runner picks up a job tagged ``protected`` from a protected GitLab branch.
    (See :ref:`protected_runners`).
-2. Based on its configuration, the runner creates a job Pod in the pipeline namespace and mounts the spack-intermediate-ci-signing-key Kubernetes secret into the build container
+2. Based on its configuration, the runner creates a job Pod in the pipeline namespace and mounts the ``spack-intermediate-ci-signing-key`` Kubernetes secret into the build container
 3. The Intermediate CI Key, affiliated institutions' public key and the Reputational Public Key are imported into a keyring by the ``spack gpg ...`` sub-command.
    This is initiated by the job's build script which is created by the generate job at the beginning of the pipeline.
 4. Assuming the package has dependencies those spec manifests are verified using the keyring.
@@ -269,7 +269,7 @@ Protected Runners and Reserved Tags
 
 Spack has a large number of Gitlab Runners operating in its build farm.
 These include runners deployed in the AWS Kubernetes cluster as well as runners deployed at affiliated institutions.
-The majority of runners are shared runners that operate across projects in gitlab.spack.io.
+The majority of runners are shared runners that operate across projects in `gitlab.spack.io <gitlab.spack.io>`_.
 These runners pick up jobs primarily from the spack/spack project and execute them in PR pipelines.
 
 A small number of runners operating on AWS and at affiliated institutions are registered as specific *protected* runners on the spack/spack project.

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -18,7 +18,7 @@ Spack uses specs to:
 
 1. Refer to a particular build configuration of a package, or
 2. Express requirements, or preferences, on packages via configuration files, or
-3. Query installed packages, or buildcaches
+3. Query installed packages, or build caches
 
 Specs are more than a package name and a version; you can use them to specify the compiler, compiler version, architecture, compile options, and dependency options for a build.
 In this section, we'll go over the full syntax of specs.
@@ -644,7 +644,7 @@ To work around this without quoting, you can avoid whitespace between the packag
 
    mpileaks ~debug   # shell may expand this to `mpileaks /home/debug`
    mpileaks~debug    # use this instead
-   
+
 Alternatively, you can use a hyphen ``-`` character to disable a variant, but be aware that this *requires* a space between the package name and the variant:
 
 .. code-block:: spec

--- a/lib/spack/docs/toolchains_yaml.rst
+++ b/lib/spack/docs/toolchains_yaml.rst
@@ -45,7 +45,7 @@ The spec ``cflags=-O3`` is *always* applied, because there is no ``when`` clause
 The toolchain can be referenced using
 
 .. code-block:: spec
-  
+
    $ spack install my-package %llvm_gfortran
 
 Toolchains are useful for three reasons:

--- a/lib/spack/docs/windows.rst
+++ b/lib/spack/docs/windows.rst
@@ -106,7 +106,7 @@ In order to install Spack with Windows support, run the following one-liner in a
 Step 3: Run and configure Spack
 -------------------------------
 
-On Windows, Spack supports both primary native shells, Powershell and the traditional command prompt.
+On Windows, Spack supports both primary native shells, PowerShell and the traditional command prompt.
 To use Spack, pick your favorite shell, and run ``bin\spack_cmd.bat`` or ``share/spack/setup-env.ps1`` (you may need to Run as Administrator) from the top-level Spack directory.
 This will provide a Spack-enabled shell.
 If you receive a warning message that Python is not in your ``PATH`` (which may happen if you installed Python from the website and not the Windows Store), add the location of the Python executable to your ``PATH`` now.


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Fixing some of my own spelling errors lead to me just do a pass over all of the docs. Excluding build systems since it is moving.

* Fix spelling
* Wrap code/package names in ``
* Remove trailing WS
* Make some of the words consistent (namely buildcache -> build cache)
* Consistent capitalization