### PR TITLE
Config: Special case Spack default config scopes

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1173,11 +1173,10 @@ class OptionalInclude:
                 prefer_modify=self.prefer_modify,
                 included=True,
             )
-
-        if ext and not is_dir:
-            raise ValueError(
-                f"File-based scope does not exist yet: should have a .yaml/.yml extension \
-for file scopes, or no extension for directory scopes (currently {ext})"
+        if not is_dir:
+            tty.debug(
+                f"Optional scope {config_path} does not exist. Treating as Directory Scope."
+                " To include as file scope, use .yml|.yaml extension"
             )
 
         # directories are treated as regular ConfigScopes


### PR DESCRIPTION
# Only default create user, system, and site config scopes

### Background

PR https://github.com/spack/spack/pull/51700 resolves an issue where previous updates to optionally included config scopes that did not exist on disk were unable to be referenced as valid scopes. This leads to an issue where if a user or system scope does not exist, those scopes cannot be referenced without creating the directories, despite the Spack CLI and docs reporting that they are valid scopes without indicating the possibility where they are invalid. 

#51700 allows optional configs to be created implicitly by Spack (i.e. when processing an optionally included scope that does not have a corresponding file/dir on disk, spack creates an empty file/dir). However that PR precluded the use of `.` characters in directory scopes, which was too strict as evidenced by this comment: https://github.com/spack/spack/pull/51700#issuecomment-3774971015

### Improved Solution

Instead of Spack creating any missing directory or file scopes implicitly when processing config files, special case `site`, `system`, and `user` scopes, create these implicitly if they're missing, otherwise, behave as before and do not create, or add that scope to Spack's configuration modeling. This allows config setups like the following to work elegantly. 

```yaml
include:
  - name: "custom_system"
    when: <condition>
    path: <config-dir>/<system-name>
    optional: true
```
Where a single config shared by multiple systems has numerous optional includes, one per system/platform. If we create all optional missing scopes implicitly, then this creates scopes named things like "tahoe" on HPC systems, which is bad. It also renders the concept of "optional" somewhat moot. 
If we only special case the user, system, and site scopes the above example works nicely.

Thanks to @rbberger for the example and helping me work through some use cases
