### PR TITLE
Add visible test stage and counts for install-time tests

### DIFF
--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -668,7 +668,54 @@ def execute_install_time_tests(builder: Builder):
     if not builder.pkg.run_tests or not builder.install_time_test_callbacks:
         return
 
-    builder.pkg.tester.phase_tests(builder, "install", builder.install_time_test_callbacks)
+    import spack.llnl.util.tty as tty
+
+    pkg = builder.pkg
+    timer = getattr(pkg, "_install_timer", None)
+    pre = getattr(pkg, "_install_pre", "")
+
+    # Start the test phase timer
+    if timer:
+        timer.start("test")
+
+    # Display test phase start message
+    tty.msg(f"{pre} Executing phase: 'test'")
+
+    try:
+        # Run the tests and get the counts
+        test_counts = pkg.tester.phase_tests(
+            builder, "install", builder.install_time_test_callbacks
+        )
+
+        # Display test summary
+        if test_counts:
+            total = test_counts.get("total", 0)
+            passed = test_counts.get("passed", 0)
+            failed = test_counts.get("failed", 0)
+            skipped = test_counts.get("skipped", 0)
+
+            if total > 0:
+                summary_parts = []
+                if passed > 0:
+                    summary_parts.append(f"{passed} passed")
+                if failed > 0:
+                    summary_parts.append(f"{failed} failed")
+                if skipped > 0:
+                    summary_parts.append(f"{skipped} skipped")
+
+                if summary_parts:
+                    summary = ", ".join(summary_parts)
+                    tty.msg(f"{pre} Tests: {summary} ({total} total)")
+                else:
+                    # Edge case: tests ran but no status recorded
+                    tty.msg(f"{pre} Tests: {total} total")
+            else:
+                # No tests were actually executed
+                tty.debug(f"{pre} No install-time tests were executed")
+    finally:
+        # Always stop the timer, even if tests fail
+        if timer:
+            timer.stop("test")
 
 
 class Package(spack.package_base.PackageBase):

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -357,9 +357,15 @@ class PackageTest:
             builder: builder for package being tested
             phase_name: the name of the build-time phase (e.g., ``build``, ``install``)
             method_names: phase-specific callback method names
+
+        Returns:
+            dict: Test counts with keys 'total', 'passed', 'failed', 'skipped'
         """
         verbose = tty.is_verbose()
         fail_fast = spack.config.get("config:fail_fast", False)
+
+        # Track initial counts to calculate what was added during this phase
+        initial_counts = dict(self.counts)
 
         with self.test_logger(verbose=verbose, externals=False) as logger:
             # Report running each of the methods in the build log
@@ -387,9 +393,19 @@ class PackageTest:
             if have_tests:
                 print_message(logger, "Completed testing", verbose)
 
-            # Raise any collected failures here
-            if self.test_failures:
-                raise TestFailure(self.test_failures)
+        # Calculate test counts for this phase (outside the logger context)
+        test_counts = {
+            "total": self.parts() - sum(initial_counts.values()),
+            "passed": self.counts[TestStatus.PASSED] - initial_counts.get(TestStatus.PASSED, 0),
+            "failed": self.counts[TestStatus.FAILED] - initial_counts.get(TestStatus.FAILED, 0),
+            "skipped": self.counts[TestStatus.SKIPPED] - initial_counts.get(TestStatus.SKIPPED, 0),
+        }
+
+        # Raise any collected failures here
+        if self.test_failures:
+            raise TestFailure(self.test_failures)
+
+        return test_counts
 
     def stand_alone_tests(self, kwargs, timeout: Optional[int] = None) -> None:
         """Run the package's stand-alone tests.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2658,6 +2658,10 @@ class BuildProcessInstaller:
             if spack.package_base.PackageBase._verbose is not None:
                 self.echo = spack.package_base.PackageBase._verbose
 
+            # Store timer on package for access in phase callbacks
+            self.pkg._install_timer = self.timer
+            self.pkg._install_pre = self.pre
+
             # Run the pre-install hook in the child process after
             # the directory is created.
             spack.hooks.pre_install(self.pkg.spec)


### PR DESCRIPTION
- Display 'Executing phase: test' message during install-time tests
- Show test counts (X passed, Y failed, Z skipped, N total) after tests run
- Include test phase timing in final installation summary
- Add try-finally block to ensure timer always stops
- Store timer and pre-message on package object for callback access
- Modify phase_tests() to return test count dictionary
- Only display test phase when --test flag is used

Addresses feature request #52130 for better visibility of install-time test execution and results, especially useful in CI contexts.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
