### PR TITLE
detection: deduplicate specs at different prefixes

### DIFF
--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -268,6 +268,7 @@ class Finder:
             return []
 
         result = []
+        resolved_specs: Dict[spack.spec.Spec, str] = {}  # spec -> prefix of first detection
         for candidate_path, items_in_prefix in _group_by_prefix(
             spack.llnl.util.lang.dedupe(paths)
         ).items():
@@ -297,21 +298,19 @@ class Finder:
                     f"part of the package {pkg.name}: {files}"
                 )
 
-            resolved_specs: Dict[spack.spec.Spec, str] = {}  # spec -> exe found for the spec
             for spec in specs:
                 prefix = self.prefix_from_path(path=candidate_path)
                 if not prefix:
                     continue
 
                 if spec in resolved_specs:
-                    prior_prefix = ", ".join(_convert_to_iterable(resolved_specs[spec]))
-                    spack.llnl.util.tty.debug(
-                        f"Files in {candidate_path} and {prior_prefix} are both associated"
-                        f" with the same spec {str(spec)}"
+                    prior_prefix = resolved_specs[spec]
+                    warnings.warn(
+                        f'"{spec}" detected in "{prefix}" was already detected in "{prior_prefix}"'
                     )
                     continue
 
-                resolved_specs[spec] = candidate_path
+                resolved_specs[spec] = prefix
                 try:
                     # Validate the spec calling a package specific method
                     pkg_cls = repo_path.get_pkg_class(spec.name)

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -169,7 +169,9 @@ def test_compiler_find_prefer_no_suffix(no_packages_yaml, working_env, compilers
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 def test_compiler_find_path_order(no_packages_yaml, working_env, compilers_dir):
-    """Ensure that we look for compilers in the same order as PATH, when there are duplicates"""
+    """When the same compiler version is found in two PATH directories, only the first
+    entry in PATH is kept and a warning is emitted for the duplicate.
+    """
     new_dir = compilers_dir / "first_in_path"
     new_dir.mkdir()
     for name in ("gcc-8", "g++-8", "gfortran-8"):
@@ -177,13 +179,14 @@ def test_compiler_find_path_order(no_packages_yaml, working_env, compilers_dir):
     # Set PATH to have the new folder searched first
     os.environ["PATH"] = f"{str(new_dir)}:{str(compilers_dir)}"
 
-    compiler("find", "--scope=site")
+    with pytest.warns(UserWarning, match="gcc@"):
+        compiler("find", "--scope=site")
 
     compilers = spack.compilers.config.all_compilers(scope="site")
     gcc = [x for x in compilers if x.satisfies("gcc@8.4")]
 
-    # Ensure we found both duplicates
-    assert len(gcc) == 2
+    # Duplicate is dropped. Only the first entry in PATH is kept
+    assert len(gcc) == 1
     assert gcc[0].extra_attributes["compilers"] == {
         "c": str(new_dir / "gcc-8"),
         "cxx": str(new_dir / "g++-8"),

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -4,10 +4,13 @@
 import collections
 import pathlib
 
+import pytest
+
 import spack.config
 import spack.detection
 import spack.detection.common
 import spack.detection.path
+import spack.repo
 import spack.spec
 
 
@@ -52,3 +55,38 @@ def test_dedupe_paths(tmp_path: pathlib.Path):
     assert spack.detection.path.dedupe_paths([str(x), str(y), str(z)]) == [str(x), str(y)]
     assert spack.detection.path.dedupe_paths([str(z), str(y), str(x)]) == [str(x), str(y)]
     assert spack.detection.path.dedupe_paths([str(y), str(z), str(x)]) == [str(y), str(x)]
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch):
+    """Tests that the same spec detected at two different prefixes should yield only one result.
+
+    Returning both causes duplicate externals in packages.yaml and non-deterministic hashes
+    during concretization.
+    """
+    # Create two independent bin/ directories, each containing the same executable name.
+    prefix_a = tmp_path / "prefix_a"
+    prefix_b = tmp_path / "prefix_b"
+    (prefix_a / "bin").mkdir(parents=True)
+    (prefix_b / "bin").mkdir(parents=True)
+    exe_a = prefix_a / "bin" / "cmake"
+    exe_b = prefix_b / "bin" / "cmake"
+    exe_a.touch()
+    exe_b.touch()
+
+    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+
+    # Patch determine_spec_details to always return the same spec, regardless of prefix.
+    @classmethod
+    def _same_spec(cls, prefix, exes_in_prefix):
+        return spack.spec.Spec("cmake@3.17.1")
+
+    monkeypatch.setattr(cmake_cls, "determine_spec_details", _same_spec)
+
+    finder = spack.detection.path.ExecutablesFinder()
+    detected = finder.detect_specs(
+        pkg=cmake_cls, paths=[str(exe_a), str(exe_b)], repo_path=spack.repo.PATH
+    )
+
+    # Both prefixes produce cmake@3.17.1; only the first should be kept.
+    assert len(detected) == 1


### PR DESCRIPTION
When the same spec (e.g. gcc@8.4.0) is discovered at two different prefixes, only the first entry is kept.
A warning is printed to users for any successive duplicate found in other prefixes.

The previous behavior of keeping all the duplicates would lead to nondeterminism in which one is selected during concretization.

**Example**
<img width="1497" height="181" alt="Screenshot from 2026-03-18 17-20-42" src="https://github.com/user-attachments/assets/6e38ca87-25c5-437d-a0fb-41a514558c39" />


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
