### PR TITLE
new_installer.py: initial multi-process support

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -117,6 +117,7 @@ class ChildInfo:
         self.control_w_conn = control_w_conn
         self.log_path = log_path
         self.explicit = explicit
+        self.prefix_lock: Optional[spack.util.lock.Lock] = None
 
     def cleanup(self, selector: selectors.BaseSelector) -> None:
         """Unregister and close file descriptors, and join the child process."""
@@ -775,7 +776,9 @@ class BuildInfo:
         "control_w_conn",
     )
 
-    def __init__(self, spec: spack.spec.Spec, explicit: bool, control_w_conn: Connection) -> None:
+    def __init__(
+        self, spec: spack.spec.Spec, explicit: bool, control_w_conn: Optional[Connection]
+    ) -> None:
         self.state: str = "starting"
         self.explicit: bool = explicit
         self.version: str = str(spec.version)
@@ -821,7 +824,9 @@ class BuildStatus:
         self.get_time = get_time
         self.is_tty = is_tty if is_tty is not None else self.stdout.isatty()
 
-    def add_build(self, spec: spack.spec.Spec, explicit: bool, control_w_conn: Connection) -> None:
+    def add_build(
+        self, spec: spack.spec.Spec, explicit: bool, control_w_conn: Optional[Connection] = None
+    ) -> None:
         """Add a new build to the display and mark the display as dirty."""
         self.builds[spec.dag_hash()] = BuildInfo(spec, explicit, control_w_conn)
         self.dirty = True
@@ -837,7 +842,9 @@ class BuildStatus:
             self.overview_mode = True
             self.dirty = True
             try:
-                os.write(self.builds[self.tracked_build_id].control_w_conn.fileno(), b"0")
+                conn = self.builds[self.tracked_build_id].control_w_conn
+                if conn is not None:
+                    os.write(conn.fileno(), b"0")
             except (KeyError, OSError):
                 pass
             self.tracked_build_id = ""
@@ -898,7 +905,9 @@ class BuildStatus:
         # Stop following the previous and start following the new build.
         if self.tracked_build_id:
             try:
-                os.write(self.builds[self.tracked_build_id].control_w_conn.fileno(), b"0")
+                conn = self.builds[self.tracked_build_id].control_w_conn
+                if conn is not None:
+                    os.write(conn.fileno(), b"0")
             except (KeyError, OSError):
                 pass
 
@@ -910,7 +919,9 @@ class BuildStatus:
         )
         self.stdout.flush()
         try:
-            os.write(new_build.control_w_conn.fileno(), b"1")
+            conn = new_build.control_w_conn
+            if conn is not None:
+                os.write(conn.fileno(), b"1")
         except (KeyError, OSError):
             pass
 
@@ -1284,6 +1295,8 @@ class PackageInstaller:
         elif tests is not False:
             raise NotImplementedError("Tests during install are not implemented")
 
+        self.db = spack.store.STORE.db
+
         specs = [pkg.spec for pkg in packages]
 
         self.root_policy: InstallPolicy = root_policy
@@ -1305,7 +1318,7 @@ class PackageInstaller:
             include_build_deps,
             install_package,
             install_deps,
-            spack.store.STORE.db,
+            self.db,
             self.overwrite,
         )
 
@@ -1349,17 +1362,7 @@ class PackageInstaller:
         self.reports: Dict[str, spack.report.RequestRecord] = {}
 
     def install(self) -> None:
-        # This installer has not implemented the per-spec exclusive locks during installation.
-        # Instead, take an exclusive lock on the entire range to avoid that other Spack install
-        # process start installing the same specs.
-        lock = spack.util.lock.Lock(
-            str(spack.store.STORE.prefix_locker.lock_path), desc="prefix lock"
-        )
-        lock.acquire_write()
-        try:
-            self._installer()
-        finally:
-            lock.release_write()
+        self._installer()
 
     def _installer(self) -> None:
         jobserver = JobServer(self.jobs)
@@ -1380,19 +1383,20 @@ class PackageInstaller:
         failures: List[spack.spec.Spec] = []
 
         try:
-            # Start the first job immediately, as it does not require a jobserver token.
-            if self.pending_builds and not self.running_builds:
-                self._start(selector, jobserver)
+            # Try to schedule builds immediately. The first job does not require a token.
+            blocked_on_locks = self._schedule_builds(selector, jobserver)
 
             while self.pending_builds or self.running_builds or finished_builds:
-                # Only monitor the jobserver if we have pending builds and capacity.
-                can_schedule_more = self.pending_builds and self.capacity > 0
+                # Monitor the jobserver when we have pending builds, capacity, and at least one
+                # spec is not locked by another process.
+                can_schedule_more = (
+                    self.pending_builds and self.capacity > 0 and not blocked_on_locks
+                )
                 if can_schedule_more and jobserver.r not in selector.get_map():
                     selector.register(jobserver.r, selectors.EVENT_READ, "jobserver")
                 elif not can_schedule_more and jobserver.r in selector.get_map():
                     selector.unregister(jobserver.r)
 
-                jobserver_token_available = False
                 stdin_ready = False
 
                 events = selector.select(timeout=SPINNER_INTERVAL)
@@ -1410,8 +1414,6 @@ class PackageInstaller:
                             self._handle_child_state(key.fd, child_info, selector)
                         elif data.name == "sentinel":
                             finished_pids.append(data.pid)
-                    elif data == "jobserver":
-                        jobserver_token_available = True
                     elif data == "stdin":
                         stdin_ready = True
 
@@ -1474,17 +1476,9 @@ class PackageInstaller:
                 ):
                     finished_builds.clear()
 
-                # Again, the first job should start immediately and does not require a token.
-                if self.pending_builds and not self.running_builds:
-                    self._start(selector, jobserver)
-
-                # For the rest we try to obtain tokens from the jobserver.
-                if self.pending_builds and self.capacity > 0 and jobserver_token_available:
-                    # Schedule as many jobs as we can acquire tokens for.
-                    max_new_jobs = min(len(self.pending_builds), self.capacity)
-                    num_acquired = jobserver.acquire(max_new_jobs)
-                    for _ in range(num_acquired):
-                        self._start(selector, jobserver)
+                # Try to schedule more builds, acquiring per-spec locks and jobserver tokens.
+                if self.capacity and self.pending_builds:
+                    blocked_on_locks = self._schedule_builds(selector, jobserver)
 
                 # Finally update the UI
                 self.build_status.update()
@@ -1498,9 +1492,15 @@ class PackageInstaller:
             raise
         finally:
             # Make sure to write any successful builds to the database before exiting
-            with spack.store.STORE.db.write_transaction():
+            with self.db.write_transaction():
                 for build in finished_builds:
-                    spack.store.STORE.db._add(build.spec, explicit=build.explicit)
+                    self.db._add(build.spec, explicit=build.explicit)
+
+            # Release any prefix write locks that were not yet released via _save_to_db
+            for build in finished_builds:
+                if build.prefix_lock is not None:
+                    build.prefix_lock.release_write()
+                    build.prefix_lock = None
 
             # Restore terminal settings
             if old_stdin_settings:
@@ -1528,23 +1528,109 @@ class PackageInstaller:
             )
 
     def _save_to_db(self, finished_builds: List[ChildInfo]) -> bool:
-        db = spack.store.STORE.db
         try:
             # Only try to get the lock once (non-blocking). If it fails, try it next time.
-            if db.lock.acquire_write(timeout=1e-9):
-                db._read()
+            if self.db.lock.acquire_write(timeout=1e-9):
+                self.db._read()
         except spack.util.lock.LockTimeoutError:
             return False
         try:
             for build in finished_builds:
-                db._add(build.spec, explicit=build.explicit)
-            return True
+                self.db._add(build.spec, explicit=build.explicit)
         finally:
-            db.lock.release_write(db._write)
+            self.db.lock.release_write(self.db._write)
 
-    def _start(self, selector: selectors.BaseSelector, jobserver: JobServer) -> None:
+        # DB has been written and flushed; release per-spec prefix write locks so other processes
+        # can see the specs are now installed and acquire their own locks.
+        for build in finished_builds:
+            if build.prefix_lock is not None:
+                build.prefix_lock.release_write()
+                build.prefix_lock = None
+
+        return True
+
+    def _schedule_builds(self, selector: selectors.BaseSelector, jobserver: JobServer) -> bool:
+        """Try to schedule as many pending builds as possible.
+
+        For each pending spec, attempts to acquire a non-blocking per-spec write lock. Under both
+        the DB read lock and the prefix write lock, checks whether another process has already
+        installed the spec. If so, skips it and enqueues its parents. Otherwise, acquires a
+        jobserver token (if needed) and starts the build.
+
+        Returns True if all remaining pending specs are locked by other processes (i.e., there is
+        no point in watching for jobserver tokens right now). Returns False if there are
+        schedulable specs or no pending builds remain."""
+
+        # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory
+        # snapshot stays consistent while we acquire per-spec prefix locks.
+        try:
+            self.db.lock.acquire_read(timeout=1e-9)
+        except spack.util.lock.LockTimeoutError:
+            return False
+
+        try:
+            self.db._read()  # refresh in-memory snapshot under the read lock
+            need_token = bool(self.running_builds)
+            any_lock_acquired = False
+            idx = 0
+
+            while idx < len(self.pending_builds):
+                dag_hash = self.pending_builds[idx]
+                if self.capacity <= 0:
+                    return False
+
+                spec = self.build_graph.nodes[dag_hash]
+                lock = spack.store.STORE.prefix_locker.lock(spec)
+                try:
+                    lock.acquire_write(timeout=1e-9)
+                except spack.util.lock.LockTimeoutError:
+                    idx += 1
+                    continue  # another process is building this spec; try the next one
+
+                # Successfully acquired the write lock for this spec.
+                any_lock_acquired = True
+
+                # Check installed status under the DB read lock and prefix write lock.
+                upstream, record = self.db.query_by_spec_hash(dag_hash)
+
+                # Don't schedule builds for specs from upstream databases.
+                assert not (
+                    upstream and record and not record.installed
+                ), f"Cannot install {spec}: it is uninstalled in an upstream database."
+
+                # If the spec is already installed by another process, skip it and enqueue parents.
+                if dag_hash not in self.overwrite and record and record.installed:
+                    lock.release_write()
+                    del self.pending_builds[idx]
+                    self.build_status.add_build(spec, explicit=dag_hash in self.explicit)
+                    self.build_status.update_state(dag_hash, "finished")
+                    self.build_graph.enqueue_parents(dag_hash, self.pending_builds)
+                    continue
+
+                # Acquire a jobserver token if needed. The first (implicit) job needs no token.
+                if need_token and not jobserver.acquire(1):
+                    lock.release_write()
+                    break  # no tokens available right now; stop scheduling
+
+                del self.pending_builds[idx]
+                self._start(selector, jobserver, dag_hash, lock)
+                need_token = True
+
+        finally:
+            self.db.lock.release_read()
+
+        # If we still have pending builds and never acquired any lock, all are blocked by other
+        # processes and there is no benefit in monitoring the jobserver for tokens.
+        return bool(self.pending_builds) and not any_lock_acquired
+
+    def _start(
+        self,
+        selector: selectors.BaseSelector,
+        jobserver: JobServer,
+        dag_hash: str,
+        prefix_lock: spack.util.lock.Lock,
+    ) -> None:
         self.capacity -= 1
-        dag_hash = self.pending_builds.pop()
         explicit = dag_hash in self.explicit
         spec = self.build_graph.nodes[dag_hash]
         is_develop = spec.is_develop
@@ -1568,6 +1654,7 @@ class PackageInstaller:
             jobserver=jobserver,
         )
         self.log_paths[dag_hash] = child_info.log_path
+        child_info.prefix_lock = prefix_lock
         pid = child_info.proc.pid
         assert type(pid) is int
         self.running_builds[pid] = child_info

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1254,6 +1254,101 @@ class BuildGraph:
                 pending_builds.append(parent)
 
 
+def schedule_builds(
+    pending: List[str],
+    build_graph: BuildGraph,
+    db: spack.database.Database,
+    prefix_locker: spack.database.SpecLocker,
+    overwrite: Set[str],
+    capacity: int,
+    needs_jobserver_token: bool,
+    jobserver: JobServer,
+) -> Tuple[bool, List[Tuple[str, spack.util.lock.Lock]], List[Tuple[str, spack.spec.Spec]]]:
+    """Try to schedule as many pending builds as possible.
+
+    For each pending spec, attempts to acquire a non-blocking per-spec write lock. Under both the
+    DB read lock and the prefix write lock, checks whether another process has already installed
+    the spec. If so, captures it as newly_installed (caller enqueues parents) and releases the
+    lock. Otherwise, acquires a jobserver token if needed and adds the (dag_hash, lock) pair to
+    to_start (caller launches the build).
+
+    Args:
+        pending: List of dag hashes pending installation; modified in-place.
+        build_graph: The build dependency graph; used for node lookup and parent enqueueing.
+        db: Package database; used for read lock and installed-status queries.
+        prefix_locker: Per-spec write locker.
+        overwrite: Set of dag hashes to overwrite even if already installed.
+        capacity: Maximum number of new builds to add to to_start in this call.
+        needs_jobserver_token: True if a jobserver token is required for the first new build.
+        jobserver: Jobserver for acquiring tokens.
+
+    Returns:
+        A (blocked, to_start, newly_installed) tuple where ``blocked`` is True if any pending
+        builds were blocked on locks; ``to_start`` contains ``(dag_hash, lock)`` pairs where the
+        write lock is held and the caller must start the build and eventually release the lock;
+        and ``newly_installed`` contains ``(dag_hash, spec)`` pairs found already installed by
+        another process for which the caller must update the UI and enqueue parents.
+    """
+    to_start: List[Tuple[str, spack.util.lock.Lock]] = []
+    newly_installed: List[Tuple[str, spack.spec.Spec]] = []
+    blocked = True
+
+    # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory snapshot
+    # stays consistent while we acquire per-spec prefix locks.
+    try:
+        db.lock.acquire_read(timeout=1e-9)
+    except spack.util.lock.LockTimeoutError:
+        return blocked, to_start, newly_installed
+
+    try:
+        db._read()  # refresh in-memory snapshot under the read lock
+
+        idx = 0
+        while capacity and idx < len(pending):
+            dag_hash = pending[idx]
+            spec = build_graph.nodes[dag_hash]
+            lock = prefix_locker.lock(spec)
+
+            try:
+                lock.acquire_write(timeout=1e-9)
+                blocked = False
+            except spack.util.lock.LockTimeoutError:
+                # another process is building this spec; try the next one
+                idx += 1
+                continue
+
+            # Check installed status under the DB read lock and prefix write lock.
+            upstream, record = db.query_by_spec_hash(dag_hash)
+
+            # Don't schedule builds for specs from upstream databases.
+            assert not (
+                upstream and record and not record.installed
+            ), f"Cannot install {spec}: it is uninstalled in an upstream database."
+
+            # If the spec is already installed by another process, capture it and enqueue parents.
+            if dag_hash not in overwrite and record and record.installed:
+                lock.release_write()
+                del pending[idx]
+                newly_installed.append((dag_hash, spec))
+                build_graph.enqueue_parents(dag_hash, pending)
+                continue
+
+            # Acquire a jobserver token if needed. The first (implicit) job needs no token.
+            if needs_jobserver_token and not jobserver.acquire(1):
+                lock.release_write()
+                break  # no tokens available right now; stop scheduling
+
+            del pending[idx]
+            to_start.append((dag_hash, lock))
+            capacity -= 1
+            needs_jobserver_token = True  # all subsequent jobs need a token
+
+    finally:
+        db.lock.release_read()
+
+    return blocked, to_start, newly_installed
+
+
 class PackageInstaller:
 
     def __init__(
@@ -1384,14 +1479,12 @@ class PackageInstaller:
 
         try:
             # Try to schedule builds immediately. The first job does not require a token.
-            blocked_on_locks = self._schedule_builds(selector, jobserver)
+            blocked = self._schedule_builds(selector, jobserver)
 
             while self.pending_builds or self.running_builds or finished_builds:
                 # Monitor the jobserver when we have pending builds, capacity, and at least one
                 # spec is not locked by another process.
-                can_schedule_more = (
-                    self.pending_builds and self.capacity > 0 and not blocked_on_locks
-                )
+                can_schedule_more = self.pending_builds and self.capacity and not blocked
                 if can_schedule_more and jobserver.r not in selector.get_map():
                     selector.register(jobserver.r, selectors.EVENT_READ, "jobserver")
                 elif not can_schedule_more and jobserver.r in selector.get_map():
@@ -1478,7 +1571,7 @@ class PackageInstaller:
 
                 # Try to schedule more builds, acquiring per-spec locks and jobserver tokens.
                 if self.capacity and self.pending_builds:
-                    blocked_on_locks = self._schedule_builds(selector, jobserver)
+                    blocked = self._schedule_builds(selector, jobserver)
 
                 # Finally update the UI
                 self.build_status.update()
@@ -1552,76 +1645,34 @@ class PackageInstaller:
     def _schedule_builds(self, selector: selectors.BaseSelector, jobserver: JobServer) -> bool:
         """Try to schedule as many pending builds as possible.
 
-        For each pending spec, attempts to acquire a non-blocking per-spec write lock. Under both
-        the DB read lock and the prefix write lock, checks whether another process has already
-        installed the spec. If so, skips it and enqueues its parents. Otherwise, acquires a
-        jobserver token (if needed) and starts the build.
+        Delegates to the module-level schedule_builds() function and then performs the
+        side-effects that require the selector and running-build state: updating build_status for
+        specs that were found already installed, and launching new builds via _start().
 
-        Returns True if all remaining pending specs are locked by other processes (i.e., there is
-        no point in watching for jobserver tokens right now). Returns False if there are
-        schedulable specs or no pending builds remain."""
+        Preconditions: self.capacity > 0 and self.pending_builds is not empty.
 
-        # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory
-        # snapshot stays consistent while we acquire per-spec prefix locks.
-        try:
-            self.db.lock.acquire_read(timeout=1e-9)
-        except spack.util.lock.LockTimeoutError:
-            return False
-
-        try:
-            self.db._read()  # refresh in-memory snapshot under the read lock
-            need_token = bool(self.running_builds)
-            any_lock_acquired = False
-            idx = 0
-
-            while idx < len(self.pending_builds):
-                dag_hash = self.pending_builds[idx]
-                if self.capacity <= 0:
-                    return False
-
-                spec = self.build_graph.nodes[dag_hash]
-                lock = spack.store.STORE.prefix_locker.lock(spec)
-                try:
-                    lock.acquire_write(timeout=1e-9)
-                except spack.util.lock.LockTimeoutError:
-                    idx += 1
-                    continue  # another process is building this spec; try the next one
-
-                # Successfully acquired the write lock for this spec.
-                any_lock_acquired = True
-
-                # Check installed status under the DB read lock and prefix write lock.
-                upstream, record = self.db.query_by_spec_hash(dag_hash)
-
-                # Don't schedule builds for specs from upstream databases.
-                assert not (
-                    upstream and record and not record.installed
-                ), f"Cannot install {spec}: it is uninstalled in an upstream database."
-
-                # If the spec is already installed by another process, skip it and enqueue parents.
-                if dag_hash not in self.overwrite and record and record.installed:
-                    lock.release_write()
-                    del self.pending_builds[idx]
-                    self.build_status.add_build(spec, explicit=dag_hash in self.explicit)
-                    self.build_status.update_state(dag_hash, "finished")
-                    self.build_graph.enqueue_parents(dag_hash, self.pending_builds)
-                    continue
-
-                # Acquire a jobserver token if needed. The first (implicit) job needs no token.
-                if need_token and not jobserver.acquire(1):
-                    lock.release_write()
-                    break  # no tokens available right now; stop scheduling
-
-                del self.pending_builds[idx]
-                self._start(selector, jobserver, dag_hash, lock)
-                need_token = True
-
-        finally:
-            self.db.lock.release_read()
-
-        # If we still have pending builds and never acquired any lock, all are blocked by other
-        # processes and there is no benefit in monitoring the jobserver for tokens.
-        return bool(self.pending_builds) and not any_lock_acquired
+        Returns True if we had capacity to schedule, but were blocked by locks held by other
+        processes. In that case we should not monitor the jobserver for new tokens, since we'd end
+        up in a busy wait loop until the locks are released.
+        """
+        blocked, to_start, newly_installed = schedule_builds(
+            pending=self.pending_builds,
+            build_graph=self.build_graph,
+            db=self.db,
+            prefix_locker=spack.store.STORE.prefix_locker,
+            overwrite=self.overwrite,
+            capacity=self.capacity,
+            needs_jobserver_token=bool(self.running_builds),
+            jobserver=jobserver,
+        )
+        # Specs installed by another process.
+        for dag_hash, spec in newly_installed:
+            self.build_status.add_build(spec, explicit=dag_hash in self.explicit)
+            self.build_status.update_state(dag_hash, "finished")
+        # Specs we can start building ourselves.
+        for dag_hash, lock in to_start:
+            self._start(selector, jobserver, dag_hash, lock)
+        return blocked
 
     def _start(
         self,

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -13,7 +13,14 @@ if sys.platform == "win32":
 
 import spack.error
 import spack.spec
-from spack.new_installer import OVERWRITE_GARBAGE_SUFFIX, PackageInstaller, PrefixPivoter
+import spack.util.lock
+from spack.new_installer import (
+    OVERWRITE_GARBAGE_SUFFIX,
+    JobServer,
+    PackageInstaller,
+    PrefixPivoter,
+    schedule_builds,
+)
 
 
 @pytest.fixture
@@ -227,3 +234,205 @@ class TestPackageInstallerConstructor:
         spec = spack.spec.Spec("trivial-install-test-package")
         spec._mark_concrete()
         assert PackageInstaller([spec.package]).capacity == 1
+
+
+class _FakeBuildGraph:
+    """Minimal stand-in for BuildGraph in schedule_builds unit tests.
+
+    Provides the two interface points that schedule_builds calls:
+      - .nodes  (dict: dag_hash -> Spec)
+      - .enqueue_parents(dag_hash, pending_builds)
+    """
+
+    def __init__(self, specs):
+        self.nodes = {spec.dag_hash(): spec for spec in specs}
+
+    def enqueue_parents(self, dag_hash, pending_builds):
+        """Remove dag_hash from nodes; no parents in these simple unit tests."""
+        self.nodes.pop(dag_hash, None)
+
+
+class TestScheduleBuilds:
+    """Unit tests for the module-level schedule_builds() function."""
+
+    def _make_spec(self, name):
+        """Return a minimal concrete spec suitable for locking and DB queries."""
+        spec = spack.spec.Spec(name)
+        spec._mark_concrete()
+        return spec
+
+    def _mark_installed(self, spec, store):
+        """Create the install directory structure and register the spec in the DB as installed."""
+        store.layout.create_install_directory(spec)
+        store.db.add(spec, explicit=True)
+
+    def test_not_installed_no_running_starts_build(self, temporary_store, mock_packages):
+        """A fresh spec with no running builds is added to to_start."""
+        spec = self._make_spec("trivial-install-test-package")
+        pending = [spec.dag_hash()]
+        bg = _FakeBuildGraph([spec])
+        jobserver = JobServer(num_jobs=2)
+        try:
+            blocked, to_start, newly_installed = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite=set(),
+                capacity=1,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+            )
+            assert not blocked
+            assert len(to_start) == 1
+            assert to_start[0][0] == spec.dag_hash()
+            assert not newly_installed
+            assert not pending  # removed from the pending list
+        finally:
+            for _, lock in to_start:
+                lock.release_write()
+            jobserver.close()
+
+    def test_already_installed_yields_newly_installed(self, temporary_store, mock_packages):
+        """A spec already in the DB is returned in newly_installed, not in to_start."""
+        spec = self._make_spec("trivial-install-test-package")
+        self._mark_installed(spec, temporary_store)
+        pending = [spec.dag_hash()]
+        bg = _FakeBuildGraph([spec])
+        jobserver = JobServer(num_jobs=2)
+        try:
+            blocked, to_start, newly_installed = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite=set(),
+                capacity=1,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+            )
+            assert not blocked
+            assert not to_start
+            assert len(newly_installed) == 1
+            assert newly_installed[0][0] == spec.dag_hash()
+            assert not pending  # removed from the pending list
+        finally:
+            jobserver.close()
+
+    def test_no_jobserver_token_returns_empty(self, temporary_store, mock_packages):
+        """When has_running_builds=True and no token is available, nothing is started."""
+        spec = self._make_spec("trivial-install-test-package")
+        pending = [spec.dag_hash()]
+        bg = _FakeBuildGraph([spec])
+        # num_jobs=1 writes 0 tokens to the FIFO. Only the implicit token exists.
+        jobserver = JobServer(num_jobs=1)
+        try:
+            blocked, to_start, newly_installed = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite=set(),
+                capacity=2,
+                needs_jobserver_token=True,
+                jobserver=jobserver,
+            )
+            assert not blocked
+            assert not to_start
+            assert not newly_installed
+            assert len(pending) == 1
+        finally:
+            jobserver.close()
+
+    def test_all_locked_returns_blocked(self, temporary_store, mock_packages, monkeypatch):
+        """When all pending specs are locked externally, blocked_on_locks is True."""
+        spec = self._make_spec("trivial-install-test-package")
+        pending = [spec.dag_hash()]
+        bg = _FakeBuildGraph([spec])
+        jobserver = JobServer(num_jobs=2)
+        # Pre-register the lock in the prefix_locker cache, then patch acquire_write to fail.
+        lock = temporary_store.prefix_locker.lock(spec)
+
+        def always_timeout(timeout=None):
+            raise spack.util.lock.LockTimeoutError("write", lock.path, 0, 1)
+
+        monkeypatch.setattr(lock, "acquire_write", always_timeout)
+        try:
+            blocked, to_start, newly_installed = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite=set(),
+                capacity=2,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+            )
+            assert blocked
+            assert not to_start
+            assert not newly_installed
+            assert len(pending) == 1
+        finally:
+            jobserver.close()
+
+    def test_overwrite_installed_spec_is_started(self, temporary_store, mock_packages):
+        """A spec in the overwrite set is scheduled even when already installed."""
+        spec = self._make_spec("trivial-install-test-package")
+        self._mark_installed(spec, temporary_store)
+        pending = [spec.dag_hash()]
+        bg = _FakeBuildGraph([spec])
+        jobserver = JobServer(num_jobs=2)
+        try:
+            blocked, to_start, newly_installed = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite={spec.dag_hash()},
+                capacity=1,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+            )
+            assert not blocked
+            assert len(to_start) == 1
+            assert to_start[0][0] == spec.dag_hash()
+            assert not newly_installed
+        finally:
+            for _, lock in to_start:
+                lock.release_write()
+            jobserver.close()
+
+    def test_mixed_locked_unlocked(self, temporary_store, mock_packages, monkeypatch):
+        """Only the unlocked spec enters to_start when one spec is externally locked."""
+        spec_a = self._make_spec("trivial-install-test-package")
+        spec_b = self._make_spec("trivial-smoke-test")
+        pending = [spec_a.dag_hash(), spec_b.dag_hash()]
+        bg = _FakeBuildGraph([spec_a, spec_b])
+        jobserver = JobServer(num_jobs=4)
+        # Patch spec_a's lock to always time out, simulating an external write lock.
+        lock_a = temporary_store.prefix_locker.lock(spec_a)
+
+        def always_timeout(timeout=None):
+            raise spack.util.lock.LockTimeoutError("write", lock_a.path, 0, 1)
+
+        monkeypatch.setattr(lock_a, "acquire_write", always_timeout)
+        try:
+            blocked, to_start, newly_installed = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite=set(),
+                capacity=2,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+            )
+            assert not blocked  # spec_b was schedulable
+            started_hashes = {h for h, _ in to_start}
+            assert spec_b.dag_hash() in started_hashes
+            assert spec_a.dag_hash() not in started_hashes
+            assert not newly_installed
+        finally:
+            for _, lock in to_start:
+                lock.release_write()
+            jobserver.close()


### PR DESCRIPTION
Allow multi-process concurrency, additionally to per-process package
parallelism.

Basic idea is as follows. If there are pending builds in this Spack
process:

* Take a read lock on the database (if this fails, re-enter event loop)
* Take a prefix write lock on the to-be-installed spec (if this fails,
  try the next pending build)
* If the spec is installed in the meantime: drop the prefix write lock,
  remove the pending build, enqueue its parents, continue
* If the spec is not installed, acquire a jobserver token if needed (if
  this fails, re-enter the event loop)
* If all succeeds, schedule the build, try to schedule more.
* Finally release the read lock on the db.

If it's not possible to obtain any write lock on the prefix lock, inform
the event loop that it shouldn't wake up on available jobserver tokens.
This is a measure to avoid a busy wait: locally there are jobserver
tokens available, but all pending builds are claimed by another process.
The hope is that the event loop then iterates every 100ms.

What this commit does not do:

* Take read locks on build dependencies and their link/run deps. So, it
  does not guard against concurrent uninstalls of (dependencies of) build
  deps.
* Avoid scheduling builds of packages that failed to install in another
  Spack process.

That's left as a follow-up PR since it's not essential and keeps the diff size
reasonably small for review.


