### PR TITLE
Concretizer sanity checks should not be applied to concrete specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3058,8 +3058,11 @@ class SpackSolverSetup:
 
         # once we've done a full traversal and know possible versions, check that the
         # requested solve is at least consistent.
-        self.impossible_dependencies_check(specs)
-        self.input_spec_version_check(specs, allow_deprecated)
+        # do not check dependency and version availability for already concrete specs
+        # as they come from reusable specs
+        abstract_specs = [s for s in specs if not s.concrete]
+        self.impossible_dependencies_check(abstract_specs)
+        self.input_spec_version_check(abstract_specs, allow_deprecated)
 
         return self.gen
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4826,6 +4826,30 @@ packages:
     assert mpileaks.satisfies("%c=gcc@12")
 
 
+def test_concrete_specs_skip_prechecks(mock_packages):
+    """Test that concrete specs are not verified by solver prechecks.
+
+    This verifies the change in commit de00d2a937 that modifies the solver
+    to skip running impossible_dependencies_check and input_spec_version_check
+    on already concrete specs, which come from reusable specs.
+
+    The test directly checks the filtering logic added in the commit.
+    """
+
+    specs = [spack.spec.Spec("zlib"), spack.spec.Spec("deprecated-versions@=1.1.0")]
+
+    with pytest.raises(spack.solver.asp.DeprecatedVersionError):
+        spack.solver.asp.SpackSolverSetup().setup(specs)
+
+    with spack.config.override("config:deprecated", True):
+        concrete_spec = spack.concretize.concretize_one(specs[1])
+
+    # Try again with the same version but a concrete spec
+    specs[1] = concrete_spec
+
+    spack.solver.asp.SpackSolverSetup().setup(specs)
+
+
 @pytest.mark.regression("51683")
 def test_activating_variant_for_conditional_language_dependency(default_mock_concretization):
     """Tests that a dependency on a conditional language can be concretized, and that the solver

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4827,14 +4827,7 @@ packages:
 
 
 def test_concrete_specs_skip_prechecks(mock_packages):
-    """Test that concrete specs are not verified by solver prechecks.
-
-    This verifies the change in commit de00d2a937 that modifies the solver
-    to skip running impossible_dependencies_check and input_spec_version_check
-    on already concrete specs, which come from reusable specs.
-
-    The test directly checks the filtering logic added in the commit.
-    """
+    """Test that concrete specs are not checked for unknown versions and dependencies."""
 
     specs = [spack.spec.Spec("zlib"), spack.spec.Spec("deprecated-versions@=1.1.0")]
 


### PR DESCRIPTION
Concrete specs are added to the solve to represent the rest of an environment when iteratively concretizing with `unify: true` or `unify: when_possible`. These concrete specs should not be pre-checked for invalid deps or invalid/deprecated versions because the concretizer is not changing those specs.

@nicholas-sly 