### PR TITLE
new_installer.py: fix non-blocking I/O

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1831,6 +1831,8 @@ class PackageInstaller:
         if sys.stdout.isatty():
             # Listen to terminal resizing events with self-pipe trick.
             sigwinch_r, sigwinch_w = os.pipe()
+            os.set_blocking(sigwinch_r, False)
+            os.set_blocking(sigwinch_w, False)
 
             def _handle_sigwinch(signum: int, frame: object) -> None:
                 try:
@@ -2176,6 +2178,8 @@ class PackageInstaller:
             # There might be more data than OUTPUT_BUFFER_SIZE, but we will read that in the next
             # iteration of the event loop to keep things responsive.
             data = os.read(r_fd, OUTPUT_BUFFER_SIZE)
+        except BlockingIOError:
+            return
         except OSError:
             data = None
 
@@ -2209,6 +2213,8 @@ class PackageInstaller:
             # There might be more data than OUTPUT_BUFFER_SIZE, but we will read that in the next
             # iteration of the event loop to keep things responsive.
             data = os.read(r_fd, OUTPUT_BUFFER_SIZE)
+        except BlockingIOError:
+            return
         except OSError:
             data = None
 


### PR DESCRIPTION
Set both ends of the sigwinch pipe to non-blocking, and distinguish
BlockingIOError from real errors/EOF in the child log and state handlers
to avoid premature fd unregistration.

