### PR TITLE
solver: parameter tuning

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -113,7 +113,16 @@ def default_clingo_control():
     control = clingo().Control()
     control.configuration.configuration = "tweety"
     control.configuration.solver.heuristic = "Domain"
-    control.configuration.solver.opt_strategy = "usc"
+    control.configuration.solver.opt_strategy = "usc,2"
+    control.configuration.solver.opt_heuristic = "model"
+    control.configuration.solver.del_max = "650000"
+    control.configuration.solver.nant = "yes"
+    control.configuration.solver.score_res = "multiset"
+    control.configuration.solver.sign_def = "neg"
+    control.configuration.solver.del_glue = "5,0"
+    control.configuration.solver.otfs = "2"
+    control.configuration.asp.trans_ext = "no"
+    control.configuration.asp.backprop = "yes"
     return control
 
 

--- a/lib/spack/spack/solver/heuristic.lp
+++ b/lib/spack/spack/solver/heuristic.lp
@@ -8,14 +8,16 @@
 
 % Decide about DAG atoms, before trying to guess facts used only in
 % the internal representation
-#heuristic attr("virtual_node", node(X, Virtual)). [80, level]
-#heuristic attr("node", PackageNode). [80, level]
-#heuristic attr("version", node(PackageID, Package), Version). [80, level]
-#heuristic attr("variant_value", PackageNode, Variant, Value). [80, level]
-#heuristic attr("node_target", node(PackageID, Package), Target). [80, level]
-#heuristic virtual_on_edge(PackageNode, ProviderNode, Virtual, Type). [80, level]
+#heuristic attr("virtual_node", node(X, Virtual)). [120, level]
+#heuristic attr("node", PackageNode). [120, level]
+#heuristic attr("version", node(PackageID, Package), Version). [120, level]
+#heuristic attr("variant_value", PackageNode, Variant, Value). [120, level]
+#heuristic attr("node_target", node(PackageID, Package), Target). [120, level]
+#heuristic virtual_on_edge(PackageNode, ProviderNode, Virtual, Type). [120, level]
+#heuristic virtual_on_edge(PackageNode, ProviderNode, Virtual, Type). [4, factor]
 
-#heuristic attr("virtual_node", node(X, Virtual)). [600, init]
+#heuristic attr("virtual_node", node(X, Virtual)). [800, init]
+#heuristic attr("virtual_node", node(X, Virtual)). [4, factor]
 #heuristic attr("virtual_node", node(X, Virtual)). [-1, sign]
 #heuristic attr("virtual_node", node(0, Virtual)) : node_depends_on_virtual(PackageNode, Virtual). [1@2, sign]
 #heuristic attr("virtual_node", node(0, "c")).     [1@3, sign]
@@ -30,6 +32,12 @@
 #heuristic attr("version", node(PackageID, Package), Version). [30, init]
 #heuristic attr("version", node(PackageID, Package), Version). [-1, sign]
 #heuristic attr("version", node(PackageID, Package), Version) : pkg_fact(Package, version_declared(Version, 0)), attr("node", node(PackageID, Package)). [ 1@2, sign]
+
+% Prefer negative sign for node_platform and node_os (default value is typically correct)
+#heuristic attr("node_platform", node(PackageID, Package), Platform). [120, level]
+#heuristic attr("node_platform", node(PackageID, Package), Platform). [-1, sign]
+#heuristic attr("node_os", node(PackageID, Package), OS). [120, level]
+#heuristic attr("node_os", node(PackageID, Package), OS). [-1, sign]
 
 % Use default targets
 #heuristic attr("node_target", node(PackageID, Package), Target). [-1, sign]


### PR DESCRIPTION
Based on 156 experiments done by Claude



| # | Change | Improvement | Notes |
|---|--------|-------------|-------|
| 1 | `--opt-strategy=usc,2` | -0.40s | sub-option 2 best; bb and other usc variants worse |
| 2 | `--del-glue=4,0` then `5,0` | -0.34s | sweet spot at 5; values 2-4 and 6-7 worse |
| 3 | `--opt-heuristic=model` | -0.25s | sign variant worse |
| 4 | `--parallel-mode=2` | -0.16s | 4 threads adds overhead; 2 is sweet spot (not included in this PR, but tried) |
| 5 | `--sign-def=neg` | -0.12s | pos and sign-fix worse |
| 6 | `--score-res=multiset` | -0.10s | solving time 3.72s→3.48s; set/min worse |
| 7 | `--backprop` | -0.08s | ASP preprocessing backpropagation |
| 8 | heuristic: `[4, factor]` on virtual_on_edge | -0.07s | factor 8 worse |
| 9 | heuristic: `[4, factor]` on virtual_node | -0.07s | factor 8 worse |
| 10 | heuristic: `[120, level]` on node atoms | -0.06s | 80, 100, 130, 160 all worse |
| 11 | heuristic: `[120, level] + [-1, sign]` for node_platform/node_os | -0.06s | solving time 3.48s→3.37s |
| 12 | `--del-max=650000` | -0.06s | tuned from 2M default; 500k-620k and 700k+ worse |
| 13 | `--trans-ext=no` | -0.05s | dynamic (tweety default) and all/choice worse |
| 14 | heuristic: virtual_node init `[800, init]` | -0.03s | 600 and 1000 worse |
| 15 | `--nant` (prefer negative antecedents) | -0.03s | |
| 16 | `--otfs=2` | -0.02s | |
| **Total** | | **-2.00s** | **19.69s → 17.69s (10.2% faster)** |