### PR TITLE
conf.py: do not document re-export of spack.package classes

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -104,6 +104,7 @@ sphinx_apidoc(
         "--implicit-namespaces",
         ".spack/spack-packages/repos/spack_repo",
         ".spack/spack-packages/repos/spack_repo/builtin/packages",
+        ".spack/spack-packages/repos/spack_repo/builtin/build_systems/generic.py",
     ]
 )
 


### PR DESCRIPTION
The module only re-exports `GenericBuilder`, `Package` from `spack.package`
and was very very briefly used before we moved it back to `spack.package` and
had to keep it as a default.

Now the re-export causes issues with `python -m sphinx` using `-j auto` (which was
recently enabled). Sphinx seems to be confused what module to put the docs in.

Upstream PR related to `-j auto`: https://github.com/readthedocs/readthedocs.org/pull/12839.






