### PR TITLE
new_installer.py: drain logs pipe before close

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1885,6 +1885,7 @@ class PackageInstaller:
                     build = self.running_builds.pop(pid)
                     self.capacity += 1
                     jobserver.release()
+                    self._drain_child_output(build)
                     build.cleanup(selector)
                     exitcode = build.proc.exitcode
                     assert exitcode is not None, "Finished build should have exit code set"
@@ -2181,6 +2182,19 @@ class PackageInstaller:
             return
 
         self.build_status.print_logs(child_info.spec.dag_hash(), data)
+
+    def _drain_child_output(self, child_info: ChildInfo) -> None:
+        """Read and print any remaining output from a finished child's pipe."""
+        dag_hash = child_info.spec.dag_hash()
+        r_fd = child_info.output_r_conn.fileno()
+        try:
+            while True:
+                data = os.read(r_fd, OUTPUT_BUFFER_SIZE)
+                if not data:
+                    break
+                self.build_status.print_logs(dag_hash, data)
+        except OSError:
+            pass
 
     def _handle_child_state(
         self, r_fd: int, child_info: ChildInfo, selector: selectors.BaseSelector


### PR DESCRIPTION
Per iteration of the event loop, we may read less than the available data from a child's logs, because there's a fixed chunk size. Normally the second iteration of the event loop fires right away in this case since the file descriptor is still readable.

This is not true for the last iteration where we are notified that the child has exited, because then the pipe is closed. So, before closing the pipe in the parent, make sure we drain the data so logs are printed until the very end.