### PR TITLE
Bugfix invalid scope error message

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -659,7 +659,8 @@ class Configuration:
 
         else:
             raise ValueError(
-                f"Invalid config scope: '{scope}'.  Must be one of {self.scopes.keys()}"
+                f"Invalid config scope: '{scope}'.  Must be one of "
+                f"{[k for k in self.scopes.keys()]}"
             )
 
     def get_config_filename(self, scope: str, section: str) -> str:

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -2027,3 +2027,9 @@ def test_include_bad_parent_scope(tmp_path: pathlib.Path):
         parent_scope = spack.config.InternalConfigScope(name, spack.config.CONFIG_DEFAULTS)
         with pytest.raises(AssertionError, match="must have a name"):
             _ = include.scopes(parent_scope)
+
+
+def test_config_invalid_scope(mock_low_high_config):
+    err = "Must be one of \['low', 'high'\]"  # noqa: W605
+    with pytest.raises(ValueError, match=err):
+        spack.config.CONFIG.get_config_filename("noscope", "nosection")


### PR DESCRIPTION
This PR adds a unit test and fix related to an unhelpful error message when validating configuration scope.

For example, instead of getting a `KeysView` such as:

```
Invalid config scope: 'noscope'.  Must be one of KeysView(<spack.llnl.util.lang.PriorityOrderedMapping object at 0x107d46940>)
```

you get:

```
Invalid config scope: 'noscope'.  Must be one of ['low', 'high']
```