### PR TITLE
remote include path: cache under enclosing scope ({spack|include}.yaml) path or tempdir (from #50207)

### DIFF
--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -49,9 +49,7 @@ Spack-specific, environment, and user path variables can be used.
 (See :ref:`config-file-variables` for more information.)
 
 A ``sha256`` is required.
-For example, suppose you have a ``/etc/spack/include.yaml`` file that specifies a remote ``config.yaml`` file as follows:
-
-.. code-block:: yaml
+For example, suppose you have a ``/etc/spack/include.yaml`` file that specifies a remote ``config.yaml`` file as follows::
 
    include:
    - path: https://github.com/path/to/raw/config/config.yaml

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -48,7 +48,8 @@ Only the ``ftp``, ``http``, and ``https`` protocols (or schemes) are supported f
 Spack-specific, environment, and user path variables can be used.
 (See :ref:`config-file-variables` for more information.)
 
-A ``sha256`` is required and must be specified as follows:
+A ``sha256`` is required.
+For example, suppose you have a ``/etc/spack/include.yaml`` file that specifies a remote ``config.yaml`` file as follows:
 
 .. code-block:: yaml
 
@@ -56,11 +57,19 @@ A ``sha256`` is required and must be specified as follows:
    - path: https://github.com/path/to/raw/config/config.yaml
      sha256: 26e871804a92cd07bb3d611b31b4156ae93d35b6a6d6e0ef3a67871fcb1d258b
 
-The ``config.yaml`` file would be cached locally to a special include location and its contents included in Spack's configuration.
+The ``config.yaml`` file is downloaded to a subdirectory of ``/etc/spack``.
+The contents of the downloaded file are read and included in Spack's configuration when Spack configuration files are processed.
+
+.. note::
+
+   You can check the destination of the downloaded file by running: ``spack config scopes -p``.
 
 .. warning::
 
    Remote file URLs must link to the **raw** form of the file's contents (e.g., `GitHub <https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#viewing-or-copying-the-raw-file-content>`_ or `GitLab <https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository>`_).
+
+   If the directory containing the ``include.yaml`` file is not writable when the remote file is downloaded, then the destination will be a temporary directory.
+
 
 ``git`` repository files
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -72,11 +81,11 @@ Inclusion of the repository (and its paths) can be optional or conditional.
 If you want to control the :ref:`name of the configuration scope <named-config-scopes>`, you can provide a ``name``.
 
 For example, suppose we only want to include the ``config.yaml`` and ``packages.yaml`` files from the `spack/spack-configs <https://github.com/spack/spack-configs>`_ repository's ``USC/config`` directory when using the ``centos7`` operating system.
-And we want the configuration scope name to start ``USC``.
-We would then configure the ``include.yaml`` file as follows::
+And we want the configuration scope name to start ``common``.
+We could then configure the include file, ``$user_cache_path/include.yaml`` for example, as follows::
 
    include:
-   - name: USC
+   - name: common
      git: https://github.com/spack/spack-configs
      branch: main
      when: os == "centos7"
@@ -86,24 +95,24 @@ We would then configure the ``include.yaml`` file as follows::
 
 .. note::
 
-   The git URL can be specified through an environment variable (e.g., ``$MY_USC_CONFIG_URL``).
+   The git URL could be specified through an environment variable (e.g., ``$MY_USC_CONFIG_URL``).
 
-If the condition is satisfied, then the ``main`` branch of the repository will be cloned when the configuration scopes are initially created.
+If the condition is satisfied, then the ``main`` branch of the repository will be cloned -- under ``$user_cache_path`` -- when configuration scopes are initially created.
 Once cloned, the settings for the two files under the ``USC/config`` directory will be integrated into Spack's configuration.
-In this example, the new scopes can be seen by running::
+In this example, the new scopes and their paths can be seen by running::
 
    $ spack config scopes -p
    Scope               Path
    command_line
-   spack               /Users/username/spack/etc/spack/
-   user                /Users/username/.spack/
-   USC:config.yaml     /Users/username/.spack/includes/nncrh7v/USC/config/config.yaml
-   USC:packages.yaml   /Users/username/.spack/includes/nncrh7v/USC/config/packages.yaml
-   site                /Users/username/spack/etc/spack/site/
-   system              /etc/spack/
-   defaults            /Users/username/spack/etc/spack/defaults/
-   defaults:darwin     /Users/username/spack/etc/spack/defaults/darwin/
-   defaults:base       /Users/username/spack/etc/spack/defaults/base/
+   spack                           /Users/username/spack/etc/spack/
+   user                            /Users/username/.spack/
+   common:USC/config/config.yaml   /Users/username/.spack/includes/USC/config/config.yaml
+   common:USC/config/packages.yaml /Users/username/.spack/includes/USC/config/packages.yaml
+   site                            /Users/username/spack/etc/spack/site/
+   system                          /etc/spack/
+   defaults                        /Users/username/spack/etc/spack/defaults/
+   defaults:darwin                 /Users/username/spack/etc/spack/defaults/darwin/
+   defaults:base                   /Users/username/spack/etc/spack/defaults/base/
    _builtin
 
 Since there are two unique paths, each results in a separate configuration scope.

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -32,7 +32,7 @@ You can include a single configuration file or an entire configuration *scope* l
    - path: /path/to/os-specific/config-dir
      when: os == "ventura"
 
-Included paths may be absolute, relative (to the configuration file), specified as URLs, or provided in an environment variable (e.g., ``$MY_SPECIAL_CONFIG_FILE``).
+Included paths may be absolute, relative (to the configuration file), specified as URLs, or provided in environment variables (e.g., ``$MY_SPECIAL_CONFIG_FILE``).
 
 * ``optional``: Spack will raise an error when an included configuration file does not exist, *unless* it is explicitly made ``optional: true``, like the second path above.
 * ``when``: Configuration scopes can also be included *conditionally* with ``when``.

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -80,7 +80,7 @@ If you want to control the :ref:`name of the configuration scope <named-config-s
 
 For example, suppose we only want to include the ``config.yaml`` and ``packages.yaml`` files from the `spack/spack-configs <https://github.com/spack/spack-configs>`_ repository's ``USC/config`` directory when using the ``centos7`` operating system.
 And we want the configuration scope name to start ``common``.
-We could then configure the include file, ``$user_cache_path/include.yaml`` for example, as follows::
+We could then configure the include in, for example, the user scope include file (i.e., ``$HOME/.spack/include.yaml`` by default), as follows::
 
    include:
    - name: common
@@ -95,7 +95,7 @@ We could then configure the include file, ``$user_cache_path/include.yaml`` for 
 
    The git URL could be specified through an environment variable (e.g., ``$MY_USC_CONFIG_URL``).
 
-If the condition is satisfied, then the ``main`` branch of the repository will be cloned -- under ``$user_cache_path`` -- when configuration scopes are initially created.
+If the condition is satisfied, then the ``main`` branch of the repository will be cloned -- under ``$HOME/.spack/includes`` -- when configuration scopes are initially created.
 Once cloned, the settings for the two files under the ``USC/config`` directory will be integrated into Spack's configuration.
 In this example, the new scopes and their paths can be seen by running::
 

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -104,8 +104,8 @@ In this example, the new scopes and their paths can be seen by running::
    command_line
    spack                           /Users/username/spack/etc/spack/
    user                            /Users/username/.spack/
-   common:USC/config/config.yaml   /Users/username/.spack/includes/spack-configs/USC/config/config.yaml
-   common:USC/config/packages.yaml /Users/username/.spack/includes/spack-configs/USC/config/packages.yaml
+   common:USC/config/config.yaml   /Users/username/.spack/includes/common/USC/config/config.yaml
+   common:USC/config/packages.yaml /Users/username/.spack/includes/common/USC/config/packages.yaml
    site                            /Users/username/spack/etc/spack/site/
    system                          /etc/spack/
    defaults                        /Users/username/spack/etc/spack/defaults/

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -44,7 +44,7 @@ The same conditions and variables in :ref:`Spec List References <spec-list-refer
 Remote file URLs
 ~~~~~~~~~~~~~~~~
 
-Only the ``file``, ``ftp``, ``http``, and ``https`` protocols (or schemes) are supported for remote file URLs.
+Only the ``ftp``, ``http``, and ``https`` protocols (or schemes) are supported for remote file URLs.
 Spack-specific, environment, and user path variables can be used.
 (See :ref:`config-file-variables` for more information.)
 

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -84,7 +84,7 @@ We could then configure the include in, for example, the user scope include file
 
    include:
    - name: common
-     git: https://github.com/spack/spack-configs
+     git: https://github.com/spack/spack-configs.git
      branch: main
      when: os == "centos7"
      paths:
@@ -104,8 +104,8 @@ In this example, the new scopes and their paths can be seen by running::
    command_line
    spack                           /Users/username/spack/etc/spack/
    user                            /Users/username/.spack/
-   common:USC/config/config.yaml   /Users/username/.spack/includes/USC/config/config.yaml
-   common:USC/config/packages.yaml /Users/username/.spack/includes/USC/config/packages.yaml
+   common:USC/config/config.yaml   /Users/username/.spack/includes/spack-configs/USC/config/config.yaml
+   common:USC/config/packages.yaml /Users/username/.spack/includes/spack-configs/USC/config/packages.yaml
    site                            /Users/username/spack/etc/spack/site/
    system                          /etc/spack/
    defaults                        /Users/username/spack/etc/spack/defaults/

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1340,7 +1340,7 @@ class GitIncludePaths(OptionalInclude):
             return self.destination
 
         # environment includes should be located under the environment
-        destination = self._destination_directory(self.git, parent_scope)
+        destination = self.local_root_directory(self.git, parent_scope)
         assert destination, f"{self} requires a local cache directory"
         tty.debug(f"Cloning {self.git} into {destination}")
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1033,54 +1033,59 @@ class OptionalInclude:
         self.remote = False
         self._scopes = []
 
-    def destination_directory(
+    def local_root_directory(
         self, path_or_url: str, parent_scope: Optional[ConfigScope] = None
     ) -> Optional[str]:
-        """Return the appropriate local directory for remote content.
+        """Return the appropriate local directory for relative or remote content.
 
         Args:
             path_or_url: the path or URL under consideration
             parent_scope: including scope
 
-        Returns:  ``None`` for a local path; an appropriate subdirectory of the enclosing (parent)
-            scope's writable directory (when available); otherwise a temporary directory.
+        Returns:  ``None`` for an absolute path or a local relative path without an enclosing
+            parent scope; an appropriate subdirectory of the enclosing (parent) scope's writable
+            directory (when available); otherwise a temporary directory.
         """
-        # A local path does not have a destination directory.
-        if not self.remote:
-            tty.debug(f"The include ({self}) is not remote so it has no local cache directory.")
+        # An absolute path does need a local root directory.
+        if os.path.isabs(path_or_url):
+            tty.debug(f"The included path ({self}) is absolute so needs no root directory")
             return None
 
-        # A relative path's destination depends on the enclosing scope's path.
-        # If there is no path, then use a temporary directory.
+        # A relative path's root directory depends on the enclosing scope's path.
+        # If there is no path, then a remote include will use a temporary directory while a local
+        # will return ``None``.
         if not parent_scope:
-            tty.debug(
-                f"There is no parent scope of the include ({self}). "
-                "Using a temporary cache directory."
-            )
-            return tempfile.TemporaryDirectory().name
+            temp_root = tempfile.TemporaryDirectory().name if self.remote else None
+            tty.debug(f"There is no parent scope of the include ({self}). Using {temp_root}.")
+            return temp_root
 
         root = getattr(parent_scope, "path", "")
         if not root:
+            temp_root = tempfile.TemporaryDirectory().name if self.remote else None
             tty.debug(
-                f"Enclosing scope ({parent_scope}) of the include ({self}) has "
-                "no path. Using a temporary cache directory."
+                f"Enclosing scope ({parent_scope.name}) of the include ({self}) "
+                f"has no path. Using {temp_root}."
             )
-            return tempfile.TemporaryDirectory().name
+            return temp_root
 
         # Return a temporary directory if the parent scope's directory is unwritable.
         root = os.path.dirname(root) if os.path.isfile(root) else root
-        if not filesystem.can_write_to_dir(root):
-            tty.debug(
-                f"Cannot write to parent scope {parent_scope.name}'s directory "
-                f"({root}). Using a temporary directory.)"
-            )
-            return tempfile.TemporaryDirectory().name
+        if self.remote:
+            if not filesystem.can_write_to_dir(root):
+                temp_root = tempfile.TemporaryDirectory().name
+                tty.debug(
+                    f"Cannot write to parent scope {parent_scope.name}'s directory "
+                    f"({root}). Using {temp_root}."
+                )
+                return temp_root
 
-        # Use an appropriate subdirectory for caching remote content locally.
-        if parent_scope.name.startswith("env:"):
-            return os.path.join(root, ".spack-env", "includes")
+            # Use an appropriate subdirectory for caching remote content locally.
+            if parent_scope.name.startswith("env:"):
+                return os.path.join(root, ".spack-env", "includes")
 
-        return os.path.join(root, "includes")
+            return os.path.join(root, "includes")
+
+        return root
 
     def _scope(
         self, path: str, config_path: str, parent_scope: ConfigScope
@@ -1257,12 +1262,10 @@ class IncludePath(OptionalInclude):
 
         # Make sure to use a proper working directory when obtaining the local
         # path for a local (or remote) file.
-        destination = self.destination_directory(self.path, parent_scope)
-        tty.debug(
-            f"Local cache destination for {self.path} is {destination} (None for local path)"
-        )
+        root = self.local_root_directory(self.path, parent_scope)
+        tty.debug(f"Local root for {self.path} is {root}")
 
-        config_path = rfc_util.local_path(self.path, self.sha256, destination)
+        config_path = rfc_util.local_path(self.path, self.sha256, root)
         assert config_path
         self.destination = config_path
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1033,55 +1033,54 @@ class OptionalInclude:
         self.remote = False
         self._scopes = []
 
-    def _destination_directory(
+    def destination_directory(
         self, path_or_url: str, parent_scope: Optional[ConfigScope] = None
     ) -> Optional[str]:
-        """Return the appropriate directory for relative or remote content
+        """Return the appropriate local directory for remote content.
 
         Args:
             path_or_url: the path or URL under consideration
             parent_scope: including scope
 
-        Returns:  ``None`` for an absolute path, an appropriate, writable
-           enclosing scope subdirectory of the parent scope path (if available);
-           otherwise a temporary directory
+        Returns:  ``None`` for a local path; an appropriate subdirectory of the enclosing (parent)
+            scope's writable directory (when available); otherwise a temporary directory.
         """
-
-        def _destination(root: Optional[str]) -> str:
-            # Ensure the destination is a writable location.
-            if root and filesystem.can_write_to_dir(root):
-                return root
-
-            return tempfile.TemporaryDirectory().name
-
-        # An absolute path does not have a destination directory.
-        if os.path.isabs(path_or_url):
+        # A local path does not have a destination directory.
+        if not self.remote:
+            tty.debug(f"The include ({self}) is not remote so it has no local cache directory.")
             return None
 
-        # A relative path's destination depends on the enclosing scope.
-        # If there is no path, then use a suitable destination.
+        # A relative path's destination depends on the enclosing scope's path.
+        # If there is no path, then use a temporary directory.
         if not parent_scope:
-            return tempfile.TemporaryDirectory().name if self.remote else None
+            tty.debug(
+                f"There is no parent scope of the include ({self}). "
+                "Using a temporary cache directory."
+            )
+            return tempfile.TemporaryDirectory().name
 
         root = getattr(parent_scope, "path", "")
         if not root:
             tty.debug(
-                f"Enclosing scope ({parent_scope}) of the include ({self}) does not have a path"
+                f"Enclosing scope ({parent_scope}) of the include ({self}) has "
+                "no path. Using a temporary cache directory."
             )
-            return None
+            return tempfile.TemporaryDirectory().name
 
+        # Return a temporary directory if the parent scope's directory is unwritable.
         root = os.path.dirname(root) if os.path.isfile(root) else root
-        if self.remote:
-            if not filesystem.can_write_to_dir(root):
-                return tempfile.TemporaryDirectory().name
+        if not filesystem.can_write_to_dir(root):
+            tty.debug(
+                f"Cannot write to parent scope {parent_scope.name}'s directory "
+                f"({root}). Using a temporary directory.)"
+            )
+            return tempfile.TemporaryDirectory().name
 
-            # Use a special subdirectory for environments
-            if parent_scope.name.startswith("env:"):
-                return os.path.join(root, ".spack-env", "includes")
+        # Use an appropriate subdirectory for caching remote content locally.
+        if parent_scope.name.startswith("env:"):
+            return os.path.join(root, ".spack-env", "includes")
 
-            return os.path.join(root, "includes")
-
-        return root
+        return os.path.join(root, "includes")
 
     def _scope(
         self, path: str, config_path: str, parent_scope: ConfigScope
@@ -1258,7 +1257,7 @@ class IncludePath(OptionalInclude):
 
         # Make sure to use a proper working directory when obtaining the local
         # path for a local (or remote) file.
-        destination = self._destination_directory(self.path, parent_scope)
+        destination = self.destination_directory(self.path, parent_scope)
         tty.debug(
             f"Local cache destination for {self.path} is {destination} (None for local path)"
         )

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1065,12 +1065,23 @@ class OptionalInclude:
         if not self.remote:
             return scope_dir
 
+        def _subdir():
+            match = re.search(r"/([^/]+?)(\.git)?$", path_or_url)
+            if match:
+                if not os.path.splitext(match.group(1))[1]:
+                    return match.group(1)
+
+            if self.name:
+                return self.name
+
+            return spack.util.hash.b32_hash(path_or_url)[-7:]
+
         # For remote includes, prefer a writable subdirectory of the parent scope.
         if scope_dir and filesystem.can_write_to_dir(scope_dir):
             assert parent_scope is not None
-            subdir = "includes"
+            subdir = os.path.join("includes", _subdir())
             if parent_scope.name.startswith("env:"):
-                subdir = os.path.join(".spack-env", "includes")
+                subdir = os.path.join(".spack-env", subdir)
             return os.path.join(scope_dir, subdir)
 
         # Fall back to a stable, unique, temporary directory, logging the reason.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1028,6 +1028,7 @@ class OptionalInclude:
     when: str
     optional: bool
     prefer_modify: bool
+    remote: bool
     _scopes: List[ConfigScope]
 
     def __init__(self, entry: dict):
@@ -1035,7 +1036,50 @@ class OptionalInclude:
         self.when = entry.get("when", "")
         self.optional = entry.get("optional", False)
         self.prefer_modify = entry.get("prefer_modify", False)
+        self.remote = False
         self._scopes = []
+
+    def _destination_directory(
+        self, path_or_url: str, parent_scope: Optional[ConfigScope] = None
+    ) -> Optional[str]:
+        """Return the appropriate directory for relative or remote content
+
+        Args:
+            path_or_url: the path or URL under consideration
+            parent_scope: including scope
+
+        Returns:  the appropriate enclosing scope subdirectory or standard
+            include cache directory for remote configuration content; otherwise,
+            ``None``
+        """
+
+        def _default_include_directory():
+            dir_name = spack.util.hash.b32_hash(path_or_url)[-7:]
+            return os.path.join(_include_cache_location(), dir_name)
+
+        # An absolute path does not have a destination directory.
+        if os.path.isabs(path_or_url):
+            return None
+
+        # A relative path's destination depends on the enclosing scope.
+        if not parent_scope:
+            return _default_include_directory() if self.remote else None
+
+        root = parent_scope.path if hasattr(parent_scope, "path") else None
+        if not root:
+            tty.debug(
+                f"Enclosing scope ({parent_scope}) of the include ({self}) does not have a path"
+            )
+            return None
+
+        root = os.path.dirname(root) if os.path.isfile(root) else root
+        if self.remote:
+            if parent_scope.name.startswith("env:"):
+                return os.path.join(root, ".spack-env", "includes")
+
+            return _default_include_directory()
+
+        return root
 
     def _scope(
         self, path: str, config_path: str, parent_scope: ConfigScope
@@ -1095,7 +1139,7 @@ class OptionalInclude:
         exists = os.path.exists(config_path)
 
         if not exists and not self.optional:
-            dest = f" at ({config_path})" if config_path != path else ""
+            dest = f" at ({config_path})" if config_path != os.path.normpath(path) else ""
             raise ValueError(f"Required path ({path}) does not exist{dest}")
 
         if (exists and not is_dir) or ext_is_yaml:
@@ -1175,6 +1219,7 @@ class IncludePath(OptionalInclude):
         self.path = spack.util.path.substitute_path_variables(path)
 
         self.sha256 = entry.get("sha256", "")
+        self.remote = "sha256" in entry
         self.destination = None
 
     def __repr__(self):
@@ -1206,17 +1251,13 @@ class IncludePath(OptionalInclude):
             return self._scopes
 
         # Make sure to use the proper (default) working directory when obtaining
-        # the local path for a local file.
-        def work_dir():
-            if not os.path.isabs(self.path) and hasattr(parent_scope, "path"):
-                if os.path.isfile(parent_scope.path):
-                    return os.path.dirname(parent_scope.path)
-                if os.path.isdir(parent_scope.path):
-                    return parent_scope.path
-            return os.getcwd()
+        # the local path for a local (or remote) file.
+        destination = self._destination_directory(self.path, parent_scope)
+        tty.debug(
+            f"Local cache destination for {self.path} is {destination} (None for local path)"
+        )
 
-        with filesystem.working_dir(work_dir()):
-            config_path = rfc_util.local_path(self.path, self.sha256, _include_cache_location())
+        config_path = rfc_util.local_path(self.path, self.sha256, destination)
         assert config_path
         self.destination = config_path
 
@@ -1254,6 +1295,7 @@ class GitIncludePaths(OptionalInclude):
             spack.util.path.substitute_path_variables(path) for path in entry.get("paths", [])
         ]
         self.destination = None
+        self.remote = True
 
         if not self.branch and not self.commit and not self.tag:
             raise spack.error.ConfigError(
@@ -1272,21 +1314,27 @@ class GitIncludePaths(OptionalInclude):
             identifier = f"commit={self.commit}, tag={self.tag}"
 
         return (
-            f"GitIncludePaths({self.git}, paths={self.paths}, "
+            f"GitIncludePaths('{self.name}', {self.git}, paths={self._paths}, "
             f"{identifier}, when='{self.when}', optional={self.optional})"
         )
 
-    def _destination(self):
-        dir_name = spack.util.hash.b32_hash(self.git)[-7:]
-        return os.path.join(_include_cache_location(), dir_name)
+    def _clone(self, parent_scope: ConfigScope) -> Optional[str]:
+        """Clone the repository.
 
-    def _clone(self) -> Optional[str]:
-        """Clone the repository."""
+        Args:
+            parent_scope: enclosing scope
+
+        Returns: destination path if cloned or ``None``
+        """
         if self.fetched():
             tty.debug(f"Repository ({self.git}) already cloned to {self.destination}")
             return self.destination
 
-        destination = self._destination()
+        # environment includes should be located under the environment
+        destination = self._destination_directory(self.git, parent_scope)
+        assert destination, f"{self} requires a local cache directory"
+        tty.debug(f"Cloning {self.git} into {destination}")
+
         with filesystem.working_dir(destination, create=True):
             if not os.path.exists(".git"):
                 try:
@@ -1324,7 +1372,7 @@ class GitIncludePaths(OptionalInclude):
             return self.destination
 
     def fetched(self):
-        return self.destination is not None and os.path.join(self.destination, ".git")
+        return self.destination and os.path.join(self.destination, ".git")
 
     def scopes(self, parent_scope: ConfigScope) -> List[ConfigScope]:
         """Instantiate configuration scopes for the included paths.
@@ -1348,8 +1396,8 @@ class GitIncludePaths(OptionalInclude):
             tty.debug(f"Using existing scopes: {[s.name for s in self._scopes]}")
             return self._scopes
 
-        destination = self._clone()
-        if destination is None:
+        destination = self._clone(parent_scope)
+        if not destination:
             raise spack.error.ConfigError(f"Unable to cache the include: {self}")
 
         scopes: List[ConfigScope] = []

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1426,7 +1426,7 @@ class GitIncludePaths(OptionalInclude):
 
         scopes: List[ConfigScope] = []
         for path in self.paths:
-            config_path = str(pathlib.Path(destination) / pathlib.Path(path))
+            config_path = str(pathlib.Path(destination) / path)
             scope = self._scope(path, config_path, parent_scope)
             if scope is not None:
                 scopes.append(scope)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -137,11 +137,6 @@ YamlConfigDict = Dict[str, Any]
 MAX_RECURSIVE_INCLUDES = 100
 
 
-def _include_cache_location():
-    """Location to cache included configuration files."""
-    return os.path.join(spack.paths.user_cache_path, "includes")
-
-
 class ConfigScope:
     def __init__(self, name: str, included: bool = False) -> None:
         self.name = name
@@ -1048,24 +1043,27 @@ class OptionalInclude:
             path_or_url: the path or URL under consideration
             parent_scope: including scope
 
-        Returns:  the appropriate enclosing scope subdirectory or standard
-            include cache directory for remote configuration content; otherwise,
-            ``None``
+        Returns:  ``None`` for an absolute path, an appropriate, writable
+           enclosing scope subdirectory of the parent scope path (if available);
+           otherwise a temporary directory
         """
+        def _destination(root: Optional[str]) -> str:
+            # Ensure the destination is a writable location.
+            if root and filesystem.can_write_to_dir(root):
+                return root
 
-        def _default_include_directory():
-            dir_name = spack.util.hash.b32_hash(path_or_url)[-7:]
-            return os.path.join(_include_cache_location(), dir_name)
+            return tempfile.TemporaryDirectory().name
 
         # An absolute path does not have a destination directory.
         if os.path.isabs(path_or_url):
             return None
 
         # A relative path's destination depends on the enclosing scope.
+        # If there is no path, then use a suitable destination.
         if not parent_scope:
-            return _default_include_directory() if self.remote else None
+            return tempfile.TemporaryDirectory().name if self.remote else None
 
-        root = parent_scope.path if hasattr(parent_scope, "path") else None
+        root = getattr(parent_scope, "path", "")
         if not root:
             tty.debug(
                 f"Enclosing scope ({parent_scope}) of the include ({self}) does not have a path"
@@ -1074,12 +1072,17 @@ class OptionalInclude:
 
         root = os.path.dirname(root) if os.path.isfile(root) else root
         if self.remote:
+            if not filesystem.can_write_to_dir(root):
+                return tempfile.TemporaryDirectory().name
+
+            # Use a special subdirectory for environments
             if parent_scope.name.startswith("env:"):
                 return os.path.join(root, ".spack-env", "includes")
 
-            return _default_include_directory()
+            return os.path.join(root, "includes")
 
         return root
+
 
     def _scope(
         self, path: str, config_path: str, parent_scope: ConfigScope
@@ -1250,8 +1253,8 @@ class IncludePath(OptionalInclude):
             tty.debug(f"Using existing scopes: {[s.name for s in self._scopes]}")
             return self._scopes
 
-        # Make sure to use the proper (default) working directory when obtaining
-        # the local path for a local (or remote) file.
+        # Make sure to use a proper working directory when obtaining the local
+        # path for a local (or remote) file.
         destination = self._destination_directory(self.path, parent_scope)
         tty.debug(
             f"Local cache destination for {self.path} is {destination} (None for local path)"
@@ -1288,6 +1291,7 @@ class GitIncludePaths(OptionalInclude):
 
         super().__init__(entry)
         self.git = spack.util.path.substitute_path_variables(entry.get("git", ""))
+
         self.branch = entry.get("branch", "")
         self.commit = entry.get("commit", "")
         self.tag = entry.get("tag", "")
@@ -1402,7 +1406,7 @@ class GitIncludePaths(OptionalInclude):
 
         scopes: List[ConfigScope] = []
         for path in self.paths:
-            config_path = os.path.join(destination, path)
+            config_path = pathlib.Path(destination) / pathlib.Path(path)
             scope = self._scope(path, config_path, parent_scope)
             if scope is not None:
                 scopes.append(scope)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1066,13 +1066,15 @@ class OptionalInclude:
             return scope_dir
 
         def _subdir():
+            # Prefer the provided include name over the git repository name.
+            # If neither, use a hash of the url or path for uniqueness.
+            if self.name:
+                return self.name
+
             match = re.search(r"/([^/]+?)(\.git)?$", path_or_url)
             if match:
                 if not os.path.splitext(match.group(1))[1]:
                     return match.group(1)
-
-            if self.name:
-                return self.name
 
             return spack.util.hash.b32_hash(path_or_url)[-7:]
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -65,6 +65,7 @@ import spack.schema.upstreams
 import spack.schema.view
 import spack.util.executable
 import spack.util.git
+import spack.util.hash
 import spack.util.remote_file_cache as rfc_util
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
@@ -1033,59 +1034,61 @@ class OptionalInclude:
         self.remote = False
         self._scopes = []
 
-    def local_root_directory(
+    @staticmethod
+    def _parent_scope_directory(parent_scope: Optional[ConfigScope]) -> Optional[str]:
+        """Return the directory of the parent scope, or ``None`` if unavailable.
+
+        Normalizes ``SingleFileScope`` to its containing directory.
+        """
+        path = getattr(parent_scope, "path", "") if parent_scope else ""
+        if not path:
+            return None
+        return os.path.dirname(path) if os.path.isfile(path) else path
+
+    def base_directory(
         self, path_or_url: str, parent_scope: Optional[ConfigScope] = None
     ) -> Optional[str]:
-        """Return the appropriate local directory for relative or remote content.
+        """Return the local directory to use for this include.
+
+        For remote includes this is the cache destination directory.
+        For local relative includes this is the working directory from which to resolve the path.
 
         Args:
-            path_or_url: the path or URL under consideration
+            path_or_url: path or URL of the include
             parent_scope: including scope
 
-        Returns:  ``None`` for an absolute path or a local relative path without an enclosing
-            parent scope; an appropriate subdirectory of the enclosing (parent) scope's writable
-            directory (when available); otherwise a temporary directory.
+        Returns: ``None`` for a local include without an enclosing parent scope;
+            an appropriate subdirectory of the enclosing (parent) scope's writable
+            directory (when available); otherwise a stable temporary directory.
         """
-        # An absolute path does need a local root directory.
-        if os.path.isabs(path_or_url):
-            tty.debug(f"The included path ({self}) is absolute so needs no root directory")
-            return None
+        scope_dir = self._parent_scope_directory(parent_scope)
+        if not self.remote:
+            return scope_dir
 
-        # A relative path's root directory depends on the enclosing scope's path.
-        # If there is no path, then a remote include will use a temporary directory while a local
-        # will return ``None``.
-        if not parent_scope:
-            temp_root = tempfile.TemporaryDirectory().name if self.remote else None
-            tty.debug(f"There is no parent scope of the include ({self}). Using {temp_root}.")
-            return temp_root
-
-        root = getattr(parent_scope, "path", "")
-        if not root:
-            temp_root = tempfile.TemporaryDirectory().name if self.remote else None
-            tty.debug(
-                f"Enclosing scope ({parent_scope.name}) of the include ({self}) "
-                f"has no path. Using {temp_root}."
-            )
-            return temp_root
-
-        # Return a temporary directory if the parent scope's directory is unwritable.
-        root = os.path.dirname(root) if os.path.isfile(root) else root
-        if self.remote:
-            if not filesystem.can_write_to_dir(root):
-                temp_root = tempfile.TemporaryDirectory().name
-                tty.debug(
-                    f"Cannot write to parent scope {parent_scope.name}'s directory "
-                    f"({root}). Using {temp_root}."
-                )
-                return temp_root
-
-            # Use an appropriate subdirectory for caching remote content locally.
+        # For remote includes, prefer a writable subdirectory of the parent scope.
+        if scope_dir and filesystem.can_write_to_dir(scope_dir):
+            assert parent_scope is not None
+            subdir = "includes"
             if parent_scope.name.startswith("env:"):
-                return os.path.join(root, ".spack-env", "includes")
+                subdir = os.path.join(".spack-env", "includes")
+            return os.path.join(scope_dir, subdir)
 
-            return os.path.join(root, "includes")
+        # Fall back to a stable, unique, temporary directory, logging the reason.
+        tmpdir = tempfile.gettempdir()
+        if path_or_url:
+            pre = self.name or getattr(parent_scope, "name", "")
+            subdir = f"{pre}:{path_or_url}" if pre else path_or_url
+            tmpdir = os.path.join(tmpdir, spack.util.hash.b32_hash(subdir)[-7:])
 
-        return root
+        if not scope_dir:
+            tty.debug(f"No parent scope directory for include ({self}). Using {tmpdir}.")
+        else:
+            assert parent_scope is not None
+            tty.debug(
+                f"Parent scope {parent_scope.name}'s directory ({scope_dir}) is not writable. "
+                f"Using {tmpdir}."
+            )
+        return tmpdir
 
     def _scope(
         self, path: str, config_path: str, parent_scope: ConfigScope
@@ -1260,12 +1263,18 @@ class IncludePath(OptionalInclude):
             tty.debug(f"Using existing scopes: {[s.name for s in self._scopes]}")
             return self._scopes
 
+        # An absolute path does not need a local base directory.
+        if os.path.isabs(self.path):
+            tty.debug(f"The included path ({self}) is absolute so needs no base directory")
+            base = None
+        else:
+            base = self.base_directory(self.path, parent_scope)
+
         # Make sure to use a proper working directory when obtaining the local
         # path for a local (or remote) file.
-        root = self.local_root_directory(self.path, parent_scope)
-        tty.debug(f"Local root for {self.path} is {root}")
+        tty.debug(f"Local base directory for {self.path} is {base}")
 
-        config_path = rfc_util.local_path(self.path, self.sha256, root)
+        config_path = rfc_util.local_path(self.path, self.sha256, base)
         assert config_path
         self.destination = config_path
 
@@ -1340,7 +1349,7 @@ class GitIncludePaths(OptionalInclude):
             return self.destination
 
         # environment includes should be located under the environment
-        destination = self.local_root_directory(self.git, parent_scope)
+        destination = self.base_directory(self.git, parent_scope)
         assert destination, f"{self} requires a local cache directory"
         tty.debug(f"Cloning {self.git} into {destination}")
 
@@ -1384,8 +1393,10 @@ class GitIncludePaths(OptionalInclude):
             self.destination = destination
             return self.destination
 
-    def fetched(self):
-        return self.destination and os.path.join(self.destination, ".git")
+    def fetched(self) -> bool:
+        return bool(self.destination) and os.path.exists(
+            os.path.join(self.destination, ".git")  # type: ignore[arg-type]
+        )
 
     def scopes(self, parent_scope: ConfigScope) -> List[ConfigScope]:
         """Instantiate configuration scopes for the included paths.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -65,7 +65,6 @@ import spack.schema.upstreams
 import spack.schema.view
 import spack.util.executable
 import spack.util.git
-import spack.util.hash
 import spack.util.remote_file_cache as rfc_util
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
@@ -1047,6 +1046,7 @@ class OptionalInclude:
            enclosing scope subdirectory of the parent scope path (if available);
            otherwise a temporary directory
         """
+
         def _destination(root: Optional[str]) -> str:
             # Ensure the destination is a writable location.
             if root and filesystem.can_write_to_dir(root):
@@ -1082,7 +1082,6 @@ class OptionalInclude:
             return os.path.join(root, "includes")
 
         return root
-
 
     def _scope(
         self, path: str, config_path: str, parent_scope: ConfigScope
@@ -1406,7 +1405,7 @@ class GitIncludePaths(OptionalInclude):
 
         scopes: List[ConfigScope] = []
         for path in self.paths:
-            config_path = pathlib.Path(destination) / pathlib.Path(path)
+            config_path = str(pathlib.Path(destination) / pathlib.Path(path))
             scope = self._scope(path, config_path, parent_scope)
             if scope is not None:
                 scopes.append(scope)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -144,7 +144,7 @@ class ConfigScope:
         self.prefer_modify = False
         self.included = included
 
-        #: names of any included scopes
+        #: included configuration scopes
         self._included_scopes: Optional[List["ConfigScope"]] = None
 
     @property
@@ -549,7 +549,7 @@ class Configuration:
         # TODO: includes AND ensure properly sorted such that the order included
         # TODO: at the highest level is reflected in the value of an option that
         # TODO: is set in multiple included files.
-        # before pushing the scope itself, push any included scopes recursively, at same priority
+        # before pushing the scope itself, push included scopes recursively, at the same priority
         for included_scope in reversed(scope.included_scopes):
             if _depth + 1 > MAX_RECURSIVE_INCLUDES:  # make sure we're not recursing endlessly
                 mark = ""
@@ -1177,6 +1177,10 @@ for file scopes, or no extension for directory scopes (currently {ext})"
         assert parent_scope.name.strip(), "Parent scope of an include must have a name"
 
     def evaluate_condition(self) -> bool:
+        """Evaluate the include condition:
+
+        Returns: ``True`` if the include condition is satisfied; else ``False``.
+        """
         # circular dependencies
         import spack.spec
 
@@ -1188,8 +1192,8 @@ for file scopes, or no extension for directory scopes (currently {ext})"
         Args:
             parent_scope: including scope
 
-        Returns: configuration scopes IF the when condition is satisfied;
-            otherwise, an empty list.
+        Returns: configuration scopes for configuration files IF the when
+            condition is satisfied; otherwise, an empty list.
 
         Raises:
             ValueError: the required configuration path does not exist
@@ -1341,6 +1345,7 @@ class GitIncludePaths(OptionalInclude):
         with filesystem.working_dir(destination, create=True):
             if not os.path.exists(".git"):
                 try:
+                    tty.debug("Initializing the git repository")
                     spack.util.git.init_git_repo(self.git)
                 except spack.util.executable.ProcessError as e:
                     raise spack.error.ConfigError(
@@ -1349,12 +1354,15 @@ class GitIncludePaths(OptionalInclude):
 
             try:
                 if self.commit:
+                    tty.debug(f"Pulling commit {self.commit}")
                     spack.util.git.pull_checkout_commit(self.commit)
                 elif self.tag:
+                    tty.debug(f"Pulling tag {self.tag}")
                     spack.util.git.pull_checkout_tag(self.tag)
                 elif self.branch:
                     # if the branch already exists we should use the
                     # previously configured remote
+                    tty.debug(f"Pulling branch {self.branch}")
                     try:
                         git = spack.util.git.git(required=True)
                         output = git("config", f"branch.{self.branch}.remote", output=str)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1220,7 +1220,7 @@ class Environment:
             if isinstance(include, spack.config.GitIncludePaths):
                 # Git includes must be cloned first; paths are relative to the
                 # clone destination, not to the manifest directory.
-                destination = include._clone()
+                destination = include._clone(self.manifest.env_config_scope)
                 if destination is None:
                     continue
                 resolved = [os.path.join(destination, p) for p in include.paths]

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4375,10 +4375,7 @@ def test_unify_when_possible_works_around_conflicts(mutable_config):
 
 
 def test_env_include_packages_url(
-    tmp_path: pathlib.Path,
-    mutable_empty_config,
-    mock_fetch_url_text,
-    mock_curl_configs,
+    tmp_path: pathlib.Path, mutable_empty_config, mock_fetch_url_text, mock_curl_configs
 ):
     """Test inclusion of a (GitHub) URL."""
     develop_url = "https://github.com/fake/fake/blob/develop/"

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4879,7 +4879,9 @@ spack:
         shutil.copy(os.path.join(e.path, ev.manifest_name), lock_in_clone.parent)
 
     # Prevent actual git operations; return the pre-built clone destination.
-    monkeypatch.setattr(spack.config.GitIncludePaths, "_clone", lambda self: str(clone_dest))
+    monkeypatch.setattr(
+        spack.config.GitIncludePaths, "_clone", lambda self, parent_scope: str(clone_dest)
+    )
 
     main_dir = tmp_path / "main_env"
     main_dir.mkdir()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4374,14 +4374,11 @@ def test_unify_when_possible_works_around_conflicts(mutable_config):
         assert len([x for x in e.all_specs() if x.satisfies("mpich")]) == 1
 
 
-# Using mock_include_cache to ensure the "remote" file is cached in a temporary
-# location and not polluting the user cache.
 def test_env_include_packages_url(
     tmp_path: pathlib.Path,
     mutable_empty_config,
     mock_fetch_url_text,
     mock_curl_configs,
-    mock_include_cache,
 ):
     """Test inclusion of a (GitHub) URL."""
     develop_url = "https://github.com/fake/fake/blob/develop/"

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1844,19 +1844,11 @@ def test_included_path_git_substitutions():
 def test_included_path_git(
     tmp_path: pathlib.Path, mock_low_high_config, ensure_debug, monkeypatch, key, value, capfd
 ):
-    monkeypatch.setattr(spack.paths, "user_cache_path", str(tmp_path))
+    """Check git includes for branch, commit, and tag using relative paths.
 
-    class MockIncludeGit(spack.util.executable.Executable):
-        def __init__(self, required: bool):
-            pass
-
-        def __call__(self, *args, **kwargs) -> str:  # type: ignore
-            action = args[0]
-
-            if action == "config":
-                return "origin"
-
-            return ""
+    Note the mock config fixture does NOT create the scope path so a temporary
+    directory will be used for caching the files.
+    """
 
     # Specifying two relative paths, one explicit, one implicit
     paths = ["./config.yaml", "packages.yaml"]
@@ -1871,18 +1863,30 @@ def test_included_path_git(
     assert isinstance(include, spack.config.GitIncludePaths)
     assert not include.optional and include.evaluate_condition()
 
-    destination = include._destination_directory(include.git)
-    assert destination and not os.path.exists(destination)
-
     # set up minimal git and repository operations
+    class MockIncludeGit(spack.util.executable.Executable):
+        def __init__(self, required: bool):
+            pass
+
+        def __call__(self, *args, **kwargs) -> str:  # type: ignore
+            action = args[0]
+
+            if action == "config":
+                return "origin"
+
+            return ""
+
     monkeypatch.setattr(spack.util.git, "git", MockIncludeGit)
 
     def _init_repo(*args, **kwargs):
-        fs.mkdirp(fs.join_path(destination, ".git"))
+        # Make sure the directory exists, where assuming called from within
+        # the working directory.
+        fs.mkdirp(fs.join_path(os.getcwd(), ".git"))
 
     def _checkout(*args, **kwargs):
-        # Make sure the files exist at the clone destination
-        with fs.working_dir(destination):
+        # Make sure the files exist at the clone destination, where assuming
+        # called from within the working directory.
+        with fs.working_dir(os.getcwd()):
             for p in paths:
                 fs.touch(p)
 
@@ -1892,7 +1896,7 @@ def test_included_path_git(
     # First successful pass builds the scope
     parent_scope = mock_low_high_config.scopes["low"]
     scopes = include.scopes(parent_scope)
-    assert scopes and len(scopes) == len(paths)
+    assert len(scopes) == len(paths)
 
     base_paths = [os.path.basename(p) for p in paths]
     for scope in scopes:

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1920,6 +1920,57 @@ def test_included_path_git(
         assert "already cloned" in captured
 
 
+@pytest.mark.parametrize("path", ["./config.yaml", "/path/to/my/special/package.yaml"])
+def test_included_path_local_no_dest(path):
+    """Confirm that local paths have no cache destination."""
+    entry = {"path": path}
+    include = spack.config.included_path(entry)
+    destination = include.destination_directory(entry["path"])
+    assert not destination, f"Expected local include ({include}) to NOT have a cache destination"
+
+
+def test_included_path_url_temp_dest(mock_low_high_config):
+    """Check that remote (raw) path under different scopes end up with temporary
+    cache destinations."""
+    entry = {
+        "path": "https://github.com/path/to/raw/config/config.yaml",
+        "sha256": "26e871804a92cd07bb3d611b31b4156ae93d35b6a6d6e0ef3a67871fcb1d258b",
+    }
+    include = spack.config.included_path(entry)
+
+    parent_scope = mock_low_high_config.scopes["low"]
+    parent_scope.path = ""
+    pre = f"Expected temporary cache destination for raw include path ({include}) for "
+
+    for scope in [None, parent_scope]:
+        rest = "parent scope with no path" if scope else "no parent scope"
+        destination = include.destination_directory(entry["path"], parent_scope=scope)
+        dest_dir = str(pathlib.Path(destination).parent)
+        temp_dir = tempfile.gettempdir()
+        assert dest_dir == temp_dir, pre + rest
+
+
+def test_included_path_git_temp_dest(mock_low_high_config):
+    """Check a remote (relative) path with different parent scope options that
+    result in a temporary cache destination."""
+    entry = {
+        "git": "https://example.com/linux/configs.git",
+        "branch": "develop",
+        "paths": ["config.yaml"],
+    }
+    include = spack.config.included_path(entry)
+    parent_scope = mock_low_high_config.scopes["low"]
+    parent_scope.path = ""
+    pre = f"Expected temporary cache destination for git include path ({include}) for "
+
+    for scope in [None, parent_scope]:
+        rest = "parent scope with no path" if scope else "no parent scope"
+        destination = include.destination_directory(entry["git"], parent_scope=scope)
+        dest_dir = str(pathlib.Path(destination).parent)
+        temp_dir = tempfile.gettempdir()
+        assert dest_dir == temp_dir, pre + rest
+
+
 def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, monkeypatch):
     monkeypatch.setattr(spack.paths, "user_cache_path", str(tmp_path))
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1871,8 +1871,8 @@ def test_included_path_git(
     assert isinstance(include, spack.config.GitIncludePaths)
     assert not include.optional and include.evaluate_condition()
 
-    destination = include._destination()
-    assert not os.path.exists(destination)
+    destination = include._destination_directory(include.git)
+    assert destination and not os.path.exists(destination)
 
     # set up minimal git and repository operations
     monkeypatch.setattr(spack.util.git, "git", MockIncludeGit)
@@ -1911,7 +1911,7 @@ def test_included_path_git(
     # A direct clone now returns already cloned destination and debug message.
     # Again only need to run this test once.
     if key == "tag":
-        assert include._clone() == include.destination
+        assert include._clone(parent_scope) == include.destination
         captured = capfd.readouterr()[1]
         assert "already cloned" in captured
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1925,7 +1925,7 @@ def test_included_path_local_no_dest(path):
     """Confirm that local paths have no cache destination."""
     entry = {"path": path}
     include = spack.config.included_path(entry)
-    destination = include.local_root_directory(entry["path"])
+    destination = include.base_directory(entry["path"])
     assert not destination, f"Expected local include ({include}) to NOT have a cache destination"
 
 
@@ -1944,7 +1944,7 @@ def test_included_path_url_temp_dest(mock_low_high_config):
 
     for scope in [None, parent_scope]:
         rest = "parent scope with no path" if scope else "no parent scope"
-        destination = include.local_root_directory(entry["path"], parent_scope=scope)
+        destination = include.base_directory(entry["path"], parent_scope=scope)
         dest_dir = str(pathlib.Path(destination).parent)
         temp_dir = tempfile.gettempdir()
         assert dest_dir == temp_dir, pre + rest
@@ -1965,7 +1965,7 @@ def test_included_path_git_temp_dest(mock_low_high_config):
 
     for scope in [None, parent_scope]:
         rest = "parent scope with no path" if scope else "no parent scope"
-        destination = include.local_root_directory(entry["git"], parent_scope=scope)
+        destination = include.base_directory(entry["git"], parent_scope=scope)
         dest_dir = str(pathlib.Path(destination).parent)
         temp_dir = tempfile.gettempdir()
         assert dest_dir == temp_dir, pre + rest

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1925,7 +1925,7 @@ def test_included_path_local_no_dest(path):
     """Confirm that local paths have no cache destination."""
     entry = {"path": path}
     include = spack.config.included_path(entry)
-    destination = include.destination_directory(entry["path"])
+    destination = include.local_root_directory(entry["path"])
     assert not destination, f"Expected local include ({include}) to NOT have a cache destination"
 
 
@@ -1944,7 +1944,7 @@ def test_included_path_url_temp_dest(mock_low_high_config):
 
     for scope in [None, parent_scope]:
         rest = "parent scope with no path" if scope else "no parent scope"
-        destination = include.destination_directory(entry["path"], parent_scope=scope)
+        destination = include.local_root_directory(entry["path"], parent_scope=scope)
         dest_dir = str(pathlib.Path(destination).parent)
         temp_dir = tempfile.gettempdir()
         assert dest_dir == temp_dir, pre + rest
@@ -1965,7 +1965,7 @@ def test_included_path_git_temp_dest(mock_low_high_config):
 
     for scope in [None, parent_scope]:
         rest = "parent scope with no path" if scope else "no parent scope"
-        destination = include.destination_directory(entry["git"], parent_scope=scope)
+        destination = include.local_root_directory(entry["git"], parent_scope=scope)
         dest_dir = str(pathlib.Path(destination).parent)
         temp_dir = tempfile.gettempdir()
         assert dest_dir == temp_dir, pre + rest

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2486,12 +2486,6 @@ def _include_cache_root():
 
 
 @pytest.fixture()
-def mock_include_cache(monkeypatch):
-    """Override the include cache directory so tests don't pollute user cache."""
-    monkeypatch.setattr(spack.config, "_include_cache_location", _include_cache_root)
-
-
-@pytest.fixture()
 def wrapper_dir(install_mockery):
     """Installs the compiler wrapper and returns the prefix where the script is installed."""
     wrapper = spack.concretize.concretize_one("compiler-wrapper")

--- a/lib/spack/spack/util/remote_file_cache.py
+++ b/lib/spack/spack/util/remote_file_cache.py
@@ -80,7 +80,7 @@ def local_path(raw_path: str, sha256: str, dest: Optional[str] = None) -> str:
 
     # Allow paths (and URLs) to contain spack config/environment variables,
     # etc.
-    path = canonicalize_path(raw_path)
+    path = canonicalize_path(raw_path, dest)
 
     # Save off the Windows drive of the canonicalized path (since now absolute)
     # to ensure recognized by URL parsing as a valid file "scheme".


### PR DESCRIPTION
Depends on #51895 

Cache remote include paths under the enclosing scope's path, where that scope is the scope of the `include.yaml` (or `spack.yaml`) file that defines the remote include.

If it has no path (is this possible anymore?) or the path is unwritable, the file will be cached under a temporary directory.

Initial work extracted from #50207's [Cache env path_sha256 includes under the environment.](https://github.com/spack/spack/pull/50207/changes/3f0d8823e7297bd0902e375565c950e47a14dd74#diff-4659603983779f9e0eb6449daeb01d7077214ec46e6285a3e9be51e419372baf) commit.

TODO
- [x]  ensure each remote include has own subdirectory of the enclosing scope