### PR TITLE
new_installer.py: clean up state_buffers on exit

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1891,6 +1891,7 @@ class PackageInstaller:
                     self.capacity += 1
                     jobserver.release()
                     self._drain_child_output(build)
+                    self.state_buffers.pop(build.state_r_conn.fileno(), None)
                     build.cleanup(selector)
                     exitcode = build.proc.exitcode
                     assert exitcode is not None, "Finished build should have exit code set"


### PR DESCRIPTION
When a child exits, if the sentinel fires before the state pipe EOF,
state_buffers retains a partial JSON fragment. If the OS reuses that fd
number for a new child's state pipe, the stale data is prepended,
corrupting the JSON stream. Pop the buffer before cleanup closes the fd.

