### PR TITLE
directives: lazy `with when(...)`

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -98,7 +98,7 @@ Patcher = Callable[[Union[PackageType, Dependency]], None]
 PatchesType = Union[Patcher, str, List[Union[Patcher, str]]]
 
 
-def _make_when_spec(value: WhenType) -> Optional[spack.spec.Spec]:
+def _make_when_spec(value: Union[WhenType, Tuple[str, ...]]) -> Optional[spack.spec.Spec]:
     """Create a ``Spec`` that indicates when a directive should be applied.
 
     Directives with ``when`` specs, e.g.:
@@ -122,11 +122,24 @@ def _make_when_spec(value: WhenType) -> Optional[spack.spec.Spec]:
 
     Arguments:
         value: a conditional Spec, constant ``bool``, or None if not supplied
-           value indicating when a directive should be applied.
+           value indicating when a directive should be applied. It can also be a tuple of when
+           conditions (as strings) to be combined together.
 
     """
+    # This branch is never taken, but our WhenType type annotation allows it, so handle it too.
     if isinstance(value, spack.spec.Spec):
         return value
+
+    if isinstance(value, tuple):
+        assert value, "when stack cannot be empty"
+        # avoid a copy when there's only one condition
+        if len(value) == 1:
+            return get_spec(value[0])
+        # reduce the when-stack to a single spec by combining all constraints.
+        combined_spec = spack.spec.Spec(value[0])
+        for cond in value[1:]:
+            combined_spec._constrain_symbolically(get_spec(cond))
+        return combined_spec
 
     # Unsatisfiable conditions are discarded by the caller, and never
     # added to the package class

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -4,7 +4,7 @@
 
 import collections
 import functools
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Set, Tuple, Type, Union
 
 import spack.error
 import spack.repo
@@ -42,7 +42,7 @@ class DirectiveMeta(type):
     #: function name (e.g. "depends_on", "version", etc.)
     _directives_to_be_executed: Dict[str, List[Callable]] = collections.defaultdict(list)
     #: Stack of when constraints from `with when(...)` context managers
-    _when_constraints_stack: List[spack.spec.Spec] = []
+    _when_constraints_stack: List[str] = []
     #: Stack of default args from `with default_args(...)` context managers
     _default_args_stack: List[dict] = []
     #: This property is set *automatically* during class definition as directives are invoked,
@@ -109,12 +109,12 @@ class DirectiveMeta(type):
         return DirectiveMeta._descriptor_cache[name]
 
     @staticmethod
-    def push_when_constraint(when_spec: spack.spec.Spec) -> None:
+    def push_when_constraint(when_spec: str) -> None:
         """Add a spec to the context constraints."""
         DirectiveMeta._when_constraints_stack.append(when_spec)
 
     @staticmethod
-    def pop_when_constraint() -> spack.spec.Spec:
+    def pop_when_constraint() -> str:
         """Pop the last constraint from the context"""
         return DirectiveMeta._when_constraints_stack.pop()
 
@@ -198,30 +198,6 @@ class DirectiveDictDescriptor:
         return getattr(objtype, self.private_name)
 
 
-def _combine_when(
-    when: Optional[str] = None,
-    when_stack: List[spack.spec.Spec] = DirectiveMeta._when_constraints_stack,
-) -> spack.spec.Spec:
-    """Compute the combined when constraints from the context and the directive keyword argument.
-
-    Arguments:
-        when: The when constraint from the directive's keyword argument as a raw string (if any).
-        when_stack: The stack of parsed when constraints from ``with when(...)`` context managers.
-    """
-    # In the following case
-    #     with when("+foo"):     # single constraint on the stack
-    #         depends_on("foo")  # unconditional directive
-    # avoid creating a new spec and just return the one from the stack
-    if len(when_stack) == 1 and not when:
-        return when_stack[0]
-
-    # Otherwise, combine all when constraints by mutating a new spec
-    when_spec = spack.spec.Spec(when)
-    for current in when_stack:
-        when_spec._constrain_symbolically(current, deps=True)
-    return when_spec
-
-
 class directive:
     def __init__(
         self,
@@ -290,14 +266,17 @@ class directive:
             else:
                 kwargs = _kwargs
 
-            # Inject when arguments from the context
+            # Inject when arguments from the `with when(...)` stack.
             if DirectiveMeta._when_constraints_stack:
                 if not self.supports_when:
                     raise DirectiveError(
                         f'directive "{decorated_function.__name__}" cannot be used within a '
                         '"when" context since it does not support a "when=" argument'
                     )
-                kwargs["when"] = _combine_when(kwargs.get("when"))
+                if "when" in kwargs:
+                    kwargs["when"] = (*DirectiveMeta._when_constraints_stack, kwargs["when"])
+                else:
+                    kwargs["when"] = tuple(DirectiveMeta._when_constraints_stack)
 
             # Remove directives passed as arguments, so they are not executed as part of this
             # class's directive execution, but handled by the called directive instead

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -247,10 +247,7 @@ class when:
         Args:
             condition (str): condition to be met
         """
-        if isinstance(condition, bool):
-            self.spec = spack.spec.EMPTY_SPEC if condition else None
-        else:
-            self.spec = spack.directives_meta.get_spec(condition)
+        self.when = condition
 
     def __call__(self, method):
         assert (
@@ -262,17 +259,20 @@ class when:
         if not isinstance(original_method, SpecMultiMethod):
             original_method = SpecMultiMethod(original_method)
 
-        if self.spec is not None:
-            original_method.register(self.spec, method)
+        if self.when is True:
+            original_method.register(spack.spec.EMPTY_SPEC, method)
+        elif self.when is not False:
+            original_method.register(spack.directives_meta.get_spec(self.when), method)
 
         return original_method
 
     def __enter__(self):
-        if self.spec is not None:
-            spack.directives_meta.DirectiveMeta.push_when_constraint(self.spec)
+        # TODO: support when=False.
+        if isinstance(self.when, str):
+            spack.directives_meta.DirectiveMeta.push_when_constraint(self.when)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.spec is not None:
+        if isinstance(self.when, str):
             spack.directives_meta.DirectiveMeta.pop_when_constraint()
 
 

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -10,8 +10,8 @@ import spack.directives
 import spack.repo
 import spack.spec
 import spack.version
-from spack.directives import depends_on, extends, patch
-from spack.directives_meta import DirectiveDictDescriptor, DirectiveMeta, _combine_when
+from spack.directives import _make_when_spec, depends_on, extends, patch
+from spack.directives_meta import DirectiveDictDescriptor, DirectiveMeta
 from spack.spec import Spec
 
 
@@ -218,19 +218,10 @@ def test_direct_dependencies_from_when_context_are_retained(mock_packages):
 
 
 def test_directives_meta_combine_when():
-    x, y = Spec("+x ^dep +a"), Spec("+y ^dep +b")
-
-    # Check that specs are combined, and do not mutate inputs
-    assert _combine_when("+z", [x, y]) == Spec("+x +y +z ^dep +a +b")
-    assert x == Spec("+x ^dep +a")
-    assert y == Spec("+y ^dep +b")
-
-    assert _combine_when(None, [x, y]) == Spec("+x +y ^dep +a +b")
-    assert x == Spec("+x ^dep +a")
-    assert y == Spec("+y ^dep +b")
-
-    # Check the optimization for single stack with no when
-    assert _combine_when(None, [x]) is x
+    x, y, z = "+x ^dep +a", "+y ^dep +b", "+z"
+    assert _make_when_spec((x, y, z)) == Spec("+x +y +z ^dep +a +b")
+    assert _make_when_spec((x, y)) == Spec("+x +y ^dep +a +b")
+    assert _make_when_spec((x,)) == Spec("+x ^dep +a")
 
 
 def test_directive_descriptor_init():


### PR DESCRIPTION
Delay parsing of spec strings in the `with when(...)` context manager until
directives are executed.

This is primarily a cleanup of the code after #51881. The when-stack is now
a tuple of strings, instead of a mix of parsed and unparsed specs or even
None. It is also slightly faster.

The bug where `with when(False)` was not taken into account is pre-existing
and not addressed here.