### PR TITLE
new_installer.py: improve non-TTY output format

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -929,8 +929,17 @@ class BuildStatus:
 
         # For non-TTY output, print state changes immediately without colors
         if not self.is_tty:
+            if build_info.external:
+                indicator = "[e]"
+            elif state == "finished":
+                indicator = "[+]"
+            elif state == "failed":
+                indicator = "[x]"
+            else:
+                indicator = "[ ]"
+            suffix = build_info.prefix if state == "finished" else state
             self.stdout.write(
-                f"{build_info.hash} {build_info.name}@{build_info.version}: {state}\n"
+                f"{indicator} {build_info.hash} {build_info.name}@{build_info.version} {suffix}\n"
             )
             self.stdout.flush()
 

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -198,9 +198,10 @@ class TestOutputRendering:
         status.update_state(build_id, "finished")
 
         output = fake_stdout.getvalue()
+        assert "[+]" in output
         assert "mypackage" in output
         assert "1.0" in output
-        assert "finished" in output
+        assert "/fake/prefix/mypackage" in output  # prefix is shown for finished builds
         # Non-TTY output should not contain ANSI escape codes
         assert "\033[" not in output
 


### PR DESCRIPTION
Show `[+]`, `[x]`, `[e]`, `[ ]` indicators and print the install prefix for
finished builds, matching the TTY display format.

