### PR TITLE
Enforce normalized line-endings for *.py

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
-*.py diff=python
-lib/spack/spack/vendor/* linguist-vendored
 *.bat text eol=crlf
+*.py diff=python
+*.py text eol=lf
+lib/spack/spack/vendor/* linguist-vendored


### PR DESCRIPTION
Carry forward work by @haampie in spack/spack-packages#3343 to normalize python file endings.

We may wish to extend this beyond just python files, but this is at least a start. Working on a style check to run in CI/CD next.
```shell
git add --renormalize .
```