### PR TITLE
chopper: add new package at 0.12.0b

### DIFF
--- a/var/spack/repos/builtin/packages/chopper/package.py
+++ b/var/spack/repos/builtin/packages/chopper/package.py
@@ -1,0 +1,42 @@
+#     spack install chopper
+#
+# You can edit this file again by typing:
+#
+#     spack edit chopper
+#
+# See the Spack documentation for more information on packaging.
+# ---------------------------------------------------------------------------
+from spack.package import *
+
+
+class Chopper(Package):
+    """Rust implementation of long read trimming and filtering."""
+
+    homepage = "https://github.com/wdecoster/chopper/"
+    url = "https://github.com/wdecoster/chopper/releases/download/v0.12.0b/chopper-linux"
+
+    maintainers = ["josue-iac"]
+
+    version("0.12.0b", sha256="183c1a344227b0f07e62a697d4c16c43548d68262d03bf5b2fda68e13ea47eb2", expand=False)
+    version("0.12.0", sha256="892f57a4a9d085eb983e1f1a9755b275220f200be13a8cc314ddff361a69eb71", expand=False)
+    version("0.11.0", sha256="d9d7e4c62e5568e0499201efda441ca23b52f92c024b09fb58c0657270d51446", expand=False)
+    version("0.10.0b", sha256="9c7c707f8de594f5d7afcdb1001ff84b62ac5c86d318c6c9b6d0260257f52382", expand=False)
+
+    # O Spack baixa o ficheiro como 'chopper-linux'
+    # Nós instalamos na pasta final como 'chopper'
+
+    def install(self, spec, prefix):
+        # Cria a pasta bin
+        mkdirp(prefix.bin)
+        
+        # Define o caminho de destino de forma simples
+        dest = join_path(prefix.bin, "chopper")
+        
+        # Instala o binário literal baixado
+        install("chopper-linux", dest)
+        
+        # Torna o binário executável
+        set_executable(dest)
+
+    def setup_run_environment(self, env):
+        env.prepend_path("PATH", self.prefix.bin)

--- a/var/spack/repos/builtin/packages/chopper/package.py
+++ b/var/spack/repos/builtin/packages/chopper/package.py
@@ -17,10 +17,26 @@ class Chopper(Package):
 
     maintainers = ["josue-iac"]
 
-    version("0.12.0b", sha256="183c1a344227b0f07e62a697d4c16c43548d68262d03bf5b2fda68e13ea47eb2", expand=False)
-    version("0.12.0", sha256="892f57a4a9d085eb983e1f1a9755b275220f200be13a8cc314ddff361a69eb71", expand=False)
-    version("0.11.0", sha256="d9d7e4c62e5568e0499201efda441ca23b52f92c024b09fb58c0657270d51446", expand=False)
-    version("0.10.0b", sha256="9c7c707f8de594f5d7afcdb1001ff84b62ac5c86d318c6c9b6d0260257f52382", expand=False)
+    version(
+        "0.12.0b",
+        sha256="183c1a344227b0f07e62a697d4c16c43548d68262d03bf5b2fda68e13ea47eb2",
+        expand=False,
+    )
+    version(
+        "0.12.0",
+        sha256="892f57a4a9d085eb983e1f1a9755b275220f200be13a8cc314ddff361a69eb71",
+        expand=False,
+    )
+    version(
+        "0.11.0",
+        sha256="d9d7e4c62e5568e0499201efda441ca23b52f92c024b09fb58c0657270d51446",
+        expand=False,
+    )
+    version(
+        "0.10.0b",
+        sha256="9c7c707f8de594f5d7afcdb1001ff84b62ac5c86d318c6c9b6d0260257f52382",
+        expand=False,
+    )
 
     # O Spack baixa o ficheiro como 'chopper-linux'
     # Nós instalamos na pasta final como 'chopper'
@@ -28,13 +44,13 @@ class Chopper(Package):
     def install(self, spec, prefix):
         # Cria a pasta bin
         mkdirp(prefix.bin)
-        
+
         # Define o caminho de destino de forma simples
         dest = join_path(prefix.bin, "chopper")
-        
+
         # Instala o binário literal baixado
         install("chopper-linux", dest)
-        
+
         # Torna o binário executável
         set_executable(dest)
 


### PR DESCRIPTION
Summary Added a new package for Chopper, a tool designed for long-read trimming and filtering.

Details

    This package installs the standalone Linux binary provided in the official release.

    I have used expand=False in the version definition because the source is a single executable file, not a compressed archive.

    The package was tested locally and installed successfully on linux-ubuntu25.10-skylake.

Verification

    [x] spack install chopper works as expected.

    [x] spack list chopper confirms the package is in the repository.