### PR TITLE
Revert "build(deps): bump black in /.github/workflows/requirements/style (#52068)"

### DIFF
--- a/.github/workflows/requirements/style/requirements.txt
+++ b/.github/workflows/requirements/style/requirements.txt
@@ -1,4 +1,4 @@
-black==26.3.1
+black==25.12.0
 clingo==5.8.0
 flake8==7.3.0
 isort==7.0.0


### PR DESCRIPTION
This reverts commit 0875e9be639bc4c8cfafeb74bfe6d7e678d1bbef.

The idea was to use ruff, potentially.
