### PR TITLE
spack checksum/versions --new: include minor/patch

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -14,6 +14,7 @@ import spack.spec
 import spack.stage
 import spack.util.web as web_util
 from spack.cmd.common import arguments
+from spack.cmd.versions import new_versions
 from spack.llnl.util import tty
 from spack.package_base import (
     ManualDownloadRequiredError,
@@ -50,6 +51,13 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         action="store_true",
         default=False,
         help="checksum the latest available version",
+    )
+    subparser.add_argument(
+        "--new",
+        "-n",
+        action="store_true",
+        default=False,
+        help="checksum remote versions newer than the known versions",
     )
     subparser.add_argument(
         "--preferred",
@@ -104,6 +112,11 @@ def checksum(parser, args):
         remote_versions = pkg.fetch_remote_versions(concurrency=args.jobs)
         if len(remote_versions) > 0:
             versions.append(max(remote_versions.keys()))
+
+    # Add new versions (including major, minor, patch)
+    if args.new:
+        remote_versions = pkg.fetch_remote_versions(concurrency=args.jobs)
+        versions.extend(new_versions(pkg.versions, remote_versions))
 
     # Add preferred version if requested (todo: exclude git versions)
     if args.preferred:

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -51,9 +51,9 @@ def new_versions(
     numeric_safe = [v for v in safe_versions if not v.isdevelop()]
     fetched_list = sorted((v for v in fetched_versions if not v.isdevelop()), reverse=True)
 
-    # Prefixes of the form (3,), (3, 14), (3, 14, 3).
+    # Prefixes of the form (3,), (3, 14), etc.
     prefixes: Set[tuple] = {
-        v.version[0][:n] for v in numeric_safe for n in range(1, len(v.version[0]) + 1)
+        v.version[0][:n] for v in numeric_safe for n in range(1, len(v.version[0]))
     }
     # Look for new major versions (empty prefix).
     prefixes.add(())

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -4,13 +4,14 @@
 
 import argparse
 import sys
+from typing import Any, Dict, Set
 
 import spack.llnl.util.tty as tty
 import spack.repo
 import spack.spec
 from spack.cmd.common import arguments
 from spack.llnl.util.tty.colify import colify
-from spack.version import infinity_versions, ver
+from spack.version import StandardVersion
 
 description = "list available versions of a package"
 section = "query"
@@ -29,9 +30,43 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "-n",
         "--new",
         action="store_true",
-        help="only list remote versions newer than the latest checksummed version",
+        help="only list remote versions newer than the checksummed versions",
     )
     arguments.add_common_arguments(subparser, ["package", "jobs"])
+
+
+def new_versions(
+    safe_versions: Dict[StandardVersion, Any], fetched_versions: Dict[StandardVersion, Any]
+) -> Set[StandardVersion]:
+    """Return the newest remote version in each version prefix branch not yet checksummed.
+
+    For every unique component-prefix derived from ``safe_versions`` (plus the empty prefix that
+    catches entirely new major series), pick the largest version in ``fetched_versions`` whose
+    release tuple starts with that prefix. Versions already in ``safe_versions`` are excluded.
+
+    For example, if the versions {3.14.3, 3.13.1} are checksummed, their corresponding prefixes
+    are the set ``{(), (3,), (3, 14), (3, 13)}``. From those, remote candidates
+    ``{4.0.0, 3.15.0, 3.14.4, 3.13.2}`` would be returned (new major, minor and patch versions).
+    """
+    numeric_safe = [v for v in safe_versions if not v.isdevelop()]
+    fetched_list = sorted((v for v in fetched_versions if not v.isdevelop()), reverse=True)
+
+    # Prefixes of the form (3,), (3, 14), (3, 14, 3).
+    prefixes: Set[tuple] = {
+        v.version[0][:n] for v in numeric_safe for n in range(1, len(v.version[0]) + 1)
+    }
+    # Look for new major versions (empty prefix).
+    prefixes.add(())
+
+    result: Set[StandardVersion] = set()
+    for prefix in prefixes:
+        n = len(prefix)
+        for v in fetched_list:
+            if v.version[0][:n] == prefix:
+                if v not in safe_versions:
+                    result.add(v)
+                break
+    return result
 
 
 def versions(parser, args):
@@ -60,11 +95,7 @@ def versions(parser, args):
     if args.new:
         if sys.stdout.isatty():
             tty.msg("New remote versions (not yet checksummed):")
-        numeric_safe_versions = list(
-            filter(lambda v: str(v) not in infinity_versions, safe_versions)
-        )
-        highest_safe_version = max(numeric_safe_versions)
-        remote_versions = set([ver(v) for v in set(fetched_versions) if v > highest_safe_version])
+        remote_versions = new_versions(safe_versions, fetched_versions)
     else:
         if sys.stdout.isatty():
             tty.msg("Remote versions (not yet checksummed):")

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -322,6 +322,39 @@ def test_checksum_verification_fails(default_mock_concretization, capfd, can_fet
     assert "Invalid checksum" in out
 
 
+def test_checksum_new(mock_packages, no_add, monkeypatch):
+    """--new checksums only the newest version in each branch derived from known versions."""
+    from spack_repo.builtin_mock.packages.brillig.package import Brillig  # type: ignore[import]
+
+    safe = {Version("3.2"): {}, Version("1.0.0"): {}}
+    remote = {
+        Version("99.99.99"): "https://example.com/brillig-99.99.99.tar.gz",  # new in () bucket
+        Version("3.2.1"): "https://example.com/brillig-3.2.1.tar.gz",  # new in (3,) bucket
+        Version("3.2"): "https://example.com/brillig-3.2.tar.gz",
+        Version("1.2.0"): "https://example.com/brillig-1.2.0.tar.gz",  # new in (1,) bucket
+        Version("1.1.0"): "https://example.com/brillig-1.1.0.tar.gz",
+        Version("1.0.1"): "https://example.com/brillig-1.0.1.tar.gz",  # new in (1, 0) bucket
+        Version("1.0.0"): "https://example.com/brillig-1.0.0.tar.gz",
+    }
+    expected_new = {Version("99.99.99"), Version("3.2.1"), Version("1.2.0"), Version("1.0.1")}
+
+    monkeypatch.setattr(Brillig, "versions", safe)
+    monkeypatch.setattr(Brillig, "fetch_remote_versions", lambda self, concurrency: remote)
+
+    checksummed: set = set()
+
+    def get_checksums_for_versions(url_by_version, package_name, **kwargs):
+        checksummed.update(url_by_version.keys())
+        return {v: "abc" * 21 + "ab" for v in url_by_version}
+
+    monkeypatch.setattr(spack.stage, "get_checksums_for_versions", get_checksums_for_versions)
+    monkeypatch.setattr(spack.util.web, "url_exists", lambda url, curl=None: True)
+
+    spack_checksum("--new", "--batch", "brillig")
+
+    assert checksummed == expected_new
+
+
 def test_checksum_manual_download_fails(mock_packages, monkeypatch):
     """Confirm that checksumming a manually downloadable package fails."""
     name = "zlib"

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -55,7 +55,7 @@ def test_new_versions_utility():
         v("1.0.0"): {},  # already checksummed
         v("0.1.0"): {},  # loses to 99.99.99 in the () bucket
     }
-    expected = {v("99.99.99"), v("3.3.0"), v("3.2.1"), v("1.2.0"), v("1.0.1")}
+    expected = {v("99.99.99"), v("3.3.0"), v("1.2.0"), v("1.0.1")}
     assert new_versions(safe, fetched) == expected
 
 
@@ -67,10 +67,9 @@ def test_new_versions_only(monkeypatch):
         mock_remote_versions = {
             # new version, we expect this to be in output:
             Version("99.99.99"): {},  # new major version in the () bucket
-            Version("3.3.0"): {},  # new minor version in the (3,) bucket
             # some packages use '3.2' equivalently to '3.2.0'
             # thus '3.2.1' is considered to be a new version
-            Version("3.2.1"): {},  # new patch version in the (3, 2) bucket
+            Version("3.2.1"): {},  # new patch version in the (3,) bucket
             Version("3.2"): {},  # already checksummed
             Version("1.2.0"): {},  # new minor version in the (1,) bucket
             Version("1.1.0"): {},  # loses to 1.2.0
@@ -88,7 +87,7 @@ def test_new_versions_only(monkeypatch):
     monkeypatch.setattr(Brillig, "versions", mock_versions)
     monkeypatch.setattr(Brillig, "fetch_remote_versions", mock_fetch_remote_versions)
     v = versions("--new", "brillig")
-    assert v.strip(" \n\t") == "99.99.99\n  3.3.0\n  3.2.1\n  1.2.0\n  1.0.1"
+    assert v.strip(" \n\t") == "99.99.99\n  3.2.1\n  1.2.0\n  1.0.1"
 
 
 def test_no_unchecksummed_versions(monkeypatch):

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -5,8 +5,9 @@
 import pytest
 
 import spack.url
+from spack.cmd.versions import new_versions
 from spack.main import SpackCommand
-from spack.version import Version
+from spack.version import StandardVersion, Version
 
 versions = SpackCommand("versions")
 
@@ -39,6 +40,25 @@ def test_remote_versions_only(monkeypatch):
     assert versions("--remote", "zlib") == "  1.3.1\n  1.3\n  1.2.13\n"
 
 
+def test_new_versions_utility():
+    """Unit test for the new_versions() prefix-bucket logic."""
+    v = StandardVersion.from_string
+    safe = {v("3.2"): {}, v("1.0.0"): {}}
+    fetched = {
+        v("99.99.99"): {},  # new in the () bucket
+        v("3.3.0"): {},  # new in (3,) bucket
+        v("3.2.1"): {},  # new in (3, 2) bucket
+        v("3.2"): {},  # already checksummed
+        v("1.2.0"): {},  # new in (1,) bucket
+        v("1.1.0"): {},  # (1,) bucket — loses to 1.2.0
+        v("1.0.1"): {},  # new in (1, 0) bucket
+        v("1.0.0"): {},  # already checksummed
+        v("0.1.0"): {},  # loses to 99.99.99 in the () bucket
+    }
+    expected = {v("99.99.99"), v("3.3.0"), v("3.2.1"), v("1.2.0"), v("1.0.1")}
+    assert new_versions(safe, fetched) == expected
+
+
 def test_new_versions_only(monkeypatch):
     """Test a package for which new versions should be available."""
     from spack_repo.builtin_mock.packages.brillig.package import Brillig  # type: ignore[import]
@@ -46,25 +66,29 @@ def test_new_versions_only(monkeypatch):
     def mock_fetch_remote_versions(*args, **kwargs):
         mock_remote_versions = {
             # new version, we expect this to be in output:
-            Version("99.99.99"): {},
+            Version("99.99.99"): {},  # new major version in the () bucket
+            Version("3.3.0"): {},  # new minor version in the (3,) bucket
             # some packages use '3.2' equivalently to '3.2.0'
             # thus '3.2.1' is considered to be a new version
-            # and expected in the output also
-            Version("3.2.1"): {},  # new version, we expect this to be in output
-            Version("3.2"): {},
-            Version("1.0.0"): {},
+            Version("3.2.1"): {},  # new patch version in the (3, 2) bucket
+            Version("3.2"): {},  # already checksummed
+            Version("1.2.0"): {},  # new minor version in the (1,) bucket
+            Version("1.1.0"): {},  # loses to 1.2.0
+            Version("1.0.1"): {},  # new patch version in the (1, 0) bucket
+            Version("1.0.0"): {},  # already checksummed
+            Version("0.1.0"): {},  # loses to 99.99.99
         }
         return mock_remote_versions
 
     mock_versions = {
-        # already checksummed versions:
+        # already checksummed versions
         Version("3.2"): {},
         Version("1.0.0"): {},
     }
     monkeypatch.setattr(Brillig, "versions", mock_versions)
     monkeypatch.setattr(Brillig, "fetch_remote_versions", mock_fetch_remote_versions)
     v = versions("--new", "brillig")
-    assert v.strip(" \n\t") == "99.99.99\n  3.2.1"
+    assert v.strip(" \n\t") == "99.99.99\n  3.3.0\n  3.2.1\n  1.2.0\n  1.0.1"
 
 
 def test_no_unchecksummed_versions(monkeypatch):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -695,7 +695,7 @@ _spack_change() {
 _spack_checksum() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --keep-stage --batch -b --latest -l --preferred -p --add-to-package -a --verify -j --jobs"
+        SPACK_COMPREPLY="-h --help --keep-stage --batch -b --latest -l --new -n --preferred -p --add-to-package -a --verify -j --jobs"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -962,7 +962,7 @@ complete -c spack -n '__fish_spack_using_command change' -s C -l concrete-only -
 complete -c spack -n '__fish_spack_using_command change' -s C -l concrete-only -d 'change only concrete specs in the environment'
 
 # spack checksum
-set -g __fish_spack_optspecs_spack_checksum h/help keep-stage b/batch l/latest p/preferred a/add-to-package verify j/jobs=
+set -g __fish_spack_optspecs_spack_checksum h/help keep-stage b/batch l/latest n/new p/preferred a/add-to-package verify j/jobs=
 complete -c spack -n '__fish_spack_using_command_pos 0 checksum' -f -a '(__fish_spack_packages)'
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 checksum' -f -a '(__fish_spack_package_versions $__fish_spack_argparse_argv[1])'
 complete -c spack -n '__fish_spack_using_command checksum' -s h -l help -f -a help
@@ -973,6 +973,8 @@ complete -c spack -n '__fish_spack_using_command checksum' -l batch -s b -f -a b
 complete -c spack -n '__fish_spack_using_command checksum' -l batch -s b -d 'don'"'"'t ask which versions to checksum'
 complete -c spack -n '__fish_spack_using_command checksum' -l latest -s l -f -a latest
 complete -c spack -n '__fish_spack_using_command checksum' -l latest -s l -d 'checksum the latest available version'
+complete -c spack -n '__fish_spack_using_command checksum' -l new -s n -f -a new
+complete -c spack -n '__fish_spack_using_command checksum' -l new -s n -d 'checksum remote versions newer than the known versions'
 complete -c spack -n '__fish_spack_using_command checksum' -l preferred -s p -f -a preferred
 complete -c spack -n '__fish_spack_using_command checksum' -l preferred -s p -d 'checksum the known Spack preferred version'
 complete -c spack -n '__fish_spack_using_command checksum' -l add-to-package -s a -f -a add_to_package
@@ -3392,7 +3394,7 @@ complete -c spack -n '__fish_spack_using_command versions' -s s -l safe -d 'only
 complete -c spack -n '__fish_spack_using_command versions' -s r -l remote -f -a remote
 complete -c spack -n '__fish_spack_using_command versions' -s r -l remote -d 'only list remote versions of the package'
 complete -c spack -n '__fish_spack_using_command versions' -s n -l new -f -a new
-complete -c spack -n '__fish_spack_using_command versions' -s n -l new -d 'only list remote versions newer than the latest checksummed version'
+complete -c spack -n '__fish_spack_using_command versions' -s n -l new -d 'only list remote versions newer than the checksummed versions'
 complete -c spack -n '__fish_spack_using_command versions' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command versions' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 


### PR DESCRIPTION
Before this, `spack versions --new` reported all newer than the very latest.
Now it effectively reports the latest major, minor and patch versions.

Also add the `spack checksum --new` flag accordingly, so users don't have to do
things like `spack versions --new | xargs spack checksum ...` as reported on Slack.

The way it works is: if you have versions `3.14.2` and `3.13.1` already checksummed,
take the set of all version prefixes `*`, `3.*`, `3.14.*`, and `3.13.*` and take the latest
remote version for each of these that aren't already checksummed.

Output of `spack checksum --new`:

<img width="863" height="536" alt="Screenshot 2026-03-12 at 15 23 38" src="https://github.com/user-attachments/assets/55a5527f-6038-4a99-8b16-240f8eab6f75" />

Without the `--new` flag in case of `py-setuptools` it would report 250+ results, which was slow and not particularly useful:

<img width="972" height="330" alt="Screenshot 2026-03-12 at 14 54 26" src="https://github.com/user-attachments/assets/062b6176-ba9c-4540-bb0e-ef770be5a771" />

Ultimately `--new` would be a reasonable default.
