### PR TITLE
cmd/location: fix --build-dir relative path anchoring

### DIFF
--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -162,9 +162,9 @@ def location(parser, args):
     if args.build_dir:
         # Out of source builds have build_directory defined
         if hasattr(builder, "build_directory"):
-            # build_directory can be either absolute or relative to the stage path
+            # build_directory can be either absolute or relative to the source path
             # in either case os.path.join makes it absolute
-            print(os.path.normpath(os.path.join(pkg.stage.path, builder.build_directory)))
+            print(os.path.normpath(os.path.join(pkg.stage.source_path, builder.build_directory)))
             return
 
         # Otherwise assume in-source builds


### PR DESCRIPTION
## Description
Resolves #27456.

This pull request addresses an issue where \spack location --build-dir\ produces incorrect, malformed directory paths for packages invoking out-of-source builds (like \AutotoolsPackage\ or \CMakePackage\ derivatives).

### Core Change:
Instead of calculating the relative build trajectory anchored to \pkg.stage.path\, the logic was corrected to \os.path.join(pkg.stage.source_path, builder.build_directory)\. The previous implementation broke expectations for \spack-build\ paths whenever the source was pulled into deeper nested structure directories.

### Testing:
- Verified proper path assembly on local simulated package environments.
- Verified inline comments correctly reflect standard Spack architecture (referencing elative to the source path\).
