### PR TITLE
config.yaml: default to new installer

### DIFF
--- a/etc/spack/defaults/base/config.yaml
+++ b/etc/spack/defaults/base/config.yaml
@@ -165,8 +165,8 @@ config:
   # Windows.
   concurrent_packages: 0
 
-  # Which installer to use: "old" or "new". The new installer is experimental.
-  installer: old
+  # Which installer to use: "old" or "new".
+  installer: new
 
   # If set to true, Spack will use ccache to cache C compiles.
   ccache: false

--- a/etc/spack/defaults/windows/config.yaml
+++ b/etc/spack/defaults/windows/config.yaml
@@ -3,3 +3,4 @@ config:
   build_stage::
     - '$user_cache_path/stage'
   stage_name: '{name}-{version}-{hash:7}'
+  installer: old

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -34,6 +34,7 @@ import spack.concretize
 import spack.config
 import spack.detection
 import spack.error
+import spack.installer_dispatch
 import spack.mirrors.mirror
 import spack.platforms
 import spack.spec
@@ -290,12 +291,7 @@ class SourceBootstrapper(Bootstrapper):
 
         # Install the spec that should make the module importable
         with spack.config.override(self.mirror_scope):
-            if spack.config.get("config:installer", "old") == "new":
-                from spack.new_installer import PackageInstaller  # type: ignore
-            else:
-                from spack.installer import PackageInstaller  # type: ignore
-
-            PackageInstaller(
+            spack.installer_dispatch.create_installer(
                 [concrete_spec.package],
                 fail_fast=True,
                 root_policy="source_only",
@@ -323,11 +319,7 @@ class SourceBootstrapper(Bootstrapper):
         msg = "[BOOTSTRAP] Try installing '{0}' from sources"
         tty.debug(msg.format(abstract_spec_str))
         with spack.config.override(self.mirror_scope):
-            if spack.config.get("config:installer", "old") == "new":
-                from spack.new_installer import PackageInstaller  # type: ignore
-            else:
-                from spack.installer import PackageInstaller  # type: ignore
-            PackageInstaller([concrete_spec.package]).install()
+            spack.installer_dispatch.create_installer([concrete_spec.package]).install()
         if _executables_in_store(executables, concrete_spec, query_info=info):
             self.last_search = info
             return True

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -11,10 +11,10 @@ import spack.cmd
 import spack.cmd.common.arguments
 import spack.concretize
 import spack.config
+import spack.installer_dispatch
 import spack.llnl.util.tty as tty
 import spack.repo
 from spack.cmd.common import arguments
-from spack.installer import PackageInstaller
 
 description = "build package from code in current working directory"
 section = "build"
@@ -132,7 +132,7 @@ def dev_build(self, args):
     elif args.test == "root":
         tests = [spec.name for spec in specs]
 
-    PackageInstaller(
+    spack.installer_dispatch.create_installer(
         [spec.package],
         tests=tests,
         keep_prefix=args.keep_prefix,

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -11,6 +11,7 @@ from typing import List
 import spack.cmd
 import spack.config
 import spack.environment as ev
+import spack.installer_dispatch
 import spack.llnl.util.filesystem as fs
 import spack.paths
 import spack.spec
@@ -439,13 +440,8 @@ def install_without_active_env(args, install_kwargs, reporter):
     installs = [s.package for s in concrete_specs]
     install_kwargs["explicit"] = [s.dag_hash() for s in concrete_specs]
 
-    if spack.config.get("config:installer", "old") == "new":
-        from spack.new_installer import PackageInstaller
-    else:
-        from spack.installer import PackageInstaller
-
     try:
-        builder = PackageInstaller(installs, **install_kwargs)
+        builder = spack.installer_dispatch.create_installer(installs, **install_kwargs)
         builder.install()
     finally:
         if reporter:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -33,6 +33,7 @@ import spack.deptypes as dt
 import spack.error
 import spack.filesystem_view as fsv
 import spack.hash_types as ht
+import spack.installer_dispatch
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.color as clr
@@ -1975,12 +1976,9 @@ class Environment:
             *(s.dag_hash() for s in roots),
         }
 
-        if spack.config.get("config:installer", "old") == "new":
-            from spack.new_installer import PackageInstaller
-        else:
-            from spack.installer import PackageInstaller  # type: ignore[assignment]
-
-        builder = PackageInstaller([spec.package for spec in specs], **install_args)
+        builder = spack.installer_dispatch.create_installer(
+            [spec.package for spec in specs], **install_args
+        )
 
         try:
             builder.install()

--- a/lib/spack/spack/installer_dispatch.py
+++ b/lib/spack/spack/installer_dispatch.py
@@ -1,0 +1,87 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+from typing import TYPE_CHECKING, List, Optional, Set, Union
+
+from spack.vendor.typing_extensions import Literal
+
+import spack.config
+import spack.traverse
+
+if TYPE_CHECKING:
+    import spack.installer
+    import spack.new_installer
+    import spack.package_base
+
+
+def create_installer(
+    packages: List["spack.package_base.PackageBase"],
+    *,
+    dirty: bool = False,
+    explicit: Union[Set[str], bool] = False,
+    overwrite: Optional[Union[List[str], Set[str]]] = None,
+    fail_fast: bool = False,
+    fake: bool = False,
+    include_build_deps: bool = False,
+    install_deps: bool = True,
+    install_package: bool = True,
+    install_source: bool = False,
+    keep_prefix: bool = False,
+    keep_stage: bool = False,
+    restage: bool = True,
+    skip_patch: bool = False,
+    stop_at: Optional[str] = None,
+    stop_before: Optional[str] = None,
+    tests: Union[bool, List[str], Set[str]] = False,
+    unsigned: Optional[bool] = None,
+    verbose: bool = False,
+    concurrent_packages: Optional[int] = None,
+    root_policy: Literal["auto", "cache_only", "source_only"] = "auto",
+    dependencies_policy: Literal["auto", "cache_only", "source_only"] = "auto",
+) -> Union["spack.installer.PackageInstaller", "spack.new_installer.PackageInstaller"]:
+    """Create an installer based on the current configuration and feature support."""
+    use_old_installer = (
+        sys.platform == "win32"
+        or spack.config.get("config:installer", "new") == "old"
+        or stop_at is not None
+        or stop_before is not None
+    )
+
+    # Use the old installer if splicing is used.
+    if not use_old_installer:
+        specs = [pkg.spec for pkg in packages]
+        for s in spack.traverse.traverse_nodes(specs):
+            if s.build_spec is not s:
+                use_old_installer = True
+                break
+    if use_old_installer:
+        from spack.installer import PackageInstaller  # type: ignore
+    else:
+        from spack.new_installer import PackageInstaller  # type: ignore
+
+    return PackageInstaller(
+        packages,
+        dirty=dirty,
+        explicit=explicit,
+        overwrite=overwrite,
+        fail_fast=fail_fast,
+        fake=fake,
+        include_build_deps=include_build_deps,
+        install_deps=install_deps,
+        install_package=install_package,
+        install_source=install_source,
+        keep_prefix=keep_prefix,
+        keep_stage=keep_stage,
+        restage=restage,
+        skip_patch=skip_patch,
+        stop_at=stop_at,
+        stop_before=stop_before,
+        tests=tests,
+        unsigned=unsigned,
+        verbose=verbose,
+        concurrent_packages=concurrent_packages,
+        root_policy=root_policy,
+        dependencies_policy=dependencies_policy,
+    )

--- a/lib/spack/spack/test/data/config/config.yaml
+++ b/lib/spack/spack/test/data/config/config.yaml
@@ -12,5 +12,6 @@ config:
   verify_ssl: true
   ssl_certs: $SSL_CERT_FILE
   checksum: true
+  installer: old  # many tests are based on stdout from old installer
   dirty: false
   locks: {1}

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -19,6 +19,7 @@ import spack.deptypes as dt
 import spack.error
 import spack.hooks
 import spack.installer as inst
+import spack.installer_dispatch
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.lock as ulk
 import spack.llnl.util.tty as tty
@@ -1389,3 +1390,28 @@ def test_print_install_test_log_failures(
     inst.print_install_test_log(pkg)
     out = capfd.readouterr()[0]
     assert "See test results at" in out
+
+
+def test_fallback_to_old_installer_for_splicing(monkeypatch, mock_packages, mutable_config):
+    """Test that the old installer is used for spliced specs (unsupported in the new installer)"""
+    mutable_config.set("config:installer", "new")
+    spec = spack.concretize.concretize_one("splice-t")
+    dep = spack.concretize.concretize_one("splice-h+foo")
+    out = spec.splice(dep)
+    assert isinstance(
+        spack.installer_dispatch.create_installer([out.package]), inst.PackageInstaller
+    )
+
+
+def test_fallback_to_old_installer_for_until(monkeypatch, mock_packages, mutable_config):
+    """Test that the old installer is used if --until is used (unsupported in the new installer)"""
+    mutable_config.set("config:installer", "new")
+    spec = spack.concretize.concretize_one("trivial-install-test-package")
+    assert isinstance(
+        spack.installer_dispatch.create_installer([spec.package], stop_at="build"),
+        inst.PackageInstaller,
+    )
+    assert isinstance(
+        spack.installer_dispatch.create_installer([spec.package], stop_before="build"),
+        inst.PackageInstaller,
+    )


### PR DESCRIPTION
The new installer should be ready to be used by default on `develop`.

The new dispatch function takes unsupported features into account and falls
back to the old installer when needed.

Currently that's splicing and --until.

It's not enabled in all unit tests yet, because:

* there are many tests that monkeypatch details from the old installer
* there are many tests that expect it raises ChildError, which the new installer does not use
* there are many tests that assert stdout details, which is different in the new installer
