### PR TITLE
externals: detect external entries with dependencies

### DIFF
--- a/lib/spack/docs/packaging_guide_advanced.rst
+++ b/lib/spack/docs/packaging_guide_advanced.rst
@@ -365,6 +365,79 @@ or like this:
            )
            raise InvalidSpecDetected(msg)
 
+
+.. _determine_dependencies:
+
+Declare dependencies of detected packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When ``spack external find`` detects a package, it can also detect how that package depends on other external packages.
+This is useful when two or more external packages are naturally installed together and their relationship should be recorded in ``packages.yaml`` automatically.
+
+To detect the dependencies of an external package, implement a ``determine_dependencies`` classmethod:
+
+.. code-block:: python
+
+   @classmethod
+   def determine_dependencies(cls, spec: Spec):
+       """Return dependencies detected alongside ``spec``.
+
+       Args:
+           spec: the detected spec whose dependencies should be found.
+
+       Returns:
+           A list of dependencies, or an empty list if none are detected.
+           Each element may be:
+
+           * a plain string such as ``"hwloc@2.9"``
+           * a dict with the following keys:
+
+             - ``"spec"`` (required): a string describing the dependency
+             - ``"prefix"`` (optional): path to the dependency's installation prefix;
+               stored as ``external_path`` on the spec and used by the detection loop
+               to search that location for the dependency if it has not been found yet
+             - ``"deptypes"`` (optional): dependency types (e.g. ``("link", "run")``)
+             - ``"virtuals"`` (optional): tuple of virtual names satisfied by this dependency
+       """
+
+The simplest form returns a list of version strings:
+
+.. code-block:: python
+
+   class Openmpi(AutotoolsPackage):
+       executables = ["^mpicc$"]
+
+       @classmethod
+       def determine_dependencies(cls, spec):
+           # Return the hwloc installation that this openmpi was built against.
+           hwloc_prefix = get_hwloc_prefix(spec.prefix)
+           if hwloc_prefix is None:
+               return []
+           hwloc_version = get_hwloc_version(hwloc_prefix)
+           return [f"hwloc@{hwloc_version}"]
+
+When a richer description is needed, a dict can carry additional information:
+
+.. code-block:: python
+
+   @classmethod
+   def determine_dependencies(cls, spec):
+       return [
+           {
+               "spec": "hwloc@2.9",
+               "prefix": "/usr",
+               "deptypes": ("link", "run"),
+               "virtuals": ("hwloc-api",),
+           }
+       ]
+
+Spack will look for ``hwloc`` among the packages it has already detected in this run and, if found, wire the two entries in ``packages.yaml`` automatically.
+
+.. note::
+
+   If an external entry for a package already exists in ``packages.yaml``, Spack will never overwrite its ``dependencies`` key.
+   Instead it emits a warning so you can update the entry manually if needed.
+
 .. _determine_spec_details:
 
 Custom detection workflow

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -4,16 +4,15 @@
 import argparse
 import errno
 import os
-import re
 import sys
-from typing import List, Optional, Set
+from typing import Set
 
-import spack
 import spack.cmd
 import spack.config
 import spack.cray_manifest as cray_manifest
 import spack.detection
 import spack.error
+import spack.externals
 import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.colify as colify
 import spack.package_base
@@ -127,15 +126,24 @@ def external_find(args):
         # If the user didn't specify anything, search for build tools by default
         args.tags = ["core-packages", "build-tools"]
 
-    candidate_packages = packages_to_search_for(
+    candidate_packages = spack.detection.packages_to_search_for(
         names=args.packages, tags=args.tags, exclude=args.exclude
     )
-    detected_packages = spack.detection.by_path(
-        candidate_packages, path_hints=args.path, max_workers=args.jobs
-    )
 
+    packages_yaml = spack.config.CONFIG.get_config("packages", scope=args.scope)
+    known_packages = spack.externals.root_nodes_from_config(packages_yaml)
+    detected_packages, detected_dependencies = spack.detection.by_path_with_dependencies(
+        candidate_packages,
+        path_hints=args.path,
+        max_workers=args.jobs,
+        known_packages=known_packages,
+        exclude=args.exclude,
+    )
     new_specs = spack.detection.update_configuration(
-        detected_packages, scope=args.scope, buildable=not args.not_buildable
+        detected_packages,
+        scope=args.scope,
+        buildable=not args.not_buildable,
+        resolved_dependencies=detected_dependencies,
     )
 
     # If the user runs `spack external find --not-buildable mpich` we also mark `mpi` non-buildable
@@ -156,28 +164,6 @@ def external_find(args):
         spack.cmd.display_specs(new_specs)
     else:
         tty.msg("No new external packages detected")
-
-
-def packages_to_search_for(
-    *, names: Optional[List[str]], tags: List[str], exclude: Optional[List[str]]
-):
-    result = list(
-        {pkg for tag in tags for pkg in spack.repo.PATH.packages_with_tags(tag, full=True)}
-    )
-
-    if names:
-        # Match both fully qualified and unqualified
-        parts = [rf"(^{x}$|[.]{x}$)" for x in names]
-        select_re = re.compile("|".join(parts))
-        result = [x for x in result if select_re.search(x)]
-
-    if exclude:
-        # Match both fully qualified and unqualified
-        parts = [rf"(^{x}$|[.]{x}$)" for x in exclude]
-        select_re = re.compile("|".join(parts))
-        result = [x for x in result if not select_re.search(x)]
-
-    return result
 
 
 def external_read_cray_manifest(args):

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -21,6 +21,7 @@ import spack.llnl.util.tty as tty
 import spack.platforms
 import spack.repo
 import spack.spec
+import spack.util.environment
 from spack.externals import ExternalSpecsParser, external_spec
 from spack.operating_systems import windows_os
 
@@ -70,7 +71,7 @@ def find_compilers(
         default_paths = fs.search_paths_for_executables(*path_hints)
 
     if sys.platform == "win32":
-        default_paths = default_paths or []
+        default_paths = default_paths or spack.util.environment.get_path("PATH")
         default_paths.extend(windows_os.WindowsOs().compiler_search_paths)
 
     compiler_pkgs = spack.repo.PATH.packages_with_tags(COMPILER_TAG, full=True)

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -14,6 +14,7 @@ import spack.config
 import spack.detection
 import spack.detection.path
 import spack.error
+import spack.externals
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
@@ -22,7 +23,6 @@ import spack.repo
 import spack.spec
 from spack.externals import ExternalSpecsParser, external_spec
 from spack.operating_systems import windows_os
-from spack.util.environment import get_path
 
 #: Tag used to identify packages providing a compiler
 COMPILER_TAG = "compiler"
@@ -65,19 +65,27 @@ def find_compilers(
         scope: configuration scope to modify
         max_workers: number of processes used to search for compilers
     """
-    if path_hints is None:
-        path_hints = get_path("PATH")
-    default_paths = fs.search_paths_for_executables(*path_hints)
+    default_paths = path_hints
+    if path_hints is not None:
+        default_paths = fs.search_paths_for_executables(*path_hints)
+
     if sys.platform == "win32":
+        default_paths = default_paths or []
         default_paths.extend(windows_os.WindowsOs().compiler_search_paths)
+
     compiler_pkgs = spack.repo.PATH.packages_with_tags(COMPILER_TAG, full=True)
 
-    detected_packages = spack.detection.by_path(
-        compiler_pkgs, path_hints=default_paths, max_workers=max_workers
-    )
+    packages_yaml = spack.config.CONFIG.get_config("packages", scope=scope)
+    known_packages = spack.externals.root_nodes_from_config(packages_yaml)
 
+    detected_packages, detected_dependencies = spack.detection.by_path_with_dependencies(
+        compiler_pkgs,
+        path_hints=default_paths,
+        max_workers=max_workers,
+        known_packages=known_packages,
+    )
     new_compilers = spack.detection.update_configuration(
-        detected_packages, buildable=True, scope=scope
+        detected_packages, scope=scope, buildable=True, resolved_dependencies=detected_dependencies
     )
     return new_compilers
 
@@ -259,28 +267,27 @@ class CompilerFactory:
         configuration: spack.config.Configuration, *, scope: Optional[str] = None
     ) -> List[spack.spec.Spec]:
         """Returns the compiler specs defined in the "packages" section of the configuration"""
-        externals_dicts = []
         compiler_package_names = supported_compilers()
-        packages_yaml = configuration.get_config("packages", scope=scope)
-        for name, entry in packages_yaml.items():
-            if name not in compiler_package_names:
-                continue
+        # Use a deep copy to prevent ExternalSpecsParser mutations from being written back into
+        # the memoized config objects returned by get_config.
+        packages_yaml = configuration.deepcopy_as_builtin("packages", scope=scope)
 
-            externals_config = entry.get("externals", None)
-            if not externals_config:
-                continue
+        # Pass all external entries to ExternalSpecsParser so that dependency ids can be resolved
+        # even when a compiler's dependency is not itself a compiler package
+        all_external_dicts = spack.externals.extract_dicts_from_configuration(packages_yaml)
+        discarded_dicts, selected_dicts = spack.llnl.util.lang.stable_partition(
+            all_external_dicts,
+            lambda x: spack.spec.Spec(x.get("spec", "")).name in compiler_package_names
+            and _EXTRA_ATTRIBUTES_KEY not in x,
+        )
+        for entry in discarded_dicts:
+            header = f"The external spec '{entry['spec']}' cannot be used as a compiler"
+            tty.debug(f"[{__file__}] {header}: missing the '{_EXTRA_ATTRIBUTES_KEY}' key")
 
-            for current in externals_config:
-                # If extra_attributes is not there don't use this entry as a compiler.
-                if _EXTRA_ATTRIBUTES_KEY not in current:
-                    header = f"The external spec '{current['spec']}' cannot be used as a compiler"
-                    tty.debug(f"[{__file__}] {header}: missing the '{_EXTRA_ATTRIBUTES_KEY}' key")
-                    continue
-
-                externals_dicts.append(current)
-
-        external_parser = ExternalSpecsParser(externals_dicts)
-        return external_parser.all_specs()
+        external_parser = ExternalSpecsParser(selected_dicts)
+        return [
+            spec for spec in external_parser.all_specs() if spec.name in compiler_package_names
+        ]
 
     @staticmethod
     def from_legacy_yaml(compiler_dict: Dict[str, Any]) -> List[spack.spec.Spec]:

--- a/lib/spack/spack/detection/__init__.py
+++ b/lib/spack/spack/detection/__init__.py
@@ -1,14 +1,31 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from .common import executable_prefix, set_virtuals_nonbuildable, update_configuration
-from .path import by_path, executables_in_path
+from .common import (
+    determine_external_dependencies,
+    executable_prefix,
+    set_virtuals_nonbuildable,
+    update_configuration,
+)
+from .path import (
+    by_path,
+    by_path_with_dependencies,
+    collect_dependencies,
+    executables_in_path,
+    missing_dependency_package_names,
+    packages_to_search_for,
+)
 from .test import detection_tests
 
 __all__ = [
     "by_path",
+    "by_path_with_dependencies",
+    "collect_dependencies",
+    "determine_external_dependencies",
     "executables_in_path",
     "executable_prefix",
+    "missing_dependency_package_names",
+    "packages_to_search_for",
     "update_configuration",
     "set_virtuals_nonbuildable",
     "detection_tests",

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -18,9 +18,14 @@ import os
 import pathlib
 import re
 import sys
-from typing import Dict, List, Optional, Set, Tuple, Union
+import uuid
+import warnings
+from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple, Union
+
+from spack.vendor.typing_extensions import TypedDict
 
 import spack.config
+import spack.deptypes
 import spack.error
 import spack.operating_systems.windows_os as winOs
 import spack.schema
@@ -41,11 +46,144 @@ def _externals_in_packages_yaml() -> Set[spack.spec.Spec]:
     return already_defined_specs
 
 
-ExternalEntryType = Union[str, Dict[str, str]]
+ExternalEntryType = Union[str, Dict[str, Any], List[Any]]
+
+
+class DependencyHint(TypedDict, total=False):
+    """Dict form accepted by ``determine_dependencies``.
+
+    Package authors may return plain dicts with these keys instead of just a spec. When returning
+    a dict, the ``spec`` key is required and all other keys are optional.
+    """
+
+    spec: str
+    prefix: str
+    deptypes: "spack.deptypes.DepTypes"
+    virtuals: Tuple[str, ...]
+
+
+#: Keys that are valid in a ``DependencyHint`` dict.
+_DEPENDENCY_HINT_KEYS: frozenset = frozenset(DependencyHint.__annotations__)
+
+
+class DetectedDependency(NamedTuple):
+    """A dependency detected alongside an external package"""
+
+    spec: "spack.spec.Spec"
+    deptypes: Optional[spack.deptypes.DepTypes] = None
+    virtuals: Optional[Tuple[str, ...]] = None
+
+
+def _normalize_dependency(dep: Union[str, Dict]) -> DetectedDependency:
+    """Normalize a single value returned by ``determine_dependencies``."""
+    if isinstance(dep, dict):
+        if "spec" not in dep:
+            raise ValueError(
+                f"determine_dependencies returned a dict without the required 'spec' key: {dep!r}"
+            )
+        unknown = set(dep) - _DEPENDENCY_HINT_KEYS
+        if unknown:
+            warnings.warn(
+                f"determine_dependencies returned a dict with unknown keys {sorted(unknown)};"
+                f" valid keys are {sorted(_DEPENDENCY_HINT_KEYS)}. Unknown keys are ignored."
+            )
+        spec = spack.spec.Spec(dep["spec"])
+        if "prefix" in dep:
+            spec.external_path = dep["prefix"]
+        return DetectedDependency(
+            spec=spec, deptypes=dep.get("deptypes"), virtuals=dep.get("virtuals")
+        )
+
+    return DetectedDependency(spec=spack.spec.Spec(dep))
+
+
+def determine_external_dependencies(
+    *,
+    detected_packages: Dict[str, List["spack.spec.Spec"]],
+    detected_dependencies: Dict["spack.spec.Spec", List["DetectedDependency"]],
+    known_packages: Optional[List["spack.spec.Spec"]] = None,
+) -> Dict["spack.spec.Spec", List["DetectedDependency"]]:
+    """Resolves dependency candidates against the available specs.
+
+    The resolution tries ``known_packages`` first (specs already present in ``packages.yaml``
+    from a previous run), then falls back to the detected specs.
+
+    For each resolved candidate:
+
+    - 0 matches  -> warning, dependency skipped.
+    - 1 match    -> the matching Spec object replaces the abstract candidate.
+    - 2+ matches -> warning (ambiguous), dependency skipped.
+
+    Args:
+        detected_packages: mapping of package name to detected specs, used as the
+            fallback resolution pool.
+        detected_dependencies: pre-collected output of ``collect_dependencies``
+        known_packages: optional list of specs already present in ``packages.yaml``.
+            Each spec must have ``external_path`` set so that ``update_configuration``
+            can locate the corresponding YAML entry via ``_find_entry``.
+
+    Returns:
+        Mapping of detected Spec to its list of resolved ``DetectedDependency`` entries.
+        Only specs for which at least one dependency was successfully resolved appear as keys.
+    """
+    all_detected = [spec for specs in detected_packages.values() for spec in specs]
+    known = known_packages or []
+
+    result = {}
+
+    for spec, deps in detected_dependencies.items():
+        resolved = []
+        for dep in deps:
+            # Prefer known packages
+            matches = [s for s in known if s.satisfies(dep.spec)]
+            if not matches:
+                matches = [s for s in all_detected if s.satisfies(dep.spec)]
+
+            if len(matches) == 0:
+                warnings.warn(
+                    f'"{dep.spec}" declared as a dependency of "{spec}" was not detected'
+                    f" on the system and will be skipped"
+                )
+            elif len(matches) > 1:
+                warnings.warn(
+                    f'"{dep.spec}" declared as a dependency of "{spec}" is ambiguous:'
+                    f" {len(matches)} detected specs satisfy it. Skipping"
+                )
+            else:
+                resolved.append(
+                    DetectedDependency(
+                        spec=matches[0], deptypes=dep.deptypes, virtuals=dep.virtuals
+                    )
+                )
+
+        if resolved:
+            result[spec] = resolved
+
+    return result
+
+
+def _find_entry(packages_yaml: Dict, spec: "spack.spec.Spec") -> Optional[Dict]:
+    """Return the raw YAML external entry in ``packages_yaml`` that matches ``spec``."""
+    if not spec.external_path:
+        return None
+    target_prefix = pathlib.Path(spec.external_path).as_posix()
+    pkg_config = packages_yaml.get(spec.name)
+    if not isinstance(pkg_config, dict):
+        return None
+    for entry in pkg_config.get("externals", []):
+        entry_prefix = pathlib.Path(entry.get("prefix", "")).as_posix()
+        if entry_prefix != target_prefix:
+            continue
+        if spec.satisfies(spack.spec.Spec(entry["spec"])):
+            return entry
+    return None
 
 
 def _pkg_config_dict(
     external_pkg_entries: List["spack.spec.Spec"],
+    *,
+    ids: Optional[Dict["spack.spec.Spec", str]] = None,
+    dependencies: Optional[Dict["spack.spec.Spec", List]] = None,
 ) -> Dict[str, Union[bool, List[Dict[str, ExternalEntryType]]]]:
     """Generate a package specific config dict according to the packages.yaml schema.
 
@@ -79,6 +217,12 @@ def _pkg_config_dict(
             external_items.append(
                 ("extra_attributes", spack.util.spack_yaml.syaml_dict(e.extra_attributes.items()))
             )
+
+        if ids and e in ids:
+            external_items.append(("id", ids[e]))
+
+        if dependencies and e in dependencies:
+            external_items.append(("dependencies", dependencies[e]))
 
         # external_items.extend(e.spec.extra_attributes.items())
         pkg_dict["externals"].append(spack.util.spack_yaml.syaml_dict(external_items))
@@ -204,6 +348,7 @@ def update_configuration(
     detected_packages: Dict[str, List["spack.spec.Spec"]],
     scope: Optional[str] = None,
     buildable: bool = True,
+    resolved_dependencies: Optional[Dict["spack.spec.Spec", List[DetectedDependency]]] = None,
 ) -> List[spack.spec.Spec]:
     """Add the packages passed as arguments to packages.yaml
 
@@ -211,13 +356,62 @@ def update_configuration(
         detected_packages: list of specs to be added
         scope: configuration scope where to add the detected packages
         buildable: whether the detected packages are buildable or not
+        resolved_dependencies: optional mapping from a detected spec to the list of its resolved
+            dependencies. When provided, the generated packages.yaml entries include ``id`` and
+            ``dependencies`` fields. Pre-existing entries that lack ``dependencies`` are augmented
+            in-place. Entries that already have ``dependencies`` are left untouched.
     """
+    # Read the target scope up-front so we can reuse existing IDs and augment after merge.
+    scope = scope or spack.config.default_modify_scope()
+    packages_yaml = spack.config.CONFIG.deepcopy_as_builtin("packages", scope=scope)
+
+    # Build stable IDs and serialized dependency lists for participating specs.
+    ids, serialized_deps = {}, {}
+    if resolved_dependencies:
+        # Collect all specs that appear as a parent or a child in the dependency map.
+        participating = set()
+        for parent_spec, dependencies in resolved_dependencies.items():
+            if dependencies:
+                participating.add(parent_spec)
+                participating.update(dep.spec for dep in dependencies)
+
+        # Assign UUIDs, reusing any ID that already exists in the target scope.
+        for spec in participating:
+            existing_entry = _find_entry(packages_yaml, spec)
+            if existing_entry and "id" in existing_entry:
+                ids[spec] = existing_entry["id"]
+            else:
+                ids[spec] = str(uuid.uuid4())
+
+        # Serialize each parent's dependency list into DependencyDict-compatible dicts.
+        for parent_spec, dependencies in resolved_dependencies.items():
+            dep_dicts = []
+            for dep in dependencies:
+                if dep.spec not in ids:
+                    continue
+                dep_items: List[Tuple[str, Any]] = [("id", ids[dep.spec])]
+                if dep.deptypes is not None:
+                    dep_items.append(("deptypes", list(dep.deptypes)))
+                if dep.virtuals is not None:
+                    dep_items.append(("virtuals", ",".join(dep.virtuals)))
+                dep_dicts.append(spack.util.spack_yaml.syaml_dict(dep_items))
+            if dep_dicts:
+                serialized_deps[parent_spec] = dep_dicts
+
+        # Record which parent specs already have a 'dependencies' field *before* we write
+        # anything, so the post-merge warning only fires for truly pre-existing entries.
+        specs_with_existing_deps = set()
+        for parent_spec in resolved_dependencies:
+            existing = _find_entry(packages_yaml, parent_spec)
+            if existing is not None and "dependencies" in existing:
+                specs_with_existing_deps.add(parent_spec)
+
     predefined_external_specs = _externals_in_packages_yaml()
     pkg_to_cfg, all_new_specs = {}, []
     for package_name, entries in detected_packages.items():
         new_entries = [s for s in entries if s not in predefined_external_specs]
 
-        pkg_config = _pkg_config_dict(new_entries)
+        pkg_config = _pkg_config_dict(new_entries, ids=ids, dependencies=serialized_deps)
         external_entries = pkg_config.get("externals", [])
         assert not isinstance(external_entries, bool), "unexpected value for external entry"
 
@@ -226,10 +420,28 @@ def update_configuration(
             pkg_config["buildable"] = False
         pkg_to_cfg[package_name] = pkg_config
 
-    scope = scope or spack.config.default_modify_scope()
-    pkgs_cfg = spack.config.get("packages", scope=scope)
-    pkgs_cfg = spack.schema.merge_yaml(pkgs_cfg, pkg_to_cfg)
-    spack.config.set("packages", pkgs_cfg, scope=scope)
+    packages_yaml = spack.schema.merge_yaml(packages_yaml, pkg_to_cfg)
+    if resolved_dependencies:
+        # Backfill 'id' on all pre-existing entries that participate in the
+        # dependency graph so they can be referenced by other entries.
+        # Never add a 'dependencies' field to a pre-existing entry: manually
+        # written dependency relationships are authoritative and must not be
+        # changed by auto-detection.
+        for spec, spec_id in ids.items():
+            entry = _find_entry(packages_yaml, spec)
+            if entry is not None and "id" not in entry:
+                entry["id"] = spec_id
+
+        for parent_spec, deps in resolved_dependencies.items():
+            if parent_spec in specs_with_existing_deps:
+                dep_names = ", ".join(str(d.spec) for d in deps)
+                warnings.warn(
+                    f"{parent_spec} already exists in packages.yaml;"
+                    f" skipping auto-detected dependencies [{dep_names}]."
+                    f" Edit packages.yaml directly to update dependency relationships."
+                )
+
+    spack.config.set("packages", packages_yaml, scope=scope)
 
     return all_new_specs
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -26,11 +26,14 @@ import spack.util.ld_so_conf
 import spack.util.parallel
 
 from .common import (
+    DetectedDependency,
     WindowsCompilerExternalPaths,
     WindowsKitExternalPaths,
     _convert_to_iterable,
+    _normalize_dependency,
     compute_windows_program_path_for_package,
     compute_windows_user_path_for_package,
+    determine_external_dependencies,
     executable_prefix,
     find_win32_additional_install_paths,
     library_prefix,
@@ -41,6 +44,12 @@ from .common import (
 DETECTION_TIMEOUT = 60
 if sys.platform == "win32":
     DETECTION_TIMEOUT = 120
+
+
+#: Maps a package name to a list of detected specs.
+PkgToSpecsDict = Dict[str, List["spack.spec.Spec"]]
+#: Maps a detected spec to a list of its dependencies.
+SpecToDepsDict = Dict["spack.spec.Spec", List[DetectedDependency]]
 
 
 def common_windows_package_paths(pkg_cls=None) -> List[str]:
@@ -411,6 +420,36 @@ class LibrariesFinder(Finder):
         return result
 
 
+def packages_to_search_for(
+    *, names: Optional[List[str]], tags: List[str], exclude: Optional[List[str]]
+) -> List[str]:
+    """Return the list of packages to search for, filtered by names, tags, and exclusions.
+
+    Args:
+        names: optional list of package names (qualified or unqualified) to restrict the search
+        tags: list of tags used to select the candidate packages from the repository
+        exclude: optional list of package names to exclude from the result
+    """
+    # TODO: move to top-level once the circular import with spack.repo is resolved
+    import spack.repo
+
+    result = list(
+        {pkg for tag in tags for pkg in spack.repo.PATH.packages_with_tags(tag, full=True)}
+    )
+
+    if names:
+        parts = [rf"(^{x}$|[.]{x}$)" for x in names]
+        select_re = re.compile("|".join(parts))
+        result = [x for x in result if select_re.search(x)]
+
+    if exclude:
+        parts = [rf"(^{x}$|[.]{x}$)" for x in exclude]
+        select_re = re.compile("|".join(parts))
+        result = [x for x in result if not select_re.search(x)]
+
+    return result
+
+
 def by_path(
     packages_to_search: Iterable[str],
     *,
@@ -426,6 +465,7 @@ def by_path(
         path_hints: initial list of paths to be searched
         max_workers: maximum number of workers to search for packages in parallel
     """
+    # TODO: move to top-level once the circular import with spack.repo is resolved
     from spack.repo import PATH, partition_package_name
 
     # TODO: Packages should be able to define both .libraries and .executables in the future
@@ -474,3 +514,187 @@ def by_path(
                     )
 
     return result
+
+
+def _prefix_hints_from_unresolved_deps(
+    detected_dependencies: "SpecToDepsDict",
+    detected_packages: "PkgToSpecsDict",
+    known_packages: List["spack.spec.Spec"],
+) -> List[str]:
+    """Return prefix hints from unresolved dependency specs that carry ``external_path``.
+
+    When a package author declares a dependency via the dict form with a ``prefix`` key,
+    ``_normalize_dependency`` stores that path as ``dep.spec.external_path``.  This helper
+    collects those paths for deps that are not yet resolvable so the caller can pass them
+    as additional ``path_hints`` to the next ``by_path`` round.
+
+    Args:
+        detected_dependencies: raw dependencies as returned by ``collect_dependencies``
+        detected_packages: all currently detected packages
+        known_packages: specs already present in ``packages.yaml``
+    """
+    all_available = [s for specs in detected_packages.values() for s in specs]
+    all_available.extend(known_packages)
+
+    hints = set()
+    for dep_list in detected_dependencies.values():
+        for dep in dep_list:
+            if any(s.satisfies(dep.spec) for s in all_available):
+                continue  # already resolvable, no need to hint
+            if dep.spec.external_path:
+                hints.add(dep.spec.external_path)
+    return sorted(hints)
+
+
+def by_path_with_dependencies(
+    packages_to_search: Iterable[str],
+    *,
+    path_hints: Optional[List[str]] = None,
+    max_workers: Optional[int] = None,
+    known_packages: Optional[List["spack.spec.Spec"]] = None,
+    exclude: Optional[List[str]] = None,
+) -> Tuple[PkgToSpecsDict, SpecToDepsDict]:
+    """Detect packages by path, then iteratively detect any missing dependencies.
+
+    Starts with an initial round of ``by_path`` detection on ``packages_to_search``, then
+    repeats detection for dependency packages that were declared by already-detected specs
+    but could not yet be resolved. Iteration stops when no new packages are found or all
+    declared dependencies are accounted for.
+
+    Args:
+        packages_to_search: initial list of packages to detect (qualified or unqualified names)
+        path_hints: additional paths to search; falls back to PATH when ``None``
+        max_workers: maximum number of parallel detection workers
+        known_packages: specs already present in ``packages.yaml``. Used to skip deps that are
+            already known without re-detecting them
+        exclude: package names to exclude from every detection round
+
+    Returns:
+        A tuple ``(detected_packages, detected_dependencies)`` accumulated across all rounds.
+    """
+    detected_packages = by_path(packages_to_search, path_hints=path_hints, max_workers=max_workers)
+    detected_dependencies = collect_dependencies(detected_packages)
+
+    already_searched = set(detected_packages)
+    known_packages = known_packages or []
+
+    extra_prefix_hints = _prefix_hints_from_unresolved_deps(
+        detected_dependencies, detected_packages, known_packages
+    )
+
+    to_detect = (
+        missing_dependency_package_names(
+            detected_packages=detected_packages,
+            detected_dependencies=detected_dependencies,
+            known_packages=known_packages,
+        )
+        - already_searched
+    )
+
+    while to_detect:
+        extra_pkgs = packages_to_search_for(
+            names=list(to_detect), tags=["detectable"], exclude=exclude
+        )
+        already_searched.update(to_detect)
+
+        if not extra_pkgs:
+            break
+
+        combined_hints = (list(path_hints or []) + extra_prefix_hints) or None
+        extra_detected = by_path(extra_pkgs, path_hints=combined_hints, max_workers=max_workers)
+
+        if not extra_detected:
+            break
+
+        for name, specs in extra_detected.items():
+            detected_packages.setdefault(name, []).extend(specs)
+
+        extra_dependencies = collect_dependencies(extra_detected)
+        detected_dependencies.update(extra_dependencies)
+
+        extra_prefix_hints = _prefix_hints_from_unresolved_deps(
+            extra_dependencies, detected_packages, known_packages
+        )
+
+        to_detect = (
+            missing_dependency_package_names(
+                detected_packages=detected_packages,
+                detected_dependencies=extra_dependencies,
+                known_packages=known_packages,
+            )
+            - already_searched
+        )
+
+    resolved_dependencies = determine_external_dependencies(
+        detected_packages=detected_packages,
+        detected_dependencies=detected_dependencies,
+        known_packages=known_packages,
+    )
+
+    return detected_packages, resolved_dependencies
+
+
+def collect_dependencies(detected_packages: PkgToSpecsDict) -> SpecToDepsDict:
+    """Call ``determine_dependencies`` once per detected spec and returns a mapping from each
+    detected spec to its list of unresolved dependencies.
+
+    Args:
+        detected_packages: mapping of package name to detected specs.
+    """
+    # TODO: move to top-level once the circular import with spack.repo is resolved
+    import spack.repo
+
+    result = {}
+    for pkg_name, specs in detected_packages.items():
+        try:
+            pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        except Exception as e:
+            spack.llnl.util.tty.debug(
+                f"[{__name__}] cannot load package class for '{pkg_name}': {e}"
+            )
+            continue
+
+        if not hasattr(pkg_cls, "determine_dependencies"):
+            continue
+
+        for spec in specs:
+            try:
+                detected_deps = _convert_to_iterable(pkg_cls.determine_dependencies(spec))
+                normalized = [_normalize_dependency(dep) for dep in detected_deps]
+            except Exception as e:
+                warnings.warn(f'error calling determine_dependencies for "{spec}": {e}')
+                continue
+
+            if not normalized:
+                continue
+
+            result[spec] = normalized
+
+    return result
+
+
+def missing_dependency_package_names(
+    *,
+    detected_packages: Optional[Dict[str, List["spack.spec.Spec"]]] = None,
+    detected_dependencies: Dict["spack.spec.Spec", List[DetectedDependency]],
+    known_packages: Optional[List["spack.spec.Spec"]] = None,
+) -> Set[str]:
+    """Returns the package names declared as dependencies that cannot be resolved.
+
+    Args:
+        detected_packages: all currently detected packages
+        detected_dependencies: pre-collected output of ``collect_dependencies`` for the packages
+        known_packages: specs already present in ``packages.yaml``. Dependency candidates that
+            match entries here are considered resolved and are not included in the returned set.
+    """
+    all_available = []
+    if detected_packages is not None:
+        all_available = [s for specs in detected_packages.values() for s in specs]
+    all_available.extend(known_packages or [])
+
+    missing = set()
+    for dep_list in detected_dependencies.values():
+        for dep in dep_list:
+            if not any(s.satisfies(dep.spec) for s in all_available):
+                missing.add(dep.spec.name)
+    return missing

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -414,6 +414,23 @@ def external_spec(config: ExternalDict) -> spack.spec.Spec:
     return ExternalSpecsParser([config]).all_specs()[0]
 
 
+def root_nodes_from_config(packages_yaml) -> List[spack.spec.Spec]:
+    """Returns the root nodes of external specs from a packages.yaml configuration dict.
+
+    Invalid or unparseable entries are silently skipped.
+
+    Args:
+        packages_yaml: the parsed ``packages`` section of Spack configuration
+    """
+    result = []
+    for entry_dict in extract_dicts_from_configuration(packages_yaml):
+        try:
+            result.append(node_from_dict(entry_dict))
+        except Exception:
+            tty.debug(f"[{__name__}] Invalid external spec in packages.yaml: {entry_dict}")
+    return result
+
+
 class DuplicateExternalError(SpackError):
     """Raised when a duplicate external is detected."""
 

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -13,6 +13,7 @@ import spack.cray_manifest
 import spack.detection
 import spack.detection.path
 import spack.repo
+from spack.compilers.config import CompilerFactory
 from spack.llnl.util.filesystem import getuid, touch
 from spack.main import SpackCommand
 from spack.spec import Spec
@@ -107,6 +108,7 @@ def test_find_external_cmd_not_buildable(
                 "builtin_mock.intel-oneapi-compilers",
                 "builtin_mock.llvm",
                 "builtin_mock.mpich",
+                "builtin_mock.mpileaks",
             ],
         ),
         # find --all --exclude find-externals1
@@ -120,6 +122,7 @@ def test_find_external_cmd_not_buildable(
                 "builtin_mock.intel-oneapi-compilers",
                 "builtin_mock.llvm",
                 "builtin_mock.mpich",
+                "builtin_mock.mpileaks",
             ],
         ),
         (
@@ -132,6 +135,7 @@ def test_find_external_cmd_not_buildable(
                 "builtin_mock.intel-oneapi-compilers",
                 "builtin_mock.llvm",
                 "builtin_mock.mpich",
+                "builtin_mock.mpileaks",
             ],
         ),
         # find hwloc (and mock hwloc is not detectable)
@@ -141,7 +145,7 @@ def test_find_external_cmd_not_buildable(
 def test_package_selection(names, tags, exclude, expected):
     """Tests various cases of selecting packages"""
     # In the mock repo we only have 'find-externals1' that is detectable
-    result = spack.cmd.external.packages_to_search_for(names=names, tags=tags, exclude=exclude)
+    result = spack.detection.packages_to_search_for(names=names, tags=tags, exclude=exclude)
     assert set(result) == set(expected)
 
 
@@ -352,6 +356,146 @@ def test_failures_in_scanning_do_not_result_in_an_error(
         assert vers in output
 
 
+@pytest.fixture()
+def mock_detection(monkeypatch):
+
+    def _detect(pkg_cls, *, version, dependencies=None):
+        @classmethod
+        def _version(cls, exe):
+            return version
+
+        monkeypatch.setattr(pkg_cls, "determine_version", _version, raising=False)
+
+        if dependencies is not None:
+
+            @classmethod
+            def _deps(cls, spec):
+                return dependencies
+
+            monkeypatch.setattr(pkg_cls, "determine_dependencies", _deps, raising=False)
+
+    return _detect
+
+
+@pytest.mark.not_on_windows("the test uses bash scripts")
+def test_find_external_wires_dependencies(mock_executable, mutable_config, mock_detection):
+    """Tests that deps are written to packages.yaml when ``spack external find`` is called"""
+    mpileaks_version, mpich_version = "2.3", "4.0.2"
+
+    mpileaks_cls = spack.repo.PATH.get_pkg_class("mpileaks")
+    mock_detection(mpileaks_cls, version=mpileaks_version, dependencies=[f"mpich@{mpich_version}"])
+    mpileaks_exe = mock_executable("mpileaks", output=f"echo mpileaks version {mpileaks_version}")
+
+    mpich_cls = spack.repo.PATH.get_pkg_class("mpich")
+    mpich_exe = mock_executable("mpichversion", output=f"echo MPICH Version: {mpich_version}")
+    mock_detection(mpich_cls, version=mpich_version)
+
+    external(
+        "find",
+        "--path",
+        str(mpileaks_exe.parent),
+        "--path",
+        str(mpich_exe.parent),
+        "mpileaks",
+        "mpich",
+    )
+
+    packages_yaml = mutable_config.get_config("packages")
+    mpileaks_entry = packages_yaml["mpileaks"]["externals"][0]
+    mpich_entry = packages_yaml["mpich"]["externals"][0]
+
+    # Both entries must have an ID
+    assert "id" in mpileaks_entry and "id" in mpich_entry
+
+    # mpileaks must list mpich as a dependency.
+    assert "dependencies" in mpileaks_entry and len(mpileaks_entry["dependencies"]) == 1
+    assert mpileaks_entry["dependencies"][0]["id"] == mpich_entry["id"]
+
+    # mpich is a leaf: no dependencies field.
+    assert "dependencies" not in mpich_entry
+
+
+@pytest.mark.not_on_windows("the test uses bash scripts")
+def test_find_external_augments_preexisting_entry(mock_executable, mutable_config, mock_detection):
+    """Tests that preexisting packages.yaml entries get an id added when they appear as a
+    dependency.
+    """
+    mpileaks_version, mpich_version = "2.3", "4.0.2"
+    mpich_prefix = "/opt/mpich"
+
+    # Seed packages.yaml with mpich already present (no id).
+    mutable_config.set(
+        "packages",
+        {"mpich": {"externals": [{"spec": f"mpich@{mpich_version}", "prefix": mpich_prefix}]}},
+    )
+
+    mpileaks_cls = spack.repo.PATH.get_pkg_class("mpileaks")
+    mock_detection(mpileaks_cls, version=mpileaks_version, dependencies=["mpich@4.0.2"])
+    mpileaks_exe = mock_executable("mpileaks", output=f"echo mpileaks version {mpileaks_version}")
+
+    external("find", "--path", str(mpileaks_exe.parent), "mpileaks")
+
+    packages_yaml = mutable_config.get_config("packages")
+    mpileaks_entry = packages_yaml["mpileaks"]["externals"][0]
+    mpich_entry = packages_yaml["mpich"]["externals"][0]
+
+    # mpileaks must be wired up with id and dependency.
+    assert "id" in mpileaks_entry and "dependencies" in mpileaks_entry
+    assert mpileaks_entry["dependencies"][0]["id"] == mpich_entry["id"]
+
+    # The preexisting mpich entry must have received an id.
+    assert "id" in mpich_entry
+
+
+@pytest.mark.not_on_windows("the test uses bash scripts")
+def test_find_external_no_dependencies_no_id(mock_executable, mutable_config, mock_detection):
+    """Tests that packages that are not dependencies get no id or dependencies in YAML"""
+    cmake_version = "3.27.5"
+
+    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    mock_detection(cmake_cls, version=cmake_version)
+    cmake_exe = mock_executable("cmake", output=f"echo cmake version {cmake_version}")
+
+    external("find", "--path", str(cmake_exe.parent), "cmake")
+
+    packages_yaml = mutable_config.get_config("packages")
+    cmake_entry = packages_yaml["cmake"]["externals"][0]
+    assert "id" not in cmake_entry
+    assert "dependencies" not in cmake_entry
+
+
+@pytest.mark.not_on_windows("the test uses bash scripts")
+def test_find_external_idempotent(mock_executable, mutable_config, mock_detection):
+    """Running external find twice with determine_dependencies produces stable config."""
+    mpileaks_version, mpich_version = "2.3", "4.0.2"
+
+    mpileaks_cls = spack.repo.PATH.get_pkg_class("mpileaks")
+    mock_detection(mpileaks_cls, version=mpileaks_version, dependencies=[f"mpich@{mpich_version}"])
+    mpileaks_exe = mock_executable("mpileaks", output=f"echo mpileaks version {mpileaks_version}")
+
+    mpich_cls = spack.repo.PATH.get_pkg_class("mpich")
+    mpich_exe = mock_executable("mpichversion", output=f"echo MPICH Version: {mpich_version}")
+    mock_detection(mpich_cls, version=mpich_version)
+
+    find_args = [
+        "find",
+        "--path",
+        str(mpileaks_exe.parent),
+        "--path",
+        str(mpich_exe.parent),
+        "cmake",
+        "mpich",
+    ]
+
+    external(*find_args)
+    packages_yaml_first = mutable_config.deepcopy_as_builtin("packages")
+
+    external(*find_args)
+    packages_yaml_second = mutable_config.get_config("packages")
+
+    assert packages_yaml_first == packages_yaml_second
+
+
 def test_detect_virtuals(mock_executable, mutable_config, monkeypatch):
     """Test whether external find --not-buildable sets virtuals as non-buildable (unless user
     config sets them to buildable)"""
@@ -385,3 +529,57 @@ def test_detect_virtuals(mock_executable, mutable_config, monkeypatch):
 
     # Check that the mpi:buildable entry was not overwritten
     assert mutable_config.get("packages:mpi:buildable") is True
+
+
+def test_from_packages_yaml_compiler_with_non_compiler_dependency(mutable_config):
+    """Tests that we can read compiler dependencies (e.g. binutils) when retrieving compilers."""
+    binutils_id = "binutils-test-uuid"
+    gcc_id = "gcc-test-uuid"
+    mutable_config.set(
+        "packages",
+        {
+            "gcc": {
+                "externals": [
+                    {
+                        "spec": "gcc@14.1.0",
+                        "prefix": "/usr/local/gcc-14",
+                        "id": gcc_id,
+                        "extra_attributes": {"compilers": {"c": "/usr/local/gcc-14/bin/gcc"}},
+                        "dependencies": [{"id": binutils_id}],
+                    }
+                ]
+            },
+            "binutils": {
+                "externals": [{"spec": "binutils@2.42", "prefix": "/usr", "id": binutils_id}]
+            },
+        },
+    )
+    # Must not raise ExternalDependencyError
+    compilers = CompilerFactory.from_packages_yaml(mutable_config)
+    assert any(c.satisfies("gcc@14.1.0") for c in compilers)
+
+
+def test_from_packages_yaml_malformed_non_compiler_entry_is_skipped(mutable_config):
+    """Tests that a non-compiler entry with a malformed spec (no concrete version) must not prevent
+    reading compilers.
+    """
+    mutable_config.set(
+        "packages",
+        {
+            "gcc": {
+                "externals": [
+                    {
+                        "spec": "gcc@14.1.0",
+                        "prefix": "/usr/local/gcc-14",
+                        "extra_attributes": {"compilers": {"c": "/usr/local/gcc-14/bin/gcc"}},
+                    }
+                ]
+            },
+            # No version — ExternalSpecError("doesn't have a concrete version") inside the parser.
+            "binutils": {"externals": [{"spec": "binutils", "prefix": "/usr"}]},
+        },
+    )
+    # Must not raise; the malformed binutils entry must be silently skipped with a warning.
+    with pytest.warns(UserWarning, match="concrete version"):
+        compilers = CompilerFactory.from_packages_yaml(spack.config.CONFIG)
+    assert any(c.satisfies("gcc@14.1.0") for c in compilers)

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -8,10 +8,11 @@ import pytest
 
 import spack.config
 import spack.detection
-import spack.detection.common
 import spack.detection.path
 import spack.repo
 import spack.spec
+from spack.detection.common import DetectedDependency, _normalize_dependency
+from spack.detection.path import _prefix_hints_from_unresolved_deps, by_path_with_dependencies
 
 
 def test_detection_update_config(mutable_config):
@@ -20,7 +21,7 @@ def test_detection_update_config(mutable_config):
     detected_packages["cmake"] = [spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")]
 
     # update config for new package
-    spack.detection.common.update_configuration(detected_packages)
+    spack.detection.update_configuration(detected_packages)
     # Check entries in 'packages.yaml'
     packages_yaml = spack.config.get("packages")
     assert "cmake" in packages_yaml
@@ -90,3 +91,598 @@ def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch):
 
     # Both prefixes produce cmake@3.17.1; only the first should be kept.
     assert len(detected) == 1
+
+
+def _make_detected(pkg_name, version, prefix):
+    """Return a Spec with the external path set, as detection would produce."""
+    return spack.spec.Spec(f"{pkg_name}@{version}", external_path=prefix)
+
+
+def _run_pipeline(detected, *, configuration):
+    """Run one round of the detect -> resolve -> write pipeline against the current config.
+
+    Reads known packages from whatever is already in ``packages`` config, resolves dependencies for
+    ``detected``, and writes the result back.
+    """
+    packages_yaml = configuration.get_config("packages")
+    known = [
+        spack.spec.Spec(entry["spec"], external_path=entry.get("prefix", ""))
+        for pkg_cfg in packages_yaml.values()
+        if isinstance(pkg_cfg, dict)
+        for entry in pkg_cfg.get("externals", [])
+    ]
+    raw_deps = spack.detection.collect_dependencies(detected)
+    deps = spack.detection.determine_external_dependencies(
+        detected_packages=detected, detected_dependencies=raw_deps, known_packages=known
+    )
+    spack.detection.update_configuration(detected, resolved_dependencies=deps)
+
+
+@pytest.mark.parametrize(
+    "dep_kwargs,expected_dep_keys,unexpected_dep_keys",
+    [
+        # No explicit deptypes or virtuals — only 'id' in the dependency entry
+        ({}, ["id"], ["deptypes", "virtuals"]),
+        # Explicit deptypes serialised as a list
+        ({"deptypes": ("link", "run")}, ["id", "deptypes"], ["virtuals"]),
+        # Explicit virtuals serialised as a comma-separated string
+        ({"virtuals": ("mpi",)}, ["id", "virtuals"], ["deptypes"]),
+    ],
+)
+def test_update_config_insert_with_dependencies(
+    mutable_config, dep_kwargs, expected_dep_keys, unexpected_dep_keys
+):
+    """Tests that new external entries are written with 'id' and 'dependencies' fields."""
+    mpich = _make_detected("mpich", "4.0", "/usr/local/mpich")
+    hwloc = _make_detected("hwloc", "2.7", "/usr/local/hwloc")
+
+    detected_packages = {"mpich": [mpich], "hwloc": [hwloc]}
+    detected_dependencies = {mpich: [DetectedDependency(spec=hwloc, **dep_kwargs)]}
+
+    spack.detection.update_configuration(
+        detected_packages, resolved_dependencies=detected_dependencies
+    )
+
+    packages_yaml = mutable_config.get_config("packages")
+
+    # Both packages must appear
+    assert "mpich" in packages_yaml and "hwloc" in packages_yaml
+
+    mpich_entries = packages_yaml["mpich"]["externals"]
+    hwloc_entries = packages_yaml["hwloc"]["externals"]
+    assert len(mpich_entries) == 1 and len(hwloc_entries) == 1
+
+    mpich_entry, hwloc_entry = mpich_entries[0], hwloc_entries[0]
+
+    # Both get 'id' because they participate in a dependency relationship
+    assert "id" in mpich_entry and "id" in hwloc_entry
+
+    # mpich references hwloc via 'dependencies'
+    assert "dependencies" in mpich_entry
+    assert len(mpich_entry["dependencies"]) == 1
+    dep = mpich_entry["dependencies"][0]
+    assert dep["id"] == hwloc_entry["id"]
+
+    for key in expected_dep_keys:
+        assert key in dep
+    for key in unexpected_dep_keys:
+        assert key not in dep
+
+    # hwloc is a leaf: no 'dependencies' key
+    assert "dependencies" not in hwloc_entry
+
+
+def test_update_config_non_participating_spec_has_no_id(mutable_config):
+    """Tests that specs that are not part of any dependency relationship must not get an 'id'"""
+    cmake = _make_detected("cmake", "3.27.5", "/usr/bin")
+    mpich = _make_detected("mpich", "4.0", "/usr/local/mpich")
+    hwloc = _make_detected("hwloc", "2.7", "/usr/local/hwloc")
+
+    detected_packages = {"cmake": [cmake], "mpich": [mpich], "hwloc": [hwloc]}
+    detected_dependencies = {mpich: [DetectedDependency(spec=hwloc)]}
+
+    spack.detection.update_configuration(
+        detected_packages, resolved_dependencies=detected_dependencies
+    )
+
+    packages_yaml = mutable_config.get_config("packages")
+    cmake_entry = packages_yaml["cmake"]["externals"][0]
+    assert "id" not in cmake_entry
+
+
+def test_update_config_augments_existing_entry(mutable_config):
+    """Tests that pre-existing entries get an 'id' backfilled but never a 'dependencies' field"""
+    mpich = _make_detected("mpich", "4.0", "/usr/local/mpich")
+    hwloc = _make_detected("hwloc", "2.7", "/usr/local/hwloc")
+
+    detected_packages = {"mpich": [mpich], "hwloc": [hwloc]}
+
+    # First call: write entries without dependency info (simulating an older Spack run)
+    spack.detection.update_configuration(detected_packages)
+    pkgs_before = mutable_config.get_config("packages")
+    assert "id" not in pkgs_before["mpich"]["externals"][0]
+
+    # Second call: same specs but now with dependency information
+    detected_dependencies = {mpich: [DetectedDependency(spec=hwloc)]}
+    spack.detection.update_configuration(
+        detected_packages, resolved_dependencies=detected_dependencies
+    )
+
+    packages_yaml = mutable_config.get_config("packages")
+    mpich_entry = packages_yaml["mpich"]["externals"][0]
+
+    # Original fields must be preserved
+    assert mpich_entry["spec"] == "mpich@4.0"
+    assert mpich_entry["prefix"] == "/usr/local/mpich"
+
+    # 'id' is backfilled so this entry can be referenced; 'dependencies' is never added
+    # to a pre-existing entry — the manually written (or absent) state is authoritative.
+    assert "id" in mpich_entry
+    assert "dependencies" not in mpich_entry
+
+
+def test_update_config_preserves_existing_dependencies(mutable_config):
+    """Tests that auto-detection never overwrites pre-existing 'dependencies' fields"""
+    mpich = _make_detected("mpich", "4.0", "/usr/local/mpich")
+    hwloc = _make_detected("hwloc", "2.7", "/usr/local/hwloc")
+
+    detected_packages = {"mpich": [mpich], "hwloc": [hwloc]}
+
+    # The first call writes a fresh entry that includes dependencies
+    spack.detection.update_configuration(
+        detected_packages, resolved_dependencies={mpich: [DetectedDependency(spec=hwloc)]}
+    )
+    original_deps = mutable_config.get("packages")["mpich"]["externals"][0]["dependencies"]
+
+    # The second call must not touch the dependencies that are now part of the stored entry
+    # and must warn the user that auto-detected dependencies were suppressed.
+    with pytest.warns(UserWarning, match="mpich@4.0.*skipping auto-detected dependencies"):
+        spack.detection.update_configuration(
+            detected_packages, resolved_dependencies={mpich: [DetectedDependency(spec=hwloc)]}
+        )
+
+    packages_yaml = mutable_config.get_config("packages")
+    assert packages_yaml["mpich"]["externals"][0]["dependencies"] == original_deps
+
+
+def test_update_config_without_dependencies_is_unchanged(mutable_config):
+    """Tests that calling update_configuration without detected_dependencies preserves existing
+    behavior.
+    """
+    detected_packages = collections.defaultdict(list)
+    detected_packages["cmake"] = [spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")]
+
+    spack.detection.update_configuration(detected_packages)
+
+    entry = mutable_config.get_config("packages")["cmake"]["externals"][0]
+    assert "id" not in entry
+    assert "dependencies" not in entry
+
+
+@pytest.fixture()
+def mock_deps(monkeypatch):
+
+    def _detect(pkg_cls, *, dependencies):
+        @classmethod
+        def _deps(cls, spec):
+            return dependencies
+
+        monkeypatch.setattr(pkg_cls, "determine_dependencies", _deps, raising=False)
+
+    return _detect
+
+
+def _make_pkg_with_determine_deps(pkg_name, dependencies):
+    """Return a classmethod suitable for monkeypatching determine_dependencies."""
+
+    @classmethod
+    def _determine_dependencies(cls, spec):
+        return dependencies
+
+    return _determine_dependencies
+
+
+# ── tests for determine_external_dependencies ─────────────────────────────────
+
+
+@pytest.mark.usefixtures("mock_packages")
+@pytest.mark.parametrize(
+    "dep_return,expected_deptypes",
+    [
+        # Bare str — parsed to Spec, deptypes remain None
+        (["mpich@4.0"], None),
+        # Dict with str spec and explicit deptypes
+        ([{"spec": "mpich@4.0", "deptypes": ("link", "run")}], ("link", "run")),
+        # Dict with str spec, no deptypes
+        ([{"spec": "mpich@4.0"}], None),
+    ],
+)
+def test_determine_external_dependencies_resolves(mock_deps, dep_return, expected_deptypes):
+    """Tests that str and dict returns are normalized and resolved correctly."""
+    cmake = spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")
+    mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
+    detected = {"cmake": [cmake], "mpich": [mpich]}
+
+    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    mock_deps(cmake_cls, dependencies=dep_return)
+
+    raw_deps = spack.detection.collect_dependencies(detected)
+    result = spack.detection.determine_external_dependencies(
+        detected_packages=detected, detected_dependencies=raw_deps
+    )
+
+    assert len(result) == 1 and cmake in result
+    deps = result[cmake]
+    assert len(deps) == 1
+    # The resolved spec must be the *same object* as mpich (not just an equal spec).
+    assert deps[0].spec is mpich and deps[0].deptypes == expected_deptypes
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_dict_unknown_keys(mock_deps):
+    """Tests that a dict with unknown keys produces a warning and the unknown keys are ignored"""
+    cmake = spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")
+    mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
+    detected = {"cmake": [cmake], "mpich": [mpich]}
+
+    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    mock_deps(cmake_cls, dependencies=[{"spec": "mpich@4.0", "typo_key": "oops"}])
+
+    with pytest.warns(UserWarning, match="unknown keys.*typo_key"):
+        raw_deps = spack.detection.collect_dependencies(detected)
+
+    assert cmake in raw_deps
+    assert raw_deps[cmake][0].spec.satisfies("mpich@4.0")
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_no_method():
+    """Tests that packages without determine_dependencies produce no output."""
+    cmake = spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")
+    detected = {"cmake": [cmake]}
+
+    raw_deps = spack.detection.collect_dependencies(detected)
+    result = spack.detection.determine_external_dependencies(
+        detected_packages=detected, detected_dependencies=raw_deps
+    )
+
+    assert result == {}
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_zero_matches(mock_deps):
+    """Tests that a dependency spec that matches no detected spec is warned about and skipped"""
+    cmake = spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")
+    detected = {"cmake": [cmake]}  # mpich is NOT detected
+
+    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    mock_deps(cmake_cls, dependencies=["mpich@4.0"])
+
+    raw_deps = spack.detection.collect_dependencies(detected)
+    with pytest.warns(UserWarning, match="mpich"):
+        result = spack.detection.determine_external_dependencies(
+            detected_packages=detected, detected_dependencies=raw_deps
+        )
+
+    assert result == {}
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_multiple_matches(mock_deps):
+    """A dependency spec matching multiple detected specs is warned about and skipped."""
+    mpileaks = spack.spec.Spec("mpileaks@2.3", external_path="/usr/bin")
+    mpich_40 = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich40")
+    mpich_41 = spack.spec.Spec("mpich@4.1", external_path="/usr/local/mpich41")
+    detected = {"mpileaks": [mpileaks], "mpich": [mpich_40, mpich_41]}
+
+    mpileaks_cls = spack.repo.PATH.get_pkg_class("mpileaks")
+    # "mpich" (no version) matches both mpich@4.0 and mpich@4.1.
+    mock_deps(mpileaks_cls, dependencies=["mpich"])
+
+    raw_deps = spack.detection.collect_dependencies(detected)
+    with pytest.warns(UserWarning, match="ambiguous"):
+        result = spack.detection.determine_external_dependencies(
+            detected_packages=detected, detected_dependencies=raw_deps
+        )
+
+    assert result == {}
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_exception_is_skipped(monkeypatch):
+    """Tests that an exception from determine_dependencies is caught, warned about, and skipped"""
+    cmake = spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")
+    detected = {"cmake": [cmake]}
+
+    @classmethod
+    def _raises(cls, spec):
+        raise RuntimeError("boom")
+
+    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    monkeypatch.setattr(cmake_cls, "determine_dependencies", _raises, raising=False)
+
+    with pytest.warns(UserWarning, match="boom"):
+        raw_deps = spack.detection.collect_dependencies(detected)
+    result = spack.detection.determine_external_dependencies(
+        detected_packages=detected, detected_dependencies=raw_deps
+    )
+
+    assert result == {}
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_empty_return(mock_deps):
+    """Tests that an empty list from determine_dependencies produces no output."""
+    cmake = spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")
+    detected = {"cmake": [cmake]}
+
+    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    mock_deps(cmake_cls, dependencies=[])
+
+    raw_deps = spack.detection.collect_dependencies(detected)
+    result = spack.detection.determine_external_dependencies(
+        detected_packages=detected, detected_dependencies=raw_deps
+    )
+
+    assert result == {}
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_partial_resolution(mock_deps):
+    """Tests that only fully resolved dependencies are kept, while unresolved ones are warned
+    and skipped.
+    """
+    cmake = spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")
+    mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
+    detected = {"cmake": [cmake], "mpich": [mpich]}
+
+    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    # mpich resolves (1 match); hwloc does not (0 matches → warning).
+    mock_deps(cmake_cls, dependencies=["mpich@4.0", "hwloc@2.7"])
+
+    raw_deps = spack.detection.collect_dependencies(detected)
+    with pytest.warns(UserWarning, match="hwloc"):
+        result = spack.detection.determine_external_dependencies(
+            detected_packages=detected, detected_dependencies=raw_deps
+        )
+
+    assert cmake in result and len(result[cmake]) == 1
+    assert result[cmake][0].spec is mpich
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_resolves_against_known_packages(mock_deps):
+    """Tests that a dep not in detected_packages but present in known_packages resolves
+    correctly.
+    """
+    mpich = _make_detected("mpich", "4.0", "/usr/local/mpich")
+    hwloc = _make_detected("hwloc", "2.7", "/usr/local/hwloc")
+
+    detected = {"mpich": [mpich]}  # hwloc is NOT detected
+    known = [hwloc]  # hwloc IS in known_packages
+
+    mpich_cls = spack.repo.PATH.get_pkg_class("mpich")
+    mock_deps(mpich_cls, dependencies=["hwloc@2.7"])
+
+    raw_deps = spack.detection.collect_dependencies(detected)
+    result = spack.detection.determine_external_dependencies(
+        detected_packages=detected, detected_dependencies=raw_deps, known_packages=known
+    )
+
+    assert mpich in result and len(result[mpich]) == 1
+    assert result[mpich][0].spec is hwloc
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_prefers_known_over_detected(mock_deps):
+    """Tests that when both known_packages and detected_packages match, known_packages wins"""
+    mpich = _make_detected("mpich", "4.0", "/usr/local/mpich")
+    hwloc_known = _make_detected("hwloc", "2.7", "/usr/local/hwloc-old")
+    hwloc_detected = _make_detected("hwloc", "2.7", "/usr/local/hwloc-new")
+
+    detected = {"mpich": [mpich], "hwloc": [hwloc_detected]}
+    known = [hwloc_known]
+
+    mpich_cls = spack.repo.PATH.get_pkg_class("mpich")
+    mock_deps(mpich_cls, dependencies=["hwloc@2.7"])
+
+    raw_deps = spack.detection.collect_dependencies(detected)
+    result = spack.detection.determine_external_dependencies(
+        detected_packages=detected, detected_dependencies=raw_deps, known_packages=known
+    )
+
+    assert mpich in result
+    # known_packages entry (hwloc_known) is preferred over the freshly detected one.
+    assert result[mpich][0].spec is hwloc_known
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_idempotent_from_empty(mutable_config, mock_deps):
+    """Tests that running the pipeline twice from an empty config produces stable config."""
+    mpich = _make_detected("mpich", "4.0", "/usr/local/mpich")
+    hwloc = _make_detected("hwloc", "2.7", "/usr/local/hwloc")
+    detected = {"mpich": [mpich], "hwloc": [hwloc]}
+
+    mpich_cls = spack.repo.PATH.get_pkg_class("mpich")
+    mock_deps(mpich_cls, dependencies=["hwloc@2.7"])
+
+    _run_pipeline(detected, configuration=mutable_config)
+    pkgs_first = spack.config.get("packages")
+
+    _run_pipeline(detected, configuration=mutable_config)
+    pkgs_second = spack.config.get("packages")
+
+    # IDs and deps must be identical after the second run.
+    assert pkgs_first == pkgs_second
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_idempotent_partial_initial(mutable_config, mock_deps):
+    """Tests that running pipeline when a package is already in YAML (no id) augments and then
+    stabilizes.
+    """
+    mpich = _make_detected("mpich", "4.0", "/usr/local/mpich")
+    hwloc = _make_detected("hwloc", "2.7", "/usr/local/hwloc")
+
+    # Pre-populate config with hwloc only (no id, no deps).
+    spack.detection.update_configuration({"hwloc": [hwloc]})
+    pkgs_before = spack.config.get("packages")
+    assert "id" not in pkgs_before["hwloc"]["externals"][0]
+
+    mpich_cls = spack.repo.PATH.get_pkg_class("mpich")
+    mock_deps(mpich_cls, dependencies=["hwloc@2.7"])
+
+    detected_mpich = {"mpich": [mpich]}
+
+    _run_pipeline(detected_mpich, configuration=mutable_config)
+    packages_yaml_first = spack.config.get("packages")
+
+    # hwloc must have been augmented with an id.
+    assert "id" in packages_yaml_first["hwloc"]["externals"][0]
+    hwloc_id = packages_yaml_first["hwloc"]["externals"][0]["id"]
+
+    _run_pipeline(detected_mpich, configuration=mutable_config)
+    packages_yaml_second = spack.config.get("packages")
+
+    # Second run must not change anything.
+    assert packages_yaml_second == packages_yaml_first
+    assert packages_yaml_second["hwloc"]["externals"][0]["id"] == hwloc_id
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_determine_external_dependencies_idempotent_existing_deps(mutable_config, mock_deps):
+    """Tests that entries that already have dependencies are left untouched by subsequent runs"""
+    mpich = _make_detected("mpich", "4.0", "/usr/local/mpich")
+    hwloc = _make_detected("hwloc", "2.7", "/usr/local/hwloc")
+
+    mpich_cls = spack.repo.PATH.get_pkg_class("mpich")
+    mock_deps(mpich_cls, dependencies=["mpich", "hwloc@2.7"])
+    detected_both = {"mpich": [mpich], "hwloc": [hwloc]}
+
+    # The first run writes everything fresh
+    _run_pipeline(detected_both, configuration=mutable_config)
+    pkgs_after_first = spack.config.get("packages")
+    mpich_deps_first = pkgs_after_first["mpich"]["externals"][0]["dependencies"]
+
+    # Second run — deps already present, must not overwrite
+    _run_pipeline(detected_both, configuration=mutable_config)
+    pkgs_after_second = spack.config.get("packages")
+    assert pkgs_after_second == pkgs_after_first
+    assert pkgs_after_second["mpich"]["externals"][0]["dependencies"] == mpich_deps_first
+
+
+def test_normalize_dependency_dict_with_prefix():
+    """Tests that a dict hint with 'prefix' sets external_path on the resulting spec."""
+    dep = _normalize_dependency({"spec": "hwloc@2.7", "prefix": "/opt/hwloc"})
+    assert dep.spec.external_path == "/opt/hwloc"
+    assert dep.spec.satisfies("hwloc@2.7")
+
+
+def test_normalize_dependency_dict_without_prefix():
+    """Tests that a dict hint without 'prefix' leaves external_path unset."""
+    dep = _normalize_dependency({"spec": "hwloc@2.7"})
+    assert not dep.spec.external_path
+
+
+def test_normalize_dependency_bare_string_no_prefix():
+    """Tests that a bare string produces a spec with no external_path."""
+    dep = _normalize_dependency("hwloc@2.7")
+    assert not dep.spec.external_path
+
+
+def test_prefix_hints_returns_hint_for_unresolved_dep():
+    """Tests that external_path is returned as a hint when the dep is not yet resolved."""
+    mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
+    hwloc_dep = _normalize_dependency({"spec": "hwloc@2.7", "prefix": "/opt/hwloc"})
+
+    detected_packages = {"mpich": [mpich]}
+    detected_dependencies = {mpich: [hwloc_dep]}
+
+    hints = _prefix_hints_from_unresolved_deps(detected_dependencies, detected_packages, [])
+    assert "/opt/hwloc" in hints
+
+
+def test_prefix_hints_excludes_already_resolved_dep():
+    """Tests that no hint is returned when the dep is already in detected_packages."""
+    mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
+    hwloc_detected = spack.spec.Spec("hwloc@2.7", external_path="/usr/local/hwloc")
+    hwloc_dep = _normalize_dependency({"spec": "hwloc@2.7", "prefix": "/opt/hwloc"})
+
+    detected_packages = {"mpich": [mpich], "hwloc": [hwloc_detected]}
+    detected_dependencies = {mpich: [hwloc_dep]}
+
+    hints = _prefix_hints_from_unresolved_deps(detected_dependencies, detected_packages, [])
+    assert hints == []
+
+
+def test_prefix_hints_excludes_dep_satisfied_by_known_packages():
+    """Tests that no hint is returned when the dep is satisfied by known_packages."""
+    mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
+    hwloc_known = spack.spec.Spec("hwloc@2.7", external_path="/usr/local/hwloc")
+    hwloc_dep = _normalize_dependency({"spec": "hwloc@2.7", "prefix": "/opt/hwloc"})
+
+    detected_packages = {"mpich": [mpich]}
+    detected_dependencies = {mpich: [hwloc_dep]}
+
+    hints = _prefix_hints_from_unresolved_deps(
+        detected_dependencies, detected_packages, [hwloc_known]
+    )
+    assert hints == []
+
+
+def test_prefix_hints_no_hint_for_abstract_dep():
+    """Tests that a dep with no external_path (bare string) yields no path hint"""
+    mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
+    hwloc_dep = _normalize_dependency("hwloc@2.7")
+
+    detected_packages = {"mpich": [mpich]}
+    detected_dependencies = {mpich: [hwloc_dep]}
+
+    hints = _prefix_hints_from_unresolved_deps(detected_dependencies, detected_packages, [])
+    assert hints == []
+
+
+@pytest.mark.usefixtures("mock_packages")
+def test_by_path_with_dependencies_uses_prefix_hint(monkeypatch):
+    """Tests that the detection loop passes dep prefix hints to subsequent by_path calls"""
+    hwloc_prefix = "/opt/hwloc"
+    mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
+    hwloc = spack.spec.Spec("hwloc@2.7", external_path=hwloc_prefix)
+
+    mpich_cls = spack.repo.PATH.get_pkg_class("mpich")
+
+    @classmethod
+    def _deps(cls, spec):
+        return [{"spec": "hwloc@2.7", "prefix": hwloc_prefix}]
+
+    monkeypatch.setattr(mpich_cls, "determine_dependencies", _deps, raising=False)
+
+    # Track what path_hints each by_path call receives.
+    call_hints: list = []
+    call_count = {"n": 0}
+
+    def fake_by_path(pkgs, *, path_hints=None, max_workers=None):
+        call_hints.append(path_hints)
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return {"mpich": [mpich]}
+        # Second call: return hwloc only if the prefix hint was injected.
+        if path_hints and hwloc_prefix in path_hints:
+            return {"hwloc": [hwloc]}
+        return {}
+
+    monkeypatch.setattr(spack.detection.path, "by_path", fake_by_path)
+    monkeypatch.setattr(
+        spack.detection.path, "packages_to_search_for", lambda *, names, tags, exclude: names or []
+    )
+
+    detected_pkgs, resolved_deps = by_path_with_dependencies(
+        ["mpich"], path_hints=["/usr/local/mpich/bin"]
+    )
+
+    # The second by_path call must have received the dep prefix as a hint.
+    assert len(call_hints) == 2 and hwloc_prefix in call_hints[1]
+
+    # hwloc must appear in detected packages and be resolved as a dependency of mpich.
+    assert "hwloc" in detected_pkgs and mpich in resolved_deps
+    assert resolved_deps[mpich][0].spec is hwloc

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -571,6 +571,7 @@ def test_determine_external_dependencies_idempotent_existing_deps(mutable_config
     assert pkgs_after_second["mpich"]["externals"][0]["dependencies"] == mpich_deps_first
 
 
+@pytest.mark.not_on_windows("Uses POSIX paths")
 def test_normalize_dependency_dict_with_prefix():
     """Tests that a dict hint with 'prefix' sets external_path on the resulting spec."""
     dep = _normalize_dependency({"spec": "hwloc@2.7", "prefix": "/opt/hwloc"})
@@ -590,6 +591,7 @@ def test_normalize_dependency_bare_string_no_prefix():
     assert not dep.spec.external_path
 
 
+@pytest.mark.not_on_windows("Uses POSIX paths")
 def test_prefix_hints_returns_hint_for_unresolved_dep():
     """Tests that external_path is returned as a hint when the dep is not yet resolved."""
     mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
@@ -602,6 +604,7 @@ def test_prefix_hints_returns_hint_for_unresolved_dep():
     assert "/opt/hwloc" in hints
 
 
+@pytest.mark.not_on_windows("Uses POSIX paths")
 def test_prefix_hints_excludes_already_resolved_dep():
     """Tests that no hint is returned when the dep is already in detected_packages."""
     mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
@@ -615,6 +618,7 @@ def test_prefix_hints_excludes_already_resolved_dep():
     assert hints == []
 
 
+@pytest.mark.not_on_windows("Uses POSIX paths")
 def test_prefix_hints_excludes_dep_satisfied_by_known_packages():
     """Tests that no hint is returned when the dep is satisfied by known_packages."""
     mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
@@ -630,6 +634,7 @@ def test_prefix_hints_excludes_dep_satisfied_by_known_packages():
     assert hints == []
 
 
+@pytest.mark.not_on_windows("Uses POSIX paths")
 def test_prefix_hints_no_hint_for_abstract_dep():
     """Tests that a dep with no external_path (bare string) yields no path hint"""
     mpich = spack.spec.Spec("mpich@4.0", external_path="/usr/local/mpich")
@@ -643,6 +648,7 @@ def test_prefix_hints_no_hint_for_abstract_dep():
 
 
 @pytest.mark.usefixtures("mock_packages")
+@pytest.mark.not_on_windows("Uses POSIX paths")
 def test_by_path_with_dependencies_uses_prefix_hint(monkeypatch):
     """Tests that the detection loop passes dep prefix hints to subsequent by_path calls"""
     hwloc_prefix = "/opt/hwloc"

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/binutils/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/binutils/package.py
@@ -1,0 +1,13 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Binutils(Package):
+    """Mock binutils package used in tests."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/binutils-1.0.tar.gz"
+
+    version("2.42", md5="0123456789abcdef0123456789abcdef")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/mpileaks/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/mpileaks/package.py
@@ -13,6 +13,9 @@ class Mpileaks(Package):
     homepage = "http://www.spack.llnl.gov"
     url = "http://www.spack.llnl.gov/mpileaks-1.0.tar.gz"
 
+    tags = ["detectable"]
+    executables = ["^mpileaks$"]
+
     version("2.3", sha256="2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825")
     version("2.2", sha256="2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825")
     version("2.1", sha256="2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825")


### PR DESCRIPTION
### Summary

`spack external find` can now automatically discover and record how external packages depend on one another. 

Package authors declare these relationships by implementing a new `determine_dependencies` classmethod alongside the existing `determine_spec_details`. When Spack detects an external package that provides this method:
1. It calls it
2. It resolves the declared dependencies against the rest of the detection results
3. It writes both the parent and child entries — with proper cross-references — into `packages.yaml`.

### How it works

**Package side — new `determine_dependencies` method**

```python
class Openmpi(AutotoolsPackage):
    executables = ["^mpicc$"]

    @classmethod
    def determine_dependencies(cls, spec):
        hwloc_prefix = get_hwloc_prefix(spec.prefix)
        if hwloc_prefix is None:
            return []
        return [{"spec": f"hwloc@{get_hwloc_version(hwloc_prefix)}", "prefix": str(hwloc_prefix)}]
```

Each element of the returned list may be a plain version string or a dict with keys:
- `"spec"` (required) — dependency spec as a string
- `"prefix"` (optional) — installation prefix; stored as `external_path` and used to guide a follow-up detection pass
- `"deptypes"` (optional) — e.g. `("link", "run")`
- `"virtuals"` (optional) — virtual names satisfied by this dependency

**Detection loop — iterative dependency resolution (`by_path_with_dependencies`)**

After the initial `by_path` pass, the loop:
1. Calls `collect_dependencies` to gather raw hints from every detected spec.
4. Identifies packages declared as dependencies that were not yet detected.
5. Runs additional `by_path` passes restricted to those missing packages, using any `prefix` hints supplied by the package as extra path hints.
6. Repeats until nothing new is found.
7. Calls `determine_external_dependencies` to resolve candidates against the full detection pool and the pre-existing `packages.yaml` entries, warning on ambiguous or missing matches.

**`packages.yaml` output — IDs and dependency sections**

New entries that participate in a dependency relationship are written with:
- an `id` field
- a `dependencies` section listing each resolved dependency by its `id`, plus optional `deptypes` and `virtuals`

Pre-existing entries that already carry a `dependencies` field are left untouched; Spack emits a warning instead so the user can update them manually. Pre-existing entries that lack `dependencies` but are referenced as a dependency target have their `id` backfilled automatically.
