### PR TITLE
new_installer.py: no status line at the end

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1275,25 +1275,27 @@ class BuildStatus:
         self.finished_builds.clear()
 
         # Then a header followed by the active builds. This is the "mutable" part of the display.
-        if self.color:
-            bold = "\033[1m"
-            reset = "\033[0m"
-            cyan = "\033[36m"
-        else:
-            bold = reset = cyan = ""
 
-        long_header_len = len(
-            f"Progress: {self.completed}/{self.total}  /: filter  v: logs  n/p: next/prev"
-        )
-        if long_header_len < max_width:
-            self._println(
-                buffer,
-                f"{bold}Progress:{reset} {self.completed}/{self.total}"
-                f"  {cyan}/{reset}: filter  {cyan}v{reset}: logs"
-                f"  {cyan}n{reset}/{cyan}p{reset}: next/prev",
+        if not finalize:
+            if self.color:
+                bold = "\033[1m"
+                reset = "\033[0m"
+                cyan = "\033[36m"
+            else:
+                bold = reset = cyan = ""
+
+            long_header_len = len(
+                f"Progress: {self.completed}/{self.total}  /: filter  v: logs  n/p: next/prev"
             )
-        else:
-            self._println(buffer, f"{bold}Progress:{reset} {self.completed}/{self.total}")
+            if long_header_len < max_width:
+                self._println(
+                    buffer,
+                    f"{bold}Progress:{reset} {self.completed}/{self.total}"
+                    f"  {cyan}/{reset}: filter  {cyan}v{reset}: logs"
+                    f"  {cyan}n{reset}/{cyan}p{reset}: next/prev",
+                )
+            else:
+                self._println(buffer, f"{bold}Progress:{reset} {self.completed}/{self.total}")
 
         displayed_builds = (
             [b for b in self.builds.values() if self._is_displayed(b)]

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -1197,6 +1197,23 @@ class TestEdgeCases:
         assert "Progress:" in output
         assert "0/0" in output
 
+    def test_no_header_with_finalize(self):
+        """Test that we don't print a header with finalize=True"""
+        status, _, fake_stdout = create_build_status(total=2, color=False)
+        spec_a, spec_b = add_mock_builds(status, 2)
+        status.update_state(spec_a.dag_hash(), "finished")
+        status.update_state(spec_b.dag_hash(), "failed")
+        status.update(finalize=True)
+
+        output = fake_stdout.getvalue()
+
+        # Should not contain header
+        assert "Progress:" not in output
+
+        # Should contain final status lines for both builds
+        assert f"[+] {spec_a.dag_hash(7)} {spec_a.name}@{spec_a.version}" in output
+        assert f"[x] {spec_b.dag_hash(7)} {spec_b.name}@{spec_b.version}" in output
+
     def test_all_builds_finished(self):
         """Test when all builds are finished"""
         status, fake_time, _ = create_build_status(total=2)


### PR DESCRIPTION
After interactive install there's no point in showing the progress line, so drop it.

Then the final output looks like this:

```
$ spack install foo
[+] ... /opt/...
[+] ... /opt/...
[x] ... failed
$ 
```

Before it was


```
$ spack install foo
[+] ... /opt/...
[+] ... /opt/...
[x] ... failed
Progress: 3/3  /: filter ...
```

Best reviewed with "hide whitespace"
<img width="514" height="127" alt="Screenshot 2026-03-17 at 19 52 05" src="https://github.com/user-attachments/assets/669582f7-169e-430d-81e6-5361fd59771a" />

