### PR TITLE
Git: Ensure git server configured for tests

### DIFF
--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -283,7 +283,7 @@ def test_get_full_repo(
         s.variants["commit"] = SingleValuedVariant("commit", commit)
         if can_use_direct_commit:
             path = mock_git_repository.path
-            git_exe("-C", path, "config", "set", "uploadpack.allowReachableSHA1InWant", "true")
+            git_exe("-C", path, "config", "uploadpack.allowReachableSHA1InWant", "true")
 
     with s.package.stage:
         with spack.config.override("config:verify_ssl", secure):

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -281,6 +281,9 @@ def test_get_full_repo(
         url = mock_git_repository.url
         commit = git_exe("ls-remote", url, t.revision, output=str).strip().split()[0]
         s.variants["commit"] = SingleValuedVariant("commit", commit)
+        if can_use_direct_commit:
+            path = mock_git_repository.path
+            git_exe("-C", path, "config", "set", "uploadpack.allowReachableSHA1InWant", "true")
 
     with s.package.stage:
         with spack.config.override("config:verify_ssl", secure):

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -324,8 +324,9 @@ def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
 
     filter_args = FILTER_BLOB_NONE(version)
     if filter_args:
-        fetch.extend([*filter_args, url, ref])
+        fetch.extend(filter_args)
         cmds.insert(1, ["config", "extensions.partialClone", "true"])
+    fetch.extend([url, ref])
     _exec_git_commands_unique_dir(git_exe, cmds, debug, dest)
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -315,14 +315,17 @@ def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
     remote = ["remote", "add", "origin", url]
     config = ["config", "remote.origin.fetch", "+refs/heads/*:origin/refs/*"]
     fetch = ["fetch"]
+    cmds = [init, remote, config, fetch]
 
     if not debug:
         fetch.append("--quiet")
     if depth and protocol_supports_shallow_clone(url):
         fetch.extend(DEPTH(version, str(depth)))
 
-    fetch.extend([*FILTER_BLOB_NONE(version), url, ref])
-    cmds = [init, remote, config, fetch]
+    filter_args = FILTER_BLOB_NONE(version)
+    if filter_args:
+        fetch.extend([*filter_args, url, ref])
+        cmds.insert(1, ["config", "extensions.partialClone", "true"])
     _exec_git_commands_unique_dir(git_exe, cmds, debug, dest)
 
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -315,7 +315,6 @@ def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
     remote = ["remote", "add", "origin", url]
     config = ["config", "remote.origin.fetch", "+refs/heads/*:origin/refs/*"]
     fetch = ["fetch"]
-    cmds = [init, remote, config, fetch]
 
     if not debug:
         fetch.append("--quiet")
@@ -325,8 +324,13 @@ def git_init_fetch(url, ref, depth=None, debug=False, dest=None, git_exe=None):
     filter_args = FILTER_BLOB_NONE(version)
     if filter_args:
         fetch.extend(filter_args)
-        cmds.insert(1, ["config", "extensions.partialClone", "true"])
     fetch.extend([url, ref])
+
+    partial_clone = ["config", "extensions.partialClone", "true"] if filter_args else None
+    if partial_clone is not None:
+        cmds = [init, partial_clone, remote, config, fetch]
+    else:
+        cmds = [init, remote, config, fetch]
     _exec_git_commands_unique_dir(git_exe, cmds, debug, dest)
 
 


### PR DESCRIPTION
This change ensures that compatible versions of git are using the proper git server configuration to test optimized git checkout procedures.

We assume that the git server has `uploadpack.allowReachableSHA1InWant` on inside our unit-test for full_repo checkout purely on git version. However in unit-tests this is driven by the OS defaults AND the git version. In practice the code can adapt if the server is not configured, but we want uniform behavior for the test.

Resolves #51984 
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
