### PR TITLE
docs: upgrade insecure HTTP links to HTTPS in developer contributions

### DIFF
--- a/lib/spack/docs/build_systems/perlpackage.rst
+++ b/lib/spack/docs/build_systems/perlpackage.rst
@@ -267,6 +267,6 @@ If you need to install to your home directory or need to install a module with n
 External documentation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-You can find more information on installing Perl modules from source at: http://www.perlmonks.org/?node_id=128077
+You can find more information on installing Perl modules from source at: https://www.perlmonks.org/?node_id=128077
 
-More generic Perl module installation instructions can be found at: http://www.cpan.org/modules/INSTALL.html
+More generic Perl module installation instructions can be found at: https://www.cpan.org/modules/INSTALL.html

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -98,8 +98,8 @@ And this would run the ``test_platform`` test from that file:
    $ spack unit-test lib/spack/spack/test/architecture.py::test_platform
 
 This allows you to develop iteratively: make a change, test that change, make another change, test that change, etc.
-We use `pytest <http://pytest.org/>`_ as our tests framework, and these types of arguments are just passed to the ``pytest`` command underneath.
-See `the pytest docs <https://doc.pytest.org/en/latest/how-to/usage.html#specifying-which-tests-to-run>`_ for more details on test selection syntax.
+We use `pytest <https://docs.pytest.org/>`_ as our tests framework, and these types of arguments are just passed to the ``pytest`` command underneath.
+See `the pytest docs <https://docs.pytest.org/en/latest/how-to/usage.html#specifying-which-tests-to-run>`_ for more details on test selection syntax.
 
 ``spack unit-test`` has a few special options that can help you understand what tests are available.
 To get a list of all available unit test files, run:
@@ -123,7 +123,7 @@ For example, to see just the tests in ``architecture.py``:
 .. command-output:: spack unit-test --list-long lib/spack/spack/test/architecture.py
 
 You can also combine any of these options with a ``pytest`` keyword search.
-See the `pytest usage documentation <https://doc.pytest.org/en/latest/how-to/usage.html#specifying-which-tests-to-run>`_ for more details on test selection syntax.
+See the `pytest usage documentation <https://docs.pytest.org/en/latest/how-to/usage.html#specifying-which-tests-to-run>`_ for more details on test selection syntax.
 For example, to see the names of all tests that have "spec" or "concretize" somewhere in their names:
 
 .. command-output:: spack unit-test --list-names -k "spec and concretize"
@@ -139,7 +139,7 @@ To see the output *live*, use the ``-s`` argument to ``pytest``:
 Unit tests are crucial to making sure bugs are not introduced into Spack.
 If you are modifying core Spack libraries or adding new functionality, please add new unit tests for your feature and consider strengthening existing tests.
 You will likely be asked to do this if you submit a pull request to the Spack project on GitHub.
-Check out the `pytest documentation <http://pytest.org/>`_ and feel free to ask for guidance on how to write tests!
+Check out the `pytest documentation <https://docs.pytest.org/>`_ and feel free to ask for guidance on how to write tests!
 
 .. note::
 


### PR DESCRIPTION
### Description
While reviewing the documentation on developer contribution and Perl building systems, I noticed several deprecated HTTP fallback links and broken doc.pytest.org subdomains. 

This PR updates them to their securely encrypted equivalent https:// protocols specifically:
- Modernized pytest.org links to docs.pytest.org properly supporting secure documentation routing.
- Secured external links directly into perlmonks and cpan.

Small maintenance update to ensure the ecosystem documentation stays perfectly reliable for new contributors!

### General Information

- [X] I have run \spack debug report\ and reported the version of Spack/Python/Platform
- [X] I have searched the issues of this repo and believe this is not a duplicate
- [X] I have run the failing commands in debug mode and reported the output