### PR TITLE
solver: rename `NodeArgument` to `NodeId`

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -71,7 +71,7 @@ from spack.util.compression import GZipFileType
 from .core import (
     AspFunction,
     AspVar,
-    NodeArgument,
+    NodeId,
     SourceContext,
     clingo,
     extract_args,
@@ -472,7 +472,7 @@ class Result:
         def _dict_to_node_argument(dict):
             id = dict["id"]
             pkg = dict["pkg"]
-            return NodeArgument(id=id, pkg=pkg)
+            return NodeId(id=id, pkg=pkg)
 
         def _str_to_spec(spec_str):
             return spack.spec.Spec(spec_str)
@@ -3434,7 +3434,7 @@ def possible_compilers(*, configuration) -> Tuple[Set["spack.spec.Spec"], Set["s
     return result, rejected
 
 
-FunctionTupleT = Tuple[str, Tuple[Union[str, NodeArgument], ...]]
+FunctionTupleT = Tuple[str, Tuple[Union[str, NodeId], ...]]
 
 
 class SpecBuilder:
@@ -3461,23 +3461,23 @@ class SpecBuilder:
     )
 
     @staticmethod
-    def make_node(*, pkg: str) -> NodeArgument:
+    def make_node(*, pkg: str) -> NodeId:
         """Given a package name, returns the string representation of the "min_dupe_id" node in
         the ASP encoding.
 
         Args:
             pkg: name of a package
         """
-        return NodeArgument(id="0", pkg=pkg)
+        return NodeId(id="0", pkg=pkg)
 
     def __init__(self, specs, hash_lookup=None):
-        self._specs: Dict[NodeArgument, spack.spec.Spec] = {}
+        self._specs: Dict[NodeId, spack.spec.Spec] = {}
 
         # Matches parent nodes to splice node
         self._splices: Dict[spack.spec.Spec, List[spack.solver.splicing.Splice]] = {}
         self._result = None
         self._command_line_specs = specs
-        self._flag_sources: Dict[Tuple[NodeArgument, str], Set[str]] = collections.defaultdict(
+        self._flag_sources: Dict[Tuple[NodeId, str], Set[str]] = collections.defaultdict(
             lambda: set()
         )
 
@@ -3656,15 +3656,11 @@ class SpecBuilder:
 
                 spec.compiler_flags.update({flag_type: ordered_flags})
 
-    def deprecated(self, node: NodeArgument, version: str) -> None:
+    def deprecated(self, node: NodeId, version: str) -> None:
         tty.warn(f'using "{node.pkg}@{version}" which is a deprecated version')
 
     def splice_at_hash(
-        self,
-        parent_node: NodeArgument,
-        splice_node: NodeArgument,
-        child_name: str,
-        child_hash: str,
+        self, parent_node: NodeId, splice_node: NodeId, child_name: str, child_hash: str
     ):
         parent_spec = self._specs[parent_node]
         splice_spec = self._specs[splice_node]
@@ -3712,7 +3708,7 @@ class SpecBuilder:
             # predicates on virtual packages.
             if name != "error":
                 node = args[0]
-                assert isinstance(node, NodeArgument), (
+                assert isinstance(node, NodeId), (
                     f"internal solver error: expected a node, but got a {type(args[0])}. "
                     "Please report a bug at https://github.com/spack/spack/issues"
                 )
@@ -3820,7 +3816,7 @@ class SpecBuilder:
                     if not replacement.concrete:
                         replacement.replace_hash()
                     current_spec = current_spec.splice(replacement, transitive)
-            new_key = NodeArgument(id=key.id, pkg=current_spec.name)
+            new_key = NodeId(id=key.id, pkg=current_spec.name)
             specs[new_key] = current_spec
 
         return specs

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -588,11 +588,11 @@ imposed_packages(ID, A1) :- imposed_constraint(ID, _, A1, _, _).
 imposed_packages(ID, A1) :- imposed_constraint(ID, _, A1, _, _, _).
 imposed_packages(ID, A1) :- imposed_constraint(ID, "depends_on", _, A1, _).
 
-imposed_nodes(node(NodeID, Package), node(X, A1))
-  :- condition_set(node(NodeID, Package), node(X, A1)),
+imposed_nodes(node(ID, Package), node(X, A1))
+  :- condition_set(node(ID, Package), node(X, A1)),
      % We don't want to add build requirements to imposed nodes, to avoid
      % unsat problems when we deal with self-dependencies: gcc@14 %gcc@10
-     not self_build_requirement(node(NodeID, Package), node(X, A1)).
+     not self_build_requirement(node(ID, Package), node(X, A1)).
 
 self_build_requirement(node(X, Package), node(Y, Package)) :- build_requirement(node(X, Package), node(Y, Package)).
 
@@ -1336,14 +1336,14 @@ error(50000, Message) :-
 
 % Variant definitions come from package facts in two ways:
 % 1. unconditional variants are always defined on all nodes for a given package
-variant_definition(node(NodeID, Package), Name, VariantID) :-
+variant_definition(node(ID, Package), Name, VariantID) :-
   pkg_fact(Package, variant_definition(Name, VariantID)),
-  attr("node", node(NodeID, Package)).
+  attr("node", node(ID, Package)).
 
 % 2. conditional variants are only defined if the conditions hold for the node
-variant_definition(node(NodeID, Package), Name, VariantID) :-
+variant_definition(node(ID, Package), Name, VariantID) :-
   pkg_fact(Package, variant_condition(Name, VariantID, ConditionID)),
-  condition_holds(ConditionID, node(NodeID, Package)).
+  condition_holds(ConditionID, node(ID, Package)).
 
 % If there are any definitions for a variant on a node, the variant is "defined".
 variant_defined(PackageNode, Name) :- variant_definition(PackageNode, Name, _).
@@ -1366,19 +1366,19 @@ node_has_variant(PackageNode, Name, SelectedVariantID) :-
 % packages.yaml and CLI are associated with just the variant name.
 % Also, settings specified on the CLI apply to all duplicates, but always have
 % `min_dupe_id` as their node id.
-variant_default_value(node(NodeID, Package), VariantName, Value) :-
-  node_has_variant(node(NodeID, Package), VariantName, VariantID),
+variant_default_value(node(ID, Package), VariantName, Value) :-
+  node_has_variant(node(ID, Package), VariantName, VariantID),
   pkg_fact(Package, variant_default_value_from_package_py(VariantID, Value)),
   not variant_default_value_from_packages_yaml(Package, VariantName, _),
   not attr("variant_default_value_from_cli", node(min_dupe_id, Package), VariantName, _).
 
-variant_default_value(node(NodeID, Package), VariantName, Value) :-
-  node_has_variant(node(NodeID, Package), VariantName, _),
+variant_default_value(node(ID, Package), VariantName, Value) :-
+  node_has_variant(node(ID, Package), VariantName, _),
   variant_default_value_from_packages_yaml(Package, VariantName, Value),
   not attr("variant_default_value_from_cli", node(min_dupe_id, Package), VariantName, _).
 
-variant_default_value(node(NodeID, Package), VariantName, Value) :-
-    node_has_variant(node(NodeID, Package), VariantName, _),
+variant_default_value(node(ID, Package), VariantName, Value) :-
+    node_has_variant(node(ID, Package), VariantName, _),
     attr("variant_default_value_from_cli", node(min_dupe_id, Package), VariantName, Value).
 
 % Penalty from the variant definition
@@ -1401,21 +1401,21 @@ variant_penalty(node(NodeID, Package), Variant, Value, Penalty) :-
     not propagate(node(NodeID, Package), variant_value(Variant, Value, _)).
 
 % -- Associate the definition's possible values with the node
-variant_possible_value(node(NodeID, Package), VariantName, Value) :-
-  node_has_variant(node(NodeID, Package), VariantName, VariantID),
+variant_possible_value(node(ID, Package), VariantName, Value) :-
+  node_has_variant(node(ID, Package), VariantName, VariantID),
   pkg_fact(Package, variant_possible_value(VariantID, Value)).
 
-variant_possible_value(node(NodeID, Package), VariantName, Value) :-
-  node_has_variant(node(NodeID, Package), VariantName, VariantID),
+variant_possible_value(node(ID, Package), VariantName, Value) :-
+  node_has_variant(node(ID, Package), VariantName, VariantID),
   pkg_fact(Package, variant_penalty(VariantID, Value, _)).
 
-variant_value_from_disjoint_sets(node(NodeID, Package), VariantName, Value1, Set1) :-
-  node_has_variant(node(NodeID, Package), VariantName, VariantID),
+variant_value_from_disjoint_sets(node(ID, Package), VariantName, Value1, Set1) :-
+  node_has_variant(node(ID, Package), VariantName, VariantID),
   pkg_fact(Package, variant_value_from_disjoint_sets(VariantID, Value1, Set1)).
 
 % -- Associate definition's arity with the node
-variant_single_value(node(NodeID, Package), VariantName) :-
-  node_has_variant(node(NodeID, Package), VariantName, VariantID),
+variant_single_value(node(ID, Package), VariantName) :-
+  node_has_variant(node(ID, Package), VariantName, VariantID),
   variant_type(VariantID, VariantType),
   VariantType != "multi".
 

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -213,7 +213,7 @@ def parse_term(*args, **kwargs):
         return clingo().parse_term(*args, **kwargs)
 
 
-class NodeArgument(NamedTuple):
+class NodeId(NamedTuple):
     """Represents a node in the DAG"""
 
     id: str
@@ -230,10 +230,10 @@ class NodeFlag(NamedTuple):
 def intermediate_repr(sym):
     """Returns an intermediate representation of clingo models for Spack's spec builder.
 
-    Currently, transforms symbols from clingo models either to strings or to NodeArgument objects.
+    Currently, transforms symbols from clingo models either to strings or to NodeId objects.
 
     Returns:
-        This will turn a ``clingo.Symbol`` into a string or NodeArgument, or a sequence of
+        This will turn a ``clingo.Symbol`` into a string or NodeId, or a sequence of
         ``clingo.Symbol`` objects into a tuple of those objects.
     """
     # TODO: simplify this when we no longer have to support older clingo versions.
@@ -242,7 +242,7 @@ def intermediate_repr(sym):
 
     try:
         if sym.name == "node":
-            return NodeArgument(
+            return NodeId(
                 id=intermediate_repr(sym.arguments[0]), pkg=intermediate_repr(sym.arguments[1])
             )
         elif sym.name == "node_flag":


### PR DESCRIPTION
`NodeArgument` is used as an argument when reconstructing specs, but I think it's clearer to call it a `NodeId`, since its real function is to disambiguate "dupes", which is what we call different configurations of the same package.

- [x] Rename `NodeArgument` to `NodeId` in `core.py` and `asp.py`
- [x] Call `NodeID` `ID` in `concretize.lp` for consistency with `asp.py`
