### PR TITLE
new_installer.py: always pivot prefix, decouple from `--overwrite`

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -243,20 +243,17 @@ def install_from_buildcache(
 class PrefixPivoter:
     """Manages the installation prefix during overwrite installations."""
 
-    def __init__(self, prefix: str, overwrite: bool, keep_prefix: bool = False) -> None:
+    def __init__(self, prefix: str, keep_prefix: bool = False) -> None:
         """Initialize the prefix pivoter.
 
         Args:
             prefix: The installation prefix path
-            overwrite: Whether to allow overwriting an existing prefix
-            keep_prefix: Whether to keep a failed installation prefix (when not overwriting)
+            keep_prefix: Whether to keep a failed installation prefix
         """
         self.prefix = prefix
-        #: Whether to allow installation when the prefix exists
-        self.overwrite = overwrite
         #: Whether to keep a failed installation prefix
         self.keep_prefix = keep_prefix
-        #: Temporary location for the original prefix during overwrite
+        #: Temporary location for the original prefix
         self.tmp_prefix: Optional[str] = None
         self.parent = os.path.dirname(prefix)
 
@@ -264,9 +261,7 @@ class PrefixPivoter:
         """Enter the context: move existing prefix to temporary location if needed."""
         if not self._lexists(self.prefix):
             return self
-        if not self.overwrite:
-            raise spack.error.InstallError(f"Install prefix {self.prefix} already exists")
-        # Move the existing prefix to a temporary location
+        # Move the existing prefix to a temporary location so the build starts fresh
         self.tmp_prefix = self._mkdtemp(
             dir=self.parent, prefix=".", suffix=OVERWRITE_BACKUP_SUFFIX
         )
@@ -278,36 +273,32 @@ class PrefixPivoter:
     ) -> None:
         """Exit the context: cleanup on success, restore on failure."""
         if exc_type is None:
-            # Success: remove the backup in case of overwrite
+            # Success: remove the backup
             if self.tmp_prefix is not None:
                 self._rmtree_ignore_errors(self.tmp_prefix)
             return
 
         # Failure handling:
-        # Priority 1: If we're overwriting, always restore the original prefix
-        # Priority 2: If keep_prefix is False, remove the failed installation
-
-        if self.overwrite and self.tmp_prefix is not None:
-            # Overwrite case: restore the original prefix if it existed
-            # The highest priority is to restore the original prefix, so we try to:
-            # rename prefix -> garbage: move failed dir out of the way
-            # rename tmp_prefix -> prefix: restore original prefix
-            # remove garbage (this is allowed to fail)
+        if self.keep_prefix:
+            # Leave the failed prefix in place, discard the backup
+            if self.tmp_prefix is not None:
+                self._rmtree_ignore_errors(self.tmp_prefix)
+        elif self.tmp_prefix is not None:
+            # There was a pre-existing prefix: pivot back to it and discard the failed build
             garbage = self._mkdtemp(dir=self.parent, prefix=".", suffix=OVERWRITE_GARBAGE_SUFFIX)
             try:
                 self._rename(self.prefix, garbage)
                 has_failed_prefix = True
-            except FileNotFoundError:  # prefix dir does not exist, so we don't have to delete it.
+            except FileNotFoundError:  # build never created the prefix dir
                 has_failed_prefix = False
             self._rename(self.tmp_prefix, self.prefix)
             if has_failed_prefix:
                 self._rmtree_ignore_errors(garbage)
-        elif not self.keep_prefix and self._lexists(self.prefix):
-            # Not overwriting, keep_prefix is False: remove the failed installation
+        elif self._lexists(self.prefix):
+            # No backup, just remove the failed installation
             garbage = self._mkdtemp(dir=self.parent, prefix=".", suffix=OVERWRITE_GARBAGE_SUFFIX)
             self._rename(self.prefix, garbage)
             self._rmtree_ignore_errors(garbage)
-        # else: keep_prefix is True, leave the failed prefix in place
 
     def _lexists(self, path: str) -> bool:
         return os.path.lexists(path)
@@ -331,7 +322,6 @@ def worker_function(
     dirty: bool,
     keep_stage: bool,
     restage: bool,
-    overwrite: bool,
     keep_prefix: bool,
     skip_patch: bool,
     state: Connection,
@@ -357,7 +347,6 @@ def worker_function(
         dirty: Whether to preserve user environment in the build environment
         keep_stage: Whether to keep the build stage after installation
         restage: Whether to restage the source before building
-        overwrite: Whether to overwrite the existing install prefix
         keep_prefix: Whether to keep a failed installation prefix
         skip_patch: Whether to skip the patch phase
         state: Connection to send state updates to
@@ -404,7 +393,7 @@ def worker_function(
     exit_code = 0
 
     try:
-        with PrefixPivoter(spec.prefix, overwrite, keep_prefix):
+        with PrefixPivoter(spec.prefix, keep_prefix):
             _install(
                 spec,
                 explicit,
@@ -618,7 +607,6 @@ def start_build(
     dirty: bool,
     keep_stage: bool,
     restage: bool,
-    overwrite: bool,
     keep_prefix: bool,
     skip_patch: bool,
     jobserver: JobServer,
@@ -653,7 +641,6 @@ def start_build(
             dirty,
             keep_stage,
             restage,
-            overwrite,
             keep_prefix,
             skip_patch,
             state_w_conn,
@@ -1547,7 +1534,6 @@ class PackageInstaller:
             # keep_stage/restage logic taken from installer.py
             keep_stage=self.keep_stage or is_develop,
             restage=self.restage and not is_develop,
-            overwrite=dag_hash in self.overwrite,
             keep_prefix=self.keep_prefix,
             skip_patch=self.skip_patch,
             jobserver=jobserver,

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -241,7 +241,7 @@ def install_from_buildcache(
 
 
 class PrefixPivoter:
-    """Manages the installation prefix during overwrite installations."""
+    """Manages the installation prefix of a build."""
 
     def __init__(self, prefix: str, keep_prefix: bool = False) -> None:
         """Initialize the prefix pivoter.

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests for the new_installer.py module"""
 
-import pathlib as pathlb
+import pathlib
 import sys
 
 import pytest
@@ -11,13 +11,12 @@ import pytest
 if sys.platform == "win32":
     pytest.skip("No Windows support", allow_module_level=True)
 
-import spack.error
 import spack.spec
 from spack.new_installer import OVERWRITE_GARBAGE_SUFFIX, PackageInstaller, PrefixPivoter
 
 
 @pytest.fixture
-def existing_prefix(tmp_path: pathlb.Path) -> pathlb.Path:
+def existing_prefix(tmp_path: pathlib.Path) -> pathlib.Path:
     """Creates a standard existing prefix with content."""
     prefix = tmp_path / "existing_prefix"
     prefix.mkdir()
@@ -28,28 +27,22 @@ def existing_prefix(tmp_path: pathlb.Path) -> pathlb.Path:
 class TestPrefixPivoter:
     """Tests for the PrefixPivoter class."""
 
-    def test_no_existing_prefix(self, tmp_path: pathlb.Path):
+    def test_no_existing_prefix(self, tmp_path: pathlib.Path):
         """Test installation when prefix doesn't exist yet."""
         prefix = tmp_path / "new_prefix"
 
-        with PrefixPivoter(str(prefix), overwrite=False):
+        with PrefixPivoter(str(prefix)):
             prefix.mkdir()
             (prefix / "installed_file").write_text("content")
 
         assert prefix.exists()
         assert (prefix / "installed_file").read_text() == "content"
 
-    def test_existing_prefix_no_overwrite_raises(self, existing_prefix: pathlb.Path):
-        """Test that existing prefix raises error when overwrite=False."""
-        with pytest.raises(spack.error.InstallError, match="already exists"):
-            with PrefixPivoter(str(existing_prefix), overwrite=False):
-                pass
-
-    def test_overwrite_success_cleans_up_old_prefix(
-        self, tmp_path: pathlb.Path, existing_prefix: pathlb.Path
+    def test_existing_prefix_success_cleans_up_old_prefix(
+        self, tmp_path: pathlib.Path, existing_prefix: pathlib.Path
     ):
-        """Test that overwrite=True moves old prefix and cleans it up on success."""
-        with PrefixPivoter(str(existing_prefix), overwrite=True):
+        """Test that an existing prefix is moved aside, and cleaned up on success."""
+        with PrefixPivoter(str(existing_prefix)):
             assert not existing_prefix.exists()
             existing_prefix.mkdir()
             (existing_prefix / "new_file").write_text("new content")
@@ -60,15 +53,12 @@ class TestPrefixPivoter:
         # Only the existing_prefix directory should remain
         assert len(list(tmp_path.iterdir())) == 1
 
-    def test_overwrite_failure_restores_original_prefix(
-        self, tmp_path: pathlb.Path, existing_prefix: pathlb.Path
+    def test_existing_prefix_failure_restores_original_prefix(
+        self, tmp_path: pathlib.Path, existing_prefix: pathlib.Path
     ):
-        """Test that original prefix is restored when installation fails.
-
-        Note: keep_prefix=True is passed but should be ignored since overwrite=True
-        takes precedence."""
+        """Test that the original prefix is restored when installation fails."""
         with pytest.raises(RuntimeError, match="simulated failure"):
-            with PrefixPivoter(str(existing_prefix), overwrite=True, keep_prefix=True):
+            with PrefixPivoter(str(existing_prefix), keep_prefix=False):
                 existing_prefix.mkdir()
                 (existing_prefix / "partial_file").write_text("partial")
                 raise RuntimeError("simulated failure")
@@ -76,22 +66,24 @@ class TestPrefixPivoter:
         assert existing_prefix.exists()
         assert (existing_prefix / "old_file").read_text() == "old content"
         assert not (existing_prefix / "partial_file").exists()
-        # Only the existing_prefix directory should remain
+        # Only the original prefix should remain
         assert len(list(tmp_path.iterdir())) == 1
 
-    def test_overwrite_failure_no_partial_prefix_created(self, existing_prefix: pathlb.Path):
-        """Test restoration when failure occurs before any prefix is created."""
+    def test_existing_prefix_failure_no_partial_prefix_created(
+        self, existing_prefix: pathlib.Path
+    ):
+        """Test restoration when failure occurs before the build creates the prefix dir."""
         with pytest.raises(RuntimeError, match="early failure"):
-            with PrefixPivoter(str(existing_prefix), overwrite=True):
+            with PrefixPivoter(str(existing_prefix)):
                 raise RuntimeError("early failure")
 
         assert existing_prefix.exists()
         assert (existing_prefix / "old_file").read_text() == "old content"
 
-    def test_overwrite_true_no_existing_prefix(self, tmp_path: pathlb.Path):
-        """Test that overwrite=True works fine when prefix doesn't exist."""
+    def test_no_existing_prefix_success(self, tmp_path: pathlib.Path):
+        """Test that a fresh install with no pre-existing prefix works fine."""
         prefix = tmp_path / "new_prefix"
-        with PrefixPivoter(str(prefix), overwrite=True):
+        with PrefixPivoter(str(prefix)):
             prefix.mkdir()
             (prefix / "installed_file").write_text("content")
 
@@ -99,34 +91,64 @@ class TestPrefixPivoter:
         # Only the new_prefix directory should remain
         assert len(list(tmp_path.iterdir())) == 1
 
-    def test_keep_prefix_true_leaves_failed_install(self, tmp_path: pathlb.Path):
-        """Test that keep_prefix=True preserves the failed installation."""
-        prefix = tmp_path / "new_prefix"
-
+    def test_keep_prefix_true_with_existing_prefix_keeps_failed_install(
+        self, tmp_path: pathlib.Path, existing_prefix: pathlib.Path
+    ):
+        """Test that keep_prefix=True keeps the failed install and discards the backup."""
         with pytest.raises(RuntimeError, match="simulated failure"):
-            with PrefixPivoter(str(prefix), overwrite=False, keep_prefix=True):
-                prefix.mkdir()
-                (prefix / "partial_file").write_text("partial content")
+            with PrefixPivoter(str(existing_prefix), keep_prefix=True):
+                existing_prefix.mkdir()
+                (existing_prefix / "partial_file").write_text("partial content")
                 raise RuntimeError("simulated failure")
 
-        # Failed prefix should still exist
-        assert prefix.exists()
-        assert (prefix / "partial_file").exists()
-        assert (prefix / "partial_file").read_text() == "partial content"
-        # Only the failed prefix should remain
+        # The failed prefix should be kept (not the original)
+        assert existing_prefix.exists()
+        assert (existing_prefix / "partial_file").exists()
+        assert not (existing_prefix / "old_file").exists()
+        # Backup should have been removed
         assert len(list(tmp_path.iterdir())) == 1
 
-    def test_keep_prefix_false_removes_failed_install(self, tmp_path: pathlb.Path):
-        """Test that keep_prefix=False removes the failed installation."""
+    def test_keep_prefix_false_removes_failed_install(self, tmp_path: pathlib.Path):
+        """Test that keep_prefix=False removes the failed installation (no pre-existing prefix)."""
         prefix = tmp_path / "new_prefix"
 
         with pytest.raises(RuntimeError, match="simulated failure"):
-            with PrefixPivoter(str(prefix), overwrite=False, keep_prefix=False):
+            with PrefixPivoter(str(prefix), keep_prefix=False):
                 prefix.mkdir()
                 (prefix / "partial_file").write_text("partial content")
                 raise RuntimeError("simulated failure")
 
         # Failed prefix should be removed
+        assert not prefix.exists()
+        # Nothing should remain
+        assert len(list(tmp_path.iterdir())) == 0
+
+    def test_keep_prefix_true_no_existing_prefix(self, tmp_path: pathlib.Path):
+        """Test failure with keep_prefix=True when no prefix existed beforehand."""
+        prefix = tmp_path / "new_prefix"
+
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            with PrefixPivoter(str(prefix), keep_prefix=True):
+                prefix.mkdir()
+                (prefix / "partial_file").write_text("partial content")
+                raise RuntimeError("simulated failure")
+
+        # The failed prefix should be kept
+        assert prefix.exists()
+        assert (prefix / "partial_file").exists()
+        # No backup should exist
+        assert len(list(tmp_path.iterdir())) == 1
+
+    def test_failure_no_prefix_created(self, tmp_path: pathlib.Path):
+        """Test failure when the prefix directory was never created."""
+        prefix = tmp_path / "new_prefix"
+
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            with PrefixPivoter(str(prefix), keep_prefix=False):
+                # Do NOT create the prefix directory
+                raise RuntimeError("simulated failure")
+
+        # Prefix should not exist
         assert not prefix.exists()
         # Nothing should remain
         assert len(list(tmp_path.iterdir())) == 0
@@ -138,12 +160,11 @@ class FailingPrefixPivoter(PrefixPivoter):
     def __init__(
         self,
         prefix: str,
-        overwrite: bool,
         keep_prefix: bool = False,
         fail_on_restore: bool = False,
         fail_on_move_garbage: bool = False,
     ):
-        super().__init__(prefix, overwrite, keep_prefix)
+        super().__init__(prefix, keep_prefix)
         self.fail_on_restore = fail_on_restore
         self.fail_on_move_garbage = fail_on_move_garbage
         self.restore_rename_count = 0
@@ -168,10 +189,10 @@ class TestPrefixPivoterFailureRecovery:
     """Tests for edge cases and failure recovery in PrefixPivoter."""
 
     def test_restore_failure_leaves_backup(
-        self, tmp_path: pathlb.Path, existing_prefix: pathlb.Path
+        self, tmp_path: pathlib.Path, existing_prefix: pathlib.Path
     ):
         """Test that if restoration fails, the backup is not deleted."""
-        pivoter = FailingPrefixPivoter(str(existing_prefix), overwrite=True, fail_on_restore=True)
+        pivoter = FailingPrefixPivoter(str(existing_prefix), fail_on_restore=True)
 
         with pytest.raises(OSError, match="Simulated rename failure during restore"):
             with pivoter:
@@ -184,12 +205,10 @@ class TestPrefixPivoterFailureRecovery:
         assert len(list(tmp_path.iterdir())) == 2
 
     def test_garbage_move_failure_leaves_backup(
-        self, tmp_path: pathlb.Path, existing_prefix: pathlb.Path
+        self, tmp_path: pathlib.Path, existing_prefix: pathlib.Path
     ):
         """Test that if moving the failed install to garbage fails, the backup is preserved."""
-        pivoter = FailingPrefixPivoter(
-            str(existing_prefix), overwrite=True, fail_on_move_garbage=True
-        )
+        pivoter = FailingPrefixPivoter(str(existing_prefix), fail_on_move_garbage=True)
 
         with pytest.raises(OSError, match="Simulated rename failure moving to garbage"):
             with pivoter:


### PR DESCRIPTION
Previously the `--overwrite` flag was passed on all the way to the build
process, where it was used to decide whether to error if the install
prefix exists prior to the build. That would lead to hard to overcome
install failures if an initial build didn't clear its prefix on failure (which
was the case due to `SIGTERM` exiting the interpreter immediately, see
#51967)

With this change, `--overwrite` is only used to determine what specs will
get rebuild. The build process always does an "overwrite install" in the
sense that if a prefix exists, it's moved out of the way.

* On success and generally with `--keep-prefix`, the old prefix is removed.
* Otherwise, on failure, the old prefix is moved back in place.

Also fix the weird alias `pathlib as pathlb`, probably an artifact from
auto-import in my editor at some point in time.
