### PR TITLE
new_installer.py: use longer timeout for non-TTY

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1864,7 +1864,8 @@ class PackageInstaller:
 
                 stdin_ready = False
 
-                events = selector.select(timeout=SPINNER_INTERVAL)
+                timeout = SPINNER_INTERVAL if self.build_status.is_tty else DATABASE_WRITE_INTERVAL
+                events = selector.select(timeout=timeout)
 
                 finished_pids = []
 


### PR DESCRIPTION
selector.select() wakes every 100ms even in non-TTY mode where there is
no spinner to update. The only periodic task in non-TTY is DB writes
(every 5s), so use that as the timeout instead.

