### PR TITLE
spack repo: render help docs for sub-commands like `spack ci`

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -23,6 +23,8 @@ from spack.cmd.common import arguments
 from spack.error import SpackError
 from spack.llnl.util.tty import color
 
+from . import doc_dedented, doc_first_line
+
 description = "manage package source repositories"
 section = "config"
 level = "long"
@@ -32,7 +34,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="repo_command")
 
     # Create
-    create_parser = sp.add_parser("create", help=repo_create.__doc__)
+    create_parser = sp.add_parser(
+        "create", description=doc_dedented(repo_create), help=doc_first_line(repo_create)
+    )
     create_parser.add_argument("directory", help="directory to create the repo in")
     create_parser.add_argument(
         "namespace", help="name or namespace to identify packages in the repository"
@@ -48,7 +52,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     # List
-    list_parser = sp.add_parser("list", aliases=["ls"], help=repo_list.__doc__)
+    list_parser = sp.add_parser(
+        "list", aliases=["ls"], description=doc_dedented(repo_list), help=doc_first_line(repo_list)
+    )
     list_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
@@ -65,7 +71,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     # Add
-    add_parser = sp.add_parser("add", help=repo_add.__doc__)
+    add_parser = sp.add_parser(
+        "add", description=doc_dedented(repo_add), help=doc_first_line(repo_add)
+    )
     add_parser.add_argument(
         "path_or_repo", help="path or git repository of a Spack package repository"
     )
@@ -96,7 +104,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     # Set (modify existing repository configuration)
-    set_parser = sp.add_parser("set", help=repo_set.__doc__)
+    set_parser = sp.add_parser(
+        "set", description=doc_dedented(repo_set), help=doc_first_line(repo_set)
+    )
     set_parser.add_argument("namespace", help="namespace of a Spack package repository")
     set_parser.add_argument(
         "--destination", help="destination to clone git repository into", action="store"
@@ -116,7 +126,12 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     # Remove
-    remove_parser = sp.add_parser("remove", help=repo_remove.__doc__, aliases=["rm"])
+    remove_parser = sp.add_parser(
+        "remove",
+        description=doc_dedented(repo_remove),
+        help=doc_first_line(repo_remove),
+        aliases=["rm"],
+    )
     remove_parser.add_argument(
         "namespace_or_path", help="namespace or path of a Spack package repository"
     )
@@ -131,7 +146,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     # Migrate
-    migrate_parser = sp.add_parser("migrate", help=repo_migrate.__doc__)
+    migrate_parser = sp.add_parser(
+        "migrate", description=doc_dedented(repo_migrate), help=doc_first_line(repo_migrate)
+    )
     migrate_parser.add_argument(
         "namespace_or_path", help="path to a Spack package repository directory"
     )
@@ -148,7 +165,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     # Update
-    update_parser = sp.add_parser("update", help=repo_update.__doc__)
+    update_parser = sp.add_parser(
+        "update", description=doc_dedented(repo_update), help=doc_first_line(repo_update)
+    )
     update_parser.add_argument("names", nargs="*", default=[], help="repositories to update")
     update_parser.add_argument(
         "--remote",
@@ -311,14 +330,6 @@ def repo_list(args):
 
     List all package repositories known to Spack. Repositories
     can be local directories or remote git repositories.
-
-    The output can be filtered by:
-      --scope=<name>    to list repositories from a specific scope
-
-    The output format can be controlled using one of:
-      --names           to show only configuration names
-      --namespaces      to show only repository namespaces
-      --json            to output repositories as machine-readable json records
     """
     descriptors = spack.repo.RepoDescriptors.from_config(
         lock=spack.repo.package_repository_lock(), config=spack.config.CONFIG, scope=args.scope
@@ -399,7 +410,7 @@ def repo_list(args):
 
 
 def _get_repo(name_or_path: str) -> Optional[spack.repo.Repo]:
-    """Get a repo by path or namespace"""
+    """get a repo by path or namespace"""
     try:
         return spack.repo.from_path(name_or_path)
     except spack.repo.RepoError:


### PR DESCRIPTION
Update the repo command to parse help docs from docstrings like is done in the `spack ci` command.

**Before:**
```
> spack repo -h
usage: spack repo [-h] SUBCOMMAND ...

manage package source repositories

positional arguments:
  SUBCOMMAND
    create       create a new package repository
    list (ls)    show registered repositories and their namespaces

                 List all package repositories known to Spack. Repositories
                 can be local directories or remote git repositories.

                 The output can be filtered by:
                   --scope=<name>    to list repositories from a specific scope

                 The output format can be controlled using one of:
                   --names           to show only configuration names
                   --namespaces      to show only repository namespaces
                   --json            to output repositories as machine-readable json records
    add          add package repositories to Spack's configuration
    set          modify an existing repository configuration
    remove (rm)  remove a repository from Spack's configuration
    migrate      migrate a package repository to the latest Package API
    update       update one or more package repositories

options:
  -h, --help     show this help message and exit
```

**After:**
```
> spack repo -h
usage: spack repo [-h] SUBCOMMAND ...

manage package source repositories

positional arguments:
  SUBCOMMAND
    create       create a new package repository
    list (ls)    show registered repositories and their namespaces
    add          add package repositories to Spack's configuration
    set          modify an existing repository configuration
    remove (rm)  remove a repository from Spack's configuration
    migrate      migrate a package repository to the latest Package API
    update       update one or more package repositories

options:
  -h, --help     show this help message and exit

> spack repo list -h
usage: spack repo list [-h] [--scope {defaults,system,site,user,command_line} or env:ENVIRONMENT] [--names | --namespaces | --json]

show registered repositories and their namespaces

List all package repositories known to Spack. Repositories
can be local directories or remote git repositories.

options:
  --json                output repositories as machine-readable json records
  --names               show configuration names only
  --namespaces          show repository namespaces only
  --scope {defaults,system,site,user,command_line} or env:ENVIRONMENT
                        configuration scope to read from
  -h, --help            show this help message and exit
```