### PR TITLE
new_installer.py: warn when jobserver tokens are not released

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -568,6 +568,25 @@ class JobServer:
         self.tokens_acquired -= 1
 
     def close(self) -> None:
+        if self.created and self.num_jobs > 1:
+            if self.tokens_acquired != 0:
+                # It's a non-fatal internal error to close the jobserver with acquired tokens.
+                print("Warning: Spack failed to release jobserver tokens", file=sys.stderr)
+            else:
+                # Verify that all build processes released the tokens they acquired.
+                total = self.num_jobs - 1
+                drained = self.acquire(total)
+                if drained != total:
+                    print(
+                        f"Warning: {total - drained} jobserver tokens were not released by "
+                        "build processes. This can indicate that the build ran with limited "
+                        "parallelism.",
+                        file=sys.stderr,
+                    )
+
+        self.r_conn.close()
+        self.w_conn.close()
+
         # Remove the FIFO if we created it.
         if self.created and self.fifo_path:
             try:
@@ -578,11 +597,6 @@ class JobServer:
                 os.rmdir(os.path.dirname(self.fifo_path))
             except OSError:
                 pass
-        # TODO: implement a sanity check here:
-        # 1. did we release all tokens we acquired?
-        # 2. if we created the jobserver, did the children return all tokens?
-        self.r_conn.close()
-        self.w_conn.close()
 
 
 def start_build(
@@ -1439,6 +1453,7 @@ class PackageInstaller:
             for child in self.running_builds.values():
                 child.proc.terminate()
             for child in self.running_builds.values():
+                jobserver.release()
                 child.proc.join()
             raise
         finally:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -35,6 +35,7 @@ import threading
 import time
 import traceback
 import tty
+import warnings
 from gzip import GzipFile
 from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
@@ -571,17 +572,18 @@ class JobServer:
         if self.created and self.num_jobs > 1:
             if self.tokens_acquired != 0:
                 # It's a non-fatal internal error to close the jobserver with acquired tokens.
-                print("Warning: Spack failed to release jobserver tokens", file=sys.stderr)
+                warnings.warn("Spack failed to release jobserver tokens", stacklevel=2)
             else:
                 # Verify that all build processes released the tokens they acquired.
                 total = self.num_jobs - 1
                 drained = self.acquire(total)
                 if drained != total:
-                    print(
-                        f"Warning: {total - drained} jobserver tokens were not released by "
-                        "build processes. This can indicate that the build ran with limited "
-                        "parallelism.",
-                        file=sys.stderr,
+                    n = total - drained
+                    warnings.warn(
+                        f"{n} jobserver {'token was' if n == 1 else 'tokens were'} not released "
+                        "by the build processes. This can indicate that the build ran with "
+                        "limited parallelism.",
+                        stacklevel=2,
                     )
 
         self.r_conn.close()

--- a/lib/spack/spack/test/jobserver.py
+++ b/lib/spack/spack/test/jobserver.py
@@ -275,3 +275,19 @@ class TestJobServer:
             assert js.w_conn is not None and js.w_conn.fileno() == js.w
         finally:
             js.close()
+
+    def test_close_warns_when_spack_holds_tokens(self, capfd):
+        """Should warn when Spack closes the jobserver while still holding acquired tokens."""
+        js = JobServer(4)
+        js.acquire(1)  # Spack acquires a token without releasing it
+        js.close()
+
+        assert "Warning: Spack failed to release jobserver tokens" in capfd.readouterr().err
+
+    def test_close_warns_when_subprocess_holds_tokens(self, capfd):
+        """Should warn when a subprocess acquired a token but never released it."""
+        js = JobServer(4)
+        os.read(js.r, 1)  # A subprocess acquires a token without releasing it
+        js.close()
+
+        assert "1 jobserver tokens were not released by build processes" in capfd.readouterr().err

--- a/lib/spack/spack/test/jobserver.py
+++ b/lib/spack/spack/test/jobserver.py
@@ -276,18 +276,21 @@ class TestJobServer:
         finally:
             js.close()
 
-    def test_close_warns_when_spack_holds_tokens(self, capfd):
+    def test_close_warns_when_spack_holds_tokens(self):
         """Should warn when Spack closes the jobserver while still holding acquired tokens."""
         js = JobServer(4)
         js.acquire(1)  # Spack acquires a token without releasing it
-        js.close()
+        with pytest.warns(UserWarning, match="Spack failed to release jobserver tokens"):
+            js.close()
 
-        assert "Warning: Spack failed to release jobserver tokens" in capfd.readouterr().err
-
-    def test_close_warns_when_subprocess_holds_tokens(self, capfd):
+    def test_close_warns_when_subprocess_holds_tokens(self):
         """Should warn when a subprocess acquired a token but never released it."""
-        js = JobServer(4)
-        os.read(js.r, 1)  # A subprocess acquires a token without releasing it
-        js.close()
+        js1 = JobServer(4)
+        os.read(js1.r, 1)  # A subprocess acquires a token without releasing it
+        with pytest.warns(UserWarning, match="1 jobserver token was not released"):
+            js1.close()
 
-        assert "1 jobserver tokens were not released by build processes" in capfd.readouterr().err
+        js2 = JobServer(4)
+        os.read(js2.r, 2)  # A subprocess acquires two tokens without releasing them
+        with pytest.warns(UserWarning, match="2 jobserver tokens were not released"):
+            js2.close()


### PR DESCRIPTION
Similar to GNU Make, warn when at the end of execution not all jobserver tokens were returned.

