### PR TITLE
new_installer.py: read locks on installed deps

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1269,14 +1269,22 @@ def schedule_builds(
     capacity: int,
     needs_jobserver_token: bool,
     jobserver: JobServer,
-) -> Tuple[bool, List[Tuple[str, spack.util.lock.Lock]], List[Tuple[str, spack.spec.Spec]]]:
+) -> Tuple[
+    bool,
+    List[Tuple[str, spack.util.lock.Lock]],
+    List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]],
+]:
     """Try to schedule as many pending builds as possible.
 
-    For each pending spec, attempts to acquire a non-blocking per-spec write lock. Under both the
-    DB read lock and the prefix write lock, checks whether another process has already installed
-    the spec. If so, captures it as newly_installed (caller enqueues parents) and releases the
-    lock. Otherwise, acquires a jobserver token if needed and adds the (dag_hash, lock) pair to
-    to_start (caller launches the build).
+    For each pending spec, attempts to acquire a non-blocking per-spec write lock. If the write
+    lock times out, a read lock is tried as a fallback: a successful read lock means the first
+    process finished and downgraded its write lock. If the DB confirms the spec is installed, it
+    is captured as newly_installed; if the DB says it is not installed, the concurrent process was
+    likely killed mid-build, and the spec is retried next iteration. Under both the DB read lock
+    and the prefix lock, checks whether another process has already installed the spec. If so,
+    captures it as newly_installed (caller enqueues parents) and keeps a read lock on the prefix
+    to prevent concurrent uninstall. Otherwise, acquires a jobserver token if needed and adds the
+    (dag_hash, lock) pair to to_start (caller launches the build).
 
     Args:
         pending: List of dag hashes pending installation; modified in-place.
@@ -1292,11 +1300,12 @@ def schedule_builds(
         A (blocked, to_start, newly_installed) tuple where ``blocked`` is True if any pending
         builds were blocked on locks; ``to_start`` contains ``(dag_hash, lock)`` pairs where the
         write lock is held and the caller must start the build and eventually release the lock;
-        and ``newly_installed`` contains ``(dag_hash, spec)`` pairs found already installed by
-        another process for which the caller must update the UI and enqueue parents.
+        and ``newly_installed`` contains ``(dag_hash, spec, lock)`` triples found already installed
+        by another process; the read lock is held and the caller must retain it to prevent
+        concurrent uninstall.
     """
     to_start: List[Tuple[str, spack.util.lock.Lock]] = []
-    newly_installed: List[Tuple[str, spack.spec.Spec]] = []
+    newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]] = []
     blocked = True
 
     # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory snapshot
@@ -1318,26 +1327,41 @@ def schedule_builds(
             try:
                 lock.acquire_write(timeout=1e-9)
                 blocked = False
+                have_write = True
             except spack.util.lock.LockTimeoutError:
-                # another process is building this spec; try the next one
+                # Write lock failed: either another process is actively building, or it
+                # finished and downgraded to a read lock. Try a read lock to find out.
+                try:
+                    lock.acquire_read(timeout=1e-9)
+                except spack.util.lock.LockTimeoutError:
+                    idx += 1
+                    continue  # active build in progress; try the next spec
+                have_write = False
+
+            # Check installed status under the DB read lock and prefix lock.
+            upstream, record = db.query_by_spec_hash(dag_hash)
+
+            # If the spec is already installed, treat it as done regardless of lock type.
+            if dag_hash not in overwrite and record and record.installed:
+                if have_write:
+                    lock.downgrade_write_to_read()
+                # keep the read lock (either downgraded or already a read lock)
+                del pending[idx]
+                newly_installed.append((dag_hash, spec, lock))
+                build_graph.enqueue_parents(dag_hash, pending)
+                continue
+
+            if not have_write:
+                # Read lock but not installed: concurrent process was likely killed; retry later.
+                lock.release_read()
                 idx += 1
                 continue
 
-            # Check installed status under the DB read lock and prefix write lock.
-            upstream, record = db.query_by_spec_hash(dag_hash)
-
+            # Write lock acquired, spec not yet installed. Proceed with scheduling.
             # Don't schedule builds for specs from upstream databases.
             assert not (
                 upstream and record and not record.installed
             ), f"Cannot install {spec}: it is uninstalled in an upstream database."
-
-            # If the spec is already installed by another process, capture it and enqueue parents.
-            if dag_hash not in overwrite and record and record.installed:
-                lock.release_write()
-                del pending[idx]
-                newly_installed.append((dag_hash, spec))
-                build_graph.enqueue_parents(dag_hash, pending)
-                continue
 
             # Acquire a jobserver token if needed. The first (implicit) job needs no token.
             if needs_jobserver_token and not jobserver.acquire(1):
@@ -1493,13 +1517,15 @@ class PackageInstaller:
 
         # Finished builds that have not yet been written to the database.
         finished_builds: List[ChildInfo] = []
+        # Prefix read locks retained after DB flush (downgraded from write locks in _save_to_db).
+        retained_read_locks: List[spack.util.lock.Lock] = []
         next_database_write = 0.0
 
         failures: List[spack.spec.Spec] = []
 
         try:
             # Try to schedule builds immediately. The first job does not require a token.
-            blocked = self._schedule_builds(selector, jobserver)
+            blocked = self._schedule_builds(selector, jobserver, retained_read_locks)
 
             while self.pending_builds or self.running_builds or finished_builds:
                 # Monitor the jobserver when we have pending builds, capacity, and at least one
@@ -1588,13 +1614,13 @@ class PackageInstaller:
                         current_time >= next_database_write
                         or not (self.pending_builds or self.running_builds)
                     )
-                    and self._save_to_db(finished_builds)
+                    and self._save_to_db(finished_builds, retained_read_locks)
                 ):
                     finished_builds.clear()
 
                 # Try to schedule more builds, acquiring per-spec locks and jobserver tokens.
                 if self.capacity and self.pending_builds:
-                    blocked = self._schedule_builds(selector, jobserver)
+                    blocked = self._schedule_builds(selector, jobserver, retained_read_locks)
 
                 # Finally update the UI
                 self.build_status.update()
@@ -1611,6 +1637,10 @@ class PackageInstaller:
             with self.db.write_transaction():
                 for build in finished_builds:
                     self.db._add(build.spec, explicit=build.explicit)
+
+            # Release prefix read locks retained after DB flush
+            for lock in retained_read_locks:
+                lock.release_read()
 
             # Release any prefix write locks that were not yet released via _save_to_db
             for build in finished_builds:
@@ -1649,7 +1679,9 @@ class PackageInstaller:
                 "The following packages failed to install:\n" + "\n".join(lines)
             )
 
-    def _save_to_db(self, finished_builds: List[ChildInfo]) -> bool:
+    def _save_to_db(
+        self, finished_builds: List[ChildInfo], retained_read_locks: List[spack.util.lock.Lock]
+    ) -> bool:
         try:
             # Only try to get the lock once (non-blocking). If it fails, try it next time.
             if self.db.lock.acquire_write(timeout=1e-9):
@@ -1662,16 +1694,22 @@ class PackageInstaller:
         finally:
             self.db.lock.release_write(self.db._write)
 
-        # DB has been written and flushed; release per-spec prefix write locks so other processes
-        # can see the specs are now installed and acquire their own locks.
+        # DB has been written and flushed; downgrade per-spec prefix write locks to read locks so
+        # other processes can see the specs are installed, while preventing concurrent uninstalls.
         for build in finished_builds:
             if build.prefix_lock is not None:
-                build.prefix_lock.release_write()
+                build.prefix_lock.downgrade_write_to_read()
+                retained_read_locks.append(build.prefix_lock)
                 build.prefix_lock = None
 
         return True
 
-    def _schedule_builds(self, selector: selectors.BaseSelector, jobserver: JobServer) -> bool:
+    def _schedule_builds(
+        self,
+        selector: selectors.BaseSelector,
+        jobserver: JobServer,
+        retained_read_locks: List[spack.util.lock.Lock],
+    ) -> bool:
         """Try to schedule as many pending builds as possible.
 
         Delegates to the module-level schedule_builds() function and then performs the
@@ -1695,7 +1733,8 @@ class PackageInstaller:
             jobserver=jobserver,
         )
         # Specs installed by another process.
-        for dag_hash, spec in newly_installed:
+        for dag_hash, spec, lock in newly_installed:
+            retained_read_locks.append(lock)
             self.build_status.add_build(spec, explicit=dag_hash in self.explicit)
             self.build_status.update_state(dag_hash, "finished")
         # Specs we can start building ourselves.

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -39,7 +39,18 @@ import warnings
 from gzip import GzipFile
 from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
-from typing import TYPE_CHECKING, Callable, Dict, Generator, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from spack.vendor.typing_extensions import Literal
 
@@ -1260,6 +1271,19 @@ class BuildGraph:
                 pending_builds.append(parent)
 
 
+class ScheduleResult(NamedTuple):
+    """Return value of :func:`schedule_builds`."""
+
+    #: True if any pending builds were blocked on locks held by other processes.
+    blocked: bool
+    #: ``(dag_hash, lock)`` pairs where the write lock is held and the caller must start the build
+    #: and eventually release the lock.
+    to_start: List[Tuple[str, spack.util.lock.Lock]]
+    #: ``(dag_hash, spec, lock)`` triples found already installed by another process; the read lock
+    #: is held and the caller must add it to retained_read_locks.
+    newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]]
+
+
 def schedule_builds(
     pending: List[str],
     build_graph: BuildGraph,
@@ -1269,11 +1293,7 @@ def schedule_builds(
     capacity: int,
     needs_jobserver_token: bool,
     jobserver: JobServer,
-) -> Tuple[
-    bool,
-    List[Tuple[str, spack.util.lock.Lock]],
-    List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]],
-]:
+) -> ScheduleResult:
     """Try to schedule as many pending builds as possible.
 
     For each pending spec, attempts to acquire a non-blocking per-spec write lock. If the write
@@ -1297,12 +1317,8 @@ def schedule_builds(
         jobserver: Jobserver for acquiring tokens.
 
     Returns:
-        A (blocked, to_start, newly_installed) tuple where ``blocked`` is True if any pending
-        builds were blocked on locks; ``to_start`` contains ``(dag_hash, lock)`` pairs where the
-        write lock is held and the caller must start the build and eventually release the lock;
-        and ``newly_installed`` contains ``(dag_hash, spec, lock)`` triples found already installed
-        by another process; the read lock is held and the caller must retain it to prevent
-        concurrent uninstall.
+        A :class:`ScheduleResult` with ``blocked``, ``to_start``, and ``newly_installed``
+        fields; see :class:`ScheduleResult` for field semantics.
     """
     to_start: List[Tuple[str, spack.util.lock.Lock]] = []
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]] = []
@@ -1313,7 +1329,7 @@ def schedule_builds(
     try:
         db.lock.acquire_read(timeout=1e-9)
     except spack.util.lock.LockTimeoutError:
-        return blocked, to_start, newly_installed
+        return ScheduleResult(blocked, to_start, newly_installed)
 
     try:
         db._read()  # refresh in-memory snapshot under the read lock
@@ -1352,12 +1368,13 @@ def schedule_builds(
                 continue
 
             if not have_write:
-                # Read lock but not installed: concurrent process was likely killed; retry later.
+                # If have to install but only got a read lock, try it in next iteration of the
+                # event loop.
                 lock.release_read()
                 idx += 1
                 continue
 
-            # Write lock acquired, spec not yet installed. Proceed with scheduling.
+            # Write lock acquired: proceed with scheduling.
             # Don't schedule builds for specs from upstream databases.
             assert not (
                 upstream and record and not record.installed
@@ -1376,7 +1393,7 @@ def schedule_builds(
     finally:
         db.lock.release_read()
 
-    return blocked, to_start, newly_installed
+    return ScheduleResult(blocked, to_start, newly_installed)
 
 
 class PackageInstaller:
@@ -1624,46 +1641,81 @@ class PackageInstaller:
 
                 # Finally update the UI
                 self.build_status.update()
-        except KeyboardInterrupt:
-            # Cleanup running builds.
-            for child in self.running_builds.values():
-                child.proc.terminate()
-            for child in self.running_builds.values():
-                jobserver.release()
-                child.proc.join()
-            raise
         finally:
-            # Make sure to write any successful builds to the database before exiting
-            with self.db.write_transaction():
-                for build in finished_builds:
-                    self.db._add(build.spec, explicit=build.explicit)
+            # Flush any not-yet-written successful builds to the DB; save the exception on error
+            # to be re-raised after best-effort cleanup.
+            db_exc = None
+            try:
+                with self.db.write_transaction():
+                    for build in finished_builds:
+                        self.db._add(build.spec, explicit=build.explicit)
+            except Exception as e:
+                db_exc = e
 
-            # Release prefix read locks retained after DB flush
+            # Send SIGTERM to running builds; this is a no-op in the successful case.
+            for child in self.running_builds.values():
+                try:
+                    child.proc.terminate()
+                except Exception:
+                    pass
+
+            # Release our jobserver token for each terminated build and then join.
+            for child in self.running_builds.values():
+                try:
+                    jobserver.release()
+                    child.proc.join()
+                except Exception:
+                    pass
+
+            # Release all held locks best-effort, so that one failure does not prevent the others
+            # from being released.
+            for child in self.running_builds.values():
+                try:
+                    if child.prefix_lock is not None:
+                        child.prefix_lock.release_write()
+                        child.prefix_lock = None
+                except Exception:
+                    pass
             for lock in retained_read_locks:
-                lock.release_read()
-
-            # Release any prefix write locks that were not yet released via _save_to_db
+                try:
+                    lock.release_read()
+                except Exception:
+                    pass
             for build in finished_builds:
-                if build.prefix_lock is not None:
-                    build.prefix_lock.release_write()
-                    build.prefix_lock = None
+                try:
+                    if build.prefix_lock is not None:
+                        build.prefix_lock.release_write()
+                        build.prefix_lock = None
+                except Exception:
+                    pass
 
-            # Restore terminal settings
+            # Terminal related cleanup
             if old_stdin_settings:
-                termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_stdin_settings)
+                try:
+                    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_stdin_settings)
+                except Exception:
+                    pass
 
             if sigwinch_r >= 0:
-                signal.signal(signal.SIGWINCH, signal.SIG_DFL)
-                selector.unregister(sigwinch_r)
-                os.close(sigwinch_r)
-                os.close(sigwinch_w)
+                try:
+                    signal.signal(signal.SIGWINCH, signal.SIG_DFL)
+                    selector.unregister(sigwinch_r)
+                    os.close(sigwinch_r)
+                    os.close(sigwinch_w)
+                except Exception:
+                    pass
 
-            # Clean up resources
-            # Final cleanup of any remaining finished packages before exit
-            self.build_status.overview_mode = True
-            self.build_status.update(finalize=True)
-            selector.close()
-            jobserver.close()
+            try:
+                self.build_status.overview_mode = True
+                self.build_status.update(finalize=True)
+                selector.close()
+                jobserver.close()
+            except Exception:
+                pass
+
+            # Re-raise the DB exception if any.
+            if db_exc is not None:
+                raise db_exc
 
         if failures:
             for s in failures:
@@ -1698,9 +1750,14 @@ class PackageInstaller:
         # other processes can see the specs are installed, while preventing concurrent uninstalls.
         for build in finished_builds:
             if build.prefix_lock is not None:
-                build.prefix_lock.downgrade_write_to_read()
-                retained_read_locks.append(build.prefix_lock)
-                build.prefix_lock = None
+                try:
+                    build.prefix_lock.downgrade_write_to_read()
+                    retained_read_locks.append(build.prefix_lock)
+                except Exception:
+                    build.prefix_lock.release_write()
+                    raise
+                finally:
+                    build.prefix_lock = None
 
         return True
 

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -336,6 +336,8 @@ class TestScheduleBuilds:
             assert newly_installed[0][0] == spec.dag_hash()
             assert not pending  # removed from the pending list
         finally:
+            for _, _, lock in newly_installed:
+                lock.release_read()
             jobserver.close()
 
     def test_no_jobserver_token_returns_empty(self, temporary_store, mock_packages):
@@ -454,4 +456,83 @@ class TestScheduleBuilds:
         finally:
             for _, lock in to_start:
                 lock.release_write()
+            jobserver.close()
+
+    def test_write_locked_read_locked_installed_yields_newly_installed(
+        self, temporary_store, mock_packages, monkeypatch
+    ):
+        """Write lock fails but read lock succeeds and spec is installed: treated as done.
+
+        Simulates the case where another process finished building and downgraded its write lock
+        to a read lock. The spec should appear in newly_installed. blocked remains True because no
+        write lock was obtained, preventing the jobserver from firing unnecessarily.
+        """
+        spec = self._make_spec("trivial-install-test-package")
+        self._mark_installed(spec, temporary_store)
+        pending = [spec.dag_hash()]
+        bg = _FakeBuildGraph([spec])
+        jobserver = JobServer(num_jobs=2)
+        lock = temporary_store.prefix_locker.lock(spec)
+
+        def write_timeout(timeout=None):
+            raise spack.util.lock.LockTimeoutError("write", lock.path, 0, 1)
+
+        monkeypatch.setattr(lock, "acquire_write", write_timeout)
+        try:
+            blocked, to_start, newly_installed = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite=set(),
+                capacity=2,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+            )
+            assert blocked  # no write lock was obtained; jobserver should not fire
+            assert not to_start
+            assert len(newly_installed) == 1
+            dag_hash, installed_spec, lock = newly_installed[0]
+            assert dag_hash == spec.dag_hash()
+            assert installed_spec == spec
+            assert not pending  # spec was removed from pending
+        finally:
+            for _, _, lock in newly_installed:
+                lock.release_read()
+            jobserver.close()
+
+    def test_write_locked_read_locked_not_installed_still_blocked(
+        self, temporary_store, mock_packages, monkeypatch
+    ):
+        """Write lock fails, read lock succeeds, but spec is not in DB: retry later.
+
+        Simulates the case where a concurrent process was killed mid-build. The read lock is
+        released and the spec stays in pending; blocked should remain True.
+        """
+        spec = self._make_spec("trivial-install-test-package")
+        pending = [spec.dag_hash()]
+        bg = _FakeBuildGraph([spec])
+        jobserver = JobServer(num_jobs=2)
+        lock = temporary_store.prefix_locker.lock(spec)
+
+        def write_timeout(timeout=None):
+            raise spack.util.lock.LockTimeoutError("write", lock.path, 0, 1)
+
+        monkeypatch.setattr(lock, "acquire_write", write_timeout)
+        try:
+            blocked, to_start, newly_installed = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite=set(),
+                capacity=2,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+            )
+            assert blocked
+            assert not to_start
+            assert not newly_installed
+            assert pending == [spec.dag_hash()]  # spec stays in pending for retry
+        finally:
             jobserver.close()


### PR DESCRIPTION
After writing a spec to the DB, downgrade the prefix write lock to a
read lock rather than releasing it. Accumulate these read locks in
retained_read_locks and release them only at the end of the install
session. This prevents another process from uninstalling a package that
is still needed as a build dependency.

Also handle the case where a write lock times out but a read lock
succeeds: this means the competing process finished and downgraded its
write lock. If the DB confirms installation, capture the spec as done
and retain the read lock. If the DB says not installed, the process was
likely killed mid-build; skip and retry.

<img width="2104" height="1065" alt="image" src="https://github.com/user-attachments/assets/bfbdc2f1-7243-4503-b608-7e3f8cabe377" />

In the screenshot:
* left-hand side: two concurrent install processes
* right-hand side: blocked uninstall process (waiting for a write lock)