### PR TITLE
fetch_url_text: restore fetch method check (from #50207)

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -411,7 +411,7 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
 
     fetch_method = spack.config.get("config:url_fetch_method")
     tty.debug("Using '{0}' to fetch {1} into {2}".format(fetch_method, url, path))
-    if fetch_method.startswith("curl"):
+    if fetch_method and fetch_method.startswith("curl"):
         curl_exe = curl or require_curl()
         curl_args = fetch_method.split()[1:] + ["-O"]
         curl_args.extend(base_curl_fetch_args(url))


### PR DESCRIPTION
Ensure fetch method before check contents in approach introduced in #49712.

Extracts #50207's https://github.com/spack/spack/pull/50207/changes/99f5f327f95c96b9ffad4071b625ffa6e5a00f39 commit.