### PR TITLE
concretize.lp: avoid link dep also when not run

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1969,7 +1969,6 @@ imposed_constraint(Hash, "hash", PackageName, Hash) :- installed_hash(PackageNam
 % can get by with a much smaller search space.
 avoid_link_dependency(Hash, DepName) :-
   hash_attr(Hash, "depends_on", PackageName, DepName, "link"),
-  not hash_attr(Hash, "depends_on", PackageName, DepName, "run"),
   hash_attr(Hash, "hash", DepName, DepHash),
   compiler_package(PackageName),
   not compiler_used_as_a_library(node(_, PackageName), Hash).


### PR DESCRIPTION
In builtin gcc depends on binutils as build/link/run (questionable, but
besides the point).

The rule that's changed is meant to avoid tracking dependencies of reused
compilers that are not link deps to another package. The point of that is that
we don't have to count compiler deps in `max_dupes`.

The exception for `type=run` I find hard to explain, and prevents that binutils
is un-tracked, which then pulls in zlib-ng and zstd through binutils and forces
reuse of those. That's problematic for the case `compiler_mixing: false`, because
that zlib-ng and zstd depend on yet another compiler.

