### PR TITLE
package_base.py: unit_test_check is not public API

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1357,8 +1357,8 @@ class BuildTask(Task):
             self.fail(self.error_result)
 
         # hook that allows tests to inspect the Package before installation
-        # see unit_test_check() docs.
-        if not pkg.unit_test_check():
+        # see _unit_test_check() docs.
+        if not pkg._unit_test_check():
             self.succeed()
             return ExecuteResult.FAILED
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2041,8 +2041,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         self.tester.stand_alone_tests(kwargs, timeout=timeout)
 
-    def unit_test_check(self) -> bool:
-        """Hook for unit tests to assert things about package internals.
+    def _unit_test_check(self) -> bool:
+        """Hook for Spack's own unit tests to assert things about package internals.
 
         Unit tests can override this function to perform checks after
         ``Package.install`` and all post-install hooks run, but before

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -81,19 +81,19 @@ def _check_runtests_all(pkg):
 
 @pytest.mark.disable_clean_stage_check
 def test_install_runtests_notests(monkeypatch, mock_packages, install_mockery):
-    monkeypatch.setattr(spack.package_base.PackageBase, "unit_test_check", _check_runtests_none)
+    monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_none)
     install("-v", "dttop")
 
 
 @pytest.mark.disable_clean_stage_check
 def test_install_runtests_root(monkeypatch, mock_packages, install_mockery):
-    monkeypatch.setattr(spack.package_base.PackageBase, "unit_test_check", _check_runtests_dttop)
+    monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_dttop)
     install("--test=root", "dttop")
 
 
 @pytest.mark.disable_clean_stage_check
 def test_install_runtests_all(monkeypatch, mock_packages, install_mockery):
-    monkeypatch.setattr(spack.package_base.PackageBase, "unit_test_check", _check_runtests_all)
+    monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_all)
     install("--test=all", "pkg-a")
 
 


### PR DESCRIPTION
This function exists for the purpose of unit tests; it looks a lot like
a hook to be used in spack-packages, which is rather unfortunate.

Make it private.

