### PR TITLE
new_installer.py: no log file for externals

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -735,12 +735,16 @@ def start_build(
     makeflags = jobserver.makeflags(gmake)
     fifo = "--jobserver-auth=fifo:" in makeflags
 
-    log_fd, log_path = tempfile.mkstemp(
-        prefix=f"spack-stage-{spec.name}-{spec.version}-{spec.dag_hash()}-",
-        suffix=".log",
-        dir=spack.stage.get_stage_root(),
-    )
-    os.close(log_fd)  # child will open it
+    # TODO: remove once external specs do not create a build process
+    if spec.external:
+        log_path = os.devnull
+    else:
+        log_fd, log_path = tempfile.mkstemp(
+            prefix=f"spack-stage-{spec.name}-{spec.version}-{spec.dag_hash()}-",
+            suffix=".log",
+            dir=spack.stage.get_stage_root(),
+        )
+        os.close(log_fd)  # child will open it
 
     proc = Process(
         target=worker_function,


### PR DESCRIPTION
Don't create a log file for externals.

(part of the existing TODO of not creating a subprocess for externals)

