### PR TITLE
spack external find: default to compilers only

### DIFF
--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -84,7 +84,7 @@ Automatically find external packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can run the :ref:`spack external find <spack-external-find>` command to search for system-provided packages and add them to ``packages.yaml``.
-After running this command your ``packages.yaml`` may include new entries:
+For example, if you run ``spack external find cmake ninja python`` on your system, your ``packages.yaml`` may include new entries:
 
 .. code-block:: yaml
 
@@ -94,10 +94,16 @@ After running this command your ``packages.yaml`` may include new entries:
        - spec: cmake@3.17.2
          prefix: /usr
 
-Generally this is useful for detecting a small set of commonly-used packages; for now this is generally limited to finding build-only dependencies.
-Specific limitations include:
+Without further arguments, ``spack external find`` searches for compiler packages.
 
-* Packages are not discoverable by default: For a package to be discoverable with ``spack external find``, it needs to add special logic.
+Note that there are certain limitations to be aware of when using ``spack external find``:
+
+* Spack cannot detect whether a system package is partially or fully installed.
+  Linux distributions often provide a separate runtime and development version of a package (e.g. ``python3`` vs ``python3-dev``).
+  The runtime version includes executables, but lacks headers and the linkable library.
+  If only the runtime package is installed, Spack may detect the package and add it to ``packages.yaml``, but will fail to build dependent packages due to missing headers and libraries.
+* Not all Spack packages are discoverable with ``spack external find``.
+  The package has to implement the required logic to be findable.
   See :ref:`here <make-package-findable>` for more details.
 * The logic does not search through module files, it can only detect packages with executables defined in ``PATH``; you can help Spack locate externals which use module files by loading any associated modules for packages that you want Spack to know about before running ``spack external find``.
 * Spack does not overwrite existing entries in the package configuration: If there is an external defined for a spec at any configuration scope, then Spack will not add a new external entry (``spack config blame packages`` can help locate all external entries).

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -55,11 +55,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
     arguments.add_common_arguments(find_parser, ["tags", "jobs"])
     find_parser.add_argument("packages", nargs=argparse.REMAINDER)
-    find_parser.epilog = (
-        'The search is by default on packages tagged with the "build-tools" or '
-        '"core-packages" tags. Use the --all option to search for every possible '
-        "package Spack knows how to find."
-    )
+    find_parser.epilog = 'The search is by default on packages tagged with the "compiler" tag.'
 
     sp.add_parser("list", aliases=["ls"], help="list detectable packages, by repository and name")
 
@@ -125,7 +121,7 @@ def external_find(args):
         args.tags = ["detectable"]
     elif not args.tags:
         # If the user didn't specify anything, search for build tools by default
-        args.tags = ["core-packages", "build-tools"]
+        args.tags = ["compiler"]
 
     candidate_packages = packages_to_search_for(
         names=args.packages, tags=args.tags, exclude=args.exclude


### PR DESCRIPTION
The command `spack external find` currently searches for a rather arbitrary set
of packages tagged `build-tools` and `core-packages`.

These include various `py-*` packages which don't work well as externals as
they need the python interpreter attached, and also `zlib`, which isn't even
the default zlib-api provider, and system zlib is notoriously badly detected by
build systems like autotools (on some distros there is no pkg-config file, and
the library may be hiding in a multi-arch subdir).

Users are likely to waste more time making the build work with configured
externals than by compiling the Spack packages.

This commit changes `spack external find` so it defaults to compiler packages,
similar to `spack compiler find`.

Also update the documentation to avoid that users blindly run
`spack external find`, and warn about the fact that Spack cannot detect
partial package installs (e.g. python3 but not python3-dev).