### PR TITLE
new_installer.py: better color support (and a small path filtering fix)

### DIFF
--- a/lib/spack/spack/llnl/util/tty/color.py
+++ b/lib/spack/spack/llnl/util/tty/color.py
@@ -185,11 +185,13 @@ def try_enable_terminal_color_on_windows() -> None:
             _force_color = False
 
 
-def get_color_when() -> bool:
+def get_color_when(stdout=None) -> bool:
     """Return whether commands should print color or not."""
     if _force_color is not None:
         return _force_color
-    return sys.stdout.isatty()
+    if stdout is None:
+        stdout = sys.stdout
+    return stdout.isatty()
 
 
 def set_color_when(when: Union[str, bool, None]) -> None:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -68,6 +68,7 @@ import spack.error
 import spack.hooks
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty
+import spack.llnl.util.tty.color
 import spack.paths
 import spack.report
 import spack.spec
@@ -969,6 +970,7 @@ class BuildStatus:
         get_terminal_size: Callable[[], os.terminal_size] = os.get_terminal_size,
         get_time: Callable[[], float] = time.monotonic,
         is_tty: Optional[bool] = None,
+        color: Optional[bool] = None,
         verbose: bool = False,
         filter_padding: bool = False,
     ) -> None:
@@ -994,7 +996,11 @@ class BuildStatus:
         self.terminal_size = os.terminal_size((0, 0))
         self.terminal_size_changed: bool = True
         self.get_time = get_time
-        self.is_tty = is_tty if is_tty is not None else self.stdout.isatty()
+        self.is_tty = is_tty if is_tty is not None else stdout.isatty()
+        if color is not None:
+            self.color = color
+        else:
+            self.color = spack.llnl.util.tty.color.get_color_when(stdout)
         #: Verbose mode only applies to non-TTY where we want to track a single build log.
         self.verbose = verbose and not self.is_tty
         self.log_filter = spack.util.path.padding_filter_bytes if filter_padding else None
@@ -1102,9 +1108,10 @@ class BuildStatus:
         self.tracked_build_id = new_build_id
 
         # Tell the user we're following new logs, and instruct the child to start sending them.
-        self.stdout.write(
-            f"\n==> Following logs of {new_build.name}" f"\033[0;36m@{new_build.version}\033[0m\n"
+        version_str = (
+            f"\033[0;36m@{new_build.version}\033[0m" if self.color else f"@{new_build.version}"
         )
+        self.stdout.write(f"\n==> Following logs of {new_build.name}{version_str}\n")
         self.stdout.flush()
         try:
             conn = new_build.control_w_conn
@@ -1132,20 +1139,10 @@ class BuildStatus:
 
         self.dirty = True
 
-        # For non-TTY output, print state changes immediately without colors
+        # For non-TTY output, print state changes immediately
         if not self.is_tty:
-            if build_info.external:
-                indicator = "[e]"
-            elif state == "finished":
-                indicator = "[+]"
-            elif state == "failed":
-                indicator = "[x]"
-            else:
-                indicator = "[ ]"
-            suffix = build_info.prefix if state == "finished" else state
-            self.stdout.write(
-                f"{indicator} {build_info.hash} {build_info.name}@{build_info.version} {suffix}\n"
-            )
+            line = "".join(self._generate_line_components(build_info, static=True))
+            self.stdout.write(line + "\n")
             self.stdout.flush()
 
     def update_progress(self, build_id: str, current: int, total: int) -> None:
@@ -1209,18 +1206,25 @@ class BuildStatus:
         self.finished_builds.clear()
 
         # Then a header followed by the active builds. This is the "mutable" part of the display.
+        if self.color:
+            bold = "\033[1m"
+            reset = "\033[0m"
+            cyan = "\033[36m"
+        else:
+            bold = reset = cyan = ""
+
         long_header_len = len(
             f"Progress: {self.completed}/{self.total}  /: filter  v: logs  n/p: next/prev"
         )
         if long_header_len < max_width:
             self._println(
                 buffer,
-                f"\033[1mProgress:\033[0m {self.completed}/{self.total}"
-                "  \033[36m/\033[0m: filter  \033[36mv\033[0m: logs"
-                "  \033[36mn\033[0m/\033[36mp\033[0m: next/prev",
+                f"{bold}Progress:{reset} {self.completed}/{self.total}"
+                f"  {cyan}/{reset}: filter  {cyan}v{reset}: logs"
+                f"  {cyan}n{reset}/{cyan}p{reset}: next/prev",
             )
         else:
-            self._println(buffer, f"\033[1mProgress:\033[0m {self.completed}/{self.total}")
+            self._println(buffer, f"{bold}Progress:{reset} {self.completed}/{self.total}")
 
         displayed_builds = (
             [b for b in self.builds.values() if self._is_displayed(b)]
@@ -1288,7 +1292,9 @@ class BuildStatus:
             buffer.write(component)
         self._println(buffer)
 
-    def _generate_line_components(self, build_info: BuildInfo) -> Generator[str, None, None]:
+    def _generate_line_components(
+        self, build_info: BuildInfo, static: bool = False
+    ) -> Generator[str, None, None]:
         """Yield formatted line components for a package. Escape sequences are yielded as separate
         strings so they do not contribute to the line width."""
         if build_info.external:
@@ -1297,33 +1303,43 @@ class BuildStatus:
             indicator = "[+]"
         elif build_info.state == "failed":
             indicator = "[x]"
+        elif static:
+            indicator = "[ ]"
         else:
             indicator = f"[{self.spinner_chars[self.spinner_index]}]"
 
-        if build_info.state == "failed":
-            yield "\033[31m"  # red
-        elif build_info.state == "finished":
-            yield "\033[32m"  # green
+        if self.color:
+            if build_info.state == "failed":
+                yield "\033[31m"  # red
+            elif build_info.state == "finished":
+                yield "\033[32m"  # green
 
         yield indicator
-        yield "\033[0m"  # reset
+        if self.color:
+            yield "\033[0m"  # reset
         yield " "
-        yield "\033[0;90m"  # dark gray
+        if self.color:
+            yield "\033[0;90m"  # dark gray
         yield build_info.hash
-        yield "\033[0m"  # reset
+        if self.color:
+            yield "\033[0m"  # reset
         yield " "
 
         # Package name in bold white if explicit, default otherwise
         if build_info.explicit:
-            yield "\033[1;37m"  # bold white
+            if self.color:
+                yield "\033[1;37m"  # bold white
             yield build_info.name
-            yield "\033[0m"  # reset
+            if self.color:
+                yield "\033[0m"  # reset
         else:
             yield build_info.name
 
-        yield "\033[0;36m"  # cyan
+        if self.color:
+            yield "\033[0;36m"  # cyan
         yield f"@{build_info.version}"
-        yield "\033[0m"  # reset
+        if self.color:
+            yield "\033[0m"  # reset
 
         # progress or state
         if build_info.progress_percent is not None:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -79,8 +79,8 @@ import spack.traverse
 import spack.url_buildcache
 import spack.util.environment
 import spack.util.lock
-import spack.util.path
 from spack.installer import _do_fake_install, dump_packages
+from spack.util.path import padding_filter, padding_filter_bytes
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -1003,7 +1003,7 @@ class BuildStatus:
             self.color = spack.llnl.util.tty.color.get_color_when(stdout)
         #: Verbose mode only applies to non-TTY where we want to track a single build log.
         self.verbose = verbose and not self.is_tty
-        self.log_filter = spack.util.path.padding_filter_bytes if filter_padding else None
+        self.filter_padding = filter_padding
 
     def on_resize(self) -> None:
         """Refresh cached terminal size and trigger a redraw."""
@@ -1276,8 +1276,8 @@ class BuildStatus:
         # between builds.
         if build_id != self.tracked_build_id:
             return
-        if self.log_filter is not None:
-            data = self.log_filter(data)
+        if self.filter_padding:
+            data = padding_filter_bytes(data)
         self.stdout.buffer.write(data)
         self.stdout.flush()
 
@@ -1346,7 +1346,8 @@ class BuildStatus:
             yield " fetching"
             yield f": {build_info.progress_percent}%"
         elif build_info.state == "finished":
-            yield f" {build_info.prefix}"
+            prefix = build_info.prefix
+            yield f" {padding_filter(prefix) if self.filter_padding else prefix}"
         else:
             yield f" {build_info.state}"
 

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -73,6 +73,7 @@ def create_build_status(
     total: int = 0,
     verbose: bool = False,
     filter_padding: bool = False,
+    color: Optional[bool] = None,
 ) -> Tuple[BuildStatus, List[float], SimpleTextIOWrapper]:
     """Helper function to create BuildStatus with mocked dependencies"""
     fake_stdout = SimpleTextIOWrapper(tty=is_tty)
@@ -93,6 +94,7 @@ def create_build_status(
         is_tty=is_tty,
         verbose=verbose,
         filter_padding=filter_padding,
+        color=color,
     )
 
     return status, time_values, fake_stdout
@@ -1225,3 +1227,33 @@ class TestBuildStatusVerbose:
         with r_conn, w_conn:
             bs.add_build(spec, explicit=True, control_w_conn=w_conn)
             assert bs.tracked_build_id == ""
+
+
+class TestBuildStatusColor:
+    """Tests that BuildStatus respects the explicit color=True/False parameter."""
+
+    def test_non_tty_finished_color_true_emits_green(self):
+        """color=True in non-TTY mode: finished line has per-component ANSI colors."""
+        spec = MockSpec("pkg", "1.0")
+        status, _, stdout = create_build_status(is_tty=False, total=1, color=True)
+        status.add_build(spec, explicit=True)
+        status.update_state(spec.dag_hash(), "finished")
+        # green indicator, reset, dark-gray hash
+        assert stdout.getvalue().startswith("\033[32m[+]\033[0m \033[0;90m")
+
+    def test_non_tty_failed_color_true_emits_red(self):
+        """color=True in non-TTY mode: failed line has per-component ANSI colors."""
+        spec = MockSpec("pkg", "1.0")
+        status, _, stdout = create_build_status(is_tty=False, total=1, color=True)
+        status.add_build(spec, explicit=True)
+        status.update_state(spec.dag_hash(), "failed")
+        # red indicator, reset, dark-gray hash
+        assert stdout.getvalue().startswith("\033[31m[x]\033[0m \033[0;90m")
+
+    def test_non_tty_finished_color_false_no_ansi(self):
+        """color=False in non-TTY mode: finished line has no ANSI escape codes."""
+        spec = MockSpec("pkg", "1.0")
+        status, _, stdout = create_build_status(is_tty=False, total=1, color=False)
+        status.add_build(spec, explicit=True)
+        status.update_state(spec.dag_hash(), "finished")
+        assert "\033[" not in stdout.getvalue()

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -966,6 +966,22 @@ class TestToggle:
         else:
             assert written == log_output
 
+    @pytest.mark.parametrize("filter_padding", [True, False])
+    def test_prefix_padding_filter_in_status(self, filter_padding):
+        """Test that prefix in status indicator applies padding filter."""
+        padded_prefix = "/base/__spack_path_placeholder__/__spack_path_placeholder__/mypackage"
+        status, _, fake_stdout = create_build_status(is_tty=False, filter_padding=filter_padding)
+        spec = MockSpec("mypackage", "1.0", prefix=padded_prefix)
+        status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+        build_id = spec.dag_hash()
+        status.update_state(build_id, "finished")
+        output = fake_stdout.getvalue()
+        common = f"[+] {spec.dag_hash(7)} {spec.name}@{spec.version}"
+        if filter_padding:
+            assert output == f"{common} /base/[padded-to-59-chars]/mypackage\n"
+        else:
+            assert output == f"{common} {padded_prefix}\n"
+
 
 class TestSearchFilteringIntegration:
     """Test search mode with display filtering"""


### PR DESCRIPTION
* In non-TTY mode use colors when forced (`spack --color=always` or
  `SPACK_COLOR=always`)
* In TTY mode do not use colors when explicitly disabled with the flag
  `spack --color=never` or `SPACK_COLOR=never`.
* Use single code path for status line whether TTY or non-TTY.
* While at it: apply path filtering of the install prefix also in the status line to `[+] ... /path/to/__spack_path_placeholder__/...`.

