### PR TITLE
ci: only use --verbose for root install, not deps

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -464,7 +464,7 @@ def ci_rebuild(args):
     # No hash match anywhere means we need to rebuild spec
 
     # Start with spack arguments
-    spack_cmd = [SPACK_COMMAND, "--color=always", "--backtrace", "--verbose", "install"]
+    spack_cmd = [SPACK_COMMAND, "--color=always", "install"]
 
     config = cfg.get("config")
     if not config["verify_ssl"]:
@@ -490,7 +490,7 @@ def ci_rebuild(args):
 
     # Arguments when installing the root from sources
     deps_install_args = install_args + ["--only=dependencies"]
-    root_install_args = install_args + ["--keep-stage", "--only=package"]
+    root_install_args = install_args + ["--verbose", "--keep-stage", "--only=package"]
 
     if cdash_handler:
         # Add additional arguments to `spack install` for CDash reporting.


### PR DESCRIPTION
When using the new installer in CI, it's not particularly pretty to do
`--verbose` when installing dependencies. Only apply `--verbose` to the
root package to see build logs.

Also drop `--backtrace`. In the new installer the child process always
prints the full backtrace to the build log on failure, including when
installing from a build cache. The parent process shouldn't show a
backtrace to the installer event loop on install failure: that suggests
the problem is with Spack instead of with the build, causing confusion.

