### PR TITLE
spack config: add --group option

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -46,6 +46,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         choices=spack.config.SECTION_SCHEMAS,
     )
     get_parser.add_argument("--json", action="store_true", help="output configuration as JSON")
+    get_parser.add_argument(
+        "--group",
+        metavar="group",
+        default=None,
+        help="show configuration as seen by this environment spec group (requires active env)",
+    )
 
     blame_parser = sp.add_parser(
         "blame", help="print configuration annotated with source file:line"
@@ -56,6 +62,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         nargs="?",
         metavar="section",
         choices=spack.config.SECTION_SCHEMAS,
+    )
+    blame_parser.add_argument(
+        "--group",
+        metavar="group",
+        default=None,
+        help="show configuration as seen by this environment spec group (requires active env)",
     )
 
     edit_parser = sp.add_parser("edit", help="edit configuration file")
@@ -183,6 +195,22 @@ def print_configuration(args, *, blame: bool) -> None:
     if args.scope and args.section is None:
         tty.die(f"the argument --scope={args.scope} requires specifying a section.")
 
+    group = getattr(args, "group", None)
+    if group is not None:
+        env = ev.active_environment()
+        if env is None:
+            tty.die("the argument --group requires an active environment")
+        try:
+            with env.config_override_for_group(group=group):
+                _print_configuration_helper(args, blame=blame)
+        except ValueError as e:
+            tty.die(str(e))
+        return
+
+    _print_configuration_helper(args, blame=blame)
+
+
+def _print_configuration_helper(args, *, blame: bool) -> None:
     yaml = blame or not args.json
 
     if args.section is not None:

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -718,3 +718,52 @@ spack:
 
     with ev.Environment(str(tmp_path)) as e:
         assert not e.manifest.yaml_content["spack"]["config"]["ccache"]
+
+
+_GROUP_OVERRIDE_SPACK_YAML = """\
+spack:
+  specs:
+  - group: mygroup
+    specs:
+    - zlib
+    override:
+      packages:
+        zlib:
+          version: ['1.2.13']
+"""
+
+
+@pytest.mark.parametrize("cmd_str", ["get", "blame"])
+def test_config_with_group_shows_override_packages(cmd_str, tmp_path, mutable_config):
+    """Tests that packages should show that group's override packages config,
+    when the option is given.
+    """
+    (tmp_path / "spack.yaml").write_text(_GROUP_OVERRIDE_SPACK_YAML)
+
+    with ev.Environment(str(tmp_path)):
+        output = config(cmd_str, "packages")
+        assert "1.2.13" not in output
+        if cmd_str == "blame":
+            assert "env:groups:mygroup" not in output
+        output = config(cmd_str, "--group=mygroup", "packages")
+        assert "1.2.13" in output
+        if cmd_str == "blame":
+            assert "env:groups:mygroup" in output
+
+
+@pytest.mark.parametrize("cmd_str", ["get", "blame"])
+def test_config_with_group_requires_active_environment(cmd_str, mutable_config):
+    """Tests that using groups outside an environment should give a clear error."""
+    output = config(cmd_str, "--group=mygroup", "packages", fail_on_error=False)
+    assert config.returncode != 0
+    assert "--group requires an active environment" in output
+
+
+@pytest.mark.parametrize("cmd_str", ["get", "blame"])
+def test_config_with_unknown_group_gives_clear_error(cmd_str, tmp_path, mutable_config):
+    """Tests that using a non-existing group gives a clear error."""
+    (tmp_path / "spack.yaml").write_text("spack:\n  specs:\n  - zlib\n")
+    with ev.Environment(str(tmp_path)):
+        output = config(cmd_str, "--group=nonexistent", "packages", fail_on_error=False)
+    assert config.returncode != 0
+    assert "'nonexistent' not found in" in output

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -844,7 +844,7 @@ _spack_config() {
 _spack_config_get() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --json"
+        SPACK_COMPREPLY="-h --help --json --group"
     else
         _config_sections
     fi
@@ -853,7 +853,7 @@ _spack_config_get() {
 _spack_config_blame() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help --group"
     else
         _config_sections
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1264,18 +1264,22 @@ complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_bui
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
-set -g __fish_spack_optspecs_spack_config_get h/help json
+set -g __fish_spack_optspecs_spack_config_get h/help json group=
 complete -c spack -n '__fish_spack_using_command_pos 0 config get' -f -a 'bootstrap cdash ci compilers concretizer config definitions develop env_vars include mirrors modules packages repos toolchains upstreams view'
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command config get' -l json -f -a json
 complete -c spack -n '__fish_spack_using_command config get' -l json -d 'output configuration as JSON'
+complete -c spack -n '__fish_spack_using_command config get' -l group -r -f -a group
+complete -c spack -n '__fish_spack_using_command config get' -l group -r -d 'show configuration as seen by this environment spec group (requires active env)'
 
 # spack config blame
-set -g __fish_spack_optspecs_spack_config_blame h/help
+set -g __fish_spack_optspecs_spack_config_blame h/help group=
 complete -c spack -n '__fish_spack_using_command_pos 0 config blame' -f -a 'bootstrap cdash ci compilers concretizer config definitions develop env_vars include mirrors modules packages repos toolchains upstreams view'
 complete -c spack -n '__fish_spack_using_command config blame' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config blame' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command config blame' -l group -r -f -a group
+complete -c spack -n '__fish_spack_using_command config blame' -l group -r -d 'show configuration as seen by this environment spec group (requires active env)'
 
 # spack config edit
 set -g __fish_spack_optspecs_spack_config_edit h/help print-file


### PR DESCRIPTION
This option works only if an environment is active and accounts for group overrides when displaying the configuration.

Co-developed with Claude

**Example**

<img width="1469" height="242" alt="Screenshot from 2026-03-05 10-45-11" src="https://github.com/user-attachments/assets/b9f24cd7-4a74-4480-b5e0-b41d28608cf9" />


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
