### PR TITLE
`spack_json`: add `pretty` option to `to_json()`

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2550,8 +2550,8 @@ class Spec:
     def to_yaml(self, stream=None, hash=ht.dag_hash):
         return syaml.dump(self.to_dict(hash), stream=stream, default_flow_style=False)
 
-    def to_json(self, stream=None, hash=ht.dag_hash):
-        return sjson.dump(self.to_dict(hash), stream)
+    def to_json(self, stream=None, *, hash=ht.dag_hash, pretty=False):
+        return sjson.dump(self.to_dict(hash), stream=stream, pretty=pretty)
 
     @staticmethod
     def from_specfile(path):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4465,7 +4465,10 @@ def test_concretization_cache_roundtrip(
     # ensure subsequent concretizations of the same spec produce the same spec
     # object
     for _ in range(5):
-        assert h == spack.concretize.concretize_one("hdf5")
+        hdf5 = spack.concretize.concretize_one("hdf5")
+
+        assert h.to_json(pretty=True) == hdf5.to_json(pretty=True)
+        assert h == hdf5
 
 
 def test_concretization_cache_roundtrip_result(use_concretization_cache):

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -11,6 +11,7 @@ import spack.error
 __all__ = ["load", "dump", "SpackJSONError"]
 
 _json_dump_args = {"indent": None, "separators": (",", ":")}
+_pretty_dump_args = {"indent": "  ", "separators": (", ", ": ")}
 
 
 def load(stream: Any) -> Dict:
@@ -20,11 +21,12 @@ def load(stream: Any) -> Dict:
     return json.load(stream)
 
 
-def dump(data: Dict, stream: Optional[Any] = None) -> Optional[str]:
+def dump(data: Dict, stream: Optional[Any] = None, pretty: bool = False) -> Optional[str]:
     """Dump JSON with a reasonable amount of indentation and separation."""
+    dump_args = _pretty_dump_args if pretty else _json_dump_args
     if stream is None:
-        return json.dumps(data, **_json_dump_args)  # type: ignore[arg-type]
-    json.dump(data, stream, **_json_dump_args)  # type: ignore[arg-type]
+        return json.dumps(data, **dump_args)  # type: ignore[arg-type]
+    json.dump(data, stream, **dump_args)  # type: ignore[arg-type]
     return None
 
 


### PR DESCRIPTION
Comparing JSON specs in tests is not useful unless `pytest` can show us a diff.

- [x] Introduce a `pretty=True` option to Spack JSON dumps that prints with newlines and indentation.
- [x] Modify tests to show a detailed diff using the new json output.
