### PR TITLE
installer logging: pass debug as keyword arg for clarity

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2736,7 +2736,7 @@ class BuildProcessInstaller:
                     # DEBUGGING TIP - to debug this section, insert an IPython
                     # embed here, and run the sections below without log capture
                     log_contextmanager = log_output(
-                        log_file, self.echo, True, filter_fn=self.filter_fn
+                        log_file, self.echo, debug=True, filter_fn=self.filter_fn
                     )
 
                     with log_contextmanager as logger:


### PR DESCRIPTION
Came up on another PR, I had trouble parsing this and I think this makes it clearer.