### PR TITLE
solver: fix rule for virtuals that are provided together

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -986,12 +986,13 @@ node_uses_provider_with_constraints(ClientNode, node(X, Package), ID, SetID) :-
   pkg_fact(Package, provided_together(ID, SetID, V)),
   attr("virtual_on_edge", ClientNode, node(X, Package), V).
 
-% Error: package provides some but not all required virtuals from the set
-error(100, "Package '{0}' needs to also provide '{1}' (provided_together constraint)", Package, Virtual2)
+% This error is triggered if the package provides some but not all required virtuals from
+% the set that needs to be provided together
+error(100, "Package '{0}' needs to also provide '{1}' (provided_together constraint)", Package, Virtual)
 :- node_uses_provider_with_constraints(ClientNode, node(X, Package), ID, SetID),
-   pkg_fact(Package, provided_together(ID, SetID, Virtual2)),
-   node_depends_on_virtual(ClientNode, Virtual2),
-   not attr("virtual_on_edge", ClientNode, node(X, Package), Virtual2).
+   pkg_fact(Package, provided_together(ID, SetID, Virtual)),
+   node_depends_on_virtual(ClientNode, Virtual),
+   not attr("virtual_on_edge", ClientNode, node(X, Package), Virtual).
 
 % if a package depends on a virtual, it's not external and we have a
 % provider for that virtual then it depends on the provider

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -980,18 +980,18 @@ error(1, Msg) :-
 % Virtual dependencies
 %-----------------------------------------------------------------------------
 
-% Enforces all virtuals to be provided, if multiple of them are provided together
-error(100, "Package '{0}' needs to provide both '{1}' and '{2}' together, but provides only '{1}'", Package, Virtual1, Virtual2)
-:- % This package provides 2 or more virtuals together
-   condition_holds(ID, node(X, Package)),
-   pkg_fact(Package, provided_together(ID, SetID, Virtual1)),
+% Package provides to this client at least one virtual from those that need to be provided together
+node_uses_provider_with_constraints(ClientNode, node(X, Package), ID, SetID) :-
+  condition_holds(ID, node(X, Package)),
+  pkg_fact(Package, provided_together(ID, SetID, V)),
+  attr("virtual_on_edge", ClientNode, node(X, Package), V).
+
+% Error: package provides some but not all required virtuals from the set
+error(100, "Package '{0}' needs to also provide '{1}' (provided_together constraint)", Package, Virtual2)
+:- node_uses_provider_with_constraints(ClientNode, node(X, Package), ID, SetID),
    pkg_fact(Package, provided_together(ID, SetID, Virtual2)),
-   Virtual1 != Virtual2,
-   % One node depends on those virtuals AND on this package
-   virtual_on_edge(ClientNode, node(X, Package), node(Virtual1ID, Virtual1), _),
-   virtual_on_edge(ClientNode, node(ID2, Package2), node(Virtual2ID, Virtual2), _),
-   % But this package is a provider of only one of them
-   node(X, Package) != node(ID2, Package2).
+   node_depends_on_virtual(ClientNode, Virtual2),
+   not attr("virtual_on_edge", ClientNode, node(X, Package), Virtual2).
 
 % if a package depends on a virtual, it's not external and we have a
 % provider for that virtual then it depends on the provider

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -988,12 +988,10 @@ error(100, "Package '{0}' needs to provide both '{1}' and '{2}' together, but pr
    pkg_fact(Package, provided_together(ID, SetID, Virtual2)),
    Virtual1 != Virtual2,
    % One node depends on those virtuals AND on this package
-   node_depends_on_virtual(ClientNode, Virtual1),
-   node_depends_on_virtual(ClientNode, Virtual2),
-   depends_on(ClientNode, node(X, Package)),
+   virtual_on_edge(ClientNode, node(X, Package), node(Virtual1ID, Virtual1), _),
+   virtual_on_edge(ClientNode, node(ID2, Package2), node(Virtual2ID, Virtual2), _),
    % But this package is a provider of only one of them
-   provider(node(X, Package), node(_, Virtual1)),
-   not provider(node(X, Package), node(_, Virtual2)).
+   node(X, Package) != node(ID2, Package2).
 
 % if a package depends on a virtual, it's not external and we have a
 % provider for that virtual then it depends on the provider

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -2038,3 +2038,52 @@ spack:
     assert paraview.satisfies(f"%{mesa}")
     assert mesa.satisfies("%cxx=gcc %libllvm=llvm")
     assert paraview["cxx"].dag_hash() == mesa["libllvm"].dag_hash()
+
+
+@pytest.mark.regression("51512")
+def test_unified_environment_with_mixed_compilers_and_fortran(tmp_path, config):
+    """Tests that we can concretize a unified environment using two C/C++ compilers for the root
+    specs and GCC for Fortran, where both roots depend on Fortran.
+    """
+    spack_yaml = """
+    spack:
+      specs:
+      - mpich %c,cxx=llvm
+      - openblas %c,fortran=gcc
+      packages:
+        gcc::
+          externals:
+          - spec: gcc@13.2.0 languages:='c,c++,fortran'
+            prefix: /path
+            extra_attributes:
+              compilers:
+                c: /path/bin/gcc
+                cxx: /path/bin/g++
+                fortran: /path/bin/gfortran
+        llvm::
+          externals:
+          - spec: llvm@20.1.8+clang~flang
+            prefix: /usr
+            extra_attributes:
+              compilers:
+                c: /usr/bin/gcc
+                cxx: /usr/bin/g++
+                fortran: /usr/bin/gfortran
+      concretizer:
+        unify: true
+    """
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(spack_yaml)
+    with ev.Environment(tmp_path) as e:
+        e.concretize()
+
+    for x in e.concrete_roots():
+        if x.name == "mpich":
+            mpich = x
+        else:
+            openblas = x
+
+    assert mpich.satisfies("%c,cxx=llvm")
+    assert mpich.satisfies("%fortran=gcc")
+    assert openblas.satisfies("%c,fortran=gcc")
+    assert mpich["fortran"].dag_hash() == openblas["fortran"].dag_hash()


### PR DESCRIPTION
fixes #51512

Sometimes a unified environment has roots compiled with different compilers. In those cases the rule to ensure that virtuals that need to be provided together ARE provided together was wrong.

In this PR we fix it, and we add a test case to avoid regression.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
