### PR TITLE
concretizer.lp: unify build environment

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -87,10 +87,11 @@ separate_build_unification_set_allowed(ParentNode) :-
   attr("depends_on", ParentNode, node(X, Child), "build"),
   multiple_unification_sets(Child).
 
-% Build dependencies always go into a build unification set together with their siblings
+% If any of the build dependencies can be duplicated, they can go into any ("build", ID) set
 unification_set(("build", ID), node(X, Child))
   :- attr("depends_on", ParentNode, node(X, Child), "build"),
      build_set_id(ParentNode, ID),
+     separate_build_unification_set_allowed(ParentNode),
      unification_set(_, ParentNode).
 
 % If none of the build dependencies can be duplicated, they go into the ("build", 0) set

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2063,6 +2063,12 @@ opt_criterion(100, "number of nodes from the same package").
 #minimize { ID@100,Package : attr("virtual_node", node(ID, Package)) }.
 #defined optimize_for_reuse/0.
 
+% Minimize the unification set ID used for build dependencies. This reduces the number of optimal
+% solutions that differ only by which node belongs to which unification set.
+opt_criterion(90, "minimize build unification set id").
+#minimize{ 0@90: #true }.
+#minimize{ ID@90,ParentNode : build_set_id(ParentNode, ID) }.
+
 % Minimize the number of deprecated versions being used
 opt_criterion(73, "deprecated versions used").
 #minimize{ 0@273: #true }.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -82,34 +82,31 @@ error(1, "Cannot have multiple nodes for {0} in the same unification set {1}", P
 unification_set("root", PackageNode) :- attr("root", PackageNode).
 unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).
 
-build_only_dependency(ParentNode, node(X, Child)) :-
-  attr("depends_on", ParentNode, node(X, Child), "build"),
-  not attr("depends_on", ParentNode, node(X, Child), "link"),
-  not attr("depends_on", ParentNode, node(X, Child), "run").
-
-% Trigger a separate build unification set if there is a pure build dependency that is allowed
-% to go into its own unification set
+% Trigger a separate build unification set if there is build dependency that is allowed to go into
+% its own unification set
 has_separate_build_unification_set(ParentNode) :-
-  build_only_dependency(ParentNode, node(X, Child)),
+  attr("depends_on", ParentNode, node(X, Child), "build"),
   multiple_unification_sets(Child).
+
+% General case: build dependencies of any parent are put in the same unification set named
+% "generic_build"
+unification_set("generic_build", node(X, Child))
+  :- attr("depends_on", ParentNode, node(X, Child), "build"),
+     not has_separate_build_unification_set(ParentNode),
+     unification_set(_, ParentNode).
+
+% Special case: build dependencies are put into a separate unification set if one of their sibling
+% build dependencies is allowed to be duplicated
+unification_set(("build", ID), node(X, Child))
+  :- attr("depends_on", ParentNode, node(X, Child), "build"),
+     build_set_id(ParentNode, ID),
+     unification_set(_, ParentNode).
 
 % Limit the number of build unification sets to a reasonable number to avoid combinatorial
 % explosion.
 #const max_build_unification_sets = 4.
 1 { build_set_id(ParentNode, 0..max_build_unification_sets-1) } 1
   :- has_separate_build_unification_set(ParentNode).
-
-% General case: build dependencies are put in the same unification set named "generic_build"
-unification_set("generic_build", node(X, Child))
-  :- attr("depends_on", ParentNode, node(X, Child), "build"),
-     not has_separate_build_unification_set(ParentNode),
-     unification_set(_, ParentNode).
-
-% Create a separate build unification set if one of the pure build dependencies is allowed to
-unification_set(("build", ID), node(X, Child))
-  :- attr("depends_on", ParentNode, node(X, Child), "build"),
-     build_set_id(ParentNode, ID),
-     unification_set(_, ParentNode).
 
 unification_set(SetID, VirtualNode)
   :- provider(PackageNode, VirtualNode),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -83,7 +83,7 @@ unification_set("root", PackageNode) :- attr("root", PackageNode).
 unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).
 
 % A separate unification set can be created if any of the build dependencies can be duplicated
-has_separate_build_unification_set(ParentNode) :-
+separate_build_unification_set_allowed(ParentNode) :-
   attr("depends_on", ParentNode, node(X, Child), "build"),
   multiple_unification_sets(Child).
 
@@ -96,13 +96,13 @@ unification_set(("build", ID), node(X, Child))
 % If none of the build dependencies can be duplicated, they go into the ("build", 0) set
 unification_set(("build", 0), node(X, Child))
   :- attr("depends_on", ParentNode, node(X, Child), "build"),
-     not has_separate_build_unification_set(ParentNode),
+     not separate_build_unification_set_allowed(ParentNode),
      unification_set(_, ParentNode).
 
 % Limit the number of unification sets to a reasonable number to avoid combinatorial explosion
 #const max_build_unification_sets = 4.
 1 { build_set_id(ParentNode, 0..max_build_unification_sets-1) } 1
-  :- has_separate_build_unification_set(ParentNode).
+  :- separate_build_unification_set_allowed(ParentNode).
 
 unification_set(SetID, VirtualNode)
   :- provider(PackageNode, VirtualNode),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -87,14 +87,28 @@ build_only_dependency(ParentNode, node(X, Child)) :-
   not attr("depends_on", ParentNode, node(X, Child), "link"),
   not attr("depends_on", ParentNode, node(X, Child), "run").
 
-unification_set(("build", node(X, Child)), node(X, Child))
-  :- build_only_dependency(ParentNode, node(X, Child)),
-     multiple_unification_sets(Child),
+% Trigger a separate build unification set if there is a pure build dependency that is allowed
+% to go into its own unification set
+has_separate_build_unification_set(ParentNode) :-
+  build_only_dependency(ParentNode, node(X, Child)),
+  multiple_unification_sets(Child).
+
+% Limit the number of build unification sets to a reasonable number to avoid combinatorial
+% explosion.
+#const max_build_unification_sets = 4.
+1 { build_set_id(ParentNode, 0..max_build_unification_sets-1) } 1
+  :- has_separate_build_unification_set(ParentNode).
+
+% General case: build dependencies are put in the same unification set named "generic_build"
+unification_set("generic_build", node(X, Child))
+  :- attr("depends_on", ParentNode, node(X, Child), "build"),
+     not has_separate_build_unification_set(ParentNode),
      unification_set(_, ParentNode).
 
-unification_set("generic_build", node(X, Child))
-  :- build_only_dependency(ParentNode, node(X, Child)),
-     not multiple_unification_sets(Child),
+% Create a separate build unification set if one of the pure build dependencies is allowed to
+unification_set(("build", ID), node(X, Child))
+  :- attr("depends_on", ParentNode, node(X, Child), "build"),
+     build_set_id(ParentNode, ID),
      unification_set(_, ParentNode).
 
 unification_set(SetID, VirtualNode)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2062,7 +2062,7 @@ opt_criterion(100, "number of nodes from the same package").
 
 % Minimize the unification set ID used for build dependencies. This reduces the number of optimal
 % solutions that differ only by which node belongs to which unification set.
-opt_criterion(90, "minimize build unification set id").
+opt_criterion(90, "build unification sets").
 #minimize{ 0@90: #true }.
 #minimize{ ID@90,ParentNode : build_set_id(ParentNode, ID) }.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -88,18 +88,16 @@ has_separate_build_unification_set(ParentNode) :-
   attr("depends_on", ParentNode, node(X, Child), "build"),
   multiple_unification_sets(Child).
 
-% General case: build dependencies of any parent are put in the same unification set named
-% "generic_build"
-unification_set("generic_build", node(X, Child))
-  :- attr("depends_on", ParentNode, node(X, Child), "build"),
-     not has_separate_build_unification_set(ParentNode),
-     unification_set(_, ParentNode).
-
-% Special case: build dependencies are put into a separate unification set if one of their sibling
-% build dependencies is allowed to be duplicated
+% Build dependencies go into a build unification set together with their siblings
 unification_set(("build", ID), node(X, Child))
   :- attr("depends_on", ParentNode, node(X, Child), "build"),
      build_set_id(ParentNode, ID),
+     unification_set(_, ParentNode).
+
+% If none of the build dependencies can be duplicated, they go into the ("build", 0) set
+unification_set(("build", 0), node(X, Child))
+  :- attr("depends_on", ParentNode, node(X, Child), "build"),
+     not has_separate_build_unification_set(ParentNode),
      unification_set(_, ParentNode).
 
 % Limit the number of build unification sets to a reasonable number to avoid combinatorial

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -83,9 +83,7 @@ unification_set("root", PackageNode) :- attr("root", PackageNode).
 unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).
 
 % A separate unification set can be created if any of the build dependencies can be duplicated
-separate_build_unification_set_allowed(ParentNode) :-
-  attr("depends_on", ParentNode, node(X, Child), "build"),
-  multiple_unification_sets(Child).
+needs_build_unification_set(ParentNode) :- attr("depends_on", ParentNode, _, "build").
 
 % If any of the build dependencies can be duplicated, they can go into any ("build", ID) set
 unification_set(("build", ID), node(X, Child))
@@ -93,16 +91,9 @@ unification_set(("build", ID), node(X, Child))
      build_set_id(ParentNode, ID),
      unification_set(_, ParentNode).
 
-% If none of the build dependencies can be duplicated, they go into the ("build", 0) set
-unification_set(("build", 0), node(X, Child))
-  :- attr("depends_on", ParentNode, node(X, Child), "build"),
-     not separate_build_unification_set_allowed(ParentNode),
-     unification_set(_, ParentNode).
-
 % Limit the number of unification sets to a reasonable number to avoid combinatorial explosion
 #const max_build_unification_sets = 4.
-1 { build_set_id(ParentNode, 0..max_build_unification_sets-1) } 1
-  :- separate_build_unification_set_allowed(ParentNode).
+1 { build_set_id(ParentNode, 0..max_build_unification_sets-1) } 1 :- needs_build_unification_set(ParentNode).
 
 unification_set(SetID, VirtualNode)
   :- provider(PackageNode, VirtualNode),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -91,7 +91,6 @@ separate_build_unification_set_allowed(ParentNode) :-
 unification_set(("build", ID), node(X, Child))
   :- attr("depends_on", ParentNode, node(X, Child), "build"),
      build_set_id(ParentNode, ID),
-     separate_build_unification_set_allowed(ParentNode),
      unification_set(_, ParentNode).
 
 % If none of the build dependencies can be duplicated, they go into the ("build", 0) set

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -82,13 +82,12 @@ error(1, "Cannot have multiple nodes for {0} in the same unification set {1}", P
 unification_set("root", PackageNode) :- attr("root", PackageNode).
 unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).
 
-% Trigger a separate build unification set if there is build dependency that is allowed to go into
-% its own unification set
+% A separate unification set can be created if any of the build dependencies can be duplicated
 has_separate_build_unification_set(ParentNode) :-
   attr("depends_on", ParentNode, node(X, Child), "build"),
   multiple_unification_sets(Child).
 
-% Build dependencies go into a build unification set together with their siblings
+% Build dependencies always go into a build unification set together with their siblings
 unification_set(("build", ID), node(X, Child))
   :- attr("depends_on", ParentNode, node(X, Child), "build"),
      build_set_id(ParentNode, ID),
@@ -100,8 +99,7 @@ unification_set(("build", 0), node(X, Child))
      not has_separate_build_unification_set(ParentNode),
      unification_set(_, ParentNode).
 
-% Limit the number of build unification sets to a reasonable number to avoid combinatorial
-% explosion.
+% Limit the number of unification sets to a reasonable number to avoid combinatorial explosion
 #const max_build_unification_sets = 4.
 1 { build_set_id(ParentNode, 0..max_build_unification_sets-1) } 1
   :- has_separate_build_unification_set(ParentNode).

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2966,6 +2966,26 @@ class TestConcretizeSeparately:
         assert len(edges) == 1
         assert edges[0].spec.satisfies("@=60")
 
+    def test_build_environment_is_unified(self):
+        """A pure build dep that is marked build-tool can creates its own unification set. This
+        test ensures that its sibling build dependencies are unified with it, together with their
+        runtime dependencies. It ensures the same package cannot appear multiple times in a single
+        build environment, for example when it's both a direct build dep, as well as pulled in as
+        a transitive runtime dep of a sibling build dep."""
+        spack.config.CONFIG.set("concretizer:duplicates", {"max_dupes": {"unify-build-deps-c": 2}})
+
+        # Fails because unify-build-deps-c version @1 and @2 are needed in the build environment
+        with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
+            spack.concretize.concretize_one("unify-build-deps-a@1.0")
+
+        # Succeeds because unify-build-deps-c version @2 is not needed in the build environment
+        spack.concretize.concretize_one("unify-build-deps-a@2.0")
+
+        # Lastly, a sanity check that max_dupes is a requirement for this to work.
+        spack.config.CONFIG.set("concretizer:duplicates", {"max_dupes": {"unify-build-deps-c": 1}})
+        with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
+            spack.concretize.concretize_one("unify-build-deps-a@2.0")
+
     @pytest.mark.regression("43647")
     def test_specifying_different_versions_build_deps(self):
         """Tests that we can concretize a spec with nodes using the same build

--- a/var/spack/test_repos/spack_repo/duplicates_test/packages/py_numpy/package.py
+++ b/var/spack/test_repos/spack_repo/duplicates_test/packages/py_numpy/package.py
@@ -17,5 +17,5 @@ class PyNumpy(Package):
     version("1.25.0", md5="0123456789abcdef0123456789abcdef")
 
     extends("python")
-    depends_on("py-setuptools@=59", type=("build", "run"))
+    depends_on("py-setuptools@=59", type="build")
     depends_on("gmake@4.1", type="build")

--- a/var/spack/test_repos/spack_repo/duplicates_test/packages/unify_build_deps_a/package.py
+++ b/var/spack/test_repos/spack_repo/duplicates_test/packages/unify_build_deps_a/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class UnifyBuildDepsA(Package):
+    """Used to test that we cannot have a build environment with two conflicting versions of
+    a package (unify-build-deps-c), even if that package is tagged as a build-tool with duplicates
+    allowed."""
+
+    url = "http://example.com/unify-build-deps-a-1.0.tar.gz"
+    version("2.0", sha256="d41d8cd98f00b204e9800998ecf8427ed41d8cd98f00b204e9800998ecf8427e")
+    version("1.0", sha256="d41d8cd98f00b204e9800998ecf8427ed41d8cd98f00b204e9800998ecf8427e")
+
+    depends_on("unify-build-deps-c@1", type="build")
+
+    # If unify-build-deps-b is used as a build dependency, we cannot unify the build environment.
+    depends_on("unify-build-deps-b", type=("build", "run"), when="@1")
+
+    # If unify-build-deps-b is not used as build dependency, we can unify the build environment
+    depends_on("unify-build-deps-b", type=("link", "run"), when="@2")

--- a/var/spack/test_repos/spack_repo/duplicates_test/packages/unify_build_deps_b/package.py
+++ b/var/spack/test_repos/spack_repo/duplicates_test/packages/unify_build_deps_b/package.py
@@ -1,0 +1,11 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class UnifyBuildDepsB(Package):
+    url = "http://example.com/unify-build-deps-b-1.0.tar.gz"
+    version("1.0", sha256="d41d8cd98f00b204e9800998ecf8427ed41d8cd98f00b204e9800998ecf8427e")
+
+    depends_on("unify-build-deps-c@2", type="run")

--- a/var/spack/test_repos/spack_repo/duplicates_test/packages/unify_build_deps_c/package.py
+++ b/var/spack/test_repos/spack_repo/duplicates_test/packages/unify_build_deps_c/package.py
@@ -1,0 +1,11 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class UnifyBuildDepsC(Package):
+    tags = ["build-tools"]
+    url = "http://example.com/unify-build-deps-c-1.0.tar.gz"
+    version("2.0", sha256="d41d8cd98f00b204e9800998ecf8427ed41d8cd98f00b204e9800998ecf8427e")
+    version("1.0", sha256="d41d8cd98f00b204e9800998ecf8427ed41d8cd98f00b204e9800998ecf8427e")


### PR DESCRIPTION
Closes #51889

The concretizer currently has a bug where the build environment does not unify
properly. This is triggered when a package has two build deps `A` and `B@1`,
and `A` has a conflicting *runtime* dependency on `B@2`. That should be a
concretization error, but currently Spack allows this when `B` is tagged as
`build-tool` and has `max_dupes: 2` or higher.

The reason for this bug is that the unification `"generic_build"` contains the
items `{A, B@2}` while the special build unification set is independent and
contains `{B@1}`.

Funnily enough, this bug was explicitly tested as if it was desired behavior:
`py-shapely` depends on `py-setuptools@60`, so it cannot be that the sibling
build dependency `py-numpy` pulls in `py-setuptools@59` into the same build
environment as a runtime dependency. This test case is fixed by making
`py-setuptools@59` only a pure build dependency of `py-numpy`.

The proposed fix is to put all sibling build dependencies into the same
`"build"` unification set.

To avoid a combinatorial explosion, the total number of these `"build"`
unification sets is limited to a constant 4.

Finally, this change relaxes the trigger of `"build"` unification set from
"pure build dependencies" to "build dependencies", as I don't see a reason
why not. Performance does not seem to be affected by it.

