### PR TITLE
Support cxx and fortran for Lmod compiler hierarchy

### DIFF
--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -104,20 +104,23 @@ class LmodConfiguration(BaseConfiguration):
         super().__init__(spec, module_set_name, explicit)
 
         candidates = collections.defaultdict(list)
+        language_virtuals = ("c", "cxx", "fortran")
+
         for node in spec.traverse(deptype=("link", "run")):
-            candidates["c"].extend(node.dependencies(virtuals=("c",)))
-            candidates["cxx"].extend(node.dependencies(virtuals=("c",)))
+            for language in language_virtuals:
+                candidates[language].extend(node.dependencies(virtuals=(language,)))
 
-        if candidates["c"]:
-            self.compiler = candidates["c"][0]
-            if len(set(candidates["c"])) > 1:
-                warnings.warn(
-                    f"{spec.short_spec} uses more than one compiler, and might not fit the "
-                    f"LMod hierarchy. Using {self.compiler.short_spec} as the LMod compiler."
-                )
+        self.compiler = None
 
-        elif not candidates["c"]:
-            self.compiler = None
+        for language in language_virtuals:
+            if candidates[language]:
+                self.compiler = candidates[language][0]
+                if len(set(candidates[language])) > 1:
+                    warnings.warn(
+                        f"{spec.short_spec} uses more than one compiler, and might not fit the "
+                        f"LMod hierarchy. Using {self.compiler.short_spec} as the LMod compiler."
+                    )
+                break
 
     @property
     def core_compilers(self) -> List[spack.spec.Spec]:

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -123,6 +123,16 @@ class TestLmod:
             assert "compiler" in provides
             assert provides["compiler"] == spack.spec.Spec("intel-oneapi-compilers@=3.0")
 
+    @pytest.mark.parametrize("language", ["c", "cxx", "fortran"])
+    def test_compiler_language_virtuals(self, factory, module_configuration, language):
+        """Tests all compiler virtuals for hierarchical module placement."""
+        module_configuration("complex_hierarchy")
+        module, spec = factory(f"single-language-virtual +{language} %{language}=gcc@=10.2.1")
+
+        requires = module.conf.requires
+
+        assert "gcc@=10.2.1" in requires["compiler"]
+
     def test_simple_case(self, modulefile_content, module_configuration):
         """Tests the generation of a simple Lua module file."""
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/single_language_virtual/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/single_language_virtual/package.py
@@ -1,0 +1,24 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class SingleLanguageVirtual(Package):
+    """Package using a single language virtual for compilation"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/foo-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    variant("c", default=False)
+    variant("cxx", default=False)
+    variant("fortran", default=False)
+
+    depends_on("c", when="+c")
+    depends_on("cxx", when="+cxx")
+    depends_on("fortran", when="+fortran")


### PR DESCRIPTION
In develop, Spack only checks for `c`-language virtuals when deciding what compiler it should use in the Lmod hierarchy. This means that if a package (e.g., Kokkos) only uses `cxx` and/or `fortran`, it will end up in Core and you'll get unexpected path clashes if you have multiple builds with different compilers.

This PR generalizes the compiler detection code to loop through all current "language" virtuals. It addresses one of the two Spack 1.0 Lmod behavior differences observed in #51328.

For mixed-toolchain packages, the `c` virtual is preferred, followed by the `cxx` virtual, and finally `fortran`.