### PR TITLE
urlopen: clean up resources

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -888,15 +888,14 @@ def _linting_package_file(pkgs, error_cls):
         # Does the homepage have http, and if so, does https work?
         if homepage.startswith("http://"):
             try:
-                response = urlopen(f"https://{homepage[7:]}")
+                with urlopen(f"https://{homepage[7:]}") as response:
+                    if response.getcode() == 200:
+                        msg = 'Package "{0}" uses http but has a valid https endpoint.'
+                        errors.append(msg.format(pkg_cls.name))
             except Exception as e:
                 msg = 'Error with attempting https for "{0}": '
                 errors.append(error_cls(msg.format(pkg_cls.name), [str(e)]))
                 continue
-
-            if response.getcode() == 200:
-                msg = 'Package "{0}" uses http but has a valid https endpoint.'
-                errors.append(msg.format(pkg_cls.name))
 
     return spack.llnl.util.lang.dedupe(errors)
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1759,18 +1759,18 @@ def download_tarball(
 
             # Fetch the manifest
             try:
-                response = spack.oci.opener.urlopen(
+                with spack.oci.opener.urlopen(
                     urllib.request.Request(
                         url=ref.manifest_url(),
                         headers={"Accept": ", ".join(spack.oci.oci.manifest_content_type)},
                     )
-                )
+                ) as response:
+                    manifest = json.load(response)
             except Exception:
                 continue
 
             # Download the config = spec.json and the relevant tarball
             try:
-                manifest = json.load(response)
                 spec_digest = spack.oci.image.Digest.from_string(manifest["config"]["digest"])
                 tarball_digest = spack.oci.image.Digest.from_string(
                     manifest["layers"][-1]["digest"]
@@ -2335,8 +2335,7 @@ def _get_keys_v2(mirror_url, install=False, trust=False, force=False):
     tty.debug("Finding public keys in {0}".format(url_util.format(mirror_url)))
 
     try:
-        _, _, json_file = web_util.read_from_url(keys_index)
-        json_index = sjson.load(json_file)
+        json_index = web_util.read_json(keys_index)
     except (web_util.SpackWebError, OSError, ValueError) as url_err:
         # TODO: avoid repeated request
         if web_util.url_exists(keys_index):
@@ -2621,8 +2620,10 @@ class DefaultIndexFetcherV2(IndexFetcher):
         # Failure to fetch index.json.hash is not fatal
         url_index_hash = url_util.join(self.url, "build_cache", "index.json.hash")
         try:
-            response = self.urlopen(urllib.request.Request(url_index_hash, headers=self.headers))
-            remote_hash = response.read(64)
+            with self.urlopen(
+                urllib.request.Request(url_index_hash, headers=self.headers)
+            ) as response:
+                remote_hash = response.read(64)
         except OSError:
             return None
 
@@ -2647,10 +2648,20 @@ class DefaultIndexFetcherV2(IndexFetcher):
         except OSError as e:
             raise FetchIndexError(f"Could not fetch index from {url_index}", e) from e
 
-        try:
-            result = io.TextIOWrapper(response, encoding="utf-8").read()
-        except (ValueError, OSError) as e:
-            raise FetchIndexError(f"Remote index {url_index} is invalid") from e
+        with response:
+            try:
+                result = io.TextIOWrapper(response, encoding="utf-8").read()
+            except (ValueError, OSError) as e:
+                raise FetchIndexError(f"Remote index {url_index} is invalid") from e
+
+            # For now we only handle etags on http(s), since 304 error handling
+            # in s3:// is not there yet.
+            if urllib.parse.urlparse(self.url).scheme not in ("http", "https"):
+                etag = None
+            else:
+                etag = web_util.parse_etag(
+                    response.headers.get("Etag", None) or response.headers.get("etag", None)
+                )
 
         computed_hash = compute_hash(result)
 
@@ -2661,15 +2672,6 @@ class DefaultIndexFetcherV2(IndexFetcher):
         # while we fetched index.json.hash. Warning about an issue thus feels
         # wrong, as it's more of an issue with race conditions in the cache
         # invalidation strategy.
-
-        # For now we only handle etags on http(s), since 304 error handling
-        # in s3:// is not there yet.
-        if urllib.parse.urlparse(self.url).scheme not in ("http", "https"):
-            etag = None
-        else:
-            etag = web_util.parse_etag(
-                response.headers.get("Etag", None) or response.headers.get("etag", None)
-            )
 
         warn_v2_layout(self.url, "Fetching an index")
 
@@ -2699,15 +2701,18 @@ class EtagIndexFetcherV2(IndexFetcher):
         except OSError as e:  # URLError, socket.timeout, etc.
             raise FetchIndexError(f"Could not fetch index {url}", e) from e
 
-        try:
-            result = io.TextIOWrapper(response, encoding="utf-8").read()
-        except (ValueError, OSError) as e:
-            raise FetchIndexError(f"Remote index {url} is invalid", e) from e
+        with response:
+            try:
+                result = io.TextIOWrapper(response, encoding="utf-8").read()
+            except (ValueError, OSError) as e:
+                raise FetchIndexError(f"Remote index {url} is invalid", e) from e
 
-        warn_v2_layout(self.url, "Fetching an index")
+            warn_v2_layout(self.url, "Fetching an index")
 
-        headers = response.headers
-        etag_header_value = headers.get("Etag", None) or headers.get("etag", None)
+            etag_header_value = response.headers.get("Etag", None) or response.headers.get(
+                "etag", None
+            )
+
         return FetchIndexResult(
             etag=web_util.parse_etag(etag_header_value),
             hash=compute_hash(result),
@@ -2735,10 +2740,11 @@ class OCIIndexFetcher(IndexFetcher):
         except OSError as e:
             raise FetchIndexError(f"Could not fetch manifest from {url_manifest}", e) from e
 
-        try:
-            manifest = json.load(response)
-        except Exception as e:
-            raise FetchIndexError(f"Remote index {url_manifest} is invalid", e) from e
+        with response:
+            try:
+                manifest = json.load(response)
+            except Exception as e:
+                raise FetchIndexError(f"Remote index {url_manifest} is invalid", e) from e
 
         # Get first blob hash, which should be the index.json
         try:
@@ -2752,13 +2758,13 @@ class OCIIndexFetcher(IndexFetcher):
 
         # Otherwise fetch the blob / index.json
         try:
-            response = self.urlopen(
+            with self.urlopen(
                 urllib.request.Request(
                     url=self.ref.blob_url(index_digest),
                     headers={"Accept": "application/vnd.oci.image.layer.v1.tar+gzip"},
                 )
-            )
-            result = io.TextIOWrapper(response, encoding="utf-8").read()
+            ) as response:
+                result = io.TextIOWrapper(response, encoding="utf-8").read()
         except (OSError, ValueError) as e:
             raise FetchIndexError(f"Remote index {url_manifest} is invalid", e) from e
 
@@ -2793,7 +2799,8 @@ class DefaultIndexFetcher(IndexFetcher):
                 f"Could not read index manifest from {url_index_manifest}"
             ) from e
 
-        index_blob_record = self.get_index_manifest(response)
+        with response:
+            index_blob_record = self.get_index_manifest(response)
 
         # Early exit if our cache is up to date.
         if self.local_hash and self.local_hash == index_blob_record.checksum:
@@ -2856,14 +2863,15 @@ class EtagIndexFetcher(IndexFetcher):
             raise FetchIndexError(f"Could not fetch index manifest {manifest_url}", e) from e
 
         # We need to read the index manifest and fetch the associated blob
-        cache_entry = cache_class(self.url, allow_unsigned=True)
-        computed_hash, result = self.fetch_index_blob(
-            cache_entry, self.get_index_manifest(response)
-        )
-        cache_entry.destroy()
+        with response:
+            index_blob_record = self.get_index_manifest(response)
+            etag_header_value = response.headers.get("Etag", None) or response.headers.get(
+                "etag", None
+            )
 
-        headers = response.headers
-        etag_header_value = headers.get("Etag", None) or headers.get("etag", None)
+        cache_entry = cache_class(self.url, allow_unsigned=True)
+        computed_hash, result = self.fetch_index_blob(cache_entry, index_blob_record)
+        cache_entry.destroy()
 
         return FetchIndexResult(
             etag=web_util.parse_etag(etag_header_value),

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import io
 import json
 import os
 import pathlib
@@ -104,8 +103,7 @@ def _migrate_spec(
 
     for meta_url in v2_metadata_urls:
         try:
-            _, _, meta_file = web_util.read_from_url(meta_url)
-            spec_contents = io.TextIOWrapper(meta_file, encoding="utf-8").read()
+            spec_contents = web_util.read_text(meta_url)
             v2_spec_url = meta_url
             break
         except (web_util.SpackWebError, OSError):
@@ -279,8 +277,7 @@ def migrate(
     contents = None
 
     try:
-        _, _, index_file = web_util.read_from_url(index_url)
-        contents = io.TextIOWrapper(index_file, encoding="utf-8").read()
+        contents = web_util.read_text(index_url)
     except (web_util.SpackWebError, OSError):
         raise MigrationException("Buildcache migration requires a buildcache index")
 

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import base64
-import io
 import json
 import os
 import pathlib
@@ -715,9 +714,9 @@ def download_and_extract_artifacts(url: str, work_dir: str) -> str:
     os.makedirs(work_dir, exist_ok=True)
 
     try:
-        response = urlopen(request, timeout=SPACK_CDASH_TIMEOUT)
-        with open(artifacts_zip_path, "wb") as out_file:
-            shutil.copyfileobj(response, out_file)
+        with urlopen(request, timeout=SPACK_CDASH_TIMEOUT) as response:
+            with open(artifacts_zip_path, "wb") as out_file:
+                shutil.copyfileobj(response, out_file)
 
         with zipfile.ZipFile(artifacts_zip_path) as zip_file:
             zip_file.extractall(work_dir)
@@ -1299,12 +1298,11 @@ def read_broken_spec(broken_spec_url):
     object.
     """
     try:
-        _, _, fs = web_util.read_from_url(broken_spec_url)
+        broken_spec_contents = web_util.read_text(broken_spec_url)
     except web_util.SpackWebError:
         tty.warn(f"Unable to read broken spec from {broken_spec_url}")
         return None
 
-    broken_spec_contents = io.TextIOWrapper(fs, encoding="utf-8").read()
     return syaml.load(broken_spec_contents)
 
 

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -268,7 +268,8 @@ class CDashHandler:
         group_id = None
 
         try:
-            response_text = _urlopen(request, timeout=SPACK_CDASH_TIMEOUT).read()
+            with _urlopen(request, timeout=SPACK_CDASH_TIMEOUT) as response:
+                response_text = response.read()
         except OSError as e:
             tty.warn(f"Failed to create CDash buildgroup: {e}")
 
@@ -713,8 +714,8 @@ class SpackCIConfig:
                         endpoint_url._replace(query=query).geturl(), headers=header, method="GET"
                     )
                     try:
-                        response = _urlopen(request)
-                        config = json.load(response)
+                        with _urlopen(request) as response:
+                            config = json.load(response)
                     except Exception as e:
                         # For now just ignore any errors from dynamic mapping and continue
                         # This is still experimental, and failures should not stop CI

--- a/lib/spack/spack/oci/oci.py
+++ b/lib/spack/spack/oci/oci.py
@@ -7,7 +7,6 @@ import json
 import os
 import urllib.error
 import urllib.parse
-from http.client import HTTPResponse
 from typing import List, NamedTuple, Tuple
 from urllib.request import Request
 
@@ -59,12 +58,12 @@ def list_tags(ref: ImageReference, _urlopen: spack.oci.opener.MaybeOpen = None) 
     while True:
         # Fetch tags
         request = Request(url=fetch_url)
-        response = _urlopen(request)
-        spack.oci.opener.ensure_status(request, response, 200)
-        tags.update(json.load(response)["tags"])
+        with _urlopen(request) as response:
+            spack.oci.opener.ensure_status(request, response, 200)
+            tags.update(json.load(response)["tags"])
 
-        # Check for pagination
-        link_header = response.headers["Link"]
+            # Check for pagination
+            link_header = response.headers["Link"]
 
         if link_header is None:
             break
@@ -141,20 +140,20 @@ def upload_blob(
                 url=ref.uploads_url(), method="POST", headers={"Content-Length": "0"}
             )
 
-        response = _urlopen(request)
+        with _urlopen(request) as response:
+            # Created the blob in one go.
+            if response.status == 201:
+                return True
 
-        # Created the blob in one go.
-        if response.status == 201:
-            return True
+            # Otherwise, do another PUT request.
+            spack.oci.opener.ensure_status(request, response, 202)
+            assert "Location" in response.headers
 
-        # Otherwise, do another PUT request.
-        spack.oci.opener.ensure_status(request, response, 202)
-        assert "Location" in response.headers
+            # Can be absolute or relative, joining handles both
+            upload_url = with_query_param(
+                ref.endpoint(response.headers["Location"]), "digest", str(digest)
+            )
 
-        # Can be absolute or relative, joining handles both
-        upload_url = with_query_param(
-            ref.endpoint(response.headers["Location"]), "digest", str(digest)
-        )
         f.seek(0)
 
         request = Request(
@@ -164,9 +163,8 @@ def upload_blob(
             headers={"Content-Type": "application/octet-stream", "Content-Length": str(file_size)},
         )
 
-        response = _urlopen(request)
-
-        spack.oci.opener.ensure_status(request, response, 201)
+        with _urlopen(request) as response:
+            spack.oci.opener.ensure_status(request, response, 201)
 
     return True
 
@@ -205,9 +203,8 @@ def upload_manifest(
         headers={"Content-Type": manifest["mediaType"]},
     )
 
-    response = _urlopen(request)
-
-    spack.oci.opener.ensure_status(request, response, 201)
+    with _urlopen(request) as response:
+        spack.oci.opener.ensure_status(request, response, 201)
     return digest, size
 
 
@@ -222,8 +219,8 @@ def blob_exists(
     """Checks if a blob exists in an OCI registry"""
     try:
         _urlopen = _urlopen or spack.oci.opener.urlopen
-        response = _urlopen(Request(url=ref.blob_url(digest), method="HEAD"))
-        return response.status == 200
+        with _urlopen(Request(url=ref.blob_url(digest), method="HEAD")) as response:
+            return response.status == 200
     except urllib.error.HTTPError as e:
         if e.getcode() == 404:
             return False
@@ -314,34 +311,33 @@ def get_manifest_and_config(
     _urlopen = _urlopen or spack.oci.opener.urlopen
 
     # Get manifest
-    response: HTTPResponse = _urlopen(
+    with _urlopen(
         Request(url=ref.manifest_url(), headers={"Accept": ", ".join(all_content_type)})
-    )
+    ) as response:
+        # Recurse when we find an index
+        if response.headers["Content-Type"] in index_content_type:
+            if recurse == 0:
+                raise Exception("Maximum recursion depth reached while fetching OCI manifest")
 
-    # Recurse when we find an index
-    if response.headers["Content-Type"] in index_content_type:
-        if recurse == 0:
-            raise Exception("Maximum recursion depth reached while fetching OCI manifest")
+            index = json.load(response)
+            manifest_meta = next(
+                manifest
+                for manifest in index["manifests"]
+                if manifest["platform"]["architecture"] == architecture
+            )
 
-        index = json.load(response)
-        manifest_meta = next(
-            manifest
-            for manifest in index["manifests"]
-            if manifest["platform"]["architecture"] == architecture
-        )
+            return get_manifest_and_config(
+                ref.with_digest(manifest_meta["digest"]),
+                architecture=architecture,
+                recurse=recurse - 1,
+                _urlopen=_urlopen,
+            )
 
-        return get_manifest_and_config(
-            ref.with_digest(manifest_meta["digest"]),
-            architecture=architecture,
-            recurse=recurse - 1,
-            _urlopen=_urlopen,
-        )
+        # Otherwise, require a manifest
+        if response.headers["Content-Type"] not in manifest_content_type:
+            raise Exception(f"Unknown content type {response.headers['Content-Type']}")
 
-    # Otherwise, require a manifest
-    if response.headers["Content-Type"] not in manifest_content_type:
-        raise Exception(f"Unknown content type {response.headers['Content-Type']}")
-
-    manifest = json.load(response)
+        manifest = json.load(response)
 
     # Download, verify and cache config file
     config_digest = Digest.from_string(manifest["config"]["digest"])

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -452,13 +452,13 @@ class CDash(Reporter):
             if self.authtoken:
                 request.add_header("Authorization", "Bearer {0}".format(self.authtoken))
             try:
-                response = web_util.urlopen(request, timeout=SPACK_CDASH_TIMEOUT)
-                if self.current_package_name not in self.buildIds:
-                    resp_value = io.TextIOWrapper(response, encoding="utf-8").read()
-                    match = self.buildid_regexp.search(resp_value)
-                    if match:
-                        buildid = match.group(1)
-                        self.buildIds[self.current_package_name] = buildid
+                with web_util.urlopen(request, timeout=SPACK_CDASH_TIMEOUT) as response:
+                    if self.current_package_name not in self.buildIds:
+                        resp_value = io.TextIOWrapper(response, encoding="utf-8").read()
+                        match = self.buildid_regexp.search(resp_value)
+                        if match:
+                            buildid = match.group(1)
+                            self.buildIds[self.current_package_name] = buildid
             except Exception as e:
                 print(f"Upload to CDash failed: {e}")
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -465,8 +465,7 @@ class URLBuildcacheEntry:
         manifest_contents = ""
 
         try:
-            _, _, manifest_file = web_util.read_from_url(manifest_url)
-            manifest_contents = io.TextIOWrapper(manifest_file, encoding="utf-8").read()
+            manifest_contents = web_util.read_text(manifest_url)
         except (web_util.SpackWebError, OSError) as e:
             raise BuildcacheEntryError(f"Error reading manifest at {manifest_url}") from e
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -268,6 +268,26 @@ def read_from_url(url, accept_content_type=None):
     return response.url, response.headers, response
 
 
+def read_text(url: str) -> str:
+    """Fetch url and return the response body decoded as UTF-8 text."""
+    request = Request(url, headers={"User-Agent": SPACK_USER_AGENT})
+    try:
+        with urlopen(request) as response:
+            return io.TextIOWrapper(response, encoding="utf-8").read()
+    except OSError as e:
+        raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
+
+
+def read_json(url: str):
+    """Fetch url and return the response body parsed as JSON."""
+    request = Request(url, headers={"User-Agent": SPACK_USER_AGENT})
+    try:
+        with urlopen(request) as response:
+            return json.load(response)
+    except OSError as e:
+        raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
+
+
 def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=None):
     remote_url = urllib.parse.urlparse(remote_path)
     if remote_url.scheme == "file":
@@ -441,9 +461,7 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
 
     else:
         try:
-            _, _, response = read_from_url(url)
-
-            output = io.TextIOWrapper(response, encoding="utf-8").read()
+            output = read_text(url)
             if output:
                 with working_dir(dest_dir, create=True):
                     with open(filename, "w", encoding="utf-8") as f:
@@ -490,11 +508,11 @@ def url_exists(url, curl=None):
 
     # Otherwise use urllib.
     try:
-        urlopen(
+        with urlopen(
             Request(url, method="HEAD", headers={"User-Agent": SPACK_USER_AGENT}),
             timeout=spack.config.get("config:connect_timeout", 10),
-        )
-        return True
+        ) as _:
+            return True
     except OSError as e:
         tty.debug(f"Failure reading {url}: {e}")
         return False
@@ -761,7 +779,8 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
         if not response_url or not response:
             return pages, links, subcalls, _visited
 
-        page = io.TextIOWrapper(response, encoding="utf-8").read()
+        with response:
+            page = io.TextIOWrapper(response, encoding="utf-8").read()
         pages[response_url] = page
 
         # Parse out the include-fragments in the page
@@ -788,7 +807,8 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
             if not fragment_response_url or not fragment_response:
                 continue
 
-            fragment = io.TextIOWrapper(fragment_response, encoding="utf-8").read()
+            with fragment_response:
+                fragment = io.TextIOWrapper(fragment_response, encoding="utf-8").read()
             fragments.add(fragment)
 
             pages[fragment_response_url] = fragment


### PR DESCRIPTION
* Ensure that the sockets of `urlopen` response objects are closed by using
  context managers.
* Add `read_text()` and `read_json()` helpers to `spack.util.web` that
  encapsulate the fetch-decode-close cycle, and use them to replace repeated
  `read_from_url` + `TextIOWrapper` boilerplate;



