### PR TITLE
repo: improve patch lookup speed

### DIFF
--- a/lib/spack/spack/cmd/resource.py
+++ b/lib/spack/spack/cmd/resource.py
@@ -28,7 +28,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 def _show_patch(sha256):
     """Show a record from the patch index."""
-    patches = spack.repo.PATH.patch_index.index
+    patches = spack.repo.PATH.get_patch_index().index
     data = patches.get(sha256)
 
     if not data:
@@ -59,7 +59,7 @@ def _show_patch(sha256):
 
 def resource_list(args):
     """list all resources known to spack (currently just patches)"""
-    patches = spack.repo.PATH.patch_index.index
+    patches = spack.repo.PATH.get_patch_index().index
     for sha256 in patches:
         if args.only_hashes:
             print(sha256)

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -461,7 +461,7 @@ class PatchCache:
                     f"Patch for {pkg.fullname} with sha256 {sha256} has no owner in cache"
                 )
             try:
-                owner_pkg_cls = self.repository.get_pkg_class(owner.split(".")[-1])
+                owner_pkg_cls = self.repository.get_pkg_class(owner)
                 current_index = PatchCache._index_patches(owner_pkg_cls, self.repository)
             except Exception as e:
                 raise spack.error.PatchLookupError(

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -420,7 +420,9 @@ class PatchCache:
         """
         sjson.dump({"patches": self.index}, stream)
 
-    def patch_for_package(self, sha256: str, pkg: "spack.package_base.PackageBase") -> Patch:
+    def patch_for_package(
+        self, sha256: str, pkg: Type["spack.package_base.PackageBase"], *, validate: bool = False
+    ) -> Patch:
         """Look up a patch in the index and build a patch object for it.
 
         We build patch objects lazily because building them requires that
@@ -428,7 +430,9 @@ class PatchCache:
 
         Args:
             sha256: sha256 hash to look up
-            pkg: Package object to get patch for.
+            pkg: Package class to get patch for.
+            validate: if True, validate the cached entry against the owner's current package
+                class and raise ``spack.error.PatchLookupError`` if the entry is missing or stale.
 
         Returns:
             The patch object.
@@ -448,6 +452,26 @@ class PatchCache:
             raise spack.error.PatchLookupError(
                 f"Couldn't find patch for package {pkg.fullname} with sha256: {sha256}"
             )
+
+        if validate:
+            # Validate the cached entry against the owner's current package class
+            owner = patch_dict.get("owner")
+            if not owner:
+                raise spack.error.PatchLookupError(
+                    f"Patch for {pkg.fullname} with sha256 {sha256} has no owner in cache"
+                )
+            try:
+                owner_pkg_cls = self.repository.get_pkg_class(owner.split(".")[-1])
+                current_index = PatchCache._index_patches(owner_pkg_cls, self.repository)
+            except Exception as e:
+                raise spack.error.PatchLookupError(
+                    f"Could not validate patch cache for {pkg.fullname}: {e}"
+                ) from e
+            current_sha_index = current_index.get(sha256)
+            if not current_sha_index or current_sha_index.get(fullname) != patch_dict:
+                raise spack.error.PatchLookupError(
+                    f"Stale patch cache entry for {pkg.fullname} with sha256: {sha256}"
+                )
 
         # add the sha256 back (we take it out on write to save space,
         # because it's the index key)

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -432,7 +432,7 @@ class PatchCache:
             sha256: sha256 hash to look up
             pkg: Package class to get patch for.
             validate: if True, validate the cached entry against the owner's current package
-                class and raise ``spack.error.PatchLookupError`` if the entry is missing or stale.
+                class and raise ``PatchLookupError`` if the entry is missing or stale.
 
         Returns:
             The patch object.

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -866,9 +866,8 @@ class RepoPath:
         """
         if self._patch_index is not None and (self._index_is_fresh or allow_stale):
             return self._patch_index
-        from spack.patch import PatchCache
 
-        index = PatchCache(repository=self)
+        index = spack.patch.PatchCache(repository=self)
         for repo in reversed(self.repos):
             index.update(repo.get_patch_index(allow_stale=allow_stale))
         self._patch_index = index
@@ -890,18 +889,16 @@ class RepoPath:
         Raises:
             PatchLookupError: if a sha256 cannot be found even after a full rebuild.
         """
-        stale_cache = self.get_patch_index(allow_stale=True)
-        if stale_cache is not None:
-            try:
-                return [
-                    stale_cache.patch_for_package(sha256, pkg_cls, validate=True)
-                    for sha256 in sha256s
-                ]
-            except spack.error.PatchLookupError:
-                pass
+        stale_index = self.get_patch_index(allow_stale=True)
+        try:
+            return [
+                stale_index.patch_for_package(sha256, pkg_cls, validate=True) for sha256 in sha256s
+            ]
+        except spack.error.PatchLookupError:
+            pass
 
-        index = self.get_patch_index()
-        return [index.patch_for_package(sha256, pkg_cls) for sha256 in sha256s]
+        current_index = self.get_patch_index(allow_stale=False)
+        return [current_index.patch_for_package(sha256, pkg_cls) for sha256 in sha256s]
 
     def providers_for(self, virtual: Union[str, "spack.spec.Spec"]) -> List["spack.spec.Spec"]:
         all_packages = self._all_package_names_set(include_virtuals=False)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -887,7 +887,7 @@ class RepoPath:
             List of Patch objects in the same order as sha256s.
 
         Raises:
-            PatchLookupError: if a sha256 cannot be found even after a full rebuild.
+            spack.error.PatchLookupError: if a sha256 cannot be found even after a full rebuild.
         """
         stale_index = self.get_patch_index(allow_stale=True)
         try:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -590,12 +590,14 @@ class RepoIndex:
 
     def __init__(
         self,
-        package_checker: FastPackageChecker,
+        packages_path: str,
+        package_checker: "Callable[[], FastPackageChecker]",
         namespace: str,
         cache: spack.util.file_cache.FileCache,
     ):
-        self.checker = package_checker
-        self.packages_path = self.checker.packages_path
+        self._get_checker = package_checker
+        self._checker: Optional[FastPackageChecker] = None
+        self.packages_path = packages_path
         if sys.platform == "win32":
             self.packages_path = spack.llnl.path.convert_to_posix_path(self.packages_path)
         self.namespace = namespace
@@ -603,6 +605,15 @@ class RepoIndex:
         self.indexers: Dict[str, Indexer] = {}
         self.indexes: Dict[str, Any] = {}
         self.cache = cache
+
+        #: Whether the indexes are up to date with the package repository.
+        self.is_fresh = False
+
+    @property
+    def checker(self) -> FastPackageChecker:
+        if self._checker is None:
+            self._checker = self._get_checker()
+        return self._checker
 
     def add_indexer(self, name: str, indexer: Indexer):
         """Add an indexer to the repo index.
@@ -613,17 +624,22 @@ class RepoIndex:
         self.indexers[name] = indexer
 
     def __getitem__(self, name):
-        """Get the index with the specified name, reindexing if needed."""
+        """Get an up-to-date index with the specified name."""
+        return self.get_index(name, allow_stale=False)
+
+    def get_index(self, name, allow_stale: bool = False):
+        """Get the index with the specified name. The index will be updated if it is stale, unless
+        allow_stale is True, in which case its contents are not validated against the package
+        repository. When no cache is available, the index will be updated regardless of the value
+        of allow_stale."""
         indexer = self.indexers.get(name)
         if not indexer:
             raise KeyError("no such index: %s" % name)
-
-        if name not in self.indexes:
-            self._build_all_indexes()
-
+        if name not in self.indexes or (not allow_stale and not self.is_fresh):
+            self._build_all_indexes(allow_stale=allow_stale)
         return self.indexes[name]
 
-    def _build_all_indexes(self):
+    def _build_all_indexes(self, allow_stale: bool = False) -> None:
         """Build all the indexes at once.
 
         We regenerate *all* indexes whenever *any* index needs an update,
@@ -631,11 +647,14 @@ class RepoIndex:
         can take tens of seconds to regenerate sequentially, and we'd
         rather only pay that cost once rather than on several
         invocations."""
+        is_fresh = True
         for name, indexer in self.indexers.items():
-            self.indexes[name] = self._build_index(name, indexer)
+            is_fresh &= self._update_index(name, indexer, allow_stale=allow_stale)
+        self.is_fresh = is_fresh
 
-    def _build_index(self, name: str, indexer: Indexer):
-        """Determine which packages need an update, and update indexes."""
+    def _update_index(self, name: str, indexer: Indexer, allow_stale: bool = False) -> bool:
+        """Determine which packages need an update, and update indexes. Returns true if the
+        index is fresh."""
 
         # Filename of the provider index cache (we assume they're all json)
         from spack.spec import SPECFILE_FORMAT_VERSION
@@ -644,13 +663,21 @@ class RepoIndex:
 
         # Compute which packages needs to be updated in the cache
         index_mtime = self.cache.mtime(cache_filename)
-        needs_update = self.checker.modified_since(index_mtime)
 
         index_existed = self.cache.init_entry(cache_filename)
+        if index_existed and allow_stale:
+            with self.cache.read_transaction(cache_filename) as f:
+                indexer.read(f)
+            self.indexes[name] = indexer.index
+            return False
+
+        needs_update = self.checker.modified_since(index_mtime)
         if index_existed and not needs_update:
             # If the index exists and doesn't need an update, read it
             with self.cache.read_transaction(cache_filename) as f:
                 indexer.read(f)
+            self.indexes[name] = indexer.index
+            return True
 
         else:
             # Otherwise update it and rewrite the cache file
@@ -666,7 +693,8 @@ class RepoIndex:
                 indexer.update({f"{self.namespace}.{pkg_name}" for pkg_name in needs_update})
                 indexer.write(new)
 
-        return indexer.index
+            self.indexes[name] = indexer.index
+            return True
 
 
 class RepoPath:
@@ -682,6 +710,7 @@ class RepoPath:
         self.by_namespace = nm.NamespaceTrie()
         self._provider_index: Optional[spack.provider_index.ProviderIndex] = None
         self._patch_index: Optional[spack.patch.PatchCache] = None
+        self._index_is_fresh: bool = False
         self._tag_index: Optional[spack.tag.TagIndex] = None
 
         for repo in repos:
@@ -828,16 +857,51 @@ class RepoPath:
                 self._tag_index.merge(repo.tag_index)
         return self._tag_index
 
-    @property
-    def patch_index(self) -> spack.patch.PatchCache:
-        """Merged PatchIndex from all Repos in the RepoPath."""
-        if self._patch_index is None:
-            from spack.patch import PatchCache
+    def get_patch_index(self, allow_stale: bool = False) -> spack.patch.PatchCache:
+        """Return the merged patch index for all repos in this path.
 
-            self._patch_index = PatchCache(repository=self)
-            for repo in reversed(self.repos):
-                self._patch_index.update(repo.patch_index)
+        Args:
+            allow_stale: if True, return a possibly out-of-date index from cache files,
+                avoiding filesystem calls to check whether the index is up to date.
+        """
+        if self._patch_index is not None and (self._index_is_fresh or allow_stale):
+            return self._patch_index
+        from spack.patch import PatchCache
+
+        index = PatchCache(repository=self)
+        for repo in reversed(self.repos):
+            index.update(repo.get_patch_index(allow_stale=allow_stale))
+        self._patch_index = index
+        self._index_is_fresh = not allow_stale
         return self._patch_index
+
+    def get_patches_for_package(
+        self, sha256s: List[str], pkg_cls: Type["spack.package_base.PackageBase"]
+    ) -> List["spack.patch.Patch"]:
+        """Look up patches by sha256, trying stale cache first to avoid stat calls.
+
+        Args:
+            sha256s: ordered list of patch sha256 hashes
+            pkg_cls: package class the patches belong to
+
+        Returns:
+            List of Patch objects in the same order as sha256s.
+
+        Raises:
+            PatchLookupError: if a sha256 cannot be found even after a full rebuild.
+        """
+        stale_cache = self.get_patch_index(allow_stale=True)
+        if stale_cache is not None:
+            try:
+                return [
+                    stale_cache.patch_for_package(sha256, pkg_cls, validate=True)
+                    for sha256 in sha256s
+                ]
+            except spack.error.PatchLookupError:
+                pass
+
+        index = self.get_patch_index()
+        return [index.patch_for_package(sha256, pkg_cls) for sha256 in sha256s]
 
     def providers_for(self, virtual: Union[str, "spack.spec.Spec"]) -> List["spack.spec.Spec"]:
         all_packages = self._all_package_names_set(include_virtuals=False)
@@ -1285,7 +1349,9 @@ class Repo:
     def index(self) -> RepoIndex:
         """Construct the index for this repo lazily."""
         if self._repo_index is None:
-            self._repo_index = RepoIndex(self._pkg_checker, self.namespace, cache=self._cache)
+            self._repo_index = RepoIndex(
+                self.packages_path, lambda: self._pkg_checker, self.namespace, cache=self._cache
+            )
             self._repo_index.add_indexer("providers", ProviderIndexer(self))
             self._repo_index.add_indexer("tags", TagIndexer(self))
             self._repo_index.add_indexer("patches", PatchIndexer(self))
@@ -1293,18 +1359,18 @@ class Repo:
 
     @property
     def provider_index(self) -> spack.provider_index.ProviderIndex:
-        """A provider index with names *specific* to this repo."""
+        """A fresh provider index with names *specific* to this repo."""
         return self.index["providers"]
 
     @property
     def tag_index(self) -> spack.tag.TagIndex:
-        """Index of tags and which packages they're defined on."""
+        """Fresh index of tags and which packages they're defined on."""
         return self.index["tags"]
 
-    @property
-    def patch_index(self) -> spack.patch.PatchCache:
-        """Index of patches and packages they're defined on."""
-        return self.index["patches"]
+    def get_patch_index(self, allow_stale: bool = False) -> spack.patch.PatchCache:
+        """Index of patches and packages they're defined on. Set allow_stale is True to bypass
+        cache validation and return a potentially stale index."""
+        return self.index.get_index("patches", allow_stale=allow_stale)
 
     def providers_for(self, virtual: Union[str, "spack.spec.Spec"]) -> List["spack.spec.Spec"]:
         providers = self.provider_index.providers_for(virtual)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3659,19 +3659,16 @@ class Spec:
 
             # translate patch sha256sums to patch objects by consulting the index
             if self._patches_assigned():
-                for sha256 in self.variants["patches"]._patches_in_order_of_appearance:
-                    index = spack.repo.PATH.patch_index
-                    pkg_cls = spack.repo.PATH.get_pkg_class(self.name)
-                    try:
-                        patch = index.patch_for_package(sha256, pkg_cls)
-                    except spack.error.PatchLookupError as e:
-                        raise spack.error.SpecError(
-                            f"{e}. This usually means the patch was modified or removed. "
-                            "To fix this, either reconcretize or use the original package "
-                            "repository"
-                        ) from e
-
-                    self._patches.append(patch)
+                sha256s = list(self.variants["patches"]._patches_in_order_of_appearance)
+                pkg_cls = spack.repo.PATH.get_pkg_class(self.name)
+                try:
+                    self._patches = spack.repo.PATH.get_patches_for_package(sha256s, pkg_cls)
+                except spack.error.PatchLookupError as e:
+                    raise spack.error.SpecError(
+                        f"{e}. This usually means the patch was modified or removed. "
+                        "To fix this, either reconcretize or use the original package "
+                        "repository"
+                    ) from e
 
         return self._patches
 

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -174,6 +174,33 @@ def test_patch_in_spec(mock_packages, config):
     )
 
 
+def test_stale_patch_cache_falls_back_to_fresh(mock_packages, config):
+    """spec.patches returns correct patches even when the stale in-memory cache is wrong."""
+    spec = spack.concretize.concretize_one("patch@=1.0")
+    pkg_cls = spack.repo.PATH.get_pkg_class("patch")
+
+    # Inject a stale PatchCache: foo_sha256 points to a non-existent patch file
+    stale_cache = spack.patch.PatchCache(repository=spack.repo.PATH)
+    stale_cache.index = {
+        foo_sha256: {
+            pkg_cls.fullname: {
+                "owner": pkg_cls.fullname,
+                "relative_path": "stale_wrong.patch",
+                "level": 1,
+                "working_dir": ".",
+                "reverse": False,
+            }
+        }
+    }
+    spack.repo.PATH._patch_index = stale_cache
+    spack.repo.PATH._index_is_fresh = False
+
+    patches = spec.patches
+
+    assert len(patches) == 2
+    assert {p.relative_path for p in patches} == {"foo.patch", "baz.patch"}
+
+
 def test_patch_mixed_versions_subset_constraint(mock_packages, config):
     """If we have a package with mixed x.y and x.y.z versions, make sure that
     a patch applied to a version range of x.y.z versions is not applied to


### PR DESCRIPTION
Part of #52155 and a companion PR to #52143 to avoid hitting
the 8k stat call penalty when looking up patch files and metadata.

When looking up patches by shasum with an existing repo cache file,
the current strategy is:

* check cache validity (8k stat calls)
* lookup the patch by shasum in cache

With this commit we add an initial "optimistic" lookup in possibly stale
cache. It's expected that we hit this code path a lot as patches directives
are rarely changed.

* lookup the patch by shasum in possibly stale cache
* validate the entry by comparing with package class metadata
* early return if the same
* otherwise check ache validity (8k stat calls)
* lookup the patch by shasum in cache

This helps with the installer in the forkserver and spawn during staging
of patches, which can now be done without validating freshness of the
patch index.