### PR TITLE
Remove amdblis and amdlibflame as defaults

### DIFF
--- a/etc/spack/defaults/base/packages.yaml
+++ b/etc/spack/defaults/base/packages.yaml
@@ -18,7 +18,7 @@ packages:
     providers:
       awk: [gawk]
       armci: [armcimpi]
-      blas: [openblas, amdblis]
+      blas: [openblas]
       c: [gcc, llvm, intel-oneapi-compilers]
       cxx: [gcc, llvm, intel-oneapi-compilers]
       daal: [intel-oneapi-daal]
@@ -36,7 +36,7 @@ packages:
       ipp: [intel-oneapi-ipp]
       java: [openjdk, jdk]
       jpeg: [libjpeg-turbo, libjpeg]
-      lapack: [openblas, amdlibflame]
+      lapack: [openblas]
       libc: [glibc, musl]
       libgfortran: [gcc-runtime]
       libglx: [mesa+glx]


### PR DESCRIPTION
The two packages are not very well maintained, and vendor-specific, so it may be surprising to see `amdblis` selected when `openblas` is not available for any reason.

Let Spack users decide if they want them as defaults or not.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
