### PR TITLE
environment: reconstruct groups from lockfiles

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -3127,13 +3127,22 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         lockfile = manifest_dir / lockfile_name
         with lockfile.open("r", encoding="utf-8") as f:
             data = sjson.load(f)
-        user_specs = data["roots"]
+        roots = data["roots"]
+
+        user_specs_by_group: Dict[str, List[str]] = {}
+        for item in roots:
+            # "group" is not there for Lockfile v6 and lower
+            group = item.get("group", DEFAULT_USER_SPEC_GROUP)
+            user_specs_by_group.setdefault(group, []).append(item["spec"])
 
         default_content = manifest_dir / manifest_name
         default_content.write_text(default_manifest_yaml())
         manifest = EnvironmentManifestFile(manifest_dir)
-        for item in user_specs:
-            manifest.add_user_spec(item["spec"])
+
+        for group, specs in user_specs_by_group.items():
+            for spec in specs:
+                manifest.add_user_spec(spec, group=group)
+
         manifest.flush()
         return manifest
 
@@ -3244,15 +3253,44 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             raise ValueError(f"user specs group '{group}' not found in {self.manifest_file}")
         return group
 
-    def add_user_spec(self, user_spec: str) -> None:
-        """Appends the user spec passed as input to the default list of root specs.
+    def add_user_spec(self, user_spec: str, *, group: Optional[str] = None) -> None:
+        """Appends the user spec passed as input to the list of root specs for the given group.
 
         Args:
             user_spec: user spec to be appended
+            group: group where the spec should be added. If None, the default group is used.
         """
-        self.configuration.setdefault("specs", []).append(user_spec)
-        self._user_specs[DEFAULT_USER_SPEC_GROUP].append(user_spec)
+        group = group or DEFAULT_USER_SPEC_GROUP
+
+        if group == DEFAULT_USER_SPEC_GROUP:
+            # Append to top-most specs: attribute
+            specs_yaml = self.configuration.setdefault("specs", [])
+            specs_yaml.append(user_spec)
+        else:
+            # Append to specs: attribute within a group
+            group_in_yaml = self._get_group(group)
+            group_in_yaml.setdefault("specs", []).append(user_spec)
+
+        self._user_specs[group].append(user_spec)
         self.changed = True
+
+    def _get_group(self, group: str) -> Dict:
+        """Find or create the group entry in the manifest"""
+        specs_yaml = self.configuration.setdefault("specs", [])
+        group_entry = None
+        for item in specs_yaml:
+            if isinstance(item, dict) and item.get("group") == group:
+                group_entry = item
+                break
+
+        if group_entry is None:
+            group_entry = {"group": group, "specs": []}
+            specs_yaml.append(group_entry)
+            self._groups[group] = tuple()
+            self._config_override[group] = None
+            self._user_specs[group] = []
+
+        return group_entry
 
     def remove_user_spec(self, user_spec: str) -> None:
         """Removes the user spec passed as input from the default list of root specs

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -4,6 +4,7 @@
 """Test environment internals without CLI"""
 
 import filecmp
+import json
 import os
 import pathlib
 import pickle
@@ -1982,6 +1983,46 @@ spack:
         with ev.Environment(manifest.manifest_dir) as e:
             with pytest.raises(ev.SpackEnvironmentConfigError, match=r"among groups: alpha, beta"):
                 e.concretize()
+
+    def test_from_lockfile_preserves_groups(self, tmp_path):
+        """Tests that EnvironmentManifestFile.from_lockfile reconstructs groups correctly
+        from a v7 lockfile that contains group information in its roots.
+        """
+        lockfile_data = {
+            "_meta": {"file-type": "spack-lockfile", "lockfile-version": 7, "specfile-version": 5},
+            "roots": [
+                {"hash": "aaa", "spec": "mpileaks", "group": "default"},
+                {"hash": "bbb", "spec": "libelf", "group": "default"},
+                {"hash": "ccc", "spec": "gcc@14", "group": "compilers"},
+            ],
+            "concrete_specs": {},
+        }
+        lockfile_path = tmp_path / "spack.lock"
+        lockfile_path.write_text(json.dumps(lockfile_data))
+
+        manifest = EnvironmentManifestFile.from_lockfile(tmp_path)
+
+        # The reconstructed manifest must have both groups
+        assert set(manifest.groups()) == {"default", "compilers"}
+        assert manifest.user_specs(group="default") == ["mpileaks", "libelf"]
+        assert manifest.user_specs(group="compilers") == ["gcc@14"]
+
+    def test_from_lockfile_without_groups_stays_default(self, tmp_path):
+        """Tests that a lockfile without group info (v6 and earlier) reconstructs all specs
+        into the default group only.
+        """
+        lockfile_data = {
+            "_meta": {"file-type": "spack-lockfile", "lockfile-version": 6, "specfile-version": 5},
+            "roots": [{"hash": "aaa", "spec": "mpileaks"}, {"hash": "bbb", "spec": "libelf"}],
+            "concrete_specs": {},
+        }
+        lockfile_path = tmp_path / "spack.lock"
+        lockfile_path.write_text(json.dumps(lockfile_data))
+
+        manifest = EnvironmentManifestFile.from_lockfile(tmp_path)
+
+        assert set(manifest.groups()) == {"default"}
+        assert manifest.user_specs(group="default") == ["mpileaks", "libelf"]
 
 
 @pytest.mark.regression("51995")


### PR DESCRIPTION
fixes #52094

When a `spack.yaml` is created from a lockfile, the groups are now taken into account. There are still parts of the manifest that cannot be reconstructed, but this can be solved in following PRs.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
