### PR TITLE
gitattributes: use lf for patch files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.py diff=python
 lib/spack/spack/vendor/* linguist-vendored
 *.bat text eol=crlf
+*.patch text eol=lf

--- a/lib/spack/spack/test/cmd/resource.py
+++ b/lib/spack/spack/test/cmd/resource.py
@@ -2,37 +2,23 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import sys
 
 from spack.main import SpackCommand
 
 resource = SpackCommand("resource")
 
 #: these are hashes used in mock packages
-mock_hashes = (
-    [
-        "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
-        "1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd",
-        "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
-        "c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8",
-        "24eceabef5fe8f575ff4b438313dc3e7b30f6a2d1c78841fbbe3b9293a589277",
-        "689b8f9b32cb1d2f9271d29ea3fca2e1de5df665e121fca14e1364b711450deb",
-        "208fcfb50e5a965d5757d151b675ca4af4ce2dfd56401721b6168fae60ab798f",
-        "bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c",
-        "7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730",
-    ]
-    if sys.platform != "win32"
-    else [
-        "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
-        "1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd",
-        "d0df7988457ec999c148a4a2af25ce831bfaad13954ba18a4446374cb0aef55e",
-        "aeb16c4dec1087e39f2330542d59d9b456dd26d791338ae6d80b6ffd10c89dfa",
-        "mid21234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
-        "ff34cb21271d16dbf928374f610bb5dd593d293d311036ddae86c4846ff79070",
-        "bf874c7dd3a83cf370fdc17e496e341de06cd596b5c66dbf3c9bb7f6c139e3ee",
-        "3c5b65abcd6a3b2c714dbf7c31ff65fe3748a1adc371f030c283007ca5534f11",
-    ]
-)
+mock_hashes = [
+    "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+    "1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd",
+    "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
+    "c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8",
+    "24eceabef5fe8f575ff4b438313dc3e7b30f6a2d1c78841fbbe3b9293a589277",
+    "689b8f9b32cb1d2f9271d29ea3fca2e1de5df665e121fca14e1364b711450deb",
+    "208fcfb50e5a965d5757d151b675ca4af4ce2dfd56401721b6168fae60ab798f",
+    "bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c",
+    "7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730",
+]
 
 
 def test_resource_list(mock_packages):
@@ -64,11 +50,7 @@ def test_resource_list_only_hashes(mock_packages):
 
 
 def test_resource_show(mock_packages):
-    test_hash = (
-        "c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8"
-        if sys.platform != "win32"
-        else "3c5b65abcd6a3b2c714dbf7c31ff65fe3748a1adc371f030c283007ca5534f11"
-    )
+    test_hash = "c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8"
     out = resource("show", test_hash)
 
     assert out.startswith(test_hash)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1399,11 +1399,7 @@ spack:
         assert "+foo+bar+baz" in d
 
     def test_all_patches_applied(self):
-        uuidpatch = (
-            "a60a42b73e03f207433c5579de207c6ed61d58e4d12dd3b5142eb525728d89ea"
-            if sys.platform != "win32"
-            else "d0df7988457ec999c148a4a2af25ce831bfaad13954ba18a4446374cb0aef55e"
-        )
+        uuidpatch = "a60a42b73e03f207433c5579de207c6ed61d58e4d12dd3b5142eb525728d89ea"
         localpatch = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         spec = Spec("conditionally-patch-dependency+jasper")
         spec = spack.concretize.concretize_one(spec)


### PR DESCRIPTION
Ensure the patch files in tests have a consistent line ending across platforms.


