### PR TITLE
env.concretize() -> concretize_environment(env)

### DIFF
--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -10,6 +10,7 @@ from typing import Iterable, List
 
 import spack.vendor.archspec.cpu
 
+import spack.concretize
 import spack.environment
 import spack.spec
 import spack.tengine
@@ -82,7 +83,7 @@ class BootstrapEnvironment(spack.environment.Environment):
         """Update the installations of this environment."""
         log_enabled = tty.is_debug() or tty.is_verbose()
         with tty.SuppressOutput(msg_enabled=log_enabled, warn_enabled=log_enabled):
-            specs = self.concretize()
+            specs = spack.concretize.EnvironmentConcretizer(self).concretize()
         if specs:
             colorized_specs = [
                 spack.spec.Spec(x).cformat("{name}{@version}")

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -83,7 +83,7 @@ class BootstrapEnvironment(spack.environment.Environment):
         """Update the installations of this environment."""
         log_enabled = tty.is_debug() or tty.is_verbose()
         with tty.SuppressOutput(msg_enabled=log_enabled, warn_enabled=log_enabled):
-            specs = spack.concretize.EnvironmentConcretizer(self).concretize()
+            specs = spack.concretize.concretize_environment(self)
         if specs:
             colorized_specs = [
                 spack.spec.Spec(x).cformat("{name}{@version}")

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -20,6 +20,7 @@ from urllib.request import Request
 import spack
 import spack.binary_distribution
 import spack.builder
+import spack.concretize
 import spack.config as cfg
 import spack.environment as ev
 import spack.llnl.path
@@ -474,7 +475,7 @@ def generate_pipeline(env: ev.Environment, args) -> None:
             line.
     """
     with env.write_transaction():
-        env.concretize()
+        spack.concretize.EnvironmentConcretizer(env).concretize()
         env.write()
 
     options = collect_pipeline_options(env, args)

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -475,7 +475,7 @@ def generate_pipeline(env: ev.Environment, args) -> None:
             line.
     """
     with env.write_transaction():
-        spack.concretize.EnvironmentConcretizer(env).concretize()
+        spack.concretize.concretize_environment(env)
         env.write()
 
     options = collect_pipeline_options(env, args)

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -8,7 +8,7 @@ import spack.cmd
 import spack.cmd.common.arguments
 import spack.environment as ev
 import spack.llnl.util.tty as tty
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.llnl.string import plural
 
 description = "concretize an environment and write a lockfile"
@@ -42,7 +42,7 @@ def concretize(parser, args):
         tests = False
 
     with env.write_transaction():
-        concretized_specs = EnvironmentConcretizer(env).concretize(tests=tests)
+        concretized_specs = concretize_environment(env, tests=tests)
         if not args.quiet:
             if concretized_specs:
                 tty.msg(f"Concretized {plural(len(concretized_specs), 'spec')}:")

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -8,6 +8,7 @@ import spack.cmd
 import spack.cmd.common.arguments
 import spack.environment as ev
 import spack.llnl.util.tty as tty
+from spack.concretize import EnvironmentConcretizer
 from spack.llnl.string import plural
 
 description = "concretize an environment and write a lockfile"
@@ -41,7 +42,7 @@ def concretize(parser, args):
         tests = False
 
     with env.write_transaction():
-        concretized_specs = env.concretize(tests=tests)
+        concretized_specs = EnvironmentConcretizer(env).concretize(tests=tests)
         if not args.quiet:
             if concretized_specs:
                 tty.msg(f"Concretized {plural(len(concretized_specs), 'spec')}:")

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -16,7 +16,7 @@ import spack.paths
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.error import InstallError, SpackError
 from spack.installer import InstallPolicy
 from spack.llnl.string import plural
@@ -356,7 +356,7 @@ def _maybe_add_and_concretize(args, env, specs):
 
         # `spack concretize`
         tests = compute_tests_install_kwargs(env.user_specs, args.test)
-        concretized_specs = EnvironmentConcretizer(env).concretize(tests=tests)
+        concretized_specs = concretize_environment(env, tests=tests)
         if concretized_specs:
             tty.msg(f"Concretized {plural(len(concretized_specs), 'spec')}")
             ev.display_specs([concrete for _, concrete in concretized_specs])

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -16,6 +16,7 @@ import spack.paths
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
+from spack.concretize import EnvironmentConcretizer
 from spack.error import InstallError, SpackError
 from spack.installer import InstallPolicy
 from spack.llnl.string import plural
@@ -355,7 +356,7 @@ def _maybe_add_and_concretize(args, env, specs):
 
         # `spack concretize`
         tests = compute_tests_install_kwargs(env.user_specs, args.test)
-        concretized_specs = env.concretize(tests=tests)
+        concretized_specs = EnvironmentConcretizer(env).concretize(tests=tests)
         if concretized_specs:
             tty.msg(f"Concretized {plural(len(concretized_specs), 'spec')}")
             ev.display_specs([concrete for _, concrete in concretized_specs])

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -7,6 +7,7 @@ import sys
 
 import spack
 import spack.cmd
+import spack.concretize
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.llnl.util.lang as lang
@@ -95,7 +96,7 @@ def spec(parser, args):
     if args.specs:
         concrete_specs = spack.cmd.parse_specs(args.specs, concretize=True)
     elif env:
-        env.concretize()
+        spack.concretize.EnvironmentConcretizer(env).concretize()
         concrete_specs = env.concrete_roots()
     else:
         tty.die("spack spec requires at least one spec or an active environment")

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -96,7 +96,7 @@ def spec(parser, args):
     if args.specs:
         concrete_specs = spack.cmd.parse_specs(args.specs, concretize=True)
     elif env:
-        spack.concretize.EnvironmentConcretizer(env).concretize()
+        spack.concretize.concretize_environment(env)
         concrete_specs = env.concrete_roots()
     else:
         tty.die("spack spec requires at least one spec or an active environment")

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -240,6 +240,32 @@ def concretize_one(spec: Union[str, Spec], tests: TestsType = False) -> Spec:
     return concretized
 
 
+def concretize_environment(
+    env: spack.environment.environment.Environment,
+    *,
+    force: Optional[bool] = None,
+    tests: Union[bool, Sequence[str]] = False,
+) -> List[SpecPair]:
+    """Concretize user_specs in this environment.
+
+    Only concretizes specs that haven't been concretized yet unless force is ``True``.
+
+    This only modifies the environment in memory. ``write()`` will write out a lockfile
+    containing concretized specs.
+
+    Arguments:
+        force: re-concretize ALL specs, even those that were already concretized;
+            defaults to ``spack.config.get("concretizer:force")``
+        tests: False to run no tests, True to test all packages, or a list of
+            package names to run tests for some
+
+    Returns:
+        List of specs that have been concretized. Each entry is a tuple of
+        the user spec and the corresponding concretized spec.
+    """
+    return EnvironmentConcretizer(env).concretize(force=force, tests=tests)
+
+
 class EnvironmentConcretizer:
 
     def __init__(self, env: spack.environment.environment.Environment):

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -10,10 +10,12 @@ from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 import spack.compilers
 import spack.compilers.config
 import spack.config
+import spack.environment.environment
 import spack.error
 import spack.llnl.util.tty as tty
 import spack.repo
 import spack.util.parallel
+from spack.llnl.util.lang import stable_partition
 from spack.spec import ArchSpec, CompilerSpec, Spec
 
 SpecPairInput = Tuple[Spec, Optional[Spec]]
@@ -236,6 +238,126 @@ def concretize_one(spec: Union[str, Spec], tests: TestsType = False) -> Spec:
 
     concretized = answer[node]
     return concretized
+
+
+class EnvironmentConcretizer:
+
+    def __init__(self, env: spack.environment.environment.Environment):
+        self.env = env
+
+    def concretize(
+        self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
+    ) -> List[SpecPair]:
+        if force is None:
+            force = spack.config.get("concretizer:force")
+
+        # Exit early if the set of concretized specs is the set of user specs
+        self._prepare_environment_for_concretization(force=force)
+        new_user_specs, kept_user_specs = self._partition_user_specs()
+        if not new_user_specs:
+            return []
+
+        # Pick the right concretization strategy
+        unify = self.env.unify
+        if unify == "when_possible":
+            return self._concretize_together_where_possible(
+                new_user_specs, kept_user_specs, tests=tests
+            )
+
+        if unify is True:
+            return self._concretize_together(new_user_specs, kept_user_specs, tests=tests)
+
+        if unify is False:
+            return self._concretize_separately(new_user_specs, kept_user_specs, tests=tests)
+
+        raise ValueError(f"concretization strategy not implemented [{unify}]")
+
+    def _prepare_environment_for_concretization(self, *, force: bool):
+        """Reset the environment concrete state and ensure consistency with user specs."""
+        if force:
+            self.env.clear_concretized_specs()
+        else:
+            self.env.sync_concretized_specs()
+
+        # If a combined env, check updated spec is in the linked envs
+        if self.env.included_concrete_envs:
+            self.env.include_concrete_envs()
+
+    def _partition_user_specs(self) -> Tuple[List[Spec], List[Spec]]:
+        """Splits the users specs in the list of the ones to be computed, and the list of
+        the ones to retain.
+        """
+        concretized_user_specs = {x.root for x in self.env.concretized_roots}
+        kept_user_specs, new_user_specs = stable_partition(
+            self.env.user_specs, lambda x: x in concretized_user_specs
+        )
+        kept_user_specs += self.env.included_user_specs
+        return new_user_specs, kept_user_specs
+
+    def _user_spec_pairs(
+        self, user_specs_to_compute: List[Spec], user_specs_to_keep: List[Spec]
+    ) -> List[SpecPair]:
+        specs_to_concretize = [(s, None) for s in user_specs_to_compute] + [
+            (abstract, concrete)
+            for abstract, concrete in self.env.concretized_specs()
+            if abstract in user_specs_to_keep
+        ]
+        return specs_to_concretize
+
+    def _concretize_together_where_possible(
+        self, to_compute: List[Spec], to_keep: List[Spec], *, tests: Union[bool, Sequence] = False
+    ) -> List[SpecPair]:
+        specs_to_concretize = self._user_spec_pairs(to_compute, to_keep)
+        result = concretize_together_when_possible(specs_to_concretize, tests=tests)
+        result = [x for x in result if x[0] in to_compute]
+        for abstract, concrete in result:
+            self.env.add_concrete_spec(abstract, concrete, new=True)
+
+        return result
+
+    def _concretize_together(
+        self, to_compute: List[Spec], to_keep: List[Spec], *, tests: Union[bool, Sequence] = False
+    ) -> List[SpecPair]:
+        to_concretize = self._user_spec_pairs(to_compute, to_keep)
+        try:
+            concrete_pairs = concretize_together(to_concretize, tests=tests)
+        except spack.error.UnsatisfiableSpecError as e:
+            # "Enhance" the error message for multiple root specs, suggest a less strict
+            # form of concretization.
+            if len(self.env.user_specs) > 1:
+                e.message += ". "
+                if to_keep:
+                    e.message += (
+                        "Couldn't concretize without changing the existing environment. "
+                        "If you are ok with changing it, try `spack concretize --force`. "
+                    )
+                e.message += (
+                    "You could consider setting `concretizer:unify` to `when_possible` "
+                    "or `false` to allow multiple versions of some packages."
+                )
+            raise
+
+        # Return the portion of the return value that is new
+        result = concrete_pairs[: len(to_compute)]
+        for abstract, concrete in result:
+            self.env.add_concrete_spec(abstract, concrete, new=True)
+        return result
+
+    def _concretize_separately(
+        self, to_compute: List[Spec], to_keep: List[Spec], *, tests: Union[bool, Sequence] = False
+    ) -> List[SpecPair]:
+        """Concretization strategy that concretizes separately one
+        user spec after the other.
+        """
+        to_concretize = [(x, None) for x in to_compute]
+        concrete_pairs = concretize_separately(to_concretize, tests=tests)
+
+        for abstract, concrete in concrete_pairs:
+            self.env.add_concrete_spec(abstract, concrete, new=True)
+
+        # Unify the specs objects, so we get correct references to all parents
+        self.env.unify_specs()
+        return concrete_pairs
 
 
 class UnavailableCompilerVersionError(spack.error.SpackError):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -12,10 +12,9 @@ import re
 import shutil
 import stat
 import warnings
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import spack
-import spack.concretize
 import spack.config
 import spack.deptypes as dt
 import spack.error
@@ -49,7 +48,7 @@ from spack.util.path import substitute_path_variables
 from ..enums import ConfigScopePriority
 from .list import SpecList, SpecListError, SpecListParser
 
-SpecPair = spack.concretize.SpecPair
+SpecPair = Tuple[Spec, Spec]
 
 #: environment variable used to indicate the active environment
 spack_env_var = "SPACK_ENV"
@@ -1538,28 +1537,6 @@ class Environment:
         if modified_roots:
             self.write()
 
-    def concretize(
-        self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
-    ) -> Sequence[SpecPair]:
-        """Concretize user_specs in this environment.
-
-        Only concretizes specs that haven't been concretized yet unless force is ``True``.
-
-        This only modifies the environment in memory. ``write()`` will write out a lockfile
-        containing concretized specs.
-
-        Arguments:
-            force: re-concretize ALL specs, even those that were already concretized;
-                defaults to ``spack.config.get("concretizer:force")``
-            tests: False to run no tests, True to test all packages, or a list of
-                package names to run tests for some
-
-        Returns:
-            List of specs that have been concretized. Each entry is a tuple of
-            the user spec and the corresponding concretized spec.
-        """
-        return EnvironmentConcretizer(self).concretize(force=force, tests=tests)
-
     def sync_concretized_specs(self) -> None:
         """Removes concrete specs that no longer correlate to a user spec"""
         to_deconcretize = [x.root for x in self.concretized_roots if x.root not in self.user_specs]
@@ -2366,127 +2343,6 @@ class Environment:
 
 def _is_uninstalled(spec):
     return not spec.installed or (spec.satisfies("dev_path=*") or spec.satisfies("^dev_path=*"))
-
-
-class EnvironmentConcretizer:
-    def __init__(self, env: Environment):
-        self.env = env
-
-    def concretize(
-        self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
-    ) -> List[SpecPair]:
-        if force is None:
-            force = spack.config.get("concretizer:force")
-
-        # Exit early if the set of concretized specs is the set of user specs
-        self._prepare_environment_for_concretization(force=force)
-        new_user_specs, kept_user_specs = self._partition_user_specs()
-        if not new_user_specs:
-            return []
-
-        # Pick the right concretization strategy
-        unify = self.env.unify
-        if unify == "when_possible":
-            return self._concretize_together_where_possible(
-                new_user_specs, kept_user_specs, tests=tests
-            )
-
-        if unify is True:
-            return self._concretize_together(new_user_specs, kept_user_specs, tests=tests)
-
-        if unify is False:
-            return self._concretize_separately(new_user_specs, kept_user_specs, tests=tests)
-
-        raise SpackEnvironmentError(f"concretization strategy not implemented [{unify}]")
-
-    def _prepare_environment_for_concretization(self, *, force: bool):
-        """Reset the environment concrete state and ensure consistency with user specs."""
-        if force:
-            self.env.clear_concretized_specs()
-        else:
-            self.env.sync_concretized_specs()
-
-        # If a combined env, check updated spec is in the linked envs
-        if self.env.included_concrete_envs:
-            self.env.include_concrete_envs()
-
-    def _partition_user_specs(self) -> Tuple[List[spack.spec.Spec], List[spack.spec.Spec]]:
-        """Splits the users specs in the list of the ones to be computed, and the list of
-        the ones to retain.
-        """
-        concretized_user_specs = {x.root for x in self.env.concretized_roots}
-        kept_user_specs, new_user_specs = stable_partition(
-            self.env.user_specs, lambda x: x in concretized_user_specs
-        )
-        kept_user_specs += self.env.included_user_specs
-        return new_user_specs, kept_user_specs
-
-    def _user_spec_pairs(
-        self, user_specs_to_compute: List[Spec], user_specs_to_keep: List[Spec]
-    ) -> List[SpecPair]:
-        specs_to_concretize = [(s, None) for s in user_specs_to_compute] + [
-            (abstract, concrete)
-            for abstract, concrete in self.env.concretized_specs()
-            if abstract in user_specs_to_keep
-        ]
-        return specs_to_concretize
-
-    def _concretize_together_where_possible(
-        self, to_compute: List[Spec], to_keep: List[Spec], *, tests: Union[bool, Sequence] = False
-    ) -> List[SpecPair]:
-        specs_to_concretize = self._user_spec_pairs(to_compute, to_keep)
-        result = spack.concretize.concretize_together_when_possible(
-            specs_to_concretize, tests=tests
-        )
-        result = [x for x in result if x[0] in to_compute]
-        for abstract, concrete in result:
-            self.env.add_concrete_spec(abstract, concrete, new=True)
-
-        return result
-
-    def _concretize_together(
-        self, to_compute: List[Spec], to_keep: List[Spec], *, tests: Union[bool, Sequence] = False
-    ) -> List[SpecPair]:
-        to_concretize = self._user_spec_pairs(to_compute, to_keep)
-        try:
-            concrete_pairs = spack.concretize.concretize_together(to_concretize, tests=tests)
-        except spack.error.UnsatisfiableSpecError as e:
-            # "Enhance" the error message for multiple root specs, suggest a less strict
-            # form of concretization.
-            if len(self.env.user_specs) > 1:
-                e.message += ". "
-                if to_keep:
-                    e.message += (
-                        "Couldn't concretize without changing the existing environment. "
-                        "If you are ok with changing it, try `spack concretize --force`. "
-                    )
-                e.message += (
-                    "You could consider setting `concretizer:unify` to `when_possible` "
-                    "or `false` to allow multiple versions of some packages."
-                )
-            raise
-
-        # Return the portion of the return value that is new
-        result = concrete_pairs[: len(to_compute)]
-        for abstract, concrete in result:
-            self.env.add_concrete_spec(abstract, concrete, new=True)
-        return result
-
-    def _concretize_separately(
-        self, to_compute: List[Spec], to_keep: List[Spec], *, tests: Union[bool, Sequence] = False
-    ) -> List[SpecPair]:
-        """Concretization strategy that concretizes separately one
-        user spec after the other.
-        """
-        to_concretize = [(x, None) for x in to_compute]
-        concrete_pairs = spack.concretize.concretize_separately(to_concretize, tests=tests)
-
-        for abstract, concrete in concrete_pairs:
-            self.env.add_concrete_spec(abstract, concrete, new=True)
-
-        # Unify the specs objects, so we get correct references to all parents
-        self.env.unify_specs()
-        return concrete_pairs
 
 
 def yaml_equivalent(first, second) -> bool:

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -17,6 +17,7 @@ import spack.llnl.util.filesystem as fs
 import spack.paths
 import spack.repo as repo
 import spack.util.git
+from spack.concretize import EnvironmentConcretizer
 from spack.spec import Spec
 from spack.test.conftest import MockHTTPResponse, RepoBuilder
 from spack.version import Version
@@ -360,7 +361,7 @@ def test_get_spec_filter_list(mutable_mock_env_path, mutable_mock_repo):
     e1 = ev.create("test")
     e1.add("mpileaks")
     e1.add("hypre")
-    e1.concretize()
+    EnvironmentConcretizer(e1).concretize()
 
     touched = {"libdwarf"}
 
@@ -418,7 +419,7 @@ def test_affected_specs_on_first_concretization(mutable_mock_env_path):
     e = ev.create("first_concretization")
     e.add("mpileaks~shared")
     e.add("mpileaks+shared")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
 
     affected_specs = ci.get_spec_filter_list(e, {"callpath"})
     mpileaks_specs = [s for s in affected_specs if s.name == "mpileaks"]

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -17,7 +17,7 @@ import spack.llnl.util.filesystem as fs
 import spack.paths
 import spack.repo as repo
 import spack.util.git
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.spec import Spec
 from spack.test.conftest import MockHTTPResponse, RepoBuilder
 from spack.version import Version
@@ -361,7 +361,7 @@ def test_get_spec_filter_list(mutable_mock_env_path, mutable_mock_repo):
     e1 = ev.create("test")
     e1.add("mpileaks")
     e1.add("hypre")
-    EnvironmentConcretizer(e1).concretize()
+    concretize_environment(e1)
 
     touched = {"libdwarf"}
 
@@ -419,7 +419,7 @@ def test_affected_specs_on_first_concretization(mutable_mock_env_path):
     e = ev.create("first_concretization")
     e.add("mpileaks~shared")
     e.add("mpileaks+shared")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
 
     affected_specs = ci.get_spec_filter_list(e, {"callpath"})
     mpileaks_specs = [s for s in affected_specs if s.name == "mpileaks"]

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -30,6 +30,7 @@ from spack.ci import gitlab as gitlab_generator
 from spack.ci.common import PipelineDag, PipelineOptions, SpackCIConfig
 from spack.ci.generator_registry import generator
 from spack.cmd.ci import FAILED_CREATE_BUILDCACHE_CODE
+from spack.concretize import EnvironmentConcretizer
 from spack.error import SpackError
 from spack.llnl.util.filesystem import mkdirp, working_dir
 from spack.schema.database_index import schema as db_idx_schema
@@ -539,7 +540,7 @@ spack:
         )
 
     with ev.Environment(env_dir) as env:
-        env.concretize()
+        EnvironmentConcretizer(env).concretize()
         env.write()
 
     shutil.copy(env_dir / "spack.yaml", tmp_path / "spack.yaml")
@@ -740,7 +741,7 @@ spack:
     with working_dir(tmp_path):
         env_cmd("create", "test", "./spack.yaml")
         with ev.read("test") as env:
-            env.concretize()
+            EnvironmentConcretizer(env).concretize()
 
             # Create environment variables as gitlab would do it
             os.environ.update(
@@ -812,7 +813,7 @@ spack:
             )
         env_cmd("create", "test", "./spack.yaml")
         with ev.read("test") as current_env:
-            current_env.concretize()
+            EnvironmentConcretizer(current_env).concretize()
             install_cmd("--keep-stage")
 
             concrete_spec = list(current_env.roots())[0]
@@ -1152,7 +1153,7 @@ spack:
     #          -> mpich
     env_hashes = {}
     with ev.read("test") as active_env:
-        active_env.concretize()
+        EnvironmentConcretizer(active_env).concretize()
         for s in active_env.all_specs():
             env_hashes[s.name] = s.dag_hash()
 
@@ -1369,7 +1370,7 @@ spack:
         )
 
     with working_dir(tmp_path), ev.Environment(".") as env:
-        env.concretize()
+        EnvironmentConcretizer(env).concretize()
         env.write()
 
     def fake_download_and_extract_artifacts(url, work_dir, merge_commit_test=True):
@@ -1885,7 +1886,7 @@ spack:
         manifest_data = json.load(fd)
 
     with ev.read("test") as active_env:
-        active_env.concretize()
+        EnvironmentConcretizer(active_env).concretize()
         for s in active_env.all_specs():
             assert s.dag_hash() in manifest_data
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -30,7 +30,7 @@ from spack.ci import gitlab as gitlab_generator
 from spack.ci.common import PipelineDag, PipelineOptions, SpackCIConfig
 from spack.ci.generator_registry import generator
 from spack.cmd.ci import FAILED_CREATE_BUILDCACHE_CODE
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.error import SpackError
 from spack.llnl.util.filesystem import mkdirp, working_dir
 from spack.schema.database_index import schema as db_idx_schema
@@ -540,7 +540,7 @@ spack:
         )
 
     with ev.Environment(env_dir) as env:
-        EnvironmentConcretizer(env).concretize()
+        concretize_environment(env)
         env.write()
 
     shutil.copy(env_dir / "spack.yaml", tmp_path / "spack.yaml")
@@ -741,7 +741,7 @@ spack:
     with working_dir(tmp_path):
         env_cmd("create", "test", "./spack.yaml")
         with ev.read("test") as env:
-            EnvironmentConcretizer(env).concretize()
+            concretize_environment(env)
 
             # Create environment variables as gitlab would do it
             os.environ.update(
@@ -813,7 +813,7 @@ spack:
             )
         env_cmd("create", "test", "./spack.yaml")
         with ev.read("test") as current_env:
-            EnvironmentConcretizer(current_env).concretize()
+            concretize_environment(current_env)
             install_cmd("--keep-stage")
 
             concrete_spec = list(current_env.roots())[0]
@@ -1153,7 +1153,7 @@ spack:
     #          -> mpich
     env_hashes = {}
     with ev.read("test") as active_env:
-        EnvironmentConcretizer(active_env).concretize()
+        concretize_environment(active_env)
         for s in active_env.all_specs():
             env_hashes[s.name] = s.dag_hash()
 
@@ -1370,7 +1370,7 @@ spack:
         )
 
     with working_dir(tmp_path), ev.Environment(".") as env:
-        EnvironmentConcretizer(env).concretize()
+        concretize_environment(env)
         env.write()
 
     def fake_download_and_extract_artifacts(url, work_dir, merge_commit_test=True):
@@ -1886,7 +1886,7 @@ spack:
         manifest_data = json.load(fd)
 
     with ev.read("test") as active_env:
-        EnvironmentConcretizer(active_env).concretize()
+        concretize_environment(active_env)
         for s in active_env.all_specs():
             assert s.dag_hash() in manifest_data
 

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -11,7 +11,7 @@ import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
 import spack.main
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 
 
 @pytest.fixture()
@@ -85,7 +85,7 @@ def test_match_spec_env(mock_packages, mutable_mock_env_path):
 
     e = ev.create("test")
     e.add("pkg-a foobar=baz")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     with e:
         env_spec = spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["pkg-a"])[0])
         assert env_spec.satisfies("foobar=baz")
@@ -96,7 +96,7 @@ def test_multiple_env_match_raises_error(mock_packages, mutable_mock_env_path):
     e = ev.create("test")
     e.add("pkg-a foobar=baz")
     e.add("pkg-a foobar=fee")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     with e:
         with pytest.raises(ev.SpackEnvironmentError) as exc_info:
             spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["pkg-a"])[0])
@@ -108,7 +108,7 @@ def test_root_and_dep_match_returns_root(mock_packages, mutable_mock_env_path):
     e = ev.create("test")
     e.add("pkg-b@0.9")
     e.add("pkg-a foobar=bar")  # Depends on b, should choose b@1.0
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     with e:
         # This query matches the root b and b as a dependency of a. In that
         # case the root instance should be preferred.

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -11,6 +11,7 @@ import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
 import spack.main
+from spack.concretize import EnvironmentConcretizer
 
 
 @pytest.fixture()
@@ -84,7 +85,7 @@ def test_match_spec_env(mock_packages, mutable_mock_env_path):
 
     e = ev.create("test")
     e.add("pkg-a foobar=baz")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     with e:
         env_spec = spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["pkg-a"])[0])
         assert env_spec.satisfies("foobar=baz")
@@ -95,7 +96,7 @@ def test_multiple_env_match_raises_error(mock_packages, mutable_mock_env_path):
     e = ev.create("test")
     e.add("pkg-a foobar=baz")
     e.add("pkg-a foobar=fee")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     with e:
         with pytest.raises(ev.SpackEnvironmentError) as exc_info:
             spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["pkg-a"])[0])
@@ -107,7 +108,7 @@ def test_root_and_dep_match_returns_root(mock_packages, mutable_mock_env_path):
     e = ev.create("test")
     e.add("pkg-b@0.9")
     e.add("pkg-a foobar=bar")  # Depends on b, should choose b@1.0
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     with e:
         # This query matches the root b and b as a dependency of a. In that
         # case the root instance should be preferred.

--- a/lib/spack/spack/test/cmd/deconcretize.py
+++ b/lib/spack/spack/test/cmd/deconcretize.py
@@ -5,7 +5,7 @@
 import pytest
 
 import spack.environment as ev
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.main import SpackCommand, SpackCommandError
 
 deconcretize = SpackCommand("deconcretize")
@@ -17,7 +17,7 @@ def test_env(mutable_mock_env_path, mock_packages):
     with ev.read("test") as e:
         e.add("pkg-a@2.0 foobar=bar ^pkg-b@1.0")
         e.add("pkg-a@1.0 foobar=bar ^pkg-b@0.9")
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         e.write()
 
 

--- a/lib/spack/spack/test/cmd/deconcretize.py
+++ b/lib/spack/spack/test/cmd/deconcretize.py
@@ -5,6 +5,7 @@
 import pytest
 
 import spack.environment as ev
+from spack.concretize import EnvironmentConcretizer
 from spack.main import SpackCommand, SpackCommandError
 
 deconcretize = SpackCommand("deconcretize")
@@ -16,7 +17,7 @@ def test_env(mutable_mock_env_path, mock_packages):
     with ev.read("test") as e:
         e.add("pkg-a@2.0 foobar=bar ^pkg-b@1.0")
         e.add("pkg-a@1.0 foobar=bar ^pkg-b@0.9")
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         e.write()
 
 

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -16,6 +16,7 @@ import spack.spec
 import spack.stage
 import spack.util.git
 import spack.util.path
+from spack.concretize import EnvironmentConcretizer
 from spack.error import SpackError
 from spack.fetch_strategy import URLFetchStrategy
 from spack.main import SpackCommand
@@ -130,7 +131,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
             e.write()
 
             monkeypatch.setattr(spack.stage.Stage, "steal_source", lambda x, y: None)
@@ -144,7 +145,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("hdf5^mpich@1.0")
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
             e.write()
 
             orig_hash = next(e.roots()).dag_hash()
@@ -161,7 +162,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
             e.write()
 
             monkeypatch.setattr(spack.stage.Stage, "steal_source", lambda x, y: None)
@@ -172,7 +173,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
             e.write()
 
             # canonicalize paths relative to env
@@ -193,7 +194,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
             e.write()
 
             monkeypatch.setattr(spack.stage.Stage, "steal_source", lambda x, y: None)
@@ -207,7 +208,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
             e.write()
 
             path = "../$user"
@@ -229,7 +230,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
             e.write()
 
             path = "$user"
@@ -296,7 +297,7 @@ def test_develop_full_git_repo(
     env("create", "test")
     with ev.read("test") as e:
         add("git-test-commit@1.2")
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         e.write()
 
         develop("git-test-commit@1.2")
@@ -313,7 +314,7 @@ def test_recursive(mutable_mock_env_path, install_mockery, mock_fetch):
 
     with ev.read("test") as e:
         add("indirect-mpich@1.0")
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         e.write()
         specs = e.all_specs()
 
@@ -338,7 +339,7 @@ def test_develop_fails_with_multiple_concrete_versions(
         add("indirect-mpich@1.0")
         add("indirect-mpich@0.9")
         e.unify = False
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
         with pytest.raises(SpackError) as develop_error:
             develop("indirect-mpich", fail_on_error=True)
@@ -358,7 +359,7 @@ def test_concretize_dev_path_with_at_symbol_in_env(
 
     with ev.read("test_at_sym") as e:
         add(spec_like)
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         e.write()
         develop(f"--path={develop_dir}", spec_like)
         result = e.concrete_roots()
@@ -404,7 +405,7 @@ def test_develop_with_devpath_staging(
 
     with ev.read("test") as e:
         e.add(spec_like)
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         e.write()
         develop(f"--path={develop_dir}", spec_like)
 

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -16,7 +16,7 @@ import spack.spec
 import spack.stage
 import spack.util.git
 import spack.util.path
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.error import SpackError
 from spack.fetch_strategy import URLFetchStrategy
 from spack.main import SpackCommand
@@ -131,7 +131,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
             e.write()
 
             monkeypatch.setattr(spack.stage.Stage, "steal_source", lambda x, y: None)
@@ -145,7 +145,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("hdf5^mpich@1.0")
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
             e.write()
 
             orig_hash = next(e.roots()).dag_hash()
@@ -162,7 +162,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
             e.write()
 
             monkeypatch.setattr(spack.stage.Stage, "steal_source", lambda x, y: None)
@@ -173,7 +173,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
             e.write()
 
             # canonicalize paths relative to env
@@ -194,7 +194,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
             e.write()
 
             monkeypatch.setattr(spack.stage.Stage, "steal_source", lambda x, y: None)
@@ -208,7 +208,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
             e.write()
 
             path = "../$user"
@@ -230,7 +230,7 @@ class TestDevelop:
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
             e.write()
 
             path = "$user"
@@ -297,7 +297,7 @@ def test_develop_full_git_repo(
     env("create", "test")
     with ev.read("test") as e:
         add("git-test-commit@1.2")
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         e.write()
 
         develop("git-test-commit@1.2")
@@ -314,7 +314,7 @@ def test_recursive(mutable_mock_env_path, install_mockery, mock_fetch):
 
     with ev.read("test") as e:
         add("indirect-mpich@1.0")
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         e.write()
         specs = e.all_specs()
 
@@ -339,7 +339,7 @@ def test_develop_fails_with_multiple_concrete_versions(
         add("indirect-mpich@1.0")
         add("indirect-mpich@0.9")
         e.unify = False
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
         with pytest.raises(SpackError) as develop_error:
             develop("indirect-mpich", fail_on_error=True)
@@ -359,7 +359,7 @@ def test_concretize_dev_path_with_at_symbol_in_env(
 
     with ev.read("test_at_sym") as e:
         add(spec_like)
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         e.write()
         develop(f"--path={develop_dir}", spec_like)
         result = e.concrete_roots()
@@ -405,7 +405,7 @@ def test_develop_with_devpath_staging(
 
     with ev.read("test") as e:
         e.add(spec_like)
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         e.write()
         develop(f"--path={develop_dir}", spec_like)
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -37,7 +37,7 @@ import spack.util.environment
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml
 from spack.cmd.env import _env_create
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.installer import PackageInstaller
 from spack.llnl.util.filesystem import readlink
 from spack.llnl.util.lang import dedupe
@@ -79,14 +79,14 @@ def setup_combined_multiple_env():
     test1 = ev.read("test1")
     with test1:
         add("mpich@1.0")
-        EnvironmentConcretizer(test1).concretize()
+        concretize_environment(test1)
         test1.write()
 
     env("create", "test2")
     test2 = ev.read("test2")
     with test2:
         add("libelf")
-        EnvironmentConcretizer(test2).concretize()
+        concretize_environment(test2)
         test2.write()
 
     env("create", "--include-concrete", "test1", "--include-concrete", "test2", "combined_env")
@@ -220,7 +220,7 @@ def installed_environment(
         with fs.working_dir(tmp_path):
             env("create", "test", "./spack.yaml")
             with ev.read("test") as current_environment:
-                EnvironmentConcretizer(current_environment).concretize()
+                concretize_environment(current_environment)
                 current_environment.install_all(fake=True)
                 current_environment.write(regenerate=True)
 
@@ -295,7 +295,7 @@ def test_env_add_virtual():
     env("create", "test")
     e = ev.read("test")
     e.add("mpi")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
 
     assert len(e.concretized_roots) == 1
     spec = e.specs_by_hash[e.concretized_roots[0].hash]
@@ -474,7 +474,7 @@ def test_env_rename_independent(tmp_path: pathlib.Path):
 def test_concretize():
     e = ev.create("test")
     e.add("mpileaks")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
 
     assert len(e.concretized_roots) == 1
     assert e.concretized_roots[0].root == Spec("mpileaks")
@@ -483,7 +483,7 @@ def test_concretize():
 def test_env_specs_partition(install_mockery, mock_fetch):
     e = ev.create("test")
     e.add("cmake-client")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
 
     # Single not installed root spec.
     roots_already_installed, roots_to_install = e._partition_roots_by_install_status()
@@ -500,7 +500,7 @@ def test_env_specs_partition(install_mockery, mock_fetch):
 
     # One installed root, one not installed root.
     e.add("mpileaks")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     roots_already_installed, roots_to_install = e._partition_roots_by_install_status()
     assert len(roots_already_installed) == 1
     assert len(roots_to_install) == 1
@@ -511,7 +511,7 @@ def test_env_specs_partition(install_mockery, mock_fetch):
 def test_env_install_all(install_mockery, mock_fetch):
     e = ev.create("test")
     e.add("cmake-client")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     e.install_all(fake=True)
     spec = next(x for x in e.all_specs_generator() if x.name == "cmake-client")
     assert spec.installed
@@ -548,7 +548,7 @@ def test_env_install_include_concrete_env(
         mutable_config.set("concretizer:unify", unify)
         mutable_config.set("concretizer:reuse", reuse)
         combined.add("mpileaks")
-        EnvironmentConcretizer(combined).concretize()
+        concretize_environment(combined)
         combined.write()
         install("--fake")
 
@@ -586,7 +586,7 @@ def test_env_roots_marked_explicit(install_mockery, mock_fetch):
     with ev.read("test") as e:
         # make implicit install a root of the env
         e.add(dependency[0].name)
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         e.install_all()
 
     explicit = spack.store.STORE.db.query(explicit=True)
@@ -639,7 +639,7 @@ def test_env_definition_symlink(install_mockery, mock_fetch, tmp_path: pathlib.P
     os.symlink(filepath, filepath_mid)
     os.symlink(filepath_mid, e.manifest_path)
 
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     e.write()
 
     assert os.path.islink(e.manifest_path)
@@ -687,10 +687,10 @@ def test_remove_after_concretize():
     e = ev.create("test")
 
     e.add("mpileaks")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
 
     e.add("python")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
 
     e.remove("mpileaks")
     assert Spec("mpileaks") not in e.user_specs
@@ -709,12 +709,12 @@ def test_remove_before_concretize(mutable_config):
     with ev.create("test") as e:
         mutable_config.set("concretizer:unify", True)
         e.add("mpileaks")
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         assert len(e.concretized_roots) == 1
         assert e.concrete_roots()[0].satisfies("mpileaks")
 
         e.remove("mpileaks")
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         assert not e.concretized_roots
 
 
@@ -801,7 +801,7 @@ def test_bad_remove_included_env():
     with test:
         add("mpileaks")
 
-    EnvironmentConcretizer(test).concretize()
+    concretize_environment(test)
     test.write()
 
     env("create", "--include-concrete", "test", "combined_env")
@@ -817,7 +817,7 @@ def test_force_remove_included_env():
     with test:
         add("mpileaks")
 
-    EnvironmentConcretizer(test).concretize()
+    concretize_environment(test)
     test.write()
 
     env("create", "--include-concrete", "test", "combined_env")
@@ -892,7 +892,7 @@ def test_env_activate_broken_view(
 def test_to_lockfile_dict():
     e = ev.create("test")
     e.add("mpileaks")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     context_dict = e._to_lockfile_dict()
 
     e_copy = ev.create("test_copy")
@@ -925,7 +925,7 @@ spack:
   - libelf
 """
     )
-    EnvironmentConcretizer(before).concretize()
+    concretize_environment(before)
     before.write()
 
     # user modifies yaml externally to spack and removes hypre
@@ -940,7 +940,7 @@ spack:
         )
 
     after = ev.read("test")
-    EnvironmentConcretizer(after).concretize()
+    concretize_environment(after)
     after.write()
 
     read = ev.read("test")
@@ -967,7 +967,7 @@ spack:
 """
     )
     with e1:
-        EnvironmentConcretizer(e1).concretize()
+        concretize_environment(e1)
         e1.write()
 
     # By reading into a second environment, we force a round trip to json
@@ -991,7 +991,7 @@ spack:
   - libelf
 """
     )
-    EnvironmentConcretizer(e1).concretize()
+    concretize_environment(e1)
     e1.write()
 
     e2 = _env_create("test2", init_file=e1.lock_path)
@@ -1016,7 +1016,7 @@ spack:
   - libelf
 """
     )
-    EnvironmentConcretizer(e1).concretize()
+    concretize_environment(e1)
     e1.write()
 
     e2 = _env_create("test2", init_file=e1.manifest_path)
@@ -1051,7 +1051,7 @@ spack:
         spack.config.set("develop", dev_config)
         fs.touch(os.path.join(e1.path, "libelf"))
 
-    EnvironmentConcretizer(e1).concretize()
+    concretize_environment(e1)
     e1.write()
 
     e2 = _env_create("test2", init_file="test" if use_name else e1.path)
@@ -1168,7 +1168,7 @@ packages:
     test_scope = spack.config.InternalConfigScope("env-external-test", data=external_config_dict)
     with spack.config.override(test_scope):
         e = ev.create("test", manifest_file)
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         # Note: normally installing specs in a test environment requires doing
         # a fake install, but not for external specs since no actions are
         # taken to install them. The installation commands also include
@@ -1224,7 +1224,7 @@ spack:
 """
     )
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1260,7 +1260,7 @@ spack:
     )
 
     with ev.Environment(env_root) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     # We've created an environment with included config file (which does
     # exist). Now we remove it and check that we get a sensible error.
@@ -1310,7 +1310,7 @@ spack:
     )
 
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1373,7 +1373,7 @@ spack:
 
     e = ev.Environment(env_root)
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1539,7 +1539,7 @@ def test_env_with_included_config_scope(mutable_mock_env_path, packages_file):
     # packages.yaml file.
     e = ev.Environment(env_root)
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1562,7 +1562,7 @@ def test_env_with_included_config_var_path(tmp_path: pathlib.Path, packages_file
 
     e = ev.Environment(env_path)
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1602,7 +1602,7 @@ spack:
 
     e = ev.Environment(tmp_path)
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1653,7 +1653,7 @@ packages:
 
     e = ev.Environment(tmp_path)
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1908,7 +1908,7 @@ def test_indirect_build_dep(repo_builder: RepoBuilder):
         _env_create("test", with_view=False)
         e = ev.read("test")
         e.add(x_spec)
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         e.write()
 
         e_read = ev.read("test")
@@ -1950,7 +1950,7 @@ def test_store_different_build_deps(repo_builder: RepoBuilder):
         e = ev.read("test")
         e.add(y_spec)
         e.add(x_spec)
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         e.write()
 
         e_read = ev.read("test")
@@ -2056,7 +2056,7 @@ def test_env_include_concrete_env_yaml(env_name):
 
     with test:
         add("mpileaks")
-    EnvironmentConcretizer(test).concretize()
+    concretize_environment(test)
     test.write()
 
     environ = "test" if env_name else test.path
@@ -2137,7 +2137,7 @@ def test_env_include_concrete_add_env():
     with new_env:
         add("mpileaks")
 
-    EnvironmentConcretizer(new_env).concretize()
+    concretize_environment(new_env)
     new_env.write()
 
     # add new env to combined
@@ -2150,7 +2150,7 @@ def test_env_include_concrete_add_env():
     assert new_env.path not in lockfile_as_dict["include_concrete"].keys()
 
     # concretize combined env with new env
-    EnvironmentConcretizer(combined).concretize()
+    concretize_environment(combined)
     combined.write()
 
     # assert changes
@@ -2173,7 +2173,7 @@ def test_env_include_concrete_remove_env():
     assert test2.path in lockfile_as_dict["include_concrete"].keys()
 
     # reconcretize combined
-    EnvironmentConcretizer(combined).concretize()
+    concretize_environment(combined)
     combined.write()
 
     # assert test2 is not in combined's lockfile
@@ -2199,7 +2199,7 @@ def configure_reuse(reuse_mode, combined_env) -> Optional[ev.Environment]:
         override_env = ev.read("external_test")
         with override_env:
             add("mpich@1.0 +debug")
-        EnvironmentConcretizer(override_env).concretize()
+        concretize_environment(override_env)
         override_env.write()
 
         # Reuse from the environment that is not included.
@@ -2256,7 +2256,7 @@ def test_env_include_concrete_reuse(reuse_mode):
         # Add mpileaks to the combined environment
         with combined:
             add("mpileaks")
-            EnvironmentConcretizer(combined).concretize()
+            concretize_environment(combined)
         comb_specs_by_hash = combined.specs_by_hash
 
         # create reference env with mpileaks that does not use reuse
@@ -2265,7 +2265,7 @@ def test_env_include_concrete_reuse(reuse_mode):
         ref_env = ev.read("new")
         with ref_env:
             add("mpileaks")
-        EnvironmentConcretizer(ref_env).concretize()
+        concretize_environment(ref_env)
         ref_specs_by_hash = ref_env.specs_by_hash
 
         # Ensure that the mpich used by the mpileaks is the mpich from the reused test environment
@@ -2300,7 +2300,7 @@ def test_env_include_concrete_env_reconcretized(mutable_config, unify):
 
     with combined:
         mutable_config.set("concretizer:unify", unify)
-        EnvironmentConcretizer(combined).concretize()
+        concretize_environment(combined)
         combined.write()
 
     with open(combined.lock_path, encoding="utf-8") as f:
@@ -2319,7 +2319,7 @@ def test_concretize_include_concrete_env():
     # Update test1 environment
     with test1:
         add("mpileaks")
-    EnvironmentConcretizer(test1).concretize()
+    concretize_environment(test1)
     test1.write()
 
     # Check the test1 environment includes mpileaks, while the combined environment does not
@@ -2327,7 +2327,7 @@ def test_concretize_include_concrete_env():
     assert Spec("mpileaks") not in combined.included_concretized_user_specs[test1.path]
 
     # If we update the combined environment, it will include mpileaks too
-    EnvironmentConcretizer(combined).concretize()
+    concretize_environment(combined)
     combined.write()
     assert Spec("mpileaks") in combined.included_concretized_user_specs[test1.path]
 
@@ -2337,14 +2337,14 @@ def test_concretize_nested_include_concrete_envs():
     test1 = ev.read("test1")
     with test1:
         add("zlib")
-    EnvironmentConcretizer(test1).concretize()
+    concretize_environment(test1)
     test1.write()
 
     env("create", "--include-concrete", "test1", "test2")
     test2 = ev.read("test2")
     with test2:
         add("libelf")
-    EnvironmentConcretizer(test2).concretize()
+    concretize_environment(test2)
     test2.write()
 
     env("create", "--include-concrete", "test2", "test3")
@@ -2366,7 +2366,7 @@ def test_concretize_nested_included_concrete():
     test1 = ev.read("test1")
     with test1:
         add("zlib")
-    EnvironmentConcretizer(test1).concretize()
+    concretize_environment(test1)
     test1.write()
 
     # test2 should include test1 with zlib
@@ -2374,7 +2374,7 @@ def test_concretize_nested_included_concrete():
     test2 = ev.read("test2")
     with test2:
         add("libelf")
-    EnvironmentConcretizer(test2).concretize()
+    concretize_environment(test2)
     test2.write()
 
     assert Spec("zlib") in test2.included_concretized_user_specs[test1.path]
@@ -2383,7 +2383,7 @@ def test_concretize_nested_included_concrete():
     with test1:
         remove("zlib")
         add("mpileaks")
-    EnvironmentConcretizer(test1).concretize()
+    concretize_environment(test1)
     test1.write()
 
     # test3 should include the latest concretization of test1
@@ -2391,7 +2391,7 @@ def test_concretize_nested_included_concrete():
     test3 = ev.read("test3")
     with test3:
         add("callpath")
-    EnvironmentConcretizer(test3).concretize()
+    concretize_environment(test3)
     test3.write()
 
     included_specs = test3.included_concretized_user_specs[test1.path]
@@ -2424,9 +2424,9 @@ def test_concretize_nested_included_concrete():
     # to remove zlib and write it out so it can be picked up by test4.
     # Re-concretize test4 to reflect the re-concretization of included test2
     # and ensure that its included specs are up-to-date
-    EnvironmentConcretizer(test2).concretize()
+    concretize_environment(test2)
     test2.write()
-    EnvironmentConcretizer(test4).concretize()
+    concretize_environment(test4)
 
     concrete_specs = [s for s, _ in test4.concretized_specs()]
     assert Spec("zlib") not in concrete_specs
@@ -2772,7 +2772,7 @@ spack:
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         with ev.read("test") as e:
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
 
             before_user = e.user_specs.specs
             concretized_roots_before = e.concretized_roots
@@ -3362,7 +3362,7 @@ def test_concretize_user_specs_together(mutable_config):
         # Concretize a first time using 'mpich' as the MPI provider
         e.add("mpileaks")
         e.add("mpich")
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
         assert all("mpich" in spec for _, spec in e.concretized_specs())
         assert all("mpich2" not in spec for _, spec in e.concretized_specs())
@@ -3375,15 +3375,15 @@ def test_concretize_user_specs_together(mutable_config):
 
         # Concretizing without invalidating the concrete spec for mpileaks fails
         with pytest.raises(exc_cls):
-            EnvironmentConcretizer(e).concretize()
-        EnvironmentConcretizer(e).concretize(force=True)
+            concretize_environment(e)
+        concretize_environment(e, force=True)
 
         assert all("mpich2" in spec for _, spec in e.concretized_specs())
         assert all("mpich" not in spec for _, spec in e.concretized_specs())
 
         # Concretize again without changing anything, check everything
         # stays the same
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
         assert all("mpich2" in spec for _, spec in e.concretized_specs())
         assert all("mpich" not in spec for _, spec in e.concretized_specs())
@@ -3400,7 +3400,7 @@ def test_duplicate_packages_raise_when_concretizing_together(mutable_config):
         match = r"You could consider setting `concretizer:unify`"
 
         with pytest.raises(exc_cls, match=match):
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
 
 
 def test_env_write_only_non_default():
@@ -3438,7 +3438,7 @@ spack:
 
     # concretize
     with ev.read("test") as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         e.write()
 
         with open(e.manifest_path, "r", encoding="utf-8") as f:
@@ -3492,12 +3492,12 @@ spack:
 
     # Concretize a first time and create a lockfile
     with ev.Environment(str(tmp_path)) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         libelf_first_hash = extract_dag_hash(e)
 
     # Check that a second run won't error
     with ev.Environment(str(tmp_path)) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         libelf_second_hash = extract_dag_hash(e)
 
     assert libelf_first_hash == libelf_second_hash
@@ -3533,7 +3533,7 @@ spack:
         spack.environment.environment.EnvironmentManifestFile, "flush", _write_helper_raise
     )
     with ev.Environment(str(tmp_path)) as e:
-        EnvironmentConcretizer(e).concretize(force=True)
+        concretize_environment(e, force=True)
         with pytest.raises(RuntimeError):
             e.clear()
             e.write()
@@ -3608,7 +3608,7 @@ def test_custom_version_concretize_together(mutable_config):
         # Concretize a first time using 'mpich' as the MPI provider
         e.add("hdf5@=myversion")
         e.add("mpich")
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         assert any(spec.satisfies("hdf5@myversion") for _, spec in e.concretized_specs())
 
 
@@ -3730,7 +3730,7 @@ def test_virtual_spec_concretize_together(mutable_config):
     with ev.create("virtual_spec") as e:
         mutable_config.set("concretizer:unify", True)
         e.add("mpi")
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         assert any(s.package.provides("mpi") for _, s in e.concretized_specs())
 
 
@@ -4367,7 +4367,7 @@ def test_unify_when_possible_works_around_conflicts(mutable_config):
         e.add("mpileaks+opt")
         e.add("mpileaks~opt")
         e.add("mpich")
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
         assert len([x for x in e.all_specs() if x.satisfies("mpileaks")]) == 2
         assert len([x for x in e.all_specs() if x.satisfies("mpileaks+opt")]) == 1
@@ -4467,7 +4467,7 @@ spack:
     )
     env("create", "disabled", str(spack_yaml))
     with ev.read("disabled") as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     assert len(e.views) == 0
     assert not os.path.exists(e.view_path_default)
@@ -4673,7 +4673,7 @@ def test_concretized_specs_and_include_concrete(mutable_config):
         mutable_config.set(
             "packages", {"mpileaks": {"require": ["@2.2"]}, "libelf": {"require": ["@0.8.12"]}}
         )
-        included_pairs = EnvironmentConcretizer(e).concretize()
+        included_pairs = concretize_environment(e)
         e.write()
 
     env("create", "--include-concrete", "included-env", "main-env")
@@ -4682,7 +4682,7 @@ def test_concretized_specs_and_include_concrete(mutable_config):
         e.add("libelf@0.8.12")
         e.add("pkg-a")
         mutable_config.set("packages", {"mpileaks": {"require": ["@2.3"]}})
-        spec_pairs = EnvironmentConcretizer(e).concretize()
+        spec_pairs = concretize_environment(e)
         concretized_specs = list(e.concretized_specs())
         assert list(dedupe(spec_pairs + included_pairs)) == concretized_specs
         assert len(concretized_specs) == 5

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -37,6 +37,7 @@ import spack.util.environment
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml
 from spack.cmd.env import _env_create
+from spack.concretize import EnvironmentConcretizer
 from spack.installer import PackageInstaller
 from spack.llnl.util.filesystem import readlink
 from spack.llnl.util.lang import dedupe
@@ -78,14 +79,14 @@ def setup_combined_multiple_env():
     test1 = ev.read("test1")
     with test1:
         add("mpich@1.0")
-        test1.concretize()
+        EnvironmentConcretizer(test1).concretize()
         test1.write()
 
     env("create", "test2")
     test2 = ev.read("test2")
     with test2:
         add("libelf")
-        test2.concretize()
+        EnvironmentConcretizer(test2).concretize()
         test2.write()
 
     env("create", "--include-concrete", "test1", "--include-concrete", "test2", "combined_env")
@@ -219,7 +220,7 @@ def installed_environment(
         with fs.working_dir(tmp_path):
             env("create", "test", "./spack.yaml")
             with ev.read("test") as current_environment:
-                current_environment.concretize()
+                EnvironmentConcretizer(current_environment).concretize()
                 current_environment.install_all(fake=True)
                 current_environment.write(regenerate=True)
 
@@ -294,7 +295,7 @@ def test_env_add_virtual():
     env("create", "test")
     e = ev.read("test")
     e.add("mpi")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
 
     assert len(e.concretized_roots) == 1
     spec = e.specs_by_hash[e.concretized_roots[0].hash]
@@ -473,7 +474,7 @@ def test_env_rename_independent(tmp_path: pathlib.Path):
 def test_concretize():
     e = ev.create("test")
     e.add("mpileaks")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
 
     assert len(e.concretized_roots) == 1
     assert e.concretized_roots[0].root == Spec("mpileaks")
@@ -482,7 +483,7 @@ def test_concretize():
 def test_env_specs_partition(install_mockery, mock_fetch):
     e = ev.create("test")
     e.add("cmake-client")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
 
     # Single not installed root spec.
     roots_already_installed, roots_to_install = e._partition_roots_by_install_status()
@@ -499,7 +500,7 @@ def test_env_specs_partition(install_mockery, mock_fetch):
 
     # One installed root, one not installed root.
     e.add("mpileaks")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     roots_already_installed, roots_to_install = e._partition_roots_by_install_status()
     assert len(roots_already_installed) == 1
     assert len(roots_to_install) == 1
@@ -510,7 +511,7 @@ def test_env_specs_partition(install_mockery, mock_fetch):
 def test_env_install_all(install_mockery, mock_fetch):
     e = ev.create("test")
     e.add("cmake-client")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     e.install_all(fake=True)
     spec = next(x for x in e.all_specs_generator() if x.name == "cmake-client")
     assert spec.installed
@@ -547,7 +548,7 @@ def test_env_install_include_concrete_env(
         mutable_config.set("concretizer:unify", unify)
         mutable_config.set("concretizer:reuse", reuse)
         combined.add("mpileaks")
-        combined.concretize()
+        EnvironmentConcretizer(combined).concretize()
         combined.write()
         install("--fake")
 
@@ -585,7 +586,7 @@ def test_env_roots_marked_explicit(install_mockery, mock_fetch):
     with ev.read("test") as e:
         # make implicit install a root of the env
         e.add(dependency[0].name)
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         e.install_all()
 
     explicit = spack.store.STORE.db.query(explicit=True)
@@ -638,7 +639,7 @@ def test_env_definition_symlink(install_mockery, mock_fetch, tmp_path: pathlib.P
     os.symlink(filepath, filepath_mid)
     os.symlink(filepath_mid, e.manifest_path)
 
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     e.write()
 
     assert os.path.islink(e.manifest_path)
@@ -686,10 +687,10 @@ def test_remove_after_concretize():
     e = ev.create("test")
 
     e.add("mpileaks")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
 
     e.add("python")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
 
     e.remove("mpileaks")
     assert Spec("mpileaks") not in e.user_specs
@@ -708,12 +709,12 @@ def test_remove_before_concretize(mutable_config):
     with ev.create("test") as e:
         mutable_config.set("concretizer:unify", True)
         e.add("mpileaks")
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         assert len(e.concretized_roots) == 1
         assert e.concrete_roots()[0].satisfies("mpileaks")
 
         e.remove("mpileaks")
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         assert not e.concretized_roots
 
 
@@ -800,7 +801,7 @@ def test_bad_remove_included_env():
     with test:
         add("mpileaks")
 
-    test.concretize()
+    EnvironmentConcretizer(test).concretize()
     test.write()
 
     env("create", "--include-concrete", "test", "combined_env")
@@ -816,7 +817,7 @@ def test_force_remove_included_env():
     with test:
         add("mpileaks")
 
-    test.concretize()
+    EnvironmentConcretizer(test).concretize()
     test.write()
 
     env("create", "--include-concrete", "test", "combined_env")
@@ -891,7 +892,7 @@ def test_env_activate_broken_view(
 def test_to_lockfile_dict():
     e = ev.create("test")
     e.add("mpileaks")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     context_dict = e._to_lockfile_dict()
 
     e_copy = ev.create("test_copy")
@@ -924,7 +925,7 @@ spack:
   - libelf
 """
     )
-    before.concretize()
+    EnvironmentConcretizer(before).concretize()
     before.write()
 
     # user modifies yaml externally to spack and removes hypre
@@ -939,7 +940,7 @@ spack:
         )
 
     after = ev.read("test")
-    after.concretize()
+    EnvironmentConcretizer(after).concretize()
     after.write()
 
     read = ev.read("test")
@@ -966,7 +967,7 @@ spack:
 """
     )
     with e1:
-        e1.concretize()
+        EnvironmentConcretizer(e1).concretize()
         e1.write()
 
     # By reading into a second environment, we force a round trip to json
@@ -990,7 +991,7 @@ spack:
   - libelf
 """
     )
-    e1.concretize()
+    EnvironmentConcretizer(e1).concretize()
     e1.write()
 
     e2 = _env_create("test2", init_file=e1.lock_path)
@@ -1015,7 +1016,7 @@ spack:
   - libelf
 """
     )
-    e1.concretize()
+    EnvironmentConcretizer(e1).concretize()
     e1.write()
 
     e2 = _env_create("test2", init_file=e1.manifest_path)
@@ -1050,7 +1051,7 @@ spack:
         spack.config.set("develop", dev_config)
         fs.touch(os.path.join(e1.path, "libelf"))
 
-    e1.concretize()
+    EnvironmentConcretizer(e1).concretize()
     e1.write()
 
     e2 = _env_create("test2", init_file="test" if use_name else e1.path)
@@ -1167,7 +1168,7 @@ packages:
     test_scope = spack.config.InternalConfigScope("env-external-test", data=external_config_dict)
     with spack.config.override(test_scope):
         e = ev.create("test", manifest_file)
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         # Note: normally installing specs in a test environment requires doing
         # a fake install, but not for external specs since no actions are
         # taken to install them. The installation commands also include
@@ -1223,7 +1224,7 @@ spack:
 """
     )
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1259,7 +1260,7 @@ spack:
     )
 
     with ev.Environment(env_root) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     # We've created an environment with included config file (which does
     # exist). Now we remove it and check that we get a sensible error.
@@ -1309,7 +1310,7 @@ spack:
     )
 
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1372,7 +1373,7 @@ spack:
 
     e = ev.Environment(env_root)
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1538,7 +1539,7 @@ def test_env_with_included_config_scope(mutable_mock_env_path, packages_file):
     # packages.yaml file.
     e = ev.Environment(env_root)
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1561,7 +1562,7 @@ def test_env_with_included_config_var_path(tmp_path: pathlib.Path, packages_file
 
     e = ev.Environment(env_path)
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1601,7 +1602,7 @@ spack:
 
     e = ev.Environment(tmp_path)
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1652,7 +1653,7 @@ packages:
 
     e = ev.Environment(tmp_path)
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     mpileaks_hash = next(x.hash for x in e.concretized_roots if x.root == Spec("mpileaks"))
     mpileaks = e.specs_by_hash[mpileaks_hash]
@@ -1907,7 +1908,7 @@ def test_indirect_build_dep(repo_builder: RepoBuilder):
         _env_create("test", with_view=False)
         e = ev.read("test")
         e.add(x_spec)
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         e.write()
 
         e_read = ev.read("test")
@@ -1949,7 +1950,7 @@ def test_store_different_build_deps(repo_builder: RepoBuilder):
         e = ev.read("test")
         e.add(y_spec)
         e.add(x_spec)
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         e.write()
 
         e_read = ev.read("test")
@@ -2055,7 +2056,7 @@ def test_env_include_concrete_env_yaml(env_name):
 
     with test:
         add("mpileaks")
-    test.concretize()
+    EnvironmentConcretizer(test).concretize()
     test.write()
 
     environ = "test" if env_name else test.path
@@ -2136,7 +2137,7 @@ def test_env_include_concrete_add_env():
     with new_env:
         add("mpileaks")
 
-    new_env.concretize()
+    EnvironmentConcretizer(new_env).concretize()
     new_env.write()
 
     # add new env to combined
@@ -2149,7 +2150,7 @@ def test_env_include_concrete_add_env():
     assert new_env.path not in lockfile_as_dict["include_concrete"].keys()
 
     # concretize combined env with new env
-    combined.concretize()
+    EnvironmentConcretizer(combined).concretize()
     combined.write()
 
     # assert changes
@@ -2172,7 +2173,7 @@ def test_env_include_concrete_remove_env():
     assert test2.path in lockfile_as_dict["include_concrete"].keys()
 
     # reconcretize combined
-    combined.concretize()
+    EnvironmentConcretizer(combined).concretize()
     combined.write()
 
     # assert test2 is not in combined's lockfile
@@ -2198,7 +2199,7 @@ def configure_reuse(reuse_mode, combined_env) -> Optional[ev.Environment]:
         override_env = ev.read("external_test")
         with override_env:
             add("mpich@1.0 +debug")
-        override_env.concretize()
+        EnvironmentConcretizer(override_env).concretize()
         override_env.write()
 
         # Reuse from the environment that is not included.
@@ -2255,7 +2256,7 @@ def test_env_include_concrete_reuse(reuse_mode):
         # Add mpileaks to the combined environment
         with combined:
             add("mpileaks")
-            combined.concretize()
+            EnvironmentConcretizer(combined).concretize()
         comb_specs_by_hash = combined.specs_by_hash
 
         # create reference env with mpileaks that does not use reuse
@@ -2264,7 +2265,7 @@ def test_env_include_concrete_reuse(reuse_mode):
         ref_env = ev.read("new")
         with ref_env:
             add("mpileaks")
-        ref_env.concretize()
+        EnvironmentConcretizer(ref_env).concretize()
         ref_specs_by_hash = ref_env.specs_by_hash
 
         # Ensure that the mpich used by the mpileaks is the mpich from the reused test environment
@@ -2299,7 +2300,7 @@ def test_env_include_concrete_env_reconcretized(mutable_config, unify):
 
     with combined:
         mutable_config.set("concretizer:unify", unify)
-        combined.concretize()
+        EnvironmentConcretizer(combined).concretize()
         combined.write()
 
     with open(combined.lock_path, encoding="utf-8") as f:
@@ -2318,7 +2319,7 @@ def test_concretize_include_concrete_env():
     # Update test1 environment
     with test1:
         add("mpileaks")
-    test1.concretize()
+    EnvironmentConcretizer(test1).concretize()
     test1.write()
 
     # Check the test1 environment includes mpileaks, while the combined environment does not
@@ -2326,7 +2327,7 @@ def test_concretize_include_concrete_env():
     assert Spec("mpileaks") not in combined.included_concretized_user_specs[test1.path]
 
     # If we update the combined environment, it will include mpileaks too
-    combined.concretize()
+    EnvironmentConcretizer(combined).concretize()
     combined.write()
     assert Spec("mpileaks") in combined.included_concretized_user_specs[test1.path]
 
@@ -2336,14 +2337,14 @@ def test_concretize_nested_include_concrete_envs():
     test1 = ev.read("test1")
     with test1:
         add("zlib")
-    test1.concretize()
+    EnvironmentConcretizer(test1).concretize()
     test1.write()
 
     env("create", "--include-concrete", "test1", "test2")
     test2 = ev.read("test2")
     with test2:
         add("libelf")
-    test2.concretize()
+    EnvironmentConcretizer(test2).concretize()
     test2.write()
 
     env("create", "--include-concrete", "test2", "test3")
@@ -2365,7 +2366,7 @@ def test_concretize_nested_included_concrete():
     test1 = ev.read("test1")
     with test1:
         add("zlib")
-    test1.concretize()
+    EnvironmentConcretizer(test1).concretize()
     test1.write()
 
     # test2 should include test1 with zlib
@@ -2373,7 +2374,7 @@ def test_concretize_nested_included_concrete():
     test2 = ev.read("test2")
     with test2:
         add("libelf")
-    test2.concretize()
+    EnvironmentConcretizer(test2).concretize()
     test2.write()
 
     assert Spec("zlib") in test2.included_concretized_user_specs[test1.path]
@@ -2382,7 +2383,7 @@ def test_concretize_nested_included_concrete():
     with test1:
         remove("zlib")
         add("mpileaks")
-    test1.concretize()
+    EnvironmentConcretizer(test1).concretize()
     test1.write()
 
     # test3 should include the latest concretization of test1
@@ -2390,7 +2391,7 @@ def test_concretize_nested_included_concrete():
     test3 = ev.read("test3")
     with test3:
         add("callpath")
-    test3.concretize()
+    EnvironmentConcretizer(test3).concretize()
     test3.write()
 
     included_specs = test3.included_concretized_user_specs[test1.path]
@@ -2423,9 +2424,9 @@ def test_concretize_nested_included_concrete():
     # to remove zlib and write it out so it can be picked up by test4.
     # Re-concretize test4 to reflect the re-concretization of included test2
     # and ensure that its included specs are up-to-date
-    test2.concretize()
+    EnvironmentConcretizer(test2).concretize()
     test2.write()
-    test4.concretize()
+    EnvironmentConcretizer(test4).concretize()
 
     concrete_specs = [s for s, _ in test4.concretized_specs()]
     assert Spec("zlib") not in concrete_specs
@@ -2771,7 +2772,7 @@ spack:
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         with ev.read("test") as e:
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
 
             before_user = e.user_specs.specs
             concretized_roots_before = e.concretized_roots
@@ -3361,7 +3362,7 @@ def test_concretize_user_specs_together(mutable_config):
         # Concretize a first time using 'mpich' as the MPI provider
         e.add("mpileaks")
         e.add("mpich")
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
         assert all("mpich" in spec for _, spec in e.concretized_specs())
         assert all("mpich2" not in spec for _, spec in e.concretized_specs())
@@ -3374,15 +3375,15 @@ def test_concretize_user_specs_together(mutable_config):
 
         # Concretizing without invalidating the concrete spec for mpileaks fails
         with pytest.raises(exc_cls):
-            e.concretize()
-        e.concretize(force=True)
+            EnvironmentConcretizer(e).concretize()
+        EnvironmentConcretizer(e).concretize(force=True)
 
         assert all("mpich2" in spec for _, spec in e.concretized_specs())
         assert all("mpich" not in spec for _, spec in e.concretized_specs())
 
         # Concretize again without changing anything, check everything
         # stays the same
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
         assert all("mpich2" in spec for _, spec in e.concretized_specs())
         assert all("mpich" not in spec for _, spec in e.concretized_specs())
@@ -3399,7 +3400,7 @@ def test_duplicate_packages_raise_when_concretizing_together(mutable_config):
         match = r"You could consider setting `concretizer:unify`"
 
         with pytest.raises(exc_cls, match=match):
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
 
 
 def test_env_write_only_non_default():
@@ -3437,7 +3438,7 @@ spack:
 
     # concretize
     with ev.read("test") as e:
-        concretize()
+        EnvironmentConcretizer(e).concretize()
         e.write()
 
         with open(e.manifest_path, "r", encoding="utf-8") as f:
@@ -3491,12 +3492,12 @@ spack:
 
     # Concretize a first time and create a lockfile
     with ev.Environment(str(tmp_path)) as e:
-        concretize()
+        EnvironmentConcretizer(e).concretize()
         libelf_first_hash = extract_dag_hash(e)
 
     # Check that a second run won't error
     with ev.Environment(str(tmp_path)) as e:
-        concretize()
+        EnvironmentConcretizer(e).concretize()
         libelf_second_hash = extract_dag_hash(e)
 
     assert libelf_first_hash == libelf_second_hash
@@ -3532,7 +3533,7 @@ spack:
         spack.environment.environment.EnvironmentManifestFile, "flush", _write_helper_raise
     )
     with ev.Environment(str(tmp_path)) as e:
-        e.concretize(force=True)
+        EnvironmentConcretizer(e).concretize(force=True)
         with pytest.raises(RuntimeError):
             e.clear()
             e.write()
@@ -3607,7 +3608,7 @@ def test_custom_version_concretize_together(mutable_config):
         # Concretize a first time using 'mpich' as the MPI provider
         e.add("hdf5@=myversion")
         e.add("mpich")
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         assert any(spec.satisfies("hdf5@myversion") for _, spec in e.concretized_specs())
 
 
@@ -3729,7 +3730,7 @@ def test_virtual_spec_concretize_together(mutable_config):
     with ev.create("virtual_spec") as e:
         mutable_config.set("concretizer:unify", True)
         e.add("mpi")
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         assert any(s.package.provides("mpi") for _, s in e.concretized_specs())
 
 
@@ -4366,7 +4367,7 @@ def test_unify_when_possible_works_around_conflicts(mutable_config):
         e.add("mpileaks+opt")
         e.add("mpileaks~opt")
         e.add("mpich")
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
         assert len([x for x in e.all_specs() if x.satisfies("mpileaks")]) == 2
         assert len([x for x in e.all_specs() if x.satisfies("mpileaks+opt")]) == 1
@@ -4466,7 +4467,7 @@ spack:
     )
     env("create", "disabled", str(spack_yaml))
     with ev.read("disabled") as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     assert len(e.views) == 0
     assert not os.path.exists(e.view_path_default)
@@ -4672,7 +4673,7 @@ def test_concretized_specs_and_include_concrete(mutable_config):
         mutable_config.set(
             "packages", {"mpileaks": {"require": ["@2.2"]}, "libelf": {"require": ["@0.8.12"]}}
         )
-        included_pairs = e.concretize()
+        included_pairs = EnvironmentConcretizer(e).concretize()
         e.write()
 
     env("create", "--include-concrete", "included-env", "main-env")
@@ -4681,7 +4682,7 @@ def test_concretized_specs_and_include_concrete(mutable_config):
         e.add("libelf@0.8.12")
         e.add("pkg-a")
         mutable_config.set("packages", {"mpileaks": {"require": ["@2.3"]}})
-        spec_pairs = e.concretize()
+        spec_pairs = EnvironmentConcretizer(e).concretize()
         concretized_specs = list(e.concretized_specs())
         assert list(dedupe(spec_pairs + included_pairs)) == concretized_specs
         assert len(concretized_specs) == 5

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -18,7 +18,7 @@ import spack.paths
 import spack.repo
 import spack.store
 import spack.user_environment as uenv
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.enums import InstallRecordStatus
 from spack.llnl.util.filesystem import working_dir
 from spack.main import SpackCommand
@@ -358,7 +358,7 @@ spack:
         env("create", "test1", "spack.yaml")
 
     test1 = ev.read("test1")
-    EnvironmentConcretizer(test1).concretize()
+    concretize_environment(test1)
     test1.write()
 
     with working_dir(str(tmp_path)):
@@ -373,7 +373,7 @@ spack:
         env("create", "test2", "spack.yaml")
 
     test2 = ev.read("test2")
-    EnvironmentConcretizer(test2).concretize()
+    concretize_environment(test2)
     test2.write()
 
     env("create", "--include-concrete", "test1", "--include-concrete", "test2", "combined_env")
@@ -404,13 +404,13 @@ spack:
         env("create", "test1", "spack.yaml")
 
     test1 = ev.read("test1")
-    EnvironmentConcretizer(test1).concretize()
+    concretize_environment(test1)
     test1.write()
 
     env("create", "--include-concrete", "test1", "test2")
     test2 = ev.read("test2")
     test2.add("libelf")
-    EnvironmentConcretizer(test2).concretize()
+    concretize_environment(test2)
     test2.write()
 
     env("create", "--include-concrete", "test2", "test3")

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -18,6 +18,7 @@ import spack.paths
 import spack.repo
 import spack.store
 import spack.user_environment as uenv
+from spack.concretize import EnvironmentConcretizer
 from spack.enums import InstallRecordStatus
 from spack.llnl.util.filesystem import working_dir
 from spack.main import SpackCommand
@@ -357,7 +358,7 @@ spack:
         env("create", "test1", "spack.yaml")
 
     test1 = ev.read("test1")
-    test1.concretize()
+    EnvironmentConcretizer(test1).concretize()
     test1.write()
 
     with working_dir(str(tmp_path)):
@@ -372,7 +373,7 @@ spack:
         env("create", "test2", "spack.yaml")
 
     test2 = ev.read("test2")
-    test2.concretize()
+    EnvironmentConcretizer(test2).concretize()
     test2.write()
 
     env("create", "--include-concrete", "test1", "--include-concrete", "test2", "combined_env")
@@ -403,13 +404,13 @@ spack:
         env("create", "test1", "spack.yaml")
 
     test1 = ev.read("test1")
-    test1.concretize()
+    EnvironmentConcretizer(test1).concretize()
     test1.write()
 
     env("create", "--include-concrete", "test1", "test2")
     test2 = ev.read("test2")
     test2.add("libelf")
-    test2.concretize()
+    EnvironmentConcretizer(test2).concretize()
     test2.write()
 
     env("create", "--include-concrete", "test2", "test3")

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -12,6 +12,7 @@ import spack.environment as ev
 import spack.main
 import spack.spec
 import spack.traverse
+from spack.concretize import EnvironmentConcretizer
 from spack.installer import PackageInstaller
 
 gc = spack.main.SpackCommand("gc")
@@ -99,7 +100,7 @@ def test_gc_except_any_environments(mutable_database, mutable_mock_env_path):
 
     e = ev.create("test_gc")
     e.add("simple-inheritance")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     e.install_all(fake=True)
     e.write()
 

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -12,7 +12,7 @@ import spack.environment as ev
 import spack.main
 import spack.spec
 import spack.traverse
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.installer import PackageInstaller
 
 gc = spack.main.SpackCommand("gc")
@@ -100,7 +100,7 @@ def test_gc_except_any_environments(mutable_database, mutable_mock_env_path):
 
     e = ev.create("test_gc")
     e.add("simple-inheritance")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     e.install_all(fake=True)
     e.write()
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -27,7 +27,7 @@ import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.package_base
 import spack.store
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.error import SpackError, SpecSyntaxError
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
@@ -756,7 +756,7 @@ def test_install_no_add_in_env(
     e.add("libelf@0.8.10")  # so env has both root and dep libelf specs
     e.add("pkg-a")
     e.add("pkg-a ~bvv")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     e.write()
     env_specs = e.all_specs()
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -27,6 +27,7 @@ import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.package_base
 import spack.store
+from spack.concretize import EnvironmentConcretizer
 from spack.error import SpackError, SpecSyntaxError
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
@@ -755,7 +756,7 @@ def test_install_no_add_in_env(
     e.add("libelf@0.8.10")  # so env has both root and dep libelf specs
     e.add("pkg-a")
     e.add("pkg-a ~bvv")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     e.write()
     env_specs = e.all_specs()
 

--- a/lib/spack/spack/test/cmd/stage.py
+++ b/lib/spack/spack/test/cmd/stage.py
@@ -11,7 +11,7 @@ import spack.environment as ev
 import spack.package_base
 import spack.traverse
 from spack.cmd.stage import StageFilter
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.version import Version
@@ -73,7 +73,7 @@ def test_stage_with_env_outside_env(mutable_mock_env_path, monkeypatch):
 
     e = ev.create("test")
     e.add("mpileaks")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
 
     with e:
         stage("trivial-install-test-package")
@@ -91,7 +91,7 @@ def test_stage_with_env_inside_env(mutable_mock_env_path, monkeypatch):
 
     e = ev.create("test")
     e.add("mpileaks@=100.100")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
 
     with e:
         stage("mpileaks")
@@ -103,7 +103,7 @@ def test_stage_full_env(mutable_mock_env_path, monkeypatch):
 
     e = ev.create("test")
     e.add("mpileaks@=100.100")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
 
     # list all the package names that should be staged
     expected, externals = set(), set()
@@ -152,7 +152,7 @@ def test_stage_spec_filters(
 ):
     e = ev.create("test")
     e.add("mpileaks@=100.100")
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     all_specs = e.all_specs()
 
     def is_installed(self):

--- a/lib/spack/spack/test/cmd/stage.py
+++ b/lib/spack/spack/test/cmd/stage.py
@@ -11,6 +11,7 @@ import spack.environment as ev
 import spack.package_base
 import spack.traverse
 from spack.cmd.stage import StageFilter
+from spack.concretize import EnvironmentConcretizer
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.version import Version
@@ -72,7 +73,7 @@ def test_stage_with_env_outside_env(mutable_mock_env_path, monkeypatch):
 
     e = ev.create("test")
     e.add("mpileaks")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
 
     with e:
         stage("trivial-install-test-package")
@@ -90,7 +91,7 @@ def test_stage_with_env_inside_env(mutable_mock_env_path, monkeypatch):
 
     e = ev.create("test")
     e.add("mpileaks@=100.100")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
 
     with e:
         stage("mpileaks")
@@ -102,7 +103,7 @@ def test_stage_full_env(mutable_mock_env_path, monkeypatch):
 
     e = ev.create("test")
     e.add("mpileaks@=100.100")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
 
     # list all the package names that should be staged
     expected, externals = set(), set()
@@ -151,7 +152,7 @@ def test_stage_spec_filters(
 ):
     e = ev.create("test")
     e.add("mpileaks@=100.100")
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     all_specs = e.all_specs()
 
     def is_installed(self):

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -9,7 +9,7 @@ import spack.cmd.uninstall
 import spack.environment
 import spack.llnl.util.tty as tty
 import spack.store
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand, SpackCommandError
 
@@ -227,7 +227,7 @@ class TestUninstallFromEnv:
         with e1:
             add("diamond-link-left")
             add("diamond-link-bottom")
-            EnvironmentConcretizer(e1).concretize()
+            concretize_environment(e1)
             install("--fake")
 
         env("create", "e2")
@@ -235,7 +235,7 @@ class TestUninstallFromEnv:
         with e2:
             add("diamond-link-right")
             add("diamond-link-bottom")
-            EnvironmentConcretizer(e2).concretize()
+            concretize_environment(e2)
             install("--fake")
         yield "environment_setup"
         env("rm", "e1", "-y")

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -9,6 +9,7 @@ import spack.cmd.uninstall
 import spack.environment
 import spack.llnl.util.tty as tty
 import spack.store
+from spack.concretize import EnvironmentConcretizer
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand, SpackCommandError
 
@@ -202,6 +203,12 @@ def test_in_memory_consistency_when_uninstalling(mutable_database, monkeypatch):
     uninstall("-y", "-a")
 
 
+env = SpackCommand("env")
+add = SpackCommand("add")
+concretize = SpackCommand("concretize")
+find = SpackCommand("find")
+
+
 # Note: I want to use https://docs.pytest.org/en/7.1.x/how-to/skipping.html#skip-all-test-functions-of-a-class-or-module
 # the style formatter insists on separating these two lines.
 class TestUninstallFromEnv:
@@ -213,31 +220,26 @@ class TestUninstallFromEnv:
     e2 has diamond-link-right -> diamond-link-bottom
     """
 
-    env = SpackCommand("env")
-    add = SpackCommand("add")
-    concretize = SpackCommand("concretize")
-    find = SpackCommand("find")
-
     @pytest.fixture(scope="function")
     def environment_setup(self, mock_packages, mutable_database, install_mockery):
-        TestUninstallFromEnv.env("create", "e1")
+        env("create", "e1")
         e1 = spack.environment.read("e1")
         with e1:
-            TestUninstallFromEnv.add("diamond-link-left")
-            TestUninstallFromEnv.add("diamond-link-bottom")
-            TestUninstallFromEnv.concretize()
+            add("diamond-link-left")
+            add("diamond-link-bottom")
+            EnvironmentConcretizer(e1).concretize()
             install("--fake")
 
-        TestUninstallFromEnv.env("create", "e2")
+        env("create", "e2")
         e2 = spack.environment.read("e2")
         with e2:
-            TestUninstallFromEnv.add("diamond-link-right")
-            TestUninstallFromEnv.add("diamond-link-bottom")
-            TestUninstallFromEnv.concretize()
+            add("diamond-link-right")
+            add("diamond-link-bottom")
+            EnvironmentConcretizer(e2).concretize()
             install("--fake")
         yield "environment_setup"
-        TestUninstallFromEnv.env("rm", "e1", "-y")
-        TestUninstallFromEnv.env("rm", "e2", "-y")
+        env("rm", "e1", "-y")
+        env("rm", "e2", "-y")
 
     def test_basic_env_sanity(self, environment_setup):
         for env_name in ["e1", "e2"]:

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -41,6 +41,7 @@ import spack.util.file_cache
 import spack.util.hash
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
+from spack.concretize import EnvironmentConcretizer
 from spack.externals import ExternalDependencyError
 from spack.installer import PackageInstaller
 from spack.solver.asp import Result
@@ -585,7 +586,7 @@ spack:
         )
 
         with ev.Environment(tmp_path) as e:
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
             for root in e.roots():
                 if root.satisfies("%gcc"):
                     assert root["dt-diamond-left"].satisfies("%gcc")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -41,7 +41,7 @@ import spack.util.file_cache
 import spack.util.hash
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.externals import ExternalDependencyError
 from spack.installer import PackageInstaller
 from spack.solver.asp import Result
@@ -586,7 +586,7 @@ spack:
         )
 
         with ev.Environment(tmp_path) as e:
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
             for root in e.roots():
                 if root.satisfies("%gcc"):
                     assert root["dt-diamond-left"].satisfies("%gcc")

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -42,7 +42,7 @@ import spack.paths
 import spack.repo
 import spack.spec
 import spack.util.spack_yaml as syaml
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 
 
 @pytest.fixture
@@ -251,7 +251,7 @@ spack:
     manifest_file.write_text(env_content)
     e = ev.create("test", manifest_file)
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
     e.write()
 
     (result,) = list(j for i, j in e.concretized_specs() if j.name == "y")

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -42,6 +42,7 @@ import spack.paths
 import spack.repo
 import spack.spec
 import spack.util.spack_yaml as syaml
+from spack.concretize import EnvironmentConcretizer
 
 
 @pytest.fixture
@@ -250,7 +251,7 @@ spack:
     manifest_file.write_text(env_content)
     e = ev.create("test", manifest_file)
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
     e.write()
 
     (result,) = list(j for i, j in e.concretized_specs() if j.name == "y")

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -15,6 +15,7 @@ import spack.llnl.util.filesystem as fs
 import spack.platforms
 import spack.solver.asp
 import spack.spec
+from spack.concretize import EnvironmentConcretizer
 from spack.environment.environment import (
     EnvironmentManifestFile,
     SpackEnvironmentViewError,
@@ -56,7 +57,7 @@ def test_hash_change_no_rehash_concrete(tmp_path: pathlib.Path, config):
     # add a spec with a rewritten build hash
     spec = spack.spec.Spec("mpileaks")
     env.add(spec)
-    env.concretize()
+    EnvironmentConcretizer(env).concretize()
 
     # rewrite the hash
     old_hash, new_hash = env.concretized_roots[0].hash, "abc"
@@ -114,7 +115,7 @@ def test_env_change_spec_in_definition(tmp_path: pathlib.Path, mutable_mock_env_
     manifest_file = tmp_path / ev.manifest_name
     manifest_file.write_text(_test_matrix_yaml)
     e = ev.create("test", manifest_file)
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     e.write()
 
     assert any(x.intersects("mpileaks@2.1%gcc") for x in e.user_specs)
@@ -137,7 +138,7 @@ def test_env_change_spec_in_matrix_raises_error(tmp_path: pathlib.Path, mutable_
     manifest_file = tmp_path / ev.manifest_name
     manifest_file.write_text(_test_matrix_yaml)
     e = ev.create("test", manifest_file)
-    e.concretize()
+    EnvironmentConcretizer(e).concretize()
     e.write()
 
     with pytest.raises(ev.SpackEnvironmentError) as error:
@@ -604,9 +605,9 @@ spack:
     with ev.Environment(manifest.parent) as e:
         if expected_raise:
             with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
-                e.concretize()
+                EnvironmentConcretizer(e).concretize()
         else:
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
             assert any(s.satisfies(expected_spec) for s in e.concrete_roots())
 
 
@@ -637,7 +638,7 @@ def test_requires_on_virtual_and_potential_providers(
     """
     )
     with ev.Environment(manifest.parent) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         assert e.matching_spec(possible_mpi_spec)
         assert e.matching_spec("mpich2")
 
@@ -728,7 +729,7 @@ def test_variant_propagation_with_unify_false(tmp_path: pathlib.Path, config):
     """
     )
     with ev.Environment(tmp_path) as env:
-        env.concretize()
+        EnvironmentConcretizer(env).concretize()
 
     root = env.matching_spec("parent-foo")
     for node in root.traverse():
@@ -766,7 +767,7 @@ def test_env_with_include_defs(mutable_mock_env_path):
 
     e = ev.Environment(env_path)
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
 
 def test_env_with_include_def_missing(mutable_mock_env_path):
@@ -820,7 +821,7 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unif
     assert len(e.concretized_roots) == 0
 
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         assert len(e.user_specs) == 3
         assert len(e.concretized_roots) == 3
         assert all(x.new for x in e.concretized_roots)
@@ -830,7 +831,7 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unif
         assert len(e.concretized_roots) == 2
         assert all(x.new for x in e.concretized_roots)
 
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         assert len(e.user_specs) == 3
         assert len(e.concretized_roots) == 3
         assert all(x.new for x in e.concretized_roots)
@@ -859,7 +860,7 @@ def test_root_version_weights_for_old_versions(mutable_mock_env_path):
     )
     e = ev.Environment(mutable_mock_env_path)
     with e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
 
     bowtie = [x for x in e.concrete_roots() if x.name == "bowtie"][0]
     gcc = [x for x in e.concrete_roots() if x.name == "gcc"][0]
@@ -874,7 +875,7 @@ def test_env_view_on_empty_dir_is_fine(tmp_path: pathlib.Path, config, temporary
     view_dir.mkdir()
     env = ev.create_in_dir(tmp_path, with_view="view")
     env.add("mpileaks")
-    env.concretize()
+    EnvironmentConcretizer(env).concretize()
     env.install_all(fake=True)
     env.regenerate_views()
     assert view_dir.is_symlink()
@@ -887,7 +888,7 @@ def test_env_view_on_non_empty_dir_errors(tmp_path: pathlib.Path, config, tempor
     (view_dir / "file").write_text("")
     env = ev.create_in_dir(tmp_path, with_view="view")
     env.add("mpileaks")
-    env.concretize()
+    EnvironmentConcretizer(env).concretize()
     env.install_all(fake=True)
     with pytest.raises(ev.SpackEnvironmentError, match="because it is a non-empty dir"):
         env.regenerate_views()
@@ -920,7 +921,7 @@ spack:
     # Here we raise different exceptions depending on whether we solve serially or not
     with pytest.raises(Exception):
         with ev.Environment(tmp_path) as e:
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
 
 
 def test_only_roots_are_explicitly_installed(tmp_path: pathlib.Path, config, temporary_store):
@@ -928,7 +929,7 @@ def test_only_roots_are_explicitly_installed(tmp_path: pathlib.Path, config, tem
     as implicitly installed. What makes installs explicit is that they are root of the env."""
     env = ev.create_in_dir(tmp_path)
     env.add("mpileaks")
-    env.concretize()
+    EnvironmentConcretizer(env).concretize()
     mpileaks = env.concrete_roots()[0]
     callpath = mpileaks["callpath"]
     env.install_specs([callpath], fake=True)
@@ -1024,7 +1025,7 @@ spack:
 """
     )
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         mpileaks = e.concrete_roots()[0]
 
     assert not mpileaks.satisfies("%gcc") and mpileaks.satisfies("%clang")
@@ -1089,7 +1090,7 @@ def test_toolchain_definitions_are_allowed(
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         mpileaks = e.concrete_roots()[0]
 
     for c in expected:
@@ -1129,7 +1130,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         roots = e.concrete_roots()
 
     expected = [
@@ -1178,7 +1179,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         roots = e.concrete_roots()
 
     mpileaks_gcc = [s for s in roots if s.satisfies("mpileaks %[virtuals=c] gcc")][0]
@@ -1215,7 +1216,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         roots = e.concrete_roots()
 
     mpileaks = [s for s in roots if s.satisfies("mpileaks")][0]
@@ -1251,7 +1252,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         roots = e.concrete_roots()
 
     dt = [s for s in roots if s.satisfies("dt-diamond-right")][0]
@@ -1276,7 +1277,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         roots = e.concrete_roots()
 
     mpileaks = [s for s in roots if s.satisfies("mpileaks")][0]
@@ -1308,7 +1309,7 @@ spack:
 """
     )
     with ev.Environment(base) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         # We need the spack.lock for reuse in the derived environment
         e.write(regenerate=False)
         base_pkga = e.concrete_roots()[0]
@@ -1330,7 +1331,7 @@ spack:
 """
     )
     with ev.Environment(derived) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         derived_pkga = e.concrete_roots()[0]
 
     assert base_pkga.dag_hash() == derived_pkga.dag_hash()
@@ -1393,7 +1394,7 @@ def test_dependency_propagation_in_environments(spack_yaml, tmp_path, mutable_co
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         roots = e.concrete_roots()
 
     mpileaks_gcc = [s for s in roots if s.satisfies("mpileaks %c=gcc")][0]
@@ -1488,7 +1489,7 @@ def test_double_percent_semantics(spack_yaml, exception_nodes, tmp_path, mutable
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         trilinos = e.concrete_roots()[0]
 
     runtime_nodes = [
@@ -1524,7 +1525,7 @@ spack:
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
         with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="failed to concretize"):
-            e.concretize()
+            EnvironmentConcretizer(e).concretize()
 
 
 @pytest.mark.parametrize(
@@ -1565,12 +1566,12 @@ def test_static_analysis_in_environments(spack_yaml, tmp_path, mutable_config):
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         no_static_analysis = {x.dag_hash() for x in e.concrete_roots()}
 
     mutable_config.set("concretizer:static_analysis", True)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         static_analysis = {x.dag_hash() for x in e.concrete_roots()}
 
     assert no_static_analysis == static_analysis
@@ -1639,7 +1640,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        e.concretize()
+        EnvironmentConcretizer(e).concretize()
         mpileaks = e.concrete_roots()[0]
 
     for node in mpileaks.traverse():

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -15,7 +15,7 @@ import spack.llnl.util.filesystem as fs
 import spack.platforms
 import spack.solver.asp
 import spack.spec
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.environment.environment import (
     EnvironmentManifestFile,
     SpackEnvironmentViewError,
@@ -57,7 +57,7 @@ def test_hash_change_no_rehash_concrete(tmp_path: pathlib.Path, config):
     # add a spec with a rewritten build hash
     spec = spack.spec.Spec("mpileaks")
     env.add(spec)
-    EnvironmentConcretizer(env).concretize()
+    concretize_environment(env)
 
     # rewrite the hash
     old_hash, new_hash = env.concretized_roots[0].hash, "abc"
@@ -115,7 +115,7 @@ def test_env_change_spec_in_definition(tmp_path: pathlib.Path, mutable_mock_env_
     manifest_file = tmp_path / ev.manifest_name
     manifest_file.write_text(_test_matrix_yaml)
     e = ev.create("test", manifest_file)
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     e.write()
 
     assert any(x.intersects("mpileaks@2.1%gcc") for x in e.user_specs)
@@ -138,7 +138,7 @@ def test_env_change_spec_in_matrix_raises_error(tmp_path: pathlib.Path, mutable_
     manifest_file = tmp_path / ev.manifest_name
     manifest_file.write_text(_test_matrix_yaml)
     e = ev.create("test", manifest_file)
-    EnvironmentConcretizer(e).concretize()
+    concretize_environment(e)
     e.write()
 
     with pytest.raises(ev.SpackEnvironmentError) as error:
@@ -605,9 +605,9 @@ spack:
     with ev.Environment(manifest.parent) as e:
         if expected_raise:
             with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
-                EnvironmentConcretizer(e).concretize()
+                concretize_environment(e)
         else:
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
             assert any(s.satisfies(expected_spec) for s in e.concrete_roots())
 
 
@@ -638,7 +638,7 @@ def test_requires_on_virtual_and_potential_providers(
     """
     )
     with ev.Environment(manifest.parent) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         assert e.matching_spec(possible_mpi_spec)
         assert e.matching_spec("mpich2")
 
@@ -729,7 +729,7 @@ def test_variant_propagation_with_unify_false(tmp_path: pathlib.Path, config):
     """
     )
     with ev.Environment(tmp_path) as env:
-        EnvironmentConcretizer(env).concretize()
+        concretize_environment(env)
 
     root = env.matching_spec("parent-foo")
     for node in root.traverse():
@@ -767,7 +767,7 @@ def test_env_with_include_defs(mutable_mock_env_path):
 
     e = ev.Environment(env_path)
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
 
 def test_env_with_include_def_missing(mutable_mock_env_path):
@@ -821,7 +821,7 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unif
     assert len(e.concretized_roots) == 0
 
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         assert len(e.user_specs) == 3
         assert len(e.concretized_roots) == 3
         assert all(x.new for x in e.concretized_roots)
@@ -831,7 +831,7 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unif
         assert len(e.concretized_roots) == 2
         assert all(x.new for x in e.concretized_roots)
 
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         assert len(e.user_specs) == 3
         assert len(e.concretized_roots) == 3
         assert all(x.new for x in e.concretized_roots)
@@ -860,7 +860,7 @@ def test_root_version_weights_for_old_versions(mutable_mock_env_path):
     )
     e = ev.Environment(mutable_mock_env_path)
     with e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
 
     bowtie = [x for x in e.concrete_roots() if x.name == "bowtie"][0]
     gcc = [x for x in e.concrete_roots() if x.name == "gcc"][0]
@@ -875,7 +875,7 @@ def test_env_view_on_empty_dir_is_fine(tmp_path: pathlib.Path, config, temporary
     view_dir.mkdir()
     env = ev.create_in_dir(tmp_path, with_view="view")
     env.add("mpileaks")
-    EnvironmentConcretizer(env).concretize()
+    concretize_environment(env)
     env.install_all(fake=True)
     env.regenerate_views()
     assert view_dir.is_symlink()
@@ -888,7 +888,7 @@ def test_env_view_on_non_empty_dir_errors(tmp_path: pathlib.Path, config, tempor
     (view_dir / "file").write_text("")
     env = ev.create_in_dir(tmp_path, with_view="view")
     env.add("mpileaks")
-    EnvironmentConcretizer(env).concretize()
+    concretize_environment(env)
     env.install_all(fake=True)
     with pytest.raises(ev.SpackEnvironmentError, match="because it is a non-empty dir"):
         env.regenerate_views()
@@ -921,7 +921,7 @@ spack:
     # Here we raise different exceptions depending on whether we solve serially or not
     with pytest.raises(Exception):
         with ev.Environment(tmp_path) as e:
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
 
 
 def test_only_roots_are_explicitly_installed(tmp_path: pathlib.Path, config, temporary_store):
@@ -929,7 +929,7 @@ def test_only_roots_are_explicitly_installed(tmp_path: pathlib.Path, config, tem
     as implicitly installed. What makes installs explicit is that they are root of the env."""
     env = ev.create_in_dir(tmp_path)
     env.add("mpileaks")
-    EnvironmentConcretizer(env).concretize()
+    concretize_environment(env)
     mpileaks = env.concrete_roots()[0]
     callpath = mpileaks["callpath"]
     env.install_specs([callpath], fake=True)
@@ -1025,7 +1025,7 @@ spack:
 """
     )
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         mpileaks = e.concrete_roots()[0]
 
     assert not mpileaks.satisfies("%gcc") and mpileaks.satisfies("%clang")
@@ -1090,7 +1090,7 @@ def test_toolchain_definitions_are_allowed(
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         mpileaks = e.concrete_roots()[0]
 
     for c in expected:
@@ -1130,7 +1130,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         roots = e.concrete_roots()
 
     expected = [
@@ -1179,7 +1179,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         roots = e.concrete_roots()
 
     mpileaks_gcc = [s for s in roots if s.satisfies("mpileaks %[virtuals=c] gcc")][0]
@@ -1216,7 +1216,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         roots = e.concrete_roots()
 
     mpileaks = [s for s in roots if s.satisfies("mpileaks")][0]
@@ -1252,7 +1252,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         roots = e.concrete_roots()
 
     dt = [s for s in roots if s.satisfies("dt-diamond-right")][0]
@@ -1277,7 +1277,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         roots = e.concrete_roots()
 
     mpileaks = [s for s in roots if s.satisfies("mpileaks")][0]
@@ -1309,7 +1309,7 @@ spack:
 """
     )
     with ev.Environment(base) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         # We need the spack.lock for reuse in the derived environment
         e.write(regenerate=False)
         base_pkga = e.concrete_roots()[0]
@@ -1331,7 +1331,7 @@ spack:
 """
     )
     with ev.Environment(derived) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         derived_pkga = e.concrete_roots()[0]
 
     assert base_pkga.dag_hash() == derived_pkga.dag_hash()
@@ -1394,7 +1394,7 @@ def test_dependency_propagation_in_environments(spack_yaml, tmp_path, mutable_co
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         roots = e.concrete_roots()
 
     mpileaks_gcc = [s for s in roots if s.satisfies("mpileaks %c=gcc")][0]
@@ -1489,7 +1489,7 @@ def test_double_percent_semantics(spack_yaml, exception_nodes, tmp_path, mutable
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         trilinos = e.concrete_roots()[0]
 
     runtime_nodes = [
@@ -1525,7 +1525,7 @@ spack:
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
         with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="failed to concretize"):
-            EnvironmentConcretizer(e).concretize()
+            concretize_environment(e)
 
 
 @pytest.mark.parametrize(
@@ -1566,12 +1566,12 @@ def test_static_analysis_in_environments(spack_yaml, tmp_path, mutable_config):
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         no_static_analysis = {x.dag_hash() for x in e.concrete_roots()}
 
     mutable_config.set("concretizer:static_analysis", True)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         static_analysis = {x.dag_hash() for x in e.concrete_roots()}
 
     assert no_static_analysis == static_analysis
@@ -1640,7 +1640,7 @@ spack:
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path) as e:
-        EnvironmentConcretizer(e).concretize()
+        concretize_environment(e)
         mpileaks = e.concrete_roots()[0]
 
     for node in mpileaks.traverse():

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -9,7 +9,7 @@ import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.spec
-from spack.concretize import EnvironmentConcretizer
+from spack.concretize import concretize_environment
 from spack.main import SpackCommand
 
 pytestmark = [
@@ -51,7 +51,7 @@ def test_mutate_internals(dep, orig_constraint, mutated_constraint):
 
     root_name = "cmake-client" if dep else "cmake"
     env.add(root_name)
-    EnvironmentConcretizer(env).concretize()
+    concretize_environment(env)
 
     root_spec = next(env.roots()).copy()
     cmake_spec = root_spec["cmake"] if dep else root_spec
@@ -98,7 +98,7 @@ def _test_mutate_from_cli(args, create=True):
     if create:
         env.add("cmake-client%cmake@3.4.3")
         env.add("cmake-client%cmake@3.23.1")
-        EnvironmentConcretizer(env).concretize()
+        concretize_environment(env)
         env.write()
 
     with env:

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -9,6 +9,7 @@ import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.spec
+from spack.concretize import EnvironmentConcretizer
 from spack.main import SpackCommand
 
 pytestmark = [
@@ -50,7 +51,7 @@ def test_mutate_internals(dep, orig_constraint, mutated_constraint):
 
     root_name = "cmake-client" if dep else "cmake"
     env.add(root_name)
-    env.concretize()
+    EnvironmentConcretizer(env).concretize()
 
     root_spec = next(env.roots()).copy()
     cmake_spec = root_spec["cmake"] if dep else root_spec
@@ -97,7 +98,7 @@ def _test_mutate_from_cli(args, create=True):
     if create:
         env.add("cmake-client%cmake@3.4.3")
         env.add("cmake-client%cmake@3.23.1")
-        env.concretize()
+        EnvironmentConcretizer(env).concretize()
         env.write()
 
     with env:


### PR DESCRIPTION
In the past we removed `Spec.concretize` because the solver imports
`spack.spec` (https://github.com/spack/spack/pull/47971)

The same applies to `Environment.concretize`, so extract that to
`spack.concretize` too.

Doesn't entirely resolve this just yet, but is a step towards it:

bootstrap -> environment -> concretize -> bootstrap

afterwards we still have

bootstrap -> concretize -> bootstrap :)

