### PR TITLE
spack buildcache update-index: parallelize read

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -672,6 +672,7 @@ def _read_specs_and_push_index(
     temp_dir: str,
     *,
     timer=timer.NULL_TIMER,
+    jobs: Optional[int] = None,
 ):
     """Read listed specs, generate the index, and push it to the mirror.
 
@@ -683,7 +684,9 @@ def _read_specs_and_push_index(
         db: A spack database used for adding specs and then writing the index.
         temp_dir: Location to write index.json and hash for pushing
     """
+    files_to_fetch = []
     with timer.measure("read"):
+        # Filter down to the files we actually need to fetch.
         for file in file_list:
             # All supported versions of build caches put the hash as the last
             # parameter before the extension
@@ -691,21 +694,32 @@ def _read_specs_and_push_index(
                 x = file.split("/")[-1].split("-")[-1].split(".")[0]
             except IndexError:
                 raise GenerateIndexError(f"Malformed metadata file name detected {file}")
+            if filter_fn(x):
+                files_to_fetch.append(file)
 
-            if not filter_fn(x):
-                continue
-
+        # Fetch all spec dicts concurrently
+        def fetch_one(file: str) -> Optional[dict]:
             cache_entry: Optional[URLBuildcacheEntry] = None
             try:
                 cache_entry = read_method(file)
-                spec_dict = cache_entry.fetch_metadata()
-                fetched_spec = spack.spec.Spec.from_dict(spec_dict)
+                return cache_entry.fetch_metadata()
             except Exception as e:
                 tty.warn(f"Unable to fetch spec for manifest {file} due to: {e}")
-                continue
+                return None
             finally:
                 if cache_entry:
                     cache_entry.destroy()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
+            spec_dicts = list(executor.map(fetch_one, files_to_fetch))
+
+        # Populate the database sequentially in the main thread.
+        for spec_dict in spec_dicts:
+            if spec_dict is None:
+                continue
+            # BuildCacheDatabase uses nullcontext for its write transactions, so it has
+            # no internal locking and is not safe to call from multiple threads.
+            fetched_spec = spack.spec.Spec.from_dict(spec_dict)
             db.add(fetched_spec)
             db.mark(fetched_spec, "in_buildcache", True)
 
@@ -721,6 +735,7 @@ def _url_generate_package_index(
     filter_fn: Callable[[str], bool] = lambda x: True,
     *,
     timer=timer.NULL_TIMER,
+    jobs: Optional[int] = None,
 ):
     """Create or replace the build cache index on the given mirror.  The
     buildcache index contains an entry for each binary package under the
@@ -758,6 +773,7 @@ def _url_generate_package_index(
                 db,
                 str(db.database_directory),
                 timer=timer,
+                jobs=jobs,
             )
         except Exception as e:
             raise GenerateIndexError(

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import contextlib
 import copy
 import datetime
+import functools
 import hashlib
 import io
 import itertools
@@ -662,6 +663,19 @@ def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str, name: 
     cache_class.maybe_push_layout_json(cache_prefix)
 
 
+def _fetch_one(read_method: Callable[[str], URLBuildcacheEntry], file: str) -> Optional[dict]:
+    cache_entry: Optional[URLBuildcacheEntry] = None
+    try:
+        cache_entry = read_method(file)
+        return cache_entry.fetch_metadata()
+    except Exception as e:
+        tty.warn(f"Unable to fetch spec for manifest {file} due to: {e}")
+        return None
+    finally:
+        if cache_entry:
+            cache_entry.destroy()
+
+
 def _read_specs_and_push_index(
     file_list: List[str],
     read_method: Callable[[str], URLBuildcacheEntry],
@@ -698,20 +712,10 @@ def _read_specs_and_push_index(
                 files_to_fetch.append(file)
 
         # Fetch all spec dicts concurrently
-        def fetch_one(file: str) -> Optional[dict]:
-            cache_entry: Optional[URLBuildcacheEntry] = None
-            try:
-                cache_entry = read_method(file)
-                return cache_entry.fetch_metadata()
-            except Exception as e:
-                tty.warn(f"Unable to fetch spec for manifest {file} due to: {e}")
-                return None
-            finally:
-                if cache_entry:
-                    cache_entry.destroy()
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
-            spec_dicts = list(executor.map(fetch_one, files_to_fetch))
+        with spack.util.parallel.make_concurrent_executor(jobs, require_fork=False) as executor:
+            spec_dicts = list(
+                executor.map(functools.partial(_fetch_one, read_method), files_to_fetch)
+            )
 
         # Populate the database sequentially in the main thread.
         for spec_dict in spec_dicts:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -349,7 +349,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         action="store_true",
         help="if provided, key index will be updated as well as package index",
     )
-    arguments.add_common_arguments(update_index, ["yes_to_all"])
+    arguments.add_common_arguments(update_index, ["jobs", "yes_to_all"])
     update_index.set_defaults(func=update_index_fn)
 
     # Migrate a buildcache from layout_version 2 to version 3
@@ -826,7 +826,10 @@ def manifest_copy(
 
 
 def update_index(
-    mirror: spack.mirrors.mirror.Mirror, update_keys=False, timer=timer_mod.NULL_TIMER
+    mirror: spack.mirrors.mirror.Mirror,
+    update_keys=False,
+    timer=timer_mod.NULL_TIMER,
+    jobs: Optional[int] = None,
 ):
     timer.start()
     # Special case OCI images for now.
@@ -846,7 +849,7 @@ def update_index(
     url = mirror.push_url
 
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
-        spack.binary_distribution._url_generate_package_index(url, tmpdir, timer=timer)
+        spack.binary_distribution._url_generate_package_index(url, tmpdir, timer=timer, jobs=jobs)
 
     if update_keys:
         mirror_update_keys(mirror)
@@ -1109,7 +1112,7 @@ def update_index_fn(args):
             yes_to_all=args.yes_to_all,
         )
     else:
-        update_index(args.mirror, update_keys=args.keys, timer=t)
+        update_index(args.mirror, update_keys=args.keys, timer=t, jobs=args.jobs)
 
     if tty.is_verbose():
         tty.msg("Timing summary:")

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -4,6 +4,7 @@
 
 import enum
 import fnmatch
+import functools
 import gzip
 import io
 import json
@@ -1079,6 +1080,12 @@ def check_mirror_for_layout(mirror: spack.mirrors.mirror.Mirror):
         tty.warn(msg)
 
 
+def _read_method(manifest_url: str, url: str, cache_class) -> "URLBuildcacheEntry":
+    cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
+    cache_entry.read_manifest(manifest_url)
+    return cache_entry
+
+
 def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str, component_type: BuildcacheComponent):
     """Use aws cli to sync all manifests into a local temporary directory.
 
@@ -1102,10 +1109,7 @@ def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str, component_type: Buil
         tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
         return file_list, read_fn
 
-    def file_read_method(manifest_path: str) -> URLBuildcacheEntry:
-        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
-        cache_entry.read_manifest(manifest_url=manifest_path)
-        return cache_entry
+    file_read_method = functools.partial(_read_method, url=url, cache_class=cache_class)
 
     include_pattern = cache_class.get_buildcache_component_include_pattern(component_type)
     component_prefix = cache_class.get_relative_path_components(component_type)
@@ -1177,10 +1181,7 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: Bui
 
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
 
-    def url_read_method(manifest_url: str) -> URLBuildcacheEntry:
-        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
-        cache_entry.read_manifest(manifest_url)
-        return cache_entry
+    url_read_method = functools.partial(_read_method, url=url, cache_class=cache_class)
 
     try:
         filename_to_mtime = {}

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -650,7 +650,7 @@ _spack_buildcache_check_index() {
 _spack_buildcache_update_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys -j --jobs -y --yes-to-all"
     else
         _mirrors
     fi
@@ -659,7 +659,7 @@ _spack_buildcache_update_index() {
 _spack_buildcache_rebuild_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help --name -n --append -a --force -f -k --keys -j --jobs -y --yes-to-all"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -874,7 +874,7 @@ complete -c spack -n '__fish_spack_using_command buildcache check-index' -l outp
 complete -c spack -n '__fish_spack_using_command buildcache check-index' -l output -s o -r -d 'File to write check details to'
 
 # spack buildcache update-index
-set -g __fish_spack_optspecs_spack_buildcache_update_index h/help n/name= a/append f/force k/keys y/yes-to-all
+set -g __fish_spack_optspecs_spack_buildcache_update_index h/help n/name= a/append f/force k/keys j/jobs= y/yes-to-all
 
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s h -l help -d 'show this help message and exit'
@@ -886,11 +886,13 @@ complete -c spack -n '__fish_spack_using_command buildcache update-index' -l for
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -l force -s f -d 'If a view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -s j -l jobs -r -f -a jobs
+complete -c spack -n '__fish_spack_using_command buildcache update-index' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command buildcache update-index' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack buildcache rebuild-index
-set -g __fish_spack_optspecs_spack_buildcache_rebuild_index h/help n/name= a/append f/force k/keys y/yes-to-all
+set -g __fish_spack_optspecs_spack_buildcache_rebuild_index h/help n/name= a/append f/force k/keys j/jobs= y/yes-to-all
 
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s h -l help -d 'show this help message and exit'
@@ -902,6 +904,8 @@ complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l fo
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -l force -s f -d 'If a view index already exists, overwrite it and suppress warnings (this is the default for non-view indices)'
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -f -a keys
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s j -l jobs -r -f -a jobs
+complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 


### PR DESCRIPTION
Reading specs is currently the slowest operation for `update-index`, and is performed serially. Here we use a `ThreadPool` to parallelize the operation.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
