### PR TITLE
new_installer.py: insert newlines when needed

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -995,6 +995,7 @@ class BuildStatus:
         self.tracked_build_id = ""  # identifier of the package whose logs we follow
         self.search_term = ""
         self.search_mode = False
+        self.log_ends_with_newline = True
 
         self.stdout = stdout
         self.get_terminal_size = get_terminal_size
@@ -1035,6 +1036,9 @@ class BuildStatus:
         if self.overview_mode:
             self.next()
         else:
+            if not self.log_ends_with_newline:
+                self.stdout.buffer.write(b"\n")
+                self.log_ends_with_newline = True
             self.active_area_rows = 0
             self.search_term = ""
             self.search_mode = False
@@ -1116,7 +1120,9 @@ class BuildStatus:
         version_str = (
             f"\033[0;36m@{new_build.version}\033[0m" if self.color else f"@{new_build.version}"
         )
-        self.stdout.write(f"\n==> Following logs of {new_build.name}{version_str}\n")
+        prefix = "" if self.log_ends_with_newline else "\n"
+        self.stdout.write(f"{prefix}==> Following logs of {new_build.name}{version_str}\n")
+        self.log_ends_with_newline = True
         self.stdout.flush()
         try:
             conn = new_build.control_w_conn
@@ -1285,6 +1291,7 @@ class BuildStatus:
             data = padding_filter_bytes(data)
         self.stdout.buffer.write(data)
         self.stdout.flush()
+        self.log_ends_with_newline = data.endswith(b"\n")
 
     def _render_build(self, build_info: BuildInfo, buffer: io.StringIO, max_width: int) -> None:
         line_width = 0

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -947,6 +947,33 @@ class TestToggle:
         assert status.overview_mode is True
         assert status.tracked_build_id == ""
 
+    def test_partial_line_newline_on_toggle_and_next(self):
+        """Ensure newline is inserted before mode transitions when log doesn't end with newline."""
+        status, _, fake_stdout = create_build_status(total=2)
+        specs = add_mock_builds(status, 2)
+        build_a, build_b = specs[0].dag_hash(), specs[1].dag_hash()
+
+        # Follow a build, toggle back and forth between logs and overview mode, and receive logs
+        # that may or may not end with newlines.
+        status.next()
+        status.print_logs(build_a, b"checking for foo...")
+        status.toggle()
+        status.next()
+        status.print_logs(build_a, b"checking for bar... yes\n")
+        status.next(1)
+        status.print_logs(build_b, b"checking for baz...")
+        status.next(-1)
+
+        written = fake_stdout.getvalue()
+
+        # There shouldn't be any double newlines:
+        assert "\n\n" not in written
+
+        # All partial and newline-terminated logs should be present with appropriate newlines:
+        assert "checking for foo...\n" in written
+        assert "checking for bar... yes\n" in written
+        assert "checking for baz...\n" in written
+
     @pytest.mark.parametrize("filter_padding", [True, False])
     def test_print_logs_filters_padding(self, filter_padding):
         """print_logs strips path-padding placeholders before writing to stdout."""


### PR DESCRIPTION
If a log line does not end with a newline, the UI should add one when
switching to overview mode or the new log. If a log line did end with a
newline, we shouldn't add double newlines.

This prevents things like:

```
checking for foo.h header... ==> following log of xyz
...
```

