### PR TITLE
update changelog for v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,35 @@
 See the [2025.11.0 release](https://github.com/spack/spack-packages/releases/tag/v2025.11.0) of [spack-packages](https://github.com/spack/spack-packages/) for more details.
 
 
+# v1.0.3 (2026-02-02)
+
+## Bug fixes
+
+* Concretizer bugfixes:
+  * solver: remove a special case for provider weighting #51347
+  * solver: improve timeout handling and add Ctrl-C interrupt safety #51341
+  * solver: simplify interrupt/timeout logic #51349
+* Repo management bugfixes:
+  * repo.py: support rhel 7 #51617
+  * repo.py: fix checking out commits #51695
+  * git: pull_checkout_branch RHEL7 git 1.8.3.1 fix #51779
+  * git: fix locking issue in pull_checkout_branch #51854
+  * spack repo remove: allow removing from unspecified scope #51563
+* build_environment.py: Prevent deadlock on install process join #51429
+* Fix typo in untrack_env #51554
+* audit.py: fix re.sub(..., N) positional count arg #51735
+
+## Enhancements
+
+* Support Macos Tahoe (#51373, #51394, #51479)
+* Support for Python 3.14, except for t-strings (#51686, #51687, #51688, #51697, #51663)
+* spack info: show conditional dependencies and licenses; allow filtering #51137
+* Spack fetch less likely to fail due to AI download protections #51496
+* config: relax concurrent_packages to minimum 0 #51840
+  * This avoids forward-incompatibility with Spack v1.2
+* Documentation improvements (#51315, #51640)
+
+
 # v1.0.2 (2025-09-11)
 
 ## Bug Fixes


### PR DESCRIPTION
forward-ports the changelog from the releases/v1.0 branch
