### PR TITLE
new_installer.py: concurrent overwrite installs

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1290,6 +1290,7 @@ def schedule_builds(
     db: spack.database.Database,
     prefix_locker: spack.database.SpecLocker,
     overwrite: Set[str],
+    overwrite_time: float,
     capacity: int,
     needs_jobserver_token: bool,
     jobserver: JobServer,
@@ -1312,6 +1313,9 @@ def schedule_builds(
         db: Package database; used for read lock and installed-status queries.
         prefix_locker: Per-spec write locker.
         overwrite: Set of dag hashes to overwrite even if already installed.
+        overwrite_time: Timestamp (from time.time()) at which the overwrite install was requested.
+            A spec in ``overwrite`` whose DB installation_time >= overwrite_time was installed by
+            a concurrent process after our request started and should be treated as done.
         capacity: Maximum number of new builds to add to to_start in this call.
         needs_jobserver_token: True if a jobserver token is required for the first new build.
         jobserver: Jobserver for acquiring tokens.
@@ -1358,7 +1362,13 @@ def schedule_builds(
             upstream, record = db.query_by_spec_hash(dag_hash)
 
             # If the spec is already installed, treat it as done regardless of lock type.
-            if dag_hash not in overwrite and record and record.installed:
+            # A spec in the overwrite set is also treated as done if another process installed it
+            # after our overwrite request was created (installation_time >= overwrite_time).
+            if (
+                record
+                and record.installed
+                and (dag_hash not in overwrite or record.installation_time >= overwrite_time)
+            ):
                 if have_write:
                     lock.downgrade_write_to_read()
                 # keep the read lock (either downgraded or already a read lock)
@@ -1446,6 +1456,8 @@ class PackageInstaller:
         self.include_build_deps = include_build_deps
         #: Set of DAG hashes to overwrite (if already installed)
         self.overwrite: Set[str] = set(overwrite) if overwrite else set()
+        #: Time at which the overwrite install was requested; used to detect concurrent overwrites.
+        self.overwrite_time: float = time.time()
         self.keep_prefix = keep_prefix
         self.fail_fast = fail_fast
 
@@ -1785,6 +1797,7 @@ class PackageInstaller:
             db=self.db,
             prefix_locker=spack.store.STORE.prefix_locker,
             overwrite=self.overwrite,
+            overwrite_time=self.overwrite_time,
             capacity=self.capacity,
             needs_jobserver_token=bool(self.running_builds),
             jobserver=jobserver,

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -5,6 +5,7 @@
 
 import pathlib
 import sys
+import time
 
 import pytest
 
@@ -298,6 +299,7 @@ class TestScheduleBuilds:
                 temporary_store.db,
                 temporary_store.prefix_locker,
                 overwrite=set(),
+                overwrite_time=0.0,
                 capacity=1,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
@@ -326,6 +328,7 @@ class TestScheduleBuilds:
                 temporary_store.db,
                 temporary_store.prefix_locker,
                 overwrite=set(),
+                overwrite_time=0.0,
                 capacity=1,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
@@ -354,6 +357,7 @@ class TestScheduleBuilds:
                 temporary_store.db,
                 temporary_store.prefix_locker,
                 overwrite=set(),
+                overwrite_time=0.0,
                 capacity=2,
                 needs_jobserver_token=True,
                 jobserver=jobserver,
@@ -385,6 +389,7 @@ class TestScheduleBuilds:
                 temporary_store.db,
                 temporary_store.prefix_locker,
                 overwrite=set(),
+                overwrite_time=0.0,
                 capacity=2,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
@@ -410,6 +415,7 @@ class TestScheduleBuilds:
                 temporary_store.db,
                 temporary_store.prefix_locker,
                 overwrite={spec.dag_hash()},
+                overwrite_time=time.time() + 100,
                 capacity=1,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
@@ -444,6 +450,7 @@ class TestScheduleBuilds:
                 temporary_store.db,
                 temporary_store.prefix_locker,
                 overwrite=set(),
+                overwrite_time=0.0,
                 capacity=2,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
@@ -485,6 +492,7 @@ class TestScheduleBuilds:
                 temporary_store.db,
                 temporary_store.prefix_locker,
                 overwrite=set(),
+                overwrite_time=0.0,
                 capacity=2,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
@@ -526,6 +534,7 @@ class TestScheduleBuilds:
                 temporary_store.db,
                 temporary_store.prefix_locker,
                 overwrite=set(),
+                overwrite_time=0.0,
                 capacity=2,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
@@ -535,4 +544,32 @@ class TestScheduleBuilds:
             assert not newly_installed
             assert pending == [spec.dag_hash()]  # spec stays in pending for retry
         finally:
+            jobserver.close()
+
+    def test_overwrite_handled_by_concurrent_process(self, temporary_store, mock_packages):
+        """When a spec in overwrite was installed AFTER overwrite_time, another process did it."""
+        spec = self._make_spec("trivial-install-test-package")
+        self._mark_installed(spec, temporary_store)  # installation_time = now()
+        pending = [spec.dag_hash()]
+        bg = _FakeBuildGraph([spec])
+        jobserver = JobServer(num_jobs=2)
+        try:
+            blocked, to_start, newly_installed = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite={spec.dag_hash()},
+                overwrite_time=0.0,  # earlier than now()
+                capacity=1,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+            )
+            assert not blocked
+            assert not to_start
+            assert len(newly_installed) == 1
+            assert newly_installed[0][0] == spec.dag_hash()
+        finally:
+            for _, _, lock in newly_installed:
+                lock.release_read()
             jobserver.close()


### PR DESCRIPTION
If two concurrent install processes do an overwrite install of the same
spec, the second one now realizes that the first one has overwritten the
install by comparing against the timestamp at which the installer was
started.