### PR TITLE
environment: allow group of specs with dependencies

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -366,6 +366,7 @@ nitpick_ignore = [
     ("py:class", "spack.traverse.EdgeAndDepth"),
     ("py:class", "spack.vendor.archspec.cpu.microarchitecture.Microarchitecture"),
     ("py:class", "spack.vendor.jinja2.Environment"),
+    ("py:class", "SpecFiltersFactory"),
     # TypeVar that is not handled correctly
     ("py:class", "spack.llnl.util.lang.ClassPropertyType"),
     ("py:class", "spack.llnl.util.lang.K"),

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -925,6 +925,83 @@ For example, the following environment has three root packages: ``gcc@8.1.0``, `
 
 This allows for a much-needed reduction in redundancy between packages and constraints.
 
+.. _environment-spec-groups:
+
+Spec Groups
+^^^^^^^^^^^
+
+.. versionadded:: 1.2
+
+Environments can be organized with named spec groups, enabling you to apply localized configuration overrides and establish concretization dependencies.
+This is extremely useful in a couple of common scenarios, as detailed below.
+
+.. _environment-spec-groups-bootstrapping-compiler:
+
+Building and using a compiler in a single environment
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+A common use case is to build a recent compiler on top of an existing system and then compile a stack of software with it.
+For instance, assume we are interested in building ``hdf5`` and ``libtree`` with ``gcc@15.2``.
+The following manifest file would do exactly that:
+
+.. code-block:: yaml
+
+   spack:
+     specs:
+     - group: compiler
+       specs:
+       - gcc@15.2
+
+     - group: apps
+       needs: [compiler]
+       specs:
+       - hdf5 %gcc@15.2
+       - libtree %gcc@15.2
+
+The ``group:`` attribute allows to name a group of specs, which are then listed under the ``specs:`` attribute in the same object.
+The simplest example is the ``compiler`` group composed of just the ``gcc@15.2`` spec.
+
+To express dependencies among groups of specs the ``needs:`` attribute is used, which is a list of names corresponding to the groups we depend on.
+The way this works is that group dependencies are always concretized *before* the current group, and their specs are *always* available for reuse when the current group is concretized.
+
+.. _environment-spec-groups-configuring-groups:
+
+Configuring a group of specs
+""""""""""""""""""""""""""""
+
+Another common scenario is the deployment of different configurations (e.g. CUDA enabled vs.
+ROCm enabled) of the same set of software.
+As an example, assume we want to install ``gromacs`` and ``quantum-espresso`` for both ``target=x86_64_v3`` and ``target=x86_64_v4``.
+That can be done with the following manifest file:
+
+.. code-block:: yaml
+
+   spack:
+     - group: apps-x86_64_v3
+       specs:
+       - gromacs
+       - quantum-espresso
+       override:
+         packages:
+           all:
+             prefer:
+             - target=x86_64_v3
+
+     - group: apps-x86_64_v4
+       specs:
+       - gromacs
+       - quantum-espresso
+       override:
+         packages:
+           all:
+             prefer:
+             - target=x86_64_v4
+
+The ``override:`` attribute allows us to override the configuration for a single group of specs.
+The overridden part is always added as the *topmost* scope when the current group is concretized.
+This ensures the override always takes precedence over other sources of configuration.
+
+
 Modifying Environment Variables
 -------------------------------
 
@@ -1085,6 +1162,42 @@ Given the example above, the spec ``zlib@1.2.8`` will be linked into ``/my/view/
 
 If the keyword ``all`` does not appear in the projections configuration file, any spec that does not satisfy any entry in the file will be linked into the root of the view as in a single-prefix view.
 Any entries that appear below the keyword ``all`` in the projections configuration file will not be used, as all specs will use the projection under ``all`` before reaching those entries.
+
+Group of Specs
+""""""""""""""
+
+Views can also be applied to a selected list of :ref:`spec groups <environment-spec-matrices>`.
+This can be done by specifying the ``group:`` attribute in the view configuration.
+For instance, with the following manifest:
+
+.. code-block:: yaml
+
+   spack:
+     concretizer:
+       unify: true
+
+     packages:
+       all:
+         require:
+         - target=x86_64_v4
+
+     specs:
+     - group: compiler
+       specs:
+       - gcc@15.2
+
+     - group: apps
+       needs: [compiler]
+       specs:
+       - hdf5~mpi %gcc@15.2
+       - libtree %gcc@15.2
+
+     view:
+       apps:
+         root: ./views/apps
+         group: apps
+
+The view will only contain entries from the ``apps`` group, and will not include specs from the ``compiler`` group.
 
 Activating environment views
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -495,13 +495,7 @@ def generate_pipeline(env: ev.Environment, args) -> None:
     rebuild_everything = not options.prune_up_to_date and not options.prune_untouched
 
     # Build a pipeline from the specs in the concrete environment
-    pipeline = PipelineDag(
-        [
-            concrete
-            for abstract, concrete in env.concretized_specs()
-            if abstract in env.spec_lists["specs"]
-        ]
-    )
+    pipeline = PipelineDag([env.specs_by_hash[x.hash] for x in env.concretized_roots])
 
     # Optionally add various pruning filters
     pruning_filters = []

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -335,7 +335,7 @@ def _find_query(args, env):
     if args.show_configured_externals:
         packages_with_externals = external_config_with_implicit_externals(spack.config.CONFIG)
         completion_mode = spack.config.CONFIG.get("concretizer:externals:completion")
-        results = spack.solver.reuse.SpecFilter.from_packages_yaml(
+        results = spack.solver.reuse.spec_filter_from_packages_yaml(
             external_parser=create_external_parser(packages_with_externals, completion_mode),
             packages_with_externals=packages_with_externals,
             include=[],

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -36,6 +36,7 @@ def _concretize_specs_together(
         abstract_specs: abstract specs to be concretized
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
+        factory: optional factory to produce a list of specs to be reused
     """
     from spack.solver.asp import Solver
 
@@ -59,6 +60,7 @@ def concretize_together(
             already concrete spec or None if not yet concretized
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
+        factory: optional factory to produce a list of specs to be reused
     """
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     abstract_specs = [abstract for abstract, _ in spec_list]
@@ -82,6 +84,7 @@ def concretize_together_when_possible(
             already concrete spec or None if not yet concretized
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
+        factory: optional factory to produce a list of specs to be reused
     """
     from spack.solver.asp import Solver
 
@@ -131,6 +134,7 @@ def concretize_separately(
             already concrete spec or None if not yet concretized
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
+        factory: optional factory to produce a list of specs to be reused
     """
     from spack.bootstrap import (
         ensure_bootstrap_configuration,

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -5,7 +5,7 @@
 import importlib
 import sys
 import time
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import spack.compilers
 import spack.compilers.config
@@ -20,9 +20,15 @@ SpecPairInput = Tuple[Spec, Optional[Spec]]
 SpecPair = Tuple[Spec, Spec]
 TestsType = Union[bool, Iterable[str]]
 
+if TYPE_CHECKING:
+    from spack.solver.reuse import SpecFiltersFactory
+
 
 def _concretize_specs_together(
-    abstract_specs: Sequence[Spec], tests: TestsType = False
+    abstract_specs: Sequence[Spec],
+    *,
+    tests: TestsType = False,
+    factory: Optional["SpecFiltersFactory"] = None,
 ) -> List[Spec]:
     """Given a number of specs as input, tries to concretize them together.
 
@@ -34,12 +40,17 @@ def _concretize_specs_together(
     from spack.solver.asp import Solver
 
     allow_deprecated = spack.config.get("config:deprecated", False)
-    result = Solver().solve(abstract_specs, tests=tests, allow_deprecated=allow_deprecated)
+    result = Solver(specs_factory=factory).solve(
+        abstract_specs, tests=tests, allow_deprecated=allow_deprecated
+    )
     return [s.copy() for s in result.specs]
 
 
 def concretize_together(
-    spec_list: Sequence[SpecPairInput], tests: TestsType = False
+    spec_list: Sequence[SpecPairInput],
+    *,
+    tests: TestsType = False,
+    factory: Optional["SpecFiltersFactory"] = None,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together.
 
@@ -51,12 +62,15 @@ def concretize_together(
     """
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     abstract_specs = [abstract for abstract, _ in spec_list]
-    concrete_specs = _concretize_specs_together(to_concretize, tests=tests)
+    concrete_specs = _concretize_specs_together(to_concretize, tests=tests, factory=factory)
     return list(zip(abstract_specs, concrete_specs))
 
 
 def concretize_together_when_possible(
-    spec_list: Sequence[SpecPairInput], tests: TestsType = False
+    spec_list: Sequence[SpecPairInput],
+    *,
+    tests: TestsType = False,
+    factory: Optional["SpecFiltersFactory"] = None,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together to the extent possible.
 
@@ -80,7 +94,7 @@ def concretize_together_when_possible(
     allow_deprecated = spack.config.get("config:deprecated", False)
     j = 0
     start = time.monotonic()
-    for result in Solver().solve_in_rounds(
+    for result in Solver(specs_factory=factory).solve_in_rounds(
         to_concretize, tests=tests, allow_deprecated=allow_deprecated
     ):
         now = time.monotonic()
@@ -105,7 +119,10 @@ def concretize_together_when_possible(
 
 
 def concretize_separately(
-    spec_list: Sequence[SpecPairInput], tests: TestsType = False
+    spec_list: Sequence[SpecPairInput],
+    *,
+    tests: TestsType = False,
+    factory: Optional["SpecFiltersFactory"] = None,
 ) -> List[SpecPair]:
     """Concretizes the input specs separately from each other.
 
@@ -123,7 +140,7 @@ def concretize_separately(
 
     to_concretize = [abstract for abstract, concrete in spec_list if not concrete]
     args = [
-        (i, str(abstract), tests)
+        (i, str(abstract), tests, factory)
         for i, abstract in enumerate(to_concretize)
         if not abstract.concrete
     ]
@@ -188,15 +205,22 @@ def concretize_separately(
     ]
 
 
-def _concretize_task(packed_arguments: Tuple[int, str, TestsType]) -> Tuple[int, Spec, float]:
-    index, spec_str, tests = packed_arguments
+def _concretize_task(
+    packed_arguments: Tuple[int, str, TestsType, Optional["SpecFiltersFactory"]],
+) -> Tuple[int, Spec, float]:
+    index, spec_str, tests, factory = packed_arguments
     with tty.SuppressOutput(msg_enabled=False):
         start = time.time()
-        spec = concretize_one(Spec(spec_str), tests=tests)
+        spec = concretize_one(Spec(spec_str), tests=tests, factory=factory)
         return index, spec, time.time() - start
 
 
-def concretize_one(spec: Union[str, Spec], tests: TestsType = False) -> Spec:
+def concretize_one(
+    spec: Union[str, Spec],
+    *,
+    tests: TestsType = False,
+    factory: Optional["SpecFiltersFactory"] = None,
+) -> Spec:
     """Return a concretized copy of the given spec.
 
     Args:
@@ -219,7 +243,9 @@ def concretize_one(spec: Union[str, Spec], tests: TestsType = False) -> Spec:
             )
 
     allow_deprecated = spack.config.get("config:deprecated", False)
-    result = Solver().solve([spec], tests=tests, allow_deprecated=allow_deprecated)
+    result = Solver(specs_factory=factory).solve(
+        [spec], tests=tests, allow_deprecated=allow_deprecated
+    )
 
     # take the best answer
     opt, i, answer = min(result.answers)

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -22,6 +22,8 @@ class ConfigScopePriority(enum.IntEnum):
     ENVIRONMENT = 2
     CUSTOM = 3
     COMMAND_LINE = 4
+    # Topmost scope reserved for internal use
+    ENVIRONMENT_SPEC_GROUPS = 5
 
 
 class PropagationPolicy(enum.Enum):

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -585,7 +585,7 @@ corresponding group.
         {
           "hash": "o72mlpqvb5xijyqg4iyubpnvd5bfcomb",
           "spec": "hdf5",
-          "group": "specs"
+          "group": "default"
         }
       ],
       "concrete_specs": {

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -54,8 +54,10 @@ upgrade Spack to use them.
      - ``v4``
      - ``v5``
      - ``v6``
+     - ``v7``
    * - ``v0.12:0.14``
      - ✅
+     -
      -
      -
      -
@@ -68,10 +70,12 @@ upgrade Spack to use them.
      -
      -
      -
+     -
    * - ``v0.17``
      - ✅
      - ✅
      - ✅
+     -
      -
      -
      -
@@ -82,6 +86,7 @@ upgrade Spack to use them.
      - ✅
      -
      -
+     -
    * - ``v0.22:v0.23``
      - ✅
      - ✅
@@ -89,7 +94,17 @@ upgrade Spack to use them.
      - ✅
      - ✅
      -
-   * - ``v1.0:``
+     -
+   * - ``v1.0:1.1``
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     -
+   * - ``v1.2:``
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -543,6 +558,40 @@ compiled. The compiler-wrapper is explicitly represented as a node in the DAG, a
         },
       }
     }
+
+Version 7
+---------
+
+Version 7 adds the additional attribute ``group`` to ``roots``.
+
+As part of Spack v1.2 each environment can define multiple groups of specs, and fine-tune their
+concretization separately. This attribute is needed to associate each root spec with the
+corresponding group.
+
+.. code-block:: json
+
+    {
+      "_meta": {
+        "file-type": "spack-lockfile",
+        "lockfile-version": 7,
+        "specfile-version": 5
+      },
+      "spack": {
+        "version": "1.2.0.dev0",
+        "type": "git",
+        "commit": "94b055476f874f424f20e3c0f33b0f22de29220a"
+      },
+      "roots": [
+        {
+          "hash": "o72mlpqvb5xijyqg4iyubpnvd5bfcomb",
+          "spec": "hdf5",
+          "group": "specs"
+        }
+      ],
+      "concrete_specs": {
+      }
+    }
+
 """
 
 from .environment import (

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2487,7 +2487,9 @@ class ReusableSpecsFactory:
         self.env = env
         self.group = group
 
-    def __call__(self, is_usable: Callable[[Spec], bool]) -> List[SpecFilter]:
+    def __call__(
+        self, is_usable: Callable[[Spec], bool], configuration: spack.config.Configuration
+    ) -> List[SpecFilter]:
         result = []
         # Specs from group dependencies _must_ be reused, regardless of configuration
         dependencies = self.env.manifest.needs(group=self.group)
@@ -2505,7 +2507,7 @@ class ReusableSpecsFactory:
             )
 
         # Included environments and _this_ group, instead, are subject to configuration
-        concretizer_yaml = spack.config.CONFIG.get_config("concretizer")
+        concretizer_yaml = configuration.get_config("concretizer")
         reuse_yaml = concretizer_yaml.get("reuse", False)
 
         # With no reuse don't account for previously concretized specs in _this_ group

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1165,13 +1165,27 @@ class Environment:
                 data=spack.config.CONFIG.get("definitions", [])
             )
         )
-        self.spec_lists[USER_SPECS_KEY] = self._spec_lists_parser.parse_user_specs(
-            name=USER_SPECS_KEY, yaml_list=self.manifest.user_specs()
-        )
+        for group in self.manifest.groups():
+            if tty.is_debug(level=2):
+                tty.debug(f"[{__name__}]: Synchronizing user specs from the '{group}' group")
+            key = self._user_specs_key(group=group)
+            self.spec_lists[key] = self._spec_lists_parser.parse_user_specs(
+                name=key, yaml_list=self.manifest.user_specs(group=group)
+            )
+
+    def _user_specs_key(self, *, group: Optional[str] = None) -> str:
+        if group is None or group == DEFAULT_USER_SPEC_GROUP:
+            return USER_SPECS_KEY
+        return f"{USER_SPECS_KEY}:{group}"
 
     @property
-    def user_specs(self):
-        return self.spec_lists[USER_SPECS_KEY]
+    def user_specs(self) -> SpecList:
+        return self.user_specs_by(group=DEFAULT_USER_SPEC_GROUP)
+
+    def user_specs_by(self, *, group: Optional[str]) -> SpecList:
+        """Returns a dictionary of user specs keyed by their group."""
+        key = self._user_specs_key(group=group)
+        return self.spec_lists[key]
 
     @property
     def dev_specs(self):
@@ -2875,9 +2889,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         return result
 
     def user_specs(self, *, group: Optional[str] = None) -> List:
-        group = DEFAULT_USER_SPEC_GROUP if group is None else group
-        if group not in self._groups:
-            raise ValueError(f"user specs group '{group}' not found in {self.manifest_file}")
+        group = self._ensure_group_exists(group)
         return self._user_specs[group]
 
     def groups(self) -> Set[str]:
@@ -2886,10 +2898,14 @@ class EnvironmentManifestFile(collections.abc.Mapping):
 
     def needs(self, *, group: Optional[str] = None) -> Tuple[str, ...]:
         """Returns the dependencies of a group of user specs."""
+        group = self._ensure_group_exists(group)
+        return self._groups[group]
+
+    def _ensure_group_exists(self, group: Optional[str]) -> str:
         group = DEFAULT_USER_SPEC_GROUP if group is None else group
         if group not in self._groups:
             raise ValueError(f"user specs group '{group}' not found in {self.manifest_file}")
-        return self._groups[group]
+        return group
 
     def add_user_spec(self, user_spec: str) -> None:
         """Appends the user spec passed as input to the default list of root specs.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -3138,6 +3138,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
     def _clear_user_specs(self) -> None:
         self._user_specs = {DEFAULT_USER_SPEC_GROUP: []}
         self._groups = {DEFAULT_USER_SPEC_GROUP: tuple()}
+        self._config_override = {DEFAULT_USER_SPEC_GROUP: None}
 
     def _all_matches(self, user_spec: str) -> List[str]:
         """Maps the input string to the first equivalent user spec in the manifest,

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -63,6 +63,8 @@ from .list import SpecList, SpecListError, SpecListParser
 
 SpecPair = Tuple[Spec, Spec]
 
+DEFAULT_USER_SPEC_GROUP = "default"
+
 #: environment variable used to indicate the active environment
 spack_env_var = "SPACK_ENV"
 
@@ -3054,9 +3056,6 @@ def initialize_environment_dir(
             continue
 
         shutil.copytree(orig_abspath, abspath, symlinks=True)
-
-
-DEFAULT_USER_SPEC_GROUP = "default"
 
 
 class EnvironmentManifestFile(collections.abc.Mapping):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2165,7 +2165,9 @@ class Environment:
         ]
 
     def has_groups(self) -> bool:
-        return self.manifest.groups() != {DEFAULT_USER_SPEC_GROUP}
+        groups = self.manifest.groups()
+        # True if groups != {DEFAULT_USER_SPEC_GROUP}
+        return len(groups) != 1 or DEFAULT_USER_SPEC_GROUP not in groups
 
     def _to_lockfile_dict(self):
         """Create a dictionary to store a lockfile for this environment."""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1207,8 +1207,7 @@ class Environment:
             )
         )
         for group in self.manifest.groups():
-            if tty.is_debug(level=2):
-                tty.debug(f"[{__name__}]: Synchronizing user specs from the '{group}' group")
+            tty.debug(f"[{__name__}]: Synchronizing user specs from the '{group}' group", level=2)
             key = self._user_specs_key(group=group)
             self.spec_lists[key] = self._spec_lists_parser.parse_user_specs(
                 name=key, yaml_list=self.manifest.user_specs(group=group)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -12,7 +12,19 @@ import re
 import shutil
 import stat
 import warnings
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import spack
 import spack.concretize
@@ -43,6 +55,7 @@ from spack.llnl.util.filesystem import copy_tree, islink, readlink, symlink
 from spack.llnl.util.lang import stable_partition
 from spack.llnl.util.link_tree import ConflictingSpecsError
 from spack.schema.env import TOP_LEVEL_KEY
+from spack.solver.reuse import SpecFilter
 from spack.spec import Spec
 from spack.util.path import substitute_path_variables
 
@@ -1954,16 +1967,25 @@ class Environment:
         for x in self.concretized_roots:
             yield x.root, self.specs_by_hash[x.hash]
 
+        yield from self.concretized_specs_from_all_included_environments()
+
+    def concretized_specs_from_all_included_environments(self):
         seen = {(x.root, x.hash) for x in self.concretized_roots}
         for included_env in self.included_concretized_user_specs:
-            for s, h in zip(
-                self.included_concretized_user_specs[included_env],
-                self.included_concretized_order[included_env],
-            ):
-                if (s, h) in seen:
-                    continue
-                seen.add((s, h))
-                yield s, self.included_specs_by_hash[included_env][h]
+            yield from self.concretized_specs_from_included_environment(included_env, _seen=seen)
+
+    def concretized_specs_from_included_environment(
+        self, included_env: str, *, _seen: Optional[set[Tuple[spack.spec.Spec, str]]] = None
+    ):
+        _seen = set() if _seen is None else _seen
+        for s, h in zip(
+            self.included_concretized_user_specs[included_env],
+            self.included_concretized_order[included_env],
+        ):
+            if (s, h) in _seen:
+                continue
+            _seen.add((s, h))
+            yield s, self.included_specs_by_hash[included_env][h]
 
     def concrete_roots(self):
         """Same as concretized_specs, except it returns the list of concrete
@@ -2435,6 +2457,92 @@ def _is_uninstalled(spec):
     return not spec.installed or (spec.satisfies("dev_path=*") or spec.satisfies("^dev_path=*"))
 
 
+class ReusableSpecsFactory:
+    """Creates a list of SpecFilters to generate the reusable specs for the environment"""
+
+    def __init__(self, *, env: Environment, group: str):
+        self.env = env
+        self.group = group
+
+    def __call__(self, is_usable: Callable[[Spec], bool]) -> List[SpecFilter]:
+        result = []
+        # Specs from group dependencies _must_ be reused, regardless of configuration
+        dependencies = self.env.manifest.needs(group=self.group)
+        necessary_specs = []
+        for d in dependencies:
+            necessary_specs.extend([x for _, x in self.env.concretized_specs_by(group=d)])
+
+        # Specs from groups listed as dependencies
+        if necessary_specs:
+            necessary_specs = list(traverse.traverse_nodes(necessary_specs))
+            result.append(
+                SpecFilter(lambda: necessary_specs, include=[], exclude=[], is_usable=is_usable)
+            )
+
+        # Included environments and _this_ group, instead, are subject to configuration
+        concretizer_yaml = spack.config.CONFIG.get_config("concretizer")
+        reuse_yaml = concretizer_yaml.get("reuse", False)
+
+        # With no reuse don't account for previously concretized specs in _this_ group
+        if reuse_yaml is False:
+            return result
+
+        this_group_specs = [x for _, x in self.env.concretized_specs_by(group=self.group)]
+        included_specs = [
+            x for _, x in self.env.concretized_specs_from_all_included_environments()
+        ]
+        additional_specs = list(traverse.traverse_nodes(this_group_specs + included_specs))
+        if not isinstance(reuse_yaml, Mapping):
+            result.append(
+                SpecFilter(lambda: additional_specs, include=[], exclude=[], is_usable=is_usable)
+            )
+            return result
+
+        # Here we know we have a complex reuse configuration
+        default_include = reuse_yaml.get("include", [])
+        default_exclude = reuse_yaml.get("exclude", [])
+        for source in reuse_yaml.get("from", []):
+            # We just need to take care of the environment-related parts
+            if source["type"] != "environment":
+                continue
+
+            include = source.get("include", default_include)
+            exclude = source.get("exclude", default_exclude)
+            if "path" not in source:
+                result.append(
+                    SpecFilter(
+                        lambda: additional_specs,
+                        include=include,
+                        exclude=exclude,
+                        is_usable=is_usable,
+                    )
+                )
+                continue
+
+            env_dir = as_env_dir(source["path"])
+            if env_dir in self.env.included_concrete_envs:
+                included_specs = list(
+                    traverse.traverse_nodes(
+                        [
+                            x
+                            for _, x in self.env.concretized_specs_from_included_environment(
+                                env_dir
+                            )
+                        ]
+                    )
+                )
+                result.append(
+                    SpecFilter(
+                        lambda: included_specs,
+                        include=include,
+                        exclude=exclude,
+                        is_usable=is_usable,
+                    )
+                )
+
+        return result
+
+
 class EnvironmentConcretizer:
     def __init__(self, env: Environment):
         self.env = env
@@ -2447,11 +2555,8 @@ class EnvironmentConcretizer:
         self._prepare_environment_for_concretization(force=force)
 
         result = []
-        groups = list(self.env.manifest.groups())
         # Sort so that the ordering is deterministic, and "default" specs are first
-        groups.sort(key=lambda x: (x == DEFAULT_USER_SPEC_GROUP, x))
-        while groups:
-            current_group = groups.pop()
+        for current_group in self._order_groups():
             # Exit early if the set of concretized specs is the set of user specs
             new_user_specs, kept_user_specs = self._partition_user_specs(group=current_group)
             if not new_user_specs:
@@ -2459,19 +2564,32 @@ class EnvironmentConcretizer:
 
             # Pick the right concretization strategy
             unify = self.env.unify
+            factory = ReusableSpecsFactory(env=self.env, group=current_group)
             if unify == "when_possible":
                 partial_result = self._concretize_together_where_possible(
-                    new_user_specs, kept_user_specs, tests=tests, group=current_group
+                    new_user_specs,
+                    kept_user_specs,
+                    tests=tests,
+                    group=current_group,
+                    factory=factory,
                 )
 
             elif unify is True:
                 partial_result = self._concretize_together(
-                    new_user_specs, kept_user_specs, tests=tests, group=current_group
+                    new_user_specs,
+                    kept_user_specs,
+                    tests=tests,
+                    group=current_group,
+                    factory=factory,
                 )
 
             elif unify is False:
                 partial_result = self._concretize_separately(
-                    new_user_specs, kept_user_specs, tests=tests, group=current_group
+                    new_user_specs,
+                    kept_user_specs,
+                    tests=tests,
+                    group=current_group,
+                    factory=factory,
                 )
             else:
                 raise SpackEnvironmentError(f"concretization strategy not implemented [{unify}]")
@@ -2517,6 +2635,29 @@ class EnvironmentConcretizer:
         kept_user_specs += self.env.included_user_specs
         return new_user_specs, kept_user_specs
 
+    def _order_groups(self) -> List[str]:
+        done, result = {DEFAULT_USER_SPEC_GROUP}, [DEFAULT_USER_SPEC_GROUP]
+        remaining = self.env.manifest.groups() - {DEFAULT_USER_SPEC_GROUP}
+        while remaining:
+            # Check we have groups that are "ready"
+            ready = []
+            for current in remaining:
+                deps = self.env.manifest.needs(group=current)
+                if all(d in done for d in deps):
+                    ready.append(current)
+
+            # Check we can progress
+            if not ready:
+                raise SpackEnvironmentConfigError(
+                    "cannot resolve dependencies for the group of specs in the environment",
+                    self.env.manifest.manifest_file,
+                )
+
+            result.extend(ready)
+            done.update(ready)
+            remaining.difference_update(ready)
+        return result
+
     def _user_spec_pairs(
         self, user_specs_to_compute: List[Spec], user_specs_to_keep: List[Spec]
     ) -> List[SpecPair]:
@@ -2534,10 +2675,11 @@ class EnvironmentConcretizer:
         *,
         group: Optional[str] = None,
         tests: Union[bool, Sequence] = False,
+        factory: ReusableSpecsFactory,
     ) -> List[SpecPair]:
         specs_to_concretize = self._user_spec_pairs(to_compute, to_keep)
         result = spack.concretize.concretize_together_when_possible(
-            specs_to_concretize, tests=tests
+            specs_to_concretize, tests=tests, factory=factory
         )
         result = [x for x in result if x[0] in to_compute]
         for abstract, concrete in result:
@@ -2552,10 +2694,13 @@ class EnvironmentConcretizer:
         *,
         group: Optional[str] = None,
         tests: Union[bool, Sequence] = False,
+        factory: ReusableSpecsFactory,
     ) -> List[SpecPair]:
         to_concretize = self._user_spec_pairs(to_compute, to_keep)
         try:
-            concrete_pairs = spack.concretize.concretize_together(to_concretize, tests=tests)
+            concrete_pairs = spack.concretize.concretize_together(
+                to_concretize, tests=tests, factory=factory
+            )
         except spack.error.UnsatisfiableSpecError as e:
             # "Enhance" the error message for multiple root specs, suggest a less strict
             # form of concretization.
@@ -2585,10 +2730,13 @@ class EnvironmentConcretizer:
         *,
         group: Optional[str] = None,
         tests: Union[bool, Sequence] = False,
+        factory: ReusableSpecsFactory,
     ) -> List[SpecPair]:
         """Concretization strategy that concretizes separately one user spec after the other"""
         to_concretize = [(x, None) for x in to_compute]
-        concrete_pairs = spack.concretize.concretize_separately(to_concretize, tests=tests)
+        concrete_pairs = spack.concretize.concretize_separately(
+            to_concretize, tests=tests, factory=factory
+        )
 
         for abstract, concrete in concrete_pairs:
             self.env.add_concrete_spec(abstract, concrete, new=True, group=group)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1624,9 +1624,7 @@ class Environment:
             if (x.group, x.root) not in user_specs:
                 to_deconcretize.append(x)
         for x in to_deconcretize:
-            # FIXME: hack to do the inverse mapping
-            group = x.group.split(":")[-1]
-            self.deconcretize_by_user_spec(x.root, group=group)
+            self.deconcretize_by_user_spec(x.root, group=x.group)
 
     def _all_user_specs_with_group(self) -> Set[Tuple[str, Spec]]:
         result = set()

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -51,6 +51,7 @@ import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack import traverse
+from spack.enums import ConfigScopePriority
 from spack.llnl.util.filesystem import copy_tree, islink, readlink, symlink
 from spack.llnl.util.lang import stable_partition
 from spack.llnl.util.link_tree import ConflictingSpecsError
@@ -59,7 +60,6 @@ from spack.solver.reuse import SpecFilter
 from spack.spec import Spec
 from spack.util.path import substitute_path_variables
 
-from ..enums import ConfigScopePriority
 from .list import SpecList, SpecListError, SpecListParser
 
 SpecPair = spack.concretize.SpecPair
@@ -1063,15 +1063,30 @@ class Environment:
             with self.manifest.use_config():
                 self._read()
 
-    @property
-    def unify(self):
-        if self._unify is None:
-            self._unify = spack.config.get("concretizer:unify", False)
-        return self._unify
+    @contextlib.contextmanager
+    def config_override_for_group(self, *, group: str):
+        key = self.manifest._ensure_group_exists(group=group)
+        internal_scope = self.manifest.config_override(group=key)
+        if internal_scope is None:
+            # No internal scope
+            tty.debug(
+                f"[{__name__}] No configuration override necessary for the '{group}' group "
+                f"in the environment at {self.manifest_path}"
+            )
+            yield
+            return
 
-    @unify.setter
-    def unify(self, value):
-        self._unify = value
+        try:
+            tty.debug(
+                f"[{__name__}] Overriding the configuration for the '{group}' group defined "
+                f"in {self.manifest_path} before concretization"
+            )
+            spack.config.CONFIG.push_scope(
+                internal_scope, priority=ConfigScopePriority.ENVIRONMENT_SPEC_GROUPS
+            )
+            yield
+        finally:
+            spack.config.CONFIG.remove_scope(internal_scope.name)
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -1975,7 +1990,7 @@ class Environment:
             yield from self.concretized_specs_from_included_environment(included_env, _seen=seen)
 
     def concretized_specs_from_included_environment(
-        self, included_env: str, *, _seen: Optional[set[Tuple[spack.spec.Spec, str]]] = None
+        self, included_env: str, *, _seen: Optional[Set[Tuple[spack.spec.Spec, str]]] = None
     ):
         _seen = set() if _seen is None else _seen
         for s, h in zip(
@@ -2474,7 +2489,9 @@ class ReusableSpecsFactory:
 
         # Specs from groups listed as dependencies
         if necessary_specs:
-            necessary_specs = list(traverse.traverse_nodes(necessary_specs))
+            necessary_specs = list(
+                traverse.traverse_nodes(necessary_specs, deptype=("link", "run"))
+            )
             result.append(
                 SpecFilter(lambda: necessary_specs, include=[], exclude=[], is_usable=is_usable)
             )
@@ -2557,25 +2574,14 @@ class EnvironmentConcretizer:
         result = []
         # Sort so that the ordering is deterministic, and "default" specs are first
         for current_group in self._order_groups():
-            partial_result = self._concretize_single_group(group=current_group, tests=tests)
-            result.extend(partial_result)
+            with self.env.config_override_for_group(group=current_group):
+                partial_result = self._concretize_single_group(group=current_group, tests=tests)
+                result.extend(partial_result)
 
         # Unify the specs objects, so we get correct references to all parents
         if result:
             self.env.unify_specs()
         return result
-
-        # for group in self.env.user_spec_groups:
-        #     # Exit early if the set of concretized specs is the set of user specs
-        #     new_user_specs, kept_user_specs = self._partition_user_specs(group)
-        #     if not new_user_specs:
-        #         continue
-        #
-        #     needed_groups = self.env.needed_groups(group)
-        #     reused_specs = self.env.concrete_specs_from_groups(*needed_groups)
-        #     group_scope = ...
-        #     with spack.config.push_scope():
-        #         [concretize and add]
 
     def _concretize_single_group(
         self, *, group: str, tests: Union[bool, Sequence[str]]
@@ -2586,7 +2592,9 @@ class EnvironmentConcretizer:
             return []
 
         # Pick the right concretization strategy
-        unify = self.env.unify
+        if group != DEFAULT_USER_SPEC_GROUP:
+            tty.msg(f"Concretizing the '{group}' group of specs")
+        unify = spack.config.CONFIG.get_config("concretizer").get("unify", False)
         factory = ReusableSpecsFactory(env=self.env, group=group)
         if unify == "when_possible":
             partial_result = self._concretize_together_where_possible(
@@ -3074,6 +3082,8 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         self._groups: Dict[str, Tuple[str, ...]] = {DEFAULT_USER_SPEC_GROUP: tuple()}
         # Raw YAML definitions of the user specs for each group
         self._user_specs: Dict[str, List] = {DEFAULT_USER_SPEC_GROUP: []}
+        # Configuration overrides for each group
+        self._config_override: Dict[str, Any] = {DEFAULT_USER_SPEC_GROUP: None}
         self._init_user_specs()
 
         self.changed = False
@@ -3096,6 +3106,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
                 if group not in self._user_specs:
                     self._user_specs[group] = []
                     self._groups[group] = tuple(item.get("needs", ()))
+                    self._config_override[group] = item.get("override", None)
 
                 if "matrix" in item:
                     # Short form if the group is composed of only one matrix
@@ -3130,6 +3141,15 @@ class EnvironmentManifestFile(collections.abc.Mapping):
     def user_specs(self, *, group: Optional[str] = None) -> List:
         group = self._ensure_group_exists(group)
         return self._user_specs[group]
+
+    def config_override(
+        self, *, group: Optional[str] = None
+    ) -> Optional[spack.config.InternalConfigScope]:
+        group = self._ensure_group_exists(group)
+        data = self._config_override[group]
+        if data is None:
+            return None
+        return spack.config.InternalConfigScope(f"env:groups:{group}", data)
 
     def groups(self) -> Set[str]:
         """Returns the list of groups defined in the manifest"""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -145,7 +145,7 @@ sep_re = re.escape(os.sep)
 valid_environment_name_re = rf"^\w[{sep_re}\w-]*$"
 
 #: version of the lockfile format. Must increase monotonically.
-lockfile_format_version = 7
+CURRENT_LOCKFILE_VERSION = 7
 
 
 READER_CLS = {
@@ -2083,12 +2083,21 @@ class Environment:
         return concrete_specs
 
     def _concrete_roots_dict(self):
+        if not self.has_groups():
+            return [
+                {"hash": x.hash, "spec": str(x.root)} for x in self.concretized_roots
+            ]
+
         return [
             {"hash": x.hash, "spec": str(x.root), "group": x.group} for x in self.concretized_roots
         ]
 
+    def has_groups(self) -> bool:
+        return self.manifest.groups() != {DEFAULT_USER_SPEC_GROUP}
+
     def _to_lockfile_dict(self):
         """Create a dictionary to store a lockfile for this environment."""
+        lockfile_version = CURRENT_LOCKFILE_VERSION if self.has_groups() else 6
         concrete_specs = self._concrete_specs_dict()
         root_specs = self._concrete_roots_dict()
 
@@ -2105,7 +2114,7 @@ class Environment:
             # metadata about the format
             "_meta": {
                 "file-type": "spack-lockfile",
-                "lockfile-version": lockfile_format_version,
+                "lockfile-version": lockfile_version,
                 "specfile-version": spack.spec.SPECFILE_FORMAT_VERSION,
             },
             # spack version information
@@ -2205,7 +2214,7 @@ class Environment:
                 f"Spack {spack.__version__} cannot read the lockfile '{self.lock_path}', using "
                 f"the v{current_lockfile_format} format."
             )
-            if lockfile_format_version < current_lockfile_format:
+            if CURRENT_LOCKFILE_VERSION < current_lockfile_format:
                 msg += " You need to use a newer Spack version."
             raise SpackEnvironmentError(msg)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1165,11 +1165,8 @@ class Environment:
                 data=spack.config.CONFIG.get("definitions", [])
             )
         )
-
-        env_configuration = self.manifest[TOP_LEVEL_KEY]
-        spec_list = env_configuration.get(user_speclist_name, [])
         self.spec_lists[user_speclist_name] = self._spec_lists_parser.parse_user_specs(
-            name=user_speclist_name, yaml_list=spec_list
+            name=user_speclist_name, yaml_list=self.manifest.user_specs()
         )
 
     @property
@@ -2838,6 +2835,9 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             raise ValueError(f"cannot find a spec equivalent to {user_spec}")
 
         return result
+
+    def user_specs(self) -> List:
+        return self.configuration.get(user_speclist_name, [])
 
     def add_user_spec(self, user_spec: str) -> None:
         """Appends the user spec passed as input to the list of root specs.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -55,8 +55,8 @@ from spack.llnl.util.filesystem import copy_tree, islink, readlink, symlink
 from spack.llnl.util.lang import stable_partition
 from spack.llnl.util.link_tree import ConflictingSpecsError
 from spack.schema.env import TOP_LEVEL_KEY
-from spack.solver.reuse import SpecFilter
 from spack.spec import Spec
+from spack.spec_filter import SpecFilter
 from spack.util.path import substitute_path_variables
 
 from .list import SpecList, SpecListError, SpecListParser

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -697,7 +697,7 @@ class ViewDescriptor:
         exclude: Optional[List[str]] = None,
         link: str = default_view_link,
         link_type: fsv.LinkType = "symlink",
-        groups: Optional[List[str]] = None,
+        groups: Optional[Union[str, List[str]]] = None,
     ) -> None:
         self.base = base_path
         self.raw_root = root
@@ -707,7 +707,9 @@ class ViewDescriptor:
         self.exclude = exclude or []
         self.link_type: fsv.LinkType = fsv.canonicalize_link_type(link_type)
         self.link = link
-        self.groups = groups
+        if isinstance(groups, str):
+            groups = [groups]
+        self.groups: Optional[List[str]] = groups
 
     def select_fn(self, spec: Spec) -> bool:
         return any(spec.satisfies(s) for s in self.select)
@@ -755,7 +757,7 @@ class ViewDescriptor:
             exclude=d.get("exclude", []),
             link=d.get("link", default_view_link),
             link_type=d.get("link_type", "symlink"),
-            groups=d.get("groups", None),
+            groups=d.get("group", None),
         )
 
     @property

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -689,35 +689,38 @@ def _error_on_nonempty_view_dir(new_root):
 class ViewDescriptor:
     def __init__(
         self,
-        base_path,
-        root,
-        projections={},
-        select=[],
-        exclude=[],
-        link=default_view_link,
-        link_type="symlink",
-    ):
+        base_path: str,
+        root: str,
+        *,
+        projections: Optional[Dict[str, str]] = None,
+        select: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+        link: str = default_view_link,
+        link_type: fsv.LinkType = "symlink",
+        groups: Optional[List[str]] = None,
+    ) -> None:
         self.base = base_path
         self.raw_root = root
         self.root = spack.util.path.canonicalize_path(root, default_wd=base_path)
-        self.projections = projections
-        self.select = select
-        self.exclude = exclude
-        self.link_type = fsv.canonicalize_link_type(link_type)
+        self.projections = projections or {}
+        self.select = select or []
+        self.exclude = exclude or []
+        self.link_type: fsv.LinkType = fsv.canonicalize_link_type(link_type)
         self.link = link
+        self.groups = groups
 
-    def select_fn(self, spec):
+    def select_fn(self, spec: Spec) -> bool:
         return any(spec.satisfies(s) for s in self.select)
 
-    def exclude_fn(self, spec):
+    def exclude_fn(self, spec: Spec) -> bool:
         return not any(spec.satisfies(e) for e in self.exclude)
 
-    def update_root(self, new_path):
+    def update_root(self, new_path: str) -> None:
         self.raw_root = new_path
         self.root = spack.util.path.canonicalize_path(new_path, default_wd=self.base)
 
-    def __eq__(self, other):
-        return all(
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, ViewDescriptor) and all(
             [
                 self.root == other.root,
                 self.projections == other.projections,
@@ -743,19 +746,20 @@ class ViewDescriptor:
         return ret
 
     @staticmethod
-    def from_dict(base_path, d):
+    def from_dict(base_path: str, d) -> "ViewDescriptor":
         return ViewDescriptor(
             base_path,
             d["root"],
-            d.get("projections", {}),
-            d.get("select", []),
-            d.get("exclude", []),
-            d.get("link", default_view_link),
-            d.get("link_type", "symlink"),
+            projections=d.get("projections", {}),
+            select=d.get("select", []),
+            exclude=d.get("exclude", []),
+            link=d.get("link", default_view_link),
+            link_type=d.get("link_type", "symlink"),
+            groups=d.get("groups", None),
         )
 
     @property
-    def _current_root(self):
+    def _current_root(self) -> Optional[str]:
         if not islink(self.root):
             return None
 
@@ -854,7 +858,12 @@ class ViewDescriptor:
 
         return self._exclude_duplicate_runtimes(result)
 
-    def regenerate(self, concrete_roots: List[Spec]) -> None:
+    def regenerate(self, env: "Environment") -> None:
+        if self.groups is None:
+            concrete_roots = env.concrete_roots()
+        else:
+            concrete_roots = [c for g in self.groups for _, c in env.concretized_specs_by(group=g)]
+
         specs = self.specs_for_view(concrete_roots)
 
         # To ensure there are no conflicts with packages being installed
@@ -1302,7 +1311,7 @@ class Environment:
         return os.path.join(self.env_subdir_path, "repos")
 
     @property
-    def view_path_default(self):
+    def view_path_default(self) -> str:
         # default path for environment views
         return os.path.join(self.env_subdir_path, "view")
 
@@ -1723,6 +1732,7 @@ class Environment:
         if default_view_name in self.views:
             self.default_view.update_root(view_path)
         else:
+            assert isinstance(view_path, str), f"expected str for 'view_path', but got {view_path}"
             self.views[default_view_name] = ViewDescriptor(self.path, view_path)
 
         self.manifest.set_default_view(self._default_view_as_yaml())
@@ -1746,7 +1756,7 @@ class Environment:
             return
 
         for view in self.views.values():
-            view.regenerate(self.concrete_roots())
+            view.regenerate(self)
 
     def check_views(self):
         """Checks if the environments default view can be activated."""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -160,7 +160,7 @@ READER_CLS = {
 
 # Magic names
 # The name of the standalone spec list in the manifest yaml
-user_speclist_name = "specs"
+USER_SPECS_KEY = "specs"
 # The name of the default view (the view loaded on env.activate)
 default_view_name = "default"
 # Default behavior to link all packages into views (vs. only root packages)
@@ -1165,13 +1165,13 @@ class Environment:
                 data=spack.config.CONFIG.get("definitions", [])
             )
         )
-        self.spec_lists[user_speclist_name] = self._spec_lists_parser.parse_user_specs(
-            name=user_speclist_name, yaml_list=self.manifest.user_specs()
+        self.spec_lists[USER_SPECS_KEY] = self._spec_lists_parser.parse_user_specs(
+            name=USER_SPECS_KEY, yaml_list=self.manifest.user_specs()
         )
 
     @property
     def user_specs(self):
-        return self.spec_lists[user_speclist_name]
+        return self.spec_lists[USER_SPECS_KEY]
 
     @property
     def dev_specs(self):
@@ -1312,7 +1312,7 @@ class Environment:
         """Remove this environment from Spack entirely."""
         shutil.rmtree(self.path)
 
-    def add(self, user_spec, list_name=user_speclist_name) -> bool:
+    def add(self, user_spec, list_name=USER_SPECS_KEY) -> bool:
         """Add a single user_spec (non-concretized) to the Environment
 
         Returns:
@@ -1325,7 +1325,7 @@ class Environment:
         if list_name not in self.spec_lists:
             raise SpackEnvironmentError(f"No list {list_name} exists in environment {self.name}")
 
-        if list_name == user_speclist_name:
+        if list_name == USER_SPECS_KEY:
             if spec.anonymous:
                 raise SpackEnvironmentError("cannot add anonymous specs to an environment")
             elif not spack.repo.PATH.exists(spec.name) and not spec.abstract_hash:
@@ -1337,7 +1337,7 @@ class Environment:
         existing = str(spec) in list_to_change.yaml_list
         if not existing:
             list_to_change.add(spec)
-            if list_name == user_speclist_name:
+            if list_name == USER_SPECS_KEY:
                 self.manifest.add_user_spec(str(user_spec))
             else:
                 self.manifest.add_definition(str(user_spec), list_name=list_name)
@@ -1348,7 +1348,7 @@ class Environment:
     def change_existing_spec(
         self,
         change_spec: Spec,
-        list_name: str = user_speclist_name,
+        list_name: str = USER_SPECS_KEY,
         match_spec: Optional[Spec] = None,
         allow_changing_multiple_specs=False,
     ):
@@ -1389,7 +1389,7 @@ class Environment:
 
         for idx, spec in matches:
             override_spec = Spec.override(spec, change_spec)
-            if list_name == user_speclist_name:
+            if list_name == USER_SPECS_KEY:
                 self.manifest.override_user_spec(str(override_spec), idx=idx)
             else:
                 self.manifest.override_definition(
@@ -1397,7 +1397,7 @@ class Environment:
                 )
         self._sync_speclists()
 
-    def remove(self, query_spec, list_name=user_speclist_name, force=False):
+    def remove(self, query_spec, list_name=USER_SPECS_KEY, force=False):
         """Remove specs from an environment that match a query_spec"""
         err_msg_header = (
             f"Cannot remove '{query_spec}' from '{list_name}' definition "
@@ -1434,7 +1434,7 @@ class Environment:
                     msg += " It will be removed from the concrete specs."
                 tty.warn(msg)
             else:
-                if list_name == user_speclist_name:
+                if list_name == USER_SPECS_KEY:
                     self.manifest.remove_user_spec(str(spec))
                 else:
                     self.manifest.remove_definition(str(spec), list_name=list_name)
@@ -2837,7 +2837,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         return result
 
     def user_specs(self) -> List:
-        return self.configuration.get(user_speclist_name, [])
+        return self.configuration.get(USER_SPECS_KEY, [])
 
     def add_user_spec(self, user_spec: str) -> None:
         """Appends the user spec passed as input to the list of root specs.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2489,6 +2489,11 @@ class ReusableSpecsFactory:
         self.env = env
         self.group = group
 
+    @staticmethod
+    def _const(specs: List[Spec]) -> Callable[[], List[Spec]]:
+        """Returns a zero-argument callable that always returns the given list."""
+        return lambda: specs
+
     def __call__(
         self, is_usable: Callable[[Spec], bool], configuration: spack.config.Configuration
     ) -> List[SpecFilter]:
@@ -2505,7 +2510,9 @@ class ReusableSpecsFactory:
                 traverse.traverse_nodes(necessary_specs, deptype=("link", "run"))
             )
             result.append(
-                SpecFilter(lambda: necessary_specs, include=[], exclude=[], is_usable=is_usable)
+                SpecFilter(
+                    self._const(necessary_specs), include=[], exclude=[], is_usable=is_usable
+                )
             )
 
         # Included environments and _this_ group, instead, are subject to configuration
@@ -2523,7 +2530,9 @@ class ReusableSpecsFactory:
         additional_specs = list(traverse.traverse_nodes(this_group_specs + included_specs))
         if not isinstance(reuse_yaml, Mapping):
             result.append(
-                SpecFilter(lambda: additional_specs, include=[], exclude=[], is_usable=is_usable)
+                SpecFilter(
+                    self._const(additional_specs), include=[], exclude=[], is_usable=is_usable
+                )
             )
             return result
 
@@ -2540,7 +2549,7 @@ class ReusableSpecsFactory:
             if "path" not in source:
                 result.append(
                     SpecFilter(
-                        lambda: additional_specs,
+                        self._const(additional_specs),
                         include=include,
                         exclude=exclude,
                         is_usable=is_usable,
@@ -2556,7 +2565,7 @@ class ReusableSpecsFactory:
                 included_specs = list(traverse.traverse_nodes(spec_pairs_from_included_envs))
                 result.append(
                     SpecFilter(
-                        lambda: included_specs,
+                        self._const(included_specs),
                         include=include,
                         exclude=exclude,
                         is_usable=is_usable,

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2546,16 +2546,10 @@ class ReusableSpecsFactory:
 
             env_dir = as_env_dir(source["path"])
             if env_dir in self.env.included_concrete_envs:
-                included_specs = list(
-                    traverse.traverse_nodes(
-                        [
-                            x
-                            for _, x in self.env.concretized_specs_from_included_environment(
-                                env_dir
-                            )
-                        ]
-                    )
-                )
+                spec_pairs_from_included_envs = [
+                    x for _, x in self.env.concretized_specs_from_included_environment(env_dir)
+                ]
+                included_specs = list(traverse.traverse_nodes(spec_pairs_from_included_envs))
                 result.append(
                     SpecFilter(
                         lambda: included_specs,

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2557,46 +2557,12 @@ class EnvironmentConcretizer:
         result = []
         # Sort so that the ordering is deterministic, and "default" specs are first
         for current_group in self._order_groups():
-            # Exit early if the set of concretized specs is the set of user specs
-            new_user_specs, kept_user_specs = self._partition_user_specs(group=current_group)
-            if not new_user_specs:
-                continue
-
-            # Pick the right concretization strategy
-            unify = self.env.unify
-            factory = ReusableSpecsFactory(env=self.env, group=current_group)
-            if unify == "when_possible":
-                partial_result = self._concretize_together_where_possible(
-                    new_user_specs,
-                    kept_user_specs,
-                    tests=tests,
-                    group=current_group,
-                    factory=factory,
-                )
-
-            elif unify is True:
-                partial_result = self._concretize_together(
-                    new_user_specs,
-                    kept_user_specs,
-                    tests=tests,
-                    group=current_group,
-                    factory=factory,
-                )
-
-            elif unify is False:
-                partial_result = self._concretize_separately(
-                    new_user_specs,
-                    kept_user_specs,
-                    tests=tests,
-                    group=current_group,
-                    factory=factory,
-                )
-            else:
-                raise SpackEnvironmentError(f"concretization strategy not implemented [{unify}]")
+            partial_result = self._concretize_single_group(group=current_group, tests=tests)
             result.extend(partial_result)
 
         # Unify the specs objects, so we get correct references to all parents
-        self.env.unify_specs()
+        if result:
+            self.env.unify_specs()
         return result
 
         # for group in self.env.user_spec_groups:
@@ -2610,6 +2576,36 @@ class EnvironmentConcretizer:
         #     group_scope = ...
         #     with spack.config.push_scope():
         #         [concretize and add]
+
+    def _concretize_single_group(
+        self, *, group: str, tests: Union[bool, Sequence[str]]
+    ) -> List[SpecPair]:
+        # Exit early if the set of concretized specs is the set of user specs
+        new_user_specs, kept_user_specs = self._partition_user_specs(group=group)
+        if not new_user_specs:
+            return []
+
+        # Pick the right concretization strategy
+        unify = self.env.unify
+        factory = ReusableSpecsFactory(env=self.env, group=group)
+        if unify == "when_possible":
+            partial_result = self._concretize_together_where_possible(
+                new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
+            )
+
+        elif unify is True:
+            partial_result = self._concretize_together(
+                new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
+            )
+
+        elif unify is False:
+            partial_result = self._concretize_separately(
+                new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
+            )
+        else:
+            raise SpackEnvironmentError(f"concretization strategy not implemented [{unify}]")
+
+        return partial_result
 
     def _prepare_environment_for_concretization(self, *, force: bool):
         """Reset the environment concrete state and ensure consistency with user specs."""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2556,7 +2556,7 @@ class ReusableSpecsFactory:
                 continue
 
             env_dir = as_env_dir(source["path"])
-            if env_dir in self.env.included_concrete_envs:
+            if env_dir in self.env.included_concrete_env_root_dirs:
                 spec_pairs_from_included_envs = [
                     x for _, x in self.env.concretized_specs_from_included_environment(env_dir)
                 ]

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2656,7 +2656,18 @@ class EnvironmentConcretizer:
 
     def _order_groups(self) -> List[str]:
         done, result = {DEFAULT_USER_SPEC_GROUP}, [DEFAULT_USER_SPEC_GROUP]
-        remaining = self.env.manifest.groups() - {DEFAULT_USER_SPEC_GROUP}
+        all_groups = self.env.manifest.groups()
+        remaining = all_groups - {DEFAULT_USER_SPEC_GROUP}
+
+        # Validate upfront that all 'needs' references point to defined groups
+        for group in remaining:
+            for dep in self.env.manifest.needs(group=group):
+                if dep not in all_groups:
+                    raise SpackEnvironmentConfigError(
+                        f"group '{group}' needs '{dep}', but '{dep}' is not a defined group",
+                        self.env.manifest.manifest_file,
+                    )
+
         while remaining:
             # Check we have groups that are "ready"
             ready = []
@@ -2665,10 +2676,10 @@ class EnvironmentConcretizer:
                 if all(d in done for d in deps):
                     ready.append(current)
 
-            # Check we can progress
+            # Check we can progress — if nothing is ready, there is a cycle
             if not ready:
                 raise SpackEnvironmentConfigError(
-                    "cannot resolve dependencies for the group of specs in the environment",
+                    f"cyclic dependency detected among groups: {', '.join(sorted(remaining))}",
                     self.env.manifest.manifest_file,
                 )
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -145,7 +145,7 @@ sep_re = re.escape(os.sep)
 valid_environment_name_re = rf"^\w[{sep_re}\w-]*$"
 
 #: version of the lockfile format. Must increase monotonically.
-lockfile_format_version = 6
+lockfile_format_version = 7
 
 
 READER_CLS = {
@@ -155,6 +155,7 @@ READER_CLS = {
     4: spack.spec.SpecfileV3,
     5: spack.spec.SpecfileV4,
     6: spack.spec.SpecfileV5,
+    7: spack.spec.SpecfileV5,
 }
 
 
@@ -968,12 +969,15 @@ def env_subdir_path(manifest_dir: Union[str, pathlib.Path]) -> str:
 class ConcretizedRootInfo:
     """Data on root specs that have been concretized"""
 
-    __slots__ = ("root", "hash", "new")
+    __slots__ = ("root", "hash", "new", "group")
 
-    def __init__(self, *, root_spec: spack.spec.Spec, root_hash: str, new: bool = False):
+    def __init__(
+        self, *, root_spec: spack.spec.Spec, root_hash: str, new: bool = False, group: str
+    ):
         self.root = root_spec
         self.hash = root_hash
         self.new = new
+        self.group = group
 
     def __str__(self):
         return f"{self.root} -> {self.hash} [new={self.new}]"
@@ -1772,7 +1776,12 @@ class Environment:
         return env_mod
 
     def add_concrete_spec(
-        self, spec: spack.spec.Spec, concrete: spack.spec.Spec, *, new: bool = True
+        self,
+        spec: spack.spec.Spec,
+        concrete: spack.spec.Spec,
+        *,
+        new: bool = True,
+        group: Optional[str] = None,
     ):
         """Called when a new concretized spec is added to the environment.
 
@@ -1785,7 +1794,10 @@ class Environment:
         """
         assert concrete.concrete
         h = concrete.dag_hash()
-        self.concretized_roots.append(ConcretizedRootInfo(root_spec=spec, root_hash=h, new=new))
+        user_specs_group = self._user_specs_key(group=group)
+        self.concretized_roots.append(
+            ConcretizedRootInfo(root_spec=spec, root_hash=h, new=new, group=user_specs_group)
+        )
         self.specs_by_hash[h] = concrete
 
     def _dev_specs_that_need_overwrite(self):
@@ -2071,7 +2083,9 @@ class Environment:
         return concrete_specs
 
     def _concrete_roots_dict(self):
-        return [{"hash": x.hash, "spec": str(x.root)} for x in self.concretized_roots]
+        return [
+            {"hash": x.hash, "spec": str(x.root), "group": x.group} for x in self.concretized_roots
+        ]
 
     def _to_lockfile_dict(self):
         """Create a dictionary to store a lockfile for this environment."""
@@ -2159,9 +2173,16 @@ class Environment:
         self.included_concretized_order = {}
 
         roots = d["roots"]
+        default_user_specs_group = self._user_specs_key()
 
         self.concretized_roots = [
-            ConcretizedRootInfo(root_spec=Spec(r["spec"]), root_hash=r["hash"], new=False)
+            # Lockfile versions < 7 don't have the "group" attribute
+            ConcretizedRootInfo(
+                root_spec=Spec(r["spec"]),
+                root_hash=r["hash"],
+                new=False,
+                group=r.get("group", default_user_specs_group),
+            )
             for r in roots
         ]
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import stat
 import warnings
+from collections.abc import KeysView
 from typing import (
     Any,
     Callable,
@@ -3183,9 +3184,9 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             return None
         return spack.config.InternalConfigScope(f"env:groups:{group}", data)
 
-    def groups(self) -> Set[str]:
+    def groups(self) -> KeysView:
         """Returns the list of groups defined in the manifest"""
-        return set(self._groups)
+        return self._groups.keys()
 
     def needs(self, *, group: Optional[str] = None) -> Tuple[str, ...]:
         """Returns the dependencies of a group of user specs."""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1970,6 +1970,13 @@ class Environment:
         roots *without* associated user spec"""
         return [root for _, root in self.concretized_specs()]
 
+    def concretized_specs_by(self, *, group: str) -> Iterable[Tuple[Spec, Spec]]:
+        """Generates all the (abstract, concrete) spec pairs for a given group"""
+        for x in self.concretized_roots:
+            if x.group != group:
+                continue
+            yield x.root, self.specs_by_hash[x.hash]
+
     def get_by_hash(self, dag_hash: str) -> List[Spec]:
         # If it's not a partial hash prefix we can early exit
         early_exit = len(dag_hash) == 32

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -988,10 +988,11 @@ class ConcretizedRootInfo:
             and self.root == other.root
             and self.hash == other.hash
             and self.new == other.new
+            and self.group == other.group
         )
 
     def __hash__(self) -> int:
-        return hash((self.root, self.hash, self.new))
+        return hash((self.root, self.hash, self.new, self.group))
 
 
 class Environment:
@@ -1578,9 +1579,23 @@ class Environment:
 
     def sync_concretized_specs(self) -> None:
         """Removes concrete specs that no longer correlate to a user spec"""
-        to_deconcretize = [x.root for x in self.concretized_roots if x.root not in self.user_specs]
-        for spec in to_deconcretize:
-            self.deconcretize_by_user_spec(spec)
+        if not self.concretized_roots:
+            return
+
+        to_deconcretize, user_specs = [], self._all_user_specs_with_group()
+        for x in self.concretized_roots:
+            if (x.group, x.root) not in user_specs:
+                to_deconcretize.append(x)
+        for x in to_deconcretize:
+            # FIXME: hack to do the inverse mapping
+            group = x.group.split(":")[-1]
+            self.deconcretize_by_user_spec(x.root, group=group)
+
+    def _all_user_specs_with_group(self) -> Set[Tuple[str, Spec]]:
+        result = set()
+        for group in self.manifest.groups():
+            result.update([(group, x) for x in self.user_specs_by(group=group)])
+        return result
 
     def clear_concretized_specs(self) -> None:
         """Clears the currently concretized specs"""
@@ -1592,15 +1607,20 @@ class Environment:
         self.concretized_roots = [x for x in self.concretized_roots if x.hash != dag_hash]
         self._maybe_remove_dag_hash(dag_hash)
 
-    def deconcretize_by_user_spec(self, spec: spack.spec.Spec) -> None:
-        """Remove a user spec from the environment concretization
+    def deconcretize_by_user_spec(
+        self, spec: spack.spec.Spec, *, group: Optional[str] = None
+    ) -> None:
+        """Removes a user spec from the environment concretization
 
         Arguments:
             spec: user spec to deconcretize
+            group: group of the spec to remove. If not specified, the spec is removed from
+                the default group
         """
+        group = group or DEFAULT_USER_SPEC_GROUP
         # spec has to be a root of the environment
-        self.concretized_roots, discarded = stable_partition(
-            self.concretized_roots, lambda x: x.root != spec
+        discarded, self.concretized_roots = stable_partition(
+            self.concretized_roots, lambda x: x.group == group and x.root == spec
         )
         assert (
             len({x.hash for x in discarded}) == 1
@@ -1794,9 +1814,9 @@ class Environment:
         """
         assert concrete.concrete
         h = concrete.dag_hash()
-        user_specs_group = self._user_specs_key(group=group)
+        group = group or DEFAULT_USER_SPEC_GROUP
         self.concretized_roots.append(
-            ConcretizedRootInfo(root_spec=spec, root_hash=h, new=new, group=user_specs_group)
+            ConcretizedRootInfo(root_spec=spec, root_hash=h, new=new, group=group)
         )
         self.specs_by_hash[h] = concrete
 
@@ -2084,9 +2104,7 @@ class Environment:
 
     def _concrete_roots_dict(self):
         if not self.has_groups():
-            return [
-                {"hash": x.hash, "spec": str(x.root)} for x in self.concretized_roots
-            ]
+            return [{"hash": x.hash, "spec": str(x.root)} for x in self.concretized_roots]
 
         return [
             {"hash": x.hash, "spec": str(x.root), "group": x.group} for x in self.concretized_roots
@@ -2182,7 +2200,7 @@ class Environment:
         self.included_concretized_order = {}
 
         roots = d["roots"]
-        default_user_specs_group = self._user_specs_key()
+        default_user_specs_group = DEFAULT_USER_SPEC_GROUP
 
         self.concretized_roots = [
             # Lockfile versions < 7 don't have the "group" attribute
@@ -2419,27 +2437,54 @@ class EnvironmentConcretizer:
     ) -> List[SpecPair]:
         if force is None:
             force = spack.config.get("concretizer:force")
-
-        # Exit early if the set of concretized specs is the set of user specs
         self._prepare_environment_for_concretization(force=force)
-        new_user_specs, kept_user_specs = self._partition_user_specs()
-        if not new_user_specs:
-            return []
 
-        # Pick the right concretization strategy
-        unify = self.env.unify
-        if unify == "when_possible":
-            return self._concretize_together_where_possible(
-                new_user_specs, kept_user_specs, tests=tests
-            )
+        result = []
+        groups = list(self.env.manifest.groups())
+        # Sort so that the ordering is deterministic, and "default" specs are first
+        groups.sort(key=lambda x: (x == DEFAULT_USER_SPEC_GROUP, x))
+        while groups:
+            current_group = groups.pop()
+            # Exit early if the set of concretized specs is the set of user specs
+            new_user_specs, kept_user_specs = self._partition_user_specs(group=current_group)
+            if not new_user_specs:
+                continue
 
-        if unify is True:
-            return self._concretize_together(new_user_specs, kept_user_specs, tests=tests)
+            # Pick the right concretization strategy
+            unify = self.env.unify
+            if unify == "when_possible":
+                partial_result = self._concretize_together_where_possible(
+                    new_user_specs, kept_user_specs, tests=tests, group=current_group
+                )
 
-        if unify is False:
-            return self._concretize_separately(new_user_specs, kept_user_specs, tests=tests)
+            elif unify is True:
+                partial_result = self._concretize_together(
+                    new_user_specs, kept_user_specs, tests=tests, group=current_group
+                )
 
-        raise SpackEnvironmentError(f"concretization strategy not implemented [{unify}]")
+            elif unify is False:
+                partial_result = self._concretize_separately(
+                    new_user_specs, kept_user_specs, tests=tests, group=current_group
+                )
+            else:
+                raise SpackEnvironmentError(f"concretization strategy not implemented [{unify}]")
+            result.extend(partial_result)
+
+        # Unify the specs objects, so we get correct references to all parents
+        self.env.unify_specs()
+        return result
+
+        # for group in self.env.user_spec_groups:
+        #     # Exit early if the set of concretized specs is the set of user specs
+        #     new_user_specs, kept_user_specs = self._partition_user_specs(group)
+        #     if not new_user_specs:
+        #         continue
+        #
+        #     needed_groups = self.env.needed_groups(group)
+        #     reused_specs = self.env.concrete_specs_from_groups(*needed_groups)
+        #     group_scope = ...
+        #     with spack.config.push_scope():
+        #         [concretize and add]
 
     def _prepare_environment_for_concretization(self, *, force: bool):
         """Reset the environment concrete state and ensure consistency with user specs."""
@@ -2452,13 +2497,15 @@ class EnvironmentConcretizer:
         if self.env.included_concrete_env_root_dirs:
             self.env.include_concrete_envs()
 
-    def _partition_user_specs(self) -> Tuple[List[spack.spec.Spec], List[spack.spec.Spec]]:
+    def _partition_user_specs(
+        self, *, group: str
+    ) -> Tuple[List[spack.spec.Spec], List[spack.spec.Spec]]:
         """Splits the users specs in the list of the ones to be computed, and the list of
         the ones to retain.
         """
-        concretized_user_specs = {x.root for x in self.env.concretized_roots}
+        concretized_user_specs = {x.root for x in self.env.concretized_roots if x.group == group}
         kept_user_specs, new_user_specs = stable_partition(
-            self.env.user_specs, lambda x: x in concretized_user_specs
+            self.env.user_specs_by(group=group), lambda x: x in concretized_user_specs
         )
         kept_user_specs += self.env.included_user_specs
         return new_user_specs, kept_user_specs
@@ -2474,7 +2521,12 @@ class EnvironmentConcretizer:
         return specs_to_concretize
 
     def _concretize_together_where_possible(
-        self, to_compute: List[Spec], to_keep: List[Spec], *, tests: Union[bool, Sequence] = False
+        self,
+        to_compute: List[Spec],
+        to_keep: List[Spec],
+        *,
+        group: Optional[str] = None,
+        tests: Union[bool, Sequence] = False,
     ) -> List[SpecPair]:
         specs_to_concretize = self._user_spec_pairs(to_compute, to_keep)
         result = spack.concretize.concretize_together_when_possible(
@@ -2482,12 +2534,17 @@ class EnvironmentConcretizer:
         )
         result = [x for x in result if x[0] in to_compute]
         for abstract, concrete in result:
-            self.env.add_concrete_spec(abstract, concrete, new=True)
+            self.env.add_concrete_spec(abstract, concrete, new=True, group=group)
 
         return result
 
     def _concretize_together(
-        self, to_compute: List[Spec], to_keep: List[Spec], *, tests: Union[bool, Sequence] = False
+        self,
+        to_compute: List[Spec],
+        to_keep: List[Spec],
+        *,
+        group: Optional[str] = None,
+        tests: Union[bool, Sequence] = False,
     ) -> List[SpecPair]:
         to_concretize = self._user_spec_pairs(to_compute, to_keep)
         try:
@@ -2495,7 +2552,7 @@ class EnvironmentConcretizer:
         except spack.error.UnsatisfiableSpecError as e:
             # "Enhance" the error message for multiple root specs, suggest a less strict
             # form of concretization.
-            if len(self.env.user_specs) > 1:
+            if len(self.env.user_specs_by(group=group)) > 1:
                 e.message += ". "
                 if to_keep:
                     e.message += (
@@ -2511,23 +2568,24 @@ class EnvironmentConcretizer:
         # Return the portion of the return value that is new
         result = concrete_pairs[: len(to_compute)]
         for abstract, concrete in result:
-            self.env.add_concrete_spec(abstract, concrete, new=True)
+            self.env.add_concrete_spec(abstract, concrete, new=True, group=group)
         return result
 
     def _concretize_separately(
-        self, to_compute: List[Spec], to_keep: List[Spec], *, tests: Union[bool, Sequence] = False
+        self,
+        to_compute: List[Spec],
+        to_keep: List[Spec],
+        *,
+        group: Optional[str] = None,
+        tests: Union[bool, Sequence] = False,
     ) -> List[SpecPair]:
-        """Concretization strategy that concretizes separately one
-        user spec after the other.
-        """
+        """Concretization strategy that concretizes separately one user spec after the other"""
         to_concretize = [(x, None) for x in to_compute]
         concrete_pairs = spack.concretize.concretize_separately(to_concretize, tests=tests)
 
         for abstract, concrete in concrete_pairs:
-            self.env.add_concrete_spec(abstract, concrete, new=True)
+            self.env.add_concrete_spec(abstract, concrete, new=True, group=group)
 
-        # Unify the specs objects, so we get correct references to all parents
-        self.env.unify_specs()
         return concrete_pairs
 
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -12,7 +12,7 @@ import re
 import shutil
 import stat
 import warnings
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 import spack
 import spack.concretize
@@ -2765,6 +2765,9 @@ def initialize_environment_dir(
         shutil.copytree(orig_abspath, abspath, symlinks=True)
 
 
+DEFAULT_USER_SPEC_GROUP = "default"
+
+
 class EnvironmentManifestFile(collections.abc.Mapping):
     """Manages the in-memory representation of a manifest file, and its synchronization
     with the actual manifest on disk.
@@ -2814,7 +2817,42 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         with self.manifest_file.open(encoding="utf-8") as f:
             self.yaml_content = _read_yaml(f)
 
+        # Maps groups to their dependencies
+        self._groups: Dict[str, Tuple[str, ...]] = {DEFAULT_USER_SPEC_GROUP: tuple()}
+        # Raw YAML definitions of the user specs for each group
+        self._user_specs: Dict[str, List] = {DEFAULT_USER_SPEC_GROUP: []}
+        self._init_user_specs()
+
         self.changed = False
+
+    def _init_user_specs(self):
+        specs_yaml = self.configuration.get(USER_SPECS_KEY, [])
+        for item in specs_yaml:
+            if isinstance(item, str):
+                self._user_specs[DEFAULT_USER_SPEC_GROUP].append(item)
+            elif isinstance(item, dict):
+                group = item.get("group", DEFAULT_USER_SPEC_GROUP)
+
+                # Error if a group is defined more than once
+                if group != DEFAULT_USER_SPEC_GROUP and group in self._groups:
+                    raise SpackEnvironmentConfigError(
+                        f"group '{group}' defined more than once", self.manifest_file
+                    )
+
+                # Add an entry for the user specs and store group dependencies
+                if group not in self._user_specs:
+                    self._user_specs[group] = []
+                    self._groups[group] = tuple(item.get("needs", ()))
+
+                if "matrix" in item:
+                    # Short form if the group is composed of only one matrix
+                    self._user_specs[group].append({"matrix": item["matrix"]})
+                elif "specs" in item:
+                    self._user_specs[group].extend(item["specs"])
+
+    def _clear_user_specs(self) -> None:
+        self._user_specs = {DEFAULT_USER_SPEC_GROUP: []}
+        self._groups = {DEFAULT_USER_SPEC_GROUP: tuple()}
 
     def _all_matches(self, user_spec: str) -> List[str]:
         """Maps the input string to the first equivalent user spec in the manifest,
@@ -2836,20 +2874,35 @@ class EnvironmentManifestFile(collections.abc.Mapping):
 
         return result
 
-    def user_specs(self) -> List:
-        return self.configuration.get(USER_SPECS_KEY, [])
+    def user_specs(self, *, group: Optional[str] = None) -> List:
+        group = DEFAULT_USER_SPEC_GROUP if group is None else group
+        if group not in self._groups:
+            raise ValueError(f"user specs group '{group}' not found in {self.manifest_file}")
+        return self._user_specs[group]
+
+    def groups(self) -> Set[str]:
+        """Returns the list of groups defined in the manifest"""
+        return set(self._groups)
+
+    def needs(self, *, group: Optional[str] = None) -> Tuple[str, ...]:
+        """Returns the dependencies of a group of user specs."""
+        group = DEFAULT_USER_SPEC_GROUP if group is None else group
+        if group not in self._groups:
+            raise ValueError(f"user specs group '{group}' not found in {self.manifest_file}")
+        return self._groups[group]
 
     def add_user_spec(self, user_spec: str) -> None:
-        """Appends the user spec passed as input to the list of root specs.
+        """Appends the user spec passed as input to the default list of root specs.
 
         Args:
             user_spec: user spec to be appended
         """
         self.configuration.setdefault("specs", []).append(user_spec)
+        self._user_specs[DEFAULT_USER_SPEC_GROUP].append(user_spec)
         self.changed = True
 
     def remove_user_spec(self, user_spec: str) -> None:
-        """Removes the user spec passed as input from the list of root specs
+        """Removes the user spec passed as input from the default list of root specs
 
         Args:
             user_spec: user spec to be removed
@@ -2860,6 +2913,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         try:
             for key in self._all_matches(user_spec):
                 self.configuration["specs"].remove(key)
+                self._user_specs[DEFAULT_USER_SPEC_GROUP].remove(key)
         except ValueError as e:
             msg = f"cannot remove {user_spec} from {self}, no such spec exists"
             raise SpackEnvironmentError(msg) from e
@@ -2868,6 +2922,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
     def clear(self) -> None:
         """Clear all user specs from the list of root specs"""
         self.configuration["specs"] = []
+        self._clear_user_specs()
         self.changed = True
 
     def override_user_spec(self, user_spec: str, idx: int) -> None:
@@ -2882,6 +2937,8 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         """
         try:
             self.configuration["specs"][idx] = user_spec
+            self._clear_user_specs()
+            self._init_user_specs()
         except ValueError as e:
             msg = f"cannot override {user_spec} from {self}"
             raise SpackEnvironmentError(msg) from e
@@ -3113,8 +3170,7 @@ class SpackEnvironmentConfigError(SpackEnvironmentError):
     """Class for Spack environment-specific configuration errors."""
 
     def __init__(self, msg, filename):
-        self.filename = filename
-        super().__init__(msg)
+        super().__init__(f"{msg} in {filename}")
 
 
 class SpackEnvironmentDevelopError(SpackEnvironmentError):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -27,7 +27,6 @@ from typing import (
 )
 
 import spack
-import spack.concretize
 import spack.config
 import spack.deptypes as dt
 import spack.error
@@ -62,7 +61,7 @@ from spack.util.path import substitute_path_variables
 
 from .list import SpecList, SpecListError, SpecListParser
 
-SpecPair = spack.concretize.SpecPair
+SpecPair = Tuple[Spec, Spec]
 
 #: environment variable used to indicate the active environment
 spack_env_var = "SPACK_ENV"
@@ -2681,6 +2680,8 @@ class EnvironmentConcretizer:
         tests: Union[bool, Sequence] = False,
         factory: ReusableSpecsFactory,
     ) -> List[SpecPair]:
+        import spack.concretize
+
         specs_to_concretize = self._user_spec_pairs(to_compute, to_keep)
         result = spack.concretize.concretize_together_when_possible(
             specs_to_concretize, tests=tests, factory=factory
@@ -2700,6 +2701,8 @@ class EnvironmentConcretizer:
         tests: Union[bool, Sequence] = False,
         factory: ReusableSpecsFactory,
     ) -> List[SpecPair]:
+        import spack.concretize
+
         to_concretize = self._user_spec_pairs(to_compute, to_keep)
         try:
             concrete_pairs = spack.concretize.concretize_together(
@@ -2737,6 +2740,8 @@ class EnvironmentConcretizer:
         factory: ReusableSpecsFactory,
     ) -> List[SpecPair]:
         """Concretization strategy that concretizes separately one user spec after the other"""
+        import spack.concretize
+
         to_concretize = [(x, None) for x in to_compute]
         concrete_pairs = spack.concretize.concretize_separately(
             to_concretize, tests=tests, factory=factory

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -104,9 +104,11 @@ def view_copy(
 
 #: Type alias for link types
 LinkType = Literal["hardlink", "hard", "copy", "relocate", "add", "symlink", "soft"]
+CanonicalLinkType = Literal["hardlink", "copy", "symlink"]
+
 
 #: supported string values for `link_type` in an env, mapped to canonical values
-_LINK_TYPES = {
+_LINK_TYPES: Dict[LinkType, CanonicalLinkType] = {
     "hardlink": "hardlink",
     "hard": "hardlink",
     "copy": "copy",
@@ -119,7 +121,7 @@ _LINK_TYPES = {
 _VALID_LINK_TYPES = sorted(set(_LINK_TYPES.values()))
 
 
-def canonicalize_link_type(link_type: LinkType) -> str:
+def canonicalize_link_type(link_type: LinkType) -> CanonicalLinkType:
     """Return canonical"""
     canonical = _LINK_TYPES.get(link_type)
     if not canonical:

--- a/lib/spack/spack/llnl/string.py
+++ b/lib/spack/spack/llnl/string.py
@@ -4,10 +4,10 @@
 """String manipulation functions that do not have other dependencies than Python
 standard library
 """
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 
-def comma_list(sequence: List[str], article: str = "") -> str:
+def comma_list(sequence: Sequence[str], article: str = "") -> str:
     if type(sequence) is not list:
         sequence = list(sequence)
 
@@ -26,7 +26,7 @@ def comma_list(sequence: List[str], article: str = "") -> str:
     return out
 
 
-def comma_or(sequence: List[str]) -> str:
+def comma_or(sequence: Sequence[str]) -> str:
     """Return a string with all the elements of the input joined by comma, but the last
     one (which is joined by ``"or"``).
     """

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -33,6 +33,12 @@ group_name_and_deps = {
         "description": "Groups of specs that are needed by this group",
         "items": {"type": "string"},
     },
+    "override": {
+        "type": "object",
+        "description": "Top-most configuration scope for this group of specs",
+        "additionalProperties": False,
+        "properties": {**spack.schema.merged.properties},
+    },
 }
 
 

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -7,11 +7,12 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/env.py
    :lines: 19-
 """
+
 from typing import Any, Dict
 
 import spack.schema.merged
 
-from .spec_list import spec_list_schema
+from .spec_list import spec_list_properties, spec_list_schema
 
 #: Top level key in a manifest file
 TOP_LEVEL_KEY = "spack"
@@ -25,6 +26,16 @@ include_concrete = {
     "items": {"type": "string"},
 }
 
+group_name_and_deps = {
+    "group": {"type": "string", "description": "Name for this group of specs"},
+    "needs": {
+        "type": "array",
+        "description": "Groups of specs that are needed by this group",
+        "items": {"type": "string"},
+    },
+}
+
+
 properties: Dict[str, Any] = {
     "spack": {
         "type": "object",
@@ -36,7 +47,37 @@ properties: Dict[str, Any] = {
             # merged configuration scope schemas
             **spack.schema.merged.properties,
             # extra environment schema properties
-            "specs": spec_list_schema,
+            "specs": {
+                "type": "array",
+                "description": "List of specs to include in the environment, "
+                "supporting both simple specs and matrix configurations",
+                "default": [],
+                "items": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "description": "Matrix configuration for generating multiple specs"
+                            " from combinations of constraints",
+                            "additionalProperties": False,
+                            "properties": {**spec_list_properties},
+                        },
+                        {"type": "string", "description": "Simple spec string"},
+                        {"type": "null"},
+                        {
+                            "type": "object",
+                            "description": "User spec group with a single matrix",
+                            "additionalProperties": False,
+                            "properties": {**spec_list_properties, **group_name_and_deps},
+                        },
+                        {
+                            "type": "object",
+                            "description": "User spec group with multiple matrices",
+                            "additionalProperties": False,
+                            "properties": {**group_name_and_deps, "specs": spec_list_schema},
+                        },
+                    ]
+                },
+            },
             "include_concrete": include_concrete,
         },
     }

--- a/lib/spack/spack/schema/spec_list.py
+++ b/lib/spack/spack/schema/spec_list.py
@@ -11,6 +11,15 @@ matrix_schema = {
     },
 }
 
+spec_list_properties = {
+    "matrix": matrix_schema,
+    "exclude": {
+        "type": "array",
+        "description": "List of specific spec combinations to exclude from the " "matrix",
+        "items": {"type": "string"},
+    },
+}
+
 spec_list_schema = {
     "type": "array",
     "description": "List of specs to include in the environment, supporting both simple specs and "
@@ -23,15 +32,7 @@ spec_list_schema = {
                 "description": "Matrix configuration for generating multiple specs from "
                 "combinations of constraints",
                 "additionalProperties": False,
-                "properties": {
-                    "matrix": matrix_schema,
-                    "exclude": {
-                        "type": "array",
-                        "description": "List of specific spec combinations to exclude from the "
-                        "matrix",
-                        "items": {"type": "string"},
-                    },
-                },
+                "properties": {**spec_list_properties},
             },
             {"type": "string", "description": "Simple spec string"},
             {"type": "null"},

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -38,10 +38,18 @@ properties: Dict[str, Any] = {
                             "type": "string",
                             "description": "Root directory path where the view will be created",
                         },
-                        "groups": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Groups of specs to include in the view",
+                        "group": {
+                            "oneOf": [
+                                {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "description": "Groups of specs to include in the view",
+                                },
+                                {
+                                    "type": "string",
+                                    "description": "Groups of specs to include in the view",
+                                },
+                            ]
                         },
                         "link": {
                             "enum": ["roots", "all", "run"],

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -36,7 +36,12 @@ properties: Dict[str, Any] = {
                     "properties": {
                         "root": {
                             "type": "string",
-                            "description": "Root directory path where the view will be " "created",
+                            "description": "Root directory path where the view will be created",
+                        },
+                        "groups": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Groups of specs to include in the view",
                         },
                         "link": {
                             "enum": ["roots", "all", "run"],

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -43,7 +43,6 @@ import spack.compilers.flags
 import spack.concretize
 import spack.config
 import spack.deptypes as dt
-import spack.environment as ev
 import spack.error
 import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
@@ -81,7 +80,7 @@ from .core import (
 )
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
-from .reuse import ReusableSpecsSelector, create_external_parser
+from .reuse import ReusableSpecsSelector, SpecFiltersFactory, create_external_parser
 from .runtimes import RuntimePropertyRecorder, all_libcs, external_config_with_implicit_externals
 from .versions import Provenance
 
@@ -2904,6 +2903,9 @@ class SpackSolverSetup:
         Return:
             A ProblemInstanceBuilder populated with facts and rules for an ASP solve.
         """
+        # TODO: remove this local import and get rid of dependency on globals
+        import spack.environment as ev
+
         reuse = reuse or []
         if packages_with_externals is None:
             packages_with_externals = external_config_with_implicit_externals(spack.config.CONFIG)
@@ -3673,6 +3675,8 @@ class SpecBuilder:
         self._splices.setdefault(parent_spec, []).append(splice)
 
     def build_specs(self, function_tuples: List[FunctionTupleT]) -> List[spack.spec.Spec]:
+        # TODO: remove this local import and get rid of dependency on globals
+        import spack.environment as ev
 
         attr_key = {
             # hash attributes are handled first, since they imply entire concrete specs
@@ -3891,7 +3895,7 @@ class Solver:
     and passes the setup method to the driver, as well.
     """
 
-    def __init__(self):
+    def __init__(self, *, specs_factory: Optional[SpecFiltersFactory] = None):
         # Compute possible compilers first, so we see them as externals
         _ = spack.compilers.config.all_compilers(init_config=True)
 
@@ -3904,6 +3908,7 @@ class Solver:
         self.selector = ReusableSpecsSelector(
             configuration=spack.config.CONFIG,
             external_parser=create_external_parser(self.packages_with_externals, completion_mode),
+            factory=specs_factory,
             packages_with_externals=self.packages_with_externals,
         )
 

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -205,7 +205,9 @@ def create_external_parser(
     return ExternalSpecsParser(external_dicts, complete_node=complete_fn)
 
 
-SpecFiltersFactory = Callable[[Callable[[spack.spec.Spec], bool]], List[SpecFilter]]
+SpecFiltersFactory = Callable[
+    [Callable[[spack.spec.Spec], bool], spack.config.Configuration], List[SpecFilter]
+]
 
 
 class ReusableSpecsSelector:
@@ -232,7 +234,7 @@ class ReusableSpecsSelector:
             is_reusable = functools.partial(
                 _is_reusable, packages_with_externals=packages_with_externals, local=True
             )
-            self.reuse_sources.extend(factory(is_reusable))
+            self.reuse_sources.extend(factory(is_reusable, configuration))
 
         if not isinstance(reuse_yaml, Mapping):
             self.reuse_sources.append(

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
 import functools
-from typing import Any, Callable, List, Mapping
+import typing
+from typing import Any, Callable, List, Mapping, Optional
 
 import spack.binary_distribution
 import spack.config
-import spack.environment
 import spack.llnl.path
 import spack.repo
 import spack.spec
@@ -21,6 +21,9 @@ from spack.externals import (
 )
 
 from .runtimes import all_libcs
+
+if typing.TYPE_CHECKING:
+    import spack.environment
 
 
 class SpecFilter:
@@ -88,23 +91,6 @@ class SpecFilter:
             _is_reusable, packages_with_externals=packages_with_externals, local=True
         )
         factory = functools.partial(_specs_from_environment, env=env)
-        return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
-
-    @staticmethod
-    def from_environment_included_concrete(
-        *,
-        packages_with_externals,
-        include: List[str],
-        exclude: List[str],
-        env: spack.environment.Environment,
-        included_concrete: str,
-    ) -> "SpecFilter":
-        is_reusable = functools.partial(
-            _is_reusable, packages_with_externals=packages_with_externals, local=True
-        )
-        factory = functools.partial(
-            _specs_from_environment_included_concrete, env=env, included_concrete=included_concrete
-        )
         return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
 
     @staticmethod
@@ -197,15 +183,6 @@ def _specs_from_environment(env):
         return []
 
 
-def _specs_from_environment_included_concrete(env, included_concrete):
-    """Return only concrete specs from the environment included from the included_concrete"""
-    if env:
-        assert included_concrete in env.included_concrete_env_root_dirs
-        return [concrete for concrete in env.included_specs_by_hash[included_concrete].values()]
-    else:
-        return []
-
-
 class ReuseStrategy(enum.Enum):
     ROOTS = enum.auto()
     DEPENDENCIES = enum.auto()
@@ -228,21 +205,35 @@ def create_external_parser(
     return ExternalSpecsParser(external_dicts, complete_node=complete_fn)
 
 
+SpecFiltersFactory = Callable[[Callable[[spack.spec.Spec], bool]], List[SpecFilter]]
+
+
 class ReusableSpecsSelector:
     """Selects specs that can be reused during concretization."""
 
     def __init__(
         self,
+        *,
         configuration: spack.config.Configuration,
         external_parser: ExternalSpecsParser,
         packages_with_externals: Any,
+        factory: Optional[SpecFiltersFactory] = None,
     ) -> None:
+        # Local import to break circular dependencies
+        import spack.environment
+
         self.configuration = configuration
         self.store = spack.store.create(configuration)
         self.reuse_strategy = ReuseStrategy.ROOTS
-
         reuse_yaml = self.configuration.get("concretizer:reuse", False)
+
         self.reuse_sources = []
+        if factory is not None:
+            is_reusable = functools.partial(
+                _is_reusable, packages_with_externals=packages_with_externals, local=True
+            )
+            self.reuse_sources.extend(factory(is_reusable))
+
         if not isinstance(reuse_yaml, Mapping):
             self.reuse_sources.append(
                 SpecFilter.from_packages_yaml(
@@ -269,12 +260,6 @@ class ReusableSpecsSelector:
                     SpecFilter.from_buildcache(
                         packages_with_externals=packages_with_externals, include=[], exclude=[]
                     ),
-                    SpecFilter.from_environment(
-                        packages_with_externals=packages_with_externals,
-                        include=[],
-                        exclude=[],
-                        env=spack.environment.active_environment(),  # with all concrete includes
-                    ),
                 ]
             )
         else:
@@ -294,19 +279,7 @@ class ReusableSpecsSelector:
                     env_dir = spack.environment.as_env_dir(source["path"])
                     active_env = spack.environment.active_environment()
                     if active_env and env_dir in active_env.included_concrete_env_root_dirs:
-                        # If the environment is included as a concrete environment, use the
-                        # local copy of specs in the active environment.
-                        # note: included concrete environments are only updated at concretization
-                        #       time, and reuse needs to match the included specs.
-                        self.reuse_sources.append(
-                            SpecFilter.from_environment_included_concrete(
-                                packages_with_externals=packages_with_externals,
-                                include=include,
-                                exclude=exclude,
-                                env=active_env,
-                                included_concrete=env_dir,
-                            )
-                        )
+                        pass
                     else:
                         # If the environment is not included as a concrete environment, use the
                         # current specs from its lockfile.
@@ -318,17 +291,6 @@ class ReusableSpecsSelector:
                                 env=spack.environment.environment_from_name_or_dir(env_dir),
                             )
                         )
-                elif source["type"] == "environment":
-                    # reusing from the current environment implicitly reuses from all of the
-                    # included concrete environments
-                    self.reuse_sources.append(
-                        SpecFilter.from_environment(
-                            packages_with_externals=packages_with_externals,
-                            include=include,
-                            exclude=exclude,
-                            env=spack.environment.active_environment(),
-                        )
-                    )
                 elif source["type"] == "local":
                     self.reuse_sources.append(
                         SpecFilter.from_store(

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -19,6 +19,7 @@ from spack.externals import (
     complete_variants_and_architecture,
     extract_dicts_from_configuration,
 )
+from spack.spec_filter import SpecFilter
 
 from .runtimes import all_libcs
 
@@ -26,83 +27,44 @@ if typing.TYPE_CHECKING:
     import spack.environment
 
 
-class SpecFilter:
-    """Given a method to produce a list of specs, this class can filter them according to
-    different criteria.
-    """
+def spec_filter_from_store(
+    configuration, *, packages_with_externals, include, exclude
+) -> SpecFilter:
+    """Constructs a filter that takes the specs from the current store."""
+    is_reusable = functools.partial(
+        _is_reusable, packages_with_externals=packages_with_externals, local=True
+    )
+    factory = functools.partial(_specs_from_store, configuration=configuration)
+    return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
 
-    def __init__(
-        self,
-        factory: Callable[[], List[spack.spec.Spec]],
-        is_usable: Callable[[spack.spec.Spec], bool],
-        include: List[str],
-        exclude: List[str],
-    ) -> None:
-        """
-        Args:
-            factory: factory to produce a list of specs
-            is_usable: predicate that takes a spec in input and returns False if the spec
-                should not be considered for this filter, True otherwise.
-            include: if present, a "good" spec must match at least one entry in the list
-            exclude: if present, a "good" spec must not match any entry in the list
-        """
-        self.factory = factory
-        self.is_usable = is_usable
-        self.include = include
-        self.exclude = exclude
 
-    def is_selected(self, s: spack.spec.Spec) -> bool:
-        if not self.is_usable(s):
-            return False
+def spec_filter_from_buildcache(*, packages_with_externals, include, exclude) -> SpecFilter:
+    """Constructs a filter that takes the specs from the configured buildcaches."""
+    is_reusable = functools.partial(
+        _is_reusable, packages_with_externals=packages_with_externals, local=False
+    )
+    return SpecFilter(
+        factory=_specs_from_mirror, is_usable=is_reusable, include=include, exclude=exclude
+    )
 
-        if self.include and not any(s.satisfies(c) for c in self.include):
-            return False
 
-        if self.exclude and any(s.satisfies(c) for c in self.exclude):
-            return False
+def spec_filter_from_environment(*, packages_with_externals, include, exclude, env) -> SpecFilter:
+    is_reusable = functools.partial(
+        _is_reusable, packages_with_externals=packages_with_externals, local=True
+    )
+    factory = functools.partial(_specs_from_environment, env=env)
+    return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
 
-        return True
 
-    def selected_specs(self) -> List[spack.spec.Spec]:
-        return [s for s in self.factory() if self.is_selected(s)]
-
-    @staticmethod
-    def from_store(configuration, *, packages_with_externals, include, exclude) -> "SpecFilter":
-        """Constructs a filter that takes the specs from the current store."""
-        is_reusable = functools.partial(
-            _is_reusable, packages_with_externals=packages_with_externals, local=True
-        )
-        factory = functools.partial(_specs_from_store, configuration=configuration)
-        return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
-
-    @staticmethod
-    def from_buildcache(*, packages_with_externals, include, exclude) -> "SpecFilter":
-        """Constructs a filter that takes the specs from the configured buildcaches."""
-        is_reusable = functools.partial(
-            _is_reusable, packages_with_externals=packages_with_externals, local=False
-        )
-        return SpecFilter(
-            factory=_specs_from_mirror, is_usable=is_reusable, include=include, exclude=exclude
-        )
-
-    @staticmethod
-    def from_environment(*, packages_with_externals, include, exclude, env) -> "SpecFilter":
-        is_reusable = functools.partial(
-            _is_reusable, packages_with_externals=packages_with_externals, local=True
-        )
-        factory = functools.partial(_specs_from_environment, env=env)
-        return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
-
-    @staticmethod
-    def from_packages_yaml(
-        *, external_parser: ExternalSpecsParser, packages_with_externals, include, exclude
-    ) -> "SpecFilter":
-        is_reusable = functools.partial(
-            _is_reusable, packages_with_externals=packages_with_externals, local=True
-        )
-        return SpecFilter(
-            external_parser.all_specs, is_usable=is_reusable, include=include, exclude=exclude
-        )
+def spec_filter_from_packages_yaml(
+    *, external_parser: ExternalSpecsParser, packages_with_externals, include, exclude
+) -> SpecFilter:
+    is_reusable = functools.partial(
+        _is_reusable, packages_with_externals=packages_with_externals, local=True
+    )
+    return SpecFilter(
+        external_parser.all_specs, is_usable=is_reusable, include=include, exclude=exclude
+    )
 
 
 def _has_runtime_dependencies(spec: spack.spec.Spec) -> bool:
@@ -238,7 +200,7 @@ class ReusableSpecsSelector:
 
         if not isinstance(reuse_yaml, Mapping):
             self.reuse_sources.append(
-                SpecFilter.from_packages_yaml(
+                spec_filter_from_packages_yaml(
                     external_parser=external_parser,
                     packages_with_externals=packages_with_externals,
                     include=[],
@@ -253,13 +215,13 @@ class ReusableSpecsSelector:
                 self.reuse_strategy = ReuseStrategy.DEPENDENCIES
             self.reuse_sources.extend(
                 [
-                    SpecFilter.from_store(
+                    spec_filter_from_store(
                         configuration=self.configuration,
                         packages_with_externals=packages_with_externals,
                         include=[],
                         exclude=[],
                     ),
-                    SpecFilter.from_buildcache(
+                    spec_filter_from_buildcache(
                         packages_with_externals=packages_with_externals, include=[], exclude=[]
                     ),
                 ]
@@ -286,7 +248,7 @@ class ReusableSpecsSelector:
                         # If the environment is not included as a concrete environment, use the
                         # current specs from its lockfile.
                         self.reuse_sources.append(
-                            SpecFilter.from_environment(
+                            spec_filter_from_environment(
                                 packages_with_externals=packages_with_externals,
                                 include=include,
                                 exclude=exclude,
@@ -295,7 +257,7 @@ class ReusableSpecsSelector:
                         )
                 elif source["type"] == "local":
                     self.reuse_sources.append(
-                        SpecFilter.from_store(
+                        spec_filter_from_store(
                             self.configuration,
                             packages_with_externals=packages_with_externals,
                             include=include,
@@ -304,7 +266,7 @@ class ReusableSpecsSelector:
                     )
                 elif source["type"] == "buildcache":
                     self.reuse_sources.append(
-                        SpecFilter.from_buildcache(
+                        spec_filter_from_buildcache(
                             packages_with_externals=packages_with_externals,
                             include=include,
                             exclude=exclude,
@@ -316,7 +278,7 @@ class ReusableSpecsSelector:
                         # Since libcs are implicit externals, we need to implicitly include them
                         include = include + sorted(all_libcs())  # type: ignore[type-var]
                     self.reuse_sources.append(
-                        SpecFilter.from_packages_yaml(
+                        spec_filter_from_packages_yaml(
                             external_parser=external_parser,
                             packages_with_externals=packages_with_externals,
                             include=include,
@@ -327,7 +289,7 @@ class ReusableSpecsSelector:
             # If "external" is not specified, we assume that all externals have to be included
             if not has_external_source:
                 self.reuse_sources.append(
-                    SpecFilter.from_packages_yaml(
+                    spec_filter_from_packages_yaml(
                         external_parser=external_parser,
                         packages_with_externals=packages_with_externals,
                         include=[],

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -242,9 +242,7 @@ class ReusableSpecsSelector:
                 if source["type"] == "environment" and "path" in source:
                     env_dir = spack.environment.as_env_dir(source["path"])
                     active_env = spack.environment.active_environment()
-                    if active_env and env_dir in active_env.included_concrete_env_root_dirs:
-                        pass
-                    else:
+                    if not active_env or env_dir not in active_env.included_concrete_env_root_dirs:
                         # If the environment is not included as a concrete environment, use the
                         # current specs from its lockfile.
                         self.reuse_sources.append(

--- a/lib/spack/spack/spec_filter.py
+++ b/lib/spack/spack/spec_filter.py
@@ -1,0 +1,48 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from typing import Callable, List
+
+import spack.spec
+
+
+class SpecFilter:
+    """Given a method to produce a list of specs, this class can filter them according to
+    different criteria.
+    """
+
+    def __init__(
+        self,
+        factory: Callable[[], List[spack.spec.Spec]],
+        is_usable: Callable[[spack.spec.Spec], bool],
+        include: List[str],
+        exclude: List[str],
+    ) -> None:
+        """
+        Args:
+            factory: factory to produce a list of specs
+            is_usable: predicate that takes a spec in input and returns False if the spec
+                should not be considered for this filter, True otherwise.
+            include: if present, a spec must match at least one entry in the list,
+                to be in the output
+            exclude: if present, a spec must not match any entry in the list to be in the output
+        """
+        self.factory = factory
+        self.is_usable = is_usable
+        self.include = include
+        self.exclude = exclude
+
+    def is_selected(self, s: spack.spec.Spec) -> bool:
+        if not self.is_usable(s):
+            return False
+
+        if self.include and not any(s.satisfies(c) for c in self.include):
+            return False
+
+        if self.exclude and any(s.satisfies(c) for c in self.exclude):
+            return False
+
+        return True
+
+    def selected_specs(self) -> List[spack.spec.Spec]:
+        return [s for s in self.factory() if self.is_selected(s)]

--- a/lib/spack/spack/test/cmd/concretize.py
+++ b/lib/spack/spack/test/cmd/concretize.py
@@ -20,36 +20,40 @@ unification_strategies = [False, True, "when_possible"]
 
 
 @pytest.mark.parametrize("unify", unification_strategies)
-def test_concretize_all_test_dependencies(unify, mutable_mock_env_path):
+def test_concretize_all_test_dependencies(unify, mutable_config, mutable_mock_env_path):
     """Check all test dependencies are concretized."""
     env("create", "test")
 
     with ev.read("test") as e:
-        e.unify = unify
+        mutable_config.set("concretizer:unify", unify)
         add("depb")
         concretize("--test", "all")
         assert e.matching_spec("test-dependency")
 
 
 @pytest.mark.parametrize("unify", unification_strategies)
-def test_concretize_root_test_dependencies_not_recursive(unify, mutable_mock_env_path):
+def test_concretize_root_test_dependencies_not_recursive(
+    unify, mutable_config, mutable_mock_env_path
+):
     """Check that test dependencies are not concretized recursively."""
     env("create", "test")
 
     with ev.read("test") as e:
-        e.unify = unify
+        mutable_config.set("concretizer:unify", unify)
         add("depb")
         concretize("--test", "root")
         assert e.matching_spec("test-dependency") is None
 
 
 @pytest.mark.parametrize("unify", unification_strategies)
-def test_concretize_root_test_dependencies_are_concretized(unify, mutable_mock_env_path):
+def test_concretize_root_test_dependencies_are_concretized(
+    unify, mutable_config, mutable_mock_env_path
+):
     """Check that root test dependencies are concretized."""
     env("create", "test")
 
     with ev.read("test") as e:
-        e.unify = unify
+        mutable_config.set("concretizer:unify", unify)
         add("pkg-a")
         add("pkg-b")
         concretize("--test", "root")

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -330,14 +330,14 @@ def test_recursive(mutable_mock_env_path, install_mockery, mock_fetch):
 
 
 def test_develop_fails_with_multiple_concrete_versions(
-    mutable_mock_env_path, install_mockery, mock_fetch
+    mutable_mock_env_path, install_mockery, mock_fetch, mutable_config
 ):
     env("create", "test")
 
     with ev.read("test") as e:
         add("indirect-mpich@1.0")
         add("indirect-mpich@0.9")
-        e.unify = False
+        mutable_config.set("concretizer:unify", False)
         e.concretize()
 
         with pytest.raises(SpackError) as develop_error:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4684,3 +4684,31 @@ def test_concretized_specs_and_include_concrete(mutable_config):
         concretized_specs = list(e.concretized_specs())
         assert list(dedupe(spec_pairs + included_pairs)) == concretized_specs
         assert len(concretized_specs) == 5
+
+
+def test_view_can_select_group_of_specs(installed_environment, tmp_path: pathlib.Path):
+    """Tests that we can select groups of specs in a view and exclude other groups"""
+    view_dir = tmp_path / "view"
+    with installed_environment(
+        f"""\
+spack:
+  specs:
+    - group: apps1
+      specs:
+      - mpileaks
+    - group: apps2
+      specs:
+      - cmake
+    - group: apps3
+      specs:
+      - pkg-a
+  view:
+    default:
+      root: {view_dir}
+      groups: [apps1, apps2]
+"""
+    ) as test:
+        for item in test.concretized_roots:
+            # Assertions are based on the behavior of the "--fake" install
+            bin_file = pathlib.Path(test.default_view.view()._root) / "bin" / item.root.name
+            assert not bin_file.exists() if item.group == "apps3" else bin_file.exists()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4705,10 +4705,37 @@ spack:
   view:
     default:
       root: {view_dir}
-      groups: [apps1, apps2]
+      group: [apps1, apps2]
 """
     ) as test:
         for item in test.concretized_roots:
             # Assertions are based on the behavior of the "--fake" install
             bin_file = pathlib.Path(test.default_view.view()._root) / "bin" / item.root.name
             assert not bin_file.exists() if item.group == "apps3" else bin_file.exists()
+
+
+def test_view_can_select_group_of_specs_using_string(
+    installed_environment, tmp_path: pathlib.Path
+):
+    """Tests that we can select groups of specs in a view and exclude other groups"""
+    view_dir = tmp_path / "view"
+    with installed_environment(
+        f"""\
+spack:
+  specs:
+    - group: apps1
+      specs:
+      - mpileaks
+    - group: apps2
+      specs:
+      - cmake
+  view:
+    default:
+      root: {view_dir}
+      group: apps1
+"""
+    ) as test:
+        for item in test.concretized_roots:
+            # Assertions are based on the behavior of the "--fake" install
+            bin_file = pathlib.Path(test.default_view.view()._root) / "bin" / item.root.name
+            assert not bin_file.exists() if item.group == "apps2" else bin_file.exists()

--- a/lib/spack/spack/test/concretization/compiler_runtimes.py
+++ b/lib/spack/spack/test/concretization/compiler_runtimes.py
@@ -16,7 +16,7 @@ import spack.repo
 import spack.solver.asp
 import spack.spec
 from spack.environment.environment import ViewDescriptor
-from spack.solver.reuse import SpecFilter, create_external_parser
+from spack.solver.reuse import create_external_parser, spec_filter_from_packages_yaml
 from spack.solver.runtimes import external_config_with_implicit_externals
 from spack.version import Version
 
@@ -25,7 +25,7 @@ def _concretize_with_reuse(*, root_str, reused_str, config):
     reused_spec = spack.concretize.concretize_one(reused_str)
     packages_with_externals = external_config_with_implicit_externals(config)
     completion_mode = config.get("concretizer:externals:completion")
-    external_specs = SpecFilter.from_packages_yaml(
+    external_specs = spec_filter_from_packages_yaml(
         external_parser=create_external_parser(packages_with_externals, completion_mode),
         packages_with_externals=packages_with_externals,
         include=[],

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -37,6 +37,7 @@ import spack.solver.core
 import spack.solver.reuse
 import spack.solver.runtimes
 import spack.spec
+import spack.spec_filter
 import spack.util.file_cache
 import spack.util.hash
 import spack.util.spack_yaml as syaml
@@ -44,7 +45,7 @@ import spack.variant as vt
 from spack.externals import ExternalDependencyError
 from spack.installer import PackageInstaller
 from spack.solver.asp import Result
-from spack.solver.reuse import SpecFilter, create_external_parser
+from spack.solver.reuse import create_external_parser, spec_filter_from_packages_yaml
 from spack.solver.runtimes import external_config_with_implicit_externals
 from spack.spec import Spec
 from spack.test.conftest import RepoBuilder
@@ -2010,7 +2011,7 @@ spack:
 
         packages_with_externals = external_config_with_implicit_externals(mutable_config)
         completion_mode = mutable_config.get("concretizer:externals:completion")
-        external_specs = SpecFilter.from_packages_yaml(
+        external_specs = spec_filter_from_packages_yaml(
             external_parser=create_external_parser(packages_with_externals, completion_mode),
             packages_with_externals=packages_with_externals,
             include=[],
@@ -2044,7 +2045,7 @@ spack:
         """Test package preferences during concretization."""
         packages_with_externals = external_config_with_implicit_externals(mutable_config)
         completion_mode = mutable_config.get("concretizer:externals:completion")
-        external_specs = SpecFilter.from_packages_yaml(
+        external_specs = spec_filter_from_packages_yaml(
             external_parser=create_external_parser(packages_with_externals, completion_mode),
             packages_with_externals=packages_with_externals,
             include=[],
@@ -2400,7 +2401,7 @@ packages:
         specs = [Spec(s) for s in specs]
         packages_with_externals = external_config_with_implicit_externals(mutable_config)
         completion_mode = mutable_config.get("concretizer:externals:completion")
-        external_specs = SpecFilter.from_packages_yaml(
+        external_specs = spec_filter_from_packages_yaml(
             external_parser=create_external_parser(packages_with_externals, completion_mode),
             packages_with_externals=packages_with_externals,
             include=[],
@@ -3341,7 +3342,7 @@ def test_selecting_reused_sources(reuse_yaml, expected_length, mutable_config):
 def test_spec_filters(specs, include, exclude, expected):
     specs = [Spec(x) for x in specs]
     expected = [Spec(x) for x in expected]
-    f = spack.solver.reuse.SpecFilter(
+    f = spack.spec_filter.SpecFilter(
         factory=lambda: specs, is_usable=lambda x: True, include=include, exclude=exclude
     )
     assert f.selected_specs() == expected

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3277,7 +3277,7 @@ def test_filtering_reused_specs(
     )
     completion_mode = mutable_config.get("concretizer:externals:completion")
     selector = spack.solver.asp.ReusableSpecsSelector(
-        mutable_config,
+        configuration=mutable_config,
         external_parser=create_external_parser(packages_with_externals, completion_mode),
         packages_with_externals=packages_with_externals,
     )
@@ -3318,7 +3318,7 @@ def test_selecting_reused_sources(reuse_yaml, expected_length, mutable_config):
     )
     completion_mode = mutable_config.get("concretizer:externals:completion")
     selector = spack.solver.asp.ReusableSpecsSelector(
-        mutable_config,
+        configuration=mutable_config,
         external_parser=create_external_parser(packages_with_externals, completion_mode),
         packages_with_externals=packages_with_externals,
     )

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -20,7 +20,7 @@ import spack.util.spack_yaml as syaml
 import spack.version
 from spack.installer import PackageInstaller
 from spack.solver.asp import InternalConcretizerError, UnsatisfiableSpecError
-from spack.solver.reuse import SpecFilter, create_external_parser
+from spack.solver.reuse import create_external_parser, spec_filter_from_packages_yaml
 from spack.solver.runtimes import external_config_with_implicit_externals
 from spack.spec import Spec
 from spack.util.url import path_to_file_url
@@ -1323,7 +1323,7 @@ def test_requirements_on_compilers_and_reuse(
     root_specs = [Spec(input_spec)]
     packages_with_externals = external_config_with_implicit_externals(mutable_config)
     completion_mode = mutable_config.get("concretizer:externals:completion")
-    external_specs = SpecFilter.from_packages_yaml(
+    external_specs = spec_filter_from_packages_yaml(
         external_parser=create_external_parser(packages_with_externals, completion_mode),
         packages_with_externals=packages_with_externals,
         include=[],
@@ -1513,7 +1513,7 @@ packages:
     reused_nodes = list(initial_mpileaks.traverse())
     packages_with_externals = external_config_with_implicit_externals(mutable_config)
     completion_mode = mutable_config.get("concretizer:externals:completion")
-    external_specs = SpecFilter.from_packages_yaml(
+    external_specs = spec_filter_from_packages_yaml(
         external_parser=create_external_parser(packages_with_externals, completion_mode),
         packages_with_externals=packages_with_externals,
         include=[],

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1816,3 +1816,47 @@ spack:
 
             _, app_mpileaks = list(e.concretized_specs_by(group="app"))[0]
             assert app_mpileaks.satisfies("@2.3")
+
+    def test_relying_on_a_dependency_group(self, create_temporary_manifest):
+        """Tests that a group of specs that would not concretize without a dependency group
+        works correctly.
+        """
+        manifest = create_temporary_manifest(
+            """
+    spack:
+      specs:
+      - group: app
+        matrix:
+        - [mpileaks]
+        - ["%c,cxx=gcc@14"]
+    """
+        )
+
+        # We have no gcc@14 configured, so this will raise an error
+        with ev.Environment(manifest.manifest_dir) as e:
+            with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
+                e.concretize()
+
+        manifest = create_temporary_manifest(
+            """
+    spack:
+      specs:
+      - group: compiler
+        specs:
+        - gcc@14
+      - group: mpileaks
+        needs: [compiler]
+        matrix:
+        - [mpileaks]
+        - ["%c,cxx=gcc@14"]
+    """
+        )
+
+        # In this case gcc@14 is taken from the "needed" group
+        with ev.Environment(manifest.manifest_dir) as e:
+            e.concretize()
+
+            _, gcc = next(iter(e.concretized_specs_by(group="compiler")))
+            assert gcc.satisfies("gcc@14")
+            _, mpileaks = next(iter(e.concretized_specs_by(group="mpileaks")))
+            assert mpileaks["c"].dag_hash() == gcc.dag_hash()

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1752,3 +1752,24 @@ spack:
             spack.spec.Spec("mpileaks@2.1 %clang"),
             spack.spec.Spec("mpich"),
         ]
+
+    def test_independent_groups_concretization(self, create_temporary_manifest):
+        """Tests that groups of specs without dependencies among them can be concretized
+        correctly
+        """
+        manifest = create_temporary_manifest(
+            """
+    spack:
+      specs:
+      - mpileaks
+      - group: compiler
+        matrix:
+        - [gcc@14]
+      - libelf
+    """
+        )
+
+        with ev.Environment(manifest.manifest_dir) as e:
+            e.concretize()
+            roots = e.concrete_roots()
+            assert len(roots) == 3

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Test environment internals without CLI"""
+
 import filecmp
 import os
 import pathlib
@@ -15,6 +16,7 @@ import spack.llnl.util.filesystem as fs
 import spack.platforms
 import spack.solver.asp
 import spack.spec
+from spack.environment import SpackEnvironmentConfigError
 from spack.environment.environment import (
     EnvironmentManifestFile,
     SpackEnvironmentViewError,
@@ -1646,3 +1648,70 @@ spack:
         if node.satisfies("%c"):
             assert node.satisfies("%c=gcc@12"), node.tree()
             assert not node.satisfies("%c=gcc@7"), node.tree()
+
+
+@pytest.fixture()
+def create_temporary_manifest(tmp_path):
+    manifest_path = tmp_path / "spack.yaml"
+
+    def _create(spack_yaml: str):
+        manifest_path.write_text(spack_yaml)
+        return EnvironmentManifestFile(tmp_path)
+
+    return _create
+
+
+@pytest.mark.usefixtures("mutable_config")
+class TestEnvironmentGroups:
+    """Tests for the environment "groups" feature"""
+
+    def test_manifest_and_groups(self, create_temporary_manifest):
+        """Tests a basic case of reading groups from a manifest file"""
+        manifest = create_temporary_manifest(
+            """
+    spack:
+      specs:
+      - mpileaks
+      - group: compiler
+        matrix:
+        - [gcc@14]
+      - group: apps
+        needs: [compiler]
+        specs:
+        - matrix:
+          - [mpileaks]
+          - ["%gcc@14"]
+        - mpich
+      - libelf
+    """
+        )
+
+        assert manifest.groups() == {"default", "compiler", "apps"}
+
+        assert manifest.user_specs(group="default") == manifest.user_specs()
+        assert manifest.user_specs() == ["mpileaks", "libelf"]
+        assert manifest.user_specs(group="compiler") == [{"matrix": [["gcc@14"]]}]
+        assert manifest.user_specs(group="apps") == [
+            {"matrix": [["mpileaks"], ["%gcc@14"]]},
+            "mpich",
+        ]
+
+        assert manifest.needs(group="default") == ()
+        assert manifest.needs(group="compiler") == ()
+        assert manifest.needs(group="apps") == ("compiler",)
+
+    def test_cannot_define_group_twice(self, create_temporary_manifest):
+        """Tests that defining the same group twice raises an error"""
+        with pytest.raises(SpackEnvironmentConfigError, match="defined more than once"):
+            create_temporary_manifest(
+                """
+    spack:
+      specs:
+      - group: compiler
+        matrix:
+        - [gcc@14]
+      - group: compiler
+        matrix:
+        - [llvm@20]
+"""
+            )

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1794,3 +1794,25 @@ spack:
 
             compiler_specs = list(e.concretized_specs_by(group="compiler"))
             assert len(compiler_specs) == 1
+
+    def test_independent_group_dont_reuse(self, create_temporary_manifest):
+        """Tests that there is no cross-groups reuse among groups of specs without dependencies."""
+        manifest = create_temporary_manifest(
+            """
+    spack:
+      specs:
+      - mpileaks@2.2
+      - group: app
+        matrix:
+        - [mpileaks]
+    """
+        )
+
+        with ev.Environment(manifest.manifest_dir) as e:
+            e.concretize()
+
+            _, default_mpileaks = list(e.concretized_specs_by(group="default"))[0]
+            assert default_mpileaks.satisfies("@2.2")
+
+            _, app_mpileaks = list(e.concretized_specs_by(group="app"))[0]
+            assert app_mpileaks.satisfies("@2.3")

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1753,6 +1753,21 @@ spack:
             spack.spec.Spec("mpich"),
         ]
 
+    def test_environment_without_groups_use_lockfile_v6(self, create_temporary_manifest):
+        manifest = create_temporary_manifest(
+            """
+spack:
+  specs:
+  - mpileaks
+  - pkg-a
+"""
+        )
+        with ev.Environment(manifest.manifest_dir) as e:
+            e.concretize()
+            lockfile_data = e._to_lockfile_dict()
+            assert lockfile_data["_meta"]["lockfile-version"] == 6
+            assert all("group" not in x for x in lockfile_data["roots"])
+
     def test_independent_groups_concretization(self, create_temporary_manifest):
         """Tests that groups of specs without dependencies among them can be concretized
         correctly

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1788,3 +1788,9 @@ spack:
             e.concretize()
             roots = e.concrete_roots()
             assert len(roots) == 3
+
+            default_specs = list(e.concretized_specs_by(group="default"))
+            assert len(default_specs) == 2
+
+            compiler_specs = list(e.concretized_specs_by(group="compiler"))
+            assert len(compiler_specs) == 1

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1685,7 +1685,7 @@ class TestEnvironmentGroups:
       - libelf
     """
         )
-
+        # Check manifest properties
         assert manifest.groups() == {"default", "compiler", "apps"}
 
         assert manifest.user_specs(group="default") == manifest.user_specs()
@@ -1699,6 +1699,18 @@ class TestEnvironmentGroups:
         assert manifest.needs(group="default") == ()
         assert manifest.needs(group="compiler") == ()
         assert manifest.needs(group="apps") == ("compiler",)
+
+        # Check user specs within the environment
+        e = ev.Environment(manifest.manifest_dir)
+        assert e.user_specs.specs == [spack.spec.Spec("mpileaks"), spack.spec.Spec("libelf")]
+
+        compiler_specs = e.user_specs_by(group="compiler")
+        assert compiler_specs.name == "specs:compiler"
+        assert compiler_specs.specs == [spack.spec.Spec("gcc@14")]
+
+        apps_specs = e.user_specs_by(group="apps")
+        assert apps_specs.name == "specs:apps"
+        assert apps_specs.specs == [spack.spec.Spec("mpileaks %gcc@14"), spack.spec.Spec("mpich")]
 
     def test_cannot_define_group_twice(self, create_temporary_manifest):
         """Tests that defining the same group twice raises an error"""
@@ -1715,3 +1727,28 @@ class TestEnvironmentGroups:
         - [llvm@20]
 """
             )
+
+    def test_matrix_can_be_expanded_in_groups(self, create_temporary_manifest):
+        """Tests that definitions can be expanded also for matrix groups"""
+        manifest = create_temporary_manifest(
+            """
+spack:
+  definitions:
+  - compilers: ["%gcc", "%clang"]
+  - desired_specs: ["mpileaks@2.1"]
+  specs:
+  - group: apps
+    specs:
+    - matrix:
+      - [$desired_specs]
+      - [$compilers]
+    - mpich
+"""
+        )
+        e = ev.Environment(manifest.manifest_dir)
+        assert e.user_specs.specs == []
+        assert e.user_specs_by(group="apps").specs == [
+            spack.spec.Spec("mpileaks@2.1 %gcc"),
+            spack.spec.Spec("mpileaks@2.1 %clang"),
+            spack.spec.Spec("mpich"),
+        ]

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1938,3 +1938,45 @@ spack:
                 assert node.satisfies(f"%[when=c]c=gcc/{gcc_hash}")
                 assert node.satisfies(f"%[when=cxx]cxx=gcc/{gcc_hash}")
                 assert node.satisfies(f"%[when=fortran]fortran=gcc/{gcc_hash}")
+
+    def test_missing_needs_group_gives_clear_error(self, create_temporary_manifest):
+        """Tests that referencing a non-existent group in 'needs' gives a clear error message
+        that includes the name of the blocked group and the missing dependency.
+        """
+        manifest = create_temporary_manifest(
+            """
+spack:
+  specs:
+  - group: apps
+    needs: [nonexistent]
+    specs:
+    - mpileaks
+"""
+        )
+        with ev.Environment(manifest.manifest_dir) as e:
+            with pytest.raises(
+                ev.SpackEnvironmentConfigError, match=r"but 'nonexistent' is not a defined group"
+            ):
+                e.concretize()
+
+    def test_cyclic_group_dependencies_give_clear_error(self, create_temporary_manifest):
+        """Tests that cyclic group dependencies give a clear error message that mentions
+        the groups involved in the cycle.
+        """
+        manifest = create_temporary_manifest(
+            """
+spack:
+  specs:
+  - group: alpha
+    needs: [beta]
+    specs:
+    - mpileaks
+  - group: beta
+    needs: [alpha]
+    specs:
+    - zlib
+"""
+        )
+        with ev.Environment(manifest.manifest_dir) as e:
+            with pytest.raises(ev.SpackEnvironmentConfigError, match=r"among groups: alpha, beta"):
+                e.concretize()

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1687,7 +1687,7 @@ class TestEnvironmentGroups:
     """
         )
         # Check manifest properties
-        assert manifest.groups() == {"default", "compiler", "apps"}
+        assert set(manifest.groups()) == {"default", "compiler", "apps"}
 
         assert manifest.user_specs(group="default") == manifest.user_specs()
         assert manifest.user_specs() == ["mpileaks", "libelf"]

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -16,6 +16,7 @@ import spack.llnl.util.filesystem as fs
 import spack.platforms
 import spack.solver.asp
 import spack.spec
+from spack.enums import ConfigScopePriority
 from spack.environment import SpackEnvironmentConfigError
 from spack.environment.environment import (
     EnvironmentManifestFile,
@@ -23,6 +24,7 @@ from spack.environment.environment import (
     _error_on_nonempty_view_dir,
 )
 from spack.environment.list import UndefinedReferenceError
+from spack.traverse import traverse_nodes
 
 pytestmark = [
     pytest.mark.not_on_windows("Envs are not supported on windows"),
@@ -554,9 +556,8 @@ spack:
     )
     mutable_config.set("concretizer:unify", unify_in_lower_scope)
     assert mutable_config.get("concretizer:unify") == unify_in_lower_scope
-    with ev.Environment(manifest.parent) as e:
+    with ev.Environment(manifest.parent):
         assert mutable_config.get("concretizer:unify") == unify_in_spack_yaml
-        assert e.unify == unify_in_spack_yaml
 
 
 @pytest.mark.parametrize("unify_in_config", [True, False, "when_possible"])
@@ -574,8 +575,8 @@ spack:
     )
 
     with spack.config.override("concretizer:unify", unify_in_config):
-        with ev.Environment(manifest.parent) as e:
-            assert e.unify == unify_in_config
+        with ev.Environment(manifest.parent):
+            assert spack.config.CONFIG.get("concretizer:unify") == unify_in_config
 
 
 @pytest.mark.parametrize(
@@ -1860,3 +1861,80 @@ spack:
             assert gcc.satisfies("gcc@14")
             _, mpileaks = next(iter(e.concretized_specs_by(group="mpileaks")))
             assert mpileaks["c"].dag_hash() == gcc.dag_hash()
+
+    def test_manifest_can_contain_config_override(self, mutable_config, create_temporary_manifest):
+        manifest = create_temporary_manifest(
+            """
+    spack:
+      concretizer:
+        unify: False
+      specs:
+      - group: compiler
+        override:
+          concretizer:
+            unify: True
+    """
+        )
+
+        with ev.Environment(manifest.manifest_dir) as e:
+            assert mutable_config.get_config("concretizer")["unify"] is False
+
+            # Assert the internal scope works when used manually
+            override = manifest.config_override(group="compiler")
+            mutable_config.push_scope(
+                override, priority=ConfigScopePriority.ENVIRONMENT_SPEC_GROUPS
+            )
+            assert mutable_config.get_config("concretizer")["unify"] is True
+            mutable_config.remove_scope(override.name)
+            assert mutable_config.get_config("concretizer")["unify"] is False
+
+            # Assert the context manager works too
+            with e.config_override_for_group(group="compiler"):
+                assert mutable_config.get_config("concretizer")["unify"] is True
+            assert mutable_config.get_config("concretizer")["unify"] is False
+
+    def test_overriding_concretization_properties_per_group(self, create_temporary_manifest):
+        manifest = create_temporary_manifest(
+            """
+    spack:
+      concretizer:
+        unify: True
+      specs:
+      - group: compiler
+        specs:
+        - gcc@14
+      - group: scalapacks
+        needs: [compiler]
+        matrix:
+        - [netlib-scalapack]
+        - ["%mpi=mpich", "%mpi=mpich2"]
+        - ["%lapack=openblas-with-lapack", "%lapack=netlib-lapack"]
+        override:
+          concretizer:
+            unify: False
+          packages:
+            c:
+              prefer: [gcc@14]
+            cxx:
+              prefer: [gcc@14]
+            fortran:
+              prefer: [gcc@14]
+    """
+        )
+
+        with ev.Environment(manifest.manifest_dir) as e:
+            e.concretize()
+
+            assert len(list(e.concretized_specs_by(group="compiler"))) == 1
+
+            gcc = next(x for _, x in e.concretized_specs_by(group="compiler"))
+            assert gcc.satisfies("gcc@14") and not gcc.external
+            assert gcc.satisfies("%c,cxx,fortran=gcc")
+            gcc_hash = gcc.dag_hash()
+
+            assert len(list(e.concretized_specs_by(group="scalapacks"))) == 4
+            scalapacks = [x for _, x in e.concretized_specs_by(group="scalapacks")]
+            for node in traverse_nodes(scalapacks, deptype=("link", "run")):
+                assert node.satisfies(f"%[when=c]c=gcc/{gcc_hash}")
+                assert node.satisfies(f"%[when=cxx]cxx=gcc/{gcc_hash}")
+                assert node.satisfies(f"%[when=fortran]fortran=gcc/{gcc_hash}")


### PR DESCRIPTION
closes #49097

Currently, there are scenarios and use cases that are difficult to express with a single `spack.yaml` file. For instance:
1. Start with an old system compiler to bootstrap a new toolchain, and then software on top of that
2. Deploy a highly heterogeneous stack (different compilers, different options for the same set of specs)  while ensuring a fine control over dependencies

These use cases are usually dealt with multiple environments[^1] or by "abusing" certain concretization strategies[^2]. Both methods are sub-optimal and error prone.

In this PR we solve these kind of issues by allowing _named group of specs_, as shown in #49097. Each named group of specs:
- Can have dependencies on other groups. If that happens, the dependency groups are concretized before the current group, and their roots specs are always available for reuse in the current concretization.
- Can override configuration scopes with details that matter only for the current group, since the override is then used _only_ for the concretization of the current group

An example environment using these features is:

```yaml
# Bootstrap gcc@15.2, then use it to build the same
# set of specs for x86_64_v3 and x86_64_v4
spack:
  definitions:
  - apps: [hdf5, mpileaks]

  packages:
    all: {prefer: [target=x86_64_v3]}

  specs:
  - group: compiler
    specs:
    - gcc@15.2

  - group: apps-x86_64_v4
    needs: [compiler]
    specs:
    - $apps
    override:
      packages:
        all: {prefer: [target=x86_64_v4]}
        c: {prefer: [gcc@15.2]}
        cxx: {prefer: [gcc@15.2]}
        fortran: {prefer: [gcc@15.2]}

  - group: apps-x86_64_v3
    needs: [compiler]
    specs:
    - $apps
    override:
      packages:
        c: {prefer: [gcc@15.2]}
        cxx: {prefer: [gcc@15.2]}
        fortran: {prefer: [gcc@15.2]}
```

The groups can also be used to create tailored views. For instance, an entry like:
```yaml
views:
  x86_64_v3:
    root: ...
    group: apps-x86_64_v3
```
will just put specs from the `apps-x86_64_v3` group into the view.


## Benchmark

Trying this PR in https://github.com/spack/spack-packages/pull/3175 already shows:
- A drastic reduction in the specs to be built for the `ml-*-x86_64` stacks, when they are unified
- The correct concretization of the tutorial stack using `unify:false`, which is currently broken on `develop` when using the `unify:when_possible` hack

## Notes

This PR requires a bump of the lockfile for environments, from v6 to v7. Nonetheless, to preserve backward compatbility, if the feature is not used Spack will continue to write lockfiles in v6 format, which are undersatood by previous version of Spack.

## To do in following PRs

- [ ] Hook "groups" into commands other than concretization e.g. modules etc. (can be split in other PRs)
- [ ] Add a behavior similar to concrete included environments between groups (can also be in a following PR)
- [ ] Parallelize concretization among groups

[^1]: See for instance the `ml-*` stack in out public pipelines
[^2]: See the `tutorial` pipeline where we use `unify:when_possible` to bootstrap `gcc@12`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
