### PR TITLE
patch: fix patch of dependency in non-builtin repo

### DIFF
--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -523,11 +523,13 @@ class PatchCache:
         if not pkg_class._patches_dependencies:
             return index
 
+        import spack.repo
+
         for deps_by_name in pkg_class.dependencies.values():
             for dependency in deps_by_name.values():
                 for patch_list in dependency.patches.values():
                     for patch in patch_list:
-                        dspec_cls = repository.get_pkg_class(dependency.spec.name)
+                        dspec_cls = spack.repo.PATH.get_pkg_class(dependency.spec.name)
                         patch_dict = patch.to_dict()
                         patch_dict.pop("sha256")  # save some space
                         index[patch.sha256] = {dspec_cls.fullname: patch_dict}

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -505,6 +505,34 @@ def test_sha256_setter(mock_packages, mock_patch_stage, config):
     patch.sha256 = "abc"
 
 
+def test_patch_index_cross_repo_dependency(mock_packages, tmp_path, config):
+    """A package that patches a dependency from another repo should not break
+    the patch index (#51505, #34961)."""
+    # Create a second repo containing only 'patch-a-dependency', which patches 'libelf'.
+    # 'libelf' is only in the builtin_mock repo, not in this second repo.
+    local_root = tmp_path / "spack_repo" / "local_test"
+    local_root.mkdir(parents=True)
+    (local_root / "repo.yaml").write_text("repo:\n  namespace: local_test\n  api: v2.1\n")
+    src = pathlib.Path(spack.paths.mock_packages_path) / "packages" / "patch_a_dependency"
+    shutil.copytree(src, local_root / "packages" / "patch_a_dependency")
+
+    local_repo = spack.repo.from_path(str(local_root))
+
+    # Use local_repo first, then the mock repo (which provides libelf).
+    with spack.repo.use_repositories(local_repo, mock_packages.repos[0], override=True):
+        # Directly call _index_patches on the local repo's package class with
+        # the local repo as repository (as happens when building a single repo's
+        # patch index). This must not fail with UnknownPackageError for 'libelf'.
+        pkg_cls = local_repo.get_pkg_class("patch-a-dependency")
+        index = spack.patch.PatchCache._index_patches(pkg_cls, local_repo)
+        # The index must contain a patch entry whose target is libelf (the cross-repo dep).
+        assert any(
+            "libelf" in fullname
+            for package_to_patch in index.values()
+            for fullname in package_to_patch
+        )
+
+
 def test_invalid_from_dict(mock_packages, config):
     dictionary = {}
     with pytest.raises(ValueError, match="Invalid patch dictionary:"):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/patch/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/patch/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 
 class Patch(Package):
-    """Package that requries a patched version of a dependency."""
+    """Package that requires a patched version of a dependency."""
 
     homepage = "http://www.example.com"
     url = "http://www.example.com/patch-1.0.tar.gz"

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/patch_a_dependency/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/patch_a_dependency/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 
 class PatchADependency(Package):
-    """Package that requries a patched version of a dependency."""
+    """Package that requires a patched version of a dependency."""
 
     homepage = "http://www.example.com"
     url = "http://www.example.com/patch-a-dependency-1.0.tar.gz"


### PR DESCRIPTION
Fixes #51505 by looking at the all the repos.

I could not find a clean way to do this without circular import.
