### PR TITLE
asp.py: make %foo=bar in when condition strict

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2317,15 +2317,18 @@ class SpackSolverSetup:
             if spec.external:
                 clauses.append(fn.attr("external", name))
 
+        # TODO: a loop over `edges_to_dependencies` is preferred over `edges_from_dependents`
+        # since dependents can point to specs out of scope for the solver.
         edges = spec.edges_from_dependents()
-        virtuals = sorted(
-            {x for x in itertools.chain.from_iterable([edge.virtuals for edge in edges])}
-        )
         if not body and not spec.concrete:
+            virtuals = sorted(set(itertools.chain.from_iterable(edge.virtuals for edge in edges)))
             for virtual in virtuals:
                 clauses.append(fn.attr("provider_set", name, virtual))
                 clauses.append(fn.attr("virtual_node", virtual))
         else:
+            # direct dependencies are handled under `edges_to_dependencies()`
+            virtual_iter = (edge.virtuals for edge in edges if not edge.direct)
+            virtuals = sorted(set(itertools.chain.from_iterable(virtual_iter)))
             for virtual in virtuals:
                 clauses.append(fn.attr("virtual_on_incoming_edges", name, virtual))
 
@@ -2424,6 +2427,9 @@ class SpackSolverSetup:
                 ###
                 for dependency_type in dt.flag_to_tuple(dspec.depflag):
                     edge_clauses.append(fn.attr("depends_on", name, dep.name, dependency_type))
+
+                for virtual in dspec.virtuals:
+                    dependency_clauses.append(fn.attr("virtual_on_edge", name, dep.name, virtual))
 
                 # By default, wrap head of rules, unless the context says otherwise
                 wrap_node_requirement = body is False

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -473,6 +473,12 @@ satisfied(trigger(PackageNode), condition_requirement("closure", A1, A2, A3)) :-
   generic_condition_requirement("closure", A1, A2, A3),
   condition_nodes(PackageNode, node(X, A1)).
 
+satisfied(trigger(PackageNode), condition_requirement("virtual_on_edge", A1, A2, A3)) :-
+  attr("virtual_on_edge", node(X, A1), node(Y, A2), A3),
+  generic_condition_requirement("virtual_on_edge", A1, A2, A3),
+  condition_nodes(PackageNode, node(X, A1)),
+  condition_nodes(PackageNode, node(Y, A2)).
+
 %%%%
 % Conditions verified on pure build deps of reused nodes
 %%%%

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4828,6 +4828,15 @@ def test_activating_variant_for_conditional_language_dependency(default_mock_con
     assert s.satisfies("+fortran")
 
 
+def test_when_condition_with_direct_dependency_on_virtual_provider(default_mock_concretization):
+    """If a when condition contains a direct dependency on a provider of a virtual, it should only
+    trigger if the provider is used for that current package, and not if the provider happens to be
+    a dependency, without its virtual being depended on."""
+    s = default_mock_concretization("direct-dep-virtuals-one")
+    assert s.satisfies("%netlib-blas")
+    assert s["direct-dep-virtuals-two"].satisfies("%blas=netlib-blas")
+
+
 def test_imposed_spec_dependency_duplication(mock_packages: spack.repo.Repo):
     """Tests that imposed dependencies triggered by identical conditions are grouped together,
     and that imposed dependencies that differ on a deptype are not grouped together."""

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4837,6 +4837,18 @@ def test_when_condition_with_direct_dependency_on_virtual_provider(default_mock_
     assert s["direct-dep-virtuals-two"].satisfies("%blas=netlib-blas")
 
 
+def test_conflict_with_direct_dependency_on_virtual_provider(default_mock_concretization):
+    """Test that conflicts on virtual providers as direct dependencies work"""
+    s = default_mock_concretization("conflict-virtual")
+    assert s.satisfies("%blas=netlib-blas")
+
+    with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
+        default_mock_concretization("conflict-virtual +conflict_direct")
+
+    with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
+        default_mock_concretization("conflict-virtual +conflict_transitive")
+
+
 def test_imposed_spec_dependency_duplication(mock_packages: spack.repo.Repo):
     """Tests that imposed dependencies triggered by identical conditions are grouped together,
     and that imposed dependencies that differ on a deptype are not grouped together."""

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/conflict_virtual/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/conflict_virtual/package.py
@@ -1,0 +1,16 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class ConflictVirtual(Package):
+    version("1.0")
+    variant("conflict_direct", default=False, description="Enable conflict")
+    variant("conflict_transitive", default=False, description="Enable conflict")
+
+    depends_on("blas")
+    requires("%blas=netlib-blas")
+
+    conflicts("%blas=netlib-blas", when="+conflict_direct")
+    conflicts("^blas=netlib-blas", when="+conflict_transitive")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/direct_dep_virtuals_one/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/direct_dep_virtuals_one/package.py
@@ -1,0 +1,14 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class DirectDepVirtualsOne(Package):
+    version("1.0")
+    # These two statements imply that %blas=netlib-blas must be false.
+    depends_on("direct-dep-virtuals-two +variant", when="%blas=netlib-blas")
+    depends_on("direct-dep-virtuals-two ~variant")
+
+    # The provider is a direct dependency, but its virtual is *not* depended on.
+    depends_on("netlib-blas")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/direct_dep_virtuals_two/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/direct_dep_virtuals_two/package.py
@@ -1,0 +1,13 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class DirectDepVirtualsTwo(Package):
+    version("1.0")
+    variant("variant", default=False)
+    # Pick netlib-blas as a provider for blas.
+    depends_on("blas")
+    # Require that netlib-blas is a dependency (and thus the provider of blas).
+    requires("%netlib-blas")


### PR DESCRIPTION
Currently, `depends_on("x", when="%foo=bar")` triggers the dependency if
`foo` is provided by `bar` to *any* of its dependents, and the current
package just happens to depend on `bar` without depending on the
virtual.

That causes concretization failure in `CMakePackage` on Windows, where
we want to express:

```python
depends_on("cmake@4.1:", when="%cxx,fortran=msvc", type="build")
```

Now, most packages don't depend on `fortran` but do have `msvc` as a
provider for `c` or `cxx`. If only one of their dependencies happens to
depend on `msvc` for `fortran` and the same or another for `cxx`, the
`when` condition would trigger.

With this commit, the when condition only triggers if the *current*
package depends on `msvc` for `cxx` and `fortran`.
