### PR TITLE
solver: add weights to virtual versions if they are declared 

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2740,7 +2740,7 @@ class SpackSolverSetup:
             else:
                 raise TypeError(f"expected version type, found: {type(v)}")
 
-        # Define a set of synthetic possible versions for virtuals that don't define them in a
+        # Define a set of synthetic possible versions for virtuals that don't define versions in a
         # package.py file. This ensures that `version_satisfies(Package, Constraint, Version)` has
         # the same semantics for virtuals as for regular packages.
         for pkg_name, versions in self.version_constraints.items():

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2729,13 +2729,6 @@ class SpackSolverSetup:
             except spack.repo.UnknownPackageError:
                 continue
 
-        # Aggregate constraints into per-virtual sets
-        constraint_map = collections.defaultdict(lambda: set())
-        for pkg_name, version_set in self.version_constraints.items():
-            if pkg_name not in self.possible_virtuals:
-                continue
-            constraint_map[pkg_name].update(version_set)
-
         # extract all the real versions mentioned in version ranges
         def versions_for(v):
             if isinstance(v, vn.StandardVersion):
@@ -2747,13 +2740,18 @@ class SpackSolverSetup:
             else:
                 raise TypeError(f"expected version type, found: {type(v)}")
 
-        # define a set of synthetic possible versions for virtuals, so
-        # that `version_satisfies(Package, Constraint, Version)` has the
-        # same semantics for virtuals as for regular packages.
-        for pkg_name, versions in sorted(constraint_map.items()):
-            # Already defined in package.py
+        # Define a set of synthetic possible versions for virtuals that don't define them in a
+        # package.py file. This ensures that `version_satisfies(Package, Constraint, Version)` has
+        # the same semantics for virtuals as for regular packages.
+        for pkg_name, versions in self.version_constraints.items():
+            # Not a virtual package
+            if pkg_name not in self.possible_virtuals:
+                continue
+
+            # Virtual versions already defined in package.py
             if pkg_name in self.possible_versions:
                 continue
+
             possible_versions = set(sum([versions_for(v) for v in versions], []))
             for version in sorted(possible_versions):
                 self.possible_versions[pkg_name][version].append(Provenance.VIRTUAL_CONSTRAINT)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1366,7 +1366,7 @@ class SpackSolverSetup:
         self.rejected_compilers: Set[spack.spec.Spec] = set()
         self.possible_oses: Set = set()
         self.variant_values_from_specs: Set = set()
-        self.version_constraints: Set = set()
+        self.version_constraints: Dict[str, Set] = collections.defaultdict(set)
         self.target_constraints: Set = set()
         self.default_targets: List = []
         self.variant_ids_by_def_id: Dict[int, int] = {}
@@ -1446,7 +1446,7 @@ class SpackSolverSetup:
             return []
 
         # record all version constraints for later
-        self.version_constraints.add((name, spec.versions))
+        self.version_constraints[name].add(spec.versions)
         return [fn.attr("node_version_satisfies", name, spec.versions)]
 
     def target_ranges(
@@ -1905,8 +1905,8 @@ class SpackSolverSetup:
         for i, (cond, (spec_to_splice, match_variants)) in enumerate(
             sorted(pkg.splice_specs.items())
         ):
-            self.version_constraints.add((pkg.name, cond.versions))
-            self.version_constraints.add((spec_to_splice.name, spec_to_splice.versions))
+            self.version_constraints[pkg.name].add(cond.versions)
+            self.version_constraints[spec_to_splice.name].add(spec_to_splice.versions)
             hash_var = AspVar("Hash")
             splice_node = fn.node(AspVar("NID"), pkg.name)
             when_spec_attrs = [
@@ -2692,24 +2692,27 @@ class SpackSolverSetup:
             self.gen.newline()
         self.gen.newline()
 
-        for pkg_name, versions in sorted(self.version_constraints):
+        for pkg_name, version_set in sorted(self.version_constraints.items()):
             possible_versions = sorted_versions.get(pkg_name)
             if possible_versions is None:
                 continue
-            # Look for contiguous ranges of versions that satisfy the constraint
-            start_idx = None
-            for current_idx, v in enumerate(possible_versions):
-                if v.satisfies(versions):
-                    if start_idx is None:
-                        start_idx = current_idx
-                elif start_idx is not None:
-                    # End of a contiguous satisfying range found
-                    version_range = fn.version_range(versions, start_idx, current_idx - 1)
+            for versions in sorted(version_set):
+                # Look for contiguous ranges of versions that satisfy the constraint
+                start_idx = None
+                for current_idx, v in enumerate(possible_versions):
+                    if v.satisfies(versions):
+                        if start_idx is None:
+                            start_idx = current_idx
+                    elif start_idx is not None:
+                        # End of a contiguous satisfying range found
+                        version_range = fn.version_range(versions, start_idx, current_idx - 1)
+                        self.gen.fact(fn.pkg_fact(pkg_name, version_range))
+                        start_idx = None
+                if start_idx is not None:
+                    version_range = fn.version_range(
+                        versions, start_idx, len(possible_versions) - 1
+                    )
                     self.gen.fact(fn.pkg_fact(pkg_name, version_range))
-                    start_idx = None
-            if start_idx is not None:
-                version_range = fn.version_range(versions, start_idx, len(possible_versions) - 1)
-                self.gen.fact(fn.pkg_fact(pkg_name, version_range))
             self.gen.newline()
 
     def collect_virtual_constraints(self):
@@ -2728,10 +2731,10 @@ class SpackSolverSetup:
 
         # Aggregate constraints into per-virtual sets
         constraint_map = collections.defaultdict(lambda: set())
-        for pkg_name, versions in self.version_constraints:
+        for pkg_name, version_set in self.version_constraints.items():
             if pkg_name not in self.possible_virtuals:
                 continue
-            constraint_map[pkg_name].add(versions)
+            constraint_map[pkg_name].update(version_set)
 
         # extract all the real versions mentioned in version ranges
         def versions_for(v):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2732,11 +2732,13 @@ class SpackSolverSetup:
         # extract all the real versions mentioned in version ranges
         def versions_for(v):
             if isinstance(v, vn.StandardVersion):
-                return [v]
+                yield v
             elif isinstance(v, vn.ClosedOpenRange):
-                return [v.lo, vn._prev_version(v.hi)]
+                yield v.lo
+                yield vn._prev_version(v.hi)
             elif isinstance(v, vn.VersionList):
-                return sum((versions_for(e) for e in v), [])
+                for e in v:
+                    yield from versions_for(e)
             else:
                 raise TypeError(f"expected version type, found: {type(v)}")
 
@@ -2752,8 +2754,8 @@ class SpackSolverSetup:
             if pkg_name in self.possible_versions:
                 continue
 
-            possible_versions = set(sum([versions_for(v) for v in versions], []))
-            for version in sorted(possible_versions):
+            possible_versions = {pv for v in versions for pv in versions_for(v)}
+            for version in possible_versions:
                 self.possible_versions[pkg_name][version].append(Provenance.VIRTUAL_CONSTRAINT)
 
     def define_target_constraints(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1410,7 +1410,10 @@ class SpackSolverSetup:
 
         # Set the deprecation penalty, according to the package. This should be enough to move the
         # first version last if deprecated.
-        self.gen.fact(fn.pkg_fact(pkg.name, fn.version_deprecation_penalty(len(ordered_versions))))
+        if ordered_versions:
+            self.gen.fact(
+                fn.pkg_fact(pkg.name, fn.version_deprecation_penalty(len(ordered_versions)))
+            )
 
         for weight, declared_version in enumerate(ordered_versions):
             self.gen.fact(fn.pkg_fact(pkg.name, fn.version_declared(declared_version, weight)))
@@ -2454,23 +2457,9 @@ class SpackSolverSetup:
         """Declare any versions in specs not declared in packages."""
         packages_yaml = spack.config.CONFIG.get_config("packages")
         for pkg_name in sorted(possible_pkgs):
-            pkg_cls = self.pkg_class(pkg_name)
-
-            # All the versions from the corresponding package.py file. Since concepts
-            # like being a "develop" version or being preferred exist only at a
-            # package.py level, sort them in this partial list here
-            from_package_py = list(pkg_cls.versions.items())
-
-            if require_checksum and pkg_cls.has_code:
-                from_package_py = [x for x in from_package_py if _is_checksummed_version(x)]
-
-            for v, version_info in from_package_py:
-                if version_info.get("deprecated", False):
-                    self.deprecated_versions[pkg_name].add(v)
-                    if not allow_deprecated:
-                        continue
-
-                self.possible_versions[pkg_name][v].append(Provenance.PACKAGE_PY)
+            self._define_versions_from_package_py(
+                pkg_name, require_checksum=require_checksum, allow_deprecated=allow_deprecated
+            )
 
             if pkg_name not in packages_yaml or "version" not in packages_yaml[pkg_name]:
                 continue
@@ -2502,6 +2491,27 @@ class SpackSolverSetup:
                     provenance = Provenance.PACKAGES_YAML_GIT_VERSION
                 self.possible_versions[pkg_name][v].append(provenance)
             self.versions_from_yaml[pkg_name] = from_packages_yaml
+
+    def _define_versions_from_package_py(
+        self, pkg_name: str, *, require_checksum: bool, allow_deprecated: bool
+    ):
+        pkg_cls = self.pkg_class(pkg_name)
+
+        # All the versions from the corresponding package.py file. Since concepts
+        # like being a "develop" version or being preferred exist only at a
+        # package.py level, sort them in this partial list here
+        from_package_py = list(pkg_cls.versions.items())
+
+        if require_checksum and pkg_cls.has_code:
+            from_package_py = [x for x in from_package_py if _is_checksummed_version(x)]
+
+        for v, version_info in from_package_py:
+            if version_info.get("deprecated", False):
+                self.deprecated_versions[pkg_name].add(v)
+                if not allow_deprecated:
+                    continue
+
+            self.possible_versions[pkg_name][v].append(Provenance.PACKAGE_PY)
 
     def define_ad_hoc_versions_from_specs(
         self, specs, origin, *, allow_deprecated: bool, require_checksum: bool
@@ -2682,7 +2692,7 @@ class SpackSolverSetup:
             self.gen.newline()
         self.gen.newline()
 
-        for pkg_name, versions in self.version_constraints:
+        for pkg_name, versions in sorted(self.version_constraints):
             possible_versions = sorted_versions.get(pkg_name)
             if possible_versions is None:
                 continue
@@ -2707,10 +2717,19 @@ class SpackSolverSetup:
 
         Must be called before define_version_constraints().
         """
-        # aggregate constraints into per-virtual sets
+        # If versions are declared in a package.py file, take the definition from there
+        for virtual_name in self.possible_virtuals:
+            try:
+                self._define_versions_from_package_py(
+                    virtual_name, require_checksum=False, allow_deprecated=False
+                )
+            except spack.repo.UnknownPackageError:
+                continue
+
+        # Aggregate constraints into per-virtual sets
         constraint_map = collections.defaultdict(lambda: set())
         for pkg_name, versions in self.version_constraints:
-            if not spack.repo.PATH.is_virtual(pkg_name):
+            if pkg_name not in self.possible_virtuals:
                 continue
             constraint_map[pkg_name].add(versions)
 
@@ -2729,6 +2748,9 @@ class SpackSolverSetup:
         # that `version_satisfies(Package, Constraint, Version)` has the
         # same semantics for virtuals as for regular packages.
         for pkg_name, versions in sorted(constraint_map.items()):
+            # Already defined in package.py
+            if pkg_name in self.possible_versions:
+                continue
             possible_versions = set(sum([versions_for(v) for v in versions], []))
             for version in sorted(possible_versions):
                 self.possible_versions[pkg_name][version].append(Provenance.VIRTUAL_CONSTRAINT)
@@ -3052,8 +3074,16 @@ class SpackSolverSetup:
         self.gen.h1("Variant Values defined in specs")
         self.define_variant_values()
 
-        self.gen.h1("Version Constraints")
         self.collect_virtual_constraints()
+        self.gen.h1("Virtual Versions")
+        for virtual_name in self.possible_virtuals:
+            try:
+                virtual_pkg_cls = self.pkg_class(virtual_name)
+            except spack.repo.UnknownPackageError:
+                continue
+            self.pkg_version_rules(virtual_pkg_cls)
+
+        self.gen.h1("Version Constraints")
         self.define_version_constraints()
 
         self.gen.h1("Target Constraints")

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -344,6 +344,11 @@ version_weight(node(ID, Package), Weight)
      attr("node", node(ID, Package)),
      pkg_fact(Package, version_declared(Version, Weight)).
 
+version_weight(node(ID, Virtual), Weight)
+  :- attr("version", node(ID, Virtual), Version),
+     attr("virtual_node", node(ID, Virtual)),
+     pkg_fact(Virtual, version_declared(Version, Weight)).
+
 version_deprecation_penalty(node(ID, Package), Penalty)
   :- pkg_fact(Package, deprecated_version(Version)),
      pkg_fact(Package, version_deprecation_penalty(Penalty)),
@@ -2314,7 +2319,7 @@ opt_criterion(3, "non-preferred targets (runtimes)").
 }.
 
 % Try to use the most optimal providers as much as possible
-opt_criterion(2, "providers on edges").
+opt_criterion(2, "providers on edges and providers version").
 #minimize{ 0@202: #true }.
 #minimize{ 0@2: #true }.
 #minimize{
@@ -2324,6 +2329,9 @@ opt_criterion(2, "providers on edges").
       not attr("root", ProviderNode),
       language(Virtual),
       depends_on(ParentNode, ProviderNode)
+}.
+#minimize{
+    Weight@2,node(X, Virtual) : version_weight(node(X, Virtual), Weight), virtual(Virtual)
 }.
 
 % Try to use latest versions of nodes as much as possible
@@ -2339,13 +2347,12 @@ opt_criterion(1, "version badness on edges").
 }.
 
 % Reduce symmetry on duplicates
-opt_criterion(0, "penalty on symmetric duplicates").
+opt_criterion(0, "penalty on symmetric duplicates and virtual versions").
 #minimize{ 0@200: #true }.
 #minimize{ 0@0: #true }.
 #minimize{
-    Weight@1,PackageNode,Reason : duplicate_penalty(PackageNode, Weight, Reason)
+    Weight@0,PackageNode,Reason : duplicate_penalty(PackageNode, Weight, Reason)
 }.
-
 
 %-----------
 % Notes

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -79,7 +79,7 @@ class RuntimePropertyRecorder:
 
         dependency_spec = spack.spec.Spec(dependency_str)
         if dependency_spec.versions != spack.version.any_version:
-            self._setup.version_constraints.add((dependency_spec.name, dependency_spec.versions))
+            self._setup.version_constraints[dependency_spec.name].add(dependency_spec.versions)
 
         self.injected_dependencies.add(dependency_spec)
         body_str, node_variable = self.rule_body_from(when_spec)
@@ -195,9 +195,7 @@ class RuntimePropertyRecorder:
         constraint_clauses = self._setup.spec_clauses(constraint_spec, body=False)
         for clause in constraint_clauses:
             if clause.args[0] == "node_version_satisfies":
-                self._setup.version_constraints.add(
-                    (constraint_spec.name, constraint_spec.versions)
-                )
+                self._setup.version_constraints[constraint_spec.name].add(constraint_spec.versions)
                 args = f'"{constraint_spec.name}", "{constraint_spec.versions}"'
                 head_str = f"propagate({node_variable}, node_version_satisfies({args}))"
                 rule = f"{head_str} :-\n{body_str}."


### PR DESCRIPTION
This would reduce the number of optimal models in clingo if we declare a version for the virtuals in `package.py`. I don't expect speed ups but I still have to measure.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
