### PR TITLE
solver: improve version constraint error messages

### DIFF
--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -88,7 +88,7 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
-error(10000, "Cannot satisfy '{0}@{1}' 3({2})", Package, Constraint, Version, startcauses, ConstraintCause, CauseID)
+error(10000, "Cannot satisfy '{0}@{1}' (selected version {2} does not match)", Package, Constraint, Version, startcauses, ConstraintCause, CauseID)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
      pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
      imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
@@ -97,7 +97,7 @@ error(10000, "Cannot satisfy '{0}@{1}' 3({2})", Package, Constraint, Version, st
      not pkg_fact(Package, version_satisfies(Constraint, Version)),
      choose_version(node(ID, Package), Version).
 
-error(100, "Cannot satisfy '{0}@{1}' 4({2})", Package, Constraint, Version, startcauses, ConstraintCause, CauseID)
+error(100, "Cannot satisfy '{0}@{1}' (version {2} does not match)", Package, Constraint, Version, startcauses, ConstraintCause, CauseID)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
      pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
      imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),


### PR DESCRIPTION
Before:

```
Cannot satisfy 'mbedtls@3:' 4(2.28.9)
```

After:

```
Cannot satisfy 'mbedtls@3:' (version 2.28.9 does not match)
```

