### PR TITLE
docs: modernize external HTTP links to HTTPS across guide documentation

### DIFF
--- a/lib/spack/docs/build_systems/perlpackage.rst
+++ b/lib/spack/docs/build_systems/perlpackage.rst
@@ -267,6 +267,6 @@ If you need to install to your home directory or need to install a module with n
 External documentation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-You can find more information on installing Perl modules from source at: http://www.perlmonks.org/?node_id=128077
+You can find more information on installing Perl modules from source at: https://www.perlmonks.org/?node_id=128077
 
-More generic Perl module installation instructions can be found at: http://www.cpan.org/modules/INSTALL.html
+More generic Perl module installation instructions can be found at: https://www.cpan.org/modules/INSTALL.html

--- a/lib/spack/docs/build_systems/qmakepackage.rst
+++ b/lib/spack/docs/build_systems/qmakepackage.rst
@@ -117,4 +117,4 @@ If the ``*.pro`` file used to tell QMake how to build the package is found in a 
 External documentation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-For more information on the QMake build system, see: http://doc.qt.io/qt-5/qmake-manual.html
+For more information on the QMake build system, see: https://doc.qt.io/qt-5/qmake-manual.html

--- a/lib/spack/docs/build_systems/sconspackage.rst
+++ b/lib/spack/docs/build_systems/sconspackage.rst
@@ -272,4 +272,4 @@ Note that this may involve passing additional flags to the build to locate depen
 External documentation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-For more information on the SCons build system, see: http://scons.org/documentation.html
+For more information on the SCons build system, see: https://scons.org/documentation.html

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -98,7 +98,7 @@ And this would run the ``test_platform`` test from that file:
    $ spack unit-test lib/spack/spack/test/architecture.py::test_platform
 
 This allows you to develop iteratively: make a change, test that change, make another change, test that change, etc.
-We use `pytest <http://pytest.org/>`_ as our tests framework, and these types of arguments are just passed to the ``pytest`` command underneath.
+We use `pytest <https://pytest.org/>`_ as our tests framework, and these types of arguments are just passed to the ``pytest`` command underneath.
 See `the pytest docs <https://doc.pytest.org/en/latest/how-to/usage.html#specifying-which-tests-to-run>`_ for more details on test selection syntax.
 
 ``spack unit-test`` has a few special options that can help you understand what tests are available.
@@ -139,7 +139,7 @@ To see the output *live*, use the ``-s`` argument to ``pytest``:
 Unit tests are crucial to making sure bugs are not introduced into Spack.
 If you are modifying core Spack libraries or adding new functionality, please add new unit tests for your feature and consider strengthening existing tests.
 You will likely be asked to do this if you submit a pull request to the Spack project on GitHub.
-Check out the `pytest documentation <http://pytest.org/>`_ and feel free to ask for guidance on how to write tests!
+Check out the `pytest documentation <https://pytest.org/>`_ and feel free to ask for guidance on how to write tests!
 
 .. note::
 
@@ -151,7 +151,7 @@ Check out the `pytest documentation <http://pytest.org/>`_ and feel free to ask 
 Style Tests
 ^^^^^^^^^^^^
 
-Spack uses `Flake8 <http://flake8.pycqa.org/en/latest/>`_ to test for `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ conformance and `mypy <https://mypy.readthedocs.io/en/stable/>`_ for type checking.
+Spack uses `Flake8 <https://flake8.pycqa.org/en/latest/>`_ to test for `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ conformance and `mypy <https://mypy.readthedocs.io/en/stable/>`_ for type checking.
 PEP 8 is a series of style guides for Python that provide suggestions for everything from variable naming to indentation.
 In order to limit the number of PRs that were mostly style changes, we decided to enforce PEP 8 conformance.
 Your PR needs to comply with PEP 8 in order to be accepted, and if it modifies the Spack library, it needs to successfully type-check with mypy as well.

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -97,7 +97,7 @@ So that you can familiarize yourself with the project, we will start with a high
                test/              <- unit test modules
                util/              <- common code
 
-Spack is designed so that it could live within a `standard UNIX directory hierarchy <http://linux.die.net/man/7/hier>`_, so ``lib``, ``var``, and ``opt`` all contain a ``spack`` subdirectory in case Spack is installed alongside other software.
+Spack is designed so that it could live within a `standard UNIX directory hierarchy <https://linux.die.net/man/7/hier>`_, so ``lib``, ``var``, and ``opt`` all contain a ``spack`` subdirectory in case Spack is installed alongside other software.
 Most of the interesting parts of Spack live in ``lib/spack``.
 
 .. note::
@@ -654,7 +654,7 @@ In order to debug Spack's URL parsing support, the ``spack url`` command can be 
 
 If you need to debug a single URL, you can use the following command:
 
-.. command-output:: spack url parse http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz
+.. command-output:: spack url parse https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz
 
 You will notice that the name and version of this URL are correctly detected, and you can even see which regular expressions it was matched to.
 However, you will notice that when it substitutes the version number in, it does not replace the ``2.2`` with ``9.9`` where we would expect ``9.9.9b`` to live.

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -81,23 +81,23 @@ Here is what it looks like:
 
    $ spack mirror create libelf libdwarf
    ==> Created new mirror in spack-mirror-2014-06-24
-   ==> Trying to fetch from http://www.mr511.de/software/libelf-0.8.13.tar.gz
+   ==> Trying to fetch from https://www.mr511.de/software/libelf-0.8.13.tar.gz
    ##########################################################                81.6%
    ==> Checksum passed for libelf@0.8.13
    ==> Added libelf@0.8.13
-   ==> Trying to fetch from http://www.mr511.de/software/libelf-0.8.12.tar.gz
+   ==> Trying to fetch from https://www.mr511.de/software/libelf-0.8.12.tar.gz
    ######################################################################    98.6%
    ==> Checksum passed for libelf@0.8.12
    ==> Added libelf@0.8.12
-   ==> Trying to fetch from http://www.prevanders.net/libdwarf-20130207.tar.gz
+   ==> Trying to fetch from https://www.prevanders.net/libdwarf-20130207.tar.gz
    ######################################################################    97.3%
    ==> Checksum passed for libdwarf@20130207
    ==> Added libdwarf@20130207
-   ==> Trying to fetch from http://www.prevanders.net/libdwarf-20130126.tar.gz
+   ==> Trying to fetch from https://www.prevanders.net/libdwarf-20130126.tar.gz
    ########################################################                  78.9%
    ==> Checksum passed for libdwarf@20130126
    ==> Added libdwarf@20130126
-   ==> Trying to fetch from http://www.prevanders.net/libdwarf-20130729.tar.gz
+   ==> Trying to fetch from https://www.prevanders.net/libdwarf-20130729.tar.gz
    #############################################################             84.7%
    ==> Added libdwarf@20130729
    ==> Added spack-mirror-2014-06-24/libdwarf/libdwarf-20130729.tar.gz to mirror

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -13,7 +13,7 @@ Modules (modules.yaml)
 ======================
 
 The use of module systems to manage user environments in a controlled way is a common practice at HPC centers that is sometimes embraced also by individual programmers on their development machines.
-To support this common practice Spack integrates with `Environment Modules <http://modules.sourceforge.net/>`_ and `Lmod <http://lmod.readthedocs.io/en/latest/>`_ by providing post-install hooks that generate module files and commands to manipulate them.
+To support this common practice Spack integrates with `Environment Modules <https://modules.sourceforge.net/>`_ and `Lmod <https://lmod.readthedocs.io/en/latest/>`_ by providing post-install hooks that generate module files and commands to manipulate them.
 
 Modules are one of several ways you can use Spack packages.
 For other options that may fit your use case better, you should also look at :ref:`spack load <spack-load>` and :ref:`environments <environments>`.
@@ -669,7 +669,7 @@ Scripts to load modules recursively may be made with the command:
 
    $ spack module tcl loads --dependencies <spec>
 
-An equivalent alternative using `process substitution <http://tldp.org/LDP/abs/html/process-sub.html>`_ is:
+An equivalent alternative using `process substitution <https://tldp.org/LDP/abs/html/process-sub.html>`_ is:
 
 .. code-block:: console
 

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -737,7 +737,7 @@ You can assign class-level attributes in the configuration:
      mpileaks:
        package_attributes:
          # Override existing attributes
-         url: http://www.somewhereelse.com/mpileaks-1.0.tar.gz
+         url: https://www.somewhereelse.com/mpileaks-1.0.tar.gz
          # ... or add new ones
          x: 1
 

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -1426,8 +1426,8 @@ The ``spack graph <spec>`` command can help you visualize the dependency graph b
 
 By default it generates an ASCII rendering of a spec's dependency graph, which can be complementary to the output of ``spack spec``.
 
-Much more powerful is the set of flags ``spack graph --color --dot ...``, which turns the dependency graph into `Dot <http://www.graphviz.org/doc/info/lang.html>`_ format.
-Tools such as `Graphviz <http://www.graphviz.org>`_ can render this.
+Much more powerful is the set of flags ``spack graph --color --dot ...``, which turns the dependency graph into `Dot <https://www.graphviz.org/doc/info/lang.html>`_ format.
+Tools such as `Graphviz <https://www.graphviz.org>`_ can render this.
 For example, you can generate a PDF of the dependency graph of a package with the following command:
 
 .. code-block:: console

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -430,7 +430,7 @@ The most straightforward way to add new versions to your package is to add a lin
 
    class Foo(Package):
 
-       url = "http://example.com/foo-8.2.1.tar.gz"
+       url = "https://example.com/foo-8.2.1.tar.gz"
 
        version("8.2.1", sha256="85f477fdd6f8194ab6a0e7afd1cb34eae46c775278d5db9d7ebc9ddaf50c23b1")
        version("8.2.0", sha256="427b2e244e73385515b8ad4f75358139d44a4c792d9b26ddffe2582835cedd8c")
@@ -447,7 +447,7 @@ The most straightforward way to add new versions to your package is to add a lin
 
 
 Notice how you only have to specify the URL once, in the ``url`` field.
-Spack is smart enough to extrapolate the URL for each version based on the version number and download version ``8.2.0`` of the ``Foo`` package above from ``http://example.com/foo-8.2.0.tar.gz``.
+Spack is smart enough to extrapolate the URL for each version based on the version number and download version ``8.2.0`` of the ``Foo`` package above from ``https://example.com/foo-8.2.0.tar.gz``.
 
 If the URL is particularly complicated or changes based on the release, you can override the default URL generation algorithm by defining your own :py:meth:`~spack.package.PackageBase.url_for_version` function.
 For example, the download URL for OpenMPI contains the ``major.minor`` version in one spot and the ``major.minor.patch`` version in another:
@@ -465,13 +465,13 @@ With the use of this ``url_for_version()``, Spack knows to download OpenMPI ``2.
 
 .. code-block:: text
 
-   http://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.bz2
+   https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.bz2
 
 but download OpenMPI ``1.10.7`` from
 
 .. code-block:: text
 
-   http://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.7.tar.bz2
+   https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.7.tar.bz2
 
 You'll notice that OpenMPI's ``url_for_version()`` function makes use of a special ``Version`` function called ``up_to()``.
 When you call ``version.up_to(2)`` on a version like ``1.10.0``, it returns ``1.10``.
@@ -521,7 +521,7 @@ If a URL cannot be derived systematically, or there is a special URL for one of 
    version(
        "8.2.1",
        sha256="91ee5e9f42ba3d34e414443b36a27b797a56a47aad6bb1e4c1769e69c77ce0ca",
-       url="http://example.com/foo-8.2.1-special-version.tar.gz",
+       url="https://example.com/foo-8.2.1-special-version.tar.gz",
    )
 
 
@@ -580,17 +580,17 @@ Using ``spack checksum`` is straightforward:
 
    $ spack checksum libelf
    ==> Found 16 versions of libelf.
-     0.8.13    http://www.mr511.de/software/libelf-0.8.13.tar.gz
-     0.8.12    http://www.mr511.de/software/libelf-0.8.12.tar.gz
-     0.8.11    http://www.mr511.de/software/libelf-0.8.11.tar.gz
-     0.8.10    http://www.mr511.de/software/libelf-0.8.10.tar.gz
-     0.8.9     http://www.mr511.de/software/libelf-0.8.9.tar.gz
-     0.8.8     http://www.mr511.de/software/libelf-0.8.8.tar.gz
-     0.8.7     http://www.mr511.de/software/libelf-0.8.7.tar.gz
-     0.8.6     http://www.mr511.de/software/libelf-0.8.6.tar.gz
-     0.8.5     http://www.mr511.de/software/libelf-0.8.5.tar.gz
+     0.8.13    https://www.mr511.de/software/libelf-0.8.13.tar.gz
+     0.8.12    https://www.mr511.de/software/libelf-0.8.12.tar.gz
+     0.8.11    https://www.mr511.de/software/libelf-0.8.11.tar.gz
+     0.8.10    https://www.mr511.de/software/libelf-0.8.10.tar.gz
+     0.8.9     https://www.mr511.de/software/libelf-0.8.9.tar.gz
+     0.8.8     https://www.mr511.de/software/libelf-0.8.8.tar.gz
+     0.8.7     https://www.mr511.de/software/libelf-0.8.7.tar.gz
+     0.8.6     https://www.mr511.de/software/libelf-0.8.6.tar.gz
+     0.8.5     https://www.mr511.de/software/libelf-0.8.5.tar.gz
      ...
-     0.5.2     http://www.mr511.de/software/libelf-0.5.2.tar.gz
+     0.5.2     https://www.mr511.de/software/libelf-0.5.2.tar.gz
 
    How many would you like to checksum? (default is 1, q to abort)
 
@@ -611,7 +611,7 @@ It fetches the tarballs you ask for and prints out a list of ``version`` command
    If that's not possible, e.g., if the package's developers don't name their source archive consistently, you'll need to manually add ``version`` calls yourself.
 
 By default, Spack will search for new versions by scraping the parent URL component of the source archive you gave it in the ``url`` attribute.
-So, if the sources are at ``http://example.com/downloads/foo-1.0.tar.gz``, Spack computes a *list URL* from it ``http://example.com/downloads/``, and scans that for links to other versions of the package.
+So, if the sources are at ``https://example.com/downloads/foo-1.0.tar.gz``, Spack computes a *list URL* from it ``https://example.com/downloads/``, and scans that for links to other versions of the package.
 If you need to search another path for download links, you can supply some extra attributes that control how your package finds new versions.
 See the documentation on :ref:`attribute_list_url` and :ref:`attribute_list_depth`.
 
@@ -661,9 +661,9 @@ For example, the following package has a ``list_url`` attribute that points to a
    :linenos:
 
    class Example(Package):
-       homepage = "http://www.example.com"
-       url = "http://www.example.com/libexample-1.2.3.tar.gz"
-       list_url = "http://www.example.com/downloads/all-versions.html"
+       homepage = "https://www.example.com"
+       url = "https://www.example.com/libexample-1.2.3.tar.gz"
+       list_url = "https://www.example.com/downloads/all-versions.html"
 
 .. _attribute_list_depth:
 
@@ -675,18 +675,18 @@ For example, ``mpich`` has a tarball URL that looks like this:
 
 .. code-block:: python
 
-   url = "http://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz"
+   url = "https://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz"
 
-But its downloads are a few clicks away from ``http://www.mpich.org/static/downloads/``.
+But its downloads are a few clicks away from ``https://www.mpich.org/static/downloads/``.
 So, we need to add a ``list_url`` *and* a ``list_depth`` attribute:
 
 .. code-block:: python
    :linenos:
 
    class Mpich(Package):
-       homepage = "http://www.mpich.org"
-       url = "http://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz"
-       list_url = "http://www.mpich.org/static/downloads/"
+       homepage = "https://www.mpich.org"
+       url = "https://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz"
+       list_url = "https://www.mpich.org/static/downloads/"
        list_depth = 1
 
 By default, Spack only looks at the top-level page available at ``list_url``.
@@ -705,7 +705,7 @@ Spack supports listing mirrors of the main URL in a package by defining the ``ur
 
   class Foo(Package):
 
-      urls = ["http://example.com/foo-1.0.tar.gz", "http://mirror.com/foo-1.0.tar.gz"]
+      urls = ["https://example.com/foo-1.0.tar.gz", "https://mirror.com/foo-1.0.tar.gz"]
 
 instead of just a single ``url``.
 This attribute is a list of possible URLs that will be tried in order when fetching packages.
@@ -1290,7 +1290,7 @@ If you want to skip this step (e.g., for self-extracting executables and other c
    version(
        "8.2.1",
        sha256="a2bbdb2de53523b8099b37013f251546f3d65dbe7a0774fa41af0a4176992fd4",
-       url="http://example.com/foo-8.2.1-special-version.sh",
+       url="https://example.com/foo-8.2.1-special-version.sh",
        expand=False,
    )
 
@@ -1647,8 +1647,8 @@ Let's take a look at the ``libdwarf`` package to see how it's done:
    :linenos:
 
    class Libdwarf(Package):
-       homepage = "http://www.prevanders.net/dwarf.html"
-       url = "http://www.prevanders.net/libdwarf-20130729.tar.gz"
+       homepage = "https://www.prevanders.net/dwarf.html"
+       url = "https://www.prevanders.net/libdwarf-20130729.tar.gz"
        list_url = homepage
 
        version("20130729", sha256="092fcfbbcfca3b5be7ae1b5e58538e92c35ab273ae13664fed0d67484c8e78a6")
@@ -1935,9 +1935,9 @@ Virtual dependencies
 
 In some cases, more than one package can satisfy another package's dependency.
 One way this can happen is if a package depends on a particular *interface*, but there are multiple *implementations* of the interface, and the package could be built with any of them.
-A *very* common interface in HPC is the `Message Passing Interface (MPI) <http://www.mcs.anl.gov/research/projects/mpi/>`_, which is used in many large-scale parallel applications.
+A *very* common interface in HPC is the `Message Passing Interface (MPI) <https://www.mcs.anl.gov/research/projects/mpi/>`_, which is used in many large-scale parallel applications.
 
-MPI has several different implementations (e.g., `MPICH <http://www.mpich.org>`_, `OpenMPI <http://www.open-mpi.org>`_, and `MVAPICH <http://mvapich.cse.ohio-state.edu>`_) and scientific applications can be built with any one of them.
+MPI has several different implementations (e.g., `MPICH <https://www.mpich.org>`_, `OpenMPI <https://www.open-mpi.org>`_, and `MVAPICH <https://mvapich.cse.ohio-state.edu>`_) and scientific applications can be built with any one of them.
 Many package managers handle interfaces like this by requiring many variations of the package recipe for each implementation of MPI, e.g., ``foo``, ``foo-mvapich``, ``foo-mpich``.
 In Spack every package is defined in a single ``package.py`` file, and avoids the combinatorial explosion through *virtual dependencies*.
 
@@ -2239,7 +2239,7 @@ Here is an example of specifying the unconditional use of a patch file URL:
 .. code-block:: python
 
    patch(
-       "http://www.nwchem-sw.org/images/Tddft_mxvec20.patch",
+       "https://www.nwchem-sw.org/images/Tddft_mxvec20.patch",
        sha256="252c0af58be3d90e5dc5e0d16658434c9efa5d20a5df6c10bf72c2d77f780866",
    )
 
@@ -2278,7 +2278,7 @@ Both the archive and patch checksum are checked when patch archives are download
 .. code-block:: python
 
    patch(
-       "http://www.nwchem-sw.org/images/Tddft_mxvec20.patch.gz",
+       "https://www.nwchem-sw.org/images/Tddft_mxvec20.patch.gz",
        sha256="252c0af58be3d90e5dc5e0d16658434c9efa5d20a5df6c10bf72c2d77f780866",
        archive_sha256="4e8092a161ec6c3a1b5253176fcf33ce7ba23ee2ff27c75dbced589dabacd06e",
    )


### PR DESCRIPTION
### Description
Modernizes the Spack documentation codebase by proactively replacing insecure \http://\ reference links with modern \https://\ endpoints where applicable across the general guide documentation.

### Changes
- Upgraded external resource links across building, contribution, and packager guides (e.g. \perlpackage.rst\, \packaging_guide_creation.rst\, \mirrors.rst\).
- Ignored local development exceptions (\localhost\, \127.0.0.1\).