### PR TITLE
package_base.py: PackageBase.versions typehint

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -60,13 +60,7 @@ from spack.dependency import Dependency
 from spack.directives_meta import DirectiveError, directive, get_spec
 from spack.resource import Resource
 from spack.spec import EMPTY_SPEC
-from spack.version import (
-    GitVersion,
-    Version,
-    VersionChecksumError,
-    VersionError,
-    VersionLookupError,
-)
+from spack.version import StandardVersion, VersionChecksumError, VersionError
 
 __all__ = [
     "DirectiveError",
@@ -261,15 +255,7 @@ def _execute_version(pkg: PackageType, ver: Union[str, int], kwargs: dict):
             f"{pkg.name}: declared version '{ver!r}' in package should be a string or int."
         )
 
-    # Declared versions are concrete
-    version = Version(ver)
-
-    if isinstance(version, GitVersion) and not hasattr(pkg, "git") and "git" not in kwargs:
-        args = ", ".join(f"{argname}='{value}'" for argname, value in kwargs.items())
-        raise VersionLookupError(
-            f"{pkg.name}: spack version directives cannot include git hashes fetched from URLs.\n"
-            f"    version('{ver}', {args})"
-        )
+    version = StandardVersion.from_string(str(ver))
 
     # Store kwargs for the package to later with a fetch_strategy.
     pkg.versions[version] = kwargs

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -547,7 +547,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     compiler = DeprecatedCompiler()
 
     #: Class level dictionary populated by :func:`~spack.directives.version` directives
-    versions: dict
+    versions: Dict[StandardVersion, Dict[str, Any]]
     #: Class level dictionary populated by :func:`~spack.directives.resource` directives
     resources: Dict[spack.spec.Spec, List[Resource]]
     #: Class level dictionary populated by :func:`~spack.directives.depends_on` and

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2479,17 +2479,17 @@ class SpackSolverSetup:
             from_packages_yaml: List[GitOrStandardVersion] = []
 
             for vstr in packages_yaml[pkg_name]["version"]:
-                v = vn.ver(vstr)
+                cfg_ver = vn.ver(vstr)
 
-                if isinstance(v, vn.GitVersion):
-                    if not require_checksum or v.is_commit:
-                        from_packages_yaml.append(v)
+                if isinstance(cfg_ver, vn.GitVersion):
+                    if not require_checksum or cfg_ver.is_commit:
+                        from_packages_yaml.append(cfg_ver)
                 else:
-                    matches = [x for x in self.possible_versions[pkg_name] if x.satisfies(v)]
+                    matches = [x for x in self.possible_versions[pkg_name] if x.satisfies(cfg_ver)]
                     matches.sort(reverse=True)
                     if not matches:
                         raise spack.error.ConfigError(
-                            f"Preference for version {v} does not match any known "
+                            f"Preference for version {cfg_ver} does not match any known "
                             f"version of {pkg_name}"
                         )
                     from_packages_yaml.extend(matches)


### PR DESCRIPTION
* Make `PackageBase.version` of type `dict[StandardVersion, ...]`.
* Use `StandardVersion.from_string` for parsing in `version("...", ...)`
* Do not parse possible `GitVersion` in the `version("...", ...)` string.

I think allowing `GitVersion` to be parsed in the `version` directive
was an oversight and really a bug. I think that because (a) it's not
tested, (b) it's not used in spack-packages, (c) all of PackageBase
has typehints except `.versions`, and (d) historically:

* `Version` was a class, *not* a function call producing a
   separate `StandardVersion` or `GitVersion` instance.
* The original `class Version` was extended to support
   git versions, meaning there was a single type for both
   sorts of versions, so we couldn't distinguish the two
   on the type level.
* At that point the `version` directive was considered not
  to produce git versions by convention (since there were
  no tests added), that was an oversight.
* Only when `GitVersion` was made a separate type, it
   was realized that the `version` directive could parse a
   `GitVersion` df44045fdb68e429bd1accdb7e7c9b947521d75c
   and some minimal validation was added, which I think was
   just "defensive coding", but again, the use case was not
   tested.

If GitVersion parsing is allowed, you get two sources of truth,
namely the version string and the kwargs:

```python
version("git.foo=1.2.3", branch="bar")
```

So, I would argue that we should have `StandardVersion` and not
`Union[StandardVersion, GitVersion]` as the type here, and I don't
think this is a breaking change, but a bug fix. With that, it's much
easier to add typing to `fetch_strategy.py`, since we don't have
to `assert isinstance(v, StandardVersion)` etc.