### PR TITLE
Revert "env: drop default venv search path from `PYTHONPATH` when activating Spack env  (#51743)"

### DIFF
--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -116,21 +116,4 @@ def environment_modifications_for_specs(
     if view:
         project_env_mods(*topo_ordered, view=view, env=env)
 
-        # we don't want to set PYTHONPATH to the default search path in virtual environments
-        view_python_pattern = re.compile(
-            r"^" + re.escape(os.path.join(view.root, "lib")) + r"/python[^/]+/site-packages$"
-        )
-
-        mods = [
-            mod.value
-            for mod in env.env_modifications
-            if (
-                isinstance(mod, environment.PrependPath)
-                and mod.name == "PYTHONPATH"
-                and view_python_pattern.match(mod.value)
-            )
-        ]
-
-        for modif in mods:
-            env.remove_path("PYTHONPATH", modif)
     return env


### PR DESCRIPTION
Two packages don't work as expected as a result of dropping PYTHONPATH
from `spack env activate`:

* `py-jupyterlab` can't locate `ipykernel_launcher` because it runs
  `python-venv/bin/python3` directly. Also, when using jupyterlab, you
  probably wanna be able to `import foo` from the Spack environment.
  #51906
* `paraview` has `pvpython`, a binary with a hard-coded path to
  `python-venv/bin/python3` which also doesn't know how to import things
  from the environment view. #paraview

This reverts commit 8266c6926ed83370113f0e41b517b638826e5d42.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
