### PR TITLE
new_installer.py: dynamic --jobs

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -309,10 +309,6 @@ class GlobalState:
             web.urlopen._instance = None
             opener.urlopen._instance = None
             s3_client_cache.clear()
-
-            # The build process shouldn't inherit the UI's signal handlers.
-            signal.signal(signal.SIGUSR1, signal.SIG_DFL)
-            signal.signal(signal.SIGUSR2, signal.SIG_DFL)
             return
         spack.store.STORE = self.store
         spack.config.CONFIG = self.config
@@ -1970,7 +1966,6 @@ class PackageInstaller:
         jobserver = JobServer(self.jobs)
         selector = selectors.DefaultSelector()
         sigwinch_r = sigwinch_w = -1
-        sigusr_r = sigusr_w = -1
 
         # Set stdin to non-blocking for key press detection
         if sys.stdin.isatty():
@@ -1994,29 +1989,6 @@ class PackageInstaller:
 
             signal.signal(signal.SIGWINCH, _handle_sigwinch)
             selector.register(sigwinch_r, selectors.EVENT_READ, "sigwinch")
-
-        sigusr_r, sigusr_w = os.pipe()
-        os.set_blocking(sigusr_r, False)
-        os.set_blocking(sigusr_w, False)
-
-        def _handle_sigusr1(signum: int, frame: object) -> None:
-            try:
-                os.write(sigusr_w, b"+")
-            except OSError:
-                pass
-
-        def _handle_sigusr2(signum: int, frame: object) -> None:
-            try:
-                os.write(sigusr_w, b"-")
-            except OSError:
-                pass
-
-        try:
-            signal.signal(signal.SIGUSR1, _handle_sigusr1)
-            signal.signal(signal.SIGUSR2, _handle_sigusr2)
-            selector.register(sigusr_r, selectors.EVENT_READ, "sigusr")
-        except Exception:
-            pass  # not a necessary feature; ignore if signals are not supported
 
         # Finished builds that have not yet been written to the database.
         finished_builds: List[ChildInfo] = []
@@ -2068,13 +2040,6 @@ class PackageInstaller:
                     elif data == "sigwinch":
                         os.read(sigwinch_r, 64)  # drain the pipe
                         self.build_status.on_resize()
-                    elif data == "sigusr":
-                        for c in os.read(sigusr_r, 64):  # drain the pipe
-                            if c == ord("+"):
-                                jobserver.increase_parallelism()
-                            elif c == ord("-"):
-                                jobserver.decrease_parallelism()
-                        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
                     elif data == "jobserver" and not jobserver.has_target_parallelism():
                         jobserver.maybe_discard_tokens()
                         self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
@@ -2221,16 +2186,6 @@ class PackageInstaller:
                     selector.unregister(sigwinch_r)
                     os.close(sigwinch_r)
                     os.close(sigwinch_w)
-                except Exception:
-                    pass
-
-            if sigusr_r >= 0:
-                try:
-                    signal.signal(signal.SIGUSR1, signal.SIG_DFL)
-                    signal.signal(signal.SIGUSR2, signal.SIG_DFL)
-                    selector.unregister(sigusr_r)
-                    os.close(sigusr_r)
-                    os.close(sigusr_w)
                 except Exception:
                     pass
 

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -704,7 +704,14 @@ class JobServer:
     def __init__(self, num_jobs: int) -> None:
         #: Keep track of how many tokens Spack itself has acquired, which is used to release them.
         self.tokens_acquired = 0
+        #: The number of jobs to run concurrently. This translates to `num_jobs - 1` tokens in the
+        #: jobserver.
         self.num_jobs = num_jobs
+        #: The target number of jobs to run concurrently, which may differ from num_jobs if the
+        #: user has requested a decrease in parallelism, but we haven't consumed enough tokens to
+        #: reflect that yet. This value is used in the UI. The invariant is that self.target_jobs
+        #: can only be modified if self.created is True.
+        self.target_jobs = num_jobs
         self.fifo_path: Optional[str] = None
         self.created = False
         self._setup()
@@ -747,6 +754,35 @@ class JobServer:
         else:
             return f" -j{self.num_jobs} --jobserver-fds={self.r},{self.w}"
 
+    def has_target_parallelism(self) -> bool:
+        return self.num_jobs == self.target_jobs
+
+    def increase_parallelism(self) -> None:
+        """Add one token to the jobserver to increase parallelism; this should always work."""
+        if not self.created:
+            return
+        os.write(self.w, b"+")
+        self.target_jobs += 1
+        self.num_jobs += 1
+
+    def decrease_parallelism(self) -> None:
+        """Request an eventual concurrency decrease by 1."""
+        if not self.created or self.target_jobs <= 1:
+            return
+        self.target_jobs -= 1
+        self.maybe_discard_tokens()
+
+    def maybe_discard_tokens(self) -> None:
+        """Try to get reduce parallelism by discarding tokens."""
+        to_discard = self.num_jobs - self.target_jobs
+        if to_discard <= 0:
+            return
+        try:
+            # The read may return zero or just fewer bytes than requested; we'll try again later.
+            self.num_jobs -= len(os.read(self.r, to_discard))
+        except BlockingIOError:
+            pass
+
     def acquire(self, jobs: int) -> int:
         """Try and acquire at most 'jobs' tokens from the jobserver. Returns the number of
         tokens actually acquired (may be less than requested, or zero)."""
@@ -762,8 +798,12 @@ class JobServer:
         # The last job to quit has an implicit token, so don't release if we have none.
         if self.tokens_acquired == 0:
             return
-        os.write(self.w, b"+")
         self.tokens_acquired -= 1
+        if self.target_jobs < self.num_jobs:
+            # If a decrease in parallelism is requested, discard a token instead of releasing it.
+            self.num_jobs -= 1
+        else:
+            os.write(self.w, b"+")
 
     def close(self) -> None:
         if self.created and self.num_jobs > 1:
@@ -1020,6 +1060,8 @@ class BuildStatus:
         self.search_term = ""
         self.search_mode = False
         self.log_ends_with_newline = True
+        self.actual_jobs: int = 0
+        self.target_jobs: int = 0
 
         self.stdout = stdout
         self.get_terminal_size = get_terminal_size
@@ -1176,6 +1218,14 @@ class BuildStatus:
             except (KeyError, OSError):
                 pass
 
+    def set_jobs(self, actual: int, target: int) -> None:
+        """Set the actual and target number of jobs to run concurrently."""
+        if actual == self.actual_jobs and target == self.target_jobs:
+            return
+        self.actual_jobs = actual
+        self.target_jobs = target
+        self.dirty = True
+
     def update_state(self, build_id: str, state: str) -> None:
         """Update the state of a package and mark the display as dirty."""
         build_info = self.builds[build_id]
@@ -1284,13 +1334,20 @@ class BuildStatus:
             else:
                 bold = reset = cyan = ""
 
+            if self.actual_jobs != self.target_jobs:
+                jobs_str = f"{self.actual_jobs}=>{self.target_jobs}"
+            else:
+                jobs_str = str(self.target_jobs)
             long_header_len = len(
-                f"Progress: {self.completed}/{self.total}  /: filter  v: logs  n/p: next/prev"
+                f"Progress: {self.completed}/{self.total}  +/-: {jobs_str} jobs"
+                "  /: filter  v: logs  n/p: next/prev"
             )
             if long_header_len < max_width:
                 self._println(
                     buffer,
                     f"{bold}Progress:{reset} {self.completed}/{self.total}"
+                    f"  {cyan}+{reset}/{cyan}-{reset}: "
+                    f"{jobs_str} jobs"
                     f"  {cyan}/{reset}: filter  {cyan}v{reset}: logs"
                     f"  {cyan}n{reset}/{cyan}p{reset}: next/prev",
                 )
@@ -1885,6 +1942,8 @@ class PackageInstaller:
             filter_padding=spack.store.STORE.has_padding(),
         )
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
+        self.build_status.actual_jobs = self.jobs
+        self.build_status.target_jobs = self.jobs
         if concurrent_packages is None:
             concurrent_packages_config = spack.config.get("config:concurrent_packages", 0)
             # The value 0 in config means no limit (other than self.jobs)
@@ -1945,11 +2004,17 @@ class PackageInstaller:
 
             while self.pending_builds or self.running_builds or finished_builds:
                 # Monitor the jobserver when we have pending builds, capacity, and at least one
-                # spec is not locked by another process.
-                can_schedule_more = self.pending_builds and self.capacity and not blocked
-                if can_schedule_more and jobserver.r not in selector.get_map():
+                # spec is not locked by another process. Also listen if the target parallelism is
+                # reduced.
+                wake_on_jobserver = (
+                    self.pending_builds
+                    and self.capacity
+                    and not blocked
+                    or not jobserver.has_target_parallelism()
+                )
+                if wake_on_jobserver and jobserver.r not in selector.get_map():
                     selector.register(jobserver.r, selectors.EVENT_READ, "jobserver")
-                elif not can_schedule_more and jobserver.r in selector.get_map():
+                elif not wake_on_jobserver and jobserver.r in selector.get_map():
                     selector.unregister(jobserver.r)
 
                 stdin_ready = False
@@ -1975,6 +2040,9 @@ class PackageInstaller:
                     elif data == "sigwinch":
                         os.read(sigwinch_r, 64)  # drain the pipe
                         self.build_status.on_resize()
+                    elif data == "jobserver" and not jobserver.has_target_parallelism():
+                        jobserver.maybe_discard_tokens()
+                        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
 
                 current_time = time.monotonic()
                 for pid in finished_pids:
@@ -1983,6 +2051,7 @@ class PackageInstaller:
                     jobserver.release()
                     self._drain_child_output(build)
                     self.state_buffers.pop(build.state_r_conn.fileno(), None)
+                    self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
                     build.cleanup(selector)
                     exitcode = build.proc.exitcode
                     assert exitcode is not None, "Finished build should have exit code set"
@@ -2026,6 +2095,12 @@ class PackageInstaller:
                         self.build_status.next(1)
                     elif char == "p" or char == "N":
                         self.build_status.next(-1)
+                    elif char == "+":
+                        jobserver.increase_parallelism()
+                        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
+                    elif char == "-":
+                        jobserver.decrease_parallelism()
+                        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
 
                 # Insert into the database if we have any finished builds, and either the delay
                 # interval has passed, or we're done with all builds. The database save is not

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -309,6 +309,10 @@ class GlobalState:
             web.urlopen._instance = None
             opener.urlopen._instance = None
             s3_client_cache.clear()
+
+            # The build process shouldn't inherit the UI's signal handlers.
+            signal.signal(signal.SIGUSR1, signal.SIG_DFL)
+            signal.signal(signal.SIGUSR2, signal.SIG_DFL)
             return
         spack.store.STORE = self.store
         spack.config.CONFIG = self.config
@@ -1966,6 +1970,7 @@ class PackageInstaller:
         jobserver = JobServer(self.jobs)
         selector = selectors.DefaultSelector()
         sigwinch_r = sigwinch_w = -1
+        sigusr_r = sigusr_w = -1
 
         # Set stdin to non-blocking for key press detection
         if sys.stdin.isatty():
@@ -1989,6 +1994,29 @@ class PackageInstaller:
 
             signal.signal(signal.SIGWINCH, _handle_sigwinch)
             selector.register(sigwinch_r, selectors.EVENT_READ, "sigwinch")
+
+        sigusr_r, sigusr_w = os.pipe()
+        os.set_blocking(sigusr_r, False)
+        os.set_blocking(sigusr_w, False)
+
+        def _handle_sigusr1(signum: int, frame: object) -> None:
+            try:
+                os.write(sigusr_w, b"+")
+            except OSError:
+                pass
+
+        def _handle_sigusr2(signum: int, frame: object) -> None:
+            try:
+                os.write(sigusr_w, b"-")
+            except OSError:
+                pass
+
+        try:
+            signal.signal(signal.SIGUSR1, _handle_sigusr1)
+            signal.signal(signal.SIGUSR2, _handle_sigusr2)
+            selector.register(sigusr_r, selectors.EVENT_READ, "sigusr")
+        except Exception:
+            pass  # not a necessary feature; ignore if signals are not supported
 
         # Finished builds that have not yet been written to the database.
         finished_builds: List[ChildInfo] = []
@@ -2040,6 +2068,13 @@ class PackageInstaller:
                     elif data == "sigwinch":
                         os.read(sigwinch_r, 64)  # drain the pipe
                         self.build_status.on_resize()
+                    elif data == "sigusr":
+                        for c in os.read(sigusr_r, 64):  # drain the pipe
+                            if c == ord("+"):
+                                jobserver.increase_parallelism()
+                            elif c == ord("-"):
+                                jobserver.decrease_parallelism()
+                        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
                     elif data == "jobserver" and not jobserver.has_target_parallelism():
                         jobserver.maybe_discard_tokens()
                         self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
@@ -2186,6 +2221,16 @@ class PackageInstaller:
                     selector.unregister(sigwinch_r)
                     os.close(sigwinch_r)
                     os.close(sigwinch_w)
+                except Exception:
+                    pass
+
+            if sigusr_r >= 0:
+                try:
+                    signal.signal(signal.SIGUSR1, signal.SIG_DFL)
+                    signal.signal(signal.SIGUSR2, signal.SIG_DFL)
+                    selector.unregister(sigusr_r)
+                    os.close(sigusr_r)
+                    os.close(sigusr_w)
                 except Exception:
                     pass
 

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -1370,3 +1370,46 @@ class TestBuildStatusColor:
         status.add_build(spec, explicit=True)
         status.update_state(spec.dag_hash(), "finished")
         assert "\033[" not in stdout.getvalue()
+
+
+class TestTargetJobs:
+    """Test set_jobs and its effect on the header."""
+
+    def test_set_jobs_marks_dirty(self):
+        """set_jobs with a new value should update target_jobs and mark dirty."""
+        status, _, _ = create_build_status()
+        status.dirty = False
+        status.set_jobs(3, 2)
+        assert status.actual_jobs == 3
+        assert status.target_jobs == 2
+        assert status.dirty is True
+        status.set_jobs(2, 2)
+        assert status.actual_jobs == 2
+        assert status.target_jobs == 2
+
+    def test_set_jobs_same_value_no_dirty(self):
+        """set_jobs with the same value should not mark dirty."""
+        status, _, _ = create_build_status()
+        status.set_jobs(5, 5)
+        status.dirty = False
+        status.set_jobs(5, 5)
+        assert status.dirty is False
+
+    def test_header_shows_target_jobs(self):
+        """The rendered header should contain the target_jobs count and the word 'jobs'."""
+        status, _, fake_stdout = create_build_status(total=1)
+        add_mock_builds(status, 1)
+        status.set_jobs(4, 4)
+        status.update()
+        output = fake_stdout.getvalue()
+        assert "4" in output
+        assert "jobs" in output
+
+    def test_header_shows_arrow_when_pending(self):
+        """When actual != target, the header should show 'actual=>target jobs'."""
+        status, _, fake_stdout = create_build_status(total=1)
+        add_mock_builds(status, 1)
+        status.set_jobs(4, 2)
+        status.update()
+        output = fake_stdout.getvalue()
+        assert "4=>2" in output

--- a/lib/spack/spack/test/jobserver.py
+++ b/lib/spack/spack/test/jobserver.py
@@ -127,6 +127,10 @@ class TestOpenExistingJobserverFifo:
         assert result is None
 
 
+#: Constant that's larger than the number of jobs used in tests.
+ALL_TOKENS = 100
+
+
 class TestJobServer:
     """Test JobServer class functionality."""
 
@@ -294,3 +298,143 @@ class TestJobServer:
         os.read(js2.r, 2)  # A subprocess acquires two tokens without releasing them
         with pytest.warns(UserWarning, match="2 jobserver tokens were not released"):
             js2.close()
+
+    def test_has_target_parallelism(self):
+        """has_target_parallelism() should be True initially."""
+        js = JobServer(4)
+        try:
+            assert js.has_target_parallelism() is True
+            js.target_jobs = js.num_jobs - 1
+            assert js.has_target_parallelism() is False
+        finally:
+            js.close()
+
+    def test_increase_parallelism_not_created(self):
+        """increase_parallelism() should be a no-op when not self.created."""
+        # Simulate an externally attached jobserver by patching created after construction.
+        js = JobServer(3)
+        try:
+            original_num = js.num_jobs
+            original_target = js.target_jobs
+            js.created = False
+            js.increase_parallelism()
+            assert js.num_jobs == original_num
+            assert js.target_jobs == original_target
+            js.decrease_parallelism()
+            assert js.num_jobs == original_num
+            assert js.target_jobs == original_target
+        finally:
+            js.created = True  # restore so close() works
+            js.close()
+
+    def test_increase_parallelism(self):
+        """increase_parallelism() should increment num_jobs and target_jobs and add a token."""
+        js = JobServer(3)
+        try:
+            original_num = js.num_jobs
+            original_target = js.target_jobs
+            js.increase_parallelism()
+            assert js.num_jobs == original_num + 1
+            assert js.target_jobs == original_target + 1
+            # Verify the "js.num_jobs - 1 tokens in the pipe" invariant.
+            assert js.acquire(ALL_TOKENS) + 1 == js.num_jobs
+        finally:
+            js.close()
+
+    def test_decrease_parallelism_at_floor(self):
+        """decrease_parallelism() should not go below target_jobs == 1."""
+        js = JobServer(1)
+        try:
+            # target_jobs starts at 1
+            assert js.target_jobs == 1
+            js.decrease_parallelism()
+            assert js.target_jobs == 1
+        finally:
+            js.close()
+
+    def test_decrease_parallelism_token_available(self):
+        """When pipe has tokens, decrease_parallelism discards one immediately."""
+        js = JobServer(3)
+        try:
+            # 3-job server starts with 2 tokens in the pipe.
+            original_num = js.num_jobs
+            js.decrease_parallelism()
+            assert js.target_jobs == original_num - 1
+            assert js.num_jobs == original_num - 1
+            assert js.acquire(ALL_TOKENS) + 1 == js.num_jobs
+        finally:
+            js.close()
+
+    def test_decrease_parallelism_no_token_available(self):
+        """When all tokens are held, decrease_parallelism defers the discard."""
+        js = JobServer(3)
+        try:
+            # Drain the pipe so no tokens are available for immediate discard.
+            assert js.acquire(ALL_TOKENS) == js.num_jobs - 1
+            original_num = js.num_jobs
+            js.decrease_parallelism()
+            # target_jobs decremented but num_jobs unchanged (no token to discard yet).
+            assert js.target_jobs == original_num - 1
+            assert js.num_jobs == original_num
+        finally:
+            js.close()
+
+    def test_maybe_discard_tokens_noop_at_target(self):
+        """maybe_discard_tokens() should be a no-op when num_jobs == target_jobs."""
+        js = JobServer(3)
+        try:
+            original_num = js.num_jobs
+            js.maybe_discard_tokens()  # to_discard == 0
+            assert js.num_jobs == original_num
+        finally:
+            js.close()
+
+    def test_maybe_discard_tokens_discards_when_available(self):
+        """maybe_discard_tokens() should consume tokens from the pipe."""
+        js = JobServer(4)
+        try:
+            # Manually set target lower to create a discard requirement.
+            js.target_jobs = js.num_jobs - 2
+            original_num = js.num_jobs
+            js.maybe_discard_tokens()
+            assert js.num_jobs < original_num
+        finally:
+            js.close()
+
+    def test_maybe_discard_tokens_noop_on_blocking(self):
+        """maybe_discard_tokens() should not raise when pipe is empty."""
+        js = JobServer(3)
+        try:
+            # Drain all tokens from the pipe (simulates subprocesses holding them).
+            assert js.acquire(ALL_TOKENS) == js.num_jobs - 1
+            original_num = js.num_jobs
+            # Artificially lower target so a discard is requested, but pipe is empty.
+            js.target_jobs = js.num_jobs - 1
+            js.maybe_discard_tokens()  # Should not raise; num_jobs unchanged.
+            assert js.num_jobs == original_num
+        finally:
+            js.close()
+
+    def test_release_discards_token_when_target_below_num(self):
+        """release() should discard a token (not return it) when target_jobs < num_jobs."""
+        js = JobServer(4)
+        try:
+            # Acquire a token.
+            assert js.acquire(1) == 1
+            assert js.tokens_acquired == 1
+            # Manually lower target to simulate a pending decrease.
+            js.target_jobs = js.num_jobs - 1
+            original_num = js.num_jobs
+            # Drain the free tokens from the pipe so we can count them after.
+            drained = os.read(js.r, ALL_TOKENS)
+            # Release should discard the token (decrement num_jobs) instead of writing to pipe.
+            js.release()
+            assert js.tokens_acquired == 0
+            assert js.num_jobs == original_num - 1
+            # Pipe should remain empty (nothing written back).
+            with pytest.raises(BlockingIOError):
+                os.read(js.r, 1)
+        finally:
+            # Restore drained tokens so close() can clean up cleanly.
+            os.write(js.w, drained)
+            js.close()


### PR DESCRIPTION
When you run `spack install -j 4` the number of jobs is `4` from start to
finish.

In the new installer we can make this dynamic with `+` and `-` keyboard input,
provided that we are the owner of the jobserver.

* On `+`: write a byte to `jobserver.w`
* On `-`: eventually read a byte from `jobserver.r`

So, `+` applies immediately, while `-` happens at some point in the event loop.
If the target number of jobs is less than the effective number of jobs because
the Spack process didn't get to read from the jobserver pipe, the terminal UI
renders it as `8=>4` meaning it's in the process of decreasing from 8 to 4 jobs.

<img width="1166" height="717" alt="image" src="https://github.com/user-attachments/assets/10e41447-e8a1-4a37-9f34-44bf0fb306ad" />


There are two ways in which parallelism is reduced:

1. A parallel build finishes: do not write back the Spack-acquired token
2. The `jobserver.r` becomes readable: read at most `num_jobs - target_jobs` bytes.

Note: `gmake` and probably `ninja` recycle tokens internally. If they have work to
do and one subprocess finishes, it does not go through release-acquire, but
immediately starts the next job using the same token. That means that Spack can
only reduce parallelism when `gmake` or `ninja` hit a bottleneck with limited
parallelism. In practice that happens enough.