### PR TITLE
Support named git includes

### DIFF
--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -13,6 +13,8 @@ Include Settings (include.yaml)
 ===============================
 
 Spack allows you to include configuration files through ``include.yaml``, or in the ``include:`` section in an environment.
+You can specify includes using local paths, remote paths, and ``git`` URLs.
+Included paths become configuration scopes in Spack and can even be used to override built-in scopes.
 
 Local files
 ~~~~~~~~~~~
@@ -62,27 +64,54 @@ The ``config.yaml`` file would be cached locally to a special include location a
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can also include configuration files from a ``git`` repository.
-The `branch`, `commit`, or `tag` to be checked out is required.
+The ``branch``, ``commit``, or ``tag`` to be checked out is required.
 A list of relative paths in which to find the configuration files is also required.
 Inclusion of the repository (and its paths) can be optional or conditional.
+If you want to control the :ref:`name of the configuration scope <named-config-scopes>`, you can provide a ``name``.
 
 For example, suppose we only want to include the ``config.yaml`` and ``packages.yaml`` files from the `spack/spack-configs <https://github.com/spack/spack-configs>`_ repository's ``USC/config`` directory when using the ``centos7`` operating system.
-We would then configure the ``include.yaml`` file as follows:
+And we want the configuration scope name to start ``USC``.
+We would then configure the ``include.yaml`` file as follows::
 
 .. code-block:: yaml
 
    include:
-   - git: https://github.com/spack/spack-configs
+   - name: USC
+     git: https://github.com/spack/spack-configs
      branch: main
      when: os == "centos7"
      paths:
      - USC/config/config.yaml
      - USC/config/packages.yaml
 
-If the condition is satisfied, then the ``main`` branch of the repository will be cloned and the settings for the two files integrated into Spack's configuration.
+If the condition is satisfied, then the ``main`` branch of the repository will be cloned when the configuration scopes are initially created.
+Once cloned, the settings for the two files under the ``USC/config`` directory will be integrated into Spack's configuration.
+In this example, the new scopes can be seen by running::
+
+.. code-block:: console
+
+   $ spack config scopes -p
+   Scope               Path
+   command_line
+   spack               /Users/username/spack/etc/spack/
+   user                /Users/username/.spack/
+   USC:config.yaml     /Users/username/.spack/includes/nncrh7v/USC/config/config.yaml
+   USC:packages.yaml   /Users/username/.spack/includes/nncrh7v/USC/config/packages.yaml
+   site                /Users/username/spack/etc/spack/site/
+   system              /etc/spack/
+   defaults            /Users/username/spack/etc/spack/defaults/
+   defaults:darwin     /Users/username/spack/etc/spack/defaults/darwin/
+   defaults:base       /Users/username/spack/etc/spack/defaults/base/
+   _builtin
+
+Since there are two unique paths, each results in a separate configuration scope.
+If only the ``USC/config`` directory was listed under ``paths``, then there would be only one configuration scope, named ``USC``, and the configuration settings from all of the configuration files within that directory would be integrated.
 
 .. versionadded:: 1.1
    ``git:``, ``branch:``, ``commit:``, and ``tag:`` attributes.
+
+.. versionadded:: 1.2
+   ``name:`` attribute.
 
 Precedence
 ~~~~~~~~~~
@@ -143,13 +172,17 @@ If not, Spack will instead use the ``path:`` specified in configuration.
 .. versionadded:: 1.1
    The ``path_override_env_var:`` attribute.
 
+.. _named-config-scopes:
+
 Named configuration scopes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the included scope names are is constructed by appending ``:`` and the included scope's basename to the parent scope name.
+By default, the included scope names are constructed by appending ``:`` and the included scope's basename to the parent scope name.
 For example, Spack's own ``defaults`` scope includes a ``base`` scope and a platform-specific scope::
 
-    > spack config scopes -p
+.. code-block:: console
+
+    $ spack config scopes -p
     Scope            Path
     command_line
     spack            /home/username/spack/etc/spack/
@@ -200,8 +233,8 @@ You can see that all three of these scopes are given meaningful names, and all t
 The ``user`` and ``system`` scopes can also be disabled by setting ``SPACK_DISABLE_LOCAL_CONFIG``.
 Finally, the ``user`` scope can be overridden with a path in ``SPACK_USER_CONFIG_PATH`` if it is set.
 
-Overriding scopes by name:
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Overriding scopes by name
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Configuration scopes have unique names.
 This means that you can use the ``name:`` attribute to *replace* a builtin scope.
@@ -230,7 +263,7 @@ The newly included ``user`` scope will *completely* override the builtin ``user`
 
 .. warning::
 
-   Using ``name:`` to override the ``defaults`` scope can have *very* unexpected consequences and is not advised.
+   Overriding the ``defaults`` scope can have **very** unexpected consequences and is not advised.
 
 .. versionadded:: 1.1
    The ``name:`` attribute.

--- a/lib/spack/docs/include_yaml.rst
+++ b/lib/spack/docs/include_yaml.rst
@@ -73,8 +73,6 @@ For example, suppose we only want to include the ``config.yaml`` and ``packages.
 And we want the configuration scope name to start ``USC``.
 We would then configure the ``include.yaml`` file as follows::
 
-.. code-block:: yaml
-
    include:
    - name: USC
      git: https://github.com/spack/spack-configs
@@ -87,8 +85,6 @@ We would then configure the ``include.yaml`` file as follows::
 If the condition is satisfied, then the ``main`` branch of the repository will be cloned when the configuration scopes are initially created.
 Once cloned, the settings for the two files under the ``USC/config`` directory will be integrated into Spack's configuration.
 In this example, the new scopes can be seen by running::
-
-.. code-block:: console
 
    $ spack config scopes -p
    Scope               Path
@@ -179,8 +175,6 @@ Named configuration scopes
 
 By default, the included scope names are constructed by appending ``:`` and the included scope's basename to the parent scope name.
 For example, Spack's own ``defaults`` scope includes a ``base`` scope and a platform-specific scope::
-
-.. code-block:: console
 
     $ spack config scopes -p
     Scope            Path

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -292,7 +292,7 @@ def _config_scope_info(args, scope, active, included):
             result.append(
                 section_path
                 if section_path and os.path.exists(section_path)
-                else f"{scope.path}{''if os.path.isfile(scope.path) else os.sep}"
+                else f"{scope.path}{'' if os.path.isfile(scope.path) else os.sep}"
             )
         else:
             result.append(" ")

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -292,7 +292,7 @@ def _config_scope_info(args, scope, active, included):
             result.append(
                 section_path
                 if section_path and os.path.exists(section_path)
-                else f"{scope.path}{os.sep}"
+                else f"{scope.path}{''if os.path.isfile(scope.path) else os.sep}"
             )
         else:
             result.append(" ")

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1046,6 +1046,7 @@ class OptionalInclude:
         # Ensure the parent scope is valid
         self._validate_parent_scope(parent_scope)
 
+
         # use specified name if there is one
         config_name = self.name
         if not config_name:
@@ -1077,6 +1078,16 @@ class OptionalInclude:
             raise ValueError(f"Required path ({path}) does not exist{dest}")
 
         if (exists and not is_dir) or ext_is_yaml:
+            if self.name and hasattr(self, "paths") and len(self.paths) > 1:
+                # TODO: Remove the try-except once the minimum Python is 3.9
+                # TODO: since that is when removeprefix was introduced
+                prefix = f".{os.sep}"
+                try:
+                    base_path = path.removeprefix(prefix)
+                except AttributeError:
+                    base_path = path[len(prefix):] if path.startswith(prefix) else path
+                config_name = f"{config_name}:{os.path.basename(base_path)}"
+
             # files are assumed to be SingleFileScopes
             tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
             return SingleFileScope(

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -71,7 +71,6 @@ import spack.util.spack_yaml as syaml
 from spack.llnl.util import filesystem, lang, tty
 from spack.util.cpus import cpus_available
 from spack.util.spack_yaml import get_mark_from_yaml_data
-from spack.util.path import substitute_path_variables
 
 from .enums import ConfigScopePriority
 
@@ -1054,6 +1053,9 @@ class OptionalInclude:
         Raises:
             ValueError: the required configuration path does not exist
         """
+        # circular dependencies
+        import spack.util.path
+
         # Ensure the parent scope is valid
         self._validate_parent_scope(parent_scope)
 
@@ -1063,7 +1065,7 @@ class OptionalInclude:
         # But ensure that name is unique if there are multiple paths.
         if not self.name or (hasattr(self, "paths") and len(self.paths) > 1):
             parent_path = getattr(parent_scope, "path", None)
-            path = substitute_path_variables(path)
+            path = spack.util.path.substitute_path_variables(path)
 
             if parent_path and str(parent_path) == os.path.commonprefix([parent_path, path]):
                 included_name = os.path.relpath(path, parent_path)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1072,9 +1072,13 @@ class OptionalInclude:
             else:
                 included_name = path
 
-            included_name = _remove_prefix(included_name, f".{os.sep}")
+            # Remove relative prefix from linux local and git repo paths
+            included_name = _remove_prefix(included_name, "./")
 
             if sys.platform == "win32":
+                # Remove relative prefix from windows paths
+                included_name = _remove_prefix(included_name, ".\\")
+
                 # Clean windows path for use in config name that looks nicer
                 # ie. The path: C:\\some\\path\\to\\a\\file
                 # becomes C/some/path/to/a/file

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1015,7 +1015,7 @@ def _remove_prefix(path: str, prefix: str) -> str:
         path = path.removeprefix(prefix)
     except AttributeError:
         if path.startswith(prefix):
-            path = path[len(prefix) :]
+            path = path[len(prefix):]
     return path
 
 
@@ -1060,10 +1060,10 @@ class OptionalInclude:
         self._validate_parent_scope(parent_scope)
 
         # Determine the configuration scope name
-        config_name = self.name if self.name else parent_scope.name
+        config_name = self.name or parent_scope.name
 
         # But ensure that name is unique if there are multiple paths.
-        if not self.name or (hasattr(self, "paths") and len(self.paths) > 1):
+        if not self.name or len(getattr(self, "paths", [])) > 1:
             parent_path = getattr(parent_scope, "path", None)
             path = spack.util.path.substitute_path_variables(path)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -71,6 +71,7 @@ import spack.util.spack_yaml as syaml
 from spack.llnl.util import filesystem, lang, tty
 from spack.util.cpus import cpus_available
 from spack.util.spack_yaml import get_mark_from_yaml_data
+from spack.util.path import substitute_path_variables
 
 from .enums import ConfigScopePriority
 
@@ -1009,6 +1010,16 @@ def override(
         assert scope is overrides
 
 
+def _remove_prefix(path: str, prefix: str) -> str:
+    try:
+        # TODO: Retain only this call once the minimum version is Python 3.9
+        path = path.removeprefix(prefix)
+    except AttributeError:
+        if path.startswith(prefix):
+            path = path[len(prefix) :]
+    return path
+
+
 #: Class for the relevance of an optional path conditioned on a limited
 #: python code that evaluates to a boolean and or explicit specification
 #: as optional.
@@ -1046,18 +1057,20 @@ class OptionalInclude:
         # Ensure the parent scope is valid
         self._validate_parent_scope(parent_scope)
 
+        # Determine the configuration scope name
+        config_name = self.name if self.name else parent_scope.name
 
-        # use specified name if there is one
-        config_name = self.name
-        if not config_name:
-            # Try to use the relative path to create the included scope name
+        # But ensure that name is unique if there are multiple paths.
+        if not self.name or (hasattr(self, "paths") and len(self.paths) > 1):
             parent_path = getattr(parent_scope, "path", None)
-            if parent_path and str(parent_path) == os.path.commonprefix(
-                [parent_path, config_path]
-            ):
-                included_name = os.path.relpath(config_path, parent_path)
+            path = substitute_path_variables(path)
+
+            if parent_path and str(parent_path) == os.path.commonprefix([parent_path, path]):
+                included_name = os.path.relpath(path, parent_path)
             else:
-                included_name = config_path
+                included_name = path
+
+            included_name = _remove_prefix(included_name, f".{os.sep}")
 
             if sys.platform == "win32":
                 # Clean windows path for use in config name that looks nicer
@@ -1066,7 +1079,7 @@ class OptionalInclude:
                 included_name = included_name.replace("\\", "/")
                 included_name = included_name.replace(":", "")
 
-            config_name = f"{parent_scope.name}:{included_name}"
+            config_name = f"{config_name}:{included_name}"
 
         _, ext = os.path.splitext(config_path)
         ext_is_yaml = ext == ".yaml" or ext == ".yml"
@@ -1078,17 +1091,6 @@ class OptionalInclude:
             raise ValueError(f"Required path ({path}) does not exist{dest}")
 
         if (exists and not is_dir) or ext_is_yaml:
-            if self.name and hasattr(self, "paths") and len(self.paths) > 1:
-                # TODO: Remove the try-except once the minimum Python is 3.9
-                # TODO: since that is when removeprefix was introduced
-                prefix = f".{os.sep}"
-                try:
-                    base_path = path.removeprefix(prefix)
-                except AttributeError:
-                    base_path = path[len(prefix):] if path.startswith(prefix) else path
-                config_name = f"{config_name}:{os.path.basename(base_path)}"
-
-            # files are assumed to be SingleFileScopes
             tty.debug(f"Creating SingleFileScope {config_name} for '{config_path}'")
             return SingleFileScope(
                 config_name,
@@ -1333,9 +1335,14 @@ class GitIncludePaths(OptionalInclude):
             raise spack.error.ConfigError(f"Unable to cache the include: {self}")
 
         scopes: List[ConfigScope] = []
-        for relative_path in self.paths:
-            config_path = os.path.join(destination, relative_path)
-            scope = self._scope(relative_path, config_path, parent_scope)
+        prefix = os.path.commonpath(self.paths)
+        if prefix:
+            prefix += os.sep
+
+        for path in self.paths:
+            config_path = os.path.join(destination, path)
+            path = _remove_prefix(path, prefix)
+            scope = self._scope(path, config_path, parent_scope)
             if scope is not None:
                 scopes.append(scope)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1009,16 +1009,6 @@ def override(
         assert scope is overrides
 
 
-def _remove_prefix(path: str, prefix: str) -> str:
-    try:
-        # TODO: Retain only this call once the minimum version is Python 3.9
-        path = path.removeprefix(prefix)
-    except AttributeError:
-        if path.startswith(prefix):
-            path = path[len(prefix):]
-    return path
-
-
 #: Class for the relevance of an optional path conditioned on a limited
 #: python code that evaluates to a boolean and or explicit specification
 #: as optional.
@@ -1064,26 +1054,19 @@ class OptionalInclude:
 
         # But ensure that name is unique if there are multiple paths.
         if not self.name or len(getattr(self, "paths", [])) > 1:
-            parent_path = getattr(parent_scope, "path", None)
-            path = spack.util.path.substitute_path_variables(path)
+            parent_path = pathlib.Path(getattr(parent_scope, "path", ""))
+            real_path = pathlib.Path(spack.util.path.substitute_path_variables(path))
 
-            if parent_path and str(parent_path) == os.path.commonprefix([parent_path, path]):
-                included_name = os.path.relpath(path, parent_path)
-            else:
-                included_name = path
-
-            # Remove relative prefix from linux local and git repo paths
-            included_name = _remove_prefix(included_name, "./")
+            try:
+                included_name = real_path.relative_to(parent_path)
+            except ValueError:
+                included_name = real_path
 
             if sys.platform == "win32":
-                # Remove relative prefix from windows paths
-                included_name = _remove_prefix(included_name, ".\\")
-
                 # Clean windows path for use in config name that looks nicer
                 # ie. The path: C:\\some\\path\\to\\a\\file
                 # becomes C/some/path/to/a/file
-                included_name = included_name.replace("\\", "/")
-                included_name = included_name.replace(":", "")
+                included_name = included_name.as_posix().replace(":", "")
 
             config_name = f"{config_name}:{included_name}"
 
@@ -1341,13 +1324,8 @@ class GitIncludePaths(OptionalInclude):
             raise spack.error.ConfigError(f"Unable to cache the include: {self}")
 
         scopes: List[ConfigScope] = []
-        prefix = os.path.commonpath(self.paths)
-        if prefix:
-            prefix += os.sep
-
         for path in self.paths:
             config_path = os.path.join(destination, path)
-            path = _remove_prefix(path, prefix)
             scope = self._scope(path, config_path, parent_scope)
             if scope is not None:
                 scopes.append(scope)

--- a/lib/spack/spack/schema/include.py
+++ b/lib/spack/spack/schema/include.py
@@ -92,6 +92,7 @@ properties: Dict[str, Any] = {
                             "description": "List of relative paths within the repository where "
                             "configuration files are located",
                         },
+                        "name": {"type": "string"},
                         "when": {
                             "type": "string",
                             "description": "Include this config only when the condition (as "

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1819,10 +1819,12 @@ def test_included_path_git(
 
             return ""
 
-    paths = ["config.yaml", "packages.yaml"]
+    # Specifying two relative paths, one explicit, one implicit
+    paths = ["./config.yaml", "packages.yaml"]
     entry = {
         "git": "https://example.com/windows/configs.git",
         key: value,
+        "name": "site",
         "paths": paths,
         "when": 'platform == "test"',
     }
@@ -1852,9 +1854,12 @@ def test_included_path_git(
     parent_scope = mock_low_high_config.scopes["low"]
     scopes = include.scopes(parent_scope)
     assert scopes and len(scopes) == len(paths)
+
+    base_paths = [os.path.basename(p) for p in paths]
     for scope in scopes:
         assert isinstance(scope, spack.config.SingleFileScope)
-        assert os.path.basename(scope.path) in paths  # type: ignore[union-attr]
+        assert os.path.basename(scope.path) in base_paths  # type: ignore[union-attr]
+        assert scope.name.split(":")[1] in base_paths
 
     # Second pass uses the scopes previously built.
     # Only need to do this for one of the parameters.

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -2035,6 +2035,6 @@ def test_include_bad_parent_scope(tmp_path: pathlib.Path):
 
 
 def test_config_invalid_scope(mock_low_high_config):
-    err = "Must be one of \['low', 'high'\]"  # noqa: W605
+    err = "Must be one of \\['low', 'high'\\]"  # noqa: W605
     with pytest.raises(ValueError, match=err):
         spack.config.CONFIG.get_config_filename("noscope", "nosection")


### PR DESCRIPTION
This PR adds support for specifying the `name` of a `git` include (https://spack.readthedocs.io/en/latest/include_yaml.html#named-configuration-scopes). It also changes paths for SingleFileScopes reported using `spack config scopes -p` so they do NOT end with the path separator.

It does NOT change the current default destination for caching git includes. That will be handled in a follow-on PR.

For example, given

```
include:
- name: site
  git: https://github.com/spack/spack-configs.git
  branch: main
  paths:
  - USC/config
```

the scope names would be:

```
$ spack config scopes -p
Scope               Path
command_line
spack               $spack/etc/spack/
user                $HOME/.spack/
site                $HOME/.spack/includes/nncrh7v/USC/config/
system              /etc/spack/
defaults            $spack/etc/spack/defaults/
defaults:darwin     $spack/etc/spack/defaults/darwin/
defaults:base       $spack/etc/spack/defaults/base/
_builtin
```

Consequently the default `site` configuration is overridden.

Suppose you only want two of the current five (https://github.com/spack/spack-configs/tree/main/USC/config) configuration files. If you provide multiple explicit paths (https://spack.readthedocs.io/en/latest/include_yaml.html#git-repository-files), then the name will be prepended to each path entry to ensure uniqueness. 

Given you only want the `config.yaml` and `packages.yaml` files from the repository:
```
include:
- name: site
  git: https://github.com/spack/spack-configs.git
  branch: main
  paths:
  - USC/config/config.yaml
  - USC/config/packages.yaml
```
then the scope names are:
```
$ spack config scopes -p
Scope               Path
command_line
spack               $spack/etc/spack/
user                $HOME/.spack/
site:config.yaml    $HOME/.spack/includes/nncrh7v/USC/config/config.yaml
site:packages.yaml  $HOME/.spack/includes/nncrh7v/USC/config/packages.yaml
site                $HOME/github/prs/spack/etc/spack/site/
system              /etc/spack/
defaults            $spack/etc/spack/defaults/
defaults:darwin     $spack/etc/spack/defaults/darwin/
defaults:base       $spack/etc/spack/defaults/base/
_builtin
```

Which means those configuration files do NOT override the default `site` configuration but their contents do have higher precedence.

TODO

- [x] Shorten the scope name to the base name if multiple files, not the associated destination on the file system
- [x] Add/update unit tests
- [x] Update documentation 