### PR TITLE
tests: isolate binary index cache in some tests

### DIFF
--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -273,8 +273,11 @@ def test_use_bin_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
     """Check use of binary cache index: perform an operation that
     instantiates it, and a second operation that reconstructs it.
     """
+    index_cache_root = str(tmp_path / "index_cache")
     monkeypatch.setattr(
-        spack.binary_distribution, "BINARY_INDEX", spack.binary_distribution.BinaryCacheIndex()
+        spack.binary_distribution,
+        "BINARY_INDEX",
+        spack.binary_distribution.BinaryCacheIndex(index_cache_root),
     )
 
     # Create a mirror, configure us to point at it, install a spec, and
@@ -289,7 +292,9 @@ def test_use_bin_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
 
     # Now the test
     buildcache_cmd("list", "-al")
-    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex()
+    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex(
+        index_cache_root
+    )
     cache_list = buildcache_cmd("list", "-al")
     assert "libdwarf" in cache_list
 
@@ -301,8 +306,11 @@ def test_use_bin_index_active_env_with_view(
     """Check use of binary cache index: perform an operation that
     instantiates it, and a second operation that reconstructs it.
     """
+    index_cache_root = str(tmp_path / "index_cache")
     monkeypatch.setattr(
-        spack.binary_distribution, "BINARY_INDEX", spack.binary_distribution.BinaryCacheIndex()
+        spack.binary_distribution,
+        "BINARY_INDEX",
+        spack.binary_distribution.BinaryCacheIndex(index_cache_root),
     )
 
     # Create a mirror, configure us to point at it, install a spec, and
@@ -321,7 +329,9 @@ def test_use_bin_index_active_env_with_view(
 
     # Now the test
     buildcache_cmd("list", "-al")
-    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex()
+    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex(
+        index_cache_root
+    )
     cache_list = buildcache_cmd("list", "-al")
     assert "libdwarf" in cache_list
 
@@ -333,8 +343,11 @@ def test_use_bin_index_with_view(
     """Check use of binary cache index: perform an operation that
     instantiates it, and a second operation that reconstructs it.
     """
+    index_cache_root = str(tmp_path / "index_cache")
     monkeypatch.setattr(
-        spack.binary_distribution, "BINARY_INDEX", spack.binary_distribution.BinaryCacheIndex()
+        spack.binary_distribution,
+        "BINARY_INDEX",
+        spack.binary_distribution.BinaryCacheIndex(index_cache_root),
     )
 
     # Create a mirror, configure us to point at it, install a spec, and
@@ -354,7 +367,9 @@ def test_use_bin_index_with_view(
 
     # Now the test
     buildcache_cmd("list", "-al")
-    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex()
+    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex(
+        index_cache_root
+    )
     cache_list = buildcache_cmd("list", "-al")
     assert "libdwarf" in cache_list
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1047,7 +1047,12 @@ spack:
 
 
 def test_ci_rebuild_index(
-    tmp_path: pathlib.Path, working_env, mutable_mock_env_path, install_mockery, mock_fetch
+    tmp_path: pathlib.Path,
+    working_env,
+    mutable_mock_env_path,
+    install_mockery,
+    mock_fetch,
+    mock_binary_index,
 ):
     scratch = tmp_path / "working_dir"
     mirror_dir = scratch / "mirror"

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1418,9 +1418,7 @@ def mock_gnupghome(monkeypatch, tmp_path):
     short_name_tmpdir = tempfile.mkdtemp()
     # Redirect bootstrap root before gpg.init() so each xdist worker writes
     # bootstrap config to its own isolated directory.
-    monkeypatch.setattr(
-        spack.paths, "default_user_bootstrap_path", str(tmp_path / "bootstrap")
-    )
+    monkeypatch.setattr(spack.paths, "default_user_bootstrap_path", str(tmp_path / "bootstrap"))
     try:
         spack.util.gpg.init()
     except spack.util.gpg.SpackGPGError:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1410,18 +1410,23 @@ def module_configuration(monkeypatch, request, mutable_config):
 
 
 @pytest.fixture()
-def mock_gnupghome(monkeypatch):
+def mock_gnupghome(monkeypatch, tmp_path):
     # GNU PGP can't handle paths longer than 108 characters (wtf!@#$) so we
     # have to make our own tmp_path with a shorter name than pytest's.
     # This comes up because tmp paths on macOS are already long-ish, and
     # pytest makes them longer.
+    short_name_tmpdir = tempfile.mkdtemp()
+    # Redirect bootstrap root before gpg.init() so each xdist worker writes
+    # bootstrap config to its own isolated directory.
+    monkeypatch.setattr(
+        spack.paths, "default_user_bootstrap_path", str(tmp_path / "bootstrap")
+    )
     try:
         spack.util.gpg.init()
     except spack.util.gpg.SpackGPGError:
         if not spack.util.gpg.GPG:
             pytest.skip("This test requires gpg")
 
-    short_name_tmpdir = tempfile.mkdtemp()
     with spack.util.gpg.gnupghome_override(short_name_tmpdir):
         yield short_name_tmpdir
 


### PR DESCRIPTION
Likely fixes the most common failure seen on develop.

