### PR TITLE
WIP: Separate canonicalization for files and urls

### DIFF
--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -239,7 +239,7 @@ def add_padding(path, length):
 
 
 def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
-    """Same as substitute_path_variables, but also take absolute path.
+    """Same as substitute_path_variables, but also takes an absolute path.
 
     If the string is a yaml object with file annotations, make absolute paths
     relative to that file's directory.
@@ -249,10 +249,8 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
         path: path being converted as needed
         default_wd: optional working directory/root for non-yaml string paths
 
-    Returns: An absolute path or non-file URL with path variable substitution
+    Returns: An absolute path with path variable substitution
     """
-    import urllib.parse
-    import urllib.request
 
     # Get file in which path was written in case we need to make it absolute
     # relative to that path.
@@ -270,17 +268,7 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
         # (though DOS does allow drive-relative paths).
         return os.path.normpath(str(win_path))
 
-    # Now process linux-like paths and remote URLs
-    url = urllib.parse.urlparse(path)
-    url_path = urllib.request.url2pathname(url.path)
-    if url.scheme:
-        if url.scheme != "file":
-            # Have a remote URL so simply return it with substitutions
-            return path
-
-        # Drop the URL scheme from the local path
-        path = url_path
-
+    # Now process linux-like paths
     if os.path.isabs(path):
         return os.path.normpath(path)
 

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -7,13 +7,17 @@ Utility functions for parsing, formatting, and manipulating URLs.
 """
 
 import posixpath
+import pathlib
 import re
 import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Optional
 
-from spack.util.path import sanitize_filename
+from spack.util.path import sanitize_filename, substitute_path_variables
+import spack.util.spack_yaml as syaml
+
+from llnl.util import tty
 
 
 def validate_scheme(scheme):
@@ -153,58 +157,52 @@ def parse_link_rel_next(link_value: str) -> Optional[str]:
     return None
 
 
-def canonicalize_url(url: str, default_wd: Optional[str] = None) -> str:
+def canonicalize_url(url: str, default_wd: Optional[pathlib.Path] = None) -> str:
     """Same as substitute_path_variables, but for urls.
 
-    If the url is a yaml object with file annotations, make absolute paths
-    relative to that file's directory.
-    Otherwise, use ``default_wd`` if specified, otherwise ``os.getcwd()``
+    If the url is a file url:
+        If represented by a yaml object with file annotations,
+        make absolute paths relative to that file's directory.
+        Otherwise, use ``default_wd`` if specified, otherwise
+        ``os.getcwd()``
 
     Arguments:
         url: url being converted as needed
-        default_wd: optional working directory/root for non-yaml urls
+        default_wd: optional working directory/root for non-yaml file urls
 
-    Returns: An absolute path or non-file URL with path variable substitution
+    Returns: A canonicalized url. File urls are returned as absolute file urls.
     """
+    c_url = substitute_path_variables(url)
+
+    # Now process linux-like paths and remote URLs
+    p_url = urllib.parse.urlparse(c_url)
+    path = pathlib.PurePath(urllib.request.url2pathname(p_url.path))
+
+    if not p_url.scheme:
+        # url argument is not a valid url
+        raise RuntimeError("Attempting to canonicalize a non url object from url canonicalization")
+    
+    if p_url.scheme != "file":
+        # Have a remote URL so simply return it with substitutions
+        return c_url
 
     # Get file in which path was written in case we need to make it absolute
     # relative to that path.
     
     filename = None
-    if isinstance(path, syaml.syaml_str):
-        filename = os.path.dirname(path._start_mark.name)  # type: ignore[attr-defined]
-        assert path._start_mark.name == path._end_mark.name  # type: ignore[attr-defined]
+    if isinstance(url, syaml.syaml_str):
+        filename = pathlib.Path(os.path.dirname(url._start_mark.name))  # type: ignore[attr-defined]
+        assert url._start_mark.name == url._end_mark.name  # type: ignore[attr-defined]
 
-    path = substitute_path_variables(path)
-
-    # Ensure properly process a Windows path
-    win_path = pathlib.PureWindowsPath(path)
-    if win_path.drive:
-        # Assume only absolute paths are supported with a Windows drive
-        # (though DOS does allow drive-relative paths).
-        return os.path.normpath(str(win_path))
-
-    # Now process linux-like paths and remote URLs
-    url = urllib.parse.urlparse(path)
-    url_path = urllib.request.url2pathname(url.path)
-    if url.scheme:
-        if url.scheme != "file":
-            # Have a remote URL so simply return it with substitutions
-            return path
-
-        # Drop the URL scheme from the local path
-        path = url_path
-
-    if os.path.isabs(path):
-        return os.path.normpath(path)
+    if path.is_absolute():
+        return urllib.parse.urlunparse(("file", "", os.path.normpath(path), "", "", ""))
 
     # Have a relative path so prepend the appropriate dir to make it absolute
     if filename:
         # Prepend the directory of the syaml path
-        return os.path.normpath(os.path.join(filename, path))
+        return urllib.parse.urlunparse(("file", "", os.path.normpath(filename / path), "", "", ""))
 
     # Prepend the default, if provided, or current working directory.
-    base = default_wd or os.getcwd()
+    base = default_wd or pathlib.Path.cwd()
     tty.debug(f"Using working directory {base} as base for abspath")
-    return os.path.normpath(os.path.join(base, path))
-
+    return urllib.parse.urlunparse(("file", "", os.path.normpath(base / path), "", "", ""))

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -151,3 +151,60 @@ def parse_link_rel_next(link_value: str) -> Optional[str]:
         data = data[1:]
 
     return None
+
+
+def canonicalize_url(url: str, default_wd: Optional[str] = None) -> str:
+    """Same as substitute_path_variables, but for urls.
+
+    If the url is a yaml object with file annotations, make absolute paths
+    relative to that file's directory.
+    Otherwise, use ``default_wd`` if specified, otherwise ``os.getcwd()``
+
+    Arguments:
+        url: url being converted as needed
+        default_wd: optional working directory/root for non-yaml urls
+
+    Returns: An absolute path or non-file URL with path variable substitution
+    """
+
+    # Get file in which path was written in case we need to make it absolute
+    # relative to that path.
+    
+    filename = None
+    if isinstance(path, syaml.syaml_str):
+        filename = os.path.dirname(path._start_mark.name)  # type: ignore[attr-defined]
+        assert path._start_mark.name == path._end_mark.name  # type: ignore[attr-defined]
+
+    path = substitute_path_variables(path)
+
+    # Ensure properly process a Windows path
+    win_path = pathlib.PureWindowsPath(path)
+    if win_path.drive:
+        # Assume only absolute paths are supported with a Windows drive
+        # (though DOS does allow drive-relative paths).
+        return os.path.normpath(str(win_path))
+
+    # Now process linux-like paths and remote URLs
+    url = urllib.parse.urlparse(path)
+    url_path = urllib.request.url2pathname(url.path)
+    if url.scheme:
+        if url.scheme != "file":
+            # Have a remote URL so simply return it with substitutions
+            return path
+
+        # Drop the URL scheme from the local path
+        path = url_path
+
+    if os.path.isabs(path):
+        return os.path.normpath(path)
+
+    # Have a relative path so prepend the appropriate dir to make it absolute
+    if filename:
+        # Prepend the directory of the syaml path
+        return os.path.normpath(os.path.join(filename, path))
+
+    # Prepend the default, if provided, or current working directory.
+    base = default_wd or os.getcwd()
+    tty.debug(f"Using working directory {base} as base for abspath")
+    return os.path.normpath(os.path.join(base, path))
+

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -6,18 +6,19 @@
 Utility functions for parsing, formatting, and manipulating URLs.
 """
 
-import posixpath
+import os
 import pathlib
+import posixpath
 import re
 import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Optional, Union
 
-from spack.util.path import sanitize_filename, substitute_path_variables
-import spack.util.spack_yaml as syaml
-
 from llnl.util import tty
+
+import spack.util.spack_yaml as syaml
+from spack.util.path import sanitize_filename, substitute_path_variables
 
 
 def validate_scheme(scheme):
@@ -156,6 +157,7 @@ def parse_link_rel_next(link_value: str) -> Optional[str]:
 
     return None
 
+
 def handle_windows_file_urls(url: str) -> str:
     """Handles file urls with Windows style paths.
     Colons are present in both network paths as well as
@@ -167,7 +169,7 @@ def handle_windows_file_urls(url: str) -> str:
 
     Many file urls with Windows style paths are naively and inccorectly
     composed as 'file://' + path, which results in incorrect parsing
-    
+
     This method contains some heuristics to detect a Windows file url,
     and marshall it so it's properly formed and thus can be reasoned about
 
@@ -204,7 +206,6 @@ def make_file_url(path: Union[str, pathlib.Path]) -> str:
     if check_path.drive:
         url_path = "/" + url_path
     return urllib.parse.urlunparse(("file", "", url_path, "", "", ""))
-    
 
 
 def canonicalize_url(url: str, default_wd: Optional[pathlib.Path] = None) -> str:
@@ -231,17 +232,19 @@ def canonicalize_url(url: str, default_wd: Optional[pathlib.Path] = None) -> str
     if not p_url.scheme:
         # url argument is not a valid url
         raise RuntimeError("Attempting to canonicalize a non url object from url canonicalization")
-    
+
     if p_url.scheme != "file":
         # Have a remote URL so simply return it with substitutions
         return c_url
 
     # Get file in which path was written in case we need to make it absolute
     # relative to that path.
-    
+
     filename = None
     if isinstance(url, syaml.syaml_str):
-        filename = pathlib.Path(os.path.dirname(url._start_mark.name))  # type: ignore[attr-defined]
+        filename = pathlib.Path(
+            os.path.dirname(url._start_mark.name)  # type: ignore[attr-defined]
+        )
         assert url._start_mark.name == url._end_mark.name  # type: ignore[attr-defined]
 
     if path.is_absolute():

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -12,7 +12,7 @@ import re
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from spack.util.path import sanitize_filename, substitute_path_variables
 import spack.util.spack_yaml as syaml
@@ -196,6 +196,14 @@ def handle_windows_file_urls(url: str) -> str:
     # special handling w.r.t. Windows
     return url
 
+
+def make_file_url(path: Union[str, pathlib.Path]) -> str:
+    """Create properly formatted file url"""
+    check_path = pathlib.PureWindowsPath(str(path))
+    url_path = str(path)
+    if check_path.drive:
+        url_path = "/" + url_path
+    return urllib.parse.urlunparse(("file", "", url_path, "", "", ""))
     
 
 

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -156,6 +156,48 @@ def parse_link_rel_next(link_value: str) -> Optional[str]:
 
     return None
 
+def handle_windows_file_urls(url: str) -> str:
+    """Handles file urls with Windows style paths.
+    Colons are present in both network paths as well as
+    Windows drive separators.
+    A proper Windows file url will have any drive
+    delineators prefixed with a forward slash to prevent
+    the file path component of the url from being interpreted
+    a network location.
+
+    Many file urls with Windows style paths are naively and inccorectly
+    composed as 'file://' + path, which results in incorrect parsing
+    
+    This method contains some heuristics to detect a Windows file url,
+    and marshall it so it's properly formed and thus can be reasoned about
+
+    Arguments:
+        url: url being evalulated as a potential Windows file url
+
+    Returns: url if url is not a Windows file url, a properly formated
+    Windows file url if it is.
+    """
+    processed_url = urllib.parse.urlparse(url)
+    if not processed_url.scheme:
+        # definitely not a url, file or otherwise
+        return url
+    is_file_url = processed_url.scheme == "file"
+    if not is_file_url:
+        # not a file url, no need to process
+        return url
+    if processed_url.path and pathlib.PureWindowsPath(processed_url.path.lstrip("/")).drive:
+        # url was actually properly formed
+        return url
+    if processed_url.netloc and pathlib.PureWindowsPath(processed_url.netloc):
+        # A file url shouldn't have a netloc, but a poorly formed Windows url will
+        return "file:///" + processed_url.netloc
+
+    # if the above didn't catch this, this is likely a relative path, and requires no
+    # special handling w.r.t. Windows
+    return url
+
+    
+
 
 def canonicalize_url(url: str, default_wd: Optional[pathlib.Path] = None) -> str:
     """Same as substitute_path_variables, but for urls.


### PR DESCRIPTION
WIP: need to add better "is a url" detection

`canonicalize_path` previous endeavored to handle the canonicalization of files and urls, which lead to increased complexity and a lack of specification in that method.

This PR separates those methods into type specific canonicalizations, and attempts to determine which should be used for a given context. 

The actual functionality of the canonicalization procedure has not changed substantively in this PR, it's more of a refactor into two semi-equivalent methods, with more specific roles. This also allows us to remove a local import of urllib into `canonicalize_path`. 

To do:

Update tests and call sites