### PR TITLE
concretize.lp: avoid imposing transitive link deps of compiler run deps

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2920,12 +2920,11 @@ class SpackSolverSetup:
         candidate_compilers, self.rejected_compilers = possible_compilers(
             configuration=spack.config.CONFIG
         )
-        for x in candidate_compilers:
-            if x.external or x in reuse:
-                continue
-            reuse.append(x)
-            for dep in x.traverse(root=False, deptype="run"):
-                reuse.extend(dep.traverse(deptype=("link", "run")))
+        reuse_from_compilers = traverse.traverse_nodes(
+            [x for x in candidate_compilers if not x.external], deptype=("link", "run")
+        )
+        reused_set = set(reuse)
+        reuse += [x for x in reuse_from_compilers if x not in reused_set]
 
         candidate_compilers.update(compilers_from_reuse)
         self.possible_compilers = list(candidate_compilers)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1979,6 +1979,31 @@ avoid_link_dependency(Hash, DepName) :-
   compiler_package(PackageName),
   not compiler_used_as_a_library(node(_, PackageName), Hash).
 
+% When a compiler is not used as a library, its transitive run-type dependencies are unified in the
+% build environment (they appear in PATH etc.), but their pure link-type dependencies are NOT. This
+% is different from unification sets that include all link/run deps: the goal is to avoid imposing
+% transitive link constraints from the toolchain, which would add to max_dupes and require us to
+% increase the max_dupes threshold for many packages.
+
+% Base case: direct run dep of a non-library compiler
+compiler_non_lib_run_dep(DepHash, DepName) :-
+  compiler_package(CompilerName),
+  not compiler_used_as_a_library(node(_, CompilerName), CompilerHash),
+  hash_attr(CompilerHash, "depends_on", CompilerName, DepName, "run"),
+  hash_attr(CompilerHash, "hash", DepName, DepHash).
+
+% Recursive case: run deps of run deps (full transitive closure)
+compiler_non_lib_run_dep(TransDepHash, TransDepName) :-
+  compiler_non_lib_run_dep(DepHash, DepName),
+  hash_attr(DepHash, "depends_on", DepName, TransDepName, "run"),
+  hash_attr(DepHash, "hash", TransDepName, TransDepHash).
+
+% Pure link deps (link but not run) of any node in that closure are avoided
+avoid_link_dependency(DepHash, LinkDepName) :-
+  compiler_non_lib_run_dep(DepHash, DepName),
+  hash_attr(DepHash, "depends_on", DepName, LinkDepName, "link"),
+  not hash_attr(DepHash, "depends_on", DepName, LinkDepName, "run").
+
 % Without splicing, we simply recover the exact semantics
 imposed_constraint(ParentHash, "hash", ChildName, ChildHash) :-
   hash_attr(ParentHash, "hash", ChildName, ChildHash),

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -20,8 +20,9 @@ MPIS = [
     "multi-provider-mpi",
     "zmpi",
 ]
-COMPILERS = ["gcc", "llvm"]
+COMPILERS = ["gcc", "llvm", "compiler-with-deps"]
 MPI_DEPS = ["fake"]
+COMPILER_DEPS = ["binutils-for-test", "zlib"]
 
 
 @pytest.mark.parametrize(
@@ -30,7 +31,13 @@ MPI_DEPS = ["fake"]
         (["mpileaks"], set(["callpath"] + MPIS + COMPILERS)),
         (
             ["--transitive", "mpileaks"],
-            set(["callpath", "dyninst", "libdwarf", "libelf"] + MPIS + MPI_DEPS + COMPILERS),
+            set(
+                ["callpath", "dyninst", "libdwarf", "libelf"]
+                + MPIS
+                + MPI_DEPS
+                + COMPILERS
+                + COMPILER_DEPS
+            ),
         ),
         (["--transitive", "--deptype=link,run", "dtbuild1"], {"dtlink2", "dtrun2"}),
         (["--transitive", "--deptype=build", "dtbuild1"], {"dtbuild2", "dtlink2"}),

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -570,6 +570,29 @@ class TestConcretize:
             assert x.satisfies("%c=gcc")
             assert "llvm" in x
 
+    def test_compiler_run_dep_link_dep_not_forced(self, temporary_store):
+        """When a compiler is used as a pure build dependency, its transitive run-reachable deps
+        are unified in the build environment, but their pure link-type dependencies must NOT be
+        forced onto the package.
+
+        Scenario: compiler-with-deps has a run+link dep on binutils-for-test, which has a pure
+        link dep on zlib. A package that depends on zlib and uses compiler-with-deps as its C
+        compiler should be free to pick its own zlib (here: zlib@1.2.8) independently of the
+        toolchain's zlib (zlib@1.2.11). Without the fix the imposed hash from binutils-for-test
+        forces the toolchain version onto the package, causing a conflict.
+        """
+        # Pre-install the compiler with its transitive deps binutils-for-test and zlib@1.2.11
+        compiler = spack.concretize.concretize_one("compiler-with-deps ^zlib@1.2.11")
+        assert compiler["zlib"].satisfies("@1.2.11")
+        PackageInstaller([compiler.package], fake=True, explicit=True).install()
+
+        # Concretize a package that depends on a different zlib from its compiler's toolchain.
+        pkg = spack.concretize.concretize_one(
+            "pkg-with-zlib-dep %c=compiler-with-deps ^zlib@1.2.8"
+        )
+
+        assert pkg["zlib"].satisfies("@1.2.8")
+
     def test_disable_mixing_env(
         self, mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mutable_config
     ):

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -52,6 +52,9 @@ def mpileaks_possible_deps(mock_packages, mpi_names, compiler_names):
         "mpileaks": set(["callpath"] + mpi_names + compiler_names),
         "multi-provider-mpi": set(),
         "zmpi": set(["fake"] + compiler_names),
+        "compiler-with-deps": set(["binutils-for-test", "zlib"] + compiler_names),
+        "binutils-for-test": set(["zlib"] + compiler_names),
+        "zlib": set(),
     }
     return possible
 
@@ -85,6 +88,9 @@ def mpi_names(mock_inspector):
                 "mpileaks",
                 "gcc",
                 "llvm",
+                "compiler-with-deps",
+                "binutils-for-test",
+                "zlib",
                 "multi-provider-mpi",
                 "callpath",
                 "dyninst",

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/binutils_for_test/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/binutils_for_test/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class BinutilsForTest(Package):
+    """A mock binutils-like package with a pure link dependency on zlib.
+    Used to test that transitive link-only deps of compiler run-deps are
+    not forced onto packages that use the compiler as a build dependency."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/binutils-for-test-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("c", type="build")
+    depends_on("zlib", type="link")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/compiler_with_deps/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/compiler_with_deps/package.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.compiler import CompilerPackage
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class CompilerWithDeps(CompilerPackage, Package):
+    """A mock compiler that has a run+link dependency on binutils-for-test,
+    which itself has a pure link dependency on zlib. Used to test that
+    transitive link-only deps of compiler run-deps are not forced onto
+    packages that use this compiler as a build dependency."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/compiler-with-deps-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    provides("c")
+
+    depends_on("c", type="build")
+    depends_on("binutils-for-test", type=("run", "link"))
+
+    c_names = ["compiler-with-deps-cc"]
+    compiler_version_regex = r"([0-9.]+)"
+    compiler_version_argument = "--version"
+
+    compiler_wrapper_link_paths = {"c": "compiler-with-deps/cc"}

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/pkg_with_zlib_dep/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/pkg_with_zlib_dep/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class PkgWithZlibDep(Package):
+    """A minimal mock package that depends on C (build) and zlib (link).
+    Used to test that the compiler's transitive link-only deps (reachable
+    through its run-dep binutils-for-test -> zlib) are not forced onto
+    this package's own zlib dependency."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/pkg-with-zlib-dep-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("c", type="build")
+    depends_on("zlib", type="link")


### PR DESCRIPTION
When a compiler is reused as a pure build dependency, its run-reachable
transitive deps are unified in the build environment (they appear in
PATH etc.), but their pure link-type dependencies are local to the
compiler's toolchain and must not be forced onto the package being
built.

Previously, avoid_link_dependency only suppressed direct link-only deps
of the compiler itself. This missed the transitive case: if the compiler
has a run+link dep on binutils and binutils has a pure link dep on zlib,
the imposed hash on zlib from binutils was propagated to the package,
causing an UnsatisfiableSpecError when the package requested a different
zlib version.

Fix: add compiler_non_lib_run_dep/2 rules that compute the full
transitive run-dep closure of non-library compilers, then extend
avoid_link_dependency to suppress hash/edge constraints for pure link
deps at every level of that closure.

asp.py also now includes transitive link deps of reusable compilers as
reusable candidates (not just run deps). This fixes two further issues:

1. A bug under --fresh concretization: when a compiler is also used as
   a link dependency, the transitive link deps should be part of the runtime
   unification set, but previously they were pruned.
2. A O(n^2) complexity bug related to iteration during iteration.
