### PR TITLE
environment: split `deconcretize` into two functions

### DIFF
--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -32,7 +32,7 @@ class BootstrapEnvironment(spack.environment.Environment):
         # Remove python package roots created before python-venv was introduced
         for s in self.concrete_roots():
             if "python" in s.package.extendees and not s.dependencies("python-venv"):
-                self.deconcretize(s, concrete=True)
+                self.deconcretize_by_hash(s.dag_hash())
 
     @classmethod
     def spack_dev_requirements(cls) -> List[str]:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -32,7 +32,7 @@ class BootstrapEnvironment(spack.environment.Environment):
         # Remove python package roots created before python-venv was introduced
         for s in self.concrete_roots():
             if "python" in s.package.extendees and not s.dependencies("python-venv"):
-                self.deconcretize(s)
+                self.deconcretize(s, concrete=True)
 
     @classmethod
     def spack_dev_requirements(cls) -> List[str]:

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -86,7 +86,7 @@ def deconcretize_specs(args, specs):
 
     with env.write_transaction():
         for spec in deconcretize_list:
-            env.deconcretize(spec, concrete=True)
+            env.deconcretize_by_hash(spec.dag_hash())
         env.write()
 
 

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -86,7 +86,7 @@ def deconcretize_specs(args, specs):
 
     with env.write_transaction():
         for spec in deconcretize_list:
-            env.deconcretize(spec)
+            env.deconcretize(spec, concrete=True)
         env.write()
 
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1622,7 +1622,7 @@ class Environment:
         self.concretized_roots = []
         self.specs_by_hash = {}
 
-    def deconcretize(self, spec: spack.spec.Spec, concrete: bool = True):
+    def deconcretize(self, spec: spack.spec.Spec, *, concrete: bool) -> None:
         """
         Remove specified spec from environment concretization
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1615,35 +1615,35 @@ class Environment:
         """Removes concrete specs that no longer correlate to a user spec"""
         to_deconcretize = [x.root for x in self.concretized_roots if x.root not in self.user_specs]
         for spec in to_deconcretize:
-            self.deconcretize(spec, concrete=False)
+            self.deconcretize_by_user_spec(spec)
 
     def clear_concretized_specs(self) -> None:
         """Clears the currently concretized specs"""
         self.concretized_roots = []
         self.specs_by_hash = {}
 
-    def deconcretize(self, spec: spack.spec.Spec, *, concrete: bool) -> None:
-        """
-        Remove specified spec from environment concretization
+    def deconcretize_by_hash(self, dag_hash: str) -> None:
+        """Removes a concrete spec from the environment concretization"""
+        self.concretized_roots = [x for x in self.concretized_roots if x.hash != dag_hash]
+        self._maybe_remove_dag_hash(dag_hash)
+
+    def deconcretize_by_user_spec(self, spec: spack.spec.Spec) -> None:
+        """Remove a user spec from the environment concretization
 
         Arguments:
-            spec: Spec to deconcretize. This must be a root of the environment
-            concrete: If True, find all instances of spec as concrete in the environment.
-                If False, find a single instance of the abstract spec as root of the environment.
+            spec: user spec to deconcretize
         """
         # spec has to be a root of the environment
-        if concrete:
-            dag_hash = spec.dag_hash()
-            self.concretized_roots = [x for x in self.concretized_roots if x.hash != dag_hash]
-        else:
-            self.concretized_roots, discarded = stable_partition(
-                self.concretized_roots, lambda x: x.root != spec
-            )
-            assert (
-                len({x.hash for x in discarded}) == 1
-            ), "More than one hash associated with a single user spec"
-            dag_hash = discarded[0].hash
+        self.concretized_roots, discarded = stable_partition(
+            self.concretized_roots, lambda x: x.root != spec
+        )
+        assert (
+            len({x.hash for x in discarded}) == 1
+        ), "More than one hash associated with a single user spec"
+        dag_hash = discarded[0].hash
+        self._maybe_remove_dag_hash(dag_hash)
 
+    def _maybe_remove_dag_hash(self, dag_hash: str):
         # If this was the only user spec that concretized to this concrete spec, remove it
         if not self.user_spec_with_hash(dag_hash) and dag_hash in self.specs_by_hash:
             # if we deconcretized a dependency that doesn't correspond to a root, it won't be here.

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -824,7 +824,7 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unif
         assert len(e.concretized_roots) == 3
         assert all(x.new for x in e.concretized_roots)
 
-        e.deconcretize(spack.spec.Spec("pkg-a"), concrete=False)
+        e.deconcretize_by_user_spec(spack.spec.Spec("pkg-a"))
         assert len(e.user_specs) == 3
         assert len(e.concretized_roots) == 2
         assert all(x.new for x in e.concretized_roots)


### PR DESCRIPTION
The `Environment.deconcretize` method has an argument to tell whether the first spec is meant to be concrete or not. Since that argument is never used in a dynamic way, but always with `True` or `False` literals, split the method into two.

This is also extracted from the work done to implement #49097
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
