### PR TITLE
spec_parser.py: extract toolchain expansion from SpecParser

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -182,7 +182,8 @@ def parse_specs(
     args = [args] if isinstance(args, str) else args
     arg_string = " ".join([quote_kvp(arg) for arg in args])
 
-    specs = spack.spec_parser.parse(arg_string)
+    toolchains = spack.config.CONFIG.get("toolchains", {})
+    specs = spack.spec_parser.parse(arg_string, toolchains=toolchains)
     if not concretize:
         return specs
 

--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -61,7 +61,7 @@ def change(parser, args):
 
     match_spec = None
     if args.match_spec:
-        match_spec = spack.spec.Spec(args.match_spec)
+        match_spec = spack.cmd.parse_specs([args.match_spec])[0]
     specs = spack.cmd.parse_specs(args.specs)
 
     with env.write_transaction():

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1247,6 +1247,9 @@ class Environment:
         self._process_included_lockfiles()
 
     def _sync_speclists(self):
+        self._spec_lists_parser = SpecListParser(
+            toolchains=spack.config.CONFIG.get("toolchains", {})
+        )
         self.spec_lists = {}
         self.spec_lists.update(
             self._spec_lists_parser.parse_definitions(

--- a/lib/spack/spack/environment/list.py
+++ b/lib/spack/spack/environment/list.py
@@ -9,10 +9,13 @@ import spack.util.spack_yaml
 import spack.variant
 from spack.error import SpackError
 from spack.spec import Spec
+from spack.spec_parser import expand_toolchains
 
 
 class SpecList:
-    def __init__(self, *, name: str = "specs", yaml_list=None, expanded_list=None):
+    def __init__(
+        self, *, name: str = "specs", yaml_list=None, expanded_list=None, toolchains=None
+    ):
         self.name = name
         self.yaml_list = yaml_list[:] if yaml_list is not None else []
         # Expansions can be expensive to compute and difficult to keep updated
@@ -20,6 +23,7 @@ class SpecList:
         self.specs_as_yaml_list = expanded_list or []
         self._constraints = None
         self._specs: Optional[List[Spec]] = None
+        self._toolchains = toolchains
 
     @property
     def is_matrix(self):
@@ -51,6 +55,8 @@ class SpecList:
                 spec = constraint_list[0].copy()
                 for const in constraint_list[1:]:
                     spec.constrain(const)
+                if self._toolchains:
+                    expand_toolchains(spec, self._toolchains)
                 specs.append(spec)
             self._specs = specs
 
@@ -178,8 +184,9 @@ class Definition(NamedTuple):
 class SpecListParser:
     """Parse definitions and user specs from data in environments"""
 
-    def __init__(self):
+    def __init__(self, *, toolchains=None):
         self.definitions: Dict[str, SpecList] = {}
+        self._toolchains = toolchains
 
     def parse_definitions(self, *, data: List[Dict[str, Any]]) -> Dict[str, SpecList]:
         definitions_from_yaml: Dict[str, List[Definition]] = {}
@@ -225,7 +232,12 @@ class SpecListParser:
                 continue
             combined_yaml_list.extend(def_part.yaml_list)
         expanded_list = self._expand_yaml_list(combined_yaml_list)
-        return SpecList(name=name, yaml_list=combined_yaml_list, expanded_list=expanded_list)
+        return SpecList(
+            name=name,
+            yaml_list=combined_yaml_list,
+            expanded_list=expanded_list,
+            toolchains=self._toolchains,
+        )
 
     def _expand_yaml_list(self, raw_yaml_list):
         result = []

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -9,6 +9,7 @@ import spack.error
 import spack.package_base
 import spack.repo
 import spack.spec
+import spack.spec_parser
 import spack.traverse
 from spack.enums import PropagationPolicy
 from spack.llnl.util import tty
@@ -104,6 +105,13 @@ class RequirementParser:
         self.runtime_pkgs = spack.repo.PATH.packages_with_tags("runtime")
         self.compiler_pkgs = spack.repo.PATH.packages_with_tags("compiler")
         self.preferences_from_input: List[Tuple[spack.spec.Spec, str]] = []
+        self.toolchains = configuration.get_config("toolchains")
+
+    def _parse_and_expand(self, string: str, *, named: bool = False) -> spack.spec.Spec:
+        result = parse_spec_from_yaml_string(string, named=named)
+        if self.toolchains:
+            spack.spec_parser.expand_toolchains(result, self.toolchains)
+        return result
 
     def rules(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
         result = []
@@ -248,7 +256,7 @@ class RequirementParser:
 
                 # validate specs from YAML first, and fail with line numbers if parsing fails.
                 constraints = [
-                    parse_spec_from_yaml_string(constraint, named=kind == RequirementKind.VIRTUAL)
+                    self._parse_and_expand(constraint, named=kind == RequirementKind.VIRTUAL)
                     for constraint in constraints
                 ]
                 when_str = requirement.get("when")

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -79,6 +79,7 @@ from spack.vendor.typing_extensions import Literal
 import spack
 import spack.aliases
 import spack.compilers.flags
+import spack.config
 import spack.deptypes as dt
 import spack.error
 import spack.hash_types as ht
@@ -1488,7 +1489,9 @@ class Spec:
         s.architecture = ArchSpec.default_arch()
         return s
 
-    def __init__(self, spec_like=None, *, external_path=None, external_modules=None):
+    def __init__(
+        self, spec_like=None, *, external_path=None, external_modules=None, expand_toolchains=True
+    ):
         """Create a new Spec.
 
         Arguments:
@@ -1497,8 +1500,8 @@ class Spec:
 
         Keyword arguments:
             external_path: prefix, if this is a spec for an external package
-            external_modules: list of external modules, if this is an external package
-                using modules.
+            external_modules: list of external modules, for an external package using modules
+            expand_toolchains: whether to expand toolchains from configuration
         """
         # Copy if spec_like is a Spec.
         if isinstance(spec_like, Spec):
@@ -1548,7 +1551,12 @@ class Spec:
         self.annotations = SpecAnnotations()
 
         if isinstance(spec_like, str):
-            spack.spec_parser.parse_one_or_raise(spec_like, self)
+            toolchains = {}
+            if expand_toolchains:
+                configuration = getattr(spack.config, "CONFIG", None)
+                if configuration is not None:
+                    toolchains = configuration.get_config("toolchains")
+            spack.spec_parser.parse_one_or_raise(spec_like, self, toolchains=toolchains)
 
         elif spec_like is not None:
             raise TypeError(f"Can't make spec out of {type(spec_like)}")

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -79,7 +79,6 @@ from spack.vendor.typing_extensions import Literal
 import spack
 import spack.aliases
 import spack.compilers.flags
-import spack.config
 import spack.deptypes as dt
 import spack.error
 import spack.hash_types as ht
@@ -1489,9 +1488,7 @@ class Spec:
         s.architecture = ArchSpec.default_arch()
         return s
 
-    def __init__(
-        self, spec_like=None, *, external_path=None, external_modules=None, expand_toolchains=True
-    ):
+    def __init__(self, spec_like=None, *, external_path=None, external_modules=None):
         """Create a new Spec.
 
         Arguments:
@@ -1501,7 +1498,6 @@ class Spec:
         Keyword arguments:
             external_path: prefix, if this is a spec for an external package
             external_modules: list of external modules, for an external package using modules
-            expand_toolchains: whether to expand toolchains from configuration
         """
         # Copy if spec_like is a Spec.
         if isinstance(spec_like, Spec):
@@ -1551,12 +1547,7 @@ class Spec:
         self.annotations = SpecAnnotations()
 
         if isinstance(spec_like, str):
-            toolchains = {}
-            if expand_toolchains:
-                configuration = getattr(spack.config, "CONFIG", None)
-                if configuration is not None:
-                    toolchains = configuration.get_config("toolchains")
-            spack.spec_parser.parse_one_or_raise(spec_like, self, toolchains=toolchains)
+            spack.spec_parser.parse_one_or_raise(spec_like, self)
 
         elif spec_like is not None:
             raise TypeError(f"Can't make spec out of {type(spec_like)}")

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -623,9 +623,7 @@ def parse_one_or_raise(
     return result
 
 
-def _parse_toolchain_config(
-    toolchain_config: Union[str, List[Dict]], name: str
-) -> "spack.spec.Spec":
+def _parse_toolchain_config(toolchain_config: Union[str, List[Dict]]) -> "spack.spec.Spec":
     """Parse a toolchain config entry (string or list) into a Spec."""
     if isinstance(toolchain_config, str):
         toolchain = parse_one_or_raise(toolchain_config)
@@ -694,7 +692,7 @@ def expand_toolchains(
 
             # Parse and cache toolchain
             if name not in _cache:
-                _cache[name] = _parse_toolchain_config(toolchains[name], name)
+                _cache[name] = _parse_toolchain_config(toolchains[name])
 
             propagation = edge.propagation
             propagation_arg = None if propagation != PropagationPolicy.PREFERENCE else propagation

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -62,7 +62,6 @@ import re
 import sys
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple, Union
 
-import spack.config
 import spack.deptypes
 import spack.error
 import spack.version
@@ -290,18 +289,11 @@ def parse_virtual_assignment(context: TokenContext) -> Tuple[str]:
 class SpecParser:
     """Parse text into specs"""
 
-    __slots__ = "literal_str", "ctx", "toolchains", "parsed_toolchains"
+    __slots__ = "literal_str", "ctx"
 
     def __init__(self, literal_str: str):
         self.literal_str = literal_str
         self.ctx = TokenContext(parseable_tokens(literal_str))
-
-        # TODO: Move toolchains out of the parser, and expand them as a separate step
-        self.toolchains = {}
-        configuration = getattr(spack.config, "CONFIG", None)
-        if configuration is not None:
-            self.toolchains = configuration.get_config("toolchains")
-        self.parsed_toolchains: Dict[str, "spack.spec.Spec"] = {}
 
     def tokens(self) -> List[Token]:
         """Return the entire list of token from the initial text. White spaces are
@@ -339,71 +331,39 @@ class SpecParser:
         current_spec = root_spec
         while True:
             if self.ctx.accept(SpecTokens.START_EDGE_PROPERTIES):
-                is_direct = self.ctx.current_token.value[0] == "%"
-
-                propagation = PropagationPolicy.NONE
-                if is_direct and self.ctx.current_token.value.startswith("%%"):
-                    propagation = PropagationPolicy.PREFERENCE
-
-                edge_properties = EdgeAttributeParser(self.ctx, self.literal_str).parse()
-                edge_properties.setdefault("virtuals", ())
-                edge_properties["direct"] = is_direct
-                edge_properties.setdefault("depflag", 0)
-                edge_properties["propagation"] = propagation
-
-                dependency = self._parse_node(root_spec)
-
-                if is_direct:
-                    target_spec = current_spec
-                    if dependency.name in LEGACY_COMPILER_TO_BUILTIN:
-                        dependency.name = LEGACY_COMPILER_TO_BUILTIN[dependency.name]
-                else:
-                    current_spec = dependency
-                    target_spec = root_spec
-
-                add_dependency(dependency, **edge_properties)
-
+                has_edge_attrs = True
             elif self.ctx.accept(SpecTokens.DEPENDENCY):
-                is_direct = self.ctx.current_token.value[0] == "%"
-                propagation = PropagationPolicy.NONE
-
-                if is_direct and self.ctx.current_token.value.startswith("%%"):
-                    propagation = PropagationPolicy.PREFERENCE
-
-                virtuals = parse_virtual_assignment(self.ctx)
-
-                # if no virtual assignment, check for a toolchain - look ahead to find the
-                # toolchain and substitute it
-                if not virtuals and is_direct and self.ctx.next_token.value in self.toolchains:
-                    assert self.ctx.accept(SpecTokens.UNQUALIFIED_PACKAGE_NAME)
-                    try:
-                        self._apply_toolchain(
-                            current_spec, self.ctx.current_token.value, propagation=propagation
-                        )
-                    except spack.error.SpecError as e:
-                        raise SpecParsingError(str(e), self.ctx.current_token, self.literal_str)
-                    continue
-
-                edge_properties = {
-                    "direct": is_direct,
-                    "virtuals": virtuals,
-                    "depflag": 0,
-                    "propagation": propagation,
-                }
-                dependency = self._parse_node(root_spec)
-
-                if is_direct:
-                    target_spec = current_spec
-                    if dependency.name in LEGACY_COMPILER_TO_BUILTIN:
-                        dependency.name = LEGACY_COMPILER_TO_BUILTIN[dependency.name]
-                else:
-                    current_spec = dependency
-                    target_spec = root_spec
-
-                add_dependency(dependency, **edge_properties)
-
+                has_edge_attrs = False
             else:
                 break
+
+            is_direct = self.ctx.current_token.value[0] == "%"
+            propagation = PropagationPolicy.NONE
+            if is_direct and self.ctx.current_token.value.startswith("%%"):
+                propagation = PropagationPolicy.PREFERENCE
+
+            if has_edge_attrs:
+                edge_properties = EdgeAttributeParser(self.ctx, self.literal_str).parse()
+                edge_properties.setdefault("virtuals", ())
+                edge_properties.setdefault("depflag", 0)
+            else:
+                virtuals = parse_virtual_assignment(self.ctx)
+                edge_properties = {"virtuals": virtuals, "depflag": 0}
+
+            edge_properties["direct"] = is_direct
+            edge_properties["propagation"] = propagation
+
+            dependency = self._parse_node(root_spec)
+
+            if is_direct:
+                target_spec = current_spec
+                if dependency.name in LEGACY_COMPILER_TO_BUILTIN:
+                    dependency.name = LEGACY_COMPILER_TO_BUILTIN[dependency.name]
+            else:
+                current_spec = dependency
+                target_spec = root_spec
+
+            add_dependency(dependency, **edge_properties)
 
         return root_spec
 
@@ -418,54 +378,6 @@ class SpecParser:
         if root_spec.concrete:
             raise spack.error.SpecError(str(root_spec), "^" + str(dependency))
         return dependency
-
-    def _apply_toolchain(
-        self, spec: "spack.spec.Spec", name: str, *, propagation: PropagationPolicy
-    ) -> None:
-        if name not in self.parsed_toolchains:
-            toolchain = self._parse_toolchain(name)
-            self.parsed_toolchains[name] = toolchain
-
-        propagation_arg = None if propagation != PropagationPolicy.PREFERENCE else propagation
-        # Here we need to copy because we want "foo %toolc ^bar %toolc" to generate different
-        # objects for the toolc attached to foo and bar, since the solver depends on that to
-        # generate facts
-        toolchain = self.parsed_toolchains[name].copy(propagation=propagation_arg)
-        spec.constrain(toolchain)
-
-    def _parse_toolchain(self, name: str) -> "spack.spec.Spec":
-        toolchain_config = self.toolchains[name]
-        if isinstance(toolchain_config, str):
-            toolchain = parse_one_or_raise(toolchain_config)
-            self._ensure_all_direct_edges(toolchain)
-        else:
-            from spack.spec import EMPTY_SPEC, Spec
-
-            toolchain = Spec()
-            for entry in toolchain_config:
-                toolchain_part = parse_one_or_raise(entry["spec"])
-                when = entry.get("when", "")
-                self._ensure_all_direct_edges(toolchain_part)
-
-                # Apply global "when" to all edges in toolchain part
-                if when:
-                    when_spec = Spec(when)
-                    for edge in toolchain_part.traverse_edges():
-                        # EMPTY_SPEC is immutable by convention, so create a mutable instance.
-                        if edge.when is EMPTY_SPEC:
-                            edge.when = when_spec.copy()
-                        else:
-                            edge.when.constrain(when_spec)
-                toolchain.constrain(toolchain_part)
-        return toolchain
-
-    def _ensure_all_direct_edges(self, constraint: "spack.spec.Spec") -> None:
-        for edge in constraint.traverse_edges(root=False):
-            if not edge.direct:
-                raise spack.error.SpecError(
-                    f"cannot use '^' in toolchain definitions, and the current "
-                    f"toolchain contains '{edge.format()}'"
-                )
 
     def all_specs(self) -> List["spack.spec.Spec"]:
         """Return all the specs that remain to be parsed"""
@@ -661,26 +573,36 @@ class EdgeAttributeParser:
         return attributes
 
 
-def parse(text: str) -> List["spack.spec.Spec"]:
-    """Parse text into a list of strings
+def parse(text: str, *, toolchains: Optional[Dict] = None) -> List["spack.spec.Spec"]:
+    """Parse text into a list of specs
 
     Args:
-        text (str): text to be parsed
+        text: text to be parsed
+        toolchains: optional toolchain definitions to expand after parsing
 
     Return:
         List of specs
     """
-    return SpecParser(text).all_specs()
+    specs = SpecParser(text).all_specs()
+    if toolchains:
+        cache: Dict[str, "spack.spec.Spec"] = {}
+        for spec in specs:
+            expand_toolchains(spec, toolchains, _cache=cache)
+    return specs
 
 
 def parse_one_or_raise(
-    text: str, initial_spec: Optional["spack.spec.Spec"] = None
+    text: str,
+    initial_spec: Optional["spack.spec.Spec"] = None,
+    *,
+    toolchains: Optional[Dict] = None,
 ) -> "spack.spec.Spec":
     """Parse exactly one spec from text and return it, or raise
 
     Args:
-        text (str): text to be parsed
+        text: text to be parsed
         initial_spec: buffer where to parse the spec. If None a new one will be created.
+        toolchains: optional toolchain definitions to expand after parsing
     """
     parser = SpecParser(text)
     result = parser.next_spec(initial_spec)
@@ -695,7 +617,90 @@ def parse_one_or_raise(
     if result is None:
         raise ValueError("expected a single spec, but got none")
 
+    if toolchains:
+        expand_toolchains(result, toolchains)
+
     return result
+
+
+def _parse_toolchain_config(
+    toolchain_config: Union[str, List[Dict]], name: str
+) -> "spack.spec.Spec":
+    """Parse a toolchain config entry (string or list) into a Spec."""
+    if isinstance(toolchain_config, str):
+        toolchain = parse_one_or_raise(toolchain_config)
+        _ensure_all_direct_edges(toolchain)
+    else:
+        from spack.spec import EMPTY_SPEC, Spec
+
+        toolchain = Spec()
+        for entry in toolchain_config:
+            toolchain_part = parse_one_or_raise(entry["spec"])
+            when = entry.get("when", "")
+            _ensure_all_direct_edges(toolchain_part)
+
+            if when:
+                when_spec = Spec(when)
+                for edge in toolchain_part.traverse_edges():
+                    if edge.when is EMPTY_SPEC:
+                        edge.when = when_spec.copy()
+                    else:
+                        edge.when.constrain(when_spec)
+            toolchain.constrain(toolchain_part)
+    return toolchain
+
+
+def _ensure_all_direct_edges(constraint: "spack.spec.Spec") -> None:
+    """Validate that a toolchain spec only has direct (%) edges."""
+    for edge in constraint.traverse_edges(root=False):
+        if not edge.direct:
+            raise spack.error.SpecError(
+                f"cannot use '^' in toolchain definitions, and the current "
+                f"toolchain contains '{edge.format()}'"
+            )
+
+
+def expand_toolchains(
+    spec: "spack.spec.Spec",
+    toolchains: Dict,
+    *,
+    _cache: Optional[Dict[str, "spack.spec.Spec"]] = None,
+) -> None:
+    """Replace toolchain placeholder deps with expanded toolchain constraints.
+
+    Walks every node in the spec DAG. For each node, finds direct dependency
+    edges whose child name is a key in ``toolchains``. Removes the placeholder
+    edge, parses the toolchain config, copies with the edge's propagation
+    policy, and constrains the node.
+    """
+    if _cache is None:
+        _cache = {}
+
+    for node in list(spec.traverse()):
+        for edge in list(node.edges_to_dependencies()):
+            if not edge.direct:
+                continue
+            name = edge.spec.name
+            if name not in toolchains:
+                continue
+
+            # Remove the placeholder edge (both directions)
+            node._dependencies[name].remove(edge)
+            if not node._dependencies[name]:
+                del node._dependencies[name]
+            edge.spec._dependents[node.name].remove(edge)
+            if not edge.spec._dependents[node.name]:
+                del edge.spec._dependents[node.name]
+
+            # Parse and cache toolchain
+            if name not in _cache:
+                _cache[name] = _parse_toolchain_config(toolchains[name], name)
+
+            propagation = edge.propagation
+            propagation_arg = None if propagation != PropagationPolicy.PREFERENCE else propagation
+            # Copy so each usage gets a distinct object (solver depends on this)
+            toolchain = _cache[name].copy(propagation=propagation_arg)
+            node.constrain(toolchain)
 
 
 class SpecParsingError(spack.error.SpecSyntaxError):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -16,6 +16,7 @@ import spack.llnl.util.filesystem as fs
 import spack.platforms
 import spack.solver.asp
 import spack.spec
+import spack.spec_parser
 from spack.enums import ConfigScopePriority
 from spack.environment import SpackEnvironmentConfigError
 from spack.environment.environment import (
@@ -1602,7 +1603,8 @@ spack:
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path):
         # We rely on this behavior when emitting facts for the solver
-        s = spack.spec.Spec("mpileaks %gnu ^callpath %gnu")
+        toolchains = spack.config.CONFIG.get("toolchains", {})
+        s = spack.spec_parser.parse("mpileaks %gnu ^callpath %gnu", toolchains=toolchains)[0]
         assert id(s["gcc"]) != id(s["callpath"]["gcc"])
 
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -12,7 +12,6 @@ import pytest
 import spack.binary_distribution
 import spack.cmd
 import spack.concretize
-import spack.config
 import spack.error
 import spack.llnl.util.filesystem as fs
 import spack.platforms.test
@@ -26,6 +25,7 @@ from spack.spec_parser import (
     SpecParsingError,
     SpecTokenizationError,
     SpecTokens,
+    expand_toolchains,
     parse_one_or_raise,
 )
 from spack.tokenize import Token
@@ -1211,10 +1211,12 @@ def test_cli_spec_roundtrip(args, expected):
     ],
 )
 def test_parse_toolchain(spec_str, toolchain, expected_roundtrip, mutable_config):
-    spack.config.CONFIG.set("toolchains", toolchain)
+    """Tests that toolchains are expanded correctly"""
     parser = SpecParser(spec_str)
     for expected in expected_roundtrip:
-        assert expected == str(parser.next_spec())
+        result = parser.next_spec()
+        expand_toolchains(result, toolchain)
+        assert expected == str(result)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Co-developed with Claude Opus 4.6

Toolchain references are now parsed as regular dependencies and expanded in a separate post-parse step via `expand_toolchains`. 

Toolchain expansion now happens in these entry points:
- SpecList/SpecListParser for environment YAML
- RequirementParser for packages.yaml requirements
- spack.cmd.parse_specs for CLI


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
