### PR TITLE
solver: fix concretizer hanging on binutils

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1492,6 +1492,19 @@ error(100, "{0} variant '{1}' cannot have values '{2}' and '{3}' as they come fr
 :- attr("variant_set", node(ID, Package), Variant, Value),
    not attr("variant_value", node(ID, Package), Variant, Value).
 
+% If we set a conditional variant, which depends on another variant taking a value,
+% set also the other variant. This short circuits the variant rules, and makes the
+% minimization easier for clingo. It avoids a long chain of decisions that may require
+% a lot of backtracking and result in no conflict learnt (e.g. setting "binutils+gold"
+% implies "binutils+ld")
+attr("variant_set", node(ID, Package), AnotherVariant, AnotherValue)
+  :- attr("variant_set", node(ID, Package), Variant, Value),
+     attr("variant_selected", node(ID, Package), Variant, _, _, VariantID),
+     pkg_fact(Package, variant_condition(Variant, VariantID, ConditionID)),
+     pkg_fact(Package, condition_trigger(ConditionID, TriggerID)),
+     condition_requirement(TriggerID,"variant_value",Package, AnotherVariant, AnotherValue),
+     build(node(ID, Package)).
+
 % A default variant value that is not used, makes sense only for multi valued variants
 variant_default_not_used(node(ID, Package), Variant, Value)
   :- variant_default_value(node(ID, Package), Variant, Value),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1492,11 +1492,9 @@ error(100, "{0} variant '{1}' cannot have values '{2}' and '{3}' as they come fr
 :- attr("variant_set", node(ID, Package), Variant, Value),
    not attr("variant_value", node(ID, Package), Variant, Value).
 
-% If we set a conditional variant, which depends on another variant taking a value,
-% set also the other variant. This short circuits the variant rules, and makes the
-% minimization easier for clingo. It avoids a long chain of decisions that may require
-% a lot of backtracking and result in no conflict learnt (e.g. setting "binutils+gold"
-% implies "binutils+ld")
+% In a case with `variant("foo", when="+bar")` and a user request for +foo or ~foo,
+% assume that +bar is set too. This gives no penalty if `+bar` is not the default value, and
+% optimizes a long chain of deductions that may cause clingo to hang
 attr("variant_set", node(ID, Package), AnotherVariant, AnotherValue)
   :- attr("variant_set", node(ID, Package), Variant, Value),
      attr("variant_selected", node(ID, Package), Variant, _, _, VariantID),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1493,8 +1493,8 @@ error(100, "{0} variant '{1}' cannot have values '{2}' and '{3}' as they come fr
    not attr("variant_value", node(ID, Package), Variant, Value).
 
 % In a case with `variant("foo", when="+bar")` and a user request for +foo or ~foo,
-% assume that +bar is set too. This gives no penalty if `+bar` is not the default value, and
-% optimizes a long chain of deductions that may cause clingo to hang
+% force +bar to be set too. This gives no penalty if `+bar` is not the default value, and
+% optimizes a long chain of deductions that may cause clingo to hang.
 attr("variant_set", node(ID, Package), AnotherVariant, AnotherValue)
   :- attr("variant_set", node(ID, Package), Variant, Value),
      attr("variant_selected", node(ID, Package), Variant, _, _, VariantID),


### PR DESCRIPTION
When using:

* **Spack:** 1.2.0.dev0 (https://github.com/spack/spack/commit/124b9686d153a7e6d6eb9eed7fb318d7fc65272f)
* **Builtin repo:** https://github.com/spack/spack-packages (a19611d)
* **Python:** 3.13.2
* **Platform:** linux-ubuntu20.04-icelake

the concretizer hangs to solve for:
```console
$ spack solve binutils+gold
```

The cause seems to be the long chain of decisions that clingo needs to go through to reason about variants. That long chain makes it difficult to learn conflicts, in particular when a conditional variant implies that a non-default value of another variant is taken.

Here we short-circuit that decision and make minimization easier by saying that setting a variant to a value that implies another one also sets the other value.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
