### PR TITLE
Build Environment: Handle system paths better

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1086,23 +1086,25 @@ class SetupContext:
         return env
 
     def _make_buildtime_detectable(self, dep: spack.spec.Spec, env: EnvironmentModifications):
-        if is_system_path(dep.prefix):
-            return
+        add_path = getattr(env, "prepend_path")
+        if dep.external:
+            add_path = getattr(env, "append_path")
 
-        env.prepend_path("CMAKE_PREFIX_PATH", dep.prefix)
+        add_path("CMAKE_PREFIX_PATH", dep.prefix)
         for d in ("lib", "lib64", "share"):
             pcdir = os.path.join(dep.prefix, d, "pkgconfig")
             if os.path.isdir(pcdir):
-                env.prepend_path("PKG_CONFIG_PATH", pcdir)
+                add_path("PKG_CONFIG_PATH", pcdir)
 
     def _make_runnable(self, dep: spack.spec.Spec, env: EnvironmentModifications):
-        if is_system_path(dep.prefix):
-            return
+        add_path = getattr(env, "prepend_path")
+        if dep.external:
+            add_path = getattr(env, "append_path")
 
         for d in ("bin", "bin64"):
             bin_dir = os.path.join(dep.prefix, d)
             if os.path.isdir(bin_dir):
-                env.prepend_path("PATH", bin_dir)
+                add_path("PATH", bin_dir)
 
 
 def load_external_modules(context: SetupContext) -> None:


### PR DESCRIPTION
The function `is_system_path` is problematic as it does not capture many of the system paths. It is also incomplete as the real issue it is trying to solve in these contexts is not adding paths that may contain installations of packages not used by spack.

Since the issue of duplicate deps in a search path is more generally going to only occur for external specs, this solution forces externals to be listed last and spack installed specs to be listed first for search. This should solve _most_ of the issues related to this.

This does not solve the issue of pointing at Spack installed specs as externals that are duplicate with system installed versions of that spec. External paths with duplicates is outside the scope of what this is trying to fix.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
