### PR TITLE
Revert "build(deps): bump black from 25.12.0 to 26.3.1 in /.github/workflows/requirements/style"

### DIFF
--- a/.github/workflows/requirements/style/requirements.txt
+++ b/.github/workflows/requirements/style/requirements.txt
@@ -1,4 +1,4 @@
-black==26.3.1
+black==25.12.0
 clingo==5.8.0
 flake8==7.3.0
 isort==7.0.0


### PR DESCRIPTION
Reverts spack/spack#52068