### PR TITLE
spack ci: add create-source-mirror sub-command

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -23,6 +23,7 @@ import spack.hash_types as ht
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty.color as clr
 import spack.mirrors.mirror
+import spack.mirrors.utils
 import spack.package_base
 import spack.repo
 import spack.spec
@@ -33,7 +34,7 @@ import spack.util.timer as timer
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.llnl.util import tty
-from spack.version import StandardVersion
+from spack.version import StandardVersion, VersionList
 
 from . import doc_dedented, doc_first_line
 
@@ -242,6 +243,26 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     verify_versions.add_argument("from_ref", help="git ref from which start looking at changes")
     verify_versions.add_argument("to_ref", help="git ref to end looking at changes")
     verify_versions.set_defaults(func=ci_verify_versions)
+
+    # Create a source mirror with package versions added between git refs
+    create_source_mirror = subparsers.add_parser(
+        "create-source-mirror",
+        description=doc_dedented(ci_create_source_mirror),
+        help=doc_first_line(ci_create_source_mirror),
+    )
+    create_source_mirror.add_argument(
+        "from_ref", help="git ref from which start looking at changes"
+    )
+    create_source_mirror.add_argument("to_ref", help="git ref to end looking at changes")
+    create_source_mirror.add_argument(
+        "-d", "--directory", required=True, help="directory to create or update the source mirror"
+    )
+    create_source_mirror.add_argument(
+        "--private",
+        action="store_true",
+        help="for a private mirror, include non-redistributable packages",
+    )
+    create_source_mirror.set_defaults(func=ci_create_source_mirror)
 
 
 def ci_generate(args):
@@ -727,6 +748,26 @@ def _gitlab_artifacts_url(url: str) -> str:
     return urlunparse(parsed._replace(path="/".join(parts), fragment="", query=""))
 
 
+def filter_added_versions(
+    versions: Dict[StandardVersion, str], path: str, from_ref: str, to_ref: str
+) -> List[StandardVersion]:
+    """Return versions whose checksums/commits were added between two git refs.
+
+    Args:
+        versions: dict mapping version to checksum/commit
+        path: path to the package.py file
+        from_ref: starting git ref
+        to_ref: ending git ref
+
+    Returns:
+        list of versions that were added between the refs
+    """
+    added_checksums = spack_ci.filter_added_checksums(
+        versions.values(), path, from_ref=from_ref, to_ref=to_ref
+    )
+    return [v for v, c in versions.items() if c in added_checksums]
+
+
 def validate_standard_versions(
     pkg: spack.package_base.PackageBase, versions: List[StandardVersion]
 ) -> bool:
@@ -863,15 +904,13 @@ def ci_verify_versions(args):
             # TODO: enforce every version have a commit or a sha256 defined if not
             # an infinite version (there are a lot of packages where this doesn't work yet.)
 
-        def filter_added_versions(versions: Dict[StandardVersion, str]) -> List[StandardVersion]:
-            added_checksums = spack_ci.filter_added_checksums(
-                versions.values(), path, from_ref=args.from_ref, to_ref=args.to_ref
-            )
-            return [v for v, c in versions.items() if c in added_checksums]
-
         with fs.working_dir(os.path.dirname(path)):
-            new_url_versions = filter_added_versions(url_version_to_checksum)
-            new_git_versions = filter_added_versions(git_version_to_checksum)
+            new_url_versions = filter_added_versions(
+                url_version_to_checksum, path, args.from_ref, args.to_ref
+            )
+            new_git_versions = filter_added_versions(
+                git_version_to_checksum, path, args.from_ref, args.to_ref
+            )
 
         if new_url_versions:
             success &= validate_standard_versions(pkg, new_url_versions)
@@ -880,6 +919,90 @@ def ci_verify_versions(args):
             success &= validate_git_versions(pkg, new_git_versions)
 
     if not success:
+        sys.exit(1)
+
+
+def ci_create_source_mirror(args):
+    """\
+    create a source mirror with package versions added between refs
+    """
+    # Get a list of all packages that have been changed or added
+    # between from_ref and to_ref
+    pkgs = spack.repo.get_all_package_diffs(
+        "AC", spack.repo.builtin_repo(), args.from_ref, args.to_ref
+    )
+
+    specs_to_mirror = []
+    for pkg_name in pkgs:
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        path = spack.repo.PATH.package_path(pkg_name)
+
+        # Skip manual download packages
+        if pkg_cls.manual_download:
+            tty.warn(f"Skipping manual download package: {pkg_name}")
+            continue
+
+        # Skip non-redistributable packages unless this is a private mirror
+        if not args.private:
+            spec = spack.spec.Spec(pkg_name)
+            if not pkg_cls.redistribute_source(spec):
+                tty.warn(f"Skipping non-redistributable package: {pkg_name}")
+                continue
+
+        version_to_checksum: Dict[StandardVersion, str] = {}
+        for version in pkg_cls.versions:
+            if "sha256" in pkg_cls.versions[version]:
+                version_to_checksum[version] = pkg_cls.versions[version]["sha256"]
+
+            # TODO: discuss with the team to see if we should add git versions
+            # to the source mirror. Is this something we're already doing?
+
+            # elif "commit" in pkg_cls.versions[version]:
+            #     version_to_checksum[version] = pkg_cls.versions[version]["commit"]
+
+        with fs.working_dir(os.path.dirname(path)):
+            new_versions = filter_added_versions(
+                version_to_checksum, path, args.from_ref, args.to_ref
+            )
+
+        # Create specs for new versions without concretizing spec
+        # similar to what we do when creating a mirror with --all
+        for version in new_versions:
+            version_spec = spack.spec.Spec(pkg_name)
+            version_spec.versions = VersionList([version])
+            specs_to_mirror.append(version_spec)
+
+    if not specs_to_mirror:
+        tty.msg("No new package versions found to mirror")
+        return
+
+    tty.msg(f"Creating source mirror with {len(specs_to_mirror)} package version(s)")
+
+    mirror_cache = spack.mirrors.utils.get_mirror_cache(
+        args.directory, skip_unstable_versions=True
+    )
+    mirror_stats = spack.mirrors.utils.MirrorStatsForAllSpecs()
+
+    for spec in specs_to_mirror:
+        pkg_obj = spack.repo.PATH.get_pkg_class(spec.name)(spec)
+        spec_stats = spack.mirrors.utils.MirrorStatsForOneSpec(spec)
+        spack.mirrors.utils.create_mirror_from_package_object(pkg_obj, mirror_cache, spec_stats)
+        spec_stats.finalize()
+        mirror_stats.merge(spec_stats)
+
+    # Display statistics
+    present, mirrored, error = mirror_stats.stats()
+    tty.msg(
+        "Mirror stats:",
+        f"  {len(present):4d} already present",
+        f"  {len(mirrored):4d} added",
+        f"  {len(error):4d} failed to fetch.",
+    )
+
+    if error:
+        tty.error("Failed downloads:")
+        for spec in error:
+            tty.error(f"  {spec.format('{name}{@version}')}")
         sys.exit(1)
 
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -16,9 +16,11 @@ import spack.ci as ci
 import spack.cmd
 import spack.cmd.ci
 import spack.concretize
+import spack.config
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.main
+import spack.mirrors.utils
 import spack.paths
 import spack.repo
 import spack.spec
@@ -2245,3 +2247,89 @@ def test_ci_verify_versions_manual_package(monkeypatch, mock_packages, mock_git_
 
         out = ci_cmd("verify-versions", commits[-1], commits[-2])
         assert "Skipping manual download package: diff-test" in out
+
+
+def test_ci_create_source_mirror_success(
+    monkeypatch, mock_packages, mock_git_package_changes, tmp_path: pathlib.Path, mock_fetch
+):
+    """Test that create-source-mirror successfully creates a mirror with correct specs and stats"""
+    repo, _, commits = mock_git_package_changes
+    mirror_dir = tmp_path / "test-mirror"
+
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
+
+        # Mock mirror creation to verify it's called with correct specs
+        created_specs = []
+
+        def mock_create_mirror(pkg_obj, mirror_cache, spec_stats):
+            created_specs.append(pkg_obj.spec)
+            # Simulate successful addition
+            spec_stats.added_resources.add(f"{pkg_obj.spec.name}-{pkg_obj.spec.version}")
+            return True
+
+        monkeypatch.setattr(
+            spack.mirrors.utils, "create_mirror_from_package_object", mock_create_mirror
+        )
+
+        with spack.config.override("config:checksum", False):
+            # Use commits[-1] to commits[-2] to find version 2.1.5 (sha256-based)
+            # Note: version 2.1.6 uses commit, not sha256, so it's not included
+            out = ci_cmd("create-source-mirror", commits[-1], commits[-2], "-d", str(mirror_dir))
+
+        # Verify that we attempted to mirror the new version
+        assert "Creating source mirror with" in out
+        assert "package version(s)" in out
+        assert (
+            len(created_specs) == 1
+        )  # Should have 1 version (2.1.5 only, not 2.1.6 which uses commit)
+
+        # Verify version 2.1.5 was included (sha256-based)
+        spec_names_versions = [(s.name, str(s.version)) for s in created_specs]
+        assert ("diff-test", "2.1.5") in spec_names_versions
+
+        # Verify mirror directory was created
+        assert mirror_dir.exists()
+
+        # Verify statistics are displayed
+        assert "Mirror stats:" in out
+        assert "already present" in out
+        assert "added" in out
+        assert "failed to fetch" in out
+
+
+def test_ci_create_source_mirror_no_changes(
+    monkeypatch, mock_packages, mock_git_package_changes, tmp_path: pathlib.Path
+):
+    """Test that create-source-mirror handles no new versions gracefully"""
+    repo, _, commits = mock_git_package_changes
+    mirror_dir = tmp_path / "test-mirror"
+
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
+
+        # Use the same commit for both refs - no changes
+        with spack.config.override("config:checksum", False):
+            out = ci_cmd("create-source-mirror", commits[-1], commits[-1], "-d", str(mirror_dir))
+
+        assert "No new package versions found to mirror" in out
+
+
+def test_ci_create_source_mirror_manual_package(
+    monkeypatch, mock_packages, mock_git_package_changes, tmp_path: pathlib.Path
+):
+    """Test that create-source-mirror skips manual download packages"""
+    repo, _, commits = mock_git_package_changes
+    mirror_dir = tmp_path / "test-mirror"
+
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
+
+        pkg_class = spack.repo.PATH.get_pkg_class("diff-test")
+        monkeypatch.setattr(pkg_class, "manual_download", True)
+
+        with spack.config.override("config:checksum", False):
+            out = ci_cmd("create-source-mirror", commits[-1], commits[-2], "-d", str(mirror_dir))
+
+        assert "Skipping manual download package: diff-test" in out
+        assert "No new package versions found to mirror" in out

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -14,6 +14,7 @@ from spack.vendor.typing_extensions import Literal
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.lang
 import spack.util.executable as exe
+from spack.util.environment import EnvironmentModifications
 
 # regex for a commit version
 COMMIT_VERSION = re.compile(r"^[a-f0-9]{40}$")
@@ -117,6 +118,13 @@ def git(required: bool = False) -> Optional[GitExecutable]:
     # git 2.38.1+. Do this in one place; we need git to do this in all parts of Spack.
     if git and "pytest" in sys.modules:
         git.add_default_arg("-c", "protocol.file.allow=always")
+
+    # Blacklist environment variables that can interfere with git diff operations
+    # this can cause problems for spack ci verify-versions and spack ci create-source-mirror
+    env_blacklist = EnvironmentModifications()
+    env_blacklist.unset("GIT_EXTERNAL_DIFF")
+    env_blacklist.unset("GIT_DIFF_OPTS")
+    git.add_default_envmod(env_blacklist)
 
     return git
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -706,7 +706,7 @@ _spack_ci() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="generate rebuild-index rebuild reproduce-build verify-versions"
+        SPACK_COMPREPLY="generate rebuild-index rebuild reproduce-build verify-versions create-source-mirror"
     fi
 }
 
@@ -735,6 +735,15 @@ _spack_ci_verify_versions() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_ci_create_source_mirror() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -d --directory --private"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -989,6 +989,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a rebuild-index -
 complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a rebuild -d 'rebuild a spec if it is not on the remote mirror'
 complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a reproduce-build -d 'generate instructions for reproducing the spec rebuild job'
 complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a verify-versions -d 'validate version checksum & commits between git refs'
+complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a create-source-mirror -d 'create a source mirror with package versions added between refs'
 complete -c spack -n '__fish_spack_using_command ci' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command ci' -s h -l help -d 'show this help message and exit'
 
@@ -1072,6 +1073,16 @@ set -g __fish_spack_optspecs_spack_ci_verify_versions h/help
 
 complete -c spack -n '__fish_spack_using_command ci verify-versions' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command ci verify-versions' -s h -l help -d 'show this help message and exit'
+
+# spack ci create-source-mirror
+set -g __fish_spack_optspecs_spack_ci_create_source_mirror h/help d/directory= private
+
+complete -c spack -n '__fish_spack_using_command ci create-source-mirror' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command ci create-source-mirror' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command ci create-source-mirror' -s d -l directory -r -f -a directory
+complete -c spack -n '__fish_spack_using_command ci create-source-mirror' -s d -l directory -r -d 'directory to create or update the source mirror'
+complete -c spack -n '__fish_spack_using_command ci create-source-mirror' -l private -f -a private
+complete -c spack -n '__fish_spack_using_command ci create-source-mirror' -l private -d 'for a private mirror, include non-redistributable packages'
 
 # spack clean
 set -g __fish_spack_optspecs_spack_clean h/help s/stage d/downloads f/failures m/misc-cache p/python-cache b/bootstrap a/all


### PR DESCRIPTION
This PR adds a `create-source-mirror` sub-command to `spack ci` allowing us to create (or update) a source mirror with the package versions added between two git refs. The intention would be to eventually run this command in GitHub Actions on pushes to the packages repository to update the public source mirror in real time when a PR merges.

I kept a number of the same flags from the `spack mirror` command so that we can include or exclude non-redistributable packages and point the command at a custom filepath in which to create the mirror. For example:
```bash
$ spack ci create-source-mirror -d path/to/mirror [from-ref] [to-ref]
```

While I was testing these changes I also ran into an issue where I'd set `$GIT_EXTERNAL_DIFF` in my environment to point to difftastic but that caused the diffs to be printed out in a non-standard format, I updated the `git()` initialization logic to blacklist the set of variables that could modify this behavior and break our parsing of git diffs.