### PR TITLE
Mark opengl as `buildable:false`

### DIFF
--- a/etc/spack/defaults/base/packages.yaml
+++ b/etc/spack/defaults/base/packages.yaml
@@ -103,6 +103,8 @@ packages:
     buildable: false
   musl:
     buildable: false
+  opengl:
+    buildable: false
   spectrum-mpi:
     buildable: false
   xl:


### PR DESCRIPTION
The `opengl` package fails at runtime with a message, saying it's a placeholder for external libraries. Make it fail at concretization time instead by default.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
