### PR TITLE
Bugfix/cmd list: return proper path for json and html output

### DIFF
--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -149,7 +149,7 @@ def github_url(pkg: Type[spack.package_base.PackageBase]) -> Optional[str]:
     Args:
         pkg: package instance
 
-    Returns: link to the package file on github, the local file path, or ``None``.
+    Returns: URL to the package file on github or the local file path; otherwise, ``None``.
     """
     git = None
     module_path = f"{pkg.__module__.replace('.', '/')}.py"
@@ -163,8 +163,8 @@ def github_url(pkg: Type[spack.package_base.PackageBase]) -> Optional[str]:
 
         git = git or spack.util.git.git()
         if not git:
-            tty.debug("Cannot determine package URL for {pkg} without 'git'")
-            return None
+            tty.debug("Cannot determine package URL for {pkg} without 'git', using path URL")
+            return path_to_file_url(path)
 
         tty.debug(f"Checking git for repository path '{path}'")
         with working_dir(os.path.dirname(path)):
@@ -174,14 +174,26 @@ def github_url(pkg: Type[spack.package_base.PackageBase]) -> Optional[str]:
                 "remote.origin.url",
                 output=str,
                 error=os.devnull,
-                fail_on_error=True,
+                fail_on_error=False,
             )
-            tty.debug(f"Processing the git URL '{origin_url}'")
-            if "github.com" not in origin_url:
+
+            if not origin_url:
+                tty.debug("Cannot determine remote origin url, using path URL")
                 return path_to_file_url(path)
 
-            if "spack-packages" in origin_url:
-                return f"https://github.com/spack/spack-packages/blob/develop/repos/{module_path}"
+            # Handle spack repositories cloned with any scheme (e.g., ssh) by
+            # ignoring the scheme designation.
+            if any([name in origin_url for name in ["spack.git", "spack-packages.git"]]):
+                git_repo = (origin_url.split("/")[-1]).replace(".git", "").strip()
+                prefix = git(
+                    "rev-parse", "--show-prefix", output=str, error=os.devnull, fail_on_error=False
+                )
+                return (
+                    f"https://github.com/spack/{git_repo}/blob/develop/{prefix.strip()}package.py"
+                )
+
+            tty.debug(f"Unrecognized repository for {pkg}, using path URL")
+            return path_to_file_url(path)
 
     tty.debug(f"Unable to determine the package repository URL for {pkg}")
     return None

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -10,14 +10,17 @@ import os
 import re
 import sys
 from html import escape
-from typing import Type
+from typing import Optional, Type
 
 import spack.deptypes as dt
 import spack.llnl.util.tty as tty
 import spack.package_base
 import spack.repo
+import spack.util.git
 from spack.cmd.common import arguments
+from spack.llnl.util.filesystem import working_dir
 from spack.llnl.util.tty.colify import colify
+from spack.util.url import path_to_file_url
 from spack.version import VersionList
 
 description = "list and search available packages"
@@ -140,10 +143,48 @@ def name_only(pkgs, out):
         tty.msg("%d packages" % len(pkgs))
 
 
-def github_url(pkg: Type[spack.package_base.PackageBase]) -> str:
-    """Link to a package file on github."""
-    mod_path = pkg.__module__.replace(".", "/")
-    return f"https://github.com/spack/spack/blob/develop/var/spack/{mod_path}.py"
+def github_url(pkg: Type[spack.package_base.PackageBase]) -> Optional[str]:
+    """Link to a package file in spack package's github or the path to the file.
+
+    Args:
+        pkg: package instance
+
+    Returns: link to the package file on github, the local file path, or ``None``.
+    """
+    git = None
+    module_path = f"{pkg.__module__.replace('.', '/')}.py"
+    for repo in spack.repo.PATH.repos:
+        if not repo.python_path:
+            continue
+
+        path = os.path.join(repo.python_path, module_path)
+        if not os.path.exists(path):
+            continue
+
+        git = git or spack.util.git.git()
+        if not git:
+            tty.debug("Cannot determine package URL for {pkg} without 'git'")
+            return None
+
+        tty.debug(f"Checking git for repository path '{path}'")
+        with working_dir(os.path.dirname(path)):
+            origin_url = git(
+                "config",
+                "--get",
+                "remote.origin.url",
+                output=str,
+                error=os.devnull,
+                fail_on_error=True,
+            )
+            tty.debug(f"Processing the git URL '{origin_url}'")
+            if "github.com" not in origin_url:
+                return path_to_file_url(path)
+
+            if "spack-packages" in origin_url:
+                return f"https://github.com/spack/spack-packages/blob/develop/repos/{module_path}"
+
+    tty.debug(f"Unable to determine the package repository URL for {pkg}")
+    return None
 
 
 def rows_for_ncols(elts, ncols):

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -63,6 +63,8 @@ def test_list_format_version_json():
     output = list("--format", "version_json")
     assert '{"name": "zmpi",' in output
     assert '{"name": "dyninst",' in output
+    assert "packages/zmpi/package.py" in output
+
     import json
 
     json.loads(output)
@@ -75,6 +77,84 @@ def test_list_format_html():
 
     assert '<div class="section" id="hdf5">' in output
     assert "<h1>hdf5" in output
+    assert "packages/hdf5/package.py" in output
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "git@github.com:username/spack-packages.git",
+        "https://github.com/username/spack-packages.git",
+        "git@github.com:username/spack.git",
+        "https://github.com/username/spack.git",
+    ],
+)
+def test_list_url_schemes(mock_util_executable, url):
+    """Confirm the command handles supported repository URLs."""
+    pkg_name = "hdf5"
+
+    _, _, registered_responses = mock_util_executable
+    registered_responses["config"] = url
+    registered_responses["rev-parse"] = f"path/to/builtin/packages/{pkg_name}/"
+
+    output = list("--format", "version_json", pkg_name)
+    assert f"{registered_responses['rev-parse']}package.py" in output
+    assert os.path.basename(url).replace(".git", "") in output
+
+
+def test_list_format_local_repo(tmp_path: pathlib.Path):
+    """Confirm a file path is returned for local repository."""
+    pkg_name = "mypkg"
+    repo_root = tmp_path / "repos" / "spack_repo" / "builtin"
+    repo_root.mkdir(parents=True)
+    (repo_root / "repo.yaml").write_text("repo:\n  namespace: builtin\n  api: v2.2\n")
+    package_root = repo_root / "packages" / pkg_name
+    package_root.mkdir(parents=True)
+    (package_root / "package.py").write_text(
+        """\
+from spack.package import *
+
+class Mypkg(Package):
+    pass
+"""
+    )
+
+    test_repo = spack.repo.from_path(str(repo_root))
+    with spack.repo.use_repositories(test_repo):
+        # Confirm a path is returned when fail to retrieve the remote origin URL
+        output = list("--format", "version_json", pkg_name)
+        assert "github.com" not in output
+        assert "packages{0}{1}{0}package.py".format(os.sep, pkg_name) in output
+
+
+def test_list_format_non_github_repo(tmp_path: pathlib.Path, mock_util_executable):
+    """Confirm a file path is returned for a non-github repository."""
+    pkg_name = "mypkg"
+    repo_root = tmp_path / "my" / "project" / "spack_repo" / "builtin"
+    repo_root.mkdir(parents=True)
+    (repo_root / "repo.yaml").write_text("repo:\n  namespace: builtin\n  api: v2.2\n")
+    package_root = repo_root / "packages" / pkg_name
+    package_root.mkdir(parents=True)
+    (package_root / "package.py").write_text(
+        """\
+from spack.package import *
+
+class Mypkg(Package):
+    pass
+"""
+    )
+
+    test_repo = spack.repo.from_path(str(repo_root))
+    with spack.repo.use_repositories(test_repo):
+        # Confirm a path is returned for a non-standard spack repository
+        _, _, registered_responses = mock_util_executable
+        registered_responses["config"] = "https://gitlab.com/username/my-packages.git"
+        registered_responses["rev-parse"] = str(package_root) + os.sep
+
+        output = list("--format", "version_json", pkg_name)
+        for ln in output.split("\n"):
+            print(f"TLD: {ln}")
+        assert f"{registered_responses['rev-parse']}package.py" in output
 
 
 def test_list_update(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -135,7 +135,8 @@ def test_list_format_non_github_repo(tmp_path: pathlib.Path, mock_util_executabl
     (repo_root / "repo.yaml").write_text("repo:\n  namespace: builtin\n  api: v2.2\n")
     package_root = repo_root / "packages" / pkg_name
     package_root.mkdir(parents=True)
-    (package_root / "package.py").write_text(
+    package_path = package_root / "package.py"
+    package_path.write_text(
         """\
 from spack.package import *
 
@@ -152,9 +153,7 @@ class Mypkg(Package):
         registered_responses["rev-parse"] = str(package_root) + os.sep
 
         output = list("--format", "version_json", pkg_name)
-        for ln in output.split("\n"):
-            print(f"TLD: {ln}")
-        assert f"{registered_responses['rev-parse']}package.py" in output
+        assert package_path.as_uri() in output
 
 
 def test_list_update(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -7,9 +7,12 @@ import pathlib
 
 import pytest
 
+import spack.cmd.list
 import spack.paths
 import spack.repo
+import spack.util.git
 from spack.main import SpackCommand
+from spack.test.conftest import RepoBuilder
 
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
 
@@ -219,3 +222,34 @@ def test_list_repos():
 
         assert total_pkgs > mock_pkgs > builder_pkgs
         assert both_repos == total_pkgs
+
+
+@pytest.mark.usefixtures("config")
+def test_list_github_url_fails(repo_builder: RepoBuilder, monkeypatch):
+    with spack.repo.use_repositories(repo_builder.root):
+        repo_builder.add_package("pkg-a")
+        repo = spack.repo.PATH.repos[0]
+        pkg = repo.get_pkg_class("pkg-a")
+
+        old_path = repo.python_path
+        try:
+            # Check that a repository with no python path has no URL
+            monkeypatch.setattr(repo, "python_path", None)
+            assert (
+                spack.cmd.list.github_url(pkg) is None
+            ), "Expected no python path means unable to determine the repo URL"
+
+            # Check that a repository path that doesn't exist has no URL
+            monkeypatch.setattr(repo, "python_path", "/repo/root/does/not/exists")
+            assert (
+                spack.cmd.list.github_url(pkg) is None
+            ), "Expected bad repo path means unable to determine the repo URL"
+        finally:
+            monkeypatch.setattr(repo, "python_path", old_path)
+
+        # Check that missing git results in the file path
+        monkeypatch.setattr(spack.util.git, "git", lambda: None)
+        filepath = spack.cmd.list.github_url(pkg)
+        assert filepath and filepath.startswith(
+            "file://"
+        ), "Expected missing 'git' results in a file URI"

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -124,7 +124,7 @@ class Mypkg(Package):
         # Confirm a path is returned when fail to retrieve the remote origin URL
         output = list("--format", "version_json", pkg_name)
         assert "github.com" not in output
-        assert "packages{0}{1}{0}package.py".format(os.sep, pkg_name) in output
+        assert f"packages/{pkg_name}/package.py" in output
 
 
 def test_list_format_non_github_repo(tmp_path: pathlib.Path, mock_util_executable):


### PR DESCRIPTION
@johnwparent 

UPDATE: Also modified the handling to support `ssh`, local, and non-spack package repositories. This means it uses `git` commands to check the remote origin URL and the relative path to the package to build a suitable package URL or, if unsupported, it returns the local file path.

Problem: `spack list` for json and html output yield `file` or `reference external` entries that point to the old `var/spack` subdirectory of the core repository. For example:

```
$ spack list --format version_json abacus
[
  {"name": "abacus",
   "latest_version": "2.2.3",
   "versions": ["develop", "2.2.3", "2.2.2", "2.2.1", "2.2.0"],
   "homepage": "http://abacus.ustc.edu.cn/",
   "file": "https://github.com/spack/spack/blob/develop/var/spack/spack_repo/builtin/packages/abacus/package.py",
   "maintainers": ["bitllion"],
   "dependencies": {"build": ["mpi", "libxc", "cxx", "c", "gmake", "mkl", "cereal", "fftw", "elpa"], "link": ["mpi", "libxc", "mkl", "cereal", "fftw", "elpa"], "run": ["mpi"], "test": []}}
]
```


This PR checks the package repository and returns the `spack/spack-packages` URL if it is a `spack-packages` GitHub repository. Otherwise, it will return either the file path (if not a GitHub repo) or ``None``. For example:

```
$ spack repo list
[+] builtin    v2.2    $HOME/spack-packages/repos/spack_repo/builtin
$ spack list --format version_json abacus
[
  {"name": "abacus",
   "latest_version": "2.2.3",
   "versions": ["develop", "2.2.3", "2.2.2", "2.2.1", "2.2.0"],
   "homepage": "http://abacus.ustc.edu.cn/",
   "file": "https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/abacus/package.py",
   "maintainers": ["bitllion"],
   "dependencies": {"build": ["libxc", "gmake", "c", "cereal", "elpa", "cxx", "fftw", "mkl", "mpi"], "link": ["libxc", "cereal", "elpa", "fftw", "mkl", "mpi"], "run": ["mpi"], "test": []}}
]
```

TODO:
- [x] Add unit tests