### PR TITLE
new_installer.py: build failure ui improvements

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -956,10 +956,16 @@ class BuildInfo:
         "finished_time",
         "progress_percent",
         "control_w_conn",
+        "log_path",
+        "log_summary",
     )
 
     def __init__(
-        self, spec: spack.spec.Spec, explicit: bool, control_w_conn: Optional[Connection]
+        self,
+        spec: spack.spec.Spec,
+        explicit: bool,
+        control_w_conn: Optional[Connection],
+        log_path: Optional[str] = None,
     ) -> None:
         self.state: str = "starting"
         self.explicit: bool = explicit
@@ -971,6 +977,8 @@ class BuildInfo:
         self.finished_time: Optional[float] = None
         self.progress_percent: Optional[int] = None
         self.control_w_conn = control_w_conn
+        self.log_path: Optional[str] = log_path
+        self.log_summary: Optional[str] = None
 
 
 class BuildStatus:
@@ -1025,10 +1033,14 @@ class BuildStatus:
         self.dirty = True
 
     def add_build(
-        self, spec: spack.spec.Spec, explicit: bool, control_w_conn: Optional[Connection] = None
+        self,
+        spec: spack.spec.Spec,
+        explicit: bool,
+        control_w_conn: Optional[Connection] = None,
+        log_path: Optional[str] = None,
     ) -> None:
         """Add a new build to the display and mark the display as dirty."""
-        self.builds[spec.dag_hash()] = BuildInfo(spec, explicit, control_w_conn)
+        self.builds[spec.dag_hash()] = BuildInfo(spec, explicit, control_w_conn, log_path)
         self.dirty = True
         # Track the new build's logs when we're not already following another build. This applies
         # only in non-TTY verbose mode.
@@ -1063,6 +1075,7 @@ class BuildStatus:
     def search_input(self, input: str) -> None:
         """Handle keyboard input when in search mode"""
         if input in ("\r", "\n"):
+            self.log_ends_with_newline = False
             self.next(1)
         elif input == "\x1b":  # Escape
             self.search_mode = False
@@ -1090,7 +1103,8 @@ class BuildStatus:
         matching = [
             build_id
             for build_id, build in self.builds.items()
-            if build.finished_time is None and self._is_displayed(build)
+            if (build.finished_time is None or build.state == "failed")
+            and self._is_displayed(build)
         ]
         if not matching:
             return None
@@ -1124,20 +1138,35 @@ class BuildStatus:
 
         self.tracked_build_id = new_build_id
 
-        # Tell the user we're following new logs, and instruct the child to start sending them.
         version_str = (
             f"\033[0;36m@{new_build.version}\033[0m" if self.color else f"@{new_build.version}"
         )
         prefix = "" if self.log_ends_with_newline else "\n"
-        self.stdout.write(f"{prefix}==> Following logs of {new_build.name}{version_str}\n")
-        self.log_ends_with_newline = True
-        self.stdout.flush()
-        try:
-            conn = new_build.control_w_conn
-            if conn is not None:
-                os.write(conn.fileno(), b"1")
-        except (KeyError, OSError):
-            pass
+
+        if new_build.state == "failed":
+            # For failed builds, show the stored log summary instead of following live logs.
+            self.stdout.write(f"{prefix}==> Log summary of {new_build.name}{version_str}\n")
+            self.log_ends_with_newline = True
+            if new_build.log_summary:
+                self.stdout.write(new_build.log_summary)
+            if new_build.log_path:
+                if not new_build.log_summary:
+                    self.stdout.write("No errors parsed from log, see full log: ")
+                else:
+                    self.stdout.write("Full log: ")
+                self.stdout.write(f"{new_build.log_path}\n")
+            self.stdout.flush()
+        else:
+            # Tell the user we're following new logs, and instruct the child to start sending.
+            self.stdout.write(f"{prefix}==> Following logs of {new_build.name}{version_str}\n")
+            self.log_ends_with_newline = True
+            self.stdout.flush()
+            try:
+                conn = new_build.control_w_conn
+                if conn is not None:
+                    os.write(conn.fileno(), b"1")
+            except (KeyError, OSError):
+                pass
 
     def update_state(self, build_id: str, state: str) -> None:
         """Update the state of a package and mark the display as dirty."""
@@ -1163,6 +1192,19 @@ class BuildStatus:
             line = "".join(self._generate_line_components(build_info, static=True))
             self.stdout.write(line + "\n")
             self.stdout.flush()
+
+    def parse_log_summary(self, build_id: str) -> None:
+        """Parse the build log for errors/warnings and store the summary."""
+        build_info = self.builds[build_id]
+        if not build_info.log_path or not os.path.exists(build_info.log_path):
+            return
+        buf = io.StringIO()
+        spack.build_environment.write_log_summary(
+            buf, f"{build_info.name}@{build_info.version} build", build_info.log_path
+        )
+        summary = buf.getvalue()
+        if summary:
+            build_info.log_summary = summary
 
     def update_progress(self, build_id: str, current: int, total: int) -> None:
         """Update the progress of a package and mark the display as dirty."""
@@ -1368,6 +1410,10 @@ class BuildStatus:
         elif build_info.state == "finished":
             prefix = build_info.prefix
             yield f" {padding_filter(prefix) if self.filter_padding else prefix}"
+        elif build_info.state == "failed":
+            yield " failed"
+            if build_info.log_path:
+                yield f": {build_info.log_path}"
         else:
             yield f" {build_info.state}"
 
@@ -1945,6 +1991,7 @@ class PackageInstaller:
                         # reported as failures in the UI.
                         failures.append(build.spec)
                         self.build_status.update_state(build.spec.dag_hash(), "failed")
+                        self.build_status.parse_log_summary(build.spec.dag_hash())
 
                 if failures and self.fail_fast:
                     # Terminate other builds to actually fail fast. We continue in the event loop
@@ -2076,13 +2123,9 @@ class PackageInstaller:
 
         if failures:
             for s in failures:
-                log_path = self.log_paths.get(s.dag_hash())
-                if log_path and os.path.exists(log_path):
-                    out = io.StringIO()
-                    spack.build_environment.write_log_summary(out, f"{s} build", log_path)
-                    summary = out.getvalue()
-                    if summary:
-                        sys.stderr.write(summary)
+                build_info = self.build_status.builds[s.dag_hash()]
+                if build_info and build_info.log_summary:
+                    sys.stderr.write(build_info.log_summary)
             lines = [f"{s}: {self.log_paths[s.dag_hash()]}" for s in failures]
             raise spack.error.InstallError(
                 "The following packages failed to install:\n" + "\n".join(lines)
@@ -2203,7 +2246,10 @@ class PackageInstaller:
         )
         selector.register(child_info.proc.sentinel, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
         self.build_status.add_build(
-            child_info.spec, explicit=explicit, control_w_conn=child_info.control_w_conn
+            child_info.spec,
+            explicit=explicit,
+            control_w_conn=child_info.control_w_conn,
+            log_path=child_info.log_path,
         )
         self.report_data.start_record(spec)
 

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -179,6 +179,40 @@ class TestBasicStateManagement:
         assert status.completed == 1
         assert status.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
 
+    def test_parse_log_summary(self, tmp_path):
+        """Test that parse_log_summary parses the build log and stores the summary."""
+        status, _, _ = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        # Create a fake log file with an error
+        log_file = tmp_path / "build.log"
+        log_file.write_text("error: something went wrong\n")
+
+        status.builds[build_id].log_path = str(log_file)
+        status.parse_log_summary(build_id)
+        assert status.builds[build_id].log_summary is not None
+        assert "error" in status.builds[build_id].log_summary.lower()
+
+    def test_parse_log_summary_no_log_path(self):
+        """Test that parse_log_summary is a no-op when log_path is not set."""
+        status, _, _ = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        status.parse_log_summary(build_id)
+        assert status.builds[build_id].log_summary is None
+
+    def test_parse_log_summary_missing_file(self, tmp_path):
+        """Test that parse_log_summary is a no-op when log file doesn't exist."""
+        status, _, _ = create_build_status()
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        status.builds[build_id].log_path = str(tmp_path / "nonexistent.log")
+        status.parse_log_summary(build_id)
+        assert status.builds[build_id].log_summary is None
+
     def test_update_progress(self):
         """Test that update_progress updates percentages"""
         status, _, _ = create_build_status()
@@ -757,22 +791,41 @@ class TestLogFollowing:
         # Nothing should be printed since we're tracking pkg1, not pkg2
         assert fake_stdout.getvalue() == ""
 
-    def test_cannot_follow_failed_build(self):
-        """Test that navigation skips failed builds"""
+    def test_can_navigate_to_failed_build(self):
+        """Test that navigating to a failed build shows log summary and path"""
+        status, _, fake_stdout = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        # Mark the middle build as failed and set log info
+        status.update_state(specs[1].dag_hash(), "failed")
+        build_info = status.builds[specs[1].dag_hash()]
+        build_info.log_summary = "Error: something went wrong\n"
+        build_info.log_path = "/tmp/spack/pkg1.log"
+
+        # Navigate from pkg0 to next -- should land on failed pkg1
+        status.tracked_build_id = specs[0].dag_hash()
+        next_id = status._get_next(1)
+        assert next_id == specs[1].dag_hash()
+
+        # Actually navigate to it
+        status.next(1)
+        output = fake_stdout.getvalue()
+        assert "Log summary of pkg1" in output
+        assert "Error: something went wrong" in output
+        assert "/tmp/spack/pkg1.log" in output
+
+    def test_navigation_skips_finished_build(self):
+        """Test that navigation skips successfully finished builds"""
         status, _, _ = create_build_status(total=3)
         specs = add_mock_builds(status, 3)
 
-        # Mark the middle build as failed
-        status.update_state(specs[1].dag_hash(), "failed")
+        # Mark the middle build as finished (successful)
+        status.update_state(specs[1].dag_hash(), "finished")
 
-        # The failed build should have finished_time set
-        assert status.builds[specs[1].dag_hash()].finished_time is not None
-
-        # Try to get next build, should skip the failed one
+        # Try to get next build, should skip the finished one
         status.tracked_build_id = specs[0].dag_hash()
         next_id = status._get_next(1)
 
-        # Should skip pkg1 (failed) and return pkg2
         assert next_id == specs[2].dag_hash()
 
 


### PR DESCRIPTION
* Parse logs directly on error to get a log summary
* Allow users to navigate through log summaries of build failures with `n`/`p` too
* Print the full log path in overview mode: `[x] ... failed: <log path>`
* Print the full log path in log mode after the log summary.
* Ensure we print a newline after `filter> keyword<enter>`.
