### PR TITLE
new_installer.py: catch JSONDecodeError

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2231,7 +2231,10 @@ class PackageInstaller:
         for line in lines:
             if not line:
                 continue
-            message = json.loads(line)
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
             if "state" in message:
                 self.build_status.update_state(child_info.spec.dag_hash(), message["state"])
             elif "progress" in message and "total" in message:


### PR DESCRIPTION
In practice this should never happen, but it does not hurt
to be a bit more defensive when reading from the child pipe.