### PR TITLE
new_installer.py: --verbose in non-TTY mode

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -799,6 +799,7 @@ class BuildStatus:
         get_terminal_size: Callable[[], os.terminal_size] = os.get_terminal_size,
         get_time: Callable[[], float] = time.monotonic,
         is_tty: Optional[bool] = None,
+        verbose: bool = False,
     ) -> None:
         #: Ordered dict of build ID -> info
         self.total = total
@@ -823,6 +824,8 @@ class BuildStatus:
         self.terminal_size_changed: bool = True
         self.get_time = get_time
         self.is_tty = is_tty if is_tty is not None else self.stdout.isatty()
+        #: Verbose mode only applies to non-TTY where we want to track a single build log.
+        self.verbose = verbose and not self.is_tty
 
     def on_resize(self) -> None:
         """Refresh cached terminal size and trigger a redraw."""
@@ -835,6 +838,14 @@ class BuildStatus:
         """Add a new build to the display and mark the display as dirty."""
         self.builds[spec.dag_hash()] = BuildInfo(spec, explicit, control_w_conn)
         self.dirty = True
+        # Track the new build's logs when we're not already following another build. This applies
+        # only in non-TTY verbose mode.
+        if self.verbose and not self.tracked_build_id and control_w_conn is not None:
+            self.tracked_build_id = spec.dag_hash()
+            try:
+                os.write(control_w_conn.fileno(), b"1")
+            except OSError:
+                pass
 
     def toggle(self) -> None:
         """Toggle between overview mode and following a specific build."""
@@ -940,8 +951,12 @@ class BuildStatus:
             self.completed += 1
             build_info.finished_time = self.get_time() + CLEANUP_TIMEOUT
 
-            if build_id == self.tracked_build_id and not self.overview_mode:
-                self.toggle()
+            # Stop tracking the finished build's logs.
+            if build_id == self.tracked_build_id:
+                if not self.overview_mode:
+                    self.toggle()
+                if self.verbose:
+                    self.tracked_build_id = ""
 
         self.dirty = True
 
@@ -1083,9 +1098,8 @@ class BuildStatus:
         # Discard logs we are not following. Generally this should not happen as we tell the child
         # to only send logs when we are following it. It could maybe happen while transitioning
         # between builds.
-        if self.overview_mode or build_id != self.tracked_build_id:
+        if build_id != self.tracked_build_id:
             return
-        # TODO: drop initial bytes from data until first newline (?)
         self.stdout.buffer.write(data)
         self.stdout.flush()
 
@@ -1500,9 +1514,10 @@ class PackageInstaller:
         else:
             self.explicit = explicit
 
+        self.verbose = verbose
         self.running_builds: Dict[int, ChildInfo] = {}
         self.log_paths: Dict[str, str] = {}
-        self.build_status = BuildStatus(len(self.build_graph.nodes))
+        self.build_status = BuildStatus(len(self.build_graph.nodes), verbose=verbose)
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
         if concurrent_packages is None:
             concurrent_packages_config = spack.config.get("config:concurrent_packages", 0)

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -3,15 +3,18 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests for the BuildStatus terminal UI in new_installer.py"""
 
-import io
-import os
 import sys
-from typing import List, Optional, Tuple
 
 import pytest
 
 if sys.platform == "win32":
     pytest.skip("No Windows support", allow_module_level=True)
+
+
+import io
+import os
+from multiprocessing import Pipe
+from typing import List, Optional, Tuple
 
 import spack.new_installer as inst
 from spack.new_installer import BuildStatus
@@ -64,7 +67,11 @@ class SimpleTextIOWrapper(io.TextIOWrapper):
 
 
 def create_build_status(
-    is_tty: bool = True, terminal_cols: int = 80, terminal_rows: int = 24, total: int = 0
+    is_tty: bool = True,
+    terminal_cols: int = 80,
+    terminal_rows: int = 24,
+    total: int = 0,
+    verbose: bool = False,
 ) -> Tuple[BuildStatus, List[float], SimpleTextIOWrapper]:
     """Helper function to create BuildStatus with mocked dependencies"""
     fake_stdout = SimpleTextIOWrapper(tty=is_tty)
@@ -83,6 +90,7 @@ def create_build_status(
         get_terminal_size=mock_get_terminal_size,
         get_time=mock_get_time,
         is_tty=is_tty,
+        verbose=verbose,
     )
 
     return status, time_values, fake_stdout
@@ -1102,3 +1110,97 @@ class TestEdgeCases:
 
         status.update_progress(build_id, 3, 3)
         assert status.builds[build_id].progress_percent == 100
+
+
+class TestBuildStatusVerbose:
+    """Tests for verbose non-TTY log tracking in BuildStatus."""
+
+    def test_verbose_tracks_first_build(self):
+        """First add_build() in verbose non-TTY mode sets tracked_build_id and enables echoing."""
+        bs, _, _ = create_build_status(is_tty=False, verbose=True, total=4)
+        spec = MockSpec("trivial-install-test-package", "1.0")
+
+        r_conn, w_conn = Pipe(duplex=False)
+
+        with r_conn, w_conn:
+            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
+
+            assert bs.tracked_build_id == spec.dag_hash()
+            written = os.read(r_conn.fileno(), 1)
+            assert written == b"1"
+
+    def test_verbose_does_not_track_when_already_tracking(self):
+        """Second add_build() while already tracking does not switch tracking."""
+        bs, _, _ = create_build_status(is_tty=False, verbose=True, total=4)
+        spec1 = MockSpec("pkg1", "1.0")
+        spec2 = MockSpec("pkg2", "1.0")
+
+        r1, w1 = Pipe(duplex=False)
+        r2, w2 = Pipe(duplex=False)
+        with r1, w1, r2, w2:
+            bs.add_build(spec1, explicit=True, control_w_conn=w1)
+            first_tracked = bs.tracked_build_id
+
+            bs.add_build(spec2, explicit=False, control_w_conn=w2)
+            assert bs.tracked_build_id == first_tracked
+            assert bs.tracked_build_id == spec1.dag_hash()
+
+            # Second build should not have received b"1"
+            assert not r2.poll(), "Second build should not be enabled"
+
+    def test_verbose_switches_on_finish(self):
+        """After the tracked build finishes, tracked_build_id is cleared."""
+        bs, _, _ = create_build_status(is_tty=False, verbose=True, total=4)
+        spec = MockSpec("trivial-install-test-package", "1.0")
+
+        r_conn, w_conn = Pipe(duplex=False)
+
+        with r_conn, w_conn:
+            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
+            assert bs.tracked_build_id == spec.dag_hash()
+
+            bs.update_state(spec.dag_hash(), "finished")
+            assert bs.tracked_build_id == ""
+
+    def test_verbose_print_logs_tracked(self):
+        """print_logs() for the tracked build writes to stdout."""
+        bs, _, stdout = create_build_status(is_tty=False, verbose=True, total=1)
+        spec = MockSpec("trivial-install-test-package", "1.0")
+
+        r_conn, w_conn = Pipe(duplex=False)
+
+        with r_conn, w_conn:
+            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
+            bs.print_logs(spec.dag_hash(), b"hello log\n")
+
+            stdout.flush()
+            assert stdout.buffer.getvalue() == b"hello log\n"
+
+    def test_verbose_print_logs_untracked(self):
+        """print_logs() for an untracked build discards data."""
+        bs, _, stdout = create_build_status(is_tty=False, verbose=True, total=2)
+        spec1 = MockSpec("pkg1", "1.0")
+        spec2 = MockSpec("pkg2", "1.0")
+
+        r1, w1 = Pipe(duplex=False)
+
+        with r1, w1:
+            bs.add_build(spec1, explicit=True, control_w_conn=w1)
+            bs.add_build(spec2, explicit=False, control_w_conn=None)
+
+            # Only spec1 is tracked; spec2 logs should be discarded
+            bs.print_logs(spec2.dag_hash(), b"ignored\n")
+
+            stdout.flush()
+            assert stdout.buffer.getvalue() == b""
+
+    def test_verbose_tty_no_effect(self):
+        """In TTY mode, add_build() does not set tracked_build_id automatically."""
+        bs, _, _ = create_build_status(is_tty=True, verbose=True, total=4)
+        spec = MockSpec("trivial-install-test-package", "1.0")
+
+        r_conn, w_conn = Pipe(duplex=False)
+
+        with r_conn, w_conn:
+            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
+            assert bs.tracked_build_id == ""


### PR DESCRIPTION
This adds support for `spack install --verbose` in non-TTY mode.
So, `spack install --verbose ... | tee` for those reviewing.

I've ultimately decided to go for the following strategy, which balances
readability and troubleshootability:

* Follow logs of one build and one build only
* Always follow a build from start to finish, never half-way the process
* For concurrent builds: only print install phase state changes as a
  single line, interleaved with the active build's logs.

In the case of `spack install --verbose -p1` this choice results in the
same output as people were used to from the old installer before package
parallelism

Note 1: on build failure, Spack dumps a summary of the build log. So
if a build log was not "tracked" with --verbose, you'll see its errors still.
Just in the success case you won't see *all* parallel build logs -- too bad.

Note 2: `--verbose` is intentionally ignored in the interactive case. The user
lands in the overview mode like normal.