### PR TITLE
Add debug msg for concretizer start

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1144,6 +1144,8 @@ class PyclingoDriver:
             result, concretization_stats = self._conc_cache.fetch(cache_key)
         timer.stop("cache-check")
 
+        tty.debug("Starting concretizer")
+
         # run the solver and store the result, if it wasn't cached already
         if not result:
             problem_repr = "\n".join(problem)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Added a debug message for when the concretizer starts solving in order to improve debug message clarity.
