### PR TITLE
new_installer.py: clear progress line on ^C

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1251,7 +1251,7 @@ class BuildStatus:
                 del self.builds[build_id]
                 self.dirty = True
 
-        if not self.dirty:
+        if not self.dirty and not finalize:
             return
 
         # Build the overview output in a buffer and print all at once to avoid flickering.


### PR DESCRIPTION
Very minor: on `^C` the status line "Progress: ..." is sometimes cleared
and sometimes not.

If it happened right after a spinner tick it would be removed, else it
would not because then the UI was not "dirty".

