### PR TITLE
installer: improve spawn/forkserver

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -10,6 +10,7 @@ after the system path is set up.
 import argparse
 import gc
 import inspect
+import multiprocessing
 import operator
 import os
 import pstats
@@ -1120,6 +1121,9 @@ def main(argv=None):
             the executable name. If None, parses from sys.argv.
 
     """
+    # When using the forkserver start method, preload the following modules to improve startup
+    # time of child processes.
+    multiprocessing.set_forkserver_preload(["spack.main", "spack.package", "spack.new_installer"])
     try:
         g0, g1, g2 = gc.get_threshold()
         gc.set_threshold(50 * g0, g1, g2)

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -70,6 +70,7 @@ import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty
 import spack.llnl.util.tty.color
 import spack.paths
+import spack.repo
 import spack.report
 import spack.spec
 import spack.stage
@@ -290,7 +291,7 @@ class GlobalState:
     but excludes the Spack environment, which is slow to serialize and should not be needed
     during the build."""
 
-    __slots__ = ("store", "config", "monkey_patches", "spack_working_dir")
+    __slots__ = ("store", "config", "monkey_patches", "spack_working_dir", "repo_cache")
 
     def __init__(self):
         if multiprocessing.get_start_method() == "fork":
@@ -299,6 +300,10 @@ class GlobalState:
         self.store = spack.store.STORE
         self.monkey_patches = spack.subprocess_context.TestPatches.create()
         self.spack_working_dir = spack.paths.spack_working_dir
+        # Avoid 8k stat calls in build process. The downside of this is the additional startup
+        # cost that blocks the parent process in `proc.start()`, but we avoid filesystem pressure.
+        # TODO: we don't need to send this if Spec.satisfies(...) etc does not depend on the repo.
+        self.repo_cache = spack.repo.FastPackageChecker._paths_cache
 
     def restore(self):
         if multiprocessing.get_start_method() == "fork":
@@ -315,6 +320,7 @@ class GlobalState:
         spack.config.CONFIG = self.config
         self.monkey_patches.restore()
         spack.paths.spack_working_dir = self.spack_working_dir
+        spack.repo.FastPackageChecker._paths_cache = self.repo_cache
 
 
 class PrefixPivoter:


### PR DESCRIPTION
* In the forkserver case, preload a few modules needed in the installer
* Avoid the package.py stat calls (~8k+) in build processes under spawn/forkserver

There's a bit of an annoying trade-off here. The cost of passing the 

```
{pkg: mtime}
```

dict to the build process results in about 15ms startup cost due to IPC, which
is noticable in when for example the `gmake` package unlocks 10 further builds
after it finishes.

I've added a TODO in the comments: we should just get rid of `satisfies` etc
looking up virtuals in package.py. That's a bigger change, so outside the scope
of this PR.

