### PR TITLE
remote_file_cache.local_path(): pass destination as string, not callable (from #50207)

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1157,7 +1157,7 @@ class IncludePath(OptionalInclude):
             return os.getcwd()
 
         with filesystem.working_dir(work_dir()):
-            config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location)
+            config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location())
         assert config_path
         self.destination = config_path
 

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -94,16 +94,15 @@ def test_rfc_remote_local_path(
         tty.debug(f"Expected {element} in '{filename}'")
         return False
 
-    def _dest_dir():
-        return join_path(str(tmp_path), "cache")
+    dest_dir = join_path(str(tmp_path), "cache")
 
     if err is not None:
         with spack.config.override("config:url_fetch_method", "curl"):
             with pytest.raises(err, match=msg):
-                rfc_util.local_path(url, sha256, _dest_dir)
+                rfc_util.local_path(url, sha256, dest_dir)
     else:
         with spack.config.override("config:url_fetch_method", "curl"):
-            path = rfc_util.local_path(url, sha256, _dest_dir)
+            path = rfc_util.local_path(url, sha256, dest_dir)
             assert os.path.exists(path)
             # Ensure correct file is "fetched"
             assert os.path.basename(path) == os.path.basename(url)

--- a/lib/spack/spack/util/remote_file_cache.py
+++ b/lib/spack/spack/util/remote_file_cache.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import urllib.parse
 import urllib.request
-from typing import Callable, Optional
+from typing import Optional
 
 import spack.llnl.util.tty as tty
 import spack.util.crypto
@@ -60,13 +60,13 @@ def fetch_remote_text_file(url: str, dest_dir: str) -> str:
     return fetch_url_text(raw_url, dest_dir=dest_dir)
 
 
-def local_path(raw_path: str, sha256: str, make_dest: Optional[Callable[[], str]] = None) -> str:
+def local_path(raw_path: str, sha256: str, dest: Optional[str] = None) -> str:
     """Determine the actual path and, if remote, stage its contents locally.
 
     Args:
         raw_path: raw path with possible variables needing substitution
-        sha256: the expected sha256 for the file
-        make_dest: function to create a stage for remote files, if needed (e.g., ``mkdtemp``)
+        sha256: the expected sha256 if the file is remote
+        dest: destination path
 
     Returns: resolved, normalized local path
 
@@ -98,8 +98,11 @@ def local_path(raw_path: str, sha256: str, make_dest: Optional[Callable[[], str]
     if validate_scheme(url.scheme):
         # Fetch files from supported URL schemes.
         if url.scheme in ("http", "https", "ftp"):
-            if make_dest is None:
+            if not dest:
                 raise ValueError("Requires the destination argument to cache remote files")
+            assert os.path.isabs(
+                dest
+            ), f"Remote file destination '{dest}' must be an absolute path"
 
             # Stage the remote configuration file
             tmpdir = tempfile.mkdtemp()
@@ -118,7 +121,7 @@ def local_path(raw_path: str, sha256: str, make_dest: Optional[Callable[[], str]
                     raise ValueError(f"Requires sha256 ('{checksum}') to cache remote files.")
 
                 # Copy the file to the destination directory
-                dest_dir = join_path(make_dest(), checksum)
+                dest_dir = join_path(dest, checksum)
                 if not os.path.exists(dest_dir):
                     mkdirp(dest_dir)
 


### PR DESCRIPTION
This PR replaces the `callable` `make_dest` argument with a string since the methods defined (in core) so far do nothing more than return strings.

Extracted from #50207's [Cache env path_sha256 includes under the environment.](https://github.com/spack/spack/pull/50207/changes/3f0d8823e7297bd0902e375565c950e47a14dd74#diff-4659603983779f9e0eb6449daeb01d7077214ec46e6285a3e9be51e419372baf) commit.
