### PR TITLE
fetch_strategy.py: retry urllib downloads with exponential back-off 

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -427,43 +427,53 @@ class URLFetchStrategy(FetchStrategy):
             tty.warn(msg)
 
     @_needs_stage
-    def _fetch_urllib(self, url, chunk_size=65536):
+    def _fetch_urllib(self, url, chunk_size=65536, retries=5):
+        """Fetch a URL using urllib, with retries on transient errors and progress reporting."""
         save_file = self.stage.save_filename
+        part_file = save_file + ".part"
 
         request = urllib.request.Request(
             url, headers={"User-Agent": web_util.SPACK_USER_AGENT, "Accept": "*/*"}
         )
 
-        if os.path.lexists(save_file):
-            os.remove(save_file)
-
-        try:
-            response = web_util.urlopen(request)
-            tty.verbose(f"Fetching {url}")
-            progress = FetchProgress.from_headers(response.headers, enabled=sys.stdout.isatty())
-            with open(save_file, "wb") as f:
-                while True:
-                    chunk = response.read(chunk_size)
-                    if not chunk:
-                        break
-                    f.write(chunk)
-                    progress.advance(len(chunk))
-            progress.print(final=True)
-        except OSError as e:
-            # clean up archive on failure.
-            if self.archive_file:
-                os.remove(self.archive_file)
-            if os.path.lexists(save_file):
-                os.remove(save_file)
-            raise FailedDownloadError(e) from e
+        response_headers_str = None
+        for attempt in range(retries):
+            try:
+                with web_util.urlopen(request) as response:
+                    tty.verbose(f"Fetching {url}")
+                    progress = FetchProgress.from_headers(
+                        response.headers, enabled=sys.stdout.isatty()
+                    )
+                    with open(part_file, "wb") as f:
+                        while True:
+                            chunk = response.read(chunk_size)
+                            if not chunk:
+                                break
+                            f.write(chunk)
+                            progress.advance(len(chunk))
+                    progress.print(final=True)
+                    # Capture metadata before context manager closes the connection
+                    if isinstance(response, http.client.HTTPResponse):
+                        self._effective_url = response.geturl()
+                    response_headers_str = str(response.headers)
+                os.replace(part_file, save_file)
+                break  # success: exit retry loop
+            except OSError as e:
+                # clean up archive on failure.
+                if self.archive_file:
+                    os.remove(self.archive_file)
+                if os.path.lexists(part_file):
+                    os.remove(part_file)
+                # Raise if this was the last attempt, or if the error was not transient.
+                if (attempt + 1 == retries) or not web_util.is_transient_error(e):
+                    raise FailedDownloadError(e) from e
+                tty.debug(f"Retrying fetch (attempt {attempt + 1}): {e}")
+                time.sleep(2**attempt)
 
         # Save the redirected URL for error messages. Sometimes we're redirected to an arbitrary
         # mirror that is broken, leading to spurious download failures. In that case it's helpful
         # for users to know which URL was actually fetched.
-        if isinstance(response, http.client.HTTPResponse):
-            self._effective_url = response.geturl()
-
-        self._check_headers(str(response.headers))
+        self._check_headers(response_headers_str)
 
     @_needs_stage
     def _fetch_curl(self, url, config_args=[]):

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -7,7 +7,6 @@
 import base64
 import json
 import re
-import socket
 import time
 import urllib.error
 import urllib.parse
@@ -441,20 +440,10 @@ def default_retry(f, retries: int = 5, sleep=None):
             try:
                 return f(*args, **kwargs)
             except OSError as e:
-                # Retry on internal server errors, and rate limit errors
+                # Retry on internal server errors, rate limits, and timeouts.
                 # Potentially this could take into account the Retry-After header
                 # if registries support it
-                if i + 1 != retries and (
-                    (
-                        isinstance(e, urllib.error.HTTPError)
-                        and (500 <= e.code < 600 or e.code == 429)
-                    )
-                    or (
-                        isinstance(e, urllib.error.URLError)
-                        and isinstance(e.reason, socket.timeout)
-                    )
-                    or isinstance(e, socket.timeout)
-                ):
+                if i + 1 != retries and spack.util.web.is_transient_error(e):
                     # Exponential backoff
                     sleep(2**i)
                     continue

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import shutil
+import socket
 import ssl
 import stat
 import sys
@@ -34,6 +35,21 @@ from spack.llnl.util.filesystem import mkdirp, rename, working_dir
 from .executable import CommandNotFoundError, Executable
 from .gcs import GCSBlob, GCSBucket, GCSHandler
 from .s3 import UrllibS3Handler, get_s3_session
+
+
+def is_transient_error(e: Exception) -> bool:
+    """Return True for HTTP/network errors that are worth retrying."""
+
+    if isinstance(e, HTTPError) and (500 <= e.code < 600 or e.code == 429):
+        return True
+    if isinstance(e, URLError) and isinstance(e.reason, socket.timeout):
+        return True
+    if isinstance(e, socket.timeout):
+        return True
+    # botocore.exceptions.ResponseStreamingError (IncompleteRead mid-stream)
+    if type(e).__name__ == "ResponseStreamingError":
+        return True
+    return False
 
 
 class DetailedHTTPError(HTTPError):


### PR DESCRIPTION
In CI, transient fetch errors (S3 rate limits, server errors, mid-stream
disconnects) cause spurious failures. To handle this uniformly:

- Add `web_util.is_transient_error(e)` covering HTTP 5xx/429, socket
  timeouts, and botocore ResponseStreamingError.
- Rewrite `_fetch_urllib` to retry up to `5` times with
  exponential back-off (1s, 2s, 4s, 8s)
- Write to a `.part` file for atomicity (consistent with `_fetch_curl`).
- Simplify `oci/opener.py`'s retry logic to delegate to
  `is_transient_error`.