### PR TITLE
new_installer.py: implement --fail-fast

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1238,9 +1238,7 @@ class PackageInstaller:
     ) -> None:
         assert install_package or install_deps, "Must install package, dependencies or both"
 
-        if fail_fast:
-            raise NotImplementedError("Fail-fast installs are not implemented")
-        elif fake:
+        if fake:
             raise NotImplementedError("Fake installs are not implemented")
         elif install_source:
             raise NotImplementedError("Installing sources is not implemented")
@@ -1260,6 +1258,7 @@ class PackageInstaller:
         #: Set of DAG hashes to overwrite (if already installed)
         self.overwrite: Set[str] = set(overwrite) if overwrite else set()
         self.keep_prefix = keep_prefix
+        self.fail_fast = fail_fast
 
         # Buffer for incoming, partially received state data from child processes
         self.state_buffers: Dict[int, str] = {}
@@ -1382,9 +1381,19 @@ class PackageInstaller:
                     if build.proc.exitcode == 0:
                         to_insert_in_database.append(build)
                         self.build_status.update_state(build.spec.dag_hash(), "finished")
-                    else:
+                    elif not self.fail_fast or not failures:
+                        # In fail-fast mode, only record the first failure. Subsequent failures may
+                        # be a consequence of us terminating other builds, and should not be
+                        # reported as failures in the UI.
                         failures.append(build.spec)
                         self.build_status.update_state(build.spec.dag_hash(), "failed")
+
+                if failures and self.fail_fast:
+                    # Terminate other builds to actually fail fast. We continue in the event loop
+                    # waiting for child processes to finish, which may take a little while.
+                    for child in self.running_builds.values():
+                        child.proc.terminate()
+                    self.pending_builds.clear()
 
                 if stdin_ready:
                     try:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -27,6 +27,7 @@ import os
 import re
 import selectors
 import shutil
+import signal
 import sys
 import tempfile
 import termios
@@ -359,6 +360,22 @@ def worker_function(
     # TODO: don't start a build for external packages
     if spec.external:
         return
+
+    # Start a new session, so our SIGTERM handler can kill all child processes.
+    os.setsid()
+
+    def handle_sigterm(signum, frame):
+        # This SIGTERM handler forwards the signal to child processes, and
+        # then resets the handler to default. It does not raise an exception,
+        # because the assumption is we're stuck in waitpid, and we want to
+        # let child processes finish with SIGTERM before we run the cleanup
+        # code in finally blocks and __exit__ functions and exit. If we exit
+        # too early, the child process may still write to the prefix or stage.
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        os.killpg(0, signal.SIGTERM)
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+    signal.signal(signal.SIGTERM, handle_sigterm)
 
     os.environ["MAKEFLAGS"] = makeflags
     spack.store.STORE = store
@@ -1410,6 +1427,8 @@ class PackageInstaller:
                 self.build_status.update()
         except KeyboardInterrupt:
             # Cleanup running builds.
+            for child in self.running_builds.values():
+                child.proc.terminate()
             for child in self.running_builds.values():
                 child.proc.join()
             raise


### PR DESCRIPTION
Depends on #51967 

Implement `spack install --fail-fast` for the new installer.

The idea is to send SIGTERM to all build processes after first failure,
but to stay in the event loop, because it takes a little bit before the
subprocesses exit.

We only record the first failure (and not build failures caused by Spack
itself sending SIGTERM).

