### PR TITLE
new_installer.py: fork safety of ssl/boto3/urllib3

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -301,6 +301,14 @@ class GlobalState:
 
     def restore(self):
         if multiprocessing.get_start_method() == "fork":
+            # In the forking case we must erase SSL contexts.
+            from spack.oci import opener
+            from spack.util import web
+            from spack.util.s3 import s3_client_cache
+
+            web.urlopen._instance = None
+            opener.urlopen._instance = None
+            s3_client_cache.clear()
             return
         spack.store.STORE = self.store
         spack.config.CONFIG = self.config


### PR DESCRIPTION
After wasting too much time on this, it turns out Gitlab CI was failing
with parallel downloads not because of concurrent requests that need
retry, but due to fork-safety issues of SSL context objects.

I can't specifically refer to the root cause, but the likely explanation
is that shared resources are mutated by forked process A that invalidate
them for concurrent forked process B.

The pipeline https://gitlab.spack.io/spack/spack-packages/-/pipelines/1476594
should confirm whether this fix is right. Over there, Spack is on commit 

https://github.com/spack/spack/commits/32938a23194bcb4d14dfb3d2d280b73594bfc505

which lacks the retry mechanism and only contains *this* fix.
