### PR TITLE
new_installer: mark explicit also if already installed implicit

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -107,31 +107,35 @@ OVERWRITE_BACKUP_SUFFIX = ".old"
 OVERWRITE_GARBAGE_SUFFIX = ".garbage"
 
 
-class MarkExplicitAction:
+class DatabaseAction:
+    """Base class for objects that need to be persisted to the database."""
+
+    __slots__ = ("spec", "prefix_lock")
+
+    spec: "spack.spec.Spec"
+    prefix_lock: Optional[spack.util.lock.Lock]
+
+    def save_to_db(self, db: spack.database.Database) -> None: ...
+
+
+class MarkExplicitAction(DatabaseAction):
     """Action to mark an already installed spec as explicitly installed. Similar to ChildInfo, but
     used when no build process was needed."""
 
-    __slots__ = ("spec", "explicit", "prefix_lock")
+    __slots__ = ()
 
-    def __init__(self, spec: "spack.spec.Spec", explicit: bool) -> None:
+    def __init__(self, spec: "spack.spec.Spec") -> None:
         self.spec = spec
-        self.explicit = explicit
         self.prefix_lock = None
 
+    def save_to_db(self, db: spack.database.Database) -> None:
+        db._mark(self.spec, "explicit", True)
 
-class ChildInfo:
+
+class ChildInfo(DatabaseAction):
     """Information about a child process."""
 
-    __slots__ = (
-        "proc",
-        "spec",
-        "output_r_conn",
-        "state_r_conn",
-        "control_w_conn",
-        "explicit",
-        "prefix_lock",
-        "log_path",
-    )
+    __slots__ = ("proc", "output_r_conn", "state_r_conn", "control_w_conn", "explicit", "log_path")
 
     def __init__(
         self,
@@ -151,6 +155,9 @@ class ChildInfo:
         self.log_path = log_path
         self.explicit = explicit
         self.prefix_lock: Optional[spack.util.lock.Lock] = None
+
+    def save_to_db(self, db: spack.database.Database) -> None:
+        return db._add(self.spec, explicit=self.explicit)
 
     def cleanup(self, selector: selectors.BaseSelector) -> None:
         """Unregister and close file descriptors, and join the child process."""
@@ -1653,7 +1660,7 @@ class ScheduleResult(NamedTuple):
     #: is held and the caller must add it to retained_read_locks.
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]]
     #: Actions to mark already installed specs explicit in the DB.
-    db_actions: List[MarkExplicitAction]
+    to_mark_explicit: List[MarkExplicitAction]
 
 
 def schedule_builds(
@@ -1700,13 +1707,13 @@ def schedule_builds(
     """
     to_start: List[Tuple[str, spack.util.lock.Lock]] = []
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]] = []
-    db_actions: List[MarkExplicitAction] = []
+    to_mark_explicit: List[MarkExplicitAction] = []
     blocked = True
 
     # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory snapshot
     # stays consistent while we acquire per-spec prefix locks.
     if not db.lock.try_acquire_read():
-        return ScheduleResult(blocked, to_start, newly_installed, db_actions)
+        return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit)
 
     try:
         db._read()  # refresh in-memory snapshot under the read lock
@@ -1744,7 +1751,7 @@ def schedule_builds(
                 newly_installed.append((dag_hash, spec, lock))
                 # It's already installed, but needs to be marked as explicitly installed in the DB.
                 if dag_hash in explicit and not record.explicit:
-                    db_actions.append(MarkExplicitAction(spec, explicit=True))
+                    to_mark_explicit.append(MarkExplicitAction(spec))
                 build_graph.enqueue_parents(dag_hash, pending)
                 continue
 
@@ -1774,7 +1781,7 @@ def schedule_builds(
     finally:
         db.lock.release_read()
 
-    return ScheduleResult(blocked, to_start, newly_installed, db_actions)
+    return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit)
 
 
 def _node_to_roots(roots: List[spack.spec.Spec]) -> Dict[str, FrozenSet[str]]:
@@ -2023,7 +2030,7 @@ class PackageInstaller:
             selector.register(sigwinch_r, selectors.EVENT_READ, "sigwinch")
 
         # Finished builds that have not yet been written to the database.
-        finished_builds: List[Union[ChildInfo, MarkExplicitAction]] = []
+        database_actions: List[DatabaseAction] = []
         # Prefix read locks retained after DB flush (downgraded from write locks in _save_to_db).
         retained_read_locks: List[spack.util.lock.Lock] = []
         next_database_write = 0.0
@@ -2033,10 +2040,10 @@ class PackageInstaller:
         try:
             # Try to schedule builds immediately. The first job does not require a token.
             blocked = self._schedule_builds(
-                selector, jobserver, retained_read_locks, finished_builds
+                selector, jobserver, retained_read_locks, database_actions
             )
 
-            while self.pending_builds or self.running_builds or finished_builds:
+            while self.pending_builds or self.running_builds or database_actions:
                 # Monitor the jobserver when we have pending builds, capacity, and at least one
                 # spec is not locked by another process. Also listen if the target parallelism is
                 # reduced.
@@ -2092,7 +2099,7 @@ class PackageInstaller:
                     self.report_data.finish_record(build.spec, exitcode)
                     if exitcode == 0:
                         # Add successful builds for database insertion (after a short delay)
-                        finished_builds.append(build)
+                        database_actions.append(build)
                         self.build_graph.enqueue_parents(
                             build.spec.dag_hash(), self.pending_builds
                         )
@@ -2141,19 +2148,19 @@ class PackageInstaller:
                 # guaranteed; it fails if another process holds the lock. We'll try again next
                 # iteration of the event loop in that case.
                 if (
-                    finished_builds
+                    database_actions
                     and (
                         current_time >= next_database_write
                         or not (self.pending_builds or self.running_builds)
                     )
-                    and self._save_to_db(finished_builds, retained_read_locks)
+                    and self._save_to_db(database_actions, retained_read_locks)
                 ):
-                    finished_builds.clear()
+                    database_actions.clear()
 
                 # Try to schedule more builds, acquiring per-spec locks and jobserver tokens.
                 if self.capacity and self.pending_builds:
                     blocked = self._schedule_builds(
-                        selector, jobserver, retained_read_locks, finished_builds
+                        selector, jobserver, retained_read_locks, database_actions
                     )
 
                 # Finally update the UI
@@ -2164,8 +2171,8 @@ class PackageInstaller:
             db_exc = None
             try:
                 with self.db.write_transaction():
-                    for b in finished_builds:
-                        self.db._add(b.spec, explicit=b.explicit)
+                    for action in database_actions:
+                        action.save_to_db(self.db)
             except Exception as e:
                 db_exc = e
 
@@ -2201,11 +2208,11 @@ class PackageInstaller:
                     lock.release_read()
                 except Exception:
                     pass
-            for b in finished_builds:
+            for action in database_actions:
                 try:
-                    if b.prefix_lock is not None:
-                        b.prefix_lock.release_write()
-                        b.prefix_lock = None
+                    if action.prefix_lock is not None:
+                        action.prefix_lock.release_write()
+                        action.prefix_lock = None
                 except Exception:
                     pass
 
@@ -2254,30 +2261,30 @@ class PackageInstaller:
 
     def _save_to_db(
         self,
-        finished_builds: List[Union[ChildInfo, MarkExplicitAction]],
+        database_actions: List[DatabaseAction],
         retained_read_locks: List[spack.util.lock.Lock],
     ) -> bool:
         if not self.db.lock.try_acquire_write():
             return False
         try:
             self.db._read()
-            for build in finished_builds:
-                self.db._add(build.spec, explicit=build.explicit)
+            for action in database_actions:
+                action.save_to_db(self.db)
         finally:
             self.db.lock.release_write(self.db._write)
 
         # DB has been written and flushed; downgrade per-spec prefix write locks to read locks so
         # other processes can see the specs are installed, while preventing concurrent uninstalls.
-        for build in finished_builds:
-            if build.prefix_lock is not None:
+        for action in database_actions:
+            if action.prefix_lock is not None:
                 try:
-                    build.prefix_lock.downgrade_write_to_read()
-                    retained_read_locks.append(build.prefix_lock)
+                    action.prefix_lock.downgrade_write_to_read()
+                    retained_read_locks.append(action.prefix_lock)
                 except Exception:
-                    build.prefix_lock.release_write()
+                    action.prefix_lock.release_write()
                     raise
                 finally:
-                    build.prefix_lock = None
+                    action.prefix_lock = None
 
         return True
 
@@ -2286,7 +2293,7 @@ class PackageInstaller:
         selector: selectors.BaseSelector,
         jobserver: JobServer,
         retained_read_locks: List[spack.util.lock.Lock],
-        finished_builds: List[Union[ChildInfo, MarkExplicitAction]],
+        database_actions: List[DatabaseAction],
     ) -> bool:
         """Try to schedule as many pending builds as possible.
 
@@ -2313,7 +2320,7 @@ class PackageInstaller:
             explicit=self.explicit,
         )
         blocked = result.blocked
-        finished_builds.extend(result.db_actions)
+        database_actions.extend(result.to_mark_explicit)
         # Specs installed by another process.
         for dag_hash, spec, lock in result.newly_installed:
             retained_read_locks.append(lock)

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -107,6 +107,18 @@ OVERWRITE_BACKUP_SUFFIX = ".old"
 OVERWRITE_GARBAGE_SUFFIX = ".garbage"
 
 
+class MarkExplicitAction:
+    """Action to mark an already installed spec as explicitly installed. Similar to ChildInfo, but
+    used when no build process was needed."""
+
+    __slots__ = ("spec", "explicit", "prefix_lock")
+
+    def __init__(self, spec: "spack.spec.Spec", explicit: bool) -> None:
+        self.spec = spec
+        self.explicit = explicit
+        self.prefix_lock = None
+
+
 class ChildInfo:
     """Information about a child process."""
 
@@ -1513,6 +1525,7 @@ class BuildGraph:
         database: spack.database.Database,
         overwrite_set: Optional[Set[str]] = None,
         tests: Union[bool, List[str], Set[str]] = False,
+        explicit_set: Optional[Set[str]] = None,
     ):
         """Construct a build graph from the given specs. This includes only packages that need to
         be installed. Installed packages are pruned from the graph, and build dependencies are only
@@ -1522,6 +1535,7 @@ class BuildGraph:
         self.parent_to_child: Dict[str, Set[str]] = {}
         self.child_to_parent: Dict[str, Set[str]] = {}
         overwrite_set = overwrite_set or set()
+        explicit_set = explicit_set or set()
         self.pruned: Set[str] = set()
         stack: List[Tuple[spack.spec.Spec, InstallPolicy]] = [
             (s, root_policy) for s in self.nodes.values()
@@ -1542,10 +1556,14 @@ class BuildGraph:
                 key = spec.dag_hash()
                 _, record = database.query_by_spec_hash(key)
 
-                # Conditionally include build dependencies
+                # Conditionally include build dependencies. Don't prune installed specs
+                # that need to be marked explicit so they flow through the DB write path.
                 if record and record.installed and key not in overwrite_set:
-                    self.pruned.add(key)
+                    # Installed spec only needs link/run deps traversed.
                     dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
+                    # If it needs to be marked explicit, keep it in the graph (don't prune).
+                    if not (key in explicit_set and not record.explicit):
+                        self.pruned.add(key)
                 elif install_policy == "cache_only" and not include_build_deps:
                     dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
                 else:
@@ -1634,6 +1652,8 @@ class ScheduleResult(NamedTuple):
     #: ``(dag_hash, spec, lock)`` triples found already installed by another process; the read lock
     #: is held and the caller must add it to retained_read_locks.
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]]
+    #: Actions to mark already installed specs explicit in the DB.
+    db_actions: List[MarkExplicitAction]
 
 
 def schedule_builds(
@@ -1646,6 +1666,7 @@ def schedule_builds(
     capacity: int,
     needs_jobserver_token: bool,
     jobserver: JobServer,
+    explicit: Set[str],
 ) -> ScheduleResult:
     """Try to schedule as many pending builds as possible.
 
@@ -1671,6 +1692,7 @@ def schedule_builds(
         capacity: Maximum number of new builds to add to to_start in this call.
         needs_jobserver_token: True if a jobserver token is required for the first new build.
         jobserver: Jobserver for acquiring tokens.
+        explicit: Set of dag hashes to mark explicit in the DB if found already installed.
 
     Returns:
         A :class:`ScheduleResult` with ``blocked``, ``to_start``, and ``newly_installed``
@@ -1678,12 +1700,13 @@ def schedule_builds(
     """
     to_start: List[Tuple[str, spack.util.lock.Lock]] = []
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]] = []
+    db_actions: List[MarkExplicitAction] = []
     blocked = True
 
     # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory snapshot
     # stays consistent while we acquire per-spec prefix locks.
     if not db.lock.try_acquire_read():
-        return ScheduleResult(blocked, to_start, newly_installed)
+        return ScheduleResult(blocked, to_start, newly_installed, db_actions)
 
     try:
         db._read()  # refresh in-memory snapshot under the read lock
@@ -1719,6 +1742,9 @@ def schedule_builds(
                 # keep the read lock (either downgraded or already a read lock)
                 del pending[idx]
                 newly_installed.append((dag_hash, spec, lock))
+                # It's already installed, but needs to be marked as explicitly installed in the DB.
+                if dag_hash in explicit and not record.explicit:
+                    db_actions.append(MarkExplicitAction(spec, explicit=True))
                 build_graph.enqueue_parents(dag_hash, pending)
                 continue
 
@@ -1748,7 +1774,7 @@ def schedule_builds(
     finally:
         db.lock.release_read()
 
-    return ScheduleResult(blocked, to_start, newly_installed)
+    return ScheduleResult(blocked, to_start, newly_installed, db_actions)
 
 
 def _node_to_roots(roots: List[spack.spec.Spec]) -> Dict[str, FrozenSet[str]]:
@@ -1845,6 +1871,8 @@ class ReportData:
 
 class PackageInstaller:
 
+    explicit: Set[str]
+
     def __init__(
         self,
         packages: List["spack.package_base.PackageBase"],
@@ -1898,6 +1926,13 @@ class PackageInstaller:
         # Buffer for incoming, partially received state data from child processes
         self.state_buffers: Dict[int, str] = {}
 
+        if explicit is True:
+            self.explicit = {spec.dag_hash() for spec in specs}
+        elif explicit is False:
+            self.explicit = set()
+        else:
+            self.explicit = explicit
+
         # Build the dependency graph
         self.build_graph = BuildGraph(
             specs,
@@ -1909,6 +1944,7 @@ class PackageInstaller:
             self.db,
             self.overwrite,
             tests,
+            self.explicit,
         )
 
         #: check what specs we could fetch from binaries (checks against cache, not remotely)
@@ -1928,13 +1964,6 @@ class PackageInstaller:
         self.pending_builds = [
             parent for parent, children in self.build_graph.parent_to_child.items() if not children
         ]
-
-        if explicit is True:
-            self.explicit = {spec.dag_hash() for spec in specs}
-        elif explicit is False:
-            self.explicit = set()
-        else:
-            self.explicit = explicit
 
         self.verbose = verbose
         self.running_builds: Dict[int, ChildInfo] = {}
@@ -1994,7 +2023,7 @@ class PackageInstaller:
             selector.register(sigwinch_r, selectors.EVENT_READ, "sigwinch")
 
         # Finished builds that have not yet been written to the database.
-        finished_builds: List[ChildInfo] = []
+        finished_builds: List[Union[ChildInfo, MarkExplicitAction]] = []
         # Prefix read locks retained after DB flush (downgraded from write locks in _save_to_db).
         retained_read_locks: List[spack.util.lock.Lock] = []
         next_database_write = 0.0
@@ -2003,7 +2032,9 @@ class PackageInstaller:
 
         try:
             # Try to schedule builds immediately. The first job does not require a token.
-            blocked = self._schedule_builds(selector, jobserver, retained_read_locks)
+            blocked = self._schedule_builds(
+                selector, jobserver, retained_read_locks, finished_builds
+            )
 
             while self.pending_builds or self.running_builds or finished_builds:
                 # Monitor the jobserver when we have pending builds, capacity, and at least one
@@ -2121,7 +2152,9 @@ class PackageInstaller:
 
                 # Try to schedule more builds, acquiring per-spec locks and jobserver tokens.
                 if self.capacity and self.pending_builds:
-                    blocked = self._schedule_builds(selector, jobserver, retained_read_locks)
+                    blocked = self._schedule_builds(
+                        selector, jobserver, retained_read_locks, finished_builds
+                    )
 
                 # Finally update the UI
                 self.build_status.update()
@@ -2131,8 +2164,8 @@ class PackageInstaller:
             db_exc = None
             try:
                 with self.db.write_transaction():
-                    for build in finished_builds:
-                        self.db._add(build.spec, explicit=build.explicit)
+                    for b in finished_builds:
+                        self.db._add(b.spec, explicit=b.explicit)
             except Exception as e:
                 db_exc = e
 
@@ -2168,11 +2201,11 @@ class PackageInstaller:
                     lock.release_read()
                 except Exception:
                     pass
-            for build in finished_builds:
+            for b in finished_builds:
                 try:
-                    if build.prefix_lock is not None:
-                        build.prefix_lock.release_write()
-                        build.prefix_lock = None
+                    if b.prefix_lock is not None:
+                        b.prefix_lock.release_write()
+                        b.prefix_lock = None
                 except Exception:
                     pass
 
@@ -2220,7 +2253,9 @@ class PackageInstaller:
             )
 
     def _save_to_db(
-        self, finished_builds: List[ChildInfo], retained_read_locks: List[spack.util.lock.Lock]
+        self,
+        finished_builds: List[Union[ChildInfo, MarkExplicitAction]],
+        retained_read_locks: List[spack.util.lock.Lock],
     ) -> bool:
         if not self.db.lock.try_acquire_write():
             return False
@@ -2251,6 +2286,7 @@ class PackageInstaller:
         selector: selectors.BaseSelector,
         jobserver: JobServer,
         retained_read_locks: List[spack.util.lock.Lock],
+        finished_builds: List[Union[ChildInfo, MarkExplicitAction]],
     ) -> bool:
         """Try to schedule as many pending builds as possible.
 
@@ -2264,7 +2300,7 @@ class PackageInstaller:
         processes. In that case we should not monitor the jobserver for new tokens, since we'd end
         up in a busy wait loop until the locks are released.
         """
-        blocked, to_start, newly_installed = schedule_builds(
+        result = schedule_builds(
             pending=self.pending_builds,
             build_graph=self.build_graph,
             db=self.db,
@@ -2274,14 +2310,18 @@ class PackageInstaller:
             capacity=self.capacity,
             needs_jobserver_token=bool(self.running_builds),
             jobserver=jobserver,
+            explicit=self.explicit,
         )
+        blocked = result.blocked
+        finished_builds.extend(result.db_actions)
         # Specs installed by another process.
-        for dag_hash, spec, lock in newly_installed:
+        for dag_hash, spec, lock in result.newly_installed:
             retained_read_locks.append(lock)
-            self.build_status.add_build(spec, explicit=dag_hash in self.explicit)
+            explicit = dag_hash in self.explicit
+            self.build_status.add_build(spec, explicit=explicit)
             self.build_status.update_state(dag_hash, "finished")
         # Specs we can start building ourselves.
-        for dag_hash, lock in to_start:
+        for dag_hash, lock in result.to_start:
             self._start(selector, jobserver, dag_hash, lock)
         return blocked
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -570,7 +570,7 @@ def test_env_install_include_concrete_env(
         assert mpileaks["libelf"].dag_hash() in test2_user_spec_hashes
 
 
-def test_env_roots_marked_explicit(install_mockery, mock_fetch):
+def test_env_roots_marked_explicit(install_mockery, mock_fetch, installer_variant):
     install = SpackCommand("install")
     install("--fake", "dependent-install")
 

--- a/lib/spack/spack/test/installer_build_graph.py
+++ b/lib/spack/spack/test/installer_build_graph.py
@@ -664,3 +664,26 @@ class TestBuildGraphTestDeps:
         assert specs_with_test_deps["dep"].dag_hash() in graph.nodes
         assert specs_with_test_deps["test_dep"].dag_hash() in graph.nodes
         assert specs_with_test_deps["dep_test_dep"].dag_hash() in graph.nodes
+
+    def test_mark_explicit_spec_excludes_build_only_deps(
+        self, specs_with_build_deps: Dict[str, Spec], temporary_store: Store
+    ):
+        """An installed-implicit spec in explicit_set should only traverse link/run deps,
+        not build-only deps."""
+        root = specs_with_build_deps["root"]
+        install_spec_in_db(root, temporary_store)
+        assert temporary_store.db._data[root.dag_hash()].explicit is False
+        graph = BuildGraph(
+            specs=[root],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=True,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+            explicit_set={root.dag_hash()},
+        )
+        # root should be in graph (not pruned) because it needs to be marked explicit.
+        assert root.dag_hash() in graph.nodes
+        # build-only dep should NOT be pulled in since root is already installed.
+        assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -595,7 +595,6 @@ class TestScheduleBuilds:
             )
             assert len(result.to_mark_explicit) == 1
             assert result.to_mark_explicit[0].spec is spec
-            assert result.to_mark_explicit[0].explicit is True
             assert len(result.newly_installed) == 1
         finally:
             for _, _, lock in result.newly_installed:

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -294,7 +294,7 @@ class TestScheduleBuilds:
         bg = _FakeBuildGraph([spec])
         jobserver = JobServer(num_jobs=2)
         try:
-            blocked, to_start, newly_installed = schedule_builds(
+            result = schedule_builds(
                 pending,
                 bg,
                 temporary_store.db,
@@ -304,14 +304,15 @@ class TestScheduleBuilds:
                 capacity=1,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
+                explicit=set(),
             )
-            assert not blocked
-            assert len(to_start) == 1
-            assert to_start[0][0] == spec.dag_hash()
-            assert not newly_installed
+            assert not result.blocked
+            assert len(result.to_start) == 1
+            assert result.to_start[0][0] == spec.dag_hash()
+            assert not result.newly_installed
             assert not pending  # removed from the pending list
         finally:
-            for _, lock in to_start:
+            for _, lock in result.to_start:
                 lock.release_write()
             jobserver.close()
 
@@ -323,7 +324,7 @@ class TestScheduleBuilds:
         bg = _FakeBuildGraph([spec])
         jobserver = JobServer(num_jobs=2)
         try:
-            blocked, to_start, newly_installed = schedule_builds(
+            result = schedule_builds(
                 pending,
                 bg,
                 temporary_store.db,
@@ -333,14 +334,15 @@ class TestScheduleBuilds:
                 capacity=1,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
+                explicit=set(),
             )
-            assert not blocked
-            assert not to_start
-            assert len(newly_installed) == 1
-            assert newly_installed[0][0] == spec.dag_hash()
+            assert not result.blocked
+            assert not result.to_start
+            assert len(result.newly_installed) == 1
+            assert result.newly_installed[0][0] == spec.dag_hash()
             assert not pending  # removed from the pending list
         finally:
-            for _, _, lock in newly_installed:
+            for _, _, lock in result.newly_installed:
                 lock.release_read()
             jobserver.close()
 
@@ -352,7 +354,7 @@ class TestScheduleBuilds:
         # num_jobs=1 writes 0 tokens to the FIFO. Only the implicit token exists.
         jobserver = JobServer(num_jobs=1)
         try:
-            blocked, to_start, newly_installed = schedule_builds(
+            result = schedule_builds(
                 pending,
                 bg,
                 temporary_store.db,
@@ -362,10 +364,11 @@ class TestScheduleBuilds:
                 capacity=2,
                 needs_jobserver_token=True,
                 jobserver=jobserver,
+                explicit=set(),
             )
-            assert not blocked
-            assert not to_start
-            assert not newly_installed
+            assert not result.blocked
+            assert not result.to_start
+            assert not result.newly_installed
             assert len(pending) == 1
         finally:
             jobserver.close()
@@ -381,7 +384,7 @@ class TestScheduleBuilds:
         monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
         monkeypatch.setattr(lock, "try_acquire_read", lambda: False)
         try:
-            blocked, to_start, newly_installed = schedule_builds(
+            result = schedule_builds(
                 pending,
                 bg,
                 temporary_store.db,
@@ -391,10 +394,11 @@ class TestScheduleBuilds:
                 capacity=2,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
+                explicit=set(),
             )
-            assert blocked
-            assert not to_start
-            assert not newly_installed
+            assert result.blocked
+            assert not result.to_start
+            assert not result.newly_installed
             assert len(pending) == 1
         finally:
             jobserver.close()
@@ -407,7 +411,7 @@ class TestScheduleBuilds:
         bg = _FakeBuildGraph([spec])
         jobserver = JobServer(num_jobs=2)
         try:
-            blocked, to_start, newly_installed = schedule_builds(
+            result = schedule_builds(
                 pending,
                 bg,
                 temporary_store.db,
@@ -417,13 +421,14 @@ class TestScheduleBuilds:
                 capacity=1,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
+                explicit=set(),
             )
-            assert not blocked
-            assert len(to_start) == 1
-            assert to_start[0][0] == spec.dag_hash()
-            assert not newly_installed
+            assert not result.blocked
+            assert len(result.to_start) == 1
+            assert result.to_start[0][0] == spec.dag_hash()
+            assert not result.newly_installed
         finally:
-            for _, lock in to_start:
+            for _, lock in result.to_start:
                 lock.release_write()
             jobserver.close()
 
@@ -439,7 +444,7 @@ class TestScheduleBuilds:
         monkeypatch.setattr(lock_a, "try_acquire_write", lambda: False)
         monkeypatch.setattr(lock_a, "try_acquire_read", lambda: False)
         try:
-            blocked, to_start, newly_installed = schedule_builds(
+            result = schedule_builds(
                 pending,
                 bg,
                 temporary_store.db,
@@ -449,14 +454,15 @@ class TestScheduleBuilds:
                 capacity=2,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
+                explicit=set(),
             )
-            assert not blocked  # spec_b was schedulable
-            started_hashes = {h for h, _ in to_start}
+            assert not result.blocked  # spec_b was schedulable
+            started_hashes = {h for h, _ in result.to_start}
             assert spec_b.dag_hash() in started_hashes
             assert spec_a.dag_hash() not in started_hashes
-            assert not newly_installed
+            assert not result.newly_installed
         finally:
-            for _, lock in to_start:
+            for _, lock in result.to_start:
                 lock.release_write()
             jobserver.close()
 
@@ -477,7 +483,7 @@ class TestScheduleBuilds:
         lock = temporary_store.prefix_locker.lock(spec)
         monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
         try:
-            blocked, to_start, newly_installed = schedule_builds(
+            result = schedule_builds(
                 pending,
                 bg,
                 temporary_store.db,
@@ -487,16 +493,17 @@ class TestScheduleBuilds:
                 capacity=2,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
+                explicit=set(),
             )
-            assert blocked  # no write lock was obtained; jobserver should not fire
-            assert not to_start
-            assert len(newly_installed) == 1
-            dag_hash, installed_spec, lock = newly_installed[0]
+            assert result.blocked  # no write lock was obtained; jobserver should not fire
+            assert not result.to_start
+            assert len(result.newly_installed) == 1
+            dag_hash, installed_spec, lock = result.newly_installed[0]
             assert dag_hash == spec.dag_hash()
             assert installed_spec == spec
             assert not pending  # spec was removed from pending
         finally:
-            for _, _, lock in newly_installed:
+            for _, _, lock in result.newly_installed:
                 lock.release_read()
             jobserver.close()
 
@@ -515,7 +522,7 @@ class TestScheduleBuilds:
         lock = temporary_store.prefix_locker.lock(spec)
         monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
         try:
-            blocked, to_start, newly_installed = schedule_builds(
+            result = schedule_builds(
                 pending,
                 bg,
                 temporary_store.db,
@@ -525,10 +532,11 @@ class TestScheduleBuilds:
                 capacity=2,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
+                explicit=set(),
             )
-            assert blocked
-            assert not to_start
-            assert not newly_installed
+            assert result.blocked
+            assert not result.to_start
+            assert not result.newly_installed
             assert pending == [spec.dag_hash()]  # spec stays in pending for retry
         finally:
             jobserver.close()
@@ -541,7 +549,7 @@ class TestScheduleBuilds:
         bg = _FakeBuildGraph([spec])
         jobserver = JobServer(num_jobs=2)
         try:
-            blocked, to_start, newly_installed = schedule_builds(
+            result = schedule_builds(
                 pending,
                 bg,
                 temporary_store.db,
@@ -551,13 +559,46 @@ class TestScheduleBuilds:
                 capacity=1,
                 needs_jobserver_token=False,
                 jobserver=jobserver,
+                explicit=set(),
             )
-            assert not blocked
-            assert not to_start
-            assert len(newly_installed) == 1
-            assert newly_installed[0][0] == spec.dag_hash()
+            assert not result.blocked
+            assert not result.to_start
+            assert len(result.newly_installed) == 1
+            assert result.newly_installed[0][0] == spec.dag_hash()
         finally:
-            for _, _, lock in newly_installed:
+            for _, _, lock in result.newly_installed:
+                lock.release_read()
+            jobserver.close()
+
+    def test_installed_implicit_explicit_set_produces_db_update(
+        self, temporary_store, mock_packages
+    ):
+        """An installed-implicit spec in explicit set produces a DbUpdate."""
+        spec = self._make_spec("trivial-install-test-package")
+        temporary_store.layout.create_install_directory(spec)
+        temporary_store.db.add(spec, explicit=False)
+        pending = [spec.dag_hash()]
+        bg = _FakeBuildGraph([spec])
+        jobserver = JobServer(num_jobs=2)
+        try:
+            result = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite=set(),
+                overwrite_time=0.0,
+                capacity=1,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+                explicit={spec.dag_hash()},
+            )
+            assert len(result.db_actions) == 1
+            assert result.db_actions[0].spec is spec
+            assert result.db_actions[0].explicit is True
+            assert len(result.newly_installed) == 1
+        finally:
+            for _, _, lock in result.newly_installed:
                 lock.release_read()
             jobserver.close()
 

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -593,9 +593,9 @@ class TestScheduleBuilds:
                 jobserver=jobserver,
                 explicit={spec.dag_hash()},
             )
-            assert len(result.db_actions) == 1
-            assert result.db_actions[0].spec is spec
-            assert result.db_actions[0].explicit is True
+            assert len(result.to_mark_explicit) == 1
+            assert result.to_mark_explicit[0].spec is spec
+            assert result.to_mark_explicit[0].explicit is True
             assert len(result.newly_installed) == 1
         finally:
             for _, _, lock in result.newly_installed:


### PR DESCRIPTION
When you run `spack install` and `x` in the DAG, already installed, but implicit in the db; it should then be updated to explicit.

The idea is to use the installer event loop to "schedule" the save to db instead of doing ad-hoc database updates. That way, we benefit from batched db writes and it's less likely to have bugs.

Enable an existing integration test for the new installer.