### PR TITLE
cmd/versions.py: make remote fetch opt-in

### DIFF
--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -20,10 +20,13 @@ level = "long"
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     output = subparser.add_mutually_exclusive_group()
     output.add_argument(
-        "-s", "--safe", action="store_true", help="only list safe versions of the package"
+        "-s",
+        "--safe",
+        action="store_true",
+        help="only list safe versions of the package (default, deprecated)",
     )
     output.add_argument(
-        "-r", "--remote", action="store_true", help="only list remote versions of the package"
+        "-r", "--remote", action="store_true", help="include remote versions of the package"
     )
     output.add_argument(
         "-n",
@@ -41,7 +44,7 @@ def versions(parser, args):
 
     safe_versions = pkg.versions
 
-    if not (args.remote or args.new):
+    if not args.new:
         if sys.stdout.isatty():
             tty.msg("Safe versions (already checksummed):")
 
@@ -53,6 +56,9 @@ def versions(parser, args):
             colify(sorted(safe_versions, reverse=True), indent=2)
 
         if args.safe:
+            tty.warn("--safe is deprecated: it is now the default behavior.")
+
+        if not args.remote:
             return
 
     fetched_versions = pkg.fetch_remote_versions(args.jobs)

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -23,20 +23,21 @@ def _mock_find_versions_of_archive(*args, **kwargs):
 
 
 def test_safe_versions():
-    """Only test the safe versions of a package."""
-    assert versions("--safe", "zlib") == "  1.2.11\n  1.2.8\n  1.2.3\n"
+    """--safe still works but emits a deprecation warning."""
+    out = versions("--safe", "zlib")
+    assert out.startswith("  1.2.11\n  1.2.8\n  1.2.3\n")
+    assert "--safe is deprecated: it is now the default behavior." in out
 
 
-def test_remote_versions(monkeypatch):
-    """Test a package for which remote versions should be available."""
+def test_default_shows_safe_only():
+    """Default behavior: no network access, only safe versions shown."""
+    assert versions("zlib") == "  1.2.11\n  1.2.8\n  1.2.3\n"
+
+
+def test_remote_flag(monkeypatch):
+    """--remote flag shows safe versions and then unchecksummed remote versions."""
     monkeypatch.setattr(spack.url, "find_versions_of_archive", _mock_find_versions_of_archive)
-    assert versions("zlib") == "  1.2.11\n  1.2.8\n  1.2.3\n  1.3.1\n  1.3\n  1.2.13\n"
-
-
-def test_remote_versions_only(monkeypatch):
-    """Test a package for which remote versions should be available."""
-    monkeypatch.setattr(spack.url, "find_versions_of_archive", _mock_find_versions_of_archive)
-    assert versions("--remote", "zlib") == "  1.3.1\n  1.3\n  1.2.13\n"
+    assert versions("--remote", "zlib") == "  1.2.11\n  1.2.8\n  1.2.3\n  1.3.1\n  1.3\n  1.2.13\n"
 
 
 def test_new_versions_only(monkeypatch):
@@ -80,7 +81,7 @@ def test_no_unchecksummed_versions(monkeypatch):
 
     monkeypatch.setattr(spack.url, "find_versions_of_archive", mock_find_versions_of_archive)
 
-    versions("bzip2")
+    versions("--remote", "bzip2")
 
 
 def test_versions_no_url():

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -3388,9 +3388,9 @@ complete -c spack -n '__fish_spack_using_command_pos 0 versions' -f -a '(__fish_
 complete -c spack -n '__fish_spack_using_command versions' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command versions' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command versions' -s s -l safe -f -a safe
-complete -c spack -n '__fish_spack_using_command versions' -s s -l safe -d 'only list safe versions of the package'
+complete -c spack -n '__fish_spack_using_command versions' -s s -l safe -d 'only list safe versions of the package (default, deprecated)'
 complete -c spack -n '__fish_spack_using_command versions' -s r -l remote -f -a remote
-complete -c spack -n '__fish_spack_using_command versions' -s r -l remote -d 'only list remote versions of the package'
+complete -c spack -n '__fish_spack_using_command versions' -s r -l remote -d 'include remote versions of the package'
 complete -c spack -n '__fish_spack_using_command versions' -s n -l new -f -a new
 complete -c spack -n '__fish_spack_using_command versions' -s n -l new -d 'only list remote versions newer than the latest checksummed version'
 complete -c spack -n '__fish_spack_using_command versions' -s j -l jobs -r -f -a jobs


### PR DESCRIPTION
`spack versions <pkg>` performs a remote web crawl by default to discover new package versions. This violates the principle of least surprise (--safe opt in suggests the default is unsafe ;p but just generally surprising to kick of a web crawler running a command that looks a lot like `spack info`)

| Invocation | Before | After |
|---|---|---|
| `spack versions zlib` | safe + remote (network) | safe only (no network) |
| `spack versions --safe zlib` | safe only | safe only + deprecation warning |
| `spack versions --remote zlib` | remote-only (unchecksummed) | safe + remote (network) |
| `spack versions --new zlib` | new remote only | unchanged |
