### PR TITLE
spack find: display group of specs in environment

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -17,6 +17,7 @@ import spack.solver.reuse
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
+from spack.llnl.util.tty.color import colorize
 from spack.solver.reuse import create_external_parser
 from spack.solver.runtimes import external_config_with_implicit_externals
 
@@ -256,18 +257,12 @@ def display_env(env, args, decorator, results):
     In an environment, ``spack find`` outputs a preliminary section
     showing the root specs of the environment (this is in addition
     to the section listing out specs matching the query parameters).
-
     """
-    tty.msg("In environment %s" % env.name)
+    total_roots = sum(len(env.user_specs_by(group=g)) for g in env.manifest.groups())
+    root_spec_str = f"{total_roots or 'no'} root {'spec' if total_roots == 1 else 'specs'}"
+    tty.msg(f"In environment {env.name} ({root_spec_str})")
 
-    num_roots = len(env.user_specs) or "No"
-    tty.msg(f"{num_roots} root specs")
-
-    concretized_user_specs = [x.root for x in env.concretized_roots]
-    concrete_specs = {
-        root: concrete_root
-        for root, concrete_root in zip(concretized_user_specs, env.concrete_roots())
-    }
+    concrete_specs = {x.root: env.specs_by_hash[x.hash] for x in env.concretized_roots}
 
     def root_decorator(spec, string):
         """Decorate root specs with their install status if needed"""
@@ -290,22 +285,34 @@ def display_env(env, args, decorator, results):
             return f"{status} {string}"
 
     with spack.store.STORE.db.read_transaction():
-        cmd.display_specs(
-            env.user_specs,
-            args,
-            # these are overrides of CLI args
-            paths=False,
-            long=False,
-            very_long=False,
-            # these enforce details in the root specs to show what the user asked for
-            namespaces=True,
-            show_flags=True,
-            decorator=root_decorator,
-            variants=True,
-            specfile_format=args.specfile_format,
-        )
+        for group in env.manifest.groups():
+            group_specs = env.user_specs_by(group=group)
+            if not group_specs:
+                continue
 
-    print()
+            if env.has_groups():
+                header = (
+                    f"{spack.spec.ARCHITECTURE_COLOR}{{root specs}} / "
+                    f"{spack.spec.COMPILER_COLOR}{{{group}}}"
+                )
+                tty.hline(colorize(header), char="-")
+
+            cmd.display_specs(
+                group_specs,
+                args,
+                # these are overrides of CLI args
+                paths=False,
+                long=False,
+                very_long=False,
+                # these enforce details in the root specs to show what the user asked for
+                groups=False,
+                namespaces=True,
+                show_flags=True,
+                decorator=root_decorator,
+                variants=True,
+                specfile_format=args.specfile_format,
+            )
+            print()
 
     if env.included_concrete_env_root_dirs:
         tty.msg("Included specs")

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -380,7 +380,7 @@ spack:
     with ev.read("combined_env"):
         output = find()
 
-    assert "No root specs" in output
+    assert "no root specs" in output
     assert "Included specs" in output
     assert "mpileaks" in output
     assert "libelf" in output
@@ -417,7 +417,7 @@ spack:
     with ev.read("test3"):
         output = find()
 
-    assert "No root specs" in output
+    assert "no root specs" in output
     assert "Included specs" in output
     assert "mpileaks" in output
     assert "libelf" in output
@@ -536,3 +536,52 @@ def test_find_based_on_commit_sha(mock_git_version_info, monkeypatch):
     install("--fake", f"git-test-commit commit={commits[0]}")
     output = find(f"commit={commits[0]}")
     assert "git-test-commit" in output
+
+
+@pytest.mark.usefixtures("mock_packages")
+@pytest.mark.parametrize(
+    "spack_yaml,expected,not_expected",
+    [
+        (
+            """
+spack:
+  specs:
+  - mpileaks
+  - group: extras
+    specs:
+    - libelf
+""",
+            [
+                "2 root specs",
+                # Group names
+                "extras",
+                "default",
+                # root specs
+                "mpileaks",
+                "libelf",
+            ],
+            [],
+        ),
+        (
+            """
+spack:
+  specs:
+  - group: tools
+    specs:
+    - libelf
+""",
+            ["1 root spec", "tools", "libelf"],
+            ["1 root specs", "default"],
+        ),
+    ],
+)
+def test_find_env_with_groups(spack_yaml, expected, not_expected, tmp_path: pathlib.Path):
+    """Tests that the output of spack find contains expected matches when using an
+    environment with groups.
+    """
+    (tmp_path / "spack.yaml").write_text(spack_yaml)
+    with ev.Environment(tmp_path):
+        output = find()
+
+    assert all(x in output for x in expected)
+    assert all(x not in output for x in not_expected)


### PR DESCRIPTION
This commit adds support for group of specs to `spack find`. Includes a unit test to avoid regressions.

### Example

For this environment:
```yaml
spack:
  # add package specs to the `specs` list
  specs:
  - group: compiler
    specs:
    - gcc@15.2
    
  - group: apps
    needs: [compiler]
    specs:
    - gromacs
```

**Before**
<img width="1155" height="288" alt="Screenshot from 2026-02-26 14-25-17" src="https://github.com/user-attachments/assets/57a0689e-3e0a-4833-8081-31bcb8035427" />

**After**
<img width="1136" height="391" alt="Screenshot from 2026-02-26 14-25-33" src="https://github.com/user-attachments/assets/57bbcff9-35ad-4662-a72b-d573dffedf68" />


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
