### PR TITLE
executable.py: cleanup

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -220,7 +220,7 @@ class MakeExecutable(Executable):
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         input: Optional[BinaryIO] = ...,
         output: Union[Type[str], Callable] = ...,
-        error: Union[Optional[BinaryIO], str, Type[str], Callable] = ...,
+        error: spack.util.executable.OutType = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> str: ...
 
@@ -238,7 +238,7 @@ class MakeExecutable(Executable):
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         input: Optional[BinaryIO] = ...,
-        output: Union[Optional[BinaryIO], str, Type[str], Callable] = ...,
+        output: spack.util.executable.OutType = ...,
         error: Union[Type[str], Callable] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> str: ...

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -48,13 +48,13 @@ from itertools import chain
 from multiprocessing.connection import Connection
 from typing import (
     Any,
+    BinaryIO,
     Callable,
     Dict,
     List,
     Optional,
     Sequence,
     Set,
-    TextIO,
     Tuple,
     Type,
     Union,
@@ -199,9 +199,9 @@ class MakeExecutable(Executable):
         timeout: Optional[int] = ...,
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
-        input: Optional[TextIO] = ...,
-        output: Union[Optional[TextIO], str] = ...,
-        error: Union[Optional[TextIO], str] = ...,
+        input: Optional[BinaryIO] = ...,
+        output: Union[Optional[BinaryIO], str] = ...,
+        error: Union[Optional[BinaryIO], str] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> None: ...
 
@@ -218,9 +218,9 @@ class MakeExecutable(Executable):
         timeout: Optional[int] = ...,
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
-        input: Optional[TextIO] = ...,
+        input: Optional[BinaryIO] = ...,
         output: Union[Type[str], Callable] = ...,
-        error: Union[Optional[TextIO], str, Type[str], Callable] = ...,
+        error: Union[Optional[BinaryIO], str, Type[str], Callable] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> str: ...
 
@@ -237,8 +237,8 @@ class MakeExecutable(Executable):
         timeout: Optional[int] = ...,
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
-        input: Optional[TextIO] = ...,
-        output: Union[Optional[TextIO], str, Type[str], Callable] = ...,
+        input: Optional[BinaryIO] = ...,
+        output: Union[Optional[BinaryIO], str, Type[str], Callable] = ...,
         error: Union[Type[str], Callable] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> str: ...

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -163,3 +163,17 @@ def test_construct_from_pathlib(mock_executable):
     path = mock_executable("hello", output=f"echo {expected}\n")
     hello = ex.Executable(path)
     assert expected in hello(output=str)
+
+
+def test_exe_disallows_str_split_as_input(mock_executable):
+    path = mock_executable("hello", output="echo hi\n")
+    hello = ex.Executable(path)
+    with pytest.raises(ValueError):
+        hello(input=str.split)
+
+
+def test_exe_disallows_callable_as_output(mock_executable):
+    path = mock_executable("hello", output="echo hi\n")
+    hello = ex.Executable(path)
+    with pytest.raises(ValueError):
+        hello(output=lambda line: line)

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -336,9 +336,6 @@ class Executable:
     def __eq__(self, other):
         return hasattr(other, "exe") and self.exe == other.exe
 
-    def __neq__(self, other):
-        return not (self == other)
-
     def __hash__(self):
         return hash((type(self),) + tuple(self.exe))
 

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -276,12 +276,12 @@ class Executable:
             quoted_args = [arg for arg in args if re.search(r'^".*"$|^\'.*\'$', arg)]
             if quoted_args:
                 tty.warn(
-                    "Quotes in command arguments can confuse scripts like" " configure.",
+                    "Quotes in command arguments can confuse scripts like configure.",
                     "The following arguments may cause problems when executed:",
                     str("\n".join(["    " + arg for arg in quoted_args])),
                     "Quotes aren't needed because spack doesn't use a shell. "
                     "Consider removing them.",
-                    "If multiple levels of quotation are required, use " "`ignore_quotes=True`.",
+                    "If multiple levels of quotation are required, use `ignore_quotes=True`.",
                 )
 
         cmd = self.exe + list(args)

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -304,7 +304,7 @@ class Executable:
             if " " in self.exe[0]:
                 message += "\nDid you mean to add a space to the command?"
 
-            raise ProcessError("%s: %s" % (self.exe[0], e.strerror), message)
+            raise ProcessError(f"{self.exe[0]}: {e.strerror}", message)
 
         try:
             out, err = proc.communicate(timeout=timeout)
@@ -319,7 +319,7 @@ class Executable:
                     # stdout/stderr (e.g. if 'output' is not specified)
                     long_msg += "\n" + result
 
-                raise ProcessError("Command exited with status %d:" % proc.returncode, long_msg)
+                raise ProcessError(f"Command exited with status {proc.returncode}:", long_msg)
 
         except subprocess.TimeoutExpired as te:
             proc.kill()
@@ -352,7 +352,7 @@ class Executable:
         return hash((type(self),) + tuple(self.exe))
 
     def __repr__(self):
-        return "<exe: %s>" % self.exe
+        return f"<exe: {self.exe}>"
 
     def __str__(self):
         return " ".join(self.exe)

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -8,7 +8,7 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path, PurePath
-from typing import Callable, Dict, List, Optional, Sequence, TextIO, Type, Union, overload
+from typing import BinaryIO, Callable, Dict, List, Optional, Sequence, Type, Union, overload
 
 from spack.vendor.typing_extensions import Literal
 
@@ -108,9 +108,9 @@ class Executable:
         timeout: Optional[int] = ...,
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
-        input: Optional[TextIO] = ...,
-        output: Union[Optional[TextIO], str] = ...,
-        error: Union[Optional[TextIO], str] = ...,
+        input: Optional[BinaryIO] = ...,
+        output: Union[Optional[BinaryIO], str] = ...,
+        error: Union[Optional[BinaryIO], str] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> None: ...
 
@@ -124,9 +124,9 @@ class Executable:
         timeout: Optional[int] = ...,
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
-        input: Optional[TextIO] = ...,
+        input: Optional[BinaryIO] = ...,
         output: Union[Type[str], Callable],
-        error: Union[Optional[TextIO], str, Type[str], Callable] = ...,
+        error: Union[Optional[BinaryIO], str, Type[str], Callable] = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> str: ...
 
@@ -140,8 +140,8 @@ class Executable:
         timeout: Optional[int] = ...,
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
-        input: Optional[TextIO] = ...,
-        output: Union[Optional[TextIO], str, Type[str], Callable] = ...,
+        input: Optional[BinaryIO] = ...,
+        output: Union[Optional[BinaryIO], str, Type[str], Callable] = ...,
         error: Union[Type[str], Callable],
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> str: ...
@@ -155,9 +155,9 @@ class Executable:
         timeout: Optional[int] = None,
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = None,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = None,
-        input: Optional[TextIO] = None,
-        output: Union[Optional[TextIO], str, Type[str], Callable] = None,
-        error: Union[Optional[TextIO], str, Type[str], Callable] = None,
+        input: Optional[BinaryIO] = None,
+        output: Union[Optional[BinaryIO], str, Type[str], Callable] = None,
+        error: Union[Optional[BinaryIO], str, Type[str], Callable] = None,
         _dump_env: Optional[Dict[str, str]] = None,
     ) -> Optional[str]:
         """Runs this executable in a subprocess.

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import io
 import os
 import re
 import shlex
 import subprocess
 import sys
 from pathlib import Path, PurePath
-from typing import BinaryIO, Callable, Dict, List, Optional, Sequence, Type, Union, overload
+from typing import BinaryIO, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union, overload
 
 from spack.vendor.typing_extensions import Literal
 
@@ -18,12 +19,14 @@ from spack.util.environment import EnvironmentModifications
 
 __all__ = ["Executable", "which", "which_string", "ProcessError"]
 
+OutType = Union[Optional[BinaryIO], str, Type[str], Callable]
+
 
 def _process_cmd_output(
     out: bytes,
     err: bytes,
-    output,
-    error,
+    output: OutType,
+    error: OutType,
     encoding: str = "ISO-8859-1" if sys.platform == "win32" else "utf-8",
 ) -> Optional[str]:
     if output is str or output is str.split or error is str or error is str.split:
@@ -41,6 +44,17 @@ def _process_cmd_output(
         return result
     else:
         return None
+
+
+def _streamify_output(arg: OutType, name: str) -> Tuple[Union[int, BinaryIO, None], bool]:
+    if isinstance(arg, str):
+        return open(arg, "wb"), True
+    elif arg is str or arg is str.split:
+        return subprocess.PIPE, False
+    elif callable(arg):
+        raise ValueError(f"`{name}` must be a stream, a filename, or `str`/`str.split`")
+    else:
+        return arg, False
 
 
 class Executable:
@@ -149,8 +163,8 @@ class Executable:
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         input: Optional[BinaryIO] = ...,
-        output: Union[Type[str], Callable],
-        error: Union[Optional[BinaryIO], str, Type[str], Callable] = ...,
+        output: Union[Type[str], Callable],  # str or str.split
+        error: OutType = ...,
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> str: ...
 
@@ -165,8 +179,8 @@ class Executable:
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = ...,
         input: Optional[BinaryIO] = ...,
-        output: Union[Optional[BinaryIO], str, Type[str], Callable] = ...,
-        error: Union[Type[str], Callable],
+        output: OutType = ...,
+        error: Union[Type[str], Callable],  # str or str.split
         _dump_env: Optional[Dict[str, str]] = ...,
     ) -> str: ...
 
@@ -180,8 +194,8 @@ class Executable:
         env: Optional[Union[Dict[str, str], EnvironmentModifications]] = None,
         extra_env: Optional[Union[Dict[str, str], EnvironmentModifications]] = None,
         input: Optional[BinaryIO] = None,
-        output: Union[Optional[BinaryIO], str, Type[str], Callable] = None,
-        error: Union[Optional[BinaryIO], str, Type[str], Callable] = None,
+        output: OutType = None,
+        error: OutType = None,
         _dump_env: Optional[Dict[str, str]] = None,
     ) -> Optional[str]:
         """Runs this executable in a subprocess.
@@ -250,18 +264,13 @@ class Executable:
 
         if input is str or input is str.split:
             raise ValueError("Cannot use `str` or `str.split` as input stream.")
+        elif isinstance(input, str):
+            istream, close_istream = open(input, "rb"), True
+        else:
+            istream, close_istream = input, False
 
-        def streamify(arg, mode):
-            if isinstance(arg, str):
-                return open(arg, mode), True  # pylint: disable=unspecified-encoding
-            elif arg in (str, str.split):
-                return subprocess.PIPE, False
-            else:
-                return arg, False
-
-        ostream, close_ostream = streamify(output, "wb")
-        estream, close_estream = streamify(error, "wb")
-        istream, close_istream = streamify(input, "rb")
+        ostream, close_ostream = _streamify_output(output, "output")
+        estream, close_estream = _streamify_output(error, "error")
 
         if not ignore_quotes:
             quoted_args = [arg for arg in args if re.search(r'^".*"$|^\'.*\'$', arg)]
@@ -326,11 +335,12 @@ class Executable:
                 ) from te
 
         finally:
-            if close_ostream:
+            # The isinstance checks are only needed for type checking.
+            if close_ostream and isinstance(ostream, io.IOBase):
                 ostream.close()
-            if close_estream:
+            if close_estream and isinstance(estream, io.IOBase):
                 estream.close()
-            if close_istream:
+            if close_istream and isinstance(istream, io.IOBase):
                 istream.close()
 
         return result

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -4,6 +4,7 @@
 
 import os
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path, PurePath
@@ -275,8 +276,7 @@ class Executable:
 
         cmd = self.exe + list(args)
 
-        escaped_cmd = ["'%s'" % arg.replace("'", "'\"'\"'") for arg in cmd]
-        cmd_line_string = " ".join(escaped_cmd)
+        cmd_line_string = " ".join(shlex.quote(arg) for arg in cmd)
         tty.debug(cmd_line_string)
 
         result = None

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -289,8 +289,15 @@ class Executable:
                 env=current_environment,
                 close_fds=False,
             )
-            out, err = proc.communicate(timeout=timeout)
+        except OSError as e:
+            message = "Command: " + cmd_line_string
+            if " " in self.exe[0]:
+                message += "\nDid you mean to add a space to the command?"
 
+            raise ProcessError("%s: %s" % (self.exe[0], e.strerror), message)
+
+        try:
+            out, err = proc.communicate(timeout=timeout)
             result = process_cmd_output(out, err)
             rc = self.returncode = proc.returncode
             if fail_on_error and rc != 0 and (rc not in ignore_errors):
@@ -303,12 +310,6 @@ class Executable:
                     long_msg += "\n" + result
 
                 raise ProcessError("Command exited with status %d:" % proc.returncode, long_msg)
-        except OSError as e:
-            message = "Command: " + cmd_line_string
-            if " " in self.exe[0]:
-                message += "\nDid you mean to add a space to the command?"
-
-            raise ProcessError("%s: %s" % (self.exe[0], e.strerror), message)
 
         except subprocess.TimeoutExpired as te:
             proc.kill()

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -248,8 +248,8 @@ class Executable:
         if isinstance(ignore_errors, int):
             ignore_errors = (ignore_errors,)
 
-        if input is str:
-            raise ValueError("Cannot use `str` as input stream.")
+        if input is str or input is str.split:
+            raise ValueError("Cannot use `str` or `str.split` as input stream.")
 
         def streamify(arg, mode):
             if isinstance(arg, str):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -19,6 +19,30 @@ from spack.util.environment import EnvironmentModifications
 __all__ = ["Executable", "which", "which_string", "ProcessError"]
 
 
+def _process_cmd_output(
+    out: bytes,
+    err: bytes,
+    output,
+    error,
+    encoding: str = "ISO-8859-1" if sys.platform == "win32" else "utf-8",
+) -> Optional[str]:
+    if output is str or output is str.split or error is str or error is str.split:
+        result = ""
+        if output is str or output is str.split:
+            outstr = out.decode(encoding)
+            result += outstr
+            if output is str.split:
+                sys.stdout.write(outstr)
+        if error is str or error is str.split:
+            errstr = err.decode(encoding)
+            result += errstr
+            if error is str.split:
+                sys.stderr.write(errstr)
+        return result
+    else:
+        return None
+
+
 class Executable:
     """
     Represent an executable file that can be run as a subprocess.
@@ -196,29 +220,6 @@ class Executable:
 
         By default, the subprocess inherits the parent's file descriptors.
         """
-
-        def process_cmd_output(out, err):
-            result = None
-            if output in (str, str.split) or error in (str, str.split):
-                result = ""
-                if output in (str, str.split):
-                    if sys.platform == "win32":
-                        outstr = str(out.decode("ISO-8859-1"))
-                    else:
-                        outstr = str(out.decode("utf-8"))
-                    result += outstr
-                    if output is str.split:
-                        sys.stdout.write(outstr)
-                if error in (str, str.split):
-                    if sys.platform == "win32":
-                        errstr = str(err.decode("ISO-8859-1"))
-                    else:
-                        errstr = str(err.decode("utf-8"))
-                    result += errstr
-                    if error is str.split:
-                        sys.stderr.write(errstr)
-            return result
-
         # Setup default environment
         current_environment = os.environ.copy() if env is None else {}
         self._default_envmod.apply_modifications(current_environment)
@@ -298,7 +299,7 @@ class Executable:
 
         try:
             out, err = proc.communicate(timeout=timeout)
-            result = process_cmd_output(out, err)
+            result = _process_cmd_output(out, err, output, error)
             rc = self.returncode = proc.returncode
             if fail_on_error and rc != 0 and (rc not in ignore_errors):
                 long_msg = cmd_line_string
@@ -314,7 +315,7 @@ class Executable:
         except subprocess.TimeoutExpired as te:
             proc.kill()
             out, err = proc.communicate()
-            result = process_cmd_output(out, err)
+            result = _process_cmd_output(out, err, output, error)
             long_msg = cmd_line_string + f"\n{result}"
             if fail_on_error:
                 raise ProcessTimeoutError(


### PR DESCRIPTION
Refactor of executable.py, mostly to improve static type analysis.

* The use of `TextIO` in `Executable.__call__` was a bug, only `BinaryIO` was allowed.
* `input=` doesn't support `str` or `str.split` values.

