### PR TITLE
lock.py: add non-blocking api

### DIFF
--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -528,6 +528,42 @@ class Lock:
         if not self._poll_lock(op):
             raise LockTimeoutError(op, self.path, time=0, attempts=1)
 
+    def try_acquire_read(self) -> bool:
+        """Non-blocking attempt to acquire a shared read lock.
+
+        Returns True if the lock was acquired, False if it would block.
+        """
+        if self._reads == 0 and self._writes == 0:
+            self._ensure_valid_handle()
+            if not self._poll_lock(LockType.READ):
+                return False
+            self._reads += 1
+            self._log_acquired("READ LOCK", 0, 1)
+            return True
+        else:
+            self._reaffirm_lock()
+            self._reads += 1
+            return True
+
+    def try_acquire_write(self) -> bool:
+        """Non-blocking attempt to acquire an exclusive write lock.
+
+        Returns True if the lock was acquired, False if it would block.
+        """
+        if self._writes == 0:
+            fh = self._ensure_valid_handle()
+            if LockType.to_module(LockType.WRITE) == fcntl.LOCK_EX and fh.mode == "rb":
+                raise LockROFileError(self.path)
+            if not self._poll_lock(LockType.WRITE):
+                return False
+            self._writes += 1
+            self._log_acquired("WRITE LOCK", 0, 1)
+            return True
+        else:
+            self._reaffirm_lock()
+            self._writes += 1
+            return True
+
     def is_write_locked(self) -> bool:
         """Returns ``True`` if the path is write locked, otherwise, ``False``"""
         try:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1616,9 +1616,7 @@ def schedule_builds(
 
     # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory snapshot
     # stays consistent while we acquire per-spec prefix locks.
-    try:
-        db.lock.acquire_read(timeout=1e-9)
-    except spack.util.lock.LockTimeoutError:
+    if not db.lock.try_acquire_read():
         return ScheduleResult(blocked, to_start, newly_installed)
 
     try:
@@ -1630,19 +1628,14 @@ def schedule_builds(
             spec = build_graph.nodes[dag_hash]
             lock = prefix_locker.lock(spec)
 
-            try:
-                lock.acquire_write(timeout=1e-9)
+            if lock.try_acquire_write():
                 blocked = False
                 have_write = True
-            except spack.util.lock.LockTimeoutError:
-                # Write lock failed: either another process is actively building, or it
-                # finished and downgraded to a read lock. Try a read lock to find out.
-                try:
-                    lock.acquire_read(timeout=1e-9)
-                except spack.util.lock.LockTimeoutError:
-                    idx += 1
-                    continue  # active build in progress; try the next spec
+            elif lock.try_acquire_read():
                 have_write = False
+            else:
+                idx += 1
+                continue
 
             # Check installed status under the DB read lock and prefix lock.
             upstream, record = db.query_by_spec_hash(dag_hash)
@@ -2145,13 +2138,10 @@ class PackageInstaller:
     def _save_to_db(
         self, finished_builds: List[ChildInfo], retained_read_locks: List[spack.util.lock.Lock]
     ) -> bool:
-        try:
-            # Only try to get the lock once (non-blocking). If it fails, try it next time.
-            if self.db.lock.acquire_write(timeout=1e-9):
-                self.db._read()
-        except spack.util.lock.LockTimeoutError:
+        if not self.db.lock.try_acquire_write():
             return False
         try:
+            self.db._read()
             for build in finished_builds:
                 self.db._add(build.spec, explicit=build.explicit)
         finally:

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -1395,6 +1395,83 @@ def test_acquire_after_fork(tmp_path: pathlib.Path, acquire: str):
         lock.release_write()
 
 
+def _child_try_acquire_write(lock_path: str, result_queue):
+    lock = lk.Lock(lock_path)
+    result_queue.put(lock.try_acquire_write())
+
+
+def _child_try_acquire_read(lock_path: str, result_queue):
+    lock = lk.Lock(lock_path)
+    result_queue.put(lock.try_acquire_read())
+
+
+def test_try_acquire_read(tmp_path: pathlib.Path):
+    """Test non-blocking try_acquire_read."""
+    lock = lk.Lock(str(tmp_path / "lockfile"))
+
+    # Succeeds on unlocked lock
+    assert lock.try_acquire_read() is True
+    assert lock._reads == 1
+
+    # Succeeds again (nested)
+    assert lock.try_acquire_read() is True
+    assert lock._reads == 2
+
+    lock.release_read()
+    lock.release_read()
+    ctx = multiprocessing.get_context()
+
+    # Fails when another process holds an exclusive write lock
+    lock.acquire_write()
+    try:
+        q = ctx.Queue()
+        p = ctx.Process(target=_child_try_acquire_read, args=(str(tmp_path / "lockfile"), q))
+        p.start()
+        p.join()
+        assert q.get() is False
+    finally:
+        lock.release_write()
+
+
+def test_try_acquire_write(tmp_path: pathlib.Path):
+    """Test non-blocking try_acquire_write."""
+    lock = lk.Lock(str(tmp_path / "lockfile"))
+    ctx = multiprocessing.get_context()
+
+    # Succeeds on unlocked lock
+    assert lock.try_acquire_write() is True
+    assert lock._writes == 1
+
+    # Succeeds again (nested)
+    assert lock.try_acquire_write() is True
+    assert lock._writes == 2
+
+    lock.release_write()
+    lock.release_write()
+
+    # Fails when another process holds a write lock
+    lock.acquire_write()
+    try:
+        q = ctx.Queue()
+        p = ctx.Process(target=_child_try_acquire_write, args=(str(tmp_path / "lockfile"), q))
+        p.start()
+        p.join()
+        assert q.get() is False
+    finally:
+        lock.release_write()
+
+    # Fails when another process holds a read lock
+    lock.acquire_read()
+    try:
+        q = ctx.Queue()
+        p = ctx.Process(target=_child_try_acquire_write, args=(str(tmp_path / "lockfile"), q))
+        p.start()
+        p.join()
+        assert q.get() is False
+    finally:
+        lock.release_read()
+
+
 def _child_fails_to_acquire_read(_lock: lk.Lock):
     try:
         _lock.acquire_read(timeout=1e-9)

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -13,7 +13,6 @@ if sys.platform == "win32":
     pytest.skip("No Windows support", allow_module_level=True)
 
 import spack.spec
-import spack.util.lock
 from spack.new_installer import (
     OVERWRITE_GARBAGE_SUFFIX,
     JobServer,
@@ -377,13 +376,10 @@ class TestScheduleBuilds:
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
         jobserver = JobServer(num_jobs=2)
-        # Pre-register the lock in the prefix_locker cache, then patch acquire_write to fail.
+        # Pre-register the lock in the prefix_locker cache, then patch try_acquire to fail.
         lock = temporary_store.prefix_locker.lock(spec)
-
-        def always_timeout(timeout=None):
-            raise spack.util.lock.LockTimeoutError("write", lock.path, 0, 1)
-
-        monkeypatch.setattr(lock, "acquire_write", always_timeout)
+        monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
+        monkeypatch.setattr(lock, "try_acquire_read", lambda: False)
         try:
             blocked, to_start, newly_installed = schedule_builds(
                 pending,
@@ -438,13 +434,10 @@ class TestScheduleBuilds:
         pending = [spec_a.dag_hash(), spec_b.dag_hash()]
         bg = _FakeBuildGraph([spec_a, spec_b])
         jobserver = JobServer(num_jobs=4)
-        # Patch spec_a's lock to always time out, simulating an external write lock.
+        # Patch spec_a's lock to always fail, simulating an external write lock.
         lock_a = temporary_store.prefix_locker.lock(spec_a)
-
-        def always_timeout(timeout=None):
-            raise spack.util.lock.LockTimeoutError("write", lock_a.path, 0, 1)
-
-        monkeypatch.setattr(lock_a, "acquire_write", always_timeout)
+        monkeypatch.setattr(lock_a, "try_acquire_write", lambda: False)
+        monkeypatch.setattr(lock_a, "try_acquire_read", lambda: False)
         try:
             blocked, to_start, newly_installed = schedule_builds(
                 pending,
@@ -482,11 +475,7 @@ class TestScheduleBuilds:
         bg = _FakeBuildGraph([spec])
         jobserver = JobServer(num_jobs=2)
         lock = temporary_store.prefix_locker.lock(spec)
-
-        def write_timeout(timeout=None):
-            raise spack.util.lock.LockTimeoutError("write", lock.path, 0, 1)
-
-        monkeypatch.setattr(lock, "acquire_write", write_timeout)
+        monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
         try:
             blocked, to_start, newly_installed = schedule_builds(
                 pending,
@@ -524,11 +513,7 @@ class TestScheduleBuilds:
         bg = _FakeBuildGraph([spec])
         jobserver = JobServer(num_jobs=2)
         lock = temporary_store.prefix_locker.lock(spec)
-
-        def write_timeout(timeout=None):
-            raise spack.util.lock.LockTimeoutError("write", lock.path, 0, 1)
-
-        monkeypatch.setattr(lock, "acquire_write", write_timeout)
+        monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
         try:
             blocked, to_start, newly_installed = schedule_builds(
                 pending,

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -57,6 +57,11 @@ class Lock(Llnl_lock):
             return super()._lock(op, timeout)
         return 0.0, 0
 
+    def _poll_lock(self, op: int) -> bool:
+        if self._enable:
+            return super()._poll_lock(op)
+        return True
+
     def _unlock(self) -> None:
         """Unlock call that always succeeds."""
         if self._enable:


### PR DESCRIPTION
Add `Lock.try_acquire_write()` and `Lock.try_acquire_read()` to simplify
the code in the new installer which only uses non-blocking lock calls in
the event loop.

