### PR TITLE
solver: choose `virtual_on_edge` and derive `depends_on`

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -876,9 +876,8 @@ edge_needed(ParentNode, node(X, Child)) :-
    attr("dependency_holds", ParentNode, Child, _).
 
 virtual_edge_needed(ParentNode, ChildNode, node(X, Virtual)) :-
-   depends_on(ParentNode, ChildNode),
    build(ParentNode),
-   node_depends_on_virtual(ParentNode, Virtual),
+   attr("virtual_on_edge", ParentNode, ChildNode, Virtual),
    provider(ChildNode, node(X, Virtual)).
 
 virtual_edge_needed(ParentNode, ChildNode, node(X, Virtual)) :-

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -76,7 +76,7 @@ attr("namespace", node(ID, Package), Namespace)
 % Rules on "unification sets", i.e. on sets of nodes allowing a single configuration of any given package
 unify(SetID, PackageName) :- unification_set(SetID, node(_, PackageName)).
 
-error(1, "Cannot have multiple nodes for {0} in the same unification set {1}", PackageName, SetID)
+error(100000, "Cannot have multiple nodes for {0} in the same unification set {1}", PackageName, SetID)
   :- 2 { unification_set(SetID, node(_, PackageName)) }, unify(SetID, PackageName).
 
 unification_set("root", PackageNode) :- attr("root", PackageNode).
@@ -979,13 +979,12 @@ node_depends_on_virtual(PackageNode, Virtual, Type)
 
 node_depends_on_virtual(PackageNode, Virtual) :- node_depends_on_virtual(PackageNode, Virtual, Type).
 
-1 { attr("depends_on", PackageNode, ProviderNode, Type) : provider(ProviderNode, node(VirtualID, Virtual)) } 1
+1 { attr("virtual_on_edge", PackageNode, ProviderNode, Virtual) : provider(ProviderNode, node(VirtualID, Virtual)) } 1
   :- node_depends_on_virtual(PackageNode, Virtual, Type).
 
-attr("virtual_on_edge", PackageNode, ProviderNode, Virtual)
-  :- attr("dependency_holds", PackageNode, Virtual, Type),
-     attr("depends_on", PackageNode, ProviderNode, Type),
-     provider(ProviderNode, node(_, Virtual)).
+attr("depends_on", PackageNode, ProviderNode, Type)
+  :- attr("virtual_on_edge", PackageNode, ProviderNode, Virtual),
+     node_depends_on_virtual(PackageNode, Virtual, Type).
 
 % If a virtual node is in the answer set, it must be either a virtual root,
 % or used somewhere


### PR DESCRIPTION
Related to #51995 (not a complete fix, there are other rules that need adjustments)

In some cases we might have a situation where:
- `pkg-a` depends on `c` provided by `llvm`
- `pkg-b` depends on `c` provided by `gcc` and `libllvm` provided by `llvm`

In such a situation the rule we currently have:
```prolog
1 { attr("depends_on", PackageNode, ProviderNode, Type) : provider(ProviderNode, node(VirtualID, Virtual)) } 1
  :- node_depends_on_virtual(PackageNode, Virtual, Type).
```
will cause the problem to be unsat for `pkg-b`. This is because:
- There are two providers for `c`
- `pkg-b` depends on both (`gcc` for `c` and `llvm` for `libllvm`)

In this PR we switch this rule to choose for `virtual_on_edge`:
```prolog
1 { attr("virtual_on_edge", PackageNode, ProviderNode, Virtual) : provider(ProviderNode, node(VirtualID, Virtual)) } 1
  :- node_depends_on_virtual(PackageNode, Virtual, Type).
```
and we derive `depends_on` from it. This ensure correctness of this rule in these edge cases.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
