### PR TITLE
solver: add virtuals to the correct unification sets

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -80,6 +80,9 @@ error(100000, "Cannot have multiple nodes for {0} in the same unification set {1
   :- 2 { unification_set(SetID, node(_, PackageName)) }, unify(SetID, PackageName).
 
 unification_set("root", PackageNode) :- attr("root", PackageNode).
+unification_set("root", PackageNode) :- attr("virtual_root", PackageNode).
+
+% A package with a dependency that *is not* build belongs to the same unification set as the parent
 unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).
 
 % A separate unification set can be created if any of the build dependencies can be duplicated
@@ -89,15 +92,33 @@ needs_build_unification_set(ParentNode) :- attr("depends_on", ParentNode, _, "bu
 unification_set(("build", ID), node(X, Child))
   :- attr("depends_on", ParentNode, node(X, Child), "build"),
      build_set_id(ParentNode, ID),
-     unification_set(_, ParentNode).
+     needs_build_unification_set(ParentNode).
+
+% A virtual that is on an edge of non-build type belongs to the same unification set as the parent of the provider
+unification_set(SetID, node(VirtualID, Virtual)) :-
+  virtual_on_edge(ParentNode, ProviderNode, Virtual, Type), Type != "build",
+  provider(ProviderNode, node(VirtualID, Virtual)),
+  unification_set(SetID, ParentNode).
+
+% A virtual that is on a build edge, goes in the build set id of the parent of the provider
+unification_set(("build", ID), node(VirtualID, Virtual)) :-
+  virtual_on_edge(ParentNode, ProviderNode, Virtual, "build"),
+  provider(ProviderNode, node(VirtualID, Virtual)),
+  build_set_id(ParentNode, ID),
+  needs_build_unification_set(ParentNode).
+
+% Needed for reused dependencies. A reused dependency has its build edges trimmed, so we
+% only care about the non-build edges.
+unification_set(SetID, node(VirtualID, Virtual)) :-
+  concrete(ParentNode),
+  attr("virtual_on_edge", ParentNode, ProviderNode, Virtual),
+  provider(ProviderNode, node(VirtualID, Virtual)),
+  unification_set(SetID, ParentNode).
 
 % Limit the number of unification sets to a reasonable number to avoid combinatorial explosion
 #const max_build_unification_sets = 4.
 1 { build_set_id(ParentNode, 0..max_build_unification_sets-1) } 1 :- needs_build_unification_set(ParentNode).
 
-unification_set(SetID, VirtualNode)
-  :- provider(PackageNode, VirtualNode),
-     unification_set(SetID, PackageNode).
 
 % Compute sub-sets of the nodes, if requested. These can be either the nodes connected
 % to another node by "link" edges, or the nodes connected to another node by "link and
@@ -593,7 +614,10 @@ attr(Name, node(X, A1), A2, A3, A4) :- impose(ID, PackageNode), imposed_constrai
 
 % Provider set is relevant only for literals, since it's the only place where `^[virtuals=foo] bar`
 % might appear in the HEAD of a rule
-attr("provider_set", node(min_dupe_id, Provider), node(min_dupe_id, Virtual))
+1 {
+  attr("provider_set", node(0..MaxProvider-1, Provider), node(0..MaxVirtual-1, Virtual)):
+  max_dupes(Provider, MaxProvider), max_dupes(Virtual, MaxVirtual)
+} 1
   :- solve_literal(TriggerID),
      trigger_and_effect(_, TriggerID, EffectID),
      impose(EffectID, _),
@@ -820,6 +844,9 @@ attr("uses_virtual", PackageNode, Virtual) :-
    attr("node_flag", node(ID, Package), node_flag(FlagType, Flag, _, _)),
    not imposed_constraint(Hash, "node_flag", Package, node_flag(FlagType, Flag, _, _)).
 
+% we cannot have two nodes with the same hash
+:- attr("hash", PackageNode1, Hash), attr("hash", PackageNode2, Hash), PackageNode1 < PackageNode2.
+
 #defined condition/1.
 #defined subcondition/2.
 #defined condition_requirement/3.
@@ -979,12 +1006,11 @@ node_depends_on_virtual(PackageNode, Virtual, Type)
 node_depends_on_virtual(PackageNode, Virtual) :- node_depends_on_virtual(PackageNode, Virtual, Type).
 virtual_is_needed(Virtual) :- node_depends_on_virtual(PackageNode, Virtual).
 
-1 { attr("virtual_on_edge", PackageNode, ProviderNode, Virtual) : provider(ProviderNode, node(VirtualID, Virtual)) } 1
+1 { virtual_on_edge(PackageNode, ProviderNode, Virtual, Type) : provider(ProviderNode, node(VirtualID, Virtual)) } 1
   :- node_depends_on_virtual(PackageNode, Virtual, Type).
 
-attr("depends_on", PackageNode, ProviderNode, Type)
-  :- attr("virtual_on_edge", PackageNode, ProviderNode, Virtual),
-     node_depends_on_virtual(PackageNode, Virtual, Type).
+attr("virtual_on_edge", PackageNode, ProviderNode, Virtual) :- virtual_on_edge(PackageNode, ProviderNode, Virtual, _).
+attr("depends_on", PackageNode, ProviderNode, Type) :- virtual_on_edge(PackageNode, ProviderNode, _, Type).
 
 % If a virtual node is in the answer set, it must be either a virtual root,
 % or used somewhere

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -95,15 +95,13 @@ unification_set(("build", ID), node(X, Child))
      needs_build_unification_set(ParentNode).
 
 % A virtual that is on an edge of non-build type belongs to the same unification set as the parent of the provider
-unification_set(SetID, node(VirtualID, Virtual)) :-
-  virtual_on_edge(ParentNode, ProviderNode, Virtual, Type), Type != "build",
-  provider(ProviderNode, node(VirtualID, Virtual)),
+unification_set(SetID, VirtualNode) :-
+  virtual_on_edge(ParentNode, ProviderNode, VirtualNode, Type), Type != "build",
   unification_set(SetID, ParentNode).
 
 % A virtual that is on a build edge, goes in the build set id of the parent of the provider
-unification_set(("build", ID), node(VirtualID, Virtual)) :-
-  virtual_on_edge(ParentNode, ProviderNode, Virtual, "build"),
-  provider(ProviderNode, node(VirtualID, Virtual)),
+unification_set(("build", ID), VirtualNode) :-
+  virtual_on_edge(ParentNode, ProviderNode, VirtualNode, "build"),
   build_set_id(ParentNode, ID),
   needs_build_unification_set(ParentNode).
 
@@ -1006,10 +1004,10 @@ node_depends_on_virtual(PackageNode, Virtual, Type)
 node_depends_on_virtual(PackageNode, Virtual) :- node_depends_on_virtual(PackageNode, Virtual, Type).
 virtual_is_needed(Virtual) :- node_depends_on_virtual(PackageNode, Virtual).
 
-1 { virtual_on_edge(PackageNode, ProviderNode, Virtual, Type) : provider(ProviderNode, node(VirtualID, Virtual)) } 1
+1 { virtual_on_edge(PackageNode, ProviderNode, node(VirtualID, Virtual), Type) : provider(ProviderNode, node(VirtualID, Virtual)) } 1
   :- node_depends_on_virtual(PackageNode, Virtual, Type).
 
-attr("virtual_on_edge", PackageNode, ProviderNode, Virtual) :- virtual_on_edge(PackageNode, ProviderNode, Virtual, _).
+attr("virtual_on_edge", PackageNode, ProviderNode, Virtual) :- virtual_on_edge(PackageNode, ProviderNode, node(_, Virtual), _).
 attr("depends_on", PackageNode, ProviderNode, Type) :- virtual_on_edge(PackageNode, ProviderNode, _, Type).
 
 % If a virtual node is in the answer set, it must be either a virtual root,

--- a/lib/spack/spack/solver/heuristic.lp
+++ b/lib/spack/spack/solver/heuristic.lp
@@ -13,6 +13,7 @@
 #heuristic attr("version", node(PackageID, Package), Version). [80, level]
 #heuristic attr("variant_value", PackageNode, Variant, Value). [80, level]
 #heuristic attr("node_target", node(PackageID, Package), Target). [80, level]
+#heuristic virtual_on_edge(PackageNode, ProviderNode, Virtual, Type). [80, level]
 
 #heuristic attr("virtual_node", node(X, Virtual)). [600, init]
 #heuristic attr("virtual_node", node(X, Virtual)). [-1, sign]

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1983,7 +1983,7 @@ spack:
 
 
 @pytest.mark.regression("51995")
-def test_mixed_compilers_and_libllvm(tmp_path, mutable_config):
+def test_mixed_compilers_and_libllvm(tmp_path, config):
     """Tests that we divide virtual nodes correctly among unification sets.
 
     This test concretizes a unified environment where one package uses gcc as a C++ compiler

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1980,3 +1980,61 @@ spack:
         with ev.Environment(manifest.manifest_dir) as e:
             with pytest.raises(ev.SpackEnvironmentConfigError, match=r"among groups: alpha, beta"):
                 e.concretize()
+
+
+@pytest.mark.regression("51995")
+def test_mixed_compilers_and_libllvm(tmp_path, mutable_config):
+    """Tests that we divide virtual nodes correctly among unification sets.
+
+    This test concretizes a unified environment where one package uses gcc as a C++ compiler
+    and depends on llvm as a provider of libllvm, while the other package uses llvm as a C++
+    compiler.
+    """
+    spack_yaml = """
+spack:
+  specs:
+  - paraview %cxx=llvm
+  - mesa %cxx=gcc %libllvm=llvm
+  packages:
+    c:
+      prefer:
+      - gcc
+    cxx:
+      prefer:
+      - gcc
+    gcc::
+      externals:
+      - spec: gcc@13.2.0 languages:='c,c++,fortran'
+        prefix: /path
+        extra_attributes:
+          compilers:
+            c: /path/bin/gcc
+            cxx: /path/bin/g++
+            fortran: /path/bin/gfortran
+    llvm::
+      externals:
+      - spec: llvm@20.1.8+clang+flang+lld+lldb
+        prefix: /usr
+        extra_attributes:
+          compilers:
+            c: /usr/bin/gcc
+            cxx: /usr/bin/g++
+            fortran: /usr/bin/gfortran
+  concretizer:
+    unify: true
+"""
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(spack_yaml)
+    with ev.Environment(tmp_path) as e:
+        e.concretize()
+
+    for x in e.concrete_roots():
+        if x.name == "mesa":
+            mesa = x
+        else:
+            paraview = x
+
+    assert paraview.satisfies("%cxx=llvm@20")
+    assert paraview.satisfies(f"%{mesa}")
+    assert mesa.satisfies("%cxx=gcc %libllvm=llvm")
+    assert paraview["cxx"].dag_hash() == mesa["libllvm"].dag_hash()

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/llvm/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/llvm/package.py
@@ -33,6 +33,7 @@ class Llvm(Package, CompilerPackage):
 
     provides("c", "cxx", when="+clang")
     provides("fortran", when="+flang")
+    provides("libllvm")
 
     depends_on("c")
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/mesa/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/mesa/package.py
@@ -1,0 +1,14 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Mesa(Package):
+    """Package depending on libllvm (a link-type virtual provided by a compiler)"""
+
+    homepage = "https://www.mesa.com"
+
+    version("2.0.1")
+    depends_on("libllvm")
+    depends_on("cxx", type="build")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/paraview/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/paraview/package.py
@@ -1,0 +1,19 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class Paraview(Package):
+    """Package depending on a library, that has a link dependency to libllvm"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/c-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("mesa")
+    depends_on("cxx", type="build")


### PR DESCRIPTION
fixes #51995

There are cases where in a unified environment one root depends on e.g. `llvm` as a provider for `libllvm`, but is compiled with `gcc`, and another root is instead compiled with `llvm`.

In those cases we have:
```prolog
provider(node(0, gcc), node(0, c)).
provider(node(0, llvm), node(1, c)).
provider(node(0, llvm), node(0, libllvm)).
```
and we have to add the virtual node that is being provided to the correct unification set. The rule:
```prolog
unification_set(SetID, VirtualNode)
  :- provider(PackageNode, VirtualNode),
     unification_set(SetID, PackageNode).
```
is therefore wrong in those cases, and so are other similar simplifying assumptions.

In this commit we fix the issue by adding virtuals to the correct unification sets.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
