### PR TITLE
Add exclude_externals option for modules

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -420,6 +420,7 @@ class BaseConfiguration:
         include_matches = [x for x in conf.get("include", []) if spec.satisfies(x)]
         exclude_matches = [x for x in conf.get("exclude", []) if spec.satisfies(x)]
         excluded_as_implicit = not self.explicit and conf.get("exclude_implicits", False)
+        exclude_as_external = self.external and conf.get("exclude_externals", False)
 
         def debug_info(line_header, match_list):
             if match_list:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -420,7 +420,7 @@ class BaseConfiguration:
         include_matches = [x for x in conf.get("include", []) if spec.satisfies(x)]
         exclude_matches = [x for x in conf.get("exclude", []) if spec.satisfies(x)]
         excluded_as_implicit = not self.explicit and conf.get("exclude_implicits", False)
-        exclude_as_external = self.external and conf.get("exclude_externals", False)
+        excluded_as_external = spec.external and conf.get("exclude_externals", False)
 
         def debug_info(line_header, match_list):
             if match_list:
@@ -434,7 +434,12 @@ class BaseConfiguration:
         if excluded_as_implicit:
             tty.debug(f"\tEXCLUDED_AS_IMPLICIT : {spec.cshort_spec}")
 
-        return not include_matches and (exclude_matches or excluded_as_implicit)
+        if excluded_as_external:
+            tty.debug(f"\tEXCLUDED_AS_EXTERNAL : {spec.cshort_spec}")
+
+        return not include_matches and (
+            exclude_matches or excluded_as_implicit or excluded_as_external
+        )
 
     @property
     def hidden(self):

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -416,7 +416,8 @@ class BaseConfiguration:
         spec = self.spec
         conf = self.module.configuration(self.name)
 
-        # Compute the list of matching include / exclude rules, and whether excluded as implicit
+        # Compute the list of matching include / exclude rules,
+        # and whether excluded as implicit or external
         include_matches = [x for x in conf.get("include", []) if spec.satisfies(x)]
         exclude_matches = [x for x in conf.get("exclude", []) if spec.satisfies(x)]
         excluded_as_implicit = not self.explicit and conf.get("exclude_implicits", False)

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -105,6 +105,12 @@ common_props = {
         "description": "Exclude implicit dependencies from module file generation while still "
         "allowing autoloading",
     },
+    "exclude_externals": {
+        "type": "boolean",
+        "default": False,
+        "description": "Exclude external dependencies from module file generation while still "
+        "allowing autoloading",
+    },
     "defaults": {
         **array_of_strings,
         "description": "List of specs for which to create default module symlinks when multiple "

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -13,6 +13,7 @@ import spack.config
 import spack.error
 import spack.modules
 import spack.modules.common
+import spack.modules.lmod
 import spack.modules.tcl
 import spack.package_base
 import spack.package_prefs
@@ -230,3 +231,19 @@ def test_module_writers_are_pickleable(default_mock_concretization, module_type)
     s = default_mock_concretization("mpileaks")
     writer = spack.modules.module_types[module_type](s, "default")
     assert pickle.loads(pickle.dumps(writer)).spec == s
+
+
+def test_modules_externals_can_be_excluded():
+    # The code tested is common to all module types, but has to be tested from
+    # one. This test uses Lmod.
+    spack.config.set("modules:mpileaks:lmod", {"exclude_externals": False})
+    spec = spack.concretize.concretize_one("mpileaks")
+    lconf = spack.modules.lmod.LmodConfiguration(spec, "mpileaks", False)
+    assert not lconf.excluded
+
+    # fake that the spec is external
+    spec.external_path = True
+    assert not lconf.excluded
+
+    spack.config.set("modules:mpileaks:lmod", {"exclude_externals": True})
+    assert lconf.excluded


### PR DESCRIPTION
Add a config option to modules to exclude module generation for external specs.