### PR TITLE
set Spack version to v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.0.3 (2026-02-02)
+# v1.0.4 (2026-02-23)
 
 ## Bug fixes
 
@@ -25,6 +25,12 @@
 * config: relax concurrent_packages to minimum 0 #51840
   * This avoids forward-incompatibility with Spack v1.2
 * Documentation improvements (#51315, #51640)
+
+
+# v1.0.3 (2026-02-20)
+
+Skipped due to a release management failure.
+
 
 # v1.0.2 (2025-09-11)
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -10,7 +10,7 @@ import spack.paths
 import spack.util.git
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 spack_version = __version__
 
 #: The current Package API version implemented by this version of Spack. The Package API defines


### PR DESCRIPTION
Fixing the broken v1.0.3 release. It will be re-released as v1.0.4, and v1.0.3 will be removed from our releases/tags.
