### PR TITLE
new_installer.py: integration testing

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -274,27 +274,21 @@ class GlobalState:
 
     __slots__ = ("store", "config", "monkey_patches", "spack_working_dir")
 
-    if multiprocessing.get_start_method() == "fork":
+    def __init__(self):
+        if multiprocessing.get_start_method() == "fork":
+            return
+        self.config = spack.config.CONFIG.ensure_unwrapped()
+        self.store = spack.store.STORE
+        self.monkey_patches = spack.subprocess_context.TestPatches.create()
+        self.spack_working_dir = spack.paths.spack_working_dir
 
-        def __init__(self):
-            pass
-
-        def restore(self):
-            pass
-
-    else:
-
-        def __init__(self):
-            self.config = spack.config.CONFIG.ensure_unwrapped()
-            self.store = spack.store.STORE
-            self.monkey_patches = spack.subprocess_context.TestPatches.create()
-            self.spack_working_dir = spack.paths.spack_working_dir
-
-        def restore(self):
-            spack.store.STORE = self.store
-            spack.config.CONFIG = self.config
-            self.monkey_patches.restore()
-            spack.paths.spack_working_dir = self.spack_working_dir
+    def restore(self):
+        if multiprocessing.get_start_method() == "fork":
+            return
+        spack.store.STORE = self.store
+        spack.config.CONFIG = self.config
+        self.monkey_patches.restore()
+        spack.paths.spack_working_dir = self.spack_working_dir
 
 
 class PrefixPivoter:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -24,6 +24,7 @@ import fcntl
 import glob
 import io
 import json
+import multiprocessing
 import os
 import re
 import selectors
@@ -71,11 +72,12 @@ import spack.report
 import spack.spec
 import spack.stage
 import spack.store
+import spack.subprocess_context
 import spack.traverse
 import spack.url_buildcache
 import spack.util.environment
 import spack.util.lock
-from spack.installer import dump_packages
+from spack.installer import _do_fake_install, dump_packages
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -265,6 +267,36 @@ def install_from_buildcache(
     return True
 
 
+class GlobalState:
+    """Global state needed in a build subprocess. This is similar to spack.subprocess_context,
+    but excludes the Spack environment, which is slow to serialize and should not be needed
+    during the build."""
+
+    __slots__ = ("store", "config", "monkey_patches", "spack_working_dir")
+
+    if multiprocessing.get_start_method() == "fork":
+
+        def __init__(self):
+            pass
+
+        def restore(self):
+            pass
+
+    else:
+
+        def __init__(self):
+            self.config = spack.config.CONFIG.ensure_unwrapped()
+            self.store = spack.store.STORE
+            self.monkey_patches = spack.subprocess_context.TestPatches.create()
+            self.spack_working_dir = spack.paths.spack_working_dir
+
+        def restore(self):
+            spack.store.STORE = self.store
+            spack.config.CONFIG = self.config
+            self.monkey_patches.restore()
+            spack.paths.spack_working_dir = self.spack_working_dir
+
+
 class PrefixPivoter:
     """Manages the installation prefix of a build."""
 
@@ -349,15 +381,15 @@ def worker_function(
     restage: bool,
     keep_prefix: bool,
     skip_patch: bool,
+    fake: bool,
     state: Connection,
     parent: Connection,
     echo_control: Connection,
     makeflags: str,
     js1: Optional[Connection],
     js2: Optional[Connection],
-    store: spack.store.Store,
-    config: spack.config.Configuration,
     log_path: str,
+    global_state: GlobalState,
 ):
     """
     Function run in the build child process. Installs the specified spec, sending state updates
@@ -380,14 +412,15 @@ def worker_function(
         makeflags: MAKEFLAGS to set, so that the build process uses the POSIX jobserver
         js1: Connection for old style jobserver read fd (if any). Unused, just to inherit fd.
         js2: Connection for old style jobserver write fd (if any). Unused, just to inherit fd.
-        store: global store instance from parent
-        config: global config instance from parent
         log_path: Path to the log file to write build output to
+        global_state: Global state to restore
     """
 
     # TODO: don't start a build for external packages
     if spec.external:
         return
+
+    global_state.restore()
 
     # Start a new session, so our SIGTERM handler can kill all child processes.
     os.setsid()
@@ -406,9 +439,6 @@ def worker_function(
     signal.signal(signal.SIGTERM, handle_sigterm)
 
     os.environ["MAKEFLAGS"] = makeflags
-    spack.store.STORE = store
-    spack.config.CONFIG = config
-    spack.paths.set_working_dir()
 
     # Open the log file created by the parent process.
     log_fd = os.open(log_path, os.O_WRONLY | os.O_TRUNC, 0o644)
@@ -430,9 +460,10 @@ def worker_function(
                 keep_stage,
                 restage,
                 skip_patch,
+                fake,
                 state_stream,
                 log_path,
-                store,
+                spack.store.STORE,
             )
     except Exception:
         traceback.print_exc()  # log the traceback to the log file
@@ -535,6 +566,7 @@ def _install(
     keep_stage: bool,
     restage: bool,
     skip_patch: bool,
+    fake: bool,
     state_stream: io.TextIOWrapper,
     log_path: str,
     store: spack.store.Store = spack.store.STORE,
@@ -543,6 +575,12 @@ def _install(
 
     # Create the stage and log file before starting the tee thread.
     pkg = spec.package
+
+    if fake:
+        store.layout.create_install_directory(spec)
+        _do_fake_install(pkg)
+        spack.hooks.post_install(spec, explicit)
+        return
 
     # Try to install from buildcache, unless user asked for source only
     if install_policy != "source_only":
@@ -721,6 +759,7 @@ def start_build(
     restage: bool,
     keep_prefix: bool,
     skip_patch: bool,
+    fake: bool,
     jobserver: JobServer,
 ) -> ChildInfo:
     """Start a new build."""
@@ -759,15 +798,15 @@ def start_build(
             restage,
             keep_prefix,
             skip_patch,
+            fake,
             state_w_conn,
             output_w_conn,
             control_r_conn,
             makeflags,
             None if fifo else jobserver.r_conn,
             None if fifo else jobserver.w_conn,
-            spack.store.STORE,
-            spack.config.CONFIG,
             log_path,
+            GlobalState(),
         ),
     )
     proc.start()
@@ -1537,9 +1576,7 @@ class PackageInstaller:
     ) -> None:
         assert install_package or install_deps, "Must install package, dependencies or both"
 
-        if fake:
-            raise NotImplementedError("Fake installs are not implemented")
-        elif install_source:
+        if install_source:
             raise NotImplementedError("Installing sources is not implemented")
         elif stop_at is not None:
             raise NotImplementedError("Stopping at an install phase is not implemented")
@@ -1585,6 +1622,7 @@ class PackageInstaller:
         }
         self.unsigned = unsigned
         self.dirty = dirty
+        self.fake = fake
         self.restage = restage
         self.keep_stage = keep_stage
         self.skip_patch = skip_patch
@@ -1940,6 +1978,7 @@ class PackageInstaller:
             restage=self.restage and not is_develop,
             keep_prefix=self.keep_prefix,
             skip_patch=self.skip_patch,
+            fake=self.fake,
             jobserver=jobserver,
         )
         self.log_paths[dag_hash] = child_info.log_path

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -196,7 +196,9 @@ def test_dev_build_can_parse_path_with_at_symbol(tmp_path: pathlib.Path, install
     assert spec.package.filename in os.listdir(spec.prefix)
 
 
-def test_dev_build_env(tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path):
+def test_dev_build_env(
+    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, installer_variant
+):
     """Test Spack does dev builds for packages in develop section of env."""
     # setup dev-build-test-install package for dev build
     build_dir = tmp_path / "build"
@@ -236,7 +238,7 @@ spack:
 
 
 def test_dev_build_env_with_vars(
-    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, monkeypatch
+    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, monkeypatch, installer_variant
 ):
     """Test Spack does dev builds for packages in develop section of env (path with variables)."""
     # setup dev-build-test-install package for dev build
@@ -279,7 +281,7 @@ spack:
 
 
 def test_dev_build_env_version_mismatch(
-    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path
+    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, installer_variant
 ):
     """Test Spack constraints concretization by develop specs."""
     # setup dev-build-test-install package for dev build

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -514,7 +514,7 @@ def test_env_install_all(install_mockery, mock_fetch):
     assert spec.installed
 
 
-def test_env_install_single_spec(install_mockery, mock_fetch):
+def test_env_install_single_spec(install_mockery, mock_fetch, installer_variant):
     env("create", "test")
     install = SpackCommand("install")
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -277,7 +277,9 @@ def test_install_commit(mock_git_version_info, install_mockery, mock_packages, m
     assert content == "[0]"  # contents are weird for another test
 
 
-def test_install_overwrite_multiple(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_install_overwrite_multiple(
+    mock_packages, mock_archive, mock_fetch, install_mockery, installer_variant
+):
     # Try to install a spec and then to reinstall it.
     libdwarf = spack.concretize.concretize_one("libdwarf")
     cmake = spack.concretize.concretize_one("cmake")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2582,3 +2582,12 @@ def reset_extension_paths():
     spack.extensions.extension_paths_from_entry_points.cache_clear()
     yield
     spack.extensions.extension_paths_from_entry_points.cache_clear()
+
+
+@pytest.fixture(params=["old", "new"])
+def installer_variant(request):
+    """Parametrize a test over the old and new installer."""
+    if request.param == "new" and sys.platform == "win32":
+        pytest.skip("New installer not supported on Windows")
+    with spack.config.override("config:installer", request.param):
+        yield request.param


### PR DESCRIPTION
* Mimic GlobalStateMarshaller when creating the build subprocess to support monkeypatching in the build process, but
   1. drop the unnecessary `pkg` serialization bits since the new installer passes specs
   2. do not serialize the active env, which shouldn't be needed
* Add support for `--fake` used in tests.
* Enable some unit tests for the new installer by parametrizing the installer config (old/new).