### PR TITLE
requirements.py: warn on `prefer:all:[%foo]`

### DIFF
--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -345,21 +345,19 @@ class RequirementParser:
                 continue
             elif edge.virtuals:
                 # The case `%c,cxx=gcc` or similar.
-                data = {"packages": {v: {section: [str(edge.spec)]} for v in edge.virtuals}}
-                suggestions.append(spack.util.spack_yaml.dump(data).rstrip())
+                keys = edge.virtuals
+                comment = ""
             elif edge.spec.name in self.compiler_pkgs:
                 # Just a package `%gcc`.
-                data = {"packages": {"c": {section: [str(edge.spec)]}}}
-                suggestions.append(
-                    "# For each language virtual (c, cxx, fortran, ...):\n"
-                    + spack.util.spack_yaml.dump(data).rstrip()
-                )
+                keys = ("c",)
+                comment = "# For each language virtual (c, cxx, fortran, ...):\n"
             else:
                 # Maybe %mpich or so? Just give a generic suggestion.
-                data = {"packages": {"<virtual>": {section: [str(edge.spec)]}}}
-                suggestions.append(
-                    "# For each virtual:\n" + spack.util.spack_yaml.dump(data).rstrip()
-                )
+                keys = ("<virtual>",)
+                comment = "# For each virtual:\n"
+            data = {"packages": {k: {section: [str(edge.spec)]} for k in keys}}
+            suggestion = spack.util.spack_yaml.dump(data).rstrip()
+            suggestions.append(f"{comment}{suggestion}")
         if suggestions:
             mark = get_mark_from_yaml_data(spec_str)
             location = f"{mark.name}:{mark.line + 1}: " if mark else ""

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
-from typing import List, NamedTuple, Optional, Sequence, Tuple
+import warnings
+from typing import List, NamedTuple, Optional, Sequence, Tuple, Union
 
 import spack.config
 import spack.error
@@ -11,6 +12,7 @@ import spack.repo
 import spack.spec
 import spack.spec_parser
 import spack.traverse
+import spack.util.spack_yaml
 from spack.enums import PropagationPolicy
 from spack.llnl.util import tty
 from spack.util.spack_yaml import get_mark_from_yaml_data
@@ -106,6 +108,7 @@ class RequirementParser:
         self.compiler_pkgs = spack.repo.PATH.packages_with_tags("compiler")
         self.preferences_from_input: List[Tuple[spack.spec.Spec, str]] = []
         self.toolchains = configuration.get_config("toolchains")
+        self._warned_compiler_all: set = set()
 
     def _parse_and_expand(self, string: str, *, named: bool = False) -> spack.spec.Spec:
         result = parse_spec_from_yaml_string(string, named=named)
@@ -183,6 +186,9 @@ class RequirementParser:
     ) -> List[RequirementRule]:
         result = []
         for item in preferences:
+            if kind == RequirementKind.DEFAULT:
+                # Warn about %gcc type of preferences under `all`.
+                self._maybe_warn_compiler_in_all(item, "prefer")
             spec, condition, msg = self._parse_prefer_conflict_item(item)
             result.append(
                 preference(pkg_name, constraint=spec, condition=condition, kind=kind, message=msg)
@@ -254,6 +260,10 @@ class RequirementParser:
                     constraints = [constraints]
                     policy = "one_of"
 
+                if kind == RequirementKind.DEFAULT:
+                    # Warn about %gcc type of requirements under `all`.
+                    self._maybe_warn_compiler_in_all(constraints, "require")
+
                 # validate specs from YAML first, and fail with line numbers if parsing fails.
                 constraints = [
                     self._parse_and_expand(constraint, named=kind == RequirementKind.VIRTUAL)
@@ -313,6 +323,61 @@ class RequirementParser:
             )
             return True
         return False
+
+    def _maybe_warn_compiler_in_all(self, items: Union[str, list, dict], section: str) -> None:
+        """Warn once if a packages:all: prefer/require entry has compiler dependencies."""
+        # Stick to single items, not complex one_of / any_of groups to keep things simple.
+        if isinstance(items, str):
+            spec_str = items
+        elif isinstance(items, dict) and "spec" in items and isinstance(items["spec"], str):
+            spec_str = items["spec"]
+        elif isinstance(items, list) and len(items) == 1 and isinstance(items[0], str):
+            spec_str = items[0]
+        else:
+            return
+        if spec_str in self._warned_compiler_all:
+            return
+        self._warned_compiler_all.add(spec_str)
+        suggestions = []
+        for edge in self._parse_and_expand(spec_str).edges_to_dependencies():
+            if edge.when != spack.spec.EMPTY_SPEC:
+                # Conditional dependencies are fine (includes toolchains after expansion).
+                continue
+            elif edge.virtuals:
+                # The case `%c,cxx=gcc` or similar.
+                data = {"packages": {v: {section: [str(edge.spec)]} for v in edge.virtuals}}
+                suggestions.append(spack.util.spack_yaml.dump(data).rstrip())
+            elif edge.spec.name in self.compiler_pkgs:
+                # Just a package `%gcc`.
+                data = {"packages": {"c": {section: [str(edge.spec)]}}}
+                suggestions.append(
+                    "# For each language virtual (c, cxx, fortran, ...):\n"
+                    + spack.util.spack_yaml.dump(data).rstrip()
+                )
+            else:
+                # Maybe %mpich or so? Just give a generic suggestion.
+                data = {"packages": {"<virtual>": {section: [str(edge.spec)]}}}
+                suggestions.append(
+                    "# For each virtual:\n" + spack.util.spack_yaml.dump(data).rstrip()
+                )
+        if suggestions:
+            mark = get_mark_from_yaml_data(spec_str)
+            location = f"{mark.name}:{mark.line + 1}: " if mark else ""
+            prefix = (
+                f"{location}'packages: all: {section}: [\"{spec_str}\"]' applies a dependency "
+                f"constraint to all packages"
+            )
+            suffix = "Consider instead:\n" + "\n".join(suggestions)
+            if section == "prefer":
+                warnings.warn(
+                    f"{prefix}. This can lead to unexpected concretizations. This was likely "
+                    f"intended as a preference for a provider of a (language) virtual. {suffix}"
+                )
+            else:
+                warnings.warn(
+                    f"{prefix}. This often leads to concretization errors. This was likely "
+                    f"intended as a requirement for a provider of a (language) virtual. {suffix}"
+                )
 
 
 def _split_edge_on_virtuals(edge: spack.spec.DependencySpec) -> List[spack.spec.Spec]:

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1652,6 +1652,6 @@ def test_penalties_for_language_preferences(concretize_scope, mock_packages):
 @pytest.mark.parametrize("section", ["prefer", "require"])
 def test_warns_on_compiler_constraint_in_all(concretize_scope, test_repo, section):
     """Compiler constraints under packages:all: are a footgun and should warn."""
-    update_packages_config("packages:\n  all:\n    prefer:\n    - '%c=gcc'\n")
+    update_packages_config(f"packages:\n  all:\n    {section}:\n    - '%c=gcc'\n")
     with pytest.warns(UserWarning, match="packages: all:"):
         spack.concretize.concretize_one("gmake")

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1647,3 +1647,11 @@ def test_penalties_for_language_preferences(concretize_scope, mock_packages):
     assert s.satisfies("%c=gcc@10")
     assert all(s[name].satisfies("%c=clang") for name in dependency_names)
     assert s["mpi"].satisfies("%c,cxx=clang %fortran=gcc@10")
+
+
+@pytest.mark.parametrize("section", ["prefer", "require"])
+def test_warns_on_compiler_constraint_in_all(concretize_scope, test_repo, section):
+    """Compiler constraints under packages:all: are a footgun and should warn."""
+    update_packages_config("packages:\n  all:\n    prefer:\n    - '%c=gcc'\n")
+    with pytest.warns(UserWarning, match="packages: all:"):
+        spack.concretize.concretize_one("gmake")

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1647,11 +1647,3 @@ def test_penalties_for_language_preferences(concretize_scope, mock_packages):
     assert s.satisfies("%c=gcc@10")
     assert all(s[name].satisfies("%c=clang") for name in dependency_names)
     assert s["mpi"].satisfies("%c,cxx=clang %fortran=gcc@10")
-
-
-@pytest.mark.parametrize("section", ["prefer", "require"])
-def test_warns_on_compiler_constraint_in_all(concretize_scope, test_repo, section):
-    """Compiler constraints under packages:all: are a footgun and should warn."""
-    update_packages_config(f"packages:\n  all:\n    {section}:\n    - '%c=gcc'\n")
-    with pytest.warns(UserWarning, match="packages: all:"):
-        spack.concretize.concretize_one("gmake")

--- a/lib/spack/spack/test/error_messages.py
+++ b/lib/spack/spack/test/error_messages.py
@@ -540,3 +540,11 @@ packages:
 
     with expect_failure_and_print(should_mention=important_points):
         concretize_one("t1")
+
+
+@pytest.mark.parametrize("section", ["prefer", "require"])
+def test_warns_on_compiler_constraint_in_all(concretize_scope, mock_packages, section):
+    """Compiler constraints under packages:all: are a footgun and should warn."""
+    update_packages_config(f"packages:\n  all:\n    {section}:\n    - '%c=gcc'\n")
+    with pytest.warns(UserWarning, match="packages: all:"):
+        concretize_one("gmake")


### PR DESCRIPTION
Closes #52141 

Since `packages:all:prefer:[%c=gcc]` and similar typically don't mean what the user intended, issue a warning when concretizing.

```
==> Warning: /path/to/spack.yaml:7: 'packages: all: prefer: ["%c,cxx=gcc"]' applies a dependency constraint to all packages. This can lead to unexpected concretizations. This was likely intended as a preference for a provider of a (language) virtual. Consider instead:
packages:
  c:
    prefer:
    - gcc
  cxx:
    prefer:
    - gcc
```
