### PR TITLE
package_hash: remove methods for spec detection from hash computation

### DIFF
--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -336,12 +336,56 @@ def test_remove_complex_package_logic_filtered():
     assert unparsed == complex_package_logic_filtered
 
 
+detection_logic_tests = {
+    "only_detection_logic": """\
+class OnlyDetectionLogic:
+    def determine_version():
+        foo=bar
+    def determine_variants():
+        pass
+    def determine_spec_details():
+        print("detection")
+""",
+    "only_detection_canonical": """\
+class OnlyDetectionLogic:
+    pass
+""",
+    "with_detection_logic": """\
+class WithDetectionLogic:
+    def determine_spec_details():
+        print()
+    def install(self, spec, prefix):
+        assert True
+""",
+    "with_detection_canonical": """\
+class WithDetectionLogic:
+
+    def install(self, spec, prefix):
+        assert True
+""",
+}
+
+
+@pytest.mark.parametrize("name", ["only_detection", "with_detection"])
+def test_remove_detection_logic(name):
+    full_name = name + "_logic"
+    filtered_name = name + "_canonical"
+
+    tree = ast.parse(detection_logic_tests[full_name])
+    spec = Spec(full_name)
+    tree = ph.RemoveDetectionMethods().visit(tree)
+    unparsed = unparse(tree, py_ver_consistent=True)
+
+    assert unparsed == detection_logic_tests[filtered_name]
+
+
 @pytest.mark.parametrize(
     "package_spec,expected_hash",
     [
         ("amdfftw", "tivb752zddjgvfkogfs7cnnvp5olj6co"),
         ("grads", "lomrsppasfxegyamz4r33zgwiqkveftv"),
-        ("llvm", "paicamlvy5jkgxw4xnacaxahrixe3f3i"),
+        # has external detection methods
+        ("llvm", "6myp3rc2ylhus46ubphmwlpkogf2w3m6"),
         # has @when("@4.1.0") and raw unicode literals
         ("mfem", "slf5qyyyhuj66mo5lpuhkrs35akh2zck"),
         ("mfem@4.0.0", "slf5qyyyhuj66mo5lpuhkrs35akh2zck"),

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -372,9 +372,8 @@ def test_remove_detection_logic(name):
     filtered_name = name + "_canonical"
 
     tree = ast.parse(detection_logic_tests[full_name])
-    spec = Spec(full_name)
-    tree = ph.RemoveDetectionMethods().visit(tree)
-    unparsed = unparse(tree, py_ver_consistent=True)
+    filtered_tree = ph.RemoveDetectionMethods().visit(tree)
+    unparsed = unparse(filtered_tree, py_ver_consistent=True)
 
     assert unparsed == detection_logic_tests[filtered_name]
 

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -170,6 +170,37 @@ class RemoveDirectives(ast.NodeTransformer):
         return node
 
 
+EXTERNAL_DETECTION_METHODS = (
+    "determine_version",
+    "determine_variants",
+    "determine_spec_details",
+    "validate_detected_spec",
+    "filter_detected_exes",
+)
+
+
+class RemoveDetectionMethods(ast.NodeTransformer):
+    """Removes methods that are only used for external detection
+
+    These methods affect the external spec and are already represented through that
+    spec in dag_hash, without needing to be included in the package_hash."""
+
+    def visit_FunctionDef(self, node):
+        if node.name in EXTERNAL_DETECTION_METHODS:
+            return None
+        return node
+
+    def visit_ClassDef(self, node):
+        self.generic_visit(node)
+
+        # replace class definition with `pass` if it's empty (e.g., child class that
+        # only overrides detection methods)
+        if not node.body:
+            node.body = [ast.Pass()]
+
+        return node
+
+
 def _is_when_decorator(node: ast.Call) -> bool:
     """Check if the node is a @when decorator."""
     return isinstance(node.func, ast.Name) and node.func.id == "when" and len(node.args) == 1
@@ -382,6 +413,9 @@ def package_ast(
     # remove docstrings, comments, and directives from the package AST
     root = RemoveDocstrings().visit(root)
     root = RemoveDirectives(spec).visit(root)
+
+    # remove methods for external spec detection from the package AST
+    root = RemoveDetectionMethods().visit(root)
 
     if filter_multimethods:
         # visit nodes and build up a dictionary of methods (no need to assign)


### PR DESCRIPTION
Currently, modification to the external detection method changes the package hash and requires rebuilds in CI. This is particularly impactful for gcc, which causes rebuilds of the entire CI stack.

In this PR: We remove the 5 package methods used in external detection from the package AST when computing the package hash. These are:

* filter_detected_exes
* determine_spec_details
* determine_version
* determine_variants
* validate_detected_spec

This will not avoid package hash changes for methods that are only called from detection methods.

@tgamblin @alalazo and others may be interested as well.

Note: This will result in a complete rebuild in CI on spack/spack-packages when we update to a commit including this.
