### PR TITLE
new_installer.py: always try build cache

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1714,7 +1714,7 @@ def download_tarball(
         spack.mirrors.mirror.MirrorCollection(binary=True).values()
     )
     if not configured_mirrors:
-        tty.die("Please add a spack mirror to allow download of pre-compiled packages.")
+        raise NoConfiguredBinaryMirrors()
 
     # Note on try_first and try_next:
     # mirrors_for_spec mostly likely came from spack caching remote
@@ -2958,3 +2958,10 @@ class CannotListKeys(GenerateIndexError):
 
 class PushToBuildCacheError(spack.error.SpackError):
     """Raised when unable to push objects to binary mirror"""
+
+
+class NoConfiguredBinaryMirrors(spack.error.SpackError):
+    """Raised when no binary mirrors are configured but an operation requires them"""
+
+    def __init__(self):
+        super().__init__("Please add a spack mirror to allow download of pre-compiled packages.")

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -254,7 +254,12 @@ def install_from_buildcache(
     state_stream: io.TextIOWrapper,
 ) -> bool:
     send_state("fetching from build cache", state_stream)
-    tarball_stage = spack.binary_distribution.download_tarball(spec.build_spec, unsigned, mirrors)
+    try:
+        tarball_stage = spack.binary_distribution.download_tarball(
+            spec.build_spec, unsigned, mirrors
+        )
+    except spack.binary_distribution.NoConfiguredBinaryMirrors:
+        return False
 
     if tarball_stage is None:
         return False

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -603,7 +603,7 @@ def _install(
 
     # Try to install from buildcache, unless user asked for source only
     if install_policy != "source_only":
-        if mirrors and install_from_buildcache(mirrors, spec, unsigned, state_stream):
+        if install_from_buildcache(mirrors, spec, unsigned, state_stream):
             spack.hooks.post_install(spec, explicit)
             return
         elif install_policy == "cache_only":


### PR DESCRIPTION
The new installer skips installation from build cache if it cannot find
the corresponding spec in a local copy of an index.

The old installer on the other hand uses the local index to prioritize
build caches that likely have the spec, but if not, tries direct
fetches.

This change makes the new installer do the same. It seems that I
originally skipped this because it would hit a curious `tty.die(...)` in
the middle of `buildcache.py`.

