### PR TITLE
new_installer.py: log filtering of path padding

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -78,6 +78,7 @@ import spack.traverse
 import spack.url_buildcache
 import spack.util.environment
 import spack.util.lock
+import spack.util.path
 from spack.installer import _do_fake_install, dump_packages
 
 if TYPE_CHECKING:
@@ -969,6 +970,7 @@ class BuildStatus:
         get_time: Callable[[], float] = time.monotonic,
         is_tty: Optional[bool] = None,
         verbose: bool = False,
+        filter_padding: bool = False,
     ) -> None:
         #: Ordered dict of build ID -> info
         self.total = total
@@ -995,6 +997,7 @@ class BuildStatus:
         self.is_tty = is_tty if is_tty is not None else self.stdout.isatty()
         #: Verbose mode only applies to non-TTY where we want to track a single build log.
         self.verbose = verbose and not self.is_tty
+        self.log_filter = spack.util.path.padding_filter_bytes if filter_padding else None
 
     def on_resize(self) -> None:
         """Refresh cached terminal size and trigger a redraw."""
@@ -1269,6 +1272,8 @@ class BuildStatus:
         # between builds.
         if build_id != self.tracked_build_id:
             return
+        if self.log_filter is not None:
+            data = self.log_filter(data)
         self.stdout.buffer.write(data)
         self.stdout.flush()
 
@@ -1781,7 +1786,11 @@ class PackageInstaller:
         self.verbose = verbose
         self.running_builds: Dict[int, ChildInfo] = {}
         self.log_paths: Dict[str, str] = {}
-        self.build_status = BuildStatus(len(self.build_graph.nodes), verbose=verbose)
+        self.build_status = BuildStatus(
+            len(self.build_graph.nodes),
+            verbose=verbose,
+            filter_padding=spack.store.STORE.has_padding(),
+        )
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
         if concurrent_packages is None:
             concurrent_packages_config = spack.config.get("config:concurrent_packages", 0)

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -185,6 +185,10 @@ class Store:
             self.root, default_timeout=lock_cfg.package_timeout
         )
 
+    def has_padding(self) -> bool:
+        """Returns True if the store layout includes path padding."""
+        return self.root != self.unpadded_root
+
     def reindex(self) -> None:
         """Convenience function to reindex the store DB with its own layout."""
         return self.db.reindex()

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -72,6 +72,7 @@ def create_build_status(
     terminal_rows: int = 24,
     total: int = 0,
     verbose: bool = False,
+    filter_padding: bool = False,
 ) -> Tuple[BuildStatus, List[float], SimpleTextIOWrapper]:
     """Helper function to create BuildStatus with mocked dependencies"""
     fake_stdout = SimpleTextIOWrapper(tty=is_tty)
@@ -91,6 +92,7 @@ def create_build_status(
         get_time=mock_get_time,
         is_tty=is_tty,
         verbose=verbose,
+        filter_padding=filter_padding,
     )
 
     return status, time_values, fake_stdout
@@ -942,6 +944,25 @@ class TestToggle:
         # Should have toggled back to overview mode
         assert status.overview_mode is True
         assert status.tracked_build_id == ""
+
+    @pytest.mark.parametrize("filter_padding", [True, False])
+    def test_print_logs_filters_padding(self, filter_padding):
+        """print_logs strips path-padding placeholders before writing to stdout."""
+        status, _, fake_stdout = create_build_status(filter_padding=filter_padding)
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+        log_output = b"--with-foo=/base/__spack_path_placeholder__/__spack_path_placeholder__/bin"
+
+        # track the build and print logs with the relevant path.
+        status.overview_mode = False
+        status.tracked_build_id = build_id
+        status.print_logs(build_id, log_output)
+        written = fake_stdout._buffer.getvalue()
+
+        if filter_padding:
+            assert written == b"--with-foo=/base/[padded-to-59-chars]/bin"
+        else:
+            assert written == log_output
 
 
 class TestSearchFilteringIntegration:

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -42,79 +42,92 @@ def test_sanitize_filename():
 # which is used for binary caching. This functionality is not supported
 # on Windows as of yet.
 @pytest.mark.not_on_windows("Padding functionality unsupported on Windows")
+@pytest.mark.parametrize("as_bytes", [False, True])
 class TestPathPadding:
+    @pytest.fixture(autouse=True)
+    def setup(self, as_bytes: bool):
+        #: The filter function, either for bytes or str
+        self.filter = sup.padding_filter_bytes if as_bytes else sup.padding_filter
+        #: A converter of str -> bytes if we're testing the bytes filter
+        self.convert = lambda s: s.encode("ascii") if as_bytes else s
+
     @pytest.mark.parametrize("padded,fixed", zip(padded_lines, fixed_lines))
     def test_padding_substitution(self, padded, fixed):
         """Ensure that all padded lines are unpadded correctly."""
-        assert fixed == sup.padding_filter(padded)
+        assert self.convert(fixed) == self.filter(self.convert(padded))
 
     def test_no_substitution(self):
         """Ensure that a line not containing one full path placeholder
         is not modified."""
         partial = "--prefix=/Users/gamblin2/padding-log-test/opt/__spack_path_pla/darwin-bigsur-skylake/apple-clang-12.0.5/zlib-1.2.11-74mwnxgn6nujehpyyalhwizwojwn5zga'"  # noqa: E501
-        assert sup.padding_filter(partial) == partial
+        p = self.convert(partial)
+        assert self.filter(p) is p  # Test fast-path identity
 
     def test_short_substitution(self):
         """Ensure that a single placeholder path component is replaced"""
         short = "--prefix=/Users/gamblin2/padding-log-test/opt/__spack_path_placeholder__/darwin-bigsur-skylake/apple-clang-12.0.5/zlib-1.2.11-74mwnxgn6nujehpyyalhwizwojwn5zga'"  # noqa: E501
         short_subst = "--prefix=/Users/gamblin2/padding-log-test/opt/[padded-to-63-chars]/darwin-bigsur-skylake/apple-clang-12.0.5/zlib-1.2.11-74mwnxgn6nujehpyyalhwizwojwn5zga'"  # noqa: E501
-        assert short_subst == sup.padding_filter(short)
+        assert self.convert(short_subst) == self.filter(self.convert(short))
 
     def test_partial_substitution(self):
         """Ensure that a single placeholder path component is replaced"""
         short = "--prefix=/Users/gamblin2/padding-log-test/opt/__spack_path_placeholder__/__spack_p/darwin-bigsur-skylake/apple-clang-12.0.5/zlib-1.2.11-74mwnxgn6nujehpyyalhwizwojwn5zga'"  # noqa: E501
         short_subst = "--prefix=/Users/gamblin2/padding-log-test/opt/[padded-to-73-chars]/darwin-bigsur-skylake/apple-clang-12.0.5/zlib-1.2.11-74mwnxgn6nujehpyyalhwizwojwn5zga'"  # noqa: E501
-        assert short_subst == sup.padding_filter(short)
+        assert self.convert(short_subst) == self.filter(self.convert(short))
 
     def test_longest_prefix_re(self):
         """Test that longest_prefix_re generates correct regular expressions."""
         assert "(s(?:t(?:r(?:i(?:ng?)?)?)?)?)" == sup.longest_prefix_re("string", capture=True)
         assert "(?:s(?:t(?:r(?:i(?:ng?)?)?)?)?)" == sup.longest_prefix_re("string", capture=False)
 
-    def test_output_filtering(self, capfd, install_mockery, mutable_config):
-        """Test filtering padding out of tty messages."""
-        long_path = "/" + "/".join([sup.SPACK_PATH_PADDING_CHARS] * 200)
-        padding_string = "[padded-to-%d-chars]" % len(long_path)
 
-        # test filtering when padding is enabled
-        with spack.config.override("config:install_tree", {"padded_length": 256}):
-            # tty.msg with filtering on the first argument
-            with sup.filter_padding():
-                tty.msg("here is a long path: %s/with/a/suffix" % long_path)
-            out, err = capfd.readouterr()
-            assert padding_string in out
+@pytest.mark.not_on_windows("Padding functionality unsupported on Windows")
+def test_output_filtering(capfd, install_mockery, mutable_config):
+    """Test filtering padding out of tty messages."""
+    long_path = "/" + "/".join([sup.SPACK_PATH_PADDING_CHARS] * 200)
+    padding_string = "[padded-to-%d-chars]" % len(long_path)
 
-            # tty.msg with filtering on a laterargument
-            with sup.filter_padding():
-                tty.msg("here is a long path:", "%s/with/a/suffix" % long_path)
-            out, err = capfd.readouterr()
-            assert padding_string in out
-
-            # tty.error with filtering on the first argument
-            with sup.filter_padding():
-                tty.error("here is a long path: %s/with/a/suffix" % long_path)
-            out, err = capfd.readouterr()
-            assert padding_string in err
-
-            # tty.error with filtering on a later argument
-            with sup.filter_padding():
-                tty.error("here is a long path:", "%s/with/a/suffix" % long_path)
-            out, err = capfd.readouterr()
-            assert padding_string in err
-
-        # test no filtering
-        tty.msg("here is a long path: %s/with/a/suffix" % long_path)
+    # test filtering when padding is enabled
+    with spack.config.override("config:install_tree", {"padded_length": 256}):
+        # tty.msg with filtering on the first argument
+        with sup.filter_padding():
+            tty.msg("here is a long path: %s/with/a/suffix" % long_path)
         out, err = capfd.readouterr()
-        assert padding_string not in out
+        assert padding_string in out
 
-    def test_pad_on_path_sep_boundary(self):
-        """Ensure that padded paths do not end with path separator."""
-        pad_length = len(sup.SPACK_PATH_PADDING_CHARS)
-        padded_length = 128
-        remainder = padded_length % (pad_length + 1)
-        path = "a" * (remainder - 1)
-        result = sup.add_padding(path, padded_length)
-        assert 128 == len(result) and not result.endswith(os.path.sep)
+        # tty.msg with filtering on a laterargument
+        with sup.filter_padding():
+            tty.msg("here is a long path:", "%s/with/a/suffix" % long_path)
+        out, err = capfd.readouterr()
+        assert padding_string in out
+
+        # tty.error with filtering on the first argument
+        with sup.filter_padding():
+            tty.error("here is a long path: %s/with/a/suffix" % long_path)
+        out, err = capfd.readouterr()
+        assert padding_string in err
+
+        # tty.error with filtering on a later argument
+        with sup.filter_padding():
+            tty.error("here is a long path:", "%s/with/a/suffix" % long_path)
+        out, err = capfd.readouterr()
+        assert padding_string in err
+
+    # test no filtering
+    tty.msg("here is a long path: %s/with/a/suffix" % long_path)
+    out, err = capfd.readouterr()
+    assert padding_string not in out
+
+
+@pytest.mark.not_on_windows("Padding functionality unsupported on Windows")
+def test_pad_on_path_sep_boundary():
+    """Ensure that padded paths do not end with path separator."""
+    pad_length = len(sup.SPACK_PATH_PADDING_CHARS)
+    padded_length = 128
+    remainder = padded_length % (pad_length + 1)
+    path = "a" * (remainder - 1)
+    result = sup.add_padding(path, padded_length)
+    assert 128 == len(result) and not result.endswith(os.path.sep)
 
 
 @pytest.mark.parametrize("debug", [1, 2])

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import tempfile
 from datetime import date
-from typing import Optional
+from typing import Optional, Union
 
 import spack.llnl.util.tty as tty
 import spack.util.spack_yaml as syaml
@@ -98,6 +98,9 @@ SPACK_MAX_INSTALL_PATH_LENGTH = 300
 #: It starts with two underscores to make it unlikely that prefix matches would
 #: include some other component of the installation path.
 SPACK_PATH_PADDING_CHARS = "__spack_path_placeholder__"
+
+#: Bytes equivalent of SPACK_PATH_PADDING_CHARS.
+SPACK_PATH_PADDING_BYTES = SPACK_PATH_PADDING_CHARS.encode("ascii")
 
 #: Special padding char if the padded string would otherwise end with a path
 #: separator (since the path separator would otherwise get collapsed out,
@@ -318,12 +321,29 @@ def longest_prefix_re(string, capture=True):
     )
 
 
-#: regex cache for padding_filter function
-_filter_re = None
+def _build_padding_re(as_bytes: bool = False):
+    """Build and return a compiled regex for filtering path padding placeholders."""
+    pad = re.escape(SPACK_PATH_PADDING_CHARS)
+    extra = SPACK_PATH_PADDING_EXTRA_CHAR
+    longest_prefix = longest_prefix_re(SPACK_PATH_PADDING_CHARS, capture=False)
+
+    regex = (
+        r"((?:/[^/\s]*)*?)"  # zero or more leading non-whitespace path components
+        r"(?:/{pad})+"  # the padding string repeated one or more times
+        # trailing prefix of padding as path component
+        r"(?:/{longest_prefix}|/{longest_prefix}{extra})?(?=/)"
+    )
+    regex = regex.replace("/", re.escape(os.sep))
+    regex = regex.format(pad=pad, extra=extra, longest_prefix=longest_prefix)
+
+    if as_bytes:
+        return re.compile(regex.encode("ascii"))
+    else:
+        return re.compile(regex)
 
 
-def padding_filter(string):
-    """Filter used to reduce output from path padding in log output.
+class _PaddingFilter:
+    """Callable that filters path-padding placeholders from a string or bytes buffer.
 
     This turns paths like this:
 
@@ -335,7 +355,7 @@ def padding_filter(string):
 
     Where ``padded-to-512-chars`` indicates that the prefix was padded with
     placeholders until it hit 512 characters. The actual value of this number
-    depends on what the `install_tree``'s ``padded_length`` is configured to.
+    depends on what the ``install_tree``'s ``padded_length`` is configured to.
 
     For a path to match and be filtered, the placeholder must appear in its
     entirety at least one time. e.g., "/spack/" would not be filtered, but
@@ -343,29 +363,32 @@ def padding_filter(string):
 
     Note that only the first padded path in the string is filtered.
     """
-    global _filter_re
 
-    pad = SPACK_PATH_PADDING_CHARS
-    if not _filter_re:
-        longest_prefix = longest_prefix_re(pad)
-        regex = (
-            r"((?:/[^/\s]*)*?)"  # zero or more leading non-whitespace path components
-            r"(/{pad})+"  # the padding string repeated one or more times
-            # trailing prefix of padding as path component
-            r"(/{longest_prefix}|/{longest_prefix}{extra_pad_character})?(?=/)"
-        )
-        regex = regex.replace("/", re.escape(os.sep))
-        regex = regex.format(
-            pad=pad,
-            extra_pad_character=SPACK_PATH_PADDING_EXTRA_CHAR,
-            longest_prefix=longest_prefix,
-        )
-        _filter_re = re.compile(regex)
+    __slots__ = ("_re", "_needle", "_fmt")
 
-    def replacer(match):
-        return "%s%s[padded-to-%d-chars]" % (match.group(1), os.sep, len(match.group(0)))
+    def __init__(self, as_bytes: bool = False) -> None:
+        self._re = _build_padding_re(as_bytes=as_bytes)
+        if as_bytes:
+            self._needle: Union[str, bytes] = SPACK_PATH_PADDING_BYTES
+            self._fmt: Union[str, bytes] = b"%b" + os.sep.encode("ascii") + b"[padded-to-%d-chars]"
+        else:
+            self._needle = SPACK_PATH_PADDING_CHARS
+            self._fmt = "%s" + os.sep + "[padded-to-%d-chars]"
 
-    return _filter_re.sub(replacer, string)
+    def _replace(self, match):
+        return self._fmt % (match.group(1), len(match.group(0)))
+
+    def __call__(self, data):
+        if self._needle not in data:
+            return data
+        return self._re.sub(self._replace, data)
+
+
+#: Callable that filters path-padding placeholders from strings
+padding_filter = _PaddingFilter(as_bytes=False)
+
+#: Callable that filters path-padding placeholders from bytes buffers
+padding_filter_bytes = _PaddingFilter(as_bytes=True)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Do log filtering in `BuildStatus`, which is a class that handles the UI of the
new installer. The Tee class in the build process still duplexes build output
verbatim to the log file and to the parent process; this is just a UI
enhancement, and therefore part of the parent process.

* Support both `str` and `bytes` in `path.py` log filtering utility
* Use bytes based log filtering in `new_installer.py` (it treats stdout/stderr as raw bytes)
* Parametrize existing tests over `str` and `bytes`.

