### PR TITLE
test/config.py: add include scope tests (from #50207)

### DIFF
--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1960,3 +1960,21 @@ def test_missing_include_scope_write_file(mock_missing_file_include_scopes):
     assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
     install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
     assert install_root == "$spack/tmp/spack"
+
+
+def test_config_scope_empty_write(tmp_path: pathlib.Path):
+    """Confirm skipping attempt to write non-existent scope section."""
+    config_scope = spack.config.DirectoryConfigScope("test", str(tmp_path))
+
+    config_scope.get_section("include") is None
+
+
+def test_config_optional_include_failures(tmp_path: pathlib.Path):
+    include = spack.config.OptionalInclude({})
+
+    with pytest.raises(NotImplementedError):
+        include.paths
+
+    config_scope = spack.config.DirectoryConfigScope("test", str(tmp_path))
+    with pytest.raises(NotImplementedError):
+        include.scopes(config_scope)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1966,15 +1966,4 @@ def test_config_scope_empty_write(tmp_path: pathlib.Path):
     """Confirm skipping attempt to write non-existent scope section."""
     config_scope = spack.config.DirectoryConfigScope("test", str(tmp_path))
 
-    config_scope.get_section("include") is None
-
-
-def test_config_optional_include_failures(tmp_path: pathlib.Path):
-    include = spack.config.OptionalInclude({})
-
-    with pytest.raises(NotImplementedError):
-        include.paths
-
-    config_scope = spack.config.DirectoryConfigScope("test", str(tmp_path))
-    with pytest.raises(NotImplementedError):
-        include.scopes(config_scope)
+    assert config_scope.get_section("include") is None


### PR DESCRIPTION
Extracted from #50207 's https://github.com/spack/spack/pull/50207/changes/b91b254367464eb780070560d5165215d614ede4.

This PR adds two unit tests related to the relatively new include feature: `test_config_scope_empty_write` and `test_config_optional_include_failures`
