### PR TITLE
solver: fix issues with the computation of `max_dupes`

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1006,6 +1006,11 @@ virtual_is_needed(Virtual) :- node_depends_on_virtual(PackageNode, Virtual).
 1 { virtual_on_edge(PackageNode, ProviderNode, node(VirtualID, Virtual), Type) : provider(ProviderNode, node(VirtualID, Virtual)) } 1
   :- node_depends_on_virtual(PackageNode, Virtual, Type).
 
+% A package that depends on a virtual with type ("build", "link") cannot have two providers
+% (one for the "build" and one for the "link")
+:- node_depends_on_virtual(PackageNode, Virtual), M = #count { VirtualID : virtual_on_edge(PackageNode, ProviderNode, node(VirtualID, Virtual), _) }, M > 1.
+
+
 attr("virtual_on_edge", PackageNode, ProviderNode, Virtual) :- virtual_on_edge(PackageNode, ProviderNode, node(_, Virtual), _).
 attr("depends_on", PackageNode, ProviderNode, Type) :- virtual_on_edge(PackageNode, ProviderNode, _, Type).
 

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -482,7 +482,7 @@ class MinimalDuplicatesCounter(NoDuplicatesCounter):
         gen.newline()
 
         gen.h2("Packages with multiple possible nodes (build-tools)")
-        default = spack.config.CONFIG.get("concretizer:duplicates:max_dupes:default", 2)
+        default = spack.config.CONFIG.get("concretizer:duplicates:max_dupes:default", 1)
         duplicates = spack.config.CONFIG.get("concretizer:duplicates:max_dupes", {})
         for package_name in sorted(self.possible_dependencies() & build_tools):
             max_dupes = duplicates.get(package_name, default)
@@ -491,13 +491,8 @@ class MinimalDuplicatesCounter(NoDuplicatesCounter):
                 gen.fact(fn.multiple_unification_sets(package_name))
         gen.newline()
 
-        gen.h2("Maximum number of nodes (link-run virtuals)")
-        for package_name in sorted(self._link_run_virtuals):
-            gen.fact(fn.max_dupes(package_name, 1))
-        gen.newline()
-
-        gen.h2("Maximum number of nodes (other virtuals)")
-        for package_name in sorted(self.possible_virtuals() - self._link_run_virtuals):
+        gen.h2("Maximum number of nodes (virtuals)")
+        for package_name in sorted(self.possible_virtuals()):
             max_dupes = duplicates.get(package_name, default)
             gen.fact(fn.max_dupes(package_name, max_dupes))
         gen.newline()

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -660,11 +660,15 @@ spack:
         """
         spack.concretize.concretize_one("hypre ^openblas-with-lapack")
 
-    def test_concretize_two_virtuals_with_dual_provider_and_a_conflict(self):
+    @pytest.mark.parametrize("max_dupes_default", [1, 2, 3])
+    def test_concretize_two_virtuals_with_dual_provider_and_a_conflict(
+        self, max_dupes_default, mutable_config
+    ):
         """Test a package with multiple virtual dependencies and force a
         provider that provides both, and another conflicting package that
         provides one.
         """
+        mutable_config.set("concretizer:duplicates:max_dupes:default", max_dupes_default)
         s = Spec("hypre ^openblas-with-lapack ^netlib-lapack")
         with pytest.raises(spack.error.SpackError):
             spack.concretize.concretize_one(s)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -34,6 +34,7 @@ import spack.platforms.test
 import spack.repo
 import spack.solver.asp
 import spack.solver.core
+import spack.solver.input_analysis
 import spack.solver.reuse
 import spack.solver.runtimes
 import spack.spec
@@ -4930,3 +4931,25 @@ def test_default_values_used_if_subset_required_by_dependent(mock_packages):
     a = spack.concretize.concretize_one("multivalue-variant-multi-defaults-dependent")
     # we still end up using baz, and we don't drop it to avoid an extra dependency.
     assert a.satisfies("%multivalue-variant-multi-defaults myvariant=bar,baz")
+
+
+def test_virtual_gets_multiple_dupes(mock_packages, config):
+    """Tests that virtual packages always get multiple dupes, according to what we have in
+    the configuration files.
+    """
+    specs = [spack.spec.Spec("pkg-with-c-link-dep")]
+    possible_graph = spack.solver.input_analysis.NoStaticAnalysis(
+        configuration=spack.config.CONFIG, repo=spack.repo.PATH
+    )
+    counter = spack.solver.input_analysis.MinimalDuplicatesCounter(
+        specs, tests=False, possible_graph=possible_graph
+    )
+    gen = spack.solver.asp.ProblemInstanceBuilder()
+    counter.possible_packages_facts(gen, spack.solver.core.fn)
+
+    asp = gen.asp_problem
+    # "c" is a compiler language virtual and must allow multiple nodes, not be capped at 1
+    selected_lines = [line for line in asp if line.startswith('max_dupes("c"')]
+    assert len(selected_lines) == 1
+    max_dupes_c = selected_lines[0]
+    assert 'max_dupes("c",2).' == max_dupes_c, f"should have max_dupes=2, but got: {max_dupes_c}"

--- a/lib/spack/spack/test/data/config/concretizer.yaml
+++ b/lib/spack/spack/test/data/config/concretizer.yaml
@@ -3,7 +3,30 @@ concretizer:
   targets:
     granularity: microarchitectures
     host_compatible: false
+
   duplicates:
     strategy: minimal
+    max_dupes:
+      default: 1
+      # Virtuals
+      c: 2
+      cxx: 2
+      fortran: 1
+      # Regular packages
+      cmake: 2
+      gmake: 2
+      python: 2
+      python-venv: 2
+      py-cython: 2
+      py-flit-core: 2
+      py-pip: 2
+      py-setuptools: 2
+      py-versioneer: 2
+      py-wheel: 2
+      xcb-proto: 2
+      # Compilers
+      gcc: 2
+      llvm: 2
+
   concretization_cache:
     enable: false

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/pkg_with_c_link_dep/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/pkg_with_c_link_dep/package.py
@@ -1,0 +1,16 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class PkgWithCLinkDep(Package):
+    """Simple package with one optional dependency"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    # This package erroneously declares a build,link dependency on c
+    depends_on("c")


### PR DESCRIPTION
This PR solves two bugs:

**Bug 1**

If a virtual is a possible link/run dependency, don't make assumption on its number of duplicates based on whether it
may appear in the link/run closure. That may cause issues if e.g. packages have typos and use:
```python
depends_on("c")
```
since the max_dupes for that language will be 1 instead of the configured default of 2.

**Bug 2**

When a virtual is depended on with multiple edge types, we must ensure that the same package gets the same provider on each of the edge types. E.g. it can't happen that a:
```python
depends_on("lapack", type=("build","link"))
```
is satisfied by `openblas` on the link part, and by `netlib-lapack` on the build part if `max_dupes("lapack", 2)`.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
