### PR TITLE
new_installer.py: add --fake

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -77,7 +77,7 @@ import spack.traverse
 import spack.url_buildcache
 import spack.util.environment
 import spack.util.lock
-from spack.installer import dump_packages
+from spack.installer import _do_fake_install, dump_packages
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -375,6 +375,7 @@ def worker_function(
     restage: bool,
     keep_prefix: bool,
     skip_patch: bool,
+    fake: bool,
     state: Connection,
     parent: Connection,
     echo_control: Connection,
@@ -453,6 +454,7 @@ def worker_function(
                 keep_stage,
                 restage,
                 skip_patch,
+                fake,
                 state_stream,
                 log_path,
                 spack.store.STORE,
@@ -558,6 +560,7 @@ def _install(
     keep_stage: bool,
     restage: bool,
     skip_patch: bool,
+    fake: bool,
     state_stream: io.TextIOWrapper,
     log_path: str,
     store: spack.store.Store = spack.store.STORE,
@@ -566,6 +569,12 @@ def _install(
 
     # Create the stage and log file before starting the tee thread.
     pkg = spec.package
+
+    if fake:
+        store.layout.create_install_directory(spec)
+        _do_fake_install(pkg)
+        spack.hooks.post_install(spec, explicit)
+        return
 
     # Try to install from buildcache, unless user asked for source only
     if install_policy != "source_only":
@@ -744,6 +753,7 @@ def start_build(
     restage: bool,
     keep_prefix: bool,
     skip_patch: bool,
+    fake: bool,
     jobserver: JobServer,
 ) -> ChildInfo:
     """Start a new build."""
@@ -778,6 +788,7 @@ def start_build(
             restage,
             keep_prefix,
             skip_patch,
+            fake,
             state_w_conn,
             output_w_conn,
             control_r_conn,
@@ -1555,9 +1566,7 @@ class PackageInstaller:
     ) -> None:
         assert install_package or install_deps, "Must install package, dependencies or both"
 
-        if fake:
-            raise NotImplementedError("Fake installs are not implemented")
-        elif install_source:
+        if install_source:
             raise NotImplementedError("Installing sources is not implemented")
         elif stop_at is not None:
             raise NotImplementedError("Stopping at an install phase is not implemented")
@@ -1603,6 +1612,7 @@ class PackageInstaller:
         }
         self.unsigned = unsigned
         self.dirty = dirty
+        self.fake = fake
         self.restage = restage
         self.keep_stage = keep_stage
         self.skip_patch = skip_patch
@@ -1958,6 +1968,7 @@ class PackageInstaller:
             restage=self.restage and not is_develop,
             keep_prefix=self.keep_prefix,
             skip_patch=self.skip_patch,
+            fake=self.fake,
             jobserver=jobserver,
         )
         self.log_paths[dag_hash] = child_info.log_path

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -24,6 +24,7 @@ import fcntl
 import glob
 import io
 import json
+import multiprocessing
 import os
 import re
 import selectors
@@ -71,6 +72,7 @@ import spack.report
 import spack.spec
 import spack.stage
 import spack.store
+import spack.subprocess_context
 import spack.traverse
 import spack.url_buildcache
 import spack.util.environment
@@ -259,6 +261,36 @@ def install_from_buildcache(
     return True
 
 
+class GlobalState:
+    """Global state needed in a build subprocess. This is similar to spack.subprocess_context,
+    but excludes the Spack environment, which is slow to serialize and should not be needed
+    during the build."""
+
+    __slots__ = ("store", "config", "monkey_patches", "spack_working_dir")
+
+    if multiprocessing.get_start_method() == "fork":
+
+        def __init__(self):
+            pass
+
+        def restore(self):
+            pass
+
+    else:
+
+        def __init__(self):
+            self.config = spack.config.CONFIG.ensure_unwrapped()
+            self.store = spack.store.STORE
+            self.monkey_patches = spack.subprocess_context.TestPatches.create()
+            self.spack_working_dir = spack.paths.spack_working_dir
+
+        def restore(self):
+            spack.store.STORE = self.store
+            spack.config.CONFIG = self.config
+            self.monkey_patches.restore()
+            spack.paths.spack_working_dir = self.spack_working_dir
+
+
 class PrefixPivoter:
     """Manages the installation prefix of a build."""
 
@@ -349,9 +381,8 @@ def worker_function(
     makeflags: str,
     js1: Optional[Connection],
     js2: Optional[Connection],
-    store: spack.store.Store,
-    config: spack.config.Configuration,
     log_path: str,
+    global_state: GlobalState,
 ):
     """
     Function run in the build child process. Installs the specified spec, sending state updates
@@ -374,14 +405,15 @@ def worker_function(
         makeflags: MAKEFLAGS to set, so that the build process uses the POSIX jobserver
         js1: Connection for old style jobserver read fd (if any). Unused, just to inherit fd.
         js2: Connection for old style jobserver write fd (if any). Unused, just to inherit fd.
-        store: global store instance from parent
-        config: global config instance from parent
         log_path: Path to the log file to write build output to
+        global_state: Global state to restore
     """
 
     # TODO: don't start a build for external packages
     if spec.external:
         return
+
+    global_state.restore()
 
     # Start a new session, so our SIGTERM handler can kill all child processes.
     os.setsid()
@@ -400,9 +432,6 @@ def worker_function(
     signal.signal(signal.SIGTERM, handle_sigterm)
 
     os.environ["MAKEFLAGS"] = makeflags
-    spack.store.STORE = store
-    spack.config.CONFIG = config
-    spack.paths.set_working_dir()
 
     # Open the log file created by the parent process.
     log_fd = os.open(log_path, os.O_WRONLY | os.O_TRUNC, 0o644)
@@ -426,7 +455,7 @@ def worker_function(
                 skip_patch,
                 state_stream,
                 log_path,
-                store,
+                spack.store.STORE,
             )
     except Exception:
         traceback.print_exc()  # log the traceback to the log file
@@ -755,9 +784,8 @@ def start_build(
             makeflags,
             None if fifo else jobserver.r_conn,
             None if fifo else jobserver.w_conn,
-            spack.store.STORE,
-            spack.config.CONFIG,
             log_path,
+            GlobalState(),
         ),
     )
     proc.start()

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -196,7 +196,9 @@ def test_dev_build_can_parse_path_with_at_symbol(tmp_path: pathlib.Path, install
     assert spec.package.filename in os.listdir(spec.prefix)
 
 
-def test_dev_build_env(tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path):
+def test_dev_build_env(
+    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, installer_variant
+):
     """Test Spack does dev builds for packages in develop section of env."""
     # setup dev-build-test-install package for dev build
     build_dir = tmp_path / "build"
@@ -236,7 +238,7 @@ spack:
 
 
 def test_dev_build_env_with_vars(
-    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, monkeypatch
+    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, monkeypatch, installer_variant
 ):
     """Test Spack does dev builds for packages in develop section of env (path with variables)."""
     # setup dev-build-test-install package for dev build
@@ -279,7 +281,7 @@ spack:
 
 
 def test_dev_build_env_version_mismatch(
-    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path
+    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, installer_variant
 ):
     """Test Spack constraints concretization by develop specs."""
     # setup dev-build-test-install package for dev build
@@ -318,7 +320,7 @@ spack:
 
 
 def test_dev_build_multiple(
-    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, mock_fetch
+    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, mock_fetch, installer_variant
 ):
     """Test spack install with multiple developer builds
 
@@ -387,7 +389,7 @@ spack:
 
 
 def test_dev_build_env_dependency(
-    tmp_path: pathlib.Path, install_mockery, mock_fetch, mutable_mock_env_path
+    tmp_path: pathlib.Path, install_mockery, mock_fetch, mutable_mock_env_path, installer_variant
 ):
     """
     Test non-root specs in an environment are properly marked for dev builds.

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2582,3 +2582,12 @@ def reset_extension_paths():
     spack.extensions.extension_paths_from_entry_points.cache_clear()
     yield
     spack.extensions.extension_paths_from_entry_points.cache_clear()
+
+
+@pytest.fixture(params=["old", "new"])
+def installer_variant(request):
+    """Parametrize a test over the old and new installer."""
+    if request.param == "new" and sys.platform == "win32":
+        pytest.skip("New installer not supported on Windows")
+    with spack.config.override("config:installer", request.param):
+        yield request.param


### PR DESCRIPTION
I wanted to avoid adding support for `--fake`, but it's used so much in the
tests that it's hard not to.

