### PR TITLE
new_installer.py: handle SIGTERM/SIGINT better

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -27,6 +27,7 @@ import os
 import re
 import selectors
 import shutil
+import signal
 import sys
 import tempfile
 import termios
@@ -359,6 +360,22 @@ def worker_function(
     # TODO: don't start a build for external packages
     if spec.external:
         return
+
+    # Start a new session, so our SIGTERM handler can kill all child processes.
+    os.setsid()
+
+    def handle_sigterm(signum, frame):
+        # This SIGTERM handler forwards the signal to child processes, and
+        # then resets the handler to default. It does not raise an exception,
+        # because the assumption is we're stuck in waitpid, and we want to
+        # let child processes finish with SIGTERM before we run the cleanup
+        # code in finally blocks and __exit__ functions and exit. If we exit
+        # too early, the child process may still write to the prefix or stage.
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        os.killpg(0, signal.SIGTERM)
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+    signal.signal(signal.SIGTERM, handle_sigterm)
 
     os.environ["MAKEFLAGS"] = makeflags
     spack.store.STORE = store
@@ -1410,6 +1427,8 @@ class PackageInstaller:
                 self.build_status.update()
         except KeyboardInterrupt:
             # Cleanup running builds.
+            for child in self.running_builds.values():
+                child.proc.terminate()
             for child in self.running_builds.values():
                 child.proc.join()
             raise


### PR DESCRIPTION
Should fix an issue reported by @JohnGouwar.

When a build sub-process receives `SIGTERM`, it exits without running
`finally` and `__exit__`. As a result, install prefixes are not cleared, and worse,
failed overwrite installs do not restore the original prefix.

To fix this, add two ingredients:

1. a `SIGTERM` handler
2. a process group for the build process

The `SIGTERM` handler forwards `SIGTERM` to its process group, which should
kill child processes (typically `cmake`, `make`, etc). It avoids the signal itself by
temporarily ignoring the signal. Afterwards, the default handler is restored and
life goes on; no exception is raised.

The consequence of this is that the Python process returns to its `waitpid` syscall
after handling `SIGTERM`, and this should finish quickly, because the `make`,
`./configure` etc executables should exit with error code right away. In the unlikely
case they trap `SIGTERM` and continue running, a subsequent `SIGTERM` kills the
Python script that's stuck in `waitpid` _without_ cleanup running, and without
killing the `./configure` etc process.

Thanks to the new process group, the orchestrator process is now the only process
receiving `SIGINT` from the terminal. Therefore, it's modified to send `SIGTERM` to
the build sub-processes after it gets `SIGINT`, before `.join()`ing build processes.

This commit is also a necessary step for `--fail-fast` to actually be fast: if a tiny
package fails in seconds, but Spack is concurrently building LLVM, which will
take dozens of minutes, it would be good to call `.terminate()` before `.join()`,
which requires a proper `SIGTERM` handler.