### PR TITLE
environment: remove unnecessary methods after refactor

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -28,6 +28,7 @@ from spack.cmd.common import arguments
 from spack.llnl.util.filesystem import islink, symlink
 from spack.llnl.util.tty.colify import colify
 from spack.llnl.util.tty.color import cescape, colorize
+from spack.traverse import traverse_nodes
 from spack.util.environment import EnvironmentModifications
 
 description = "manage environments"
@@ -870,8 +871,10 @@ def env_loads(args):
 
     loads_file = fs.join_path(env.path, "loads")
     with open(loads_file, "w", encoding="utf-8") as f:
-        specs = env._get_environment_specs(recurse_dependencies=recurse_dependencies)
-
+        if not recurse_dependencies:
+            specs = [env.specs_by_hash[x.hash] for x in env.concretized_roots]
+        else:
+            specs = list(traverse_nodes(env.concrete_roots(), deptype=("link", "run")))
         spack.cmd.modules.loads(module_type, specs, args, f)
 
     print("To load this environment, type:")

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -263,9 +263,10 @@ def display_env(env, args, decorator, results):
     num_roots = len(env.user_specs) or "No"
     tty.msg(f"{num_roots} root specs")
 
+    concretized_user_specs = [x.root for x in env.concretized_roots]
     concrete_specs = {
         root: concrete_root
-        for root, concrete_root in zip(env.concretized_user_specs, env.concrete_roots())
+        for root, concrete_root in zip(concretized_user_specs, env.concrete_roots())
     }
 
     def root_decorator(spec, string):

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -67,7 +67,7 @@ def roots_from_environments(args, active_env):
     # add root hashes from all considered environments to list of roots
     root_hashes = set()
     for env in all_environments:
-        root_hashes |= set(env.concretized_order)
+        root_hashes |= {x.hash for x in env.concretized_roots}
 
     return root_hashes
 
@@ -91,7 +91,7 @@ def gc(parser, args):
             tty.msg(f"Restricting garbage collection to environment '{active_env.name}'")
             root_hashes = set(spack.store.STORE.db.all_hashes())  # keep everything
             root_hashes -= set(active_env.all_hashes())  # except this env
-            root_hashes |= set(active_env.concretized_order)  # but keep its roots
+            root_hashes |= {x.hash for x in active_env.concretized_roots}  # but keep its roots
         else:
             # consider all explicit specs roots (the default for db.unused_specs())
             root_hashes = None

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -977,6 +977,17 @@ class ConcretizedRootInfo:
     def __str__(self):
         return f"{self.root} -> {self.hash} [new={self.new}]"
 
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, ConcretizedRootInfo)
+            and self.root == other.root
+            and self.hash == other.hash
+            and self.new == other.new
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.root, self.hash, self.new))
+
 
 class Environment:
     """A Spack environment, which bundles together configuration and a list of specs."""
@@ -1788,10 +1799,6 @@ class Environment:
         h = concrete.dag_hash()
         self.concretized_roots.append(ConcretizedRootInfo(root_spec=spec, root_hash=h, new=new))
         self.specs_by_hash[h] = concrete
-
-    @property
-    def concretized_order(self) -> List[str]:
-        return [x.hash for x in self.concretized_roots]
 
     @property
     def concretized_user_specs(self) -> List[Spec]:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1171,18 +1171,6 @@ class Environment:
             name=user_speclist_name, yaml_list=spec_list
         )
 
-    def all_concretized_user_specs(self) -> List[Spec]:
-        """Returns all of the concretized user specs of the environment and
-        its included environment(s)."""
-        concretized_user_specs = [x.root for x in self.concretized_roots]
-        for included_specs in self.included_concretized_user_specs.values():
-            for included in included_specs:
-                # Don't duplicate included spec(s)
-                if included not in concretized_user_specs:
-                    concretized_user_specs.append(included)
-
-        return concretized_user_specs
-
     def all_concretized_orders(self) -> List[str]:
         """Returns all of the concretized order of the environment and
         its included environment(s)."""
@@ -1945,14 +1933,19 @@ class Environment:
 
     def concretized_specs(self):
         """Tuples of (user spec, concrete spec) for all concrete specs."""
-        for s, h in zip(self.all_concretized_user_specs(), self.all_concretized_orders()):
-            if h in self.specs_by_hash:
-                yield (s, self.specs_by_hash[h])
-            else:
-                for env_path in self.included_specs_by_hash.keys():
-                    if h in self.included_specs_by_hash[env_path]:
-                        yield (s, self.included_specs_by_hash[env_path][h])
-                        break
+        for x in self.concretized_roots:
+            yield x.root, self.specs_by_hash[x.hash]
+
+        seen = set()
+        for included_env in self.included_concretized_user_specs:
+            for s, h in zip(
+                self.included_concretized_user_specs[included_env],
+                self.included_concretized_order[included_env],
+            ):
+                if (s, h) in seen:
+                    continue
+                seen.add((s, h))
+                yield s, self.included_specs_by_hash[included_env][h]
 
     def concrete_roots(self):
         """Same as concretized_specs, except it returns the list of concrete

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2068,22 +2068,6 @@ class Environment:
                 if d not in needed:
                     yield d
 
-    def _get_environment_specs(self, recurse_dependencies=True):
-        """Returns the specs of all the packages in an environment.
-
-        If these specs appear under different user_specs, only one copy
-        is added to the list returned.
-        """
-        specs = [self.specs_by_hash[h] for h in self.all_concretized_orders()]
-        if recurse_dependencies:
-            specs.extend(
-                traverse.traverse_nodes(
-                    specs, root=False, deptype=("link", "run"), key=traverse.by_dag_hash
-                )
-            )
-
-        return specs
-
     def _concrete_specs_dict(self):
         concrete_specs = {}
         for s in traverse.traverse_nodes(self.specs_by_hash.values(), key=traverse.by_dag_hash):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1174,7 +1174,7 @@ class Environment:
     def all_concretized_user_specs(self) -> List[Spec]:
         """Returns all of the concretized user specs of the environment and
         its included environment(s)."""
-        concretized_user_specs = self.concretized_user_specs
+        concretized_user_specs = [x.root for x in self.concretized_roots]
         for included_specs in self.included_concretized_user_specs.values():
             for included in included_specs:
                 # Don't duplicate included spec(s)
@@ -1799,10 +1799,6 @@ class Environment:
         h = concrete.dag_hash()
         self.concretized_roots.append(ConcretizedRootInfo(root_spec=spec, root_hash=h, new=new))
         self.specs_by_hash[h] = concrete
-
-    @property
-    def concretized_user_specs(self) -> List[Spec]:
-        return [x.root for x in self.concretized_roots]
 
     def _dev_specs_that_need_overwrite(self):
         """Return the hashes of all specs that need to be reinstalled due to source code change."""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1910,7 +1910,7 @@ class Environment:
         for x in self.concretized_roots:
             yield x.root, self.specs_by_hash[x.hash]
 
-        seen = set()
+        seen = {(x.root, x.hash) for x in self.concretized_roots}
         for included_env in self.included_concretized_user_specs:
             for s, h in zip(
                 self.included_concretized_user_specs[included_env],

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1171,18 +1171,6 @@ class Environment:
             name=user_speclist_name, yaml_list=spec_list
         )
 
-    def all_concretized_orders(self) -> List[str]:
-        """Returns all of the concretized order of the environment and
-        its included environment(s)."""
-        concretized_order = [x.hash for x in self.concretized_roots]
-        for included_concretized_order in self.included_concretized_order.values():
-            for included in included_concretized_order:
-                # Don't duplicate included spec(s)
-                if included not in concretized_order:
-                    concretized_order.append(included)
-
-        return concretized_order
-
     @property
     def user_specs(self):
         return self.spec_lists[user_speclist_name]
@@ -1819,22 +1807,8 @@ class Environment:
         installer, and those that should be, taking into account development
         specs. This is done in a single read transaction per environment instead
         of per spec."""
-        installed, uninstalled = [], []
         with spack.store.STORE.db.read_transaction():
-            for concretized_hash in self.all_concretized_orders():
-                if concretized_hash in self.specs_by_hash:
-                    spec = self.specs_by_hash[concretized_hash]
-                else:
-                    for env_path in self.included_specs_by_hash.keys():
-                        if concretized_hash in self.included_specs_by_hash[env_path]:
-                            spec = self.included_specs_by_hash[env_path][concretized_hash]
-                            break
-                if not spec.installed or (
-                    spec.satisfies("dev_path=*") or spec.satisfies("^dev_path=*")
-                ):
-                    uninstalled.append(spec)
-                else:
-                    installed.append(spec)
+            uninstalled, installed = stable_partition(self.concrete_roots(), _is_uninstalled)
         return installed, uninstalled
 
     def uninstalled_specs(self):
@@ -2388,6 +2362,10 @@ class Environment:
         deactivate()
         if self._previous_active:
             activate(self._previous_active)
+
+
+def _is_uninstalled(spec):
+    return not spec.installed or (spec.satisfies("dev_path=*") or spec.satisfies("^dev_path=*"))
 
 
 class EnvironmentConcretizer:

--- a/lib/spack/spack/test/cmd/deconcretize.py
+++ b/lib/spack/spack/test/cmd/deconcretize.py
@@ -43,7 +43,7 @@ def test_deconcretize_root(test_env):
     with ev.read("test") as e:
         output = deconcretize("-y", "--root", "pkg-b@1.0")
         assert "No matching specs to deconcretize" in output
-        assert len(e.concretized_order) == 2
+        assert len(e.concretized_roots) == 2
 
         deconcretize("-y", "--root", "pkg-a@2.0")
         specs = [s for s, _ in e.concretized_specs()]
@@ -59,7 +59,7 @@ def test_deconcretize_all_root(test_env):
 
         output = deconcretize("-y", "--root", "--all", "pkg-b")
         assert "No matching specs to deconcretize" in output
-        assert len(e.concretized_order) == 2
+        assert len(e.concretized_roots) == 2
 
         deconcretize("-y", "--root", "--all", "pkg-a")
         specs = [s for s, _ in e.concretized_specs()]

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -39,6 +39,7 @@ import spack.util.spack_yaml
 from spack.cmd.env import _env_create
 from spack.installer import PackageInstaller
 from spack.llnl.util.filesystem import readlink
+from spack.llnl.util.lang import dedupe
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.stage import stage_prefix
@@ -4650,3 +4651,41 @@ spack:
       branch: develop"""
     ):
         pass
+
+
+def test_concretized_specs_and_include_concrete(mutable_config):
+    """Tests the consistency of concretized specs when there are either
+    duplicate input specs or duplicate hashes.
+    """
+    # Create a structure like this one
+    #
+    # Local specs:
+    # - mpileaks -> hash1
+    # - libelf@0.8.12 -> hash2
+    # - pkg-a -> hash3
+    #
+    # Included specs:
+    # - mpileaks -> hash4
+    # - libelf -> hash2
+    # - pkg-a -> hash3
+    env("create", "included-env")
+    with ev.read("included-env") as e:
+        e.add("mpileaks")
+        e.add("libelf")
+        e.add("pkg-a")
+        mutable_config.set(
+            "packages", {"mpileaks": {"require": ["@2.2"]}, "libelf": {"require": ["@0.8.12"]}}
+        )
+        included_pairs = e.concretize()
+        e.write()
+
+    env("create", "--include-concrete", "included-env", "main-env")
+    with ev.read("main-env") as e:
+        e.add("mpileaks")
+        e.add("libelf@0.8.12")
+        e.add("pkg-a")
+        mutable_config.set("packages", {"mpileaks": {"require": ["@2.3"]}})
+        spec_pairs = e.concretize()
+        concretized_specs = list(e.concretized_specs())
+        assert list(dedupe(spec_pairs + included_pairs)) == concretized_specs
+        assert len(concretized_specs) == 5

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -43,6 +43,7 @@ from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.stage import stage_prefix
 from spack.test.conftest import RepoBuilder
+from spack.traverse import traverse_nodes
 from spack.util.executable import Executable
 from spack.util.path import substitute_path_variables
 from spack.version import Version
@@ -473,8 +474,9 @@ def test_concretize():
     e = ev.create("test")
     e.add("mpileaks")
     e.concretize()
-    env_specs = e._get_environment_specs()
-    assert any(x.name == "mpileaks" for x in env_specs)
+
+    assert len(e.concretized_roots) == 1
+    assert e.concretized_roots[0].root == Spec("mpileaks")
 
 
 def test_env_specs_partition(install_mockery, mock_fetch):
@@ -510,8 +512,7 @@ def test_env_install_all(install_mockery, mock_fetch):
     e.add("cmake-client")
     e.concretize()
     e.install_all(fake=True)
-    env_specs = e._get_environment_specs()
-    spec = next(x for x in env_specs if x.name == "cmake-client")
+    spec = next(x for x in e.all_specs_generator() if x.name == "cmake-client")
     assert spec.installed
 
 
@@ -689,16 +690,14 @@ def test_remove_after_concretize():
 
     e.remove("mpileaks")
     assert Spec("mpileaks") not in e.user_specs
-    env_specs = e._get_environment_specs()
-    assert any(s.name == "mpileaks" for s in env_specs)
+    assert any(s.name == "mpileaks" for s in e.all_specs_generator())
 
     e.add("mpileaks")
     assert any(s.name == "mpileaks" for s in e.user_specs)
 
     e.remove("mpileaks", force=True)
     assert Spec("mpileaks") not in e.user_specs
-    env_specs = e._get_environment_specs()
-    assert not any(s.name == "mpileaks" for s in env_specs)
+    assert not any(s.name == "mpileaks" for s in e.all_specs_generator())
 
 
 def test_remove_before_concretize():
@@ -940,9 +939,7 @@ spack:
     after.write()
 
     read = ev.read("test")
-    env_specs = read._get_environment_specs()
-
-    assert not any(x.name == "hypre" for x in env_specs)
+    assert not any(x.name == "hypre" for x in read.all_specs_generator())
 
 
 def test_lockfile_spliced_specs(environment_from_manifest, install_mockery):
@@ -1224,7 +1221,9 @@ spack:
     with e:
         e.concretize()
 
-    assert any(x.intersects("mpileaks@2.2") for x in e._get_environment_specs())
+    mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
+    mpileaks = e.specs_by_hash[mpileaks_hash]
+    assert mpileaks.satisfies("mpileaks@2.2")
 
 
 def test_with_config_bad_include_create(environment_from_manifest):
@@ -1308,10 +1307,13 @@ spack:
     with e:
         e.concretize()
 
-    environment_specs = e._get_environment_specs(False)
+    mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
+    mpileaks = e.specs_by_hash[mpileaks_hash]
+    assert mpileaks.satisfies("mpileaks@2.2")
 
-    assert environment_specs[0].satisfies("libelf@0.8.10")
-    assert environment_specs[1].satisfies("mpileaks@2.2")
+    libelf_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("libelf"))
+    libelf = e.specs_by_hash[libelf_hash]
+    assert libelf.satisfies("libelf@0.8.10")
 
 
 @pytest.fixture(scope="function")
@@ -1368,7 +1370,9 @@ spack:
     with e:
         e.concretize()
 
-    assert any(x.satisfies("mpileaks@2.2") for x in e._get_environment_specs())
+    mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
+    mpileaks = e.specs_by_hash[mpileaks_hash]
+    assert mpileaks.satisfies("mpileaks@2.2")
 
 
 def test_config_change_existing(
@@ -1532,7 +1536,9 @@ def test_env_with_included_config_scope(mutable_mock_env_path, packages_file):
     with e:
         e.concretize()
 
-    assert any(x.satisfies("mpileaks@2.2") for x in e._get_environment_specs())
+    mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
+    mpileaks = e.specs_by_hash[mpileaks_hash]
+    assert mpileaks.satisfies("mpileaks@2.2")
 
 
 def test_env_with_included_config_var_path(tmp_path: pathlib.Path, packages_file):
@@ -1553,7 +1559,9 @@ def test_env_with_included_config_var_path(tmp_path: pathlib.Path, packages_file
     with e:
         e.concretize()
 
-    assert any(x.satisfies("mpileaks@2.2") for x in e._get_environment_specs())
+    mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
+    mpileaks = e.specs_by_hash[mpileaks_hash]
+    assert mpileaks.satisfies("mpileaks@2.2")
 
 
 def test_env_with_included_config_precedence(tmp_path: pathlib.Path):
@@ -1590,13 +1598,15 @@ spack:
     e = ev.Environment(tmp_path)
     with e:
         e.concretize()
-    specs = e._get_environment_specs()
+
+    mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
+    mpileaks = e.specs_by_hash[mpileaks_hash]
 
     # ensure included scope took effect
-    assert any(x.satisfies("mpileaks@2.2") for x in specs)
+    assert mpileaks.satisfies("mpileaks@2.2")
 
     # ensure env file takes precedence
-    assert any(x.satisfies("libelf@0.8.12") for x in specs)
+    assert mpileaks["libelf"].satisfies("libelf@0.8.12")
 
 
 def test_env_with_included_configs_precedence(tmp_path: pathlib.Path):
@@ -1639,13 +1649,15 @@ packages:
     e = ev.Environment(tmp_path)
     with e:
         e.concretize()
-    specs = e._get_environment_specs()
 
-    # ensure included package spec took precedence over manifest spec
-    assert any(x.satisfies("mpileaks@2.2") for x in specs)
+    mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
+    mpileaks = e.specs_by_hash[mpileaks_hash]
 
-    # ensure first included package spec took precedence over one from second
-    assert any(x.satisfies("libelf@0.8.10") for x in specs)
+    # ensure the included package spec took precedence over manifest spec
+    assert mpileaks.satisfies("mpileaks@2.2")
+
+    # ensure the first included package spec took precedence over one from second
+    assert mpileaks["libelf"].satisfies("libelf@0.8.10")
 
 
 @pytest.mark.regression("39248")
@@ -2973,7 +2985,7 @@ def test_stack_combinatorial_view(
     """Tests creating a default view for a combinatorial stack."""
     view_dir = tmp_path / "view"
     with installed_environment(template_combinatorial_env.format(view_config="")) as test:
-        for spec in test._get_environment_specs():
+        for spec in traverse_nodes(test.concrete_roots(), deptype=("link", "run")):
             if spec.name == "gcc-runtime":
                 continue
             current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
@@ -2986,7 +2998,7 @@ def test_stack_view_select(
     view_dir = tmp_path / "view"
     content = template_combinatorial_env.format(view_config="select: ['target=x86_64']\n")
     with installed_environment(content) as test:
-        for spec in test._get_environment_specs():
+        for spec in traverse_nodes(test.concrete_roots(), deptype=("link", "run")):
             if spec.name == "gcc-runtime":
                 continue
             current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
@@ -2999,7 +3011,7 @@ def test_stack_view_exclude(
     view_dir = tmp_path / "view"
     content = template_combinatorial_env.format(view_config="exclude: [callpath]\n")
     with installed_environment(content) as test:
-        for spec in test._get_environment_specs():
+        for spec in traverse_nodes(test.concrete_roots(), deptype=("link", "run")):
             if spec.name == "gcc-runtime":
                 continue
             current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
@@ -3016,7 +3028,7 @@ def test_stack_view_select_and_exclude(
 """
     )
     with installed_environment(content) as test:
-        for spec in test._get_environment_specs():
+        for spec in traverse_nodes(test.concrete_roots(), deptype=("link", "run")):
             if spec.name == "gcc-runtime":
                 continue
             current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
@@ -3036,7 +3048,7 @@ def test_view_link_roots(
     """
     )
     with installed_environment(content) as test:
-        for spec in test._get_environment_specs():
+        for spec in traverse_nodes(test.concrete_roots(), deptype=("link", "run")):
             if spec.name == "gcc-runtime":
                 continue
             current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
@@ -3118,7 +3130,7 @@ def test_view_link_all(installed_environment, template_combinatorial_env, tmp_pa
     )
 
     with installed_environment(content) as test:
-        for spec in test._get_environment_specs():
+        for spec in traverse_nodes(test.concrete_roots(), deptype=("link", "run")):
             if spec.name == "gcc-runtime":
                 continue
             current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
@@ -3257,7 +3269,7 @@ def test_stack_view_multiple_views(installed_environment, tmp_path: pathlib.Path
 
     with installed_environment(content) as e:
         assert os.path.exists(str(default_dir / "bin"))
-        for spec in e._get_environment_specs():
+        for spec in traverse_nodes(e.concrete_roots(), deptype=("link", "run")):
             if spec.name == "gcc-runtime":
                 continue
             current_dir = comb_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
@@ -4567,7 +4579,7 @@ spack:
         # the view root in the included view should NOT exist
         assert not os.path.exists(str(default_dir))
 
-        for spec in e._get_environment_specs():
+        for spec in traverse_nodes(e.concrete_roots(), deptype=("link", "run")):
             # no specs will exist in the included view projection
             base_dir = view_dir / f"{spec.architecture.target}"
             included_dir = base_dir / f"{spec.name}-{spec.version}-from-view"

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -291,14 +291,12 @@ def test_change_multiple_matches():
 
 def test_env_add_virtual():
     env("create", "test")
-
     e = ev.read("test")
     e.add("mpi")
     e.concretize()
 
-    hashes = e.concretized_order
-    assert len(hashes) == 1
-    spec = e.specs_by_hash[hashes[0]]
+    assert len(e.concretized_roots) == 1
+    spec = e.specs_by_hash[e.concretized_roots[0].hash]
     assert spec.intersects("mpi")
 
 
@@ -526,9 +524,12 @@ def test_env_install_single_spec(install_mockery, mock_fetch):
         install("--fake", "--add", "cmake-client")
 
     e = ev.read("test")
-    assert e.user_specs[0].name == "cmake-client"
-    assert e.concretized_user_specs[0].name == "cmake-client"
-    assert e.specs_by_hash[e.concretized_order[0]].name == "cmake-client"
+    assert len(e.concretized_roots) == 1
+
+    item = e.concretized_roots[0]
+    assert list(e.user_specs) == [Spec("cmake-client")]
+    assert item.root == Spec("cmake-client")
+    assert e.specs_by_hash[item.hash].name == "cmake-client"
 
 
 @pytest.mark.parametrize("unify", [True, False, "when_possible"])
@@ -546,23 +547,24 @@ def test_env_install_include_concrete_env(unify, install_mockery, mock_fetch, mu
     with combined:
         install("--fake")
 
-    test1_roots = test1.concretized_order
-    test2_roots = test2.concretized_order
+    test1_user_spec_hashes = [x.hash for x in test1.concretized_roots]
+    test2_user_spec_hashes = [x.hash for x in test2.concretized_roots]
     combined_included_roots = combined.included_concretized_order
 
     for spec in combined.all_specs():
         assert spec.installed
 
-    assert test1_roots == combined_included_roots[test1.path]
-    assert test2_roots == combined_included_roots[test2.path]
+    assert test1_user_spec_hashes == combined_included_roots[test1.path]
+    assert test2_user_spec_hashes == combined_included_roots[test2.path]
 
-    mpileaks = combined.specs_by_hash[combined.concretized_order[0]]
+    mpileaks_hash = combined.concretized_roots[0].hash
+    mpileaks = combined.specs_by_hash[mpileaks_hash]
     if unify:
-        assert mpileaks["mpi"].dag_hash() in test1_roots
-        assert mpileaks["libelf"].dag_hash() in test2_roots
+        assert mpileaks["mpi"].dag_hash() in test1_user_spec_hashes
+        assert mpileaks["libelf"].dag_hash() in test2_user_spec_hashes
     else:
         # check that unification is not by accident
-        assert mpileaks["mpi"].dag_hash() not in test1_roots
+        assert mpileaks["mpi"].dag_hash() not in test1_user_spec_hashes
 
 
 def test_env_roots_marked_explicit(install_mockery, mock_fetch):
@@ -995,12 +997,10 @@ spack:
     for s1, s2 in zip(e1.user_specs, e2.user_specs):
         assert s1 == s2
 
-    for h1, h2 in zip(e1.concretized_order, e2.concretized_order):
-        assert h1 == h2
-        assert e1.specs_by_hash[h1] == e2.specs_by_hash[h2]
+    for r1, r2 in zip(e1.concretized_roots, e2.concretized_roots):
+        assert r1 == r2
 
-    for s1, s2 in zip(e1.concretized_user_specs, e2.concretized_user_specs):
-        assert s1 == s2
+    assert e1.specs_by_hash == e2.specs_by_hash
 
 
 def test_init_from_yaml(environment_from_manifest):
@@ -1022,8 +1022,7 @@ spack:
     for s1, s2 in zip(e1.user_specs, e2.user_specs):
         assert s1 == s2
 
-    assert not e2.concretized_order
-    assert not e2.concretized_user_specs
+    assert not e2.concretized_roots
     assert not e2.specs_by_hash
 
 
@@ -1058,8 +1057,7 @@ spack:
     for s1, s2 in zip(e1.user_specs, e2.user_specs):
         assert s1 == s2
 
-    assert e2.concretized_order == e1.concretized_order
-    assert e2.concretized_user_specs == e1.concretized_user_specs
+    assert e2.concretized_roots == e1.concretized_roots
     assert e2.specs_by_hash == e1.specs_by_hash
 
     assert os.path.exists(os.path.join(e2.path, "libelf"))
@@ -1847,15 +1845,15 @@ def test_uninstall_keeps_in_env(mock_stage, mock_fetch, install_mockery):
     test = ev.read("test")
     # Save this spec to check later if it is still in the env
     (mpileaks_hash,) = list(x for x, y in test.specs_by_hash.items() if y.name == "mpileaks")
-    orig_user_specs = test.user_specs
-    orig_concretized_specs = test.concretized_order
+    user_specs_before = test.user_specs
+    user_spec_hashes_before = {x.hash for x in test.concretized_roots}
 
     with ev.read("test"):
         uninstall("-ya")
 
     test = ev.read("test")
-    assert test.concretized_order == orig_concretized_specs
-    assert test.user_specs.specs == orig_user_specs.specs
+    assert {x.hash for x in test.concretized_roots} == user_spec_hashes_before
+    assert test.user_specs.specs == user_specs_before.specs
     assert mpileaks_hash in test.specs_by_hash
     assert not test.specs_by_hash[mpileaks_hash].installed
 
@@ -1873,7 +1871,7 @@ def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
 
     test = ev.read("test")
     assert not test.specs_by_hash
-    assert not test.concretized_order
+    assert not test.concretized_roots
     assert not test.user_specs
 
 
@@ -1897,8 +1895,8 @@ def test_indirect_build_dep(repo_builder: RepoBuilder):
         e.write()
 
         e_read = ev.read("test")
-        (x_env_hash,) = e_read.concretized_order
-
+        assert len(e_read.concretized_roots) == 1
+        x_env_hash = e_read.concretized_roots[0].hash
         x_env_spec = e_read.specs_by_hash[x_env_hash]
         assert x_env_spec == x_concretized
 
@@ -1939,7 +1937,7 @@ def test_store_different_build_deps(repo_builder: RepoBuilder):
         e.write()
 
         e_read = ev.read("test")
-        y_env_hash, x_env_hash = e_read.concretized_order
+        y_env_hash, x_env_hash = [x.hash for x in e_read.concretized_roots]
 
         y_read = e_read.specs_by_hash[y_env_hash]
         x_read = e_read.specs_by_hash[x_env_hash]
@@ -3612,8 +3610,8 @@ spack:
 
     with ev.read("test") as e:
         install("--fake")
-
-        spec = e.specs_by_hash[e.concretized_order[0]]
+        user_spec_hash = e.concretized_roots[0].hash
+        spec = e.specs_by_hash[user_spec_hash]
         view_prefix = e.default_view.get_projection_for_spec(spec)
         modules_glob = "%s/modules/**/*/*" % e.path
         modules = glob.glob(modules_glob)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2294,19 +2294,24 @@ def test_env_include_concrete_env_reconcretized(unify):
 
 
 def test_concretize_include_concrete_env():
+    """Tests that if we update an included environment, and later we re-concretize the environment
+    that includes it, we use the latest version of the concrete specs.
+    """
     test1, _, combined = setup_combined_multiple_env()
 
+    # Update test1 environment
     with test1:
         add("mpileaks")
     test1.concretize()
     test1.write()
 
-    assert Spec("mpileaks") in test1.concretized_user_specs
+    # Check the test1 environment includes mpileaks, while the combined environment does not
+    assert Spec("mpileaks") in {x.root for x in test1.concretized_roots}
     assert Spec("mpileaks") not in combined.included_concretized_user_specs[test1.path]
 
+    # If we update the combined environment, it will include mpileaks too
     combined.concretize()
     combined.write()
-
     assert Spec("mpileaks") in combined.included_concretized_user_specs[test1.path]
 
 
@@ -2753,18 +2758,18 @@ spack:
             e.concretize()
 
             before_user = e.user_specs.specs
-            before_conc = e.concretized_user_specs
+            concretized_roots_before = e.concretized_roots
 
             remove("-f", "-l", "packages", "mpileaks")
 
             after_user = e.user_specs.specs
-            after_conc = e.concretized_user_specs
+            concretized_roots_after = e.concretized_roots
 
             assert before_user == after_user
 
             mpileaks_spec = Spec("mpileaks target=default_target")
-            assert mpileaks_spec in before_conc
-            assert mpileaks_spec not in after_conc
+            assert mpileaks_spec in {x.root for x in concretized_roots_before}
+            assert mpileaks_spec not in {x.root for x in concretized_roots_after}
 
 
 def test_stack_definition_extension(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -70,9 +70,10 @@ def test_hash_change_no_rehash_concrete(tmp_path: pathlib.Path, config):
     read_in = ev.Environment(env_path)
 
     # Ensure read hashes are used (rewritten hash seen on read)
-    assert read_in.concretized_order
-    assert read_in.concretized_order[0] in read_in.specs_by_hash
-    _hash = read_in.specs_by_hash[read_in.concretized_order[0]]._hash  # type: ignore[attr-defined]
+    hashes = [x.hash for x in read_in.concretized_roots]
+    assert hashes
+    assert hashes[0] in read_in.specs_by_hash
+    _hash = read_in.specs_by_hash[hashes[0]]._hash  # type: ignore[attr-defined]
     assert _hash == new_hash
 
 


### PR DESCRIPTION
Extracted from #51891 

This PR just removes methods of the `Environment` class that are unnecessary after #51857 and adjusts unit tests accordingly. 

It also fixes a nasty bug where, for included environments, we may reconstruct a wrong `(user_spec, concrete_spec)` pair. This is due to the fact that the computation has been done using `zip` but there are cases where the zipped parts don't match, leading to weird situations like:

<img width="2123" height="489" alt="Screenshot from 2026-02-06 10-08-26" src="https://github.com/user-attachments/assets/50b60c9b-e032-4923-b4ed-fcef2840980c" />

Notice the last line that associates `libelf` to a concrete `mpileaks`.



<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
