### PR TITLE
Bump black version used for style tests

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -21,6 +21,7 @@ done
 echo "==> Error: spack could not find a python interpreter!" >&2
 exit 1
 ":"""
+
 # Line above is a shell no-op, and ends a python multi-line comment.
 # The code above runs this file with our preferred python interpreter.
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -34,6 +34,7 @@ Calls to each of these functions are triggered by the ``run`` method of
 the decorator object, that will forward the keyword arguments passed
 as input.
 """
+
 import ast
 import collections
 import collections.abc

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Common basic functions used through the spack.bootstrap package"""
+
 import fnmatch
 import glob
 import importlib

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -9,6 +9,7 @@ we need to rely on another mechanism to get a concrete spec that fits the curren
 This module contains the logic to get a concrete spec for clingo, starting from a prototype
 JSON file for a similar platform.
 """
+
 import pathlib
 import sys
 from typing import Dict, Optional, Tuple, Type

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Bootstrap non-core Spack dependencies from an environment."""
+
 import hashlib
 import os
 import pathlib

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -132,7 +132,7 @@ def mypy_root_spec() -> str:
 
 def black_root_spec() -> str:
     """Return the root spec used to bootstrap black"""
-    return _root_spec("py-black@:25.1.0")
+    return _root_spec("py-black@:26")
 
 
 def flake8_root_spec() -> str:

--- a/lib/spack/spack/bootstrap/status.py
+++ b/lib/spack/spack/bootstrap/status.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Query the status of bootstrapping on this machine"""
+
 import sys
 from typing import List, Optional, Sequence, Tuple, Union
 

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Caches used by Spack to store data"""
+
 import os
 
 import spack.config

--- a/lib/spack/spack/ci/generator_registry.py
+++ b/lib/spack/spack/ci/generator_registry.py
@@ -5,6 +5,7 @@
 """Generators that support writing out pipelines for various CI platforms,
 using a common pipeline graph definition.
 """
+
 import spack.error
 
 _generators = {}

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -636,8 +636,7 @@ def ci_rebuild(args):
 
         repro_job_url = f"{api_root_url}/projects/{ci_project_id}/jobs/{ci_job_id}/artifacts"
         # Control characters cause this to be printed in blue so it stands out
-        print(
-            f"""
+        print(f"""
 
 \033[34mTo reproduce this build locally, run:
 
@@ -649,8 +648,7 @@ If this project does not have public pipelines, you will need to first:
 
 ... then follow the printed instructions.\033[0;0m
 
-"""
-        )
+""")
 
     rebuild_timer.stop()
     try:

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -544,13 +544,11 @@ def add_cdash_args(subparser, add_help):
 def print_cdash_help():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=textwrap.dedent(
-            """\
+        epilog=textwrap.dedent("""\
 environment variables:
 SPACK_CDASH_AUTH_TOKEN
                     authentication token to present to CDash
-                    """
-        ),
+                    """),
     )
     add_cdash_args(parser, True)
     parser.print_help()

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -444,13 +444,10 @@ class PythonPackageTemplate(PackageTemplate):
                 self.url_line = '    pypi = "{url}"'
         else:
             # Add a reminder about spack preferring PyPI URLs
-            self.url_line = (
-                """
+            self.url_line = """
     # FIXME: ensure the package is not available through PyPI. If it is,
     # re-run `spack create --force` with the PyPI URL.
-"""
-                + self.url_line
-            )
+""" + self.url_line
 
         super().__init__(name, url, versions, languages)
 

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -12,6 +12,7 @@ place.
 It is up to the user to ensure binary compatibility between the deprecated
 installation and its deprecator.
 """
+
 import argparse
 
 import spack.cmd

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -32,6 +32,7 @@ All operations on views are performed via proxy objects such as
 YamlFilesystemView.
 
 """
+
 import argparse
 import sys
 

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -4,6 +4,7 @@
 """This module contains functions related to finding compilers on the system,
 and configuring Spack to use multiple compilers.
 """
+
 import os
 import re
 import sys

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """High-level functions to concretize list of specs"""
+
 import importlib
 import sys
 import time

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -26,6 +26,7 @@ When read in, Spack validates configurations with jsonschemas.  The
 schemas are in submodules of :py:mod:`spack.schema`.
 
 """
+
 import contextlib
 import copy
 import functools

--- a/lib/spack/spack/container/__init__.py
+++ b/lib/spack/spack/container/__init__.py
@@ -4,6 +4,7 @@
 """Package that provides functions and classes to
 generate container recipes from a Spack environment
 """
+
 import warnings
 
 import spack.vendor.jsonschema

--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Manages the details on the images used in the various stages."""
+
 import json
 import os
 import shlex

--- a/lib/spack/spack/container/writers.py
+++ b/lib/spack/spack/container/writers.py
@@ -4,6 +4,7 @@
 """Writers for different kind of recipes and related
 convenience functions.
 """
+
 import copy
 import shlex
 from collections import namedtuple

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Data structures that represent Spack's dependency relationships."""
+
 from typing import TYPE_CHECKING, Dict, List, Type
 
 import spack.deptypes as dt

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -12,6 +12,7 @@ The update in packages.yaml can then be done using the function provided here.
 The module also contains other functions that might be useful across different
 detection mechanisms.
 """
+
 import glob
 import itertools
 import os

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -4,6 +4,7 @@
 """Detection of software installed in the system, based on paths inspections
 and running executables.
 """
+
 import collections
 import concurrent.futures
 import os

--- a/lib/spack/spack/detection/test.py
+++ b/lib/spack/spack/detection/test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Create and run mock e2e tests for package detection."""
+
 import collections
 import contextlib
 import pathlib

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -39,6 +39,7 @@ package class as first argument::
     def _execute_example_directive(pkg, arg1, arg2):
         # modify pkg.example based on arg1 and arg2
 """
+
 import collections
 import collections.abc
 import os

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Enumerations used throughout Spack"""
+
 import enum
 
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -149,9 +149,7 @@ spack:
   view: true
   concretizer:
     unify: {}
-""".format(
-        "true" if spack.config.get("concretizer:unify") else "false"
-    )
+""".format("true" if spack.config.get("concretizer:unify") else "false")
 
 
 sep_re = re.escape(os.sep)

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -74,8 +74,7 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
             cmds += "export SPACK_ENV_VIEW=%s;\n" % view
         cmds += "alias despacktivate='spack env deactivate';\n"
         if prompt:
-            cmds += textwrap.dedent(
-                rf"""
+            cmds += textwrap.dedent(rf"""
                 if [ -z ${{SPACK_OLD_PS1+x}} ]; then
                     if [ -z ${{PS1+x}} ]; then
                         PS1='$$$$';
@@ -93,8 +92,7 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
                 else
                     export PS1="{prompt} ${{PS1}}";
                 fi
-                """
-            ).lstrip("\n")
+                """).lstrip("\n")
     return cmds
 
 

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -4,6 +4,7 @@
 """Service functions and classes to implement the hooks
 for Spack's command extensions.
 """
+
 import glob
 import importlib
 import os

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -14,6 +14,7 @@ This is mainly done by the ``ExternalSpecsParser`` class, which is responsible f
 The helper function ``extract_dicts_from_configuration`` is used to transform the configuration
 into the intermediate representation.
 """
+
 import re
 import uuid
 import warnings

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -25,6 +25,7 @@ in order to build it.  They need to define the following methods:
 ``archive()``
     Archive a source directory, e.g. for creating a mirror.
 """
+
 import copy
 import functools
 import hashlib

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -37,6 +37,7 @@ kind of like the graph git shows with ``git log --graph``, e.g.
 
 :func:`graph_dot` will output a graph of a spec (or multiple specs) in dot format.
 """
+
 import enum
 import sys
 from typing import List, Optional, Set, TextIO, Tuple

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -19,6 +19,7 @@ This can be used to implement support for things like module
 systems (e.g. modules, lmod, etc.) or to add other custom
 features.
 """
+
 import importlib
 import types
 from typing import List, Optional

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -91,9 +91,7 @@ def write_license_file(pkg, license_path):
    file UNCHANGED. The system may be configured if:
 
     - A license file is installed in a default location.
-""".format(
-        pkg.name
-    )
+""".format(pkg.name)
 
     if envvars:
         txt += """\
@@ -101,9 +99,7 @@ def write_license_file(pkg, license_path):
       a module file:
 
 {0}
-""".format(
-            envvars
-        )
+""".format(envvars)
 
     txt += """\
  * Otherwise, depending on the license you have, enter AT THE BEGINNING of
@@ -116,18 +112,14 @@ def write_license_file(pkg, license_path):
    this Spack-global file (relative to the installation prefix).
 
 {0}
-""".format(
-        linktargets
-    )
+""".format(linktargets)
 
     if url:
         txt += """\
  * For further information on licensing, see:
 
 {0}
-""".format(
-            url
-        )
+""".format(url)
 
     txt += """\
  Recap:

--- a/lib/spack/spack/llnl/path.py
+++ b/lib/spack/spack/llnl/path.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Path primitives that just require Python standard library."""
+
 import functools
 import sys
 from typing import List, Optional

--- a/lib/spack/spack/llnl/string.py
+++ b/lib/spack/spack/llnl/string.py
@@ -4,6 +4,7 @@
 """String manipulation functions that do not have other dependencies than Python
 standard library
 """
+
 from typing import List, Optional, Sequence
 
 

--- a/lib/spack/spack/llnl/url.py
+++ b/lib/spack/spack/llnl/url.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """URL primitives that just require Python standard library."""
+
 import itertools
 import os
 import re

--- a/lib/spack/spack/llnl/util/argparsewriter.py
+++ b/lib/spack/spack/llnl/util/argparsewriter.py
@@ -263,9 +263,7 @@ class ArgparseRstWriter(ArgparseWriter):
 {1}
 {2}
 
-""".format(
-            prog.replace(" ", "-"), prog, self.rst_levels[self.level] * len(prog)
-        )
+""".format(prog.replace(" ", "-"), prog, self.rst_levels[self.level] * len(prog))
 
     def description(self, description: str) -> str:
         """Description of a command.
@@ -292,9 +290,7 @@ class ArgparseRstWriter(ArgparseWriter):
 
     {0}
 
-""".format(
-            usage
-        )
+""".format(usage)
 
     def begin_positionals(self) -> str:
         """Text to print before positional arguments.
@@ -318,9 +314,7 @@ class ArgparseRstWriter(ArgparseWriter):
 ``{0}``
   {1}
 
-""".format(
-            name, help
-        )
+""".format(name, help)
 
     def end_positionals(self) -> str:
         """Text to print after positional arguments.
@@ -352,9 +346,7 @@ class ArgparseRstWriter(ArgparseWriter):
 ``{0}``
   {1}
 
-""".format(
-            opts, help
-        )
+""".format(opts, help)
 
     def end_optionals(self) -> str:
         """Text to print after optional arguments.

--- a/lib/spack/spack/llnl/util/tty/colify.py
+++ b/lib/spack/spack/llnl/util/tty/colify.py
@@ -5,6 +5,7 @@
 """
 Routines for printing columnar output.  See ``colify()`` for more information.
 """
+
 import io
 import os
 import shutil

--- a/lib/spack/spack/llnl/util/tty/color.py
+++ b/lib/spack/spack/llnl/util/tty/color.py
@@ -58,6 +58,7 @@ The console can be reset later to plain text with ``@.``.
 
 To output an ``@``, use ``@@``.  To output a ``}`` inside braces, use ``}}``.
 """
+
 import io
 import os
 import re

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Utility classes for logging the output of blocks of code."""
+
 import atexit
 import ctypes
 import errno

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -7,6 +7,7 @@
 In a normal Spack installation, this is invoked from the bin/spack script
 after the system path is set up.
 """
+
 import argparse
 import gc
 import inspect
@@ -307,15 +308,13 @@ class SpackArgumentParser(argparse.ArgumentParser):
             formatter.end_section()
 
         # epilog
-        help_section = textwrap.dedent(
-            """\
+        help_section = textwrap.dedent("""\
             @*C{More help}:
               @c{spack help --all}       list all commands and options
               @c{spack help <command>}   help on a specific command
               @c{spack help --spec}      help on the package specification syntax
               @c{spack docs}             open https://spack.rtfd.io/ in a browser
-            """
-        )
+            """)
         formatter.add_text(color.colorize(help_section))
 
         # determine help from format above

--- a/lib/spack/spack/mixins.py
+++ b/lib/spack/spack/mixins.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """This module contains additional behavior that can be attached to any given package."""
+
 import os
 from typing import Optional
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -23,6 +23,7 @@ and is divided among four classes:
 Each of the four classes needs to be sub-classed when implementing a new
 module type.
 """
+
 import collections
 import contextlib
 import copy

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -5,6 +5,7 @@
 """This module implements the classes necessary to generate Tcl
 non-hierarchical modules.
 """
+
 import os
 from typing import Dict, Optional, Tuple
 

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -23,6 +23,7 @@ avoids overly complicated rat nests of if statements.  Obviously,
 depending on the scenario, regular old conditionals might be clearer,
 so package authors should use their judgement.
 """
+
 import functools
 from contextlib import contextmanager
 from typing import Optional, Union

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2447,10 +2447,8 @@ class WindowsSimulatedRPath:
                 new_pth = pathlib.Path(pth)
             path_is_in_prefix = new_pth.is_relative_to(self.base_modification_prefix)
             if not path_is_in_prefix:
-                raise RuntimeError(
-                    f"Attempting to generate rpath symlink out of rpath context:\
-{str(self.base_modification_prefix)}"
-                )
+                raise RuntimeError(f"Attempting to generate rpath symlink out of rpath context:\
+{str(self.base_modification_prefix)}")
             self._additional_library_dependents.add(new_pth)
 
     @property

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -8,6 +8,7 @@ Do not import other ``spack`` modules here. This module is used
 throughout Spack and should bring in a minimal number of external
 dependencies.
 """
+
 import os
 from pathlib import PurePath
 

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Classes and functions to manage providers of virtual dependencies"""
+
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Union
 
 import spack.error

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -337,7 +337,7 @@ def fixup_macos_rpath(root, filename):
         return False
 
     # Get Mach-O header commands
-    (rpath_list, deps, id_dylib) = _macholib_get_paths(abspath)
+    rpath_list, deps, id_dylib = _macholib_get_paths(abspath)
 
     # Convert rpaths list to (name -> number of occurrences)
     add_rpaths = set()
@@ -353,7 +353,7 @@ def fixup_macos_rpath(root, filename):
     for name in deps:
         if name.startswith(spack_root):
             tty.debug("Spack-installed dependency for {0}: {1}".format(abspath, name))
-            (dirname, basename) = os.path.split(name)
+            dirname, basename = os.path.split(name)
             if dirname != root or dirname in rpaths:
                 # Only change the rpath if it's a dependency *or* if the root
                 # rpath was already added to the library (this is to prevent

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tools to produce reports of spec installations or tests"""
+
 import collections
 import gzip
 import os

--- a/lib/spack/spack/rewiring.py
+++ b/lib/spack/spack/rewiring.py
@@ -56,10 +56,6 @@ class PackageNotInstalledError(RewireError):
     """Raised when the build_spec for a splice was not installed."""
 
     def __init__(self, spliced_spec, build_spec, dep):
-        super().__init__(
-            """Rewire of {0}
+        super().__init__("""Rewire of {0}
             failed due to missing install of build spec {1}
-            for spec {2}""".format(
-                spliced_spec, build_spec, dep
-            )
-        )
+            for spec {2}""".format(spliced_spec, build_spec, dep))

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """This module contains jsonschema files for all of Spack's YAML formats."""
+
 import copy
 import typing
 import warnings

--- a/lib/spack/spack/schema/bootstrap.py
+++ b/lib/spack/spack/schema/bootstrap.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Schema for bootstrap.yaml configuration file."""
+
 from typing import Any, Dict
 
 #: Schema of a single source

--- a/lib/spack/spack/schema/buildcache_spec.py
+++ b/lib/spack/spack/schema/buildcache_spec.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/buildcache_spec.py
    :lines: 15-
 """
+
 from typing import Any, Dict
 
 import spack.schema.spec

--- a/lib/spack/spack/schema/cdash.py
+++ b/lib/spack/spack/schema/cdash.py
@@ -6,6 +6,7 @@
 .. literalinclude:: ../spack/schema/cdash.py
    :lines: 13-
 """
+
 from typing import Any, Dict
 
 #: Properties for inclusion in other schemas

--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -6,6 +6,7 @@
 .. literalinclude:: ../spack/schema/ci.py
    :lines: 16-
 """
+
 from typing import Any, Dict
 
 # Schema for script fields

--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -6,6 +6,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/compilers.py
    :lines: 15-
 """
+
 from typing import Any, Dict
 
 import spack.schema.environment

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -6,6 +6,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/concretizer.py
    :lines: 12-
 """
+
 from typing import Any, Dict
 
 LIST_OF_SPECS = {"type": "array", "items": {"type": "string"}}

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -6,6 +6,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/config.py
    :lines: 17-
 """
+
 from typing import Any, Dict
 
 import spack.schema

--- a/lib/spack/spack/schema/container.py
+++ b/lib/spack/spack/schema/container.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Schema for the ``container`` subsection of Spack environments."""
+
 from typing import Any, Dict
 
 _stages_from_dockerhub = {

--- a/lib/spack/spack/schema/cray_manifest.py
+++ b/lib/spack/spack/schema/cray_manifest.py
@@ -10,6 +10,7 @@ external entries in packages configuration).
 This does not specify a configuration - it is an input format
 that is consumed and transformed into Spack DB records.
 """
+
 from typing import Any, Dict
 
 properties: Dict[str, Any] = {

--- a/lib/spack/spack/schema/database_index.py
+++ b/lib/spack/spack/schema/database_index.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/database_index.py
    :lines: 17-
 """
+
 from typing import Any, Dict
 
 import spack.schema.spec

--- a/lib/spack/spack/schema/definitions.py
+++ b/lib/spack/spack/schema/definitions.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/definitions.py
    :lines: 16-
 """
+
 from typing import Any, Dict
 
 from .spec_list import spec_list_schema

--- a/lib/spack/spack/schema/env_vars.py
+++ b/lib/spack/spack/schema/env_vars.py
@@ -6,6 +6,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/env_vars.py
    :lines: 15-
 """
+
 from typing import Any, Dict
 
 import spack.schema.environment

--- a/lib/spack/spack/schema/environment.py
+++ b/lib/spack/spack/schema/environment.py
@@ -4,6 +4,7 @@
 """Schema for environment modifications. Meant for inclusion in other
 schemas.
 """
+
 import collections.abc
 from typing import Any, Dict
 

--- a/lib/spack/spack/schema/include.py
+++ b/lib/spack/spack/schema/include.py
@@ -6,6 +6,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/include.py
    :lines: 12-
 """
+
 from typing import Any, Dict
 
 #: Properties for inclusion in other schemas

--- a/lib/spack/spack/schema/merged.py
+++ b/lib/spack/spack/schema/merged.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/merged.py
    :lines: 32-
 """
+
 from typing import Any, Dict
 
 import spack.schema.bootstrap

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/mirrors.py
    :lines: 13-
 """
+
 from typing import Any, Dict
 
 #: Common properties for connection specification

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/modules.py
    :lines: 16-
 """
+
 from typing import Any, Dict
 
 import spack.schema.environment

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -6,6 +6,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/packages.py
    :lines: 14-
 """
+
 from typing import Any, Dict
 
 import spack.schema.environment

--- a/lib/spack/spack/schema/projections.py
+++ b/lib/spack/spack/schema/projections.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/projections.py
    :lines: 14-
 """
+
 from typing import Any, Dict
 
 #: Properties for inclusion in other schemas

--- a/lib/spack/spack/schema/spec.py
+++ b/lib/spack/spack/schema/spec.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/spec.py
    :lines: 15-
 """
+
 from typing import Any, Dict
 
 target = {

--- a/lib/spack/spack/schema/toolchains.py
+++ b/lib/spack/spack/schema/toolchains.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/toolchains.py
    :lines: 13-
 """
+
 from typing import Any, Dict
 
 #: Properties for inclusion in other schemas

--- a/lib/spack/spack/schema/url_buildcache_manifest.py
+++ b/lib/spack/spack/schema/url_buildcache_manifest.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/url_buildcache_manifest.py
    :lines: 11-
 """
+
 from typing import Any, Dict
 
 properties: Dict[str, Any] = {

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -7,6 +7,7 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/view.py
    :lines: 15-
 """
+
 from typing import Any, Dict
 
 import spack.schema

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Low-level wrappers around clingo API and other basic functionality related to ASP"""
+
 import importlib
 import pathlib
 from types import ModuleType

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Classes to analyze the input of a solve, and provide information to set up the ASP problem"""
+
 import collections
 from typing import Dict, List, NamedTuple, Set, Tuple, Union
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -46,6 +46,7 @@ line is a spec for a particular installation of the mpileaks package.
 
 6. The architecture to build with.
 """
+
 import collections
 import collections.abc
 import enum
@@ -4257,7 +4258,7 @@ class Spec:
             return clr.colorize(f"{color_fmt}{sigil}{clr.cescape(string)}@.", color=color)
 
         def format_attribute(match_object: Match) -> str:
-            (esc, sig, dep, hash, hash_len, attribute, close_brace, unmatched_close_brace) = (
+            esc, sig, dep, hash, hash_len, attribute, close_brace, unmatched_close_brace = (
                 match_object.groups()
             )
             if esc:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -56,6 +56,7 @@ thing.  Spack uses ``~variant`` in directory names and in the canonical form of
 specs to avoid ambiguity.  Both are provided because ``~`` can cause shell
 expansion when it is the first character in an id typed on the command line.
 """
+
 import json
 import pathlib
 import re

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -15,6 +15,7 @@ but we use a fancier directory layout to make browsing the store and
 debugging easier.
 
 """
+
 import contextlib
 import os
 import pathlib

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -11,6 +11,7 @@ installations performed in Spack unit tests may include additional
 modifications to global state in memory that must be replicated in the
 child process.
 """
+
 import importlib
 import io
 import multiprocessing

--- a/lib/spack/spack/tag.py
+++ b/lib/spack/spack/tag.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Classes and functions to manage package tags"""
+
 from typing import TYPE_CHECKING, Dict, List, Set
 
 import spack.error

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -173,18 +173,14 @@ def test_bootstrap_custom_store_in_environment(mutable_config, tmp_path: pathlib
     # during bootstrapping
     spack_yaml = tmp_path / "spack.yaml"
     install_root = tmp_path / "store"
-    spack_yaml.write_text(
-        """
+    spack_yaml.write_text("""
 spack:
   specs:
   - libelf
   config:
     install_tree:
       root: {0}
-""".format(
-            install_root
-        )
-    )
+""".format(install_root))
     with spack.environment.Environment(str(tmp_path)):
         assert spack.environment.active_environment()
         assert spack.config.get("config:install_tree:root") == str(install_root)

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -420,15 +420,13 @@ def test_external_prefixes_last(mutable_config, mock_packages, working_env, monk
     # the test to check if the associated paths are placed last.
     assert "dt-diamond-left" < "dt-diamond-right"
 
-    cfg_data = syaml.load_config(
-        """\
+    cfg_data = syaml.load_config("""\
 dt-diamond-left:
   externals:
   - spec: dt-diamond-left@1.0
     prefix: /fake/path1
   buildable: false
-"""
-    )
+""")
     spack.config.set("packages", cfg_data)
     top = spack.concretize.concretize_one("dt-diamond")
 

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -6,6 +6,7 @@
 This test checks that the Spack cc compiler wrapper is parsing
 arguments correctly.
 """
+
 import os
 
 import pytest

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -344,8 +344,7 @@ def test_checksum_manual_download_fails(mock_packages, monkeypatch):
 def test_upate_package_contents(tmp_path: pathlib.Path):
     """Test that the package.py file is updated with the new versions."""
     pkg_path = tmp_path / "package.py"
-    pkg_path.write_text(
-        """\
+    pkg_path.write_text("""\
 from spack.package import *
 
 class Zlib(Package):
@@ -359,8 +358,7 @@ class Zlib(Package):
 
     def install(self, spec, prefix):
         make("install")
-"""
-    )
+""")
     version_lines = """\
     version("1.2.13", sha256="abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
     version("1.2.5", sha256="abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
@@ -368,9 +366,7 @@ class Zlib(Package):
 """
     # two new versions are added
     assert spack.cmd.checksum.add_versions_to_pkg(str(pkg_path), version_lines) == 2
-    assert (
-        pkg_path.read_text()
-        == """\
+    assert pkg_path.read_text() == """\
 from spack.package import *
 
 class Zlib(Package):
@@ -387,4 +383,3 @@ class Zlib(Package):
     def install(self, spec, prefix):
         make("install")
 """
-    )

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -76,13 +76,11 @@ def mock_git_repo(git, tmp_path: pathlib.Path):
         path_to_env = os.path.sep.join(("no", "such", "env", "path", "spack.yaml"))
         os.makedirs(os.path.dirname(path_to_env))
         with open(path_to_env, "w", encoding="utf-8") as f:
-            f.write(
-                """
+            f.write("""
 spack:
     specs:
     - a
-"""
-            )
+""")
 
         git("add", path_to_env)
 
@@ -94,13 +92,11 @@ spack:
         git("-c", "commit.gpgsign=false", "commit", "-m", "initial commit")
 
         with open(".gitlab-ci.yml", "w", encoding="utf-8") as f:
-            f.write(
-                """
+            f.write("""
 testjob:
     script:
         - echo "success"
-            """
-            )
+            """)
 
         # second commit, adding a .gitlab-ci.yml
         git("add", ".gitlab-ci.yml")
@@ -275,8 +271,7 @@ def test_ci_generate_with_custom_settings(
     """Test use of user-provided scripts and attributes"""
     monkeypatch.setattr(spack, "get_version", lambda: "0.15.3")
     monkeypatch.setattr(spack, "get_spack_commit", lambda: "big ol commit sha")
-    spack_yaml, outputfile, _ = ci_generate_test(
-        f"""\
+    spack_yaml, outputfile, _ = ci_generate_test(f"""\
 spack:
   specs:
     - archive-files
@@ -308,8 +303,7 @@ spack:
           artifacts:
             paths:
             - some/custom/artifact
-"""
-    )
+""")
     yaml_contents = syaml.load(outputfile.read_text())
 
     assert yaml_contents["variables"]["SPACK_VERSION"] == "0.15.3"
@@ -350,8 +344,7 @@ spack:
 
 def test_ci_generate_pkg_with_deps(ci_generate_test, tmp_path: pathlib.Path, ci_base_environment):
     """Test pipeline generation for a package w/ dependencies"""
-    spack_yaml, outputfile, _ = ci_generate_test(
-        f"""\
+    spack_yaml, outputfile, _ = ci_generate_test(f"""\
 spack:
   specs:
     - dependent-install
@@ -370,8 +363,7 @@ spack:
         build-job:
           tags:
             - donotcare
-"""
-    )
+""")
     yaml_contents = syaml.load(outputfile.read_text())
 
     found = []
@@ -393,8 +385,7 @@ def test_ci_generate_for_pr_pipeline(ci_generate_test, tmp_path: pathlib.Path, m
     """Test generation of a PR pipeline with disabled rebuild-index"""
     monkeypatch.setenv("SPACK_PIPELINE_TYPE", "spack_pull_request")
 
-    spack_yaml, outputfile, _ = ci_generate_test(
-        f"""\
+    spack_yaml, outputfile, _ = ci_generate_test(f"""\
 spack:
   specs:
     - dependent-install
@@ -417,8 +408,7 @@ spack:
         image: donotcare
         tags: [donotcare]
     rebuild-index: False
-"""
-    )
+""")
     yaml_contents = syaml.load(outputfile.read_text())
 
     assert "rebuild-index" not in yaml_contents
@@ -432,8 +422,7 @@ spack:
 
 def test_ci_generate_with_external_pkg(ci_generate_test, tmp_path: pathlib.Path, monkeypatch):
     """Make sure we do not generate jobs for external pkgs"""
-    spack_yaml, outputfile, _ = ci_generate_test(
-        f"""\
+    spack_yaml, outputfile, _ = ci_generate_test(f"""\
 spack:
   specs:
     - archive-files
@@ -450,8 +439,7 @@ spack:
           tags:
             - donotcare
           image: donotcare
-"""
-    )
+""")
     yaml_contents = syaml.load(outputfile.read_text())
     # Check that the "externaltool" package was not erroneously staged
     assert all("externaltool" not in key for key in yaml_contents)
@@ -459,13 +447,11 @@ spack:
 
 def test_ci_rebuild_missing_config(tmp_path: pathlib.Path, working_env, mutable_mock_env_path):
     spack_yaml = tmp_path / "spack.yaml"
-    spack_yaml.write_text(
-        """
+    spack_yaml.write_text("""
     spack:
       specs:
         - archive-files
-    """
-    )
+    """)
 
     env_cmd("create", "test", str(spack_yaml))
     env_cmd("activate", "--without-view", "--sh", "test")
@@ -511,8 +497,7 @@ def create_rebuild_env(
 
     env_dir.mkdir(parents=True)
     with open(env_dir / "spack.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            f"""
+        f.write(f"""
 spack:
   definitions:
     - packages: [{pkg_name}]
@@ -536,8 +521,7 @@ spack:
     url: https://my.fake.cdash
     project: Not used
     site: Nothing
-"""
-        )
+""")
 
     with ev.Environment(env_dir) as env:
         env.concretize()
@@ -668,8 +652,7 @@ def test_ci_require_signing(
     monkeypatch,
 ):
     spack_yaml = tmp_path / "spack.yaml"
-    spack_yaml.write_text(
-        f"""
+    spack_yaml.write_text(f"""
 spack:
  specs:
    - archive-files
@@ -684,8 +667,7 @@ spack:
          tags:
            - donotcare
          image: donotcare
-"""
-    )
+""")
     env_cmd("activate", "--without-view", "--sh", "-d", str(spack_yaml.parent))
 
     # Run without the variable to make sure we don't accidentally require signing
@@ -714,8 +696,7 @@ def test_ci_nothing_to_rebuild(
     mirror_url = mirror_dir.as_uri()
 
     with open(tmp_path / "spack.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            f"""
+        f.write(f"""
 spack:
  definitions:
    - packages: [archive-files]
@@ -732,8 +713,7 @@ spack:
          tags:
            - donotcare
          image: donotcare
-"""
-        )
+""")
 
     install_cmd("archive-files")
     buildcache_cmd("push", "-f", "-u", "--update-index", mirror_url, "archive-files")
@@ -782,8 +762,7 @@ def test_push_to_build_cache(
 
     with working_dir(tmp_path):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                f"""\
+            f.write(f"""\
 spack:
  definitions:
    - packages: [patchelf]
@@ -809,8 +788,7 @@ spack:
          - nonbuildtag
        image: basicimage
        custom_attribute: custom!
-"""
-            )
+""")
         env_cmd("create", "test", "./spack.yaml")
         with ev.read("test") as current_env:
             current_env.concretize()
@@ -914,8 +892,7 @@ def test_ci_generate_override_runner_attrs(
     monkeypatch.setattr(spack, "spack_version", "0.20.0.test0")
     monkeypatch.setattr(spack, "get_version", lambda: "0.20.0.test0 (blah)")
     monkeypatch.setattr(spack, "get_spack_commit", lambda: git_version)
-    spack_yaml, outputfile, _ = ci_generate_test(
-        f"""\
+    spack_yaml, outputfile, _ = ci_generate_test(f"""\
 spack:
   specs:
     - dependent-install
@@ -974,8 +951,7 @@ spack:
     - cleanup-job:
         image: donotcare
         tags: [donotcare]
-"""
-    )
+""")
 
     yaml_contents = syaml.load(outputfile.read_text())
 
@@ -1060,8 +1036,7 @@ def test_ci_rebuild_index(
     mirror_url = mirror_dir.as_uri()
 
     with open(tmp_path / "spack.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            f"""
+        f.write(f"""
 spack:
   specs:
   - callpath
@@ -1076,8 +1051,7 @@ spack:
           tags:
           - donotcare
           image: donotcare
-"""
-        )
+""")
 
     with working_dir(tmp_path):
         env_cmd("create", "test", "./spack.yaml")
@@ -1133,8 +1107,7 @@ def test_ci_generate_prune_untouched(
     monkeypatch.setattr(ci, "get_change_revisions", fake_change_revisions)
 
     with spack.repo.use_repositories(repo_builder.root, override=False):
-        spack_yaml, outputfile, _ = ci_generate_test(
-            f"""\
+        spack_yaml, outputfile, _ = ci_generate_test(f"""\
 spack:
   specs:
     - archive-files
@@ -1149,8 +1122,7 @@ spack:
         tags:
           - donotcare
         image: donotcare
-"""
-        )
+""")
 
     # Dependency graph rooted at callpath
     # callpath -> dyninst -> libelf
@@ -1193,8 +1165,7 @@ def test_ci_subcommands_without_mirror(
 ):
     """Make sure we catch if there is not a mirror and report an error"""
     with open(tmp_path / "spack.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   specs:
     - archive-files
@@ -1207,8 +1178,7 @@ spack:
           tags:
             - donotcare
           image: donotcare
-"""
-        )
+""")
 
     with working_dir(tmp_path):
         env_cmd("create", "test", "./spack.yaml")
@@ -1251,8 +1221,7 @@ def test_ci_generate_read_broken_specs_url(
 
     # Test that `spack ci generate` notices this broken spec and fails.
     with open(tmp_path / "spack.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            f"""\
+        f.write(f"""\
 spack:
   specs:
     - dependent-install
@@ -1272,8 +1241,7 @@ spack:
           tags:
             - donotcare
           image: donotcare
-"""
-        )
+""")
 
     with working_dir(tmp_path):
         env_cmd("create", "test", "./spack.yaml")
@@ -1299,8 +1267,7 @@ def test_ci_generate_external_signing_job(
     the location where the binary hash information is written and 2) we
     properly generate a final signing job in the pipeline."""
     monkeypatch.setenv("SPACK_PIPELINE_TYPE", "spack_protected_branch")
-    _, outputfile, _ = ci_generate_test(
-        f"""\
+    _, outputfile, _ = ci_generate_test(f"""\
 spack:
   specs:
     - archive-files
@@ -1327,8 +1294,7 @@ spack:
         script::
           - echo hello
         custom_attribute: custom!
-"""
-    )
+""")
     yaml_contents = syaml.load(outputfile.read_text())
 
     assert "sign-pkgs" in yaml_contents
@@ -1353,8 +1319,7 @@ def test_ci_reproduce(
     image_name = "org/image:tag"
 
     with open(tmp_path / "spack.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            f"""
+        f.write(f"""
 spack:
  definitions:
    - packages: [archive-files]
@@ -1371,8 +1336,7 @@ spack:
          tags:
            - donotcare
          image: {image_name}
-"""
-        )
+""")
 
     with working_dir(tmp_path), ev.Environment(".") as env:
         env.concretize()
@@ -1561,8 +1525,7 @@ def test_gitlab_config_scopes(install_mockery, ci_generate_test, tmp_path: pathl
     configs_path = tmp_path / "gitlab" / "configs"
     configs_path.mkdir(parents=True, exist_ok=True)
     with open(configs_path / "ci.yaml", "w", encoding="utf-8") as fd:
-        fd.write(
-            """
+        fd.write("""
 ci:
   pipeline-gen:
   - reindex-job:
@@ -1571,12 +1534,10 @@ ci:
         KUBERNETES_CPU_REQUEST: 10
         KUBERNETES_MEMORY_REQUEST: 100
       tags: ["spack", "service"]
-"""
-        )
+""")
 
     rel_configs_path = configs_path.relative_to(tmp_path)
-    manifest, outputfile, _ = ci_generate_test(
-        f"""\
+    manifest, outputfile, _ = ci_generate_test(f"""\
 spack:
   config:
     install_tree:
@@ -1597,8 +1558,7 @@ spack:
     - build-job:
         image: "ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01"
         tags: ["some_tag"]
-"""
-    )
+""")
 
     yaml_contents = syaml.load(outputfile.read_text())
 
@@ -1654,8 +1614,7 @@ def test_ci_generate_mirror_config(
     """Make sure the correct mirror gets used as the buildcache destination"""
     fst, snd = (tmp_path / "first").as_uri(), (tmp_path / "second").as_uri()
     with open(tmp_path / "spack.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            f"""\
+        f.write(f"""\
 spack:
   specs:
     - archive-files
@@ -1671,8 +1630,7 @@ spack:
           tags:
             - donotcare
           image: donotcare
-"""
-        )
+""")
 
     with ev.Environment(tmp_path):
         ci_cmd("generate", "--output-file", str(tmp_path / ".gitlab-ci.yml"))
@@ -1686,8 +1644,7 @@ spack:
 def dynamic_mapping_setup(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   specs:
     - pkg-a
@@ -1700,8 +1657,7 @@ spack:
         require: ["variables"]
         ignore: ["ignored_field"]
         allow: ["variables", "retry"]
-"""
-        )
+""")
 
     spec_a = spack.concretize.concretize_one("pkg-a")
 

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -115,15 +115,13 @@ def test_rst():
 def test_rst_with_input_files(tmp_path: pathlib.Path):
     filename = tmp_path / "file.rst"
     with filename.open("w") as f:
-        f.write(
-            """
+        f.write("""
 .. _cmd-spack-fetch:
 cmd-spack-list:
 .. _cmd-spack-stage:
 _cmd-spack-install:
 .. _cmd-spack-patch:
-"""
-        )
+""")
 
     out = commands("--format=rst", str(filename))
     for name in ["fetch", "stage", "patch"]:

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -190,29 +190,22 @@ def test_get_config_scope_merged(mock_low_high_config):
     fs.mkdirp(high_path)
 
     with open(os.path.join(low_path, "repos.yaml"), "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 repos:
   repo3: repo3
-"""
-        )
+""")
 
     with open(os.path.join(high_path, "repos.yaml"), "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 repos:
   repo1: repo1
   repo2: repo2
-"""
-        )
+""")
 
-    assert (
-        config("get", "repos").strip()
-        == """repos:
+    assert config("get", "repos").strip() == """repos:
   repo1: repo1
   repo2: repo2
   repo3: repo3"""
-    )
 
 
 def test_config_edit(mutable_config, working_env):
@@ -266,12 +259,9 @@ def test_config_add(mutable_empty_config):
     config("add", "config:dirty:true")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   dirty: true
 """
-    )
 
 
 def test_config_add_list(mutable_empty_config):
@@ -280,15 +270,12 @@ def test_config_add_list(mutable_empty_config):
     config("add", "config:template_dirs:test3")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   template_dirs:
   - test3
   - test2
   - test1
 """
-    )
 
 
 def test_config_add_override(mutable_empty_config):
@@ -296,25 +283,19 @@ def test_config_add_override(mutable_empty_config):
     config("add", "config:template_dirs:[test2]")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   template_dirs:
   - test2
   - test1
 """
-    )
 
     config("add", "config::template_dirs:[test2]")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   template_dirs:
   - test2
 """
-    )
 
 
 def test_config_add_override_leaf(mutable_empty_config):
@@ -322,25 +303,19 @@ def test_config_add_override_leaf(mutable_empty_config):
     config("add", "config:template_dirs:[test2]")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   template_dirs:
   - test2
   - test1
 """
-    )
 
     config("add", "config:template_dirs::[test2]")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   'template_dirs:':
   - test2
 """
-    )
 
 
 def test_config_add_update_dict(mutable_empty_config):
@@ -369,13 +344,10 @@ def test_config_add_ordered_dict(mutable_empty_config):
     config("add", "mirrors:second:/path/to/second")
     output = config("get", "mirrors")
 
-    assert (
-        output
-        == """mirrors:
+    assert output == """mirrors:
   first: /path/to/first
   second: /path/to/second
 """
-    )
 
 
 def test_config_add_interpret_oneof(mutable_empty_config):
@@ -402,12 +374,9 @@ def test_config_add_from_file(mutable_empty_config, tmp_path: pathlib.Path):
     config("add", "-f", file)
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   dirty: true
 """
-    )
 
 
 def test_config_add_from_file_multiple(mutable_empty_config, tmp_path: pathlib.Path):
@@ -423,13 +392,10 @@ def test_config_add_from_file_multiple(mutable_empty_config, tmp_path: pathlib.P
     config("add", "-f", file)
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   dirty: true
   template_dirs: [test1]
 """
-    )
 
 
 def test_config_add_override_from_file(mutable_empty_config, tmp_path: pathlib.Path):
@@ -445,12 +411,9 @@ def test_config_add_override_from_file(mutable_empty_config, tmp_path: pathlib.P
     config("add", "-f", file)
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   template_dirs: [test2]
 """
-    )
 
 
 def test_config_add_override_leaf_from_file(mutable_empty_config, tmp_path: pathlib.Path):
@@ -466,12 +429,9 @@ def test_config_add_override_leaf_from_file(mutable_empty_config, tmp_path: path
     config("add", "-f", file)
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   'template_dirs:': [test2]
 """
-    )
 
 
 def test_config_add_update_dict_from_file(mutable_empty_config, tmp_path: pathlib.Path):
@@ -526,11 +486,8 @@ def test_config_remove_value(mutable_empty_config):
     config("remove", "config:dirty:true")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config: {}
+    assert output == """config: {}
 """
-    )
 
 
 def test_config_remove_alias_rm(mutable_empty_config):
@@ -538,11 +495,8 @@ def test_config_remove_alias_rm(mutable_empty_config):
     config("rm", "config:dirty:true")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config: {}
+    assert output == """config: {}
 """
-    )
 
 
 def test_config_remove_dict(mutable_empty_config):
@@ -550,11 +504,8 @@ def test_config_remove_dict(mutable_empty_config):
     config("rm", "config:dirty")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config: {}
+    assert output == """config: {}
 """
-    )
 
 
 def test_remove_from_list(mutable_empty_config):
@@ -564,14 +515,11 @@ def test_remove_from_list(mutable_empty_config):
     config("remove", "config:template_dirs:test2")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   template_dirs:
   - test3
   - test1
 """
-    )
 
 
 def test_remove_list(mutable_empty_config):
@@ -581,14 +529,11 @@ def test_remove_list(mutable_empty_config):
     config("remove", "config:template_dirs:[test2]")
     output = config("get", "config")
 
-    assert (
-        output
-        == """config:
+    assert output == """config:
   template_dirs:
   - test3
   - test1
 """
-    )
 
 
 def test_config_add_to_env(mutable_empty_config, mutable_mock_env_path):
@@ -699,13 +644,11 @@ def test_config_prefer_upstream(
 
 def test_environment_config_update(tmp_path: pathlib.Path, mutable_config, monkeypatch):
     with open(tmp_path / "spack.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   config:
     ccache: true
-"""
-        )
+""")
 
     def update_config(data):
         data["config"]["ccache"] = False

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -216,8 +216,7 @@ def test_dev_build_env(
     envdir.mkdir()
     with fs.working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                f"""\
+            f.write(f"""\
 spack:
   specs:
   - dev-build-test-install@0.0.0
@@ -226,8 +225,7 @@ spack:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
       path: {os.path.relpath(str(build_dir), start=str(envdir))}
-"""
-            )
+""")
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
             install()
@@ -259,8 +257,7 @@ def test_dev_build_env_with_vars(
     envdir.mkdir()
     with fs.working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs:
   - dev-build-test-install@0.0.0
@@ -269,8 +266,7 @@ spack:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
       path: $CUSTOM_BUILD_PATH
-"""
-            )
+""")
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
             install()
@@ -300,8 +296,7 @@ def test_dev_build_env_version_mismatch(
     envdir.mkdir()
     with fs.working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                f"""\
+            f.write(f"""\
 spack:
   specs:
   - dev-build-test-install@0.0.0
@@ -310,8 +305,7 @@ spack:
     dev-build-test-install:
       spec: dev-build-test-install@1.1.1
       path: {build_dir}
-"""
-            )
+""")
 
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
@@ -355,8 +349,7 @@ def test_dev_build_multiple(
     envdir.mkdir()
     with fs.working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                f"""\
+            f.write(f"""\
 spack:
   specs:
   - dev-build-test-dependent@0.0.0
@@ -368,8 +361,7 @@ spack:
     dev-build-test-dependent:
       spec: dev-build-test-dependent@0.0.0
       path: {root_dir}
-"""
-            )
+""")
 
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
@@ -410,8 +402,7 @@ def test_dev_build_env_dependency(
     envdir.mkdir()
     with fs.working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                f"""\
+            f.write(f"""\
 spack:
   specs:
   - dependent-of-dev-build@0.0.0
@@ -420,8 +411,7 @@ spack:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
       path: {os.path.relpath(str(build_dir), start=str(envdir))}
-"""
-            )
+""")
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
             # concretize in the environment to get the dev build info
@@ -469,8 +459,7 @@ def test_dev_build_rebuild_on_source_changes(
     envdir.mkdir()
     with fs.working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                f"""\
+            f.write(f"""\
 spack:
   specs:
   - {test_spec}@0.0.0
@@ -479,8 +468,7 @@ spack:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
       path: {build_dir}
-"""
-            )
+""")
 
         env("create", "test", "./spack.yaml")
         with ev.read("test"):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -655,14 +655,12 @@ def test_env_install_two_specs_same_dep(
 
     with fs.working_dir(str(tmp_path)):
         with open(str(path), "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs:
   - pkg-a
   - depb
-"""
-            )
+""")
 
         env("create", "test", "spack.yaml")
 
@@ -914,28 +912,24 @@ def test_env_repo():
 
 def test_user_removed_spec(environment_from_manifest):
     """Ensure a user can remove from any position in the spack.yaml file."""
-    before = environment_from_manifest(
-        """\
+    before = environment_from_manifest("""\
 spack:
   specs:
   - mpileaks
   - hypre
   - libelf
-"""
-    )
+""")
     before.concretize()
     before.write()
 
     # user modifies yaml externally to spack and removes hypre
     with open(before.manifest_path, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   specs:
   - mpileaks
   - libelf
-"""
-        )
+""")
 
     after = ev.read("test")
     after.concretize()
@@ -952,8 +946,7 @@ def test_lockfile_spliced_specs(environment_from_manifest, install_mockery):
     zmpi = spack.concretize.concretize_one("zmpi")
     PackageInstaller([zmpi.package], fake=True).install()
 
-    e1 = environment_from_manifest(
-        f"""
+    e1 = environment_from_manifest(f"""
 spack:
   specs:
   - mpileaks
@@ -962,8 +955,7 @@ spack:
       explicit:
       - target: mpi
         replacement: zmpi/{zmpi.dag_hash()}
-"""
-    )
+""")
     with e1:
         e1.concretize()
         e1.write()
@@ -980,15 +972,13 @@ spack:
 
 def test_init_from_lockfile(environment_from_manifest):
     """Test that an environment can be instantiated from a lockfile."""
-    e1 = environment_from_manifest(
-        """
+    e1 = environment_from_manifest("""
 spack:
   specs:
   - mpileaks
   - hypre
   - libelf
-"""
-    )
+""")
     e1.concretize()
     e1.write()
 
@@ -1005,15 +995,13 @@ spack:
 
 def test_init_from_yaml(environment_from_manifest):
     """Test that an environment can be instantiated from a lockfile."""
-    e1 = environment_from_manifest(
-        """
+    e1 = environment_from_manifest("""
 spack:
   specs:
   - mpileaks
   - hypre
   - libelf
-"""
-    )
+""")
     e1.concretize()
     e1.write()
 
@@ -1029,15 +1017,13 @@ spack:
 @pytest.mark.parametrize("use_name", (True, False))
 def test_init_from_env(use_name, environment_from_manifest):
     """Test that an environment can be instantiated from an environment dir"""
-    e1 = environment_from_manifest(
-        """
+    e1 = environment_from_manifest("""
 spack:
   specs:
   - mpileaks
   - hypre
   - libelf
-"""
-    )
+""")
 
     with e1:
         # Test that relative paths in the env are not rewritten
@@ -1140,27 +1126,21 @@ def test_env_view_external_prefix(tmp_path: pathlib.Path, mutable_database, mock
     manifest_dir = tmp_path / "environment"
     manifest_dir.mkdir(parents=True, exist_ok=False)
     manifest_file = manifest_dir / ev.manifest_name
-    manifest_file.write_text(
-        """\
+    manifest_file.write_text("""\
 spack:
   specs:
   - pkg-a
   view: true
-"""
-    )
+""")
 
-    external_config = io.StringIO(
-        """\
+    external_config = io.StringIO("""\
 packages:
   pkg-a:
     externals:
     - spec: pkg-a@2.0
       prefix: {a_prefix}
     buildable: false
-""".format(
-            a_prefix=str(fake_prefix)
-        )
-    )
+""".format(a_prefix=str(fake_prefix)))
     external_config_dict = spack.util.spack_yaml.load_config(external_config)
 
     test_scope = spack.config.InternalConfigScope("env-external-test", data=external_config_dict)
@@ -1188,13 +1168,11 @@ def test_init_with_file_and_remove(tmp_path: pathlib.Path, monkeypatch):
 
     with fs.working_dir(str(tmp_path)):
         with open(str(path), "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs:
   - mpileaks
-"""
-            )
+""")
 
         env("create", "test", "spack.yaml")
 
@@ -1211,16 +1189,14 @@ spack:
 
 
 def test_env_with_config(environment_from_manifest):
-    e = environment_from_manifest(
-        """
+    e = environment_from_manifest("""
 spack:
   specs:
   - mpileaks
   packages:
     mpileaks:
       version: ["2.2"]
-"""
-    )
+""")
     with e:
         e.concretize()
 
@@ -1233,13 +1209,11 @@ def test_with_config_bad_include_create(environment_from_manifest):
     """Confirm missing required include raises expected exception."""
     err = "does not exist"
     with pytest.raises(ValueError, match=err):
-        environment_from_manifest(
-            """
+        environment_from_manifest("""
 spack:
   include:
   - /no/such/directory
-"""
-        )
+""")
 
 
 def test_with_config_bad_include_activate(environment_from_manifest, tmp_path: pathlib.Path):
@@ -1249,13 +1223,11 @@ def test_with_config_bad_include_activate(environment_from_manifest, tmp_path: p
     include1.touch()
 
     spack_yaml = env_root / ev.manifest_name
-    spack_yaml.write_text(
-        """
+    spack_yaml.write_text("""
 spack:
   include:
   - ./include1.yaml
-"""
-    )
+""")
 
     with ev.Environment(env_root) as e:
         e.concretize()
@@ -1276,27 +1248,22 @@ def test_env_with_include_config_files_same_basename(
     file1 = tmp_path / "path" / "to" / "included-config.yaml"
     file1.parent.mkdir(parents=True, exist_ok=True)
     with open(file1, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
         packages:
           libelf:
               version: ["0.8.10"]
-        """
-        )
+        """)
 
     file2 = tmp_path / "second" / "path" / "included-config.yaml"
     file2.parent.mkdir(parents=True, exist_ok=True)
     with open(file2, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
         packages:
           mpileaks:
               version: ["2.2"]
-        """
-        )
+        """)
 
-    e = environment_from_manifest(
-        f"""
+    e = environment_from_manifest(f"""
 spack:
   include:
   - {file1}
@@ -1304,8 +1271,7 @@ spack:
   specs:
   - libelf
   - mpileaks
-"""
-    )
+""")
 
     with e:
         e.concretize()
@@ -1343,9 +1309,7 @@ spack:
   - {0}
   specs:
   - mpileaks
-""".format(
-        include_path
-    )
+""".format(include_path)
 
 
 def test_env_with_included_config_file(mutable_mock_env_path, packages_file):
@@ -1359,15 +1323,13 @@ def test_env_with_included_config_file(mutable_mock_env_path, packages_file):
     shutil.move(str(packages_file), included_path)
 
     spack_yaml = env_root / ev.manifest_name
-    spack_yaml.write_text(
-        f"""\
+    spack_yaml.write_text(f"""\
 spack:
   include:
   - {os.path.join(".", include_filename)}
   specs:
   - mpileaks
-"""
-    )
+""")
 
     e = ev.Environment(env_root)
     with e:
@@ -1390,8 +1352,7 @@ def test_config_change_existing(
     included_file = "included-packages.yaml"
     included_path = env_path / included_file
     with open(included_path, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 packages:
   mpich:
     require:
@@ -1401,12 +1362,10 @@ packages:
   bowtie:
     require:
     - one_of: ["@1.3.0", "@1.2.0"]
-"""
-        )
+""")
 
     spack_yaml = env_path / ev.manifest_name
-    spack_yaml.write_text(
-        f"""\
+    spack_yaml.write_text(f"""\
 spack:
   packages:
     mpich:
@@ -1415,8 +1374,7 @@ spack:
   include:
   - {os.path.join(".", included_file)}
   specs: []
-"""
-    )
+""")
 
     mutable_config.set("config:misc_cache", str(tmp_path / "cache"))
     e = ev.Environment(env_path)
@@ -1466,12 +1424,10 @@ def test_config_change_new(
     mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mutable_config
 ):
     spack_yaml = tmp_path / ev.manifest_name
-    spack_yaml.write_text(
-        """\
+    spack_yaml.write_text("""\
 spack:
   specs: []
-"""
-    )
+""")
 
     with ev.Environment(tmp_path):
         config("change", "packages:mpich:require:~debug")
@@ -1481,15 +1437,13 @@ spack:
 
     # Now check that we raise an error if we need to add a require: constraint
     # when preexisting config manually specified it as a singular spec
-    spack_yaml.write_text(
-        """\
+    spack_yaml.write_text("""\
 spack:
   specs: []
   packages:
     mpich:
       require: "@3.0.3"
-"""
-    )
+""")
     with ev.Environment(tmp_path):
         assert spack.concretize.concretize_one("mpich").satisfies("@3.0.3")
         with pytest.raises(spack.error.ConfigError, match="not a list"):
@@ -1574,19 +1528,16 @@ def test_env_with_included_config_precedence(tmp_path: pathlib.Path):
     included_file = "included-packages.yaml"
     included_path = tmp_path / included_file
     with open(included_path, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 packages:
   mpileaks:
     version: ["2.2"]
   libelf:
     version: ["0.8.10"]
-"""
-        )
+""")
 
     spack_yaml = tmp_path / ev.manifest_name
-    spack_yaml.write_text(
-        f"""\
+    spack_yaml.write_text(f"""\
 spack:
   packages:
     libelf:
@@ -1595,8 +1546,7 @@ spack:
   - {os.path.join(".", included_file)}
   specs:
   - mpileaks
-"""
-    )
+""")
 
     e = ev.Environment(tmp_path)
     with e:
@@ -1618,36 +1568,30 @@ def test_env_with_included_configs_precedence(tmp_path: pathlib.Path):
     file2 = "low-config.yaml"
 
     spack_yaml = tmp_path / ev.manifest_name
-    spack_yaml.write_text(
-        f"""\
+    spack_yaml.write_text(f"""\
 spack:
   include:
   - {os.path.join(".", file1)} # this one should take precedence
   - {os.path.join(".", file2)}
   specs:
   - mpileaks
-"""
-    )
+""")
 
     with open(tmp_path / file1, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 packages:
   libelf:
     version: ["0.8.10"]  # this should override libelf version below
-"""
-        )
+""")
 
     with open(tmp_path / file2, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 packages:
   mpileaks:
     version: ["2.2"]
   libelf:
     version: ["0.8.12"]
-"""
-        )
+""")
 
     e = ev.Environment(tmp_path)
     with e:
@@ -1669,11 +1613,9 @@ def test_bad_env_yaml_format_remove(mutable_mock_env_path):
     env("create", badenv)
     filename = mutable_mock_env_path / "spack.yaml"
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
     - mpileaks
-"""
-        )
+""")
 
     assert badenv in env("list")
     env("remove", "-y", badenv)
@@ -1743,11 +1685,9 @@ def test_multi_env_remove(mutable_mock_env_path, monkeypatch, answer):
 
     # Ensure the bad environment contains invalid yaml
     filename = mutable_mock_env_path / environments[1] / ev.manifest_name
-    filename.write_text(
-        """\
+    filename.write_text("""\
     - libdwarf
-"""
-    )
+""")
 
     assert all(e in env("list") for e in environments)
 
@@ -2441,13 +2381,11 @@ def test_env_config_view_default(
     environment_from_manifest, mock_stage, mock_fetch, install_mockery
 ):
     # This config doesn't mention whether a view is enabled
-    environment_from_manifest(
-        """
+    environment_from_manifest("""
 spack:
   specs:
   - mpileaks
-"""
-    )
+""")
 
     with ev.read("test"):
         install("--fake")
@@ -2560,15 +2498,13 @@ def test_env_activate_view_fails(mock_stage, mock_fetch, install_mockery):
 def test_stack_yaml_definitions(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [mpileaks, callpath]
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         test = ev.read("test")
@@ -2580,8 +2516,7 @@ spack:
 def test_stack_yaml_definitions_as_constraints(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [mpileaks, callpath]
@@ -2590,8 +2525,7 @@ spack:
     - matrix:
       - [$packages]
       - [$^mpis]
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         test = ev.read("test")
@@ -2605,8 +2539,7 @@ spack:
 def test_stack_yaml_definitions_as_constraints_on_matrix(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [mpileaks, callpath]
@@ -2618,8 +2551,7 @@ spack:
     - matrix:
       - [$packages]
       - [$^mpis]
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         test = ev.read("test")
@@ -2634,16 +2566,14 @@ spack:
 def test_stack_yaml_definitions_write_reference(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [mpileaks, callpath]
     - indirect: [$packages]
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
 
@@ -2658,15 +2588,13 @@ spack:
 def test_stack_yaml_add_to_list(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [mpileaks, callpath]
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
@@ -2682,15 +2610,13 @@ spack:
 def test_stack_yaml_remove_from_list(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [mpileaks, callpath]
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
@@ -2704,8 +2630,7 @@ spack:
 
 def test_stack_yaml_remove_from_list_force(tmp_path: pathlib.Path):
     spack_yaml = tmp_path / ev.manifest_name
-    spack_yaml.write_text(
-        """\
+    spack_yaml.write_text("""\
 spack:
   definitions:
     - packages: [mpileaks, callpath]
@@ -2713,8 +2638,7 @@ spack:
     - matrix:
         - [$packages]
         - [^mpich, ^zmpi]
-"""
-    )
+""")
 
     env("create", "test", str(spack_yaml))
     with ev.read("test"):
@@ -2733,8 +2657,7 @@ spack:
 def test_stack_yaml_remove_from_matrix_no_effect(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages:
@@ -2743,8 +2666,7 @@ spack:
             - [target=default_target]
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         with ev.read("test") as e:
@@ -2758,8 +2680,7 @@ spack:
 def test_stack_yaml_force_remove_from_matrix(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages:
@@ -2768,8 +2689,7 @@ spack:
             - [target=default_target]
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         with ev.read("test") as e:
@@ -2793,16 +2713,14 @@ spack:
 def test_stack_definition_extension(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [libelf, mpileaks]
     - packages: [callpath]
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
 
@@ -2816,8 +2734,7 @@ spack:
 def test_stack_definition_conditional_false(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [libelf, mpileaks]
@@ -2825,8 +2742,7 @@ spack:
       when: 'False'
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
 
@@ -2840,8 +2756,7 @@ spack:
 def test_stack_definition_conditional_true(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [libelf, mpileaks]
@@ -2849,8 +2764,7 @@ spack:
       when: 'True'
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
 
@@ -2864,8 +2778,7 @@ spack:
 def test_stack_definition_conditional_with_variable(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [libelf, mpileaks]
@@ -2873,8 +2786,7 @@ spack:
       when: platform == 'test'
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
 
@@ -2888,8 +2800,7 @@ spack:
 def test_stack_definition_conditional_with_satisfaction(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [libelf, mpileaks]
@@ -2898,8 +2809,7 @@ spack:
       when: arch.satisfies('platform=test')
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
 
@@ -2913,8 +2823,7 @@ spack:
 def test_stack_definition_complex_conditional(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [libelf, mpileaks]
@@ -2922,8 +2831,7 @@ spack:
       when: re.search(r'foo', hostname) and env['test'] == 'THISSHOULDBEFALSE'
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
 
@@ -2937,8 +2845,7 @@ spack:
 def test_stack_definition_conditional_invalid_variable(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [libelf, mpileaks]
@@ -2946,8 +2853,7 @@ spack:
       when: bad_variable == 'test'
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         with pytest.raises(NameError):
             env("create", "test", "./spack.yaml")
@@ -2956,8 +2862,7 @@ spack:
 def test_stack_definition_conditional_add_write(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   definitions:
     - packages: [libelf, mpileaks]
@@ -2965,8 +2870,7 @@ spack:
       when: platform == 'test'
   specs:
     - $packages
-"""
-        )
+""")
     with fs.working_dir(str(tmp_path)):
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
@@ -3028,11 +2932,9 @@ def test_stack_view_select_and_exclude(
     installed_environment, template_combinatorial_env, tmp_path: pathlib.Path
 ):
     view_dir = tmp_path / "view"
-    content = template_combinatorial_env.format(
-        view_config="""select: ['target=x86_64']
+    content = template_combinatorial_env.format(view_config="""select: ['target=x86_64']
           exclude: [callpath]
-"""
-    )
+""")
     with installed_environment(content) as test:
         for spec in traverse_nodes(test.concrete_roots(), deptype=("link", "run")):
             if spec.name == "gcc-runtime":
@@ -3047,12 +2949,10 @@ def test_view_link_roots(
     installed_environment, template_combinatorial_env, tmp_path: pathlib.Path
 ):
     view_dir = tmp_path / "view"
-    content = template_combinatorial_env.format(
-        view_config="""select: ['target=x86_64']
+    content = template_combinatorial_env.format(view_config="""select: ['target=x86_64']
           exclude: [callpath]
           link: 'roots'
-    """
-    )
+    """)
     with installed_environment(content) as test:
         for spec in traverse_nodes(test.concrete_roots(), deptype=("link", "run")):
             if spec.name == "gcc-runtime":
@@ -3071,8 +2971,7 @@ def test_view_link_run(
     viewdir = str(tmp_path / "view")
     envdir = str(tmp_path)
     with open(yaml, "w", encoding="utf-8") as f:
-        f.write(
-            """
+        f.write("""
 spack:
   specs:
   - dttop
@@ -3082,9 +2981,7 @@ spack:
       root: %s
       link: run
       projections:
-        all: '{name}'"""
-            % viewdir
-        )
+        all: '{name}'""" % viewdir)
 
     with ev.Environment(envdir):
         install("--fake")
@@ -3109,16 +3006,14 @@ spack:
 @pytest.mark.parametrize("link_type", ["hardlink", "copy", "symlink"])
 def test_view_link_type(link_type, installed_environment, tmp_path: pathlib.Path):
     view_dir = tmp_path / "view"
-    with installed_environment(
-        f"""\
+    with installed_environment(f"""\
 spack:
   specs:
     - mpileaks
   view:
     default:
       root: {view_dir}
-      link_type: {link_type}"""
-    ) as test:
+      link_type: {link_type}""") as test:
         for spec in test.roots():
             # Assertions are based on the behavior of the "--fake" install
             bin_file = pathlib.Path(test.default_view.view()._root) / "bin" / spec.name
@@ -3128,12 +3023,10 @@ spack:
 
 def test_view_link_all(installed_environment, template_combinatorial_env, tmp_path: pathlib.Path):
     view_dir = tmp_path / "view"
-    content = template_combinatorial_env.format(
-        view_config="""select: ['target=x86_64']
+    content = template_combinatorial_env.format(view_config="""select: ['target=x86_64']
           exclude: [callpath]
           link: 'all'
-    """
-    )
+    """)
 
     with installed_environment(content) as test:
         for spec in traverse_nodes(test.concrete_roots(), deptype=("link", "run")):
@@ -3163,16 +3056,13 @@ def test_envvar_set_in_activate(tmp_path: pathlib.Path, mock_packages, install_m
     spack_yaml = tmp_path / "spack.yaml"
     env_vars_yaml = tmp_path / "env_vars.yaml"
 
-    env_vars_yaml.write_text(
-        """
+    env_vars_yaml.write_text("""
 env_vars:
   set:
     CONFIG_ENVAR_SET_IN_ENV_LOAD: "True"
-"""
-    )
+""")
 
-    spack_yaml.write_text(
-        """
+    spack_yaml.write_text("""
 spack:
   include:
   - env_vars.yaml
@@ -3181,8 +3071,7 @@ spack:
   env_vars:
     set:
       SPACK_ENVAR_SET_IN_ENV_LOAD: "True"
-"""
-    )
+""")
 
     env("create", "test", str(spack_yaml))
     with ev.read("test"):
@@ -3341,16 +3230,14 @@ def test_env_activate_custom_view(tmp_path: pathlib.Path, mock_packages):
     default_dir = tmp_path / "defaultdir"
     nondefaultdir = tmp_path / "nondefaultdir"
     with open(env_template, "w", encoding="utf-8") as f:
-        f.write(
-            f"""\
+        f.write(f"""\
 spack:
   specs: [a]
   view:
     default:
       root: {default_dir}
     nondefault:
-      root: {nondefaultdir}"""
-        )
+      root: {nondefaultdir}""")
     env("create", "test", str(env_template))
     shell = env("activate", "--sh", "--with-view", "nondefault", "test")
     assert os.path.join(nondefaultdir, "bin") in shell
@@ -3612,8 +3499,7 @@ def test_custom_version_concretize_together(mutable_config):
 
 
 def test_modules_relative_to_views(environment_from_manifest, install_mockery, mock_fetch):
-    environment_from_manifest(
-        """
+    environment_from_manifest("""
 spack:
   specs:
   - trivial-install-test-package
@@ -3623,8 +3509,7 @@ spack:
       use_view: true
       roots:
         tcl: modules
-"""
-    )
+""")
 
     with ev.read("test") as e:
         install("--fake")
@@ -3646,8 +3531,7 @@ spack:
 def test_modules_exist_after_env_install(installed_environment, monkeypatch):
     # Some caching issue
     monkeypatch.setattr(spack.modules.tcl, "configuration_registry", {})
-    with installed_environment(
-        """
+    with installed_environment("""
 spack:
   specs:
   - mpileaks
@@ -3661,8 +3545,7 @@ spack:
       enable:: [tcl]
       roots:
         tcl: without_view
-"""
-    ) as e:
+""") as e:
         specs = e.all_specs()
         for module_set in ("uses_view", "without_view"):
             modules = glob.glob(f"{e.path}/{module_set}/**/*/*")
@@ -3694,13 +3577,11 @@ def test_install_develop_keep_stage(
     """Develop a dependency of a package and make sure that the associated
     stage for the package is retained after a successful install.
     """
-    environment_from_manifest(
-        """
+    environment_from_manifest("""
 spack:
   specs:
   - mpileaks
-"""
-    )
+""")
 
     monkeypatch.setattr(spack.stage.DevelopStage, "destroy", _always_fail)
 
@@ -3767,18 +3648,14 @@ def test_activation_and_deactivation_ambiguities(method, env, no_env, env_dir, c
 def test_custom_store_in_environment(mutable_config, tmp_path: pathlib.Path):
     spack_yaml = tmp_path / "spack.yaml"
     install_root = tmp_path / "store"
-    spack_yaml.write_text(
-        """
+    spack_yaml.write_text("""
 spack:
   specs:
   - libelf
   config:
     install_tree:
       root: {0}
-""".format(
-            install_root
-        )
-    )
+""".format(install_root))
     current_store_root = str(spack.store.STORE.root)
     assert str(current_store_root) != str(install_root)
     with ev.Environment(str(tmp_path)):
@@ -4323,8 +4200,7 @@ def test_spack_package_ids_variable(tmp_path: pathlib.Path, mock_packages):
 
     # Include in Makefile and create target that depend on SPACK_PACKAGE_IDS
     with open(makefile_path, "w", encoding="utf-8") as f:
-        f.write(
-            """
+        f.write("""
 all: post-install
 
 include include.mk
@@ -4333,8 +4209,7 @@ example/post-install/%: example/install/%
 \t$(info post-install: $(HASH)) # noqa: W191,E101
 
 post-install: $(addprefix example/post-install/,$(example/SPACK_PACKAGE_IDS))
-"""
-        )
+""")
     make = Executable("make")
 
     # Do dry run.
@@ -4389,14 +4264,12 @@ def test_env_include_packages_url(
     sha256 = "8d428c600b215e3b4a207a08236659dfc2c9ae2782c35943a00ee4204a135702"
     spack_yaml = tmp_path / "spack.yaml"
     with open(spack_yaml, "w", encoding="utf-8") as f:
-        f.write(
-            f"""\
+        f.write(f"""\
 spack:
   include:
   - path: {default_packages}
     sha256: {sha256}
-"""
-        )
+""")
 
     with spack.config.override("config:url_fetch_method", "curl"):
         env = ev.Environment(str(tmp_path))
@@ -4456,14 +4329,12 @@ def test_env_view_disabled(tmp_path: pathlib.Path, mutable_mock_env_path):
     """Ensure an inlined view being disabled means not even the default view
     is created (since the case doesn't appear to be covered in this module)."""
     spack_yaml = tmp_path / ev.manifest_name
-    spack_yaml.write_text(
-        """\
+    spack_yaml.write_text("""\
 spack:
   specs:
   - mpileaks
   view: false
-"""
-    )
+""")
     env("create", "disabled", str(spack_yaml))
     with ev.read("disabled") as e:
         e.concretize()
@@ -4487,13 +4358,11 @@ def test_env_include_mixed_views(
     custom_name = "my-test-view"
     custom_view = tmp_path / custom_name
     custom_yaml = tmp_path / "custom-view.yaml"
-    custom_yaml.write_text(
-        f"""
+    custom_yaml.write_text(f"""
 view:
   {custom_name}:
     root: {custom_view}
-"""
-    )
+""")
 
     if first == "false":
         order = [false_yaml, true_yaml, custom_yaml]
@@ -4504,15 +4373,13 @@ view:
     includes = [f"  - {yaml}\n" for yaml in order]
 
     spack_yaml = tmp_path / ev.manifest_name
-    spack_yaml.write_text(
-        f"""\
+    spack_yaml.write_text(f"""\
 spack:
   include:
 {''.join(includes)}
   specs:
   - mpileaks
-"""
-    )
+""")
 
     env("create", "test", str(spack_yaml))
     with ev.read("test") as e:
@@ -4551,8 +4418,7 @@ view:
     view_filename.write_text(default_view)
 
     view_dir = tmp_path / "view"
-    with installed_environment(
-        f"""\
+    with installed_environment(f"""\
 spack:
   include:
   - {view_filename}
@@ -4571,8 +4437,7 @@ spack:
       exclude: ['cmake']
       projections:
         all: '{{architecture.target}}/{{name}}-{{version}}'
-"""
-    ) as e:
+""") as e:
         # the view root in the included view should NOT exist
         assert not os.path.exists(str(default_dir))
 
@@ -4639,13 +4504,11 @@ def test_env_view_ignores_different_file_conflicts(
 
 @pytest.mark.regression("51054")
 def test_non_str_repos(installed_environment):
-    with installed_environment(
-        """\
+    with installed_environment("""\
 spack:
   repos:
     builtin:
-      branch: develop"""
-    ):
+      branch: develop"""):
         pass
 
 
@@ -4690,8 +4553,7 @@ def test_concretized_specs_and_include_concrete(mutable_config):
 def test_view_can_select_group_of_specs(installed_environment, tmp_path: pathlib.Path):
     """Tests that we can select groups of specs in a view and exclude other groups"""
     view_dir = tmp_path / "view"
-    with installed_environment(
-        f"""\
+    with installed_environment(f"""\
 spack:
   specs:
     - group: apps1
@@ -4707,8 +4569,7 @@ spack:
     default:
       root: {view_dir}
       group: [apps1, apps2]
-"""
-    ) as test:
+""") as test:
         for item in test.concretized_roots:
             # Assertions are based on the behavior of the "--fake" install
             bin_file = pathlib.Path(test.default_view.view()._root) / "bin" / item.root.name
@@ -4720,8 +4581,7 @@ def test_view_can_select_group_of_specs_using_string(
 ):
     """Tests that we can select groups of specs in a view and exclude other groups"""
     view_dir = tmp_path / "view"
-    with installed_environment(
-        f"""\
+    with installed_environment(f"""\
 spack:
   specs:
     - group: apps1
@@ -4734,8 +4594,7 @@ spack:
     default:
       root: {view_dir}
       group: apps1
-"""
-    ) as test:
+""") as test:
         for item in test.concretized_roots:
             # Assertions are based on the behavior of the "--fake" install
             bin_file = pathlib.Path(test.default_view.view()._root) / "bin" / item.root.name
@@ -4749,14 +4608,12 @@ def test_env_include_concrete_only(tmp_path, mock_packages, mutable_config):
     include_dir = tmp_path / "includes"
     include_dir.mkdir()
     include_manifest = include_dir / ev.manifest_name
-    include_manifest.write_text(
-        f"""\
+    include_manifest.write_text(f"""\
 spack:
   specs:
   - {specs[0]}
   - {specs[1]}
-"""
-    )
+""")
     include_env = ev.create("test_include", include_manifest)
     include_env.concretize()
     include_env.write()
@@ -4765,13 +4622,11 @@ spack:
     assert os.path.exists(include_lockfile)
 
     manifest_file = tmp_path / ev.manifest_name
-    manifest_file.write_text(
-        f"""\
+    manifest_file.write_text(f"""\
 spack:
   include:
   - {str(include_lockfile)}
-"""
-    )
+""")
     e = ev.create("test", manifest_file)
 
     # Confirm the only specs the environment has are those loaded from the
@@ -4805,13 +4660,11 @@ def test_include_concrete_deprecation_warning(
     tmp_path: pathlib.Path, environment_from_manifest, capfd
 ):
     try:
-        environment_from_manifest(
-            """\
+        environment_from_manifest("""\
 spack:
   include_concrete:
   - /path/to/some/environment
-"""
-        )
+""")
     except ev.SpackEnvironmentError:
         pass
 
@@ -4826,13 +4679,11 @@ def test_env_include_concrete_relative_path(tmp_path, mock_packages, mutable_con
     # Create and concretize the included environment.
     include_dir = tmp_path / "include_env"
     include_dir.mkdir()
-    (include_dir / ev.manifest_name).write_text(
-        """\
+    (include_dir / ev.manifest_name).write_text("""\
 spack:
   specs:
   - libdwarf
-"""
-    )
+""")
     with ev.Environment(str(include_dir)) as e:
         e.concretize()
         e.write()
@@ -4842,13 +4693,11 @@ spack:
     main_dir = tmp_path / "main_env"
     main_dir.mkdir()
     relative_lockfile = f"../include_env/{ev.lockfile_name}"
-    (main_dir / ev.manifest_name).write_text(
-        f"""\
+    (main_dir / ev.manifest_name).write_text(f"""\
 spack:
   include:
   - {relative_lockfile}
-"""
-    )
+""")
     with ev.Environment(str(main_dir)) as e:
         e.concretize()
         e.write()
@@ -4863,13 +4712,11 @@ def test_env_include_concrete_git_lockfile(tmp_path, mock_packages, mutable_conf
     # Create and concretize the included environment.
     include_dir = tmp_path / "include_env"
     include_dir.mkdir()
-    (include_dir / ev.manifest_name).write_text(
-        """\
+    (include_dir / ev.manifest_name).write_text("""\
 spack:
   specs:
   - libdwarf
-"""
-    )
+""")
     with ev.Environment(str(include_dir)) as e:
         e.concretize()
         e.write()
@@ -4889,16 +4736,14 @@ spack:
 
     main_dir = tmp_path / "main_env"
     main_dir.mkdir()
-    (main_dir / ev.manifest_name).write_text(
-        f"""\
+    (main_dir / ev.manifest_name).write_text(f"""\
 spack:
   include:
   - git: https://example.com/configs.git
     branch: main
     paths:
     - {lock_subpath}
-"""
-    )
+""")
     with ev.Environment(str(main_dir)) as e:
         e.concretize()
         e.write()

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -135,12 +135,10 @@ def test_namespaces_shown_correctly(args, with_namespace, database):
 
 @pytest.mark.db
 def test_find_cli_output_format(database, mock_tty_stdout):
-    assert find("zmpi").endswith(
-        """\
+    assert find("zmpi").endswith("""\
 zmpi@1.0
 ==> 1 installed package
-"""
-    )
+""")
 
 
 def _check_json_output(spec_list):
@@ -249,9 +247,7 @@ def test_find_format(database, config):
 @pytest.mark.db
 def test_find_format_deps(database, config):
     output = find("-d", "--format", "{name}-{version}", "mpileaks", "^zmpi")
-    assert (
-        output
-        == """\
+    assert output == """\
 mpileaks-2.3
     callpath-1.0
         dyninst-8.2
@@ -264,16 +260,13 @@ mpileaks-2.3
         fake-1.0
 
 """
-    )
 
 
 @pytest.mark.db
 def test_find_format_deps_paths(database, config):
     output = find("-dp", "--format", "{name}-{version}", "mpileaks", "^zmpi")
     mpileaks = spack.concretize.concretize_one("mpileaks ^zmpi")
-    assert (
-        output
-        == f"""\
+    assert output == f"""\
 mpileaks-2.3                   {mpileaks.prefix}
     callpath-1.0               {mpileaks['callpath'].prefix}
         dyninst-8.2            {mpileaks['dyninst'].prefix}
@@ -286,7 +279,6 @@ mpileaks-2.3                   {mpileaks.prefix}
         fake-1.0               {mpileaks['fake'].prefix}
 
 """
-    )
 
 
 @pytest.mark.db
@@ -347,13 +339,11 @@ def test_find_specs_include_concrete_env(
 
     with working_dir(str(tmp_path)):
         with open(str(path), "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs:
   - mpileaks
-"""
-            )
+""")
         env("create", "test1", "spack.yaml")
 
     test1 = ev.read("test1")
@@ -362,13 +352,11 @@ spack:
 
     with working_dir(str(tmp_path)):
         with open(str(path), "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs:
   - libelf
-"""
-            )
+""")
         env("create", "test2", "spack.yaml")
 
     test2 = ev.read("test2")
@@ -393,13 +381,11 @@ def test_find_specs_nested_include_concrete_env(
 
     with working_dir(str(tmp_path)):
         with open(str(path), "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs:
   - mpileaks
-"""
-            )
+""")
         env("create", "test1", "spack.yaml")
 
     test1 = ev.read("test1")

--- a/lib/spack/spack/test/cmd/license.py
+++ b/lib/spack/spack/test/cmd/license.py
@@ -33,18 +33,15 @@ def test_verify(tmp_path: pathlib.Path):
 
     lgpl_header = source_dir / "lgpl_header.py"
     with lgpl_header.open("w") as f:
-        f.write(
-            """\
+        f.write("""\
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: LGPL-2.1-only
-"""
-        )
+""")
 
     not_in_first_n_lines = source_dir / "not_in_first_n_lines.py"
     with not_in_first_n_lines.open("w") as f:
-        f.write(
-            """\
+        f.write("""\
 #
 #
 #
@@ -53,18 +50,15 @@ def test_verify(tmp_path: pathlib.Path):
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-"""
-        )
+""")
 
     correct_header = source_dir / "correct_header.py"
     with correct_header.open("w") as f:
-        f.write(
-            """\
+        f.write("""\
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""
-        )
+""")
 
     out = license("--root", str(tmp_path), "verify", fail_on_error=False)
 

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -26,13 +26,10 @@ def test_list():
 
 
 def test_list_cli_output_format(mock_tty_stdout):
-    assert (
-        list("mpileaks")
-        == """\
+    assert list("mpileaks") == """\
 mpileaks
 ==> 1 packages
 """
-    )
 
 
 def test_list_filter():
@@ -113,14 +110,12 @@ def test_list_format_local_repo(tmp_path: pathlib.Path):
     (repo_root / "repo.yaml").write_text("repo:\n  namespace: builtin\n  api: v2.2\n")
     package_root = repo_root / "packages" / pkg_name
     package_root.mkdir(parents=True)
-    (package_root / "package.py").write_text(
-        """\
+    (package_root / "package.py").write_text("""\
 from spack.package import *
 
 class Mypkg(Package):
     pass
-"""
-    )
+""")
 
     test_repo = spack.repo.from_path(str(repo_root))
     with spack.repo.use_repositories(test_repo):
@@ -139,14 +134,12 @@ def test_list_format_non_github_repo(tmp_path: pathlib.Path, mock_util_executabl
     package_root = repo_root / "packages" / pkg_name
     package_root.mkdir(parents=True)
     package_path = package_root / "package.py"
-    package_path.write_text(
-        """\
+    package_path.write_text("""\
 from spack.package import *
 
 class Mypkg(Package):
     pass
-"""
-    )
+""")
 
     test_repo = spack.repo.from_path(str(repo_root))
     with spack.repo.use_repositories(test_repo):

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -20,7 +20,7 @@ location = SpackCommand("location")
 def test_manpath_trailing_colon(
     install_mockery, mock_fetch, mock_archive, mock_packages, working_env
 ):
-    (shell, set_command, commandsep) = (
+    shell, set_command, commandsep = (
         ("--bat", 'set "%s=%s"', "\n")
         if sys.platform == "win32"
         else ("--sh", "export %s=%s", ";")

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -94,15 +94,13 @@ def test_env_repo_path_vars_substitution(
     envdir.mkdir()
     with working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs: []
 
   repos:
     current_dir: $CUSTOM_REPO_PATH
-"""
-            )
+""")
         # creating env from manifest file
         env("create", "test", "./spack.yaml")
         # check that repo path was correctly substituted with the environment variable

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -430,15 +430,12 @@ def test_pkg_imports():
 
 
 def test_spec_strings(tmp_path: pathlib.Path):
-    (tmp_path / "example.py").write_text(
-        """\
+    (tmp_path / "example.py").write_text("""\
 def func(x):
     print("dont fix %s me" % x, 3)
     return x.satisfies("+foo %gcc +bar") and x.satisfies("%gcc +baz")
-"""
-    )
-    (tmp_path / "example.json").write_text(
-        """\
+""")
+    (tmp_path / "example.json").write_text("""\
 {
     "spec": [
         "+foo %gcc +bar~nope   ^dep %clang +yup @3.2 target=x86_64 /abcdef ^another   %gcc   ",
@@ -446,17 +443,14 @@ def func(x):
     ],
     "%gcc x=y": 2
 }
-"""
-    )
-    (tmp_path / "example.yaml").write_text(
-        """\
+""")
+    (tmp_path / "example.yaml").write_text("""\
 spec:
   - "+foo   %gcc +bar"
   - "%gcc +baz"
   - "this is fine %clang"
 "%gcc x=y": 2
-"""
-    )
+""")
 
     issues = set()
 
@@ -502,9 +496,7 @@ spec:
         handler=spack.cmd.style._spec_str_fix_handler,
     )
 
-    assert (
-        (tmp_path / "example.json").read_text()
-        == """\
+    assert (tmp_path / "example.json").read_text() == """\
 {
     "spec": [
         "+foo +bar~nope %gcc   ^dep +yup @3.2 target=x86_64 /abcdef %clang ^another   %gcc   ",
@@ -513,22 +505,15 @@ spec:
     "x=y %gcc": 2
 }
 """
-    )
-    assert (
-        (tmp_path / "example.py").read_text()
-        == """\
+    assert (tmp_path / "example.py").read_text() == """\
 def func(x):
     print("dont fix %s me" % x, 3)
     return x.satisfies("+foo +bar %gcc") and x.satisfies("+baz %gcc")
 """
-    )
-    assert (
-        (tmp_path / "example.yaml").read_text()
-        == """\
+    assert (tmp_path / "example.yaml").read_text() == """\
 spec:
   - "+foo +bar   %gcc"
   - "+baz %gcc"
   - "this is fine %clang"
 "x=y %gcc": 2
 """
-    )

--- a/lib/spack/spack/test/cmd/undevelop.py
+++ b/lib/spack/spack/test/cmd/undevelop.py
@@ -19,8 +19,7 @@ def test_undevelop(tmp_path: pathlib.Path, mutable_config, mock_packages, mutabl
     envdir.mkdir()
     with working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs:
   - mpich
@@ -29,8 +28,7 @@ spack:
     mpich:
       spec: mpich@1.0
       path: /fake/path
-"""
-            )
+""")
 
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
@@ -51,8 +49,7 @@ def test_undevelop_all(
     envdir.mkdir()
     with working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs:
   - mpich
@@ -61,8 +58,7 @@ spack:
     mpich:
       spec: mpich@1.0
       path: /fake/path
-"""
-            )
+""")
 
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
@@ -83,8 +79,7 @@ def test_undevelop_nonexistent(
     envdir.mkdir()
     with working_dir(str(envdir)):
         with open("spack.yaml", "w", encoding="utf-8") as f:
-            f.write(
-                """\
+            f.write("""\
 spack:
   specs:
   - mpich
@@ -93,8 +88,7 @@ spack:
     mpich:
       spec: mpich@1.0
       path: /fake/path
-"""
-            )
+""")
 
         env("create", "test", "./spack.yaml")
         with ev.read("test") as e:

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -96,8 +96,8 @@ def test_url_list(mock_packages):
 def test_url_summary(mock_packages):
     """Test the URL summary command."""
     # test url_summary, the internal function that does the work
-    (total_urls, correct_names, correct_versions, name_count_dict, version_count_dict) = (
-        url_summary(None)
+    total_urls, correct_names, correct_versions, name_count_dict, version_count_dict = url_summary(
+        None
     )
 
     assert 0 < correct_names <= sum(name_count_dict.values()) <= total_urls

--- a/lib/spack/spack/test/cmd/verify.py
+++ b/lib/spack/spack/test/cmd/verify.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Tests for the `spack verify` command"""
+
 import os
 import pathlib
 import platform

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -143,23 +143,19 @@ def hello(parser, args):
         hello_folks()
     elif args.subcommand == 'global':
         print(global_message)
-""".format(
-                    ext_pname=extension.pname
-                ),
+""".format(ext_pname=extension.pname),
             )
 
             init_file = extension.main / "__init__.py"
             init_file.touch()
             implementation = extension.main / "implementation.py"
-            implementation.write_text(
-                """
+            implementation.write_text("""
 def hello_world():
     print('Hello world!')
 
 def hello_folks():
     print('Hello folks!')
-"""
-            )
+""")
             yield spack.main.SpackCommand("hello")
 
     yield _hwwmir

--- a/lib/spack/spack/test/compilers/conversion.py
+++ b/lib/spack/spack/test/compilers/conversion.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests conversions from compilers.yaml"""
+
 import pathlib
 
 import pytest

--- a/lib/spack/spack/test/compilers/libraries.py
+++ b/lib/spack/spack/test/compilers/libraries.py
@@ -79,13 +79,11 @@ class TestCompilerPropertyDetector:
     @pytest.mark.not_on_windows("Module files are not supported on Windows")
     def test_compile_dummy_c_source_load_env(self, mock_gcc, monkeypatch, tmp_path: pathlib.Path):
         gcc = tmp_path / "gcc"
-        gcc.write_text(
-            f"""#!/bin/sh
+        gcc.write_text(f"""#!/bin/sh
         if [ "$ENV_SET" = "1" ] && [ "$MODULE_LOADED" = "1" ]; then
           printf '{without_flag_output}'
         fi
-        """
-        )
+        """)
         fs.set_executable(str(gcc))
 
         # Set module load to turn compiler on

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -597,8 +597,7 @@ class TestConcretize:
         self, mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mutable_config
     ):
         spack_yaml = tmp_path / ev.manifest_name
-        spack_yaml.write_text(
-            """\
+        spack_yaml.write_text("""\
 spack:
   specs:
   - dt-diamond%gcc
@@ -606,8 +605,7 @@ spack:
   concretizer:
     compiler_mixing: false
     unify: when_possible
-"""
-        )
+""")
 
         with ev.Environment(tmp_path) as e:
             e.concretize()
@@ -3542,8 +3540,7 @@ def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusabl
 @pytest.mark.parametrize("compiler_str", ["gcc@=9.4.0", "gcc@=9.4.0-foo"])
 def test_selecting_compiler_with_suffix(mutable_config, mock_packages, compiler_str):
     """Tests that we can select compilers whose versions differ only for a suffix."""
-    packages_yaml = syaml.load_config(
-        """
+    packages_yaml = syaml.load_config("""
 packages:
   gcc:
     externals:
@@ -3553,8 +3550,7 @@ packages:
         compilers:
           c: /path/bin/gcc
           cxx: /path/bin/g++
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
     s = spack.concretize.concretize_one(f"libelf %{compiler_str}")
     assert s["c"].satisfies(compiler_str)
@@ -3562,8 +3558,7 @@ packages:
 
 def test_duplicate_compiler_in_externals(mutable_config, mock_packages):
     """Tests that having duplicate compilers in packages.yaml do not raise and error."""
-    packages_yaml = syaml.load_config(
-        """
+    packages_yaml = syaml.load_config("""
 packages:
   gcc:
     externals:
@@ -3579,8 +3574,7 @@ packages:
         compilers:
           c: /path/bin/gcc
           cxx: /path/bin/g++
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
     s = spack.concretize.concretize_one("libelf %gcc@9.4")
     assert s["c"].satisfies("gcc@9.4.0")
@@ -3610,16 +3604,14 @@ def test_compiler_attribute_is_tolerated_in_externals(
     """Tests that we don't error out if an external specifies a compiler in the old way,
     provided that a suitable external compiler exists.
     """
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
 packages:
   cmake:
     externals:
     - spec: "cmake@3.27.4 %gcc@10"
       prefix: {tmp_path}
     buildable: false
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
     s = spack.concretize.concretize_one("cmake")
     assert s.external and s.external_path == str(tmp_path)
@@ -3649,8 +3641,7 @@ def test_compiler_match_for_externals_is_taken_into_account(
     spec_str, expected, mutable_config, mock_packages, tmp_path: pathlib.Path
 ):
     """Tests that compiler annotation for externals are somehow taken into account for a match"""
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
 packages:
   libelf:
     externals:
@@ -3658,8 +3649,7 @@ packages:
       prefix: {tmp_path / 'gcc'}
     - spec: "libelf@0.8.13 %clang"
       prefix: {tmp_path / 'clang'}
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
     s = spack.concretize.concretize_one(spec_str)
     libelf = s["libelf"]
@@ -3682,8 +3672,7 @@ def test_compiler_match_for_externals_with_versions(
     """Tests that version constraints are taken into account for compiler annotations
     on externals
     """
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
 packages:
   libelf:
     buildable: false
@@ -3692,8 +3681,7 @@ packages:
       prefix: {tmp_path / 'libelf-gcc10'}
     - spec: "libelf@0.8.13 %gcc@9.4.0"
       prefix: {tmp_path / 'libelf-gcc9'}
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
     s = spack.concretize.concretize_one(spec_str)
     libelf = s["libelf"]
@@ -3788,16 +3776,14 @@ def test_installing_external_with_compilers_directly(
     on externals
     """
     spec_str = f"libelf@0.8.12 %{compiler_str}"
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
 packages:
   libelf:
     buildable: false
     externals:
     - spec: {spec_str}
       prefix: {tmp_path / 'libelf'}
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
     s = spack.concretize.concretize_one(spec_str)
 
@@ -3811,16 +3797,14 @@ def test_using_externals_with_compilers(mutable_config, mock_packages, tmp_path:
     """Tests that version constraints are taken into account for compiler annotations
     on externals, even imposed as transitive deps.
     """
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
 packages:
   libelf:
     buildable: false
     externals:
     - spec: libelf@0.8.12 %gcc@10
       prefix: {tmp_path / 'libelf'}
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
 
     with pytest.raises(spack.error.SpackError):
@@ -3858,8 +3842,7 @@ def test_concrete_multi_valued_variants_in_externals(
     """Tests that concrete multivalued variants in externals cannot be extended with additional
     values when concretizing.
     """
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
 packages:
   gcc:
     buildable: false
@@ -3876,8 +3859,7 @@ packages:
       extra_attributes:
         compilers:
             fortran: {tmp_path / 'gcc-14'}/bin/gfortran
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
 
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
@@ -3899,14 +3881,12 @@ def test_concrete_multi_valued_in_input_specs(default_mock_concretization):
 
 def test_concrete_multi_valued_variants_in_requirements(mutable_config, mock_packages):
     """Tests that concrete multivalued variants can be imposed by requirements."""
-    packages_yaml = syaml.load_config(
-        """
+    packages_yaml = syaml.load_config("""
 packages:
   pkg-a:
     require:
     - libs:=static
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
 
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
@@ -3984,16 +3964,14 @@ def test_spec_parts_on_fresh_compilers(
     are associated with `package` for `%` just as they would be for `^`, when we concretize
     without reusing.
     """
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
     packages:
       llvm::
         buildable: false
         externals:
         - spec: "llvm@20 +clang {constraint_in_yaml}"
           prefix: {tmp_path / 'llvm-20'}
-    """
-    )
+    """)
     mutable_config.set("packages", packages_yaml["packages"])
 
     # Check the abstract spec is formed correctly
@@ -4043,8 +4021,7 @@ def test_spec_parts_on_reused_compilers(
     """Tests that requests of the form <package>%<compiler> <requests> are considered for reused
     specs, even though build dependency are not part of the ASP problem.
     """
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
     packages:
       c:
         require: llvm
@@ -4057,8 +4034,7 @@ def test_spec_parts_on_reused_compilers(
           prefix: {tmp_path / 'llvm-20'}
       mpileaks:
         buildable: true
-    """
-    )
+    """)
     mutable_config.set("packages", packages_yaml["packages"])
 
     # Install the spec
@@ -4219,8 +4195,7 @@ def test_selecting_externals_with_compilers_as_root(mutable_config, mock_package
     """Tests that we can select externals that have a compiler in their spec, even when
     they are root.
     """
-    packages_yaml = syaml.load_config(
-        """
+    packages_yaml = syaml.load_config("""
 packages:
   gcc::
     externals:
@@ -4246,8 +4221,7 @@ packages:
       prefix: /path/mpich/gcc
     - spec: "mpich@3.4.3 %clang"
       prefix: /path/mpich/clang
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
 
     # Select mpich as the root spec
@@ -4280,8 +4254,7 @@ def test_selecting_externals_with_compilers_and_versions(
     """Tests different scenarios of having a compiler specified with a version constraint, either
     in the input spec or in the external spec.
     """
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
 packages:
   gcc:
     externals:
@@ -4298,8 +4271,7 @@ packages:
       prefix: /path/mpich/gcc
     - spec: "mpich@3.4.3 %clang"
       prefix: /path/mpich/clang
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
     s = spack.concretize.concretize_one(spec_str)
     assert s.external
@@ -4321,8 +4293,7 @@ def test_errors_when_specifying_externals_with_compilers(
     external_compiler, spec_str, error_match, mutable_config, mock_packages
 ):
     """Tests different errors that can occur in an external spec with a compiler specified."""
-    packages_yaml = syaml.load_config(
-        f"""
+    packages_yaml = syaml.load_config(f"""
 packages:
   mpich:
     buildable: false
@@ -4331,8 +4302,7 @@ packages:
       prefix: /path/mpich/gcc
     - spec: "mpich@3.4.3 %clang"
       prefix: /path/mpich/clang
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
     with pytest.raises(ExternalDependencyError, match=error_match):
         _ = spack.concretize.concretize_one(spec_str)
@@ -4380,8 +4350,7 @@ def test_reuse_with_mixed_compilers(mutable_config, mock_packages):
     """Tests that potentially reusing a spec with a mixed compiler set, will not interfere
     with a request on one of the languages for the same package.
     """
-    packages_yaml = syaml.load_config(
-        """
+    packages_yaml = syaml.load_config("""
 packages:
   gcc:
     externals:
@@ -4401,8 +4370,7 @@ packages:
           c: /path2/bin/clang
           cxx: /path2/bin/clang++
           fortran: /path2/bin/flang
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
 
     s = spack.concretize.concretize_one("openblas %c=gcc %fortran=llvm")
@@ -4697,8 +4665,7 @@ def test_target_requirements(default_target, expected, mutable_config, mock_pack
     """Tests different scenarios where targets might be constrained by configuration and are not
     specified in external specs
     """
-    configuration = syaml.load_config(
-        f"""
+    configuration = syaml.load_config(f"""
 packages:
   all:
     require:
@@ -4720,8 +4687,7 @@ packages:
     - spec: "mpich@3.0.4"
       prefix: /user/path
       id: mpich_id
-"""
-    )
+""")
     mutable_config.set("packages", configuration["packages"])
     s = spack.concretize.concretize_one("callpath")
     assert s.external
@@ -4819,8 +4785,7 @@ def test_reusing_gcc_same_version_different_libcs(monkeypatch, mutable_config, m
     """Tests that Spack can solve for specs when it reuses 2 GCCs at the same version,
     but injecting different libcs.
     """
-    packages_yaml = syaml.load_config(
-        """
+    packages_yaml = syaml.load_config("""
 packages:
   gcc:
     externals:
@@ -4838,8 +4803,7 @@ packages:
           c: /path/bin/gcc
           cxx: /path/bin/g++
           fortran: /path/bin/gfortran
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
     mutable_config.set("concretizer:reuse", True)
 
@@ -4989,8 +4953,7 @@ def test_compiler_selection_when_external_has_variant_penalty(mutable_config, mo
     """Tests that a compiler that should be preferred is not swapped with a less preferred
     compiler because of penalties on variants.
     """
-    packages_yaml = syaml.load_config(
-        """
+    packages_yaml = syaml.load_config("""
 packages:
   gcc::
     externals:
@@ -5009,8 +4972,7 @@ packages:
         compilers:
           c: /path/bin/gcc
           cxx: /path/bin/g++
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
 
     concrete = spack.concretize.concretize_one("libdwarf")
@@ -5025,15 +4987,13 @@ def test_mpi_selection_when_external_has_variant_penalty(mutable_config, mock_pa
     """Tests that conflicting with a default provider doesn't cause a variant values to be
     flipped to avoid the variant dependency.
     """
-    packages_yaml = syaml.load_config(
-        """
+    packages_yaml = syaml.load_config("""
 packages:
   all:
     variants: +mpi
   mpich:
     buildable: false
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
 
     concrete = spack.concretize.concretize_one("transitive-conditional-virtual-dependency")
@@ -5049,8 +5009,7 @@ def test_preferring_different_compilers_for_different_languages(mutable_config, 
     towards using a unique toolchain is lower priority with respect to flipping variants to turn
     off a language, or selecting a non-default provider.
     """
-    packages_yaml = syaml.load_config(
-        """
+    packages_yaml = syaml.load_config("""
 packages:
   all:
     providers:
@@ -5068,8 +5027,7 @@ packages:
     - gcc
   mpileaks:
     variants: +fortran
-"""
-    )
+""")
     mutable_config.set("packages", packages_yaml["packages"])
 
     mpileaks = spack.concretize.concretize_one("mpileaks")

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -20,8 +20,7 @@ from spack.version import Version
 
 @pytest.fixture()
 def configure_permissions():
-    conf = syaml.load_config(
-        """\
+    conf = syaml.load_config("""\
 all:
   permissions:
     read: group
@@ -38,8 +37,7 @@ mpileaks:
 callpath:
   permissions:
     write: world
-"""
-    )
+""")
     spack.config.set("packages", conf, scope="concretize")
 
     yield
@@ -179,8 +177,7 @@ class TestConcretizePreferences:
 
     def test_config_set_pkg_property_new(self, mock_packages_repo):
         """Test that you can set arbitrary attributes on the Package class"""
-        conf = syaml.load_config(
-            """\
+        conf = syaml.load_config("""\
 mpileaks:
   package_attributes:
     v1: 1
@@ -193,8 +190,7 @@ mpileaks:
     v6:
     - 1
     - 2
-"""
-        )
+""")
         spack.config.set("packages", conf, scope="concretize")
         with spack.repo.use_repositories(mock_packages_repo):
             spec = concretize("mpileaks")
@@ -261,8 +257,7 @@ mpileaks:
         assert not spec.external and spec.package.provides("mpi")
 
         # load config
-        conf = syaml.load_config(
-            """\
+        conf = syaml.load_config("""\
 all:
     providers:
         mpi: [mpich]
@@ -271,8 +266,7 @@ mpich:
     externals:
     - spec: mpich@3.0.4
       prefix: /dummy/path
-"""
-        )
+""")
         spack.config.set("packages", conf, scope="concretize")
 
         # ensure that once config is in place, external is used
@@ -295,8 +289,7 @@ mpich:
         assert not spec.external and spec.package.provides("mpi")
 
         # load config
-        conf = syaml.load_config(
-            """\
+        conf = syaml.load_config("""\
 all:
     providers:
         mpi: [mpich]
@@ -305,8 +298,7 @@ mpi:
     externals:
     - spec: mpich@3.0.4
       modules: [dummy]
-"""
-        )
+""")
         spack.config.set("packages", conf, scope="concretize")
 
         # ensure that once config is in place, external is used
@@ -314,12 +306,10 @@ mpi:
         assert spec["mpich"].external_path == os.path.sep + os.path.join("dummy", "path")
 
     def test_buildable_false(self):
-        conf = syaml.load_config(
-            """\
+        conf = syaml.load_config("""\
 libelf:
   buildable: false
-"""
-        )
+""")
         spack.config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert not spack.package_prefs.is_spec_buildable(spec)
@@ -328,12 +318,10 @@ libelf:
         assert spack.package_prefs.is_spec_buildable(spec)
 
     def test_buildable_false_virtual(self):
-        conf = syaml.load_config(
-            """\
+        conf = syaml.load_config("""\
 mpi:
   buildable: false
-"""
-        )
+""")
         spack.config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert spack.package_prefs.is_spec_buildable(spec)
@@ -342,12 +330,10 @@ mpi:
         assert not spack.package_prefs.is_spec_buildable(spec)
 
     def test_buildable_false_all(self):
-        conf = syaml.load_config(
-            """\
+        conf = syaml.load_config("""\
 all:
   buildable: false
-"""
-        )
+""")
         spack.config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert not spack.package_prefs.is_spec_buildable(spec)
@@ -356,14 +342,12 @@ all:
         assert not spack.package_prefs.is_spec_buildable(spec)
 
     def test_buildable_false_all_true_package(self):
-        conf = syaml.load_config(
-            """\
+        conf = syaml.load_config("""\
 all:
   buildable: false
 libelf:
   buildable: true
-"""
-        )
+""")
         spack.config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert spack.package_prefs.is_spec_buildable(spec)
@@ -372,14 +356,12 @@ libelf:
         assert not spack.package_prefs.is_spec_buildable(spec)
 
     def test_buildable_false_all_true_virtual(self):
-        conf = syaml.load_config(
-            """\
+        conf = syaml.load_config("""\
 all:
   buildable: false
 mpi:
   buildable: true
-"""
-        )
+""")
         spack.config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert not spack.package_prefs.is_spec_buildable(spec)
@@ -388,14 +370,12 @@ mpi:
         assert spack.package_prefs.is_spec_buildable(spec)
 
     def test_buildable_false_virtual_true_pacakge(self):
-        conf = syaml.load_config(
-            """\
+        conf = syaml.load_config("""\
 mpi:
   buildable: false
 mpich:
   buildable: true
-"""
-        )
+""")
         spack.config.set("packages", conf, scope="concretize")
 
         spec = Spec("zmpi")
@@ -508,8 +488,7 @@ mpich:
         """Tests that a version preference not mentioned in package.py cannot be used in
         a built spec.
         """
-        mpileaks_external = syaml.load_config(
-            """
+        mpileaks_external = syaml.load_config("""
     mpileaks:
       # Version 0.9 is not mentioned in package.py
       version: ["0.9"]
@@ -517,8 +496,7 @@ mpich:
       externals:
       - spec: mpileaks@0.9 +debug
         prefix: /path
-    """
-        )
+    """)
 
         with spack.config.override("packages", mpileaks_external):
             # Asking for mpileaks+debug results in the external being chosen

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -159,9 +159,7 @@ def test_requirement_adds_new_version(
 packages:
   v:
     require: "@{0}=2.2"
-""".format(
-        a_commit_hash
-    )
+""".format(a_commit_hash)
     update_packages_config(conf_str)
 
     s1 = spack.concretize.concretize_one("v")
@@ -192,9 +190,7 @@ def test_requirement_adds_version_satisfies(
 packages:
   t:
     require: "@{0}=2.2"
-""".format(
-        commits[0]
-    )
+""".format(commits[0])
     update_packages_config(conf_str)
 
     s1 = spack.concretize.concretize_one("t")
@@ -942,8 +938,7 @@ def test_default_requirements_semantic_with_mv_variants(
 
 @pytest.mark.regression("42084")
 def test_requiring_package_on_multiple_virtuals(concretize_scope, mock_packages):
-    update_packages_config(
-        """
+    update_packages_config("""
     packages:
       all:
         providers:
@@ -954,8 +949,7 @@ def test_requiring_package_on_multiple_virtuals(concretize_scope, mock_packages)
         require: intel-parallel-studio
       scalapack:
         require: intel-parallel-studio
-    """
-    )
+    """)
     s = spack.concretize.concretize_one("dla-future")
 
     assert s["blas"].name == "intel-parallel-studio"
@@ -1173,14 +1167,12 @@ def test_strong_preferences_higher_priority_than_reuse(concretize_scope, mock_pa
     assert ascent["adios2"].dag_hash() == reused_spec.dag_hash(), ascent
 
     # If we stick a preference, adios2 is not reused
-    update_packages_config(
-        """
+    update_packages_config("""
     packages:
       adios2:
         prefer:
         - "+bzip2"
-"""
-    )
+""")
     with spack.config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
@@ -1614,8 +1606,7 @@ def test_penalties_for_language_preferences(concretize_scope, mock_packages):
     assert s["mpich"].satisfies("%c,cxx,fortran=gcc@10")
 
     # If we prefer compilers in configuration, that has a higher priority
-    update_packages_config(
-        """
+    update_packages_config("""
     packages:
       c:
         prefer: [gcc]
@@ -1623,16 +1614,14 @@ def test_penalties_for_language_preferences(concretize_scope, mock_packages):
         prefer: [gcc]
       fortran:
         prefer: [gcc]
-"""
-    )
+""")
 
     s = spack.concretize.concretize_one("mpileaks %c=clang ^mpi=mpich2")
     assert s.satisfies("%c=clang")
     assert all(s[name].satisfies("%c=gcc@10") for name in dependency_names)
 
     # Mixed compilers in the preferences
-    update_packages_config(
-        """
+    update_packages_config("""
     packages:
       c:
         prefer: [llvm]
@@ -1640,8 +1629,7 @@ def test_penalties_for_language_preferences(concretize_scope, mock_packages):
         prefer: [llvm]
       fortran:
         prefer: [gcc]
-"""
-    )
+""")
 
     s = spack.concretize.concretize_one("mpileaks %c=gcc ^mpi=mpich")
     assert s.satisfies("%c=gcc@10")

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -65,8 +65,7 @@ def env_yaml(tmp_path: pathlib.Path):
     """Return a sample env.yaml for test purposes"""
     env_yaml = str(tmp_path / "env.yaml")
     with open(env_yaml, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
     config:
         verify_ssl: False
@@ -76,8 +75,7 @@ spack:
             compiler: [ 'gcc@4.5.3' ]
     repos:
         z: /x/y/z
-"""
-        )
+""")
     return env_yaml
 
 
@@ -884,13 +882,11 @@ def test_alternate_override(monkeypatch):
 def test_immutable_scope(tmp_path: pathlib.Path):
     config_yaml = str(tmp_path / "config.yaml")
     with open(config_yaml, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 config:
     install_tree:
       root: dummy_tree_value
-"""
-        )
+""")
     scope = spack.config.DirectoryConfigScope("test", str(tmp_path), writable=False)
 
     data = scope.get_section("config")
@@ -929,8 +925,7 @@ def test_single_file_scope_section_override(tmp_path: pathlib.Path, config):
     """
     env_yaml = str(tmp_path / "env.yaml")
     with open(env_yaml, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
     config:
         verify_ssl: False
@@ -939,8 +934,7 @@ spack:
             target: [ x86_64 ]
     repos:
         z: /x/y/z
-"""
-        )
+""")
 
     scope = spack.config.SingleFileScope(
         "env", env_yaml, spack.schema.env.schema, yaml_path=["spack"]
@@ -1241,9 +1235,7 @@ def mock_include_scope(tmp_path):
 
     include = tmp_path / "include.yaml"
     with include.open("w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """\
+        f.write(textwrap.dedent("""\
                 include::
                   - name: "test1"
                     path: "test1"
@@ -1255,9 +1247,7 @@ def mock_include_scope(tmp_path):
                   - name: "test3"
                     path: "test3"
                     when: '"SPACK_DISABLE_LOCAL_CONFIG" not in env'
-                """
-            )
-        )
+                """))
 
     yield tmp_path
 
@@ -1294,15 +1284,11 @@ def test_modify_scope_precedence(working_env, include_config_factory, tmp_path):
     subdir2.mkdir()
 
     with include_yaml.open("w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """\
+        f.write(textwrap.dedent("""\
                 include::
                   - name: "subdir"
                     path: "subdir"
-                """
-            )
-        )
+                """))
 
     cfg.push_scope(
         spack.config.DirectoryConfigScope("override", str(tmp_path)),
@@ -1315,16 +1301,12 @@ def test_modify_scope_precedence(working_env, include_config_factory, tmp_path):
     cfg.remove_scope("override")
 
     with include_yaml.open("w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """\
+        f.write(textwrap.dedent("""\
                 include::
                   - name: "subdir"
                     path: "subdir"
                     prefer_modify: true
-                """
-            )
-        )
+                """))
 
     cfg.push_scope(
         spack.config.DirectoryConfigScope("override", str(tmp_path)),
@@ -1337,18 +1319,14 @@ def test_modify_scope_precedence(working_env, include_config_factory, tmp_path):
     cfg.remove_scope("override")
 
     with include_yaml.open("w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """\
+        f.write(textwrap.dedent("""\
                 include::
                   - name: "subdir"
                     path: "subdir"
                   - name: "subdir2"
                     path: "subdir2"
                     prefer_modify: true
-                """
-            )
-        )
+                """))
 
     cfg.push_scope(
         spack.config.DirectoryConfigScope("override", str(tmp_path)),
@@ -1394,26 +1372,18 @@ def test_override_included_config(working_env, tmp_path, include_config_factory)
     anotherdir.mkdir()
 
     with include_yaml.open("w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """\
+        f.write(textwrap.dedent("""\
                 include::
                   - name: "subdir"
                     path: "subdir"
-                """
-            )
-        )
+                """))
 
     with (subdir / "include.yaml").open("w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """\
+        f.write(textwrap.dedent("""\
                 include:
                   - name: "anotherdir"
                     path: "../anotherdir"
-                """
-            )
-        )
+                """))
 
     # check the mock config is correct
     cfg = include_config_factory()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -942,9 +942,7 @@ def configuration_dir(tmp_path_factory: pytest.TempPathFactory, linux_os):
     include = tmp_path / "spack" / "include.yaml"
     # Need to use relative include paths here so it works for mutable_config fixture too
     with include.open("w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """
+        f.write(textwrap.dedent("""
                 include:
                 # user configuration scope
                 - name: "user"
@@ -965,9 +963,7 @@ def configuration_dir(tmp_path_factory: pytest.TempPathFactory, linux_os):
                   path: ../system
                   optional: true
                   when: '"SPACK_DISABLE_LOCAL_CONFIG" not in env'
-                """
-            )
-        )
+                """))
     yield tmp_path
 
 
@@ -1977,12 +1973,10 @@ def mock_test_repo(tmp_path_factory: pytest.TempPathFactory):
     packages_dir = repodir / spack.repo.packages_dir_name
     packages_dir.mkdir()
     yaml_path = repodir / "repo.yaml"
-    yaml_path.write_text(
-        """
+    yaml_path.write_text("""
 repo:
     namespace: mock_test_repo
-"""
-    )
+""")
 
     with spack.repo.use_repositories(str(repodir)) as repo:
         yield repo, repodir
@@ -1996,12 +1990,10 @@ def mock_clone_repo(tmp_path_factory: pytest.TempPathFactory):
     repo_namespace = "mock_clone_repo"
     repodir = tmp_path_factory.mktemp(repo_namespace)
     yaml_path = repodir / "repo.yaml"
-    yaml_path.write_text(
-        """
+    yaml_path.write_text("""
 repo:
     namespace: mock_clone_repo
-"""
-    )
+""")
 
     shutil.copytree(
         os.path.join(spack.paths.mock_packages_path, spack.repo.packages_dir_name),
@@ -2250,16 +2242,12 @@ def binary_with_rpaths(prefix_tmpdir: Path):
 
     def _factory(rpaths, message="Hello world!", dynamic_linker="/lib64/ld-linux.so.2"):
         source = prefix_tmpdir / "main.c"
-        source.write_text(
-            """
+        source.write_text("""
         #include <stdio.h>
         int main(){{
             printf("{0}");
         }}
-        """.format(
-                message
-            )
-        )
+        """.format(message))
         gcc = spack.util.executable.which("gcc", required=True)
         executable = source.parent / "main.x"
         # Encode relative RPATHs using `$ORIGIN` as the root prefix

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -8,6 +8,7 @@ rather than `spec_from_entry`, since the former does additional work to
 establish dependency relationships (and in general the manifest-parsing
 logic needs to consume all related specs in a single pass).
 """
+
 import json
 import pathlib
 
@@ -372,8 +373,7 @@ def test_read_old_manifest_v1_2(tmp_path: pathlib.Path, temporary_store):
     """Test reading a file using the older format ('version' instead of 'schema-version')."""
     manifest = tmp_path / "manifest_dir" / "test.json"
     manifest.parent.mkdir(parents=True)
-    manifest.write_text(
-        """\
+    manifest.write_text("""\
 {
   "_meta": {
     "file-type": "cray-pe-json",
@@ -382,8 +382,7 @@ def test_read_old_manifest_v1_2(tmp_path: pathlib.Path, temporary_store):
   },
   "specs": []
 }
-"""
-    )
+""")
     spack.cray_manifest.read(str(manifest), True)
 
 
@@ -395,11 +394,9 @@ def test_convert_validation_error(
     # Does not parse as valid JSON
     invalid_json_path = manifest_dir / "invalid-json.json"
     with open(invalid_json_path, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 {
-"""
-        )
+""")
     with pytest.raises(spack.cray_manifest.ManifestValidationError) as e:
         spack.cray_manifest.read(invalid_json_path, True)
     str(e)
@@ -408,8 +405,7 @@ def test_convert_validation_error(
     # of length > 0)
     invalid_schema_path = manifest_dir / "invalid-schema.json"
     with open(invalid_schema_path, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 {
   "_meta": {
     "file-type": "cray-pe-json",
@@ -418,8 +414,7 @@ def test_convert_validation_error(
   },
   "specs": []
 }
-"""
-        )
+""")
     with pytest.raises(spack.cray_manifest.ManifestValidationError) as e:
         spack.cray_manifest.read(invalid_schema_path, True)
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Check the database is functioning properly, both in memory and in its file."""
+
 import contextlib
 import datetime
 import functools

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -5,6 +5,7 @@
 """
 This test verifies that the Spack directory layout works properly.
 """
+
 import os
 import pathlib
 from pathlib import Path

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -192,15 +192,13 @@ def test_user_view_path_is_not_canonicalized_in_yaml(tmp_path: pathlib.Path, con
 def test_environment_cant_modify_environments_root(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
  spack:
    config:
      environments_root: /a/black/hole
    view: false
    specs: []
- """
-        )
+ """)
     with fs.working_dir(str(tmp_path)):
         with pytest.raises(ev.SpackEnvironmentError):
             e = ev.Environment(str(tmp_path))
@@ -210,16 +208,14 @@ def test_environment_cant_modify_environments_root(tmp_path: pathlib.Path):
 @pytest.mark.regression("35420")
 @pytest.mark.parametrize(
     "original_content",
-    [
-        """\
+    ["""\
 spack:
   specs:
   - matrix:
     # test
     - - a
   concretizer:
-    unify: false"""
-    ],
+    unify: false"""],
 )
 def test_roundtrip_spack_yaml_with_comments(original_content, config, tmp_path: pathlib.Path):
     """Ensure that round-tripping a spack.yaml file doesn't change its content."""
@@ -392,14 +388,12 @@ def test_can_add_specs_to_environment_without_specs_attribute(tmp_path: pathlib.
     an error.
     """
     spack_yaml = tmp_path / "spack.yaml"
-    spack_yaml.write_text(
-        """
+    spack_yaml.write_text("""
 spack:
   view: true
   concretizer:
     unify: true
-    """
-    )
+    """)
     env = ev.Environment(tmp_path)
     env.add("pkg-a")
 
@@ -485,15 +479,13 @@ def test_initialize_from_random_file_as_manifest(tmp_path: pathlib.Path, filenam
     init_file = tmp_path / filename
     env_dir = tmp_path / "env_dir"
 
-    init_file.write_text(
-        """\
+    init_file.write_text("""\
 spack:
   view: true
   concretizer:
     unify: true
   specs: []
-"""
-    )
+""")
 
     ev.create_in_dir(env_dir, init_file)
 
@@ -510,8 +502,7 @@ def test_error_message_when_using_too_new_lockfile(tmp_path: pathlib.Path):
     """
     init_file = tmp_path / ev.lockfile_name
     env_dir = tmp_path / "env_dir"
-    init_file.write_text(
-        """
+    init_file.write_text("""
 {
     "_meta": {
         "file-type": "spack-lockfile",
@@ -521,8 +512,7 @@ def test_error_message_when_using_too_new_lockfile(tmp_path: pathlib.Path):
     "roots": [],
     "concrete_specs": {}
 }\n
-"""
-    )
+""")
     ev.initialize_environment_dir(env_dir, init_file)
     with pytest.raises(ev.SpackEnvironmentError, match="You need to use a newer Spack version."):
         ev.Environment(env_dir)
@@ -547,15 +537,13 @@ def test_environment_concretizer_scheme_used(
     configuration scopes.
     """
     manifest = tmp_path / "spack.yaml"
-    manifest.write_text(
-        f"""\
+    manifest.write_text(f"""\
 spack:
   specs:
   - mpileaks
   concretizer:
     unify: {str(unify_in_spack_yaml).lower()}
-"""
-    )
+""")
     mutable_config.set("concretizer:unify", unify_in_lower_scope)
     assert mutable_config.get("concretizer:unify") == unify_in_lower_scope
     with ev.Environment(manifest.parent):
@@ -568,13 +556,11 @@ def test_environment_config_scheme_used(tmp_path: pathlib.Path, unify_in_config)
     if absent in spack.yaml.
     """
     manifest = tmp_path / "spack.yaml"
-    manifest.write_text(
-        """\
+    manifest.write_text("""\
 spack:
   specs:
   - mpileaks
-"""
-    )
+""")
 
     with spack.config.override("concretizer:unify", unify_in_config):
         with ev.Environment(manifest.parent):
@@ -596,16 +582,14 @@ def test_conflicts_with_packages_that_are_not_dependencies(
     even though they don't have a dependency relation.
     """
     manifest = tmp_path / "spack.yaml"
-    manifest.write_text(
-        f"""\
+    manifest.write_text(f"""\
 spack:
   specs:
   - {spec_str}
   - pkg-b
   concretizer:
     unify: true
-"""
-    )
+""")
     with ev.Environment(manifest.parent) as e:
         if expected_raise:
             with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
@@ -627,8 +611,7 @@ def test_requires_on_virtual_and_potential_providers(
     if they are added explicitly by their name.
     """
     manifest = tmp_path / "spack.yaml"
-    manifest.write_text(
-        f"""\
+    manifest.write_text(f"""\
     spack:
       specs:
       - {possible_mpi_spec}
@@ -639,8 +622,7 @@ def test_requires_on_virtual_and_potential_providers(
           require: mpich2
       concretizer:
         unify: {unify}
-    """
-    )
+    """)
     with ev.Environment(manifest.parent) as e:
         e.concretize()
         assert e.matching_spec(possible_mpi_spec)
@@ -661,13 +643,11 @@ def test_manifest_file_removal_works_if_spec_is_not_normalized(tmp_path: pathlib
     representation is not normalized.
     """
     manifest = tmp_path / "spack.yaml"
-    manifest.write_text(
-        f"""\
+    manifest.write_text(f"""\
 spack:
   specs:
   - {spec_str}
-"""
-    )
+""")
     s = spack.spec.Spec(spec_str)
     spack_yaml = EnvironmentManifestFile(tmp_path)
     # Doing a round trip str -> Spec -> str normalizes the representation
@@ -697,12 +677,10 @@ def test_removing_spec_from_manifest_with_exact_duplicates(
     on user edited spack.yaml files.
     """
     manifest = tmp_path / "spack.yaml"
-    manifest.write_text(
-        f"""\
+    manifest.write_text(f"""\
     spack:
       specs: [{", ".join(duplicate_specs)} , "zlib"]
-    """
-    )
+    """)
 
     with ev.Environment(tmp_path) as env:
         assert len(env.user_specs) == expected_number
@@ -722,16 +700,14 @@ def test_variant_propagation_with_unify_false(tmp_path: pathlib.Path, config):
     properly reconstructed on the worker process, if variant propagation was requested.
     """
     manifest = tmp_path / "spack.yaml"
-    manifest.write_text(
-        """
+    manifest.write_text("""
     spack:
       specs:
       - parent-foo ++foo
       - pkg-c
       concretizer:
         unify: false
-    """
-    )
+    """)
     with ev.Environment(tmp_path) as env:
         env.concretize()
 
@@ -745,16 +721,13 @@ def test_env_with_include_defs(mutable_mock_env_path):
     env_path = mutable_mock_env_path
     env_path.mkdir()
     defs_file = env_path / "definitions.yaml"
-    defs_file.write_text(
-        """definitions:
+    defs_file.write_text("""definitions:
 - core_specs: [libdwarf, libelf]
 - compilers: ['%gcc']
-"""
-    )
+""")
 
     spack_yaml = env_path / ev.manifest_name
-    spack_yaml.write_text(
-        f"""spack:
+    spack_yaml.write_text(f"""spack:
   include:
   - {defs_file.as_uri()}
 
@@ -766,8 +739,7 @@ def test_env_with_include_defs(mutable_mock_env_path):
     - [$core_specs]
     - [$compilers]
   - $my_packages
-"""
-    )
+""")
 
     e = ev.Environment(env_path)
     with e:
@@ -783,8 +755,7 @@ def test_env_with_include_def_missing(mutable_mock_env_path):
     defs_file.write_text("definitions:\n- my_compilers: ['%gcc']\n")
 
     spack_yaml = env_path / ev.manifest_name
-    spack_yaml.write_text(
-        f"""spack:
+    spack_yaml.write_text(f"""spack:
   include:
   - {defs_file.as_uri()}
 
@@ -792,8 +763,7 @@ def test_env_with_include_def_missing(mutable_mock_env_path):
   - matrix:
     - [$core_specs]
     - [$my_compilers]
-"""
-    )
+""")
 
     with pytest.raises(UndefinedReferenceError, match=r"which is not defined"):
         _ = ev.Environment(env_path)
@@ -807,8 +777,7 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unif
     """
     mutable_mock_env_path.mkdir()
     spack_yaml = mutable_mock_env_path / ev.manifest_name
-    spack_yaml.write_text(
-        f"""spack:
+    spack_yaml.write_text(f"""spack:
       specs:
       # These two specs concretize to the same hash
       - pkg-c
@@ -817,8 +786,7 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unif
       - pkg-a
       concretizer:
         unify: {unify}
-    """
-    )
+    """)
     e = ev.Environment(mutable_mock_env_path)
     # Initial state
     assert len(e.user_specs) == 3
@@ -851,8 +819,7 @@ def test_root_version_weights_for_old_versions(mutable_mock_env_path):
     """
     mutable_mock_env_path.mkdir()
     spack_yaml = mutable_mock_env_path / ev.manifest_name
-    spack_yaml.write_text(
-        """spack:
+    spack_yaml.write_text("""spack:
       specs:
       # allow any version, but the most recent
       - bowtie@:1.3
@@ -860,8 +827,7 @@ def test_root_version_weights_for_old_versions(mutable_mock_env_path):
       - gcc@1
       concretizer:
         unify: true
-    """
-    )
+    """)
     e = ev.Environment(mutable_mock_env_path)
     with e:
         e.concretize()
@@ -907,8 +873,7 @@ def test_stack_enforcement_is_strict(tmp_path: pathlib.Path, matrix_line, config
     inconsistencies between abstract user specs and concrete specs.
     """
     manifest = tmp_path / "spack.yaml"
-    manifest.write_text(
-        f"""\
+    manifest.write_text(f"""\
 spack:
   definitions:
     - packages: [libelf, mpileaks]
@@ -920,8 +885,7 @@ spack:
     - $install
   concretizer:
     unify: false
-"""
-    )
+""")
     # Here we raise different exceptions depending on whether we solve serially or not
     with pytest.raises(Exception):
         with ev.Environment(tmp_path) as e:
@@ -977,34 +941,28 @@ def test_env_include_configs(mutable_mock_env_path):
     config_root.mkdir()
     config_path = str(config_root / "config.yaml")
     with open(config_path, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 config:
   verify_ssl: False
-"""
-        )
+""")
 
     packages_path = str(env_path / "packages.yaml")
     with open(packages_path, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 packages:
   python:
     require:
     - spec: "@3.11:"
-"""
-        )
+""")
 
     spack_yaml = env_path / ev.manifest_name
-    spack_yaml.write_text(
-        f"""\
+    spack_yaml.write_text(f"""\
 spack:
   include:
   - path: {config_path}
     optional: true
   - path: {packages_path}
-"""
-    )
+""")
 
     e = ev.Environment(env_path)
     with e.manifest.use_config():
@@ -1019,15 +977,13 @@ def test_using_multiple_compilers_on_a_node_is_discouraged(tmp_path: pathlib.Pat
     languages needed by that node.
     """
     manifest = tmp_path / "spack.yaml"
-    manifest.write_text(
-        """\
+    manifest.write_text("""\
 spack:
   specs:
     - mpileaks%clang ^mpich%gcc
   concretizer:
     unify: true
-"""
-    )
+""")
     with ev.Environment(tmp_path) as e:
         e.concretize()
         mpileaks = e.concrete_roots()[0]
@@ -1304,8 +1260,7 @@ def test_reuse_environment_dependencies(tmp_path: pathlib.Path, mutable_config):
     # Concretize the first environment asking for a non-default spec. In this way we'll know
     # that reuse from the derived environment is not accidental.
     manifest_base = base / "spack.yaml"
-    manifest_base.write_text(
-        """
+    manifest_base.write_text("""
 spack:
   specs:
   - pkg-a@1.0
@@ -1313,8 +1268,7 @@ spack:
     pkg-b:
       require:
       - "@0.9"
-"""
-    )
+""")
     with ev.Environment(base) as e:
         e.concretize()
         # We need the spack.lock for reuse in the derived environment
@@ -1325,8 +1279,7 @@ spack:
     derived = tmp_path / "derived"
     derived.mkdir()
     manifest_derived = derived / "spack.yaml"
-    manifest_derived.write_text(
-        f"""
+    manifest_derived.write_text(f"""
 spack:
   specs:
   - pkg-a
@@ -1335,8 +1288,7 @@ spack:
       from:
       - type: environment
         path: {base}
-"""
-    )
+""")
     with ev.Environment(derived) as e:
         e.concretize()
         derived_pkga = e.concrete_roots()[0]
@@ -1674,8 +1626,7 @@ class TestEnvironmentGroups:
 
     def test_manifest_and_groups(self, create_temporary_manifest):
         """Tests a basic case of reading groups from a manifest file"""
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
     spack:
       specs:
       - mpileaks
@@ -1690,8 +1641,7 @@ class TestEnvironmentGroups:
           - ["%gcc@14"]
         - mpich
       - libelf
-    """
-        )
+    """)
         # Check manifest properties
         assert set(manifest.groups()) == {"default", "compiler", "apps"}
 
@@ -1722,8 +1672,7 @@ class TestEnvironmentGroups:
     def test_cannot_define_group_twice(self, create_temporary_manifest):
         """Tests that defining the same group twice raises an error"""
         with pytest.raises(SpackEnvironmentConfigError, match="defined more than once"):
-            create_temporary_manifest(
-                """
+            create_temporary_manifest("""
     spack:
       specs:
       - group: compiler
@@ -1732,13 +1681,11 @@ class TestEnvironmentGroups:
       - group: compiler
         matrix:
         - [llvm@20]
-"""
-            )
+""")
 
     def test_matrix_can_be_expanded_in_groups(self, create_temporary_manifest):
         """Tests that definitions can be expanded also for matrix groups"""
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
 spack:
   definitions:
   - compilers: ["%gcc", "%clang"]
@@ -1750,8 +1697,7 @@ spack:
       - [$desired_specs]
       - [$compilers]
     - mpich
-"""
-        )
+""")
         e = ev.Environment(manifest.manifest_dir)
         assert e.user_specs.specs == []
         assert e.user_specs_by(group="apps").specs == [
@@ -1761,14 +1707,12 @@ spack:
         ]
 
     def test_environment_without_groups_use_lockfile_v6(self, create_temporary_manifest):
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
 spack:
   specs:
   - mpileaks
   - pkg-a
-"""
-        )
+""")
         with ev.Environment(manifest.manifest_dir) as e:
             e.concretize()
             lockfile_data = e._to_lockfile_dict()
@@ -1779,8 +1723,7 @@ spack:
         """Tests that groups of specs without dependencies among them can be concretized
         correctly
         """
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
     spack:
       specs:
       - mpileaks
@@ -1788,8 +1731,7 @@ spack:
         matrix:
         - [gcc@14]
       - libelf
-    """
-        )
+    """)
 
         with ev.Environment(manifest.manifest_dir) as e:
             e.concretize()
@@ -1804,16 +1746,14 @@ spack:
 
     def test_independent_group_dont_reuse(self, create_temporary_manifest):
         """Tests that there is no cross-groups reuse among groups of specs without dependencies."""
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
     spack:
       specs:
       - mpileaks@2.2
       - group: app
         matrix:
         - [mpileaks]
-    """
-        )
+    """)
 
         with ev.Environment(manifest.manifest_dir) as e:
             e.concretize()
@@ -1828,24 +1768,21 @@ spack:
         """Tests that a group of specs that would not concretize without a dependency group
         works correctly.
         """
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
     spack:
       specs:
       - group: app
         matrix:
         - [mpileaks]
         - ["%c,cxx=gcc@14"]
-    """
-        )
+    """)
 
         # We have no gcc@14 configured, so this will raise an error
         with ev.Environment(manifest.manifest_dir) as e:
             with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
                 e.concretize()
 
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
     spack:
       specs:
       - group: compiler
@@ -1856,8 +1793,7 @@ spack:
         matrix:
         - [mpileaks]
         - ["%c,cxx=gcc@14"]
-    """
-        )
+    """)
 
         # In this case gcc@14 is taken from the "needed" group
         with ev.Environment(manifest.manifest_dir) as e:
@@ -1869,8 +1805,7 @@ spack:
             assert mpileaks["c"].dag_hash() == gcc.dag_hash()
 
     def test_manifest_can_contain_config_override(self, mutable_config, create_temporary_manifest):
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
     spack:
       concretizer:
         unify: False
@@ -1879,8 +1814,7 @@ spack:
         override:
           concretizer:
             unify: True
-    """
-        )
+    """)
 
         with ev.Environment(manifest.manifest_dir) as e:
             assert mutable_config.get_config("concretizer")["unify"] is False
@@ -1900,8 +1834,7 @@ spack:
             assert mutable_config.get_config("concretizer")["unify"] is False
 
     def test_overriding_concretization_properties_per_group(self, create_temporary_manifest):
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
     spack:
       concretizer:
         unify: True
@@ -1925,8 +1858,7 @@ spack:
               prefer: [gcc@14]
             fortran:
               prefer: [gcc@14]
-    """
-        )
+    """)
 
         with ev.Environment(manifest.manifest_dir) as e:
             e.concretize()
@@ -1949,16 +1881,14 @@ spack:
         """Tests that referencing a non-existent group in 'needs' gives a clear error message
         that includes the name of the blocked group and the missing dependency.
         """
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
 spack:
   specs:
   - group: apps
     needs: [nonexistent]
     specs:
     - mpileaks
-"""
-        )
+""")
         with ev.Environment(manifest.manifest_dir) as e:
             with pytest.raises(
                 ev.SpackEnvironmentConfigError, match=r"but 'nonexistent' is not a defined group"
@@ -1969,8 +1899,7 @@ spack:
         """Tests that cyclic group dependencies give a clear error message that mentions
         the groups involved in the cycle.
         """
-        manifest = create_temporary_manifest(
-            """
+        manifest = create_temporary_manifest("""
 spack:
   specs:
   - group: alpha
@@ -1981,8 +1910,7 @@ spack:
     needs: [alpha]
     specs:
     - zlib
-"""
-        )
+""")
         with ev.Environment(manifest.manifest_dir) as e:
             with pytest.raises(ev.SpackEnvironmentConfigError, match=r"among groups: alpha, beta"):
                 e.concretize()

--- a/lib/spack/spack/test/error_messages.py
+++ b/lib/spack/spack/test/error_messages.py
@@ -317,13 +317,10 @@ all_pkgs = [
 
 
 def _add_import(pkg_def):
-    return (
-        """\
+    return """\
 from spack.package import *
 from spack.package import Package
-"""
-        + pkg_def
-    )
+""" + pkg_def
 
 
 all_pkgs = list((x, _add_import(y)) for (x, y) in all_pkgs)
@@ -342,13 +339,11 @@ def create_test_repo(tmp_path, pkg_name_content_tuples):
         pass
     repo_yaml = os.path.join(repo_path, "repo.yaml")
     with open(str(repo_yaml), "w", encoding="utf-8") as f:
-        f.write(
-            f"""\
+        f.write(f"""\
 repo:
   namespace: {repo_name}
   api: v2.1
-"""
-        )
+""")
 
     _repo_name_id += 1
 

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -47,8 +47,7 @@ def test_ascii_graph_mpileaks(config, mock_packages, monkeypatch):
     graph_str = "\n".join([line.rstrip() for line in graph_str.split("\n")])
 
     assert (
-        graph_str
-        == r"""o mpileaks
+        graph_str == r"""o mpileaks
 |\
 | |\
 | | |\
@@ -84,8 +83,7 @@ o | | | | | mpich
 |/
 o gcc
 """
-        or graph_str
-        == r"""o mpileaks
+        or graph_str == r"""o mpileaks
 |\
 | |\
 | | |\

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -43,12 +43,10 @@ def _mock_repo(root, namespace):
     repodir = py.path.local(root) if isinstance(root, str) else root
     repodir.ensure(spack.repo.packages_dir_name, dir=True)
     yaml = repodir.join("repo.yaml")
-    yaml.write(
-        f"""
+    yaml.write(f"""
 repo:
    namespace: {namespace}
-"""
-    )
+""")
 
 
 def _noop(*args, **kwargs):

--- a/lib/spack/spack/test/installer_build_graph.py
+++ b/lib/spack/spack/test/installer_build_graph.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests for BuildGraph class in new_installer"""
+
 import sys
 from typing import Dict, List, Tuple, Union
 

--- a/lib/spack/spack/test/llnl/url.py
+++ b/lib/spack/spack/test/llnl/url.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests for spack.llnl.url functions"""
+
 import itertools
 
 import pytest

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Tests for ``llnl/util/filesystem.py``"""
+
 import filecmp
 import os
 import pathlib

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -25,6 +25,7 @@ the tests are parametrized to run on all the filesystems listed in this
 dict.
 
 """
+
 import collections
 import errno
 import getpass

--- a/lib/spack/spack/test/llnl/util/symlink.py
+++ b/lib/spack/spack/test/llnl/util/symlink.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Tests for Windows symlink functionality."""
+
 import os
 import pathlib
 import tempfile

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -29,11 +29,9 @@ pytestmark = pytest.mark.not_on_windows(
 def test_version_git_nonsense_output(tmp_path: pathlib.Path, working_env, monkeypatch):
     git = tmp_path / "git"
     with open(git, "w", encoding="utf-8") as f:
-        f.write(
-            """#!/bin/sh
+        f.write("""#!/bin/sh
 echo --|not a hash|----
-"""
-        )
+""")
     fs.set_executable(str(git))
 
     monkeypatch.setattr(spack.util.git, "git", lambda: exe.which(str(git)))
@@ -43,12 +41,10 @@ echo --|not a hash|----
 def test_version_git_fails(tmp_path: pathlib.Path, working_env, monkeypatch):
     git = tmp_path / "git"
     with open(git, "w", encoding="utf-8") as f:
-        f.write(
-            """#!/bin/sh
+        f.write("""#!/bin/sh
 echo 26552533be04e83e66be2c28e0eb5011cb54e8fa
 exit 1
-"""
-        )
+""")
     fs.set_executable(str(git))
 
     monkeypatch.setattr(spack.util.git, "git", lambda: exe.which(str(git)))
@@ -59,13 +55,9 @@ def test_git_sha_output(tmp_path: pathlib.Path, working_env, monkeypatch):
     git = tmp_path / "git"
     sha = "26552533be04e83e66be2c28e0eb5011cb54e8fa"
     with open(git, "w", encoding="utf-8") as f:
-        f.write(
-            """#!/bin/sh
+        f.write("""#!/bin/sh
 echo {0}
-""".format(
-                sha
-            )
-        )
+""".format(sha))
     fs.set_executable(str(git))
 
     monkeypatch.setattr(spack.util.git, "git", lambda: exe.which(str(git)))
@@ -96,11 +88,9 @@ def test_main_calls_get_version(capfd, working_env, monkeypatch):
 def test_get_version_bad_git(tmp_path: pathlib.Path, working_env, monkeypatch):
     bad_git = str(tmp_path / "git")
     with open(bad_git, "w", encoding="utf-8") as f:
-        f.write(
-            """#!/bin/sh
+        f.write("""#!/bin/sh
 exit 1
-"""
-        )
+""")
     fs.set_executable(bad_git)
 
     monkeypatch.setattr(spack.util.git, "git", lambda: exe.which(bad_git))
@@ -124,13 +114,11 @@ def test_bad_command_line_scopes(tmp_path: pathlib.Path, config):
 def test_add_command_line_scopes(tmp_path: pathlib.Path, mutable_config):
     config_yaml = str(tmp_path / "config.yaml")
     with open(config_yaml, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 config:
     verify_ssl: False
     dirty: False
-"""
-        )
+""")
 
     spack.main.add_command_line_scopes(mutable_config, [str(tmp_path)])
     assert mutable_config.get("config:verify_ssl") is False
@@ -142,24 +130,20 @@ def test_add_command_line_scope_env(tmp_path: pathlib.Path, mutable_mock_env_pat
     managed_env = ev.create("example").manifest_path
 
     with open(managed_env, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   config:
     install_tree:
       root: /tmp/first
-"""
-        )
+""")
 
     with open(tmp_path / "spack.yaml", "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 spack:
   config:
     install_tree:
       root: /tmp/second
-"""
-        )
+""")
 
     config = spack.config.Configuration()
     spack.main.add_command_line_scopes(config, ["example", str(tmp_path)])
@@ -177,8 +161,7 @@ spack:
 def test_include_cfg(mock_low_high_config, write_config_file, tmp_path: pathlib.Path):
     cfg1_path = str(tmp_path / "include1.yaml")
     with open(cfg1_path, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+        f.write("""\
 config:
   verify_ssl: False
   dirty: True
@@ -186,8 +169,7 @@ packages:
   python:
     require:
     - spec: "@3.11:"
-"""
-        )
+""")
 
     def python_cfg(_spec):
         return f"""\

--- a/lib/spack/spack/test/make_executable.py
+++ b/lib/spack/spack/test/make_executable.py
@@ -7,6 +7,7 @@ Tests for Spack's built-in parallel make support.
 
 This just tests whether the right args are getting passed to make.
 """
+
 import os
 import pathlib
 

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -116,9 +116,7 @@ module_index:
   {0}:
     path: /path/to/a
     use_name: a
-""".format(
-        s1.dag_hash()
-    )
+""".format(s1.dag_hash())
 
     module_indices = [{"tcl": spack.modules.common._read_module_index(tcl_module_index)}, {}]
 
@@ -154,9 +152,7 @@ module_index:
   {0}:
     path: /path/to/a
     use_name: a
-""".format(
-        s1.dag_hash()
-    )
+""".format(s1.dag_hash())
 
     module_indices = [{}, {"tcl": spack.modules.common._read_module_index(tcl_module_index)}]
 

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -5,6 +5,7 @@
 """
 This test checks the binary packaging infrastructure
 """
+
 import argparse
 import os
 import pathlib

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -103,23 +103,19 @@ def test_url_patch(mock_packages, mock_patch_stage, filename, sha256, archive_sh
         with working_dir(stage.source_path):
             # write a file to be patched
             with open("foo.txt", "w", encoding="utf-8") as f:
-                f.write(
-                    """\
+                f.write("""\
 first line
 second line
-"""
-                )
+""")
             # save it for later comparison
             shutil.copyfile("foo.txt", "foo-original.txt")
             # write the expected result of patching.
             with open("foo-expected.txt", "w", encoding="utf-8") as f:
-                f.write(
-                    """\
+                f.write("""\
 zeroth line
 first line
 third line
-"""
-                )
+""")
         # apply the patch and compare files
         patch = spack.patch.UrlPatch(s.package, url, sha256=sha256, archive_sha256=archive_sha256)
         patch_stage = Stage(patch.fetcher())

--- a/lib/spack/spack/test/provider_index.py
+++ b/lib/spack/spack/test/provider_index.py
@@ -17,6 +17,7 @@ Tests assume that mock packages provide this::
                     mpi@:10.0: set([zmpi])},
     'stuff': {stuff: set([externalvirtual])}}
 """
+
 import io
 
 import spack.repo

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -212,42 +212,42 @@ def test_fixup_macos_rpaths(make_dylib, make_object_file):
     bad_rpath = ["/nonexistent/path"]
 
     # Non-relocatable library id and duplicate rpaths
-    (root, filename) = make_dylib("abs", duplicate_rpaths)
+    root, filename = make_dylib("abs", duplicate_rpaths)
     # XCode 15 ships a new linker that takes care of deduplication
     if xcode_major_version < 15:
         assert fixup_rpath(root, filename)
     assert not fixup_rpath(root, filename)
 
     # Hardcoded but relocatable library id (but we do NOT relocate)
-    (root, filename) = make_dylib("abs_with_rpath", no_rpath)
+    root, filename = make_dylib("abs_with_rpath", no_rpath)
     assert not fixup_rpath(root, filename)
 
     # Library id uses rpath but there are extra duplicate rpaths
-    (root, filename) = make_dylib("rpath", duplicate_rpaths)
+    root, filename = make_dylib("rpath", duplicate_rpaths)
     # XCode 15 ships a new linker that takes care of deduplication
     if xcode_major_version < 15:
         assert fixup_rpath(root, filename)
     assert not fixup_rpath(root, filename)
 
     # Shared library was constructed with relocatable id from the get-go
-    (root, filename) = make_dylib("rpath", no_rpath)
+    root, filename = make_dylib("rpath", no_rpath)
     assert not fixup_rpath(root, filename)
 
     # Non-relocatable library id
-    (root, filename) = make_dylib("abs", no_rpath)
+    root, filename = make_dylib("abs", no_rpath)
     assert not fixup_rpath(root, filename)
 
     # Relocatable with executable paths and loader paths
-    (root, filename) = make_dylib("rpath", ["@executable_path/../lib", "@loader_path"])
+    root, filename = make_dylib("rpath", ["@executable_path/../lib", "@loader_path"])
     assert not fixup_rpath(root, filename)
 
     # Non-relocatable library id but nonexistent rpath
-    (root, filename) = make_dylib("abs", bad_rpath)
+    root, filename = make_dylib("abs", bad_rpath)
     assert fixup_rpath(root, filename)
     assert not fixup_rpath(root, filename)
 
     # Duplicate nonexistent rpath will need *two* passes
-    (root, filename) = make_dylib("rpath", bad_rpath * 2)
+    root, filename = make_dylib("rpath", bad_rpath * 2)
     assert fixup_rpath(root, filename)
     # XCode 15 ships a new linker that takes care of deduplication
     if xcode_major_version < 15:
@@ -257,5 +257,5 @@ def test_fixup_macos_rpaths(make_dylib, make_object_file):
     # Test on an object file, which *also* has type 'application/x-mach-binary'
     # but should be ignored (no ID headers, no RPATH)
     # (this is a corner case for GCC installation)
-    (root, filename) = make_object_file()
+    root, filename = make_object_file()
     assert not fixup_rpath(root, filename)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -27,20 +27,16 @@ def extra_repo(tmp_path_factory: pytest.TempPathFactory, request):
     cache_dir = tmp_path_factory.mktemp("cache")
     (repo_dir / request.param).mkdir(parents=True, exist_ok=True)
     if request.param == "packages":
-        (repo_dir / "repo.yaml").write_text(
-            """
+        (repo_dir / "repo.yaml").write_text("""
 repo:
   namespace: extra_test_repo
-"""
-        )
+""")
     else:
-        (repo_dir / "repo.yaml").write_text(
-            f"""
+        (repo_dir / "repo.yaml").write_text(f"""
 repo:
   namespace: extra_test_repo
   subdirectory: '{request.param}'
-"""
-        )
+""")
     repo_cache = spack.util.file_cache.FileCache(cache_dir)
     return spack.repo.Repo(str(repo_dir), cache=repo_cache), request.param
 
@@ -384,12 +380,10 @@ def test_parse_package_api_version():
 def test_repo_package_api_version(tmp_path: pathlib.Path):
     """Test that we can specify the API version of a repository."""
     (tmp_path / "example" / "packages").mkdir(parents=True)
-    (tmp_path / "example" / "repo.yaml").write_text(
-        """\
+    (tmp_path / "example" / "repo.yaml").write_text("""\
 repo:
     namespace: example
-"""
-    )
+""")
     cache = spack.util.file_cache.FileCache(tmp_path / "cache")
     assert spack.repo.Repo(str(tmp_path / "example"), cache=cache).package_api == (1, 0)
 
@@ -431,23 +425,19 @@ def test_repo_v2_invalid_module_name(tmp_path: pathlib.Path, capfd):
 
     # Create two invalid module names
     (repo_dir / "packages" / "zlib-ng").mkdir()
-    (repo_dir / "packages" / "zlib-ng" / "package.py").write_text(
-        """
+    (repo_dir / "packages" / "zlib-ng" / "package.py").write_text("""
 from spack.package import PackageBase
 
 class ZlibNg(PackageBase):
     pass
-"""
-    )
+""")
     (repo_dir / "packages" / "UPPERCASE").mkdir()
-    (repo_dir / "packages" / "UPPERCASE" / "package.py").write_text(
-        """
+    (repo_dir / "packages" / "UPPERCASE" / "package.py").write_text("""
 from spack.package import PackageBase
 
 class Uppercase(PackageBase):
     pass
-"""
-    )
+""")
 
     with spack.repo.use_repositories(str(repo_dir)) as repo:
         assert len(repo.all_package_names()) == 0
@@ -464,14 +454,12 @@ def test_repo_v2_module_and_class_to_package_name(tmp_path: pathlib.Path):
 
     # Create an invalid module name
     (repo_dir / "packages" / "_1example_2_test").mkdir()
-    (repo_dir / "packages" / "_1example_2_test" / "package.py").write_text(
-        """
+    (repo_dir / "packages" / "_1example_2_test" / "package.py").write_text("""
 from spack.package import PackageBase
 
 class _1example2Test(PackageBase):
     pass
-"""
-    )
+""")
 
     with spack.repo.use_repositories(str(repo_dir)) as repo:
         assert repo.exists("1example-2-test")
@@ -516,12 +504,10 @@ def test_namespace_is_optional_in_v2(tmp_path: pathlib.Path):
     """Test that a repo without a namespace is valid in v2."""
     repo_yaml_dir = tmp_path / "spack_repo" / "foo" / "bar" / "baz"
     (repo_yaml_dir / "packages").mkdir(parents=True)
-    (repo_yaml_dir / "repo.yaml").write_text(
-        """\
+    (repo_yaml_dir / "repo.yaml").write_text("""\
 repo:
   api: v2.0
-"""
-    )
+""")
 
     cache = spack.util.file_cache.FileCache(tmp_path / "cache")
     repo = spack.repo.Repo(str(repo_yaml_dir), cache=cache)
@@ -561,13 +547,11 @@ def test_is_package_module():
 def test_environment_activation_updates_repo_path(tmp_path: pathlib.Path):
     """Test that the environment activation updates the repo path correctly."""
     repo_root, _ = spack.repo.create_repo(str(tmp_path / "foo"), namespace="bar")
-    (tmp_path / "spack.yaml").write_text(
-        """\
+    (tmp_path / "spack.yaml").write_text("""\
 spack:
     repos:
         bar: $env/foo/spack_repo/bar
-"""
-    )
+""")
     env = spack.environment.Environment(tmp_path)
 
     with env:
@@ -734,13 +718,11 @@ a8eff4da7aab59bbf5996ac1720954bf82443247        refs/heads/develop
             elif action == "checkout":
                 # The spack-repo-index.yaml is optional; we test Spack reads from it.
                 with open(os.path.join("spack-repo-index.yaml"), "w", encoding="utf-8") as f:
-                    f.write(
-                        """\
+                    f.write("""\
 repo_index:
   paths:
   - spack_repo/foo
-"""
-                    )
+""")
 
             return ""
 
@@ -828,13 +810,11 @@ a8eff4da7aab59bbf5996ac1720954bf82443247        refs/heads/develop
             elif action == "checkout":
                 # The spack-repo-index.yaml is optional; we test Spack reads from it.
                 with open(os.path.join("spack-repo-index.yaml"), "w", encoding="utf-8") as f:
-                    f.write(
-                        """\
+                    f.write("""\
 repo_index:
   paths:
   - spack_repo/foo
-"""
-                    )
+""")
 
             return ""
 

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -41,9 +41,7 @@ def test_reporters_extract_basics():
 ==> [2022-02-15-18:44:21.250165] test: {0}: {1}
 ==> [2022-02-15-18:44:21.250200] '{2}'
 {3}: {0}
-""".format(
-        name, desc, fake_bin, status
-    ).splitlines()
+""".format(name, desc, fake_bin, status).splitlines()
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
     assert len(parts) == 1
@@ -63,9 +61,7 @@ def test_reporters_extract_no_parts(capfd):
 ==> Testing package fake-1.0-abcdefg
 ==> [2022-02-11-17:14:38.875259] Installing {0} to {1}
 {2}
-""".format(
-        fake_install_test_root, fake_test_cache, status
-    ).splitlines()
+""".format(fake_install_test_root, fake_test_cache, status).splitlines()
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
     err = capfd.readouterr()[1]
@@ -125,9 +121,7 @@ def test_reporters_extract_skipped(state):
     outputs = """
 ==> Testing package fake-1.0-abcdefg
 {0}
-""".format(
-        expected
-    ).splitlines()
+""".format(expected).splitlines()
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
 

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -5,6 +5,7 @@
 """\
 Test that Spack's shebang filtering works correctly.
 """
+
 import filecmp
 import os
 import pathlib
@@ -273,17 +274,13 @@ def configure_group_perms():
     gid = fs.group_ids(os.getuid())[0]
     group_name = grp.getgrgid(gid).gr_name
 
-    conf = syaml.load_config(
-        """\
+    conf = syaml.load_config("""\
 all:
   permissions:
     read: world
     write: group
     group: {0}
-""".format(
-            group_name
-        )
-    )
+""".format(group_name))
     spack.config.set("packages", conf, scope="user")
 
     yield
@@ -291,14 +288,12 @@ all:
 
 @pytest.fixture(scope="function")
 def configure_user_perms():
-    conf = syaml.load_config(
-        """\
+    conf = syaml.load_config("""\
 all:
   permissions:
     read: world
     write: user
-"""
-    )
+""")
     spack.config.set("packages", conf, scope="user")
 
     yield

--- a/lib/spack/spack/test/spack_yaml.py
+++ b/lib/spack/spack/test/spack_yaml.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Test Spack's custom YAML format."""
+
 import io
 import pathlib
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -4,6 +4,7 @@
 """
 These tests check Spec DAG operations using dummy packages.
 """
+
 import pytest
 
 import spack.concretize
@@ -929,21 +930,15 @@ def test_tree_cover_nodes_reduce_deptype():
     a.add_dependency_edge(b, depflag=dt.LINK, virtuals=())
     b.add_dependency_edge(d, depflag=dt.LINK, virtuals=())
     c.add_dependency_edge(d, depflag=dt.RUN | dt.TEST, virtuals=())
-    assert (
-        a.tree(cover="nodes", show_types=True)
-        == """\
+    assert a.tree(cover="nodes", show_types=True) == """\
 [    ]  a
 [ l  ]      ^b
 [bl  ]      ^d
 """
-    )
-    assert (
-        c.tree(cover="nodes", show_types=True)
-        == """\
+    assert c.tree(cover="nodes", show_types=True) == """\
 [    ]  c
 [  rt]      ^d
 """
-    )
 
 
 def test_synthetic_construction_of_split_dependencies_from_same_package(mock_packages, config):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -7,6 +7,7 @@
 The YAML and JSON formats preserve DAG information in the spec.
 
 """
+
 import collections
 import collections.abc
 import gzip
@@ -458,16 +459,13 @@ def test_anchorify_1():
     # Check if anchors are used
     out = io.StringIO()
     spack.vendor.ruamel.yaml.YAML().dump(after, out)
-    assert (
-        out.getvalue()
-        == """\
+    assert out.getvalue() == """\
 a: &id001
 - 1
 - 2
 - 3
 b: *id001
 """
-    )
 
 
 def test_anchorify_2():
@@ -481,16 +479,13 @@ def test_anchorify_2():
     # Check if anchors are used
     out = io.StringIO()
     spack.vendor.ruamel.yaml.YAML().dump(after, out)
-    assert (
-        out.getvalue()
-        == """\
+    assert out.getvalue() == """\
 a: &id001
   b: &id002
     c: true
 d: *id001
 e: *id002
 """
-    )
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Test that the Stage class works correctly."""
+
 import collections
 import errno
 import getpass
@@ -441,7 +442,7 @@ class TestStage:
 
     @pytest.mark.disable_clean_stage_check
     def test_composite_stage_with_expand_resource(self, composite_stage_with_expanding_resource):
-        (composite_stage, root_stage, resource_stage, mock_resource) = (
+        composite_stage, root_stage, resource_stage, mock_resource = (
             composite_stage_with_expanding_resource
         )
 
@@ -468,7 +469,7 @@ class TestStage:
         directory.
         """
 
-        (composite_stage, root_stage, resource_stage, mock_resource) = (
+        composite_stage, root_stage, resource_stage, mock_resource = (
             composite_stage_with_expanding_resource
         )
 

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests for tag index cache files."""
+
 import io
 
 import pytest

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Test Spack's environment utility functions."""
+
 import os
 import pathlib
 import sys

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -29,13 +29,9 @@ def test_read_unicode(tmp_path: pathlib.Path, working_env):
         os.environ["LD_LIBRARY_PATH"] = spack.main.spack_ld_library_path
         # make a script that prints some unicode
         with open(script_name, "w", encoding="utf-8") as f:
-            f.write(
-                """#!{0}
+            f.write("""#!{0}
 print(u'\\xc3')
-""".format(
-                    sys.executable
-                )
-            )
+""".format(sys.executable))
 
         # make it executable
         fs.set_executable(script_name)

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Test Spack's FileCache."""
+
 import os
 import pathlib
 

--- a/lib/spack/spack/test/util/log_parser.py
+++ b/lib/spack/spack/test/util/log_parser.py
@@ -11,8 +11,7 @@ def test_log_parser(tmp_path: pathlib.Path):
     log_file = tmp_path / "log.txt"
 
     with log_file.open("w") as f:
-        f.write(
-            """#!/bin/sh\n
+        f.write("""#!/bin/sh\n
 checking build system type... x86_64-apple-darwin16.6.0
 checking host system type... x86_64-apple-darwin16.6.0
 error: weird_error.c:145: something weird happened                          E
@@ -24,8 +23,7 @@ ld: fatal: linker thing happened                                            E
 checking for suffix of executables...
 configure: error: in /path/to/some/file:                                    E
 configure: error: cannot run C compiled programs.                           E
-"""
-        )
+""")
 
     parser = CTestLogParser()
     errors, warnings = parser.parse(str(log_file))

--- a/lib/spack/spack/test/util/spack_lock_wrapper.py
+++ b/lib/spack/spack/test/util/spack_lock_wrapper.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Tests for Spack's wrapper module around spack.llnl.util.lock."""
+
 import os
 import pathlib
 

--- a/lib/spack/spack/test/util/util_url.py
+++ b/lib/spack/spack/test/util/util_url.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Test Spack's URL handling utility functions."""
+
 import os
 import pathlib
 import urllib.parse

--- a/lib/spack/spack/test/utilities.py
+++ b/lib/spack/spack/test/utilities.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Non-fixture utilities for test code. Must be imported."""
+
 from spack.main import make_argument_parser
 
 

--- a/lib/spack/spack/test/verification.py
+++ b/lib/spack/spack/test/verification.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Tests for the `spack.verify` module"""
+
 import os
 import pathlib
 import shutil

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -6,6 +6,7 @@
 We try to maintain compatibility with RPM's version semantics
 where it makes sense.
 """
+
 import os
 import pathlib
 

--- a/lib/spack/spack/tokenize.py
+++ b/lib/spack/spack/tokenize.py
@@ -4,6 +4,7 @@
 """This module provides building blocks for tokenizing strings. Users can define tokens by
 inheriting from TokenBase and defining tokens as ordered enum members. The Tokenizer class can then
 be used to iterate over tokens in a string."""
+
 import enum
 import re
 from typing import Generator, Match, Optional, Type

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -28,6 +28,7 @@ This is useful if a user asks for a package at a particular version number;
 spack doesn't need anyone to tell it where to get the tarball even though
 it's never been told about that version before.
 """
+
 import io
 import os
 import pathlib
@@ -532,7 +533,7 @@ def substitute_version(path: str, new_version) -> str:
        >>> substitute_version("https://www.hdfgroup.org/ftp/HDF/releases/HDF4.2.12/src/hdf-4.2.12.tar.gz", "2.3")
        "https://www.hdfgroup.org/ftp/HDF/releases/HDF2.3/src/hdf-2.3.tar.gz"
     """
-    (name, ns, nl, noffs, ver, vs, vl, voffs) = substitution_offsets(path)
+    name, ns, nl, noffs, ver, vs, vl, voffs = substitution_offsets(path)
 
     new_path = ""
     last = 0
@@ -566,7 +567,7 @@ def color_url(path, **kwargs):
     errors = kwargs.get("errors", False)
     subs = kwargs.get("subs", False)
 
-    (name, ns, nl, noffs, ver, vs, vl, voffs) = substitution_offsets(path)
+    name, ns, nl, noffs, ver, vs, vl, voffs = substitution_offsets(path)
 
     nends = [no + nl - 1 for no in noffs]
     vends = [vo + vl - 1 for vo in voffs]

--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -68,6 +68,7 @@ algorithms that duplicate the way CTest scrapes log files.  To keep this
 up to date with CTest, just make sure the ``*_matches`` and
 ``*_exceptions`` lists are kept up to date with CTest's build handler.
 """
+
 import io
 import math
 import multiprocessing

--- a/lib/spack/spack/util/debug.py
+++ b/lib/spack/spack/util/debug.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Debug signal handler: enters pdb on ctrl-C."""
+
 import os
 import signal
 

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -11,6 +11,7 @@ specified editor fails (e.g. no DISPLAY for a graphical editor). If
 neither variable is set, we fall back to one of several common editors,
 raising an OSError if we are unable to find one.
 """
+
 import os
 import shlex
 from typing import Callable, List

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Set, unset or modify environment variables."""
+
 import collections
 import contextlib
 import inspect

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -176,8 +176,7 @@ def create(**kwargs):
     r, w = os.pipe()
     with contextlib.closing(os.fdopen(r, "r")) as r:
         with contextlib.closing(os.fdopen(w, "w")) as w:
-            w.write(
-                """
+            w.write("""
 Key-Type: rsa
 Key-Length: 4096
 Key-Usage: sign
@@ -187,9 +186,7 @@ Name-Comment: %(comment)s
 Expire-Date: %(expires)s
 %%no-protection
 %%commit
-"""
-                % kwargs
-            )
+""" % kwargs)
         GPG("--gen-key", "--batch", input=r)
 
 

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Wrapper for ``spack.llnl.util.lock`` allows locking to be enabled/disabled."""
+
 import os
 import stat
 import sys

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -6,6 +6,7 @@
 This module contains routines related to the module command for accessing and
 parsing environment modules.
 """
+
 import os
 import re
 import subprocess

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -6,6 +6,7 @@
 
 TODO: this is really part of spack.config. Consolidate it.
 """
+
 import contextlib
 import getpass
 import os

--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -5,6 +5,7 @@
 """
 This file contains utilities for managing the installation prefix of a package.
 """
+
 import os
 from typing import Dict
 

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -26,8 +26,6 @@ def get_s3_session(url, method="fetch"):
     # Circular dependency
     from spack.mirrors.mirror import MirrorCollection
 
-    global s3_client_cache
-
     # Parse the URL if not already done.
     if not isinstance(url, urllib.parse.ParseResult):
         url = urllib.parse.urlparse(url)

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Simple wrapper around JSON to guarantee consistent use of load/dump."""
+
 import json
 from typing import Any, Dict, Optional
 

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -11,6 +11,7 @@
   default unordered dict.
 
 """
+
 import ctypes
 import enum
 import functools

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -8,6 +8,7 @@
 a stack trace and drops the user into an interpreter.
 
 """
+
 import collections
 import sys
 import time

--- a/lib/spack/spack/util/typing.py
+++ b/lib/spack/spack/util/typing.py
@@ -11,7 +11,6 @@ calls can be very expensive.
 
 """
 
-
 from typing import TYPE_CHECKING, Any
 
 from spack.vendor.typing_extensions import Protocol

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Python-2.0
 "Usage: unparse.py <path to source file>"
+
 import ast
 import sys
 from ast import AST, FormattedValue, If, JoinedStr, Name, Tuple

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -5,6 +5,7 @@
 """The variant module contains data structures that are needed to manage
 variants both in packages and in specs.
 """
+
 import collections.abc
 import enum
 import functools

--- a/share/spack/qa/config_state.py
+++ b/share/spack/qa/config_state.py
@@ -6,6 +6,7 @@
 The option `config:cache` is supposed to be False, and overridden to True
 from the command line.
 """
+
 import multiprocessing as mp
 
 import spack.config

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/build_error/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/build_error/package.py
@@ -20,8 +20,7 @@ class BuildError(Package):
     def install(self, spec, prefix):
         if sys.platform == "win32":
             with open("configure.bat", "w", encoding="utf-8") as f:
-                f.write(
-                    """
+                f.write("""
     @ECHO off
     ECHO checking build system type... x86_64-apple-darwin16.6.0
     ECHO checking host system type... x86_64-apple-darwin16.6.0
@@ -32,15 +31,13 @@ class BuildError(Package):
     ECHO configure: error: in /path/to/some/file:
     ECHO configure: error: cannot run C compiled programs.
     EXIT /B 1
-                  """
-                )
+                  """)
 
             Executable("configure.bat")("--prefix=%s" % self.prefix)
             configure()
         else:
             with open("configure", "w", encoding="utf-8") as f:
-                f.write(
-                    """#!/bin/sh\n
+                f.write("""#!/bin/sh\n
     echo 'checking build system type... x86_64-apple-darwin16.6.0'
     echo 'checking host system type... x86_64-apple-darwin16.6.0'
     echo 'checking for gcc... /Users/gamblin2/src/spack/lib/spack/env/clang/clang'
@@ -50,6 +47,5 @@ class BuildError(Package):
     echo 'configure: error: in /path/to/some/file:'
     echo 'configure: error: cannot run C compiled programs.'
     exit 1
-    """
-                )
+    """)
             configure()

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/build_warnings/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/build_warnings/package.py
@@ -20,8 +20,7 @@ class BuildWarnings(Package):
     def install(self, spec, prefix):
         if sys.platform == "win32":
             with open("configure.bat", "w", encoding="utf-8") as f:
-                f.write(
-                    """
+                f.write("""
   @ECHO off
   ECHO 'checking for gcc... /Users/gamblin2/src/spack/lib/spack/env/clang/clang'
   ECHO 'checking whether the C compiler works... yes'
@@ -30,14 +29,12 @@ class BuildWarnings(Package):
   ECHO 'checking for suffix of executables...'
   ECHO 'foo.c:89: warning: some weird warning!'
   EXIT /B 1
-                  """
-                )
+                  """)
 
             Executable("configure.bat")("--prefix=%s" % self.prefix)
         else:
             with open("configure", "w", encoding="utf-8") as f:
-                f.write(
-                    """#!/bin/sh\n
+                f.write("""#!/bin/sh\n
   echo 'checking for gcc... /Users/gamblin2/src/spack/lib/spack/env/clang/clang'
   echo 'checking whether the C compiler works... yes'
   echo 'checking for C compiler default output file name... a.out'
@@ -45,6 +42,5 @@ class BuildWarnings(Package):
   echo 'checking for suffix of executables...'
   echo 'foo.c:89: warning: some weird warning!'
   exit 1
-  """
-                )
+  """)
             configure()

--- a/var/spack/test_repos/spack_repo/tutorial/packages/hdf5/package.py
+++ b/var/spack/test_repos/spack_repo/tutorial/packages/hdf5/package.py
@@ -458,9 +458,7 @@ int main(int argc, char **argv) {
 """
             expected = """\
 HDF5 version {version} {version}
-""".format(
-                version=str(spec.version.up_to(3))
-            )
+""".format(version=str(spec.version.up_to(3)))
             with open("check.c", "w", encoding="utf-8") as f:
                 f.write(source)
             if "+mpi" in spec:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Fixes CVEs documented in Security tab. May require running black on all files to get tests to pass.