### PR TITLE
new_installer.py: join timeout in finally block

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1976,7 +1976,10 @@ class PackageInstaller:
             for child in self.running_builds.values():
                 try:
                     jobserver.release()
-                    child.proc.join()
+                    child.proc.join(timeout=30)
+                    if child.proc.is_alive():
+                        child.proc.kill()
+                        child.proc.join()
                 except Exception:
                     pass
 


### PR DESCRIPTION
If a grandchild process ignores SIGTERM, the cleanup path hangs forever,
leaving locks, jobserver, and terminal unreleased. Add a 30-second
timeout and escalate to SIGKILL.

