### PR TITLE
Ensures sys.stdin can be epolled before registering a listener in the new installer

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1303,16 +1303,15 @@ class PackageInstaller:
 
     def _installer(self) -> None:
         jobserver = JobServer(self.jobs)
+        selector = selectors.DefaultSelector()
 
         # Set stdin to non-blocking for key press detection
         if sys.stdin.isatty():
             old_stdin_settings = termios.tcgetattr(sys.stdin)
             tty.setcbreak(sys.stdin.fileno())
+            selector.register(sys.stdin.fileno(), selectors.EVENT_READ, "stdin")
         else:
             old_stdin_settings = None
-
-        selector = selectors.DefaultSelector()
-        selector.register(sys.stdin.fileno(), selectors.EVENT_READ, "stdin")
 
         # Setup the database write lock. TODO: clean this up
         if isinstance(spack.store.STORE.db.lock, spack.util.lock.Lock):


### PR DESCRIPTION
Previously, the new installer unconditionally attempted to register a listener on stdin, even in environments where this was not possible (e.g. jobs scheduled in non-interactive sessions), leading to an error. The following now works (as a proxy for non-interactive environments):
`spack -c config:installer:new install zlib < /dev/null`

