### PR TITLE
solver: prefer best provider above one with no penalty on variants

### DIFF
--- a/etc/spack/defaults/base/packages.yaml
+++ b/etc/spack/defaults/base/packages.yaml
@@ -18,7 +18,7 @@ packages:
     providers:
       awk: [gawk]
       armci: [armcimpi]
-      blas: [openblas, amdblis]
+      blas: [openblas]
       c: [gcc, llvm, intel-oneapi-compilers]
       cxx: [gcc, llvm, intel-oneapi-compilers]
       daal: [intel-oneapi-daal]
@@ -36,7 +36,7 @@ packages:
       ipp: [intel-oneapi-ipp]
       java: [openjdk, jdk]
       jpeg: [libjpeg-turbo, libjpeg]
-      lapack: [openblas, amdlibflame]
+      lapack: [openblas]
       libc: [glibc, musl]
       libgfortran: [gcc-runtime]
       libglx: [mesa+glx]

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2158,16 +2158,6 @@ opt_criterion(65, "variant penalty (roots)").
       build_priority(PackageNode, Priority)
 }.
 
-opt_criterion(60, "preferred providers for roots").
-#minimize{ 0@260: #true }.
-#minimize{ 0@60: #true }.
-#minimize{
-    Weight@60+Priority,ProviderNode,X,Virtual
-    : provider_weight(ProviderNode, node(X, Virtual), Weight),
-      attr("root", ProviderNode), not language(Virtual), not language_runtime(Virtual),
-      build_priority(ProviderNode, Priority)
-}.
-
 opt_criterion(55, "default values of variants not being used (roots)").
 #minimize{ 0@255: #true }.
 #minimize{ 0@55: #true }.
@@ -2180,13 +2170,13 @@ opt_criterion(55, "default values of variants not being used (roots)").
 
 % Minimize the weights of the providers, i.e. use as much as
 % possible the most preferred providers
-opt_criterion(50, "preferred providers (non-roots)").
+opt_criterion(50, "preferred providers (compilers excluded)").
 #minimize{ 0@250: #true }.
 #minimize{ 0@50: #true }.
 #minimize{
     Weight@50+Priority,ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
-      not attr("root", ProviderNode), not language(Virtual), not language_runtime(Virtual),
+      not language(Virtual), not language_runtime(Virtual),
       build_priority(ProviderNode, Priority)
 }.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2178,24 +2178,13 @@ opt_criterion(55, "default values of variants not being used (roots)").
       build_priority(PackageNode, Priority)
 }.
 
-% Try to use default variants or variants that have been set
-opt_criterion(50, "variant penalty (non-roots)").
-#minimize{ 0@250: #true }.
-#minimize{ 0@50: #true }.
-#minimize {
-    Penalty@50+Priority,PackageNode,Variant,Value
-    : variant_penalty(PackageNode, Variant, Value, Penalty),
-      not attr("root", PackageNode),
-      build_priority(PackageNode, Priority)
-}.
-
 % Minimize the weights of the providers, i.e. use as much as
 % possible the most preferred providers
-opt_criterion(48, "preferred providers (non-roots)").
-#minimize{ 0@248: #true }.
-#minimize{ 0@48: #true }.
+opt_criterion(50, "preferred providers (non-roots)").
+#minimize{ 0@250: #true }.
+#minimize{ 0@50: #true }.
 #minimize{
-    Weight@48+Priority,ProviderNode,X,Virtual
+    Weight@50+Priority,ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       not attr("root", ProviderNode), not language(Virtual), not language_runtime(Virtual),
       build_priority(ProviderNode, Priority)
@@ -2207,20 +2196,19 @@ compiler_penalty(PackageNode, C-1) :-
    C = #count { CompilerNode : node_compiler(PackageNode, CompilerNode) },
    node_compiler(PackageNode, _), C > 0.
 
-opt_criterion(46, "number of compilers used on the same node").
-#minimize{ 0@246: #true }.
-#minimize{ 0@46: #true }.
+opt_criterion(48, "number of compilers used on the same node").
+#minimize{ 0@248: #true }.
+#minimize{ 0@48: #true }.
 #minimize{
-    Penalty@46+Priority,PackageNode
+    Penalty@48+Priority,PackageNode
     : compiler_penalty(PackageNode, Penalty), build_priority(PackageNode, Priority)
 }.
 
-
-opt_criterion(40, "preferred compilers").
-#minimize{ 0@240: #true }.
-#minimize{ 0@40: #true }.
+opt_criterion(46, "preferred compilers").
+#minimize{ 0@246: #true }.
+#minimize{ 0@46: #true }.
 #minimize{
-    Weight@40+Priority,ProviderNode,X,Virtual
+    Weight@46+Priority,ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       language(Virtual),
       build_priority(ProviderNode, Priority)
@@ -2230,6 +2218,17 @@ opt_criterion(41, "compiler penalty from reuse").
 #minimize{ 0@241: #true }.
 #minimize{ 0@41: #true }.
 #minimize{1@41,Hash : compiler_penalty_from_reuse(Hash)}.
+
+% Try to use default variants or variants that have been set
+opt_criterion(40, "variant penalty (non-roots)").
+#minimize{ 0@240: #true }.
+#minimize{ 0@40: #true }.
+#minimize {
+    Penalty@40+Priority,PackageNode,Variant,Value
+    : variant_penalty(PackageNode, Variant, Value, Penalty),
+      not attr("root", PackageNode),
+      build_priority(PackageNode, Priority)
+}.
 
 opt_criterion(30, "non-preferred OS's").
 #minimize{ 0@230: #true }.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2181,15 +2181,15 @@ opt_criterion(48, "number of compilers used on the same node").
     : compiler_penalty(PackageNode, Penalty), build_priority(PackageNode, Priority)
 }.
 
-% Minimize the weights of the providers, i.e. use as much as
-% possible the most preferred providers
-opt_criterion(46, "preferred providers (excluded language runtimes)").
+% Choose the preferred compiler before penalizing variants, to avoid that a variant penalty
+% on e.g. gcc causes clingo to pick another compiler e.g. llvm
+opt_criterion(46, "preferred compilers").
 #minimize{ 0@246: #true }.
 #minimize{ 0@46: #true }.
 #minimize{
     Weight@46+Priority,ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
-      not language_runtime(Virtual),
+      language(Virtual),
       build_priority(ProviderNode, Priority)
 }.
 
@@ -2207,6 +2207,17 @@ opt_criterion(40, "variant penalty (non-roots)").
     : variant_penalty(PackageNode, Variant, Value, Penalty),
       not attr("root", PackageNode),
       build_priority(PackageNode, Priority)
+}.
+
+% Minimize the weights of all the other providers (mpi, lapack, etc.)
+opt_criterion(38, "preferred providers (excluded compilers and language runtimes)").
+#minimize{ 0@238: #true }.
+#minimize{ 0@38: #true }.
+#minimize{
+    Weight@38+Priority,ProviderNode,X,Virtual
+    : provider_weight(ProviderNode, node(X, Virtual), Weight),
+      not language(Virtual), not language_runtime(Virtual),
+      build_priority(ProviderNode, Priority)
 }.
 
 opt_criterion(30, "non-preferred OS's").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2168,20 +2168,7 @@ opt_criterion(55, "default values of variants not being used (roots)").
       build_priority(PackageNode, Priority)
 }.
 
-% Minimize the weights of the providers, i.e. use as much as
-% possible the most preferred providers
-opt_criterion(50, "preferred providers (compilers excluded)").
-#minimize{ 0@250: #true }.
-#minimize{ 0@50: #true }.
-#minimize{
-    Weight@50+Priority,ProviderNode,X,Virtual
-    : provider_weight(ProviderNode, node(X, Virtual), Weight),
-      not language(Virtual), not language_runtime(Virtual),
-      build_priority(ProviderNode, Priority)
-}.
-
 % Minimize the number of compilers used on nodes
-
 compiler_penalty(PackageNode, C-1) :-
    C = #count { CompilerNode : node_compiler(PackageNode, CompilerNode) },
    node_compiler(PackageNode, _), C > 0.
@@ -2194,13 +2181,15 @@ opt_criterion(48, "number of compilers used on the same node").
     : compiler_penalty(PackageNode, Penalty), build_priority(PackageNode, Priority)
 }.
 
-opt_criterion(46, "preferred compilers").
+% Minimize the weights of the providers, i.e. use as much as
+% possible the most preferred providers
+opt_criterion(46, "preferred providers (excluded language runtimes)").
 #minimize{ 0@246: #true }.
 #minimize{ 0@46: #true }.
 #minimize{
     Weight@46+Priority,ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
-      language(Virtual),
+      not language_runtime(Virtual),
       build_priority(ProviderNode, Priority)
 }.
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4983,8 +4983,8 @@ def test_virtual_gets_multiple_dupes(mock_packages, config):
 
 
 def test_compiler_selection_when_external_has_variant_penalty(mutable_config, mock_packages):
-    """Tests that a provider that should be preferred is not swapped with a less preferred
-    provider because of penalties on variants.
+    """Tests that a compiler that should be preferred is not swapped with a less preferred
+    compiler because of penalties on variants.
     """
     packages_yaml = syaml.load_config(
         """
@@ -5016,3 +5016,26 @@ packages:
     assert concrete.satisfies("%gcc@15.2.0 ~binutils"), concrete.tree()
     # LLVM is the second provider choice, with no penalty on variants
     assert not concrete.satisfies("%llvm@20 +clang")
+
+
+def test_mpi_selection_when_external_has_variant_penalty(mutable_config, mock_packages):
+    """Tests that conflicting with a default provider doesn't cause a variant values to be
+    flipped to avoid the variant dependency.
+    """
+    packages_yaml = syaml.load_config(
+        """
+packages:
+  all:
+    variants: +mpi
+  mpich:
+    buildable: false
+"""
+    )
+    mutable_config.set("packages", packages_yaml["packages"])
+
+    concrete = spack.concretize.concretize_one("transitive-conditional-virtual-dependency")
+
+    # GCC is the preferred provider, but has a penalty on its variants
+    assert concrete.satisfies("%conditional-virtual-dependency+mpi"), concrete.tree()
+    # LLVM is the second provider choice, with no penalty on variants
+    assert concrete.satisfies("^mpi=zmpi")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4980,3 +4980,39 @@ def test_virtual_gets_multiple_dupes(mock_packages, config):
     assert len(selected_lines) == 1
     max_dupes_c = selected_lines[0]
     assert 'max_dupes("c",2).' == max_dupes_c, f"should have max_dupes=2, but got: {max_dupes_c}"
+
+
+def test_compiler_selection_when_external_has_variant_penalty(mutable_config, mock_packages):
+    """Tests that a provider that should be preferred is not swapped with a less preferred
+    provider because of penalties on variants.
+    """
+    packages_yaml = syaml.load_config(
+        """
+packages:
+  gcc::
+    externals:
+    - spec: "gcc@15.2.0 languages='c,c++' ~binutils"
+      prefix: /path
+      extra_attributes:
+        compilers:
+          c: /path/bin/gcc
+          cxx: /path/bin/g++
+  llvm::
+    buildable: false
+    externals:
+    - spec: "llvm@20 +clang"
+      prefix: /path
+      extra_attributes:
+        compilers:
+          c: /path/bin/gcc
+          cxx: /path/bin/g++
+"""
+    )
+    mutable_config.set("packages", packages_yaml["packages"])
+
+    concrete = spack.concretize.concretize_one("libdwarf")
+
+    # GCC is the preferred provider, but has a penalty on its variants
+    assert concrete.satisfies("%gcc@15.2.0 ~binutils"), concrete.tree()
+    # LLVM is the second provider choice, with no penalty on variants
+    assert not concrete.satisfies("%llvm@20 +clang")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
@@ -36,6 +36,9 @@ class Gcc(CompilerPackage, Package):
         description="Compilers and runtime libraries to build",
     )
 
+    # This variant is here so that we can test having externals using the non-default value
+    variant("binutils", default=True, description="")
+
     provides("c", "cxx", when="languages=c,c++")
     provides("c", when="languages=c")
     provides("cxx", when="languages=c++")


### PR DESCRIPTION
Before this commit there were cases where a default provider was not selected because it had penalty on variants. Instead, the second-best provider was selected.

Here we tweak optimization priorities to ensure that the provider choice is above variant penalty.


**Example**

Using a configuration like:
```yaml
packages:
  providers:
    c: [gcc, llvm]
    cxx: [gcc, llvm]
  gcc::
    externals:
    - spec: "gcc@15.2.0 languages='c,c++' ~binutils"
      prefix: /path
      extra_attributes:
        compilers:
          c: /path/bin/gcc
          cxx: /path/bin/g++
  llvm::
    externals:
    - spec: "llvm@20 +clang"
      prefix: /path
      extra_attributes:
        compilers:
          c: /path/bin/gcc
          cxx: /path/bin/g++
```
shouldn't result in `llvm` being selected as the best compiler if no constraints are given, just because `~binutils` gives a penalty to `gcc` (`+binutils` is the default)
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
