### PR TITLE
Extract pieces of #49673 that are specific to core Spack

### DIFF
--- a/etc/spack/defaults/base/packages.yaml
+++ b/etc/spack/defaults/base/packages.yaml
@@ -32,6 +32,7 @@ packages:
       glu: [mesa-glu, openglu]
       golang: [go, gcc]
       go-or-gccgo-bootstrap: [go-bootstrap, gcc]
+      hip-lang: [llvm-amdgpu]
       iconv: [libiconv]
       ipp: [intel-oneapi-ipp]
       java: [openjdk, jdk]

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1867,6 +1867,7 @@ compiler(Compiler) :- target_supported(Compiler, _, _).
 language("c").
 language("cxx").
 language("fortran").
+language("hip-lang").
 language_runtime("fortran-rt").
 
 error(10, "Only external, or concrete, compilers are allowed for the {0} language", Language)


### PR DESCRIPTION
See: https://github.com/spack/spack/pull/49673

I think this must merge, and the rest of 49673 can merge into spack-packages second (not verbatim, but I think it all generally applies).