### PR TITLE
database.py: lock-free FailureTracker

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -319,15 +319,6 @@ def prefix_lock_path(root_dir: Union[str, pathlib.Path]) -> pathlib.Path:
     return pathlib.Path(root_dir) / _DB_DIRNAME / "prefix_lock"
 
 
-def failures_lock_path(root_dir: Union[str, pathlib.Path]) -> pathlib.Path:
-    """Returns the path of the failures lock file, given the root directory.
-
-    Args:
-        root_dir: root directory containing the database directory
-    """
-    return pathlib.Path(root_dir) / _DB_DIRNAME / "prefix_failures"
-
-
 class SpecLocker:
     """Manages acquiring and releasing read or write locks on concrete specs."""
 
@@ -407,148 +398,66 @@ class SpecLocker:
 
 
 class FailureTracker:
-    """Tracks installation failures.
+    """Tracks installation failures via persistent marker files.
 
-    Prefix failure marking takes the form of a byte range lock on the nth
-    byte of a file for coordinating between concurrent parallel build
-    processes and a persistent file, named with the full hash and
-    containing the spec, in a subdirectory of the database to enable
-    persistence across overlapping but separate related build processes.
-
-    The failure lock file lives alongside the install DB.
-
-    ``n`` is the sys.maxsize-bit prefix of the associated DAG hash to make
-    the likelihood of collision very low with no cleanup required.
+    Each failed spec gets an empty marker file in a ``failures/`` subdirectory of the database.
+    Synchronization between concurrent processes is handled by the prefix lock: a process holds
+    the prefix write lock while building, writes the failure marker on failure, then releases
+    the lock. Other processes will see the marker after acquiring the prefix lock themselves.
     """
 
-    #: root directory of the failure tracker
-    dir: pathlib.Path
+    def __init__(self, root_dir: Union[str, pathlib.Path]):
+        self.dir = os.path.join(str(root_dir), _DB_DIRNAME, "failures")
 
-    #: File for locking particular concrete spec hashes
-    locker: SpecLocker
-
-    def __init__(self, root_dir: Union[str, pathlib.Path], default_timeout: Optional[float]):
-        #: Ensure a persistent location for dealing with parallel installation
-        #: failures (e.g., across near-concurrent processes).
-        self.dir = pathlib.Path(root_dir) / _DB_DIRNAME / "failures"
-        self.locker = SpecLocker(failures_lock_path(root_dir), default_timeout=default_timeout)
-
-    def _ensure_parent_directories(self) -> None:
-        """Ensure that parent directories of the FailureTracker exist.
-
-        Accesses the filesystem only once, the first time it's called on a given FailureTracker.
-        """
-        self.dir.mkdir(parents=True, exist_ok=True)
-
-    def clear(self, spec: "spack.spec.Spec", force: bool = False) -> None:
-        """Removes any persistent and cached failure tracking for the spec.
-
-        see :meth:`mark`.
-
-        Args:
-            spec: the spec whose failure indicators are being removed
-            force: True if the failure information should be cleared when a failure lock
-                exists for the file, or False if the failure should not be cleared (e.g.,
-                it may be associated with a concurrent build)
-        """
-        locked = self.lock_taken(spec)
-        if locked and not force:
-            tty.msg(f"Retaining failure marking for {spec.name} due to lock")
-            return
-
-        if locked:
-            tty.warn(f"Removing failure marking despite lock for {spec.name}")
-
-        succeeded, lock = self.locker.clear(spec)
-        if succeeded and lock is not None:
-            lock.release_write()
-
-        if self.persistent_mark(spec):
-            path = self._path(spec)
-            tty.debug(f"Removing failure marking for {spec.name}")
-            try:
-                path.unlink()
-            except OSError as err:
-                tty.warn(
-                    f"Unable to remove failure marking for {spec.name} ({str(path)}): {str(err)}"
-                )
+    def clear(self, spec: "spack.spec.Spec") -> None:
+        """Removes any persistent failure tracking for the spec."""
+        path = self._path(spec)
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except OSError as err:
+            tty.warn(f"Unable to remove failure marking for {spec.name} ({path}): {err}")
 
     def clear_all(self) -> None:
-        """Force remove install failure tracking files."""
-        tty.debug("Releasing prefix failure locks")
-        self.locker.clear_all(
-            clear_fn=lambda x: x.release_write() if x.is_write_locked() else True
-        )
-
+        """Remove all install failure tracking files."""
         tty.debug("Removing prefix failure tracking files")
         try:
-            marks = os.listdir(str(self.dir))
+            entries = os.scandir(self.dir)
         except FileNotFoundError:
-            return  # directory doesn't exist yet
+            return
         except OSError as exc:
-            tty.warn(f"Unable to remove failure marking files: {str(exc)}")
+            tty.warn(f"Unable to remove failure marking files: {exc}")
             return
 
-        for fail_mark in marks:
-            try:
-                (self.dir / fail_mark).unlink()
-            except OSError as exc:
-                tty.warn(f"Unable to remove failure marking file {fail_mark}: {str(exc)}")
+        with entries:
+            for entry in entries:
+                try:
+                    os.unlink(entry.path)
+                except OSError as exc:
+                    tty.warn(f"Unable to remove failure marking file {entry.name}: {exc}")
 
-    def mark(self, spec: "spack.spec.Spec") -> lk.Lock:
+    def mark(self, spec: "spack.spec.Spec") -> None:
         """Marks a spec as failing to install.
 
         Args:
             spec: spec that failed to install
         """
-        self._ensure_parent_directories()
-
-        # Dump the spec to the failure file for (manual) debugging purposes
         path = self._path(spec)
-        path.write_text(spec.to_json())
-
-        # Also ensure a failure lock is taken to prevent cleanup removal
-        # of failure status information during a concurrent parallel build.
-        if not self.locker.has_lock(spec):
-            try:
-                mark = self.locker.lock(spec)
-                mark.acquire_write()
-            except lk.LockTimeoutError:
-                # Unlikely that another process failed to install at the same
-                # time but log it anyway.
-                tty.debug(f"PID {os.getpid()} failed to mark install failure for {spec.name}")
-                tty.warn(f"Unable to mark {spec.name} as failed.")
-
-        return self.locker.lock(spec)
+        try:
+            open(path, "wb").close()
+        except FileNotFoundError:
+            os.makedirs(self.dir, exist_ok=True)
+            open(path, "wb").close()
 
     def has_failed(self, spec: "spack.spec.Spec") -> bool:
         """Return True if the spec is marked as failed."""
-        # The failure was detected in this process.
-        if self.locker.has_lock(spec):
-            return True
+        return os.path.lexists(self._path(spec))
 
-        # The failure was detected by a concurrent process (e.g., an srun),
-        # which is expected to be holding a write lock if that is the case.
-        if self.lock_taken(spec):
-            return True
-
-        # Determine if the spec may have been marked as failed by a separate
-        # spack build process running concurrently.
-        return self.persistent_mark(spec)
-
-    def lock_taken(self, spec: "spack.spec.Spec") -> bool:
-        """Return True if another process has a failure lock on the spec."""
-        check = self.locker.raw_lock(spec)
-        return check.is_write_locked()
-
-    def persistent_mark(self, spec: "spack.spec.Spec") -> bool:
-        """Determine if the spec has a persistent failure marking."""
-        return self._path(spec).exists()
-
-    def _path(self, spec: "spack.spec.Spec") -> pathlib.Path:
+    def _path(self, spec: "spack.spec.Spec") -> str:
         """Return the path to the spec's failure file, which may not exist."""
         assert spec.concrete, "concrete spec required for failure path"
-        return self.dir / f"{spec.name}-{spec.dag_hash()}"
+        return os.path.join(self.dir, f"{spec.name}-{spec.dag_hash()}")
 
 
 SelectType = Callable[[InstallRecord], bool]

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1567,8 +1567,8 @@ class PackageInstaller:
         # Mapping of unique package ids to task
         self.build_tasks: Dict[str, Task] = {}
 
-        # Cache of package locks for failed packages, keyed on package's ids
-        self.failed: Dict[str, Optional[lk.Lock]] = {}
+        # Set of failed packages' ids
+        self.failed: Set[str] = set()
 
         # Cache the PID for distributed build messaging
         self.pid: int = os.getpid()
@@ -1768,14 +1768,8 @@ class PackageInstaller:
         Args:
             pkg_id (str): identifier for the failed package
         """
-        lock = self.failed.get(pkg_id, None)
-        if lock is not None:
-            err = "{0} exception when removing failure tracking for {1}: {2}"
-            try:
-                tty.verbose(f"Removing failure mark on {pkg_id}")
-                lock.release_write()
-            except Exception as exc:
-                tty.warn(err.format(exc.__class__.__name__, pkg_id, str(exc)))
+        if pkg_id in self.failed:
+            tty.verbose(f"Removing failure mark on {pkg_id}")
 
     def _cleanup_task(self, pkg: "spack.package_base.PackageBase") -> None:
         """
@@ -1917,7 +1911,7 @@ class PackageInstaller:
             # Clear any persistent failure markings _unless_ they are
             # associated with another process in this parallel build
             # of the spec.
-            spack.store.STORE.failure_tracker.clear(dep, force=False)
+            spack.store.STORE.failure_tracker.clear(dep)
 
         # Queue the build spec.
         build_pkg_id = package_id(spec.build_spec)
@@ -1964,12 +1958,12 @@ class PackageInstaller:
                 # Clear any persistent failure markings _unless_ they are
                 # associated with another process in this parallel build
                 # of the spec.
-                spack.store.STORE.failure_tracker.clear(dep, force=False)
+                spack.store.STORE.failure_tracker.clear(dep)
 
         install_package = request.install_args.get("install_package")
         if install_package and request.pkg_id not in self.build_tasks:
             # Be sure to clear any previous failure
-            spack.store.STORE.failure_tracker.clear(request.spec, force=True)
+            spack.store.STORE.failure_tracker.clear(request.spec)
 
             # If not installing dependencies, then determine their
             # installation status before proceeding
@@ -2169,9 +2163,8 @@ class PackageInstaller:
         err = "" if exc is None else f": {str(exc)}"
         tty.debug(f"Flagging {pkg_id} as failed{err}")
         if mark:
-            self.failed[pkg_id] = spack.store.STORE.failure_tracker.mark(task.pkg.spec)
-        else:
-            self.failed[pkg_id] = None
+            spack.store.STORE.failure_tracker.mark(task.pkg.spec)
+        self.failed.add(pkg_id)
         task.status = BuildStatus.FAILED
 
         for dep_id in task.dependents:

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -181,9 +181,7 @@ class Store:
         self.prefix_locker = spack.database.SpecLocker(
             spack.database.prefix_lock_path(root), default_timeout=lock_cfg.package_timeout
         )
-        self.failure_tracker = spack.database.FailureTracker(
-            self.root, default_timeout=lock_cfg.package_timeout
-        )
+        self.failure_tracker = spack.database.FailureTracker(self.root)
 
     def has_padding(self) -> bool:
         """Returns True if the store layout includes path padding."""

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -681,7 +681,7 @@ def test_build_warning_output(mock_fetch, install_mockery):
     assert "foo.c:89: warning: some weird warning!" in e.value.long_message
 
 
-def test_cache_only_fails(mock_fetch, install_mockery):
+def test_cache_only_fails(mock_fetch, install_mockery, temporary_store: spack.store.Store):
     # libelf from cache fails to install, which automatically removes the
     # the libdwarf build task
     out = install("--cache-only", "libdwarf", fail_on_error=False)
@@ -691,9 +691,7 @@ def test_cache_only_fails(mock_fetch, install_mockery):
     assert "was not installed" in out
 
     # Check that failure prefix locks are still cached
-    failed_packages = [
-        pkg_name for dag_hash, pkg_name in spack.store.STORE.failure_tracker.locker.locks.keys()
-    ]
+    failed_packages = [x.split("-")[0] for x in os.listdir(temporary_store.failure_tracker.dir)]
     assert "libelf" in failed_packages
     assert "libdwarf" in failed_packages
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -31,7 +31,6 @@ import spack.vendor.jsonschema
 import spack.concretize
 import spack.database
 import spack.deptypes as dt
-import spack.llnl.util.filesystem as fs
 import spack.llnl.util.lock as lk
 import spack.package_base
 import spack.paths
@@ -970,80 +969,23 @@ def test_failed_spec_path_error(mutable_database):
 
 
 @pytest.mark.db
-def test_clear_failure_keep(mutable_database, monkeypatch, capfd):
-    """Add test coverage for clear_failure operation when to be retained."""
-
-    def _is(self, spec):
-        return True
-
-    # Pretend the spec has been failure locked
-    monkeypatch.setattr(spack.database.FailureTracker, "lock_taken", _is)
-
-    s = spack.concretize.concretize_one("pkg-a")
-    spack.store.STORE.failure_tracker.clear(s)
-    out = capfd.readouterr()[0]
-    assert "Retaining failure marking" in out
-
-
-@pytest.mark.db
-def test_clear_failure_forced(mutable_database, monkeypatch, capfd):
-    """Add test coverage for clear_failure operation when force."""
-
-    def _is(self, spec):
-        return True
-
-    # Pretend the spec has been failure locked
-    monkeypatch.setattr(spack.database.FailureTracker, "lock_taken", _is)
-    # Ensure raise OSError when try to remove the non-existent marking
-    monkeypatch.setattr(spack.database.FailureTracker, "persistent_mark", _is)
-
-    s = spack.concretize.concretize_one("pkg-a")
-    spack.store.STORE.failure_tracker.clear(s, force=True)
-    out = capfd.readouterr()[1]
-    assert "Removing failure marking despite lock" in out
-    assert "Unable to remove failure marking" in out
-
-
-@pytest.mark.db
-def test_mark_failed(mutable_database, monkeypatch, tmp_path: pathlib.Path, capfd):
-    """Add coverage to mark_failed."""
-
-    def _raise_exc(lock):
-        raise lk.LockTimeoutError(lk.LockType.WRITE, "/mock-lock", 1.234, 10)
-
-    with fs.working_dir(str(tmp_path)):
-        s = spack.concretize.concretize_one("pkg-a")
-
-        # Ensure attempt to acquire write lock on the mark raises the exception
-        monkeypatch.setattr(lk.Lock, "acquire_write", _raise_exc)
-
-        spack.store.STORE.failure_tracker.mark(s)
-        out = str(capfd.readouterr()[1])
-        assert "Unable to mark pkg-a as failed" in out
-
-    spack.store.STORE.failure_tracker.clear_all()
-
-
-@pytest.mark.db
-def test_prefix_failed(mutable_database, monkeypatch):
-    """Add coverage to failed operation."""
-
+def test_mark_and_clear_failed(mutable_database):
+    """Test the mark/has_failed/clear cycle."""
     s = spack.concretize.concretize_one("pkg-a")
 
-    # Confirm the spec is not already marked as failed
     assert not spack.store.STORE.failure_tracker.has_failed(s)
 
-    # Check that a failure entry is sufficient
     spack.store.STORE.failure_tracker.mark(s)
     assert spack.store.STORE.failure_tracker.has_failed(s)
 
-    # Remove the entry and check again
     spack.store.STORE.failure_tracker.clear(s)
     assert not spack.store.STORE.failure_tracker.has_failed(s)
 
-    # Now pretend that the prefix failure is locked
-    monkeypatch.setattr(spack.database.FailureTracker, "lock_taken", lambda self, spec: True)
+    spack.store.STORE.failure_tracker.mark(s)
     assert spack.store.STORE.failure_tracker.has_failed(s)
+
+    spack.store.STORE.failure_tracker.clear_all()
+    assert not spack.store.STORE.failure_tracker.has_failed(s)
 
 
 def test_prefix_write_lock_error(mutable_database, monkeypatch):

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -141,7 +141,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
     s.package.remove_prefix = rm_prefix_checker.remove_prefix
 
     # must clear failure markings for the package before re-installing it
-    spack.store.STORE.failure_tracker.clear(s, True)
+    spack.store.STORE.failure_tracker.clear(s)
 
     s.package.succeed = True
     spack.builder._BUILDERS.clear()  # the builder is cached with a copy of the pkg's __dict__.
@@ -297,7 +297,7 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch, w
     assert os.path.exists(s.package.prefix)
 
     # must clear failure markings for the package before re-installing it
-    spack.store.STORE.failure_tracker.clear(s, True)
+    spack.store.STORE.failure_tracker.clear(s)
 
     s.package.succeed = True
     spack.builder._BUILDERS.clear()  # the builder is cached with a copy of the pkg's __dict__.

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -485,41 +485,36 @@ def test_dump_packages_deps_errs(install_mockery, tmp_path: pathlib.Path, monkey
 
 def test_clear_failures_success(tmp_path: pathlib.Path):
     """Test the clear_failures happy path."""
-    failures = spack.database.FailureTracker(str(tmp_path), default_timeout=0.1)
+    failures = spack.database.FailureTracker(str(tmp_path))
 
     spec = spack.spec.Spec("pkg-a")
     spec._mark_concrete()
 
-    # Set up a test prefix failure lock
+    # Set up a test prefix failure mark
     failures.mark(spec)
     assert failures.has_failed(spec)
 
     # Now clear failure tracking
     failures.clear_all()
 
-    # Ensure there are no cached failure locks or failure marks
-    assert len(failures.locker.locks) == 0
+    # Ensure there are no failure marks
     assert len(os.listdir(failures.dir)) == 0
 
-    # Ensure the core directory and failure lock file still exist
+    # Ensure the core directory still exists
     assert os.path.isdir(failures.dir)
-
-    # Locks on windows are a no-op
-    if sys.platform != "win32":
-        assert os.path.isfile(failures.locker.lock_path)
 
 
 @pytest.mark.not_on_windows("chmod does not prevent removal on Win")
 @pytest.mark.skipif(fs.getuid() == 0, reason="user is root")
 def test_clear_failures_errs(tmp_path: pathlib.Path, capfd):
     """Test the clear_failures exception paths."""
-    failures = spack.database.FailureTracker(str(tmp_path), default_timeout=0.1)
+    failures = spack.database.FailureTracker(str(tmp_path))
     spec = spack.spec.Spec("pkg-a")
     spec._mark_concrete()
     failures.mark(spec)
 
     # Make the file marker not writeable, so that clearing_failures fails
-    failures.dir.chmod(0o000)
+    os.chmod(failures.dir, 0o000)
 
     # Clear failure tracking
     failures.clear_all()
@@ -527,7 +522,7 @@ def test_clear_failures_errs(tmp_path: pathlib.Path, capfd):
     # Ensure expected warning generated
     out = str(capfd.readouterr()[1])
     assert "Unable to remove failure" in out
-    failures.dir.chmod(0o750)
+    os.chmod(failures.dir, 0o750)
 
 
 def test_combine_phase_logs(tmp_path: pathlib.Path):
@@ -818,7 +813,7 @@ def test_push_task_skip_processed(install_mockery, installed):
     if installed:
         installer.installed.add(task.pkg_id)
     else:
-        installer.failed[task.pkg_id] = None
+        installer.failed.add(task.pkg_id)
 
     installer._push_task(task)
 
@@ -907,27 +902,6 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     assert expected_msg in out
 
 
-def test_cleanup_failed_err(install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd):
-    """Test _cleanup_failed exception path."""
-    msg = "Fake release_write exception"
-
-    def _raise_except(lock):
-        raise RuntimeError(msg)
-
-    installer = create_installer(["trivial-install-test-package"], {})
-
-    monkeypatch.setattr(lk.Lock, "release_write", _raise_except)
-    pkg_id = "test"
-    with fs.working_dir(str(tmp_path)):
-        lock = lk.Lock("./test", default_timeout=1e-9, desc="test")
-        installer.failed[pkg_id] = lock
-
-        installer._cleanup_failed(pkg_id)
-        out = str(capfd.readouterr()[1])
-        assert "exception when removing failure tracking" in out
-        assert msg in out
-
-
 def test_update_failed_no_dependent_task(install_mockery):
     """Test _update_failed with missing dependent build tasks."""
     installer = create_installer(["dependent-install"], {})
@@ -936,7 +910,7 @@ def test_update_failed_no_dependent_task(install_mockery):
     for dep in spec.traverse(root=False):
         task = create_build_task(dep.package)
         installer._update_failed(task, mark=False)
-        assert installer.failed[task.pkg_id] is None
+        assert task.pkg_id in installer.failed
 
 
 def test_install_uninstalled_deps(install_mockery, monkeypatch, capfd):


### PR DESCRIPTION
Remove byte-range locks from FailureTracker, keeping only persistent marker
files.

I've been going back and forth a few times with this PR. What looks awkward to
me in the current implementation of FailureTracker:

* locks are dropped on process exit, so they alone don't prevent re-install attempts; there's no barrier that keeps a lock alive.
* failure marker files are likely not seen on all distributed filesystems
* the implementation cannot be used in the old installer because there are blocking lock attempts

I believe the current changes should in principle work fine on Lustre etc. Before checking
the existence of the failure marker file, you should hold an exclusive lock on the prefix write
lock, and only when you hold an exclusive lock you are allowed to write a failure marker file.

On NFS though, the marker file may not be visible to another node if it cached a negative
stat result in the past. I have no means to verify this. At the same time, I don't think it's
a shame if on NFS a failing build is retried by another process.