### PR TITLE
solver: unify run dependencies of build tools

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -80,7 +80,27 @@ error(1, "Cannot have multiple nodes for {0} in the same unification set {1}", P
   :- 2 { unification_set(SetID, node(_, PackageName)) }, unify(SetID, PackageName).
 
 unification_set("root", PackageNode) :- attr("root", PackageNode).
-unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).
+
+isolated_build_set(SetID) :- unification_set(SetID, _), SetID = ("build", _).
+
+% Non-isolated sets inherit normally
+unification_set(SetID, ChildNode) :-
+    attr("depends_on", ParentNode, ChildNode, Type),
+    Type != "build",
+    unification_set(SetID, ParentNode),
+    not isolated_build_set(SetID).
+
+% Isolated sets (build tools) keep link deps private, but expose run deps
+unification_set(SetID, ChildNode) :-
+    attr("depends_on", ParentNode, ChildNode, Type),
+    Type != "build", Type != "run",
+    unification_set(SetID, ParentNode),
+    isolated_build_set(SetID).
+
+unification_set("generic_build", ChildNode) :-
+    attr("depends_on", ParentNode, ChildNode, "run"),
+    unification_set(SetID, ParentNode),
+    isolated_build_set(SetID).
 
 build_only_dependency(ParentNode, node(X, Child)) :-
   attr("depends_on", ParentNode, node(X, Child), "build"),


### PR DESCRIPTION
Previously, the concretizer allowed "isolated" build tools (packages
with multiple unification sets, like `py-setuptools`) to keep all their
non-build dependencies private. This was achieved by having children
inherit the parent's isolated unification set for both `link` and `run`
edges.

While likely correct for `link` dependencies, this is incorrect for
`run` dependencies. `Run` dependencies of build tools contribute to the
environment of the build (e.g. `PYTHONPATH` or `PATH`).

This caused an issue where a build tool could bring in
`py-setuptools@old` (isolated) while the root package brought in
`py-setuptools@new` (generic_build). Both would be present in the build
environment, leading to failures during the build.

This commit updates the unification rules:

1. `link` dependencies of isolated nodes continue to inherit the
   isolated set.
2. `run` dependencies of isolated nodes now "escape" isolation and are
   forced into the `generic_build` set.

This ensures that any package contributing to the runtime environment is
unified across the entire build graph.

