### PR TITLE
new_installer.py: improve SIGTERM handler of build

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -447,15 +447,21 @@ def worker_function(
     os.setsid()
 
     def handle_sigterm(signum, frame):
-        # This SIGTERM handler forwards the signal to child processes, and
-        # then resets the handler to default. It does not raise an exception,
-        # because the assumption is we're stuck in waitpid, and we want to
-        # let child processes finish with SIGTERM before we run the cleanup
-        # code in finally blocks and __exit__ functions and exit. If we exit
-        # too early, the child process may still write to the prefix or stage.
+        # This SIGTERM handler forwards the signal to child processes (cmake, make, etc). We wait
+        # for all child processes to exit before raising KeyboardInterrupt. This ensures all
+        # __exit__ and finally blocks run after the child processes have stopped, meaning that we
+        # get to clean up the prefix without risking that the child process writes to it
+        # afterwards.
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
         os.killpg(0, signal.SIGTERM)
-        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+        try:
+            while True:
+                os.waitpid(-1, 0)
+        except ChildProcessError:
+            pass
+
+        raise KeyboardInterrupt("Installation interrupted")
 
     signal.signal(signal.SIGTERM, handle_sigterm)
 
@@ -497,7 +503,7 @@ def worker_function(
                 spack.store.STORE,
                 run_tests,
             )
-    except Exception:
+    except BaseException:
         traceback.print_exc()  # log the traceback to the log file
         exit_code = 1
     finally:


### PR DESCRIPTION
The previous implementation of SIGTERM was somewhat brittle. The
assumption was that if we're stuck in `Executable("make")(...)` and
receive SIGTERM, we can just forward the signal and then return to
waiting for `make` to exit with nonzero exite code, which would trigger
an exception and ultimately build failure.

Apart from the fact that the build *could* run
`Executable("make")(fail_on_error=False)`, it could also just be running
Python code, like install from cache+relocation, which would simply
continue to run undisturbed.

So, instead of assuming we're stuck in `waitpid`, do an explicit
`waitpid` until all children have exited, and then raise
`KeyboardInterrupt`. This ensures we hit an exception in all cases
mentioned above.

---

One way to test this in practice is to run

```
spack install --fail-fast ...
```

and break the build by removing one of the stage dirs
as the build runs, and checking that the prefixes of the
other concurrent builds are cleaned up. The `--fail-fast`
flag also sends a SIGTERM to all running builds on first
failure.

