### PR TITLE
`.gitignore`: ignore coding agents state directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@ CLAUDE.md
 !/etc/spack/site/README.md
 
 ###########################
+# Coding agent state
+###########################
+.claude/
+.gemini/
+.codex/
+
+###########################
 # Python-specific ignores #
 ###########################
 


### PR DESCRIPTION
Claude, Gemini, and Codex all leave a hidden top-level directory in the project for their own saved state. Ignore these for now.

If there are helpful things in here that make sense to check in, we can modify this to allow them. For now, just prevent people from inadvertently checking these directories in.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
