### PR TITLE
urlopen: improved retry on transient error

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -379,6 +379,8 @@ nitpick_ignore = [
     ("py:obj", "spack.llnl.util.lang.KT"),
     ("py:obj", "spack.llnl.util.lang.V"),
     ("py:obj", "spack.llnl.util.lang.VT"),
+    ("py:class", "_P"),
+    ("py:class", "spack.util.web._R"),
 ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -458,7 +458,7 @@ class URLFetchStrategy(FetchStrategy):
                     response_headers_str = str(response.headers)
                 os.replace(part_file, save_file)
                 break  # success: exit retry loop
-            except OSError as e:
+            except Exception as e:
                 # clean up archive on failure.
                 if self.archive_file:
                     os.remove(self.archive_file)

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -7,7 +7,6 @@
 import base64
 import json
 import re
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -432,21 +431,4 @@ def ensure_status(request: urllib.request.Request, response: HTTPResponse, statu
     )
 
 
-def default_retry(f, retries: int = 5, sleep=None):
-    sleep = sleep or time.sleep
-
-    def wrapper(*args, **kwargs):
-        for i in range(retries):
-            try:
-                return f(*args, **kwargs)
-            except OSError as e:
-                # Retry on internal server errors, rate limits, and timeouts.
-                # Potentially this could take into account the Retry-After header
-                # if registries support it
-                if i + 1 != retries and spack.util.web.is_transient_error(e):
-                    # Exponential backoff
-                    sleep(2**i)
-                    continue
-                raise
-
-    return wrapper
+default_retry = spack.util.web.retry_on_transient_error

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -486,3 +486,28 @@ def test_retry_on_transient_error(error_code, num_errors, max_retries, expect_fa
     else:
         assert retrying() == "ok"
         assert sleep_times == [2**i for i in range(num_errors)]
+
+
+def test_retry_on_transient_error_non_oserror():
+    """Non-OSError exceptions with transient names (e.g. botocore) should be retried."""
+
+    class ResponseStreamingError(Exception):
+        pass
+
+    call_count = 0
+    sleep_times = []
+
+    def flaky_func():
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise ResponseStreamingError("IncompleteRead")
+        return "ok"
+
+    retrying = spack.util.web.retry_on_transient_error(
+        flaky_func, retries=5, sleep=sleep_times.append
+    )
+
+    assert retrying() == "ok"
+    assert call_count == 3
+    assert sleep_times == [1, 2]

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -450,3 +450,39 @@ def test_ssl_curl_cert_file(
             assert dump_env["CURL_CA_BUNDLE"] == mock_cert
         else:
             assert "CURL_CA_BUNDLE" not in dump_env
+
+
+@pytest.mark.parametrize(
+    "error_code,num_errors,max_retries,expect_failure",
+    [
+        (500, 2, 5, False),  # transient, enough retries
+        (500, 2, 2, True),  # transient, not enough retries
+        (429, 2, 5, False),  # rate limit, enough retries
+        (404, 1, 5, True),  # not transient, never retried
+    ],
+)
+def test_retry_on_transient_error(error_code, num_errors, max_retries, expect_failure):
+    import urllib.error
+
+    call_count = 0
+    sleep_times = []
+
+    def flaky_func():
+        nonlocal call_count
+        call_count += 1
+        if call_count <= num_errors:
+            raise urllib.error.HTTPError(
+                url="https://example.com", code=error_code, msg="err", hdrs={}, fp=None
+            )
+        return "ok"
+
+    retrying = spack.util.web.retry_on_transient_error(
+        flaky_func, retries=max_retries, sleep=sleep_times.append
+    )
+
+    if expect_failure:
+        with pytest.raises(urllib.error.HTTPError):
+            retrying()
+    else:
+        assert retrying() == "ok"
+        assert sleep_times == [2**i for i in range(num_errors)]

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -4,6 +4,7 @@
 
 import email.message
 import errno
+import functools
 import io
 import json
 import os
@@ -13,13 +14,16 @@ import socket
 import ssl
 import stat
 import sys
+import time
 import traceback
 import urllib.parse
 from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
-from typing import IO, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import IO, Callable, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union
 from urllib.error import HTTPError, URLError
 from urllib.request import HTTPDefaultErrorHandler, HTTPSHandler, Request, build_opener
+
+from spack.vendor.typing_extensions import ParamSpec
 
 import spack
 import spack.config
@@ -50,6 +54,31 @@ def is_transient_error(e: Exception) -> bool:
     if type(e).__name__ == "ResponseStreamingError":
         return True
     return False
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def retry_on_transient_error(
+    f: Callable[_P, _R], retries: int = 5, sleep: Optional[Callable[[float], None]] = None
+) -> Callable[_P, _R]:
+    """Retry a function on transient HTTP/network errors with exponential backoff."""
+    sleep = sleep or time.sleep
+
+    @functools.wraps(f)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        for i in range(retries):
+            try:
+                return f(*args, **kwargs)
+            except OSError as e:
+                if i + 1 != retries and is_transient_error(e):
+                    sleep(2**i)  # type: ignore[misc]  # mypy still thinks it's possibly None.
+                    continue
+                raise
+        raise AssertionError("unreachable")
+
+    return wrapper
 
 
 class DetailedHTTPError(HTTPError):
@@ -268,22 +297,34 @@ def read_from_url(url, accept_content_type=None):
     return response.url, response.headers, response
 
 
+def _read_text(url: str) -> str:
+    request = Request(url, headers={"User-Agent": SPACK_USER_AGENT})
+    with urlopen(request) as response:
+        return io.TextIOWrapper(response, encoding="utf-8").read()
+
+
+def _read_json(url: str):
+    request = Request(url, headers={"User-Agent": SPACK_USER_AGENT})
+    with urlopen(request) as response:
+        return json.load(response)
+
+
+_read_text_with_retry = retry_on_transient_error(_read_text)
+_read_json_with_retry = retry_on_transient_error(_read_json)
+
+
 def read_text(url: str) -> str:
     """Fetch url and return the response body decoded as UTF-8 text."""
-    request = Request(url, headers={"User-Agent": SPACK_USER_AGENT})
     try:
-        with urlopen(request) as response:
-            return io.TextIOWrapper(response, encoding="utf-8").read()
+        return _read_text_with_retry(url)
     except OSError as e:
         raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
 
 
 def read_json(url: str):
     """Fetch url and return the response body parsed as JSON."""
-    request = Request(url, headers={"User-Agent": SPACK_USER_AGENT})
     try:
-        with urlopen(request) as response:
-            return json.load(response)
+        return _read_json_with_retry(url)
     except OSError as e:
         raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -516,6 +516,17 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
     return None
 
 
+def _url_exists_urllib_impl(url):
+    with urlopen(
+        Request(url, method="HEAD", headers={"User-Agent": SPACK_USER_AGENT}),
+        timeout=spack.config.get("config:connect_timeout", 10),
+    ) as _:
+        pass
+
+
+_url_exists_urllib = retry_on_transient_error(_url_exists_urllib_impl)
+
+
 def url_exists(url, curl=None):
     """Determines whether url exists.
 
@@ -549,11 +560,8 @@ def url_exists(url, curl=None):
 
     # Otherwise use urllib.
     try:
-        with urlopen(
-            Request(url, method="HEAD", headers={"User-Agent": SPACK_USER_AGENT}),
-            timeout=spack.config.get("config:connect_timeout", 10),
-        ) as _:
-            return True
+        _url_exists_urllib(url)
+        return True
     except OSError as e:
         tty.debug(f"Failure reading {url}: {e}")
         return False

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -18,6 +18,7 @@ import time
 import traceback
 import urllib.parse
 from html.parser import HTMLParser
+from http.client import IncompleteRead
 from pathlib import Path, PurePosixPath
 from typing import IO, Callable, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union
 from urllib.error import HTTPError, URLError
@@ -48,10 +49,16 @@ def is_transient_error(e: Exception) -> bool:
         return True
     if isinstance(e, URLError) and isinstance(e.reason, socket.timeout):
         return True
-    if isinstance(e, socket.timeout):
+    if isinstance(e, (socket.timeout, IncompleteRead)):
         return True
-    # botocore.exceptions.ResponseStreamingError (IncompleteRead mid-stream)
-    if type(e).__name__ == "ResponseStreamingError":
+    # exceptions not inherited from the above used in urllib3 and botocore.
+    if type(e).__name__ in (
+        "ConnectionClosedError",
+        "IncompleteReadError",
+        "ProtocolError",
+        "ReadTimeoutError",
+        "ResponseStreamingError",
+    ):
         return True
     return False
 
@@ -71,7 +78,7 @@ def retry_on_transient_error(
         for i in range(retries):
             try:
                 return f(*args, **kwargs)
-            except OSError as e:
+            except Exception as e:
                 if i + 1 != retries and is_transient_error(e):
                     sleep(2**i)  # type: ignore[misc]  # mypy still thinks it's possibly None.
                     continue
@@ -317,7 +324,7 @@ def read_text(url: str) -> str:
     """Fetch url and return the response body decoded as UTF-8 text."""
     try:
         return _read_text_with_retry(url)
-    except OSError as e:
+    except Exception as e:
         raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
 
 
@@ -325,7 +332,7 @@ def read_json(url: str):
     """Fetch url and return the response body parsed as JSON."""
     try:
         return _read_json_with_retry(url)
-    except OSError as e:
+    except Exception as e:
         raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
 
 
@@ -562,7 +569,7 @@ def url_exists(url, curl=None):
     try:
         _url_exists_urllib(url)
         return True
-    except OSError as e:
+    except Exception as e:
         tty.debug(f"Failure reading {url}: {e}")
         return False
 


### PR DESCRIPTION
* Use single retry-on-transient-error mechanism throughout.
* Add exponential back-off also to `url_exists` in case of transient errors
* Widen retry mechanism exception `OSError -> Exception`, because botocore/urllib3 exceptions do not subtype `OSError` but `Exception` directly
