### PR TITLE
spack repo: add show-version-updates command

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -177,23 +177,25 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     # Show updates
-    show_updates_parser = sp.add_parser("show-updates", help=repo_show_updates.__doc__)
-    show_updates_parser.add_argument(
+    show_version_updates_parser = sp.add_parser(
+        "show-version-updates", help=repo_show_version_updates.__doc__
+    )
+    show_version_updates_parser.add_argument(
         "--no-manual-packages", action="store_true", help="exclude manual packages"
     )
-    show_updates_parser.add_argument(
+    show_version_updates_parser.add_argument(
         "--no-git-versions", action="store_true", help="exclude versions from git"
     )
-    show_updates_parser.add_argument(
+    show_version_updates_parser.add_argument(
         "--only-redistributable", action="store_true", help="exclude non-redistributable packages"
     )
-    show_updates_parser.add_argument(
+    show_version_updates_parser.add_argument(
         "repository", help="name or path of the repository to analyze"
     )
-    show_updates_parser.add_argument(
+    show_version_updates_parser.add_argument(
         "from_ref", help="git ref from which to start looking at changes"
     )
-    show_updates_parser.add_argument("to_ref", help="git ref to end looking at changes")
+    show_version_updates_parser.add_argument("to_ref", help="git ref to end looking at changes")
 
 
 def repo_create(args):
@@ -642,7 +644,7 @@ def repo_update(args):
         spack.config.set("repos", scope_repos, args.scope)
 
 
-def repo_show_updates(args):
+def repo_show_version_updates(args):
     """show version specs that were added between two commits"""
     # Get the repository by name or path
     repo = _get_repo(args.repository)
@@ -730,5 +732,5 @@ def repo(parser, args):
         "rm": repo_remove,
         "migrate": repo_migrate,
         "update": repo_update,
-        "show-updates": repo_show_updates,
+        "show-version-updates": repo_show_version_updates,
     }[args.repo_command](args)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -566,7 +566,7 @@ def _iter_repos_from_descriptors(
             yield name, descriptor.repository, None  # None indicates remote descriptor
 
 
-def repo_update(args: Any) -> int:
+def repo_update(args):
     """update one or more package repositories"""
     descriptors = spack.repo.RepoDescriptors.from_config(
         spack.repo.package_repository_lock(), spack.config.CONFIG
@@ -642,7 +642,7 @@ def repo_update(args: Any) -> int:
         spack.config.set("repos", scope_repos, args.scope)
 
 
-def repo_show_updates(args: Any) -> int:
+def repo_show_updates(args):
     """show version specs that were added between two commits"""
     # Get the repository by name or path
     repo = _get_repo(args.repository)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -11,9 +11,12 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import spack
 import spack.caches
+import spack.ci
 import spack.config
+import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.repo
+import spack.spec
 import spack.util.executable
 import spack.util.git
 import spack.util.path
@@ -22,6 +25,7 @@ import spack.util.spack_yaml
 from spack.cmd.common import arguments
 from spack.error import SpackError
 from spack.llnl.util.tty import color
+from spack.version import StandardVersion, VersionList
 
 description = "manage package source repositories"
 section = "config"
@@ -171,6 +175,25 @@ def setup_parser(subparser: argparse.ArgumentParser):
     refspec.add_argument(
         "--commit", "-c", nargs="?", default=None, help="name of a commit to change to"
     )
+
+    # Show updates
+    show_updates_parser = sp.add_parser("show-updates", help=repo_show_updates.__doc__)
+    show_updates_parser.add_argument(
+        "--no-manual-packages", action="store_true", help="exclude manual packages"
+    )
+    show_updates_parser.add_argument(
+        "--no-git-versions", action="store_true", help="exclude versions from git"
+    )
+    show_updates_parser.add_argument(
+        "--only-redistributable", action="store_true", help="exclude non-redistributable packages"
+    )
+    show_updates_parser.add_argument(
+        "repository", help="name or path of the repository to analyze"
+    )
+    show_updates_parser.add_argument(
+        "from_ref", help="git ref from which to start looking at changes"
+    )
+    show_updates_parser.add_argument("to_ref", help="git ref to end looking at changes")
 
 
 def repo_create(args):
@@ -621,6 +644,85 @@ def repo_update(args: Any) -> int:
     return 0
 
 
+def repo_show_updates(args: Any) -> int:
+    """show version specs that were added between two commits"""
+    # Get the repository by name or path
+    repo = _get_repo(args.repository)
+
+    if repo is None:
+        tty.die(f"No such repository: {args.repository}")
+
+    # Get packages that were changed or added between the refs
+    pkgs = spack.repo.get_all_package_diffs("AC", repo, args.from_ref, args.to_ref)
+
+    # Filter out manual packages if requested
+    if args.no_manual_packages:
+        pkgs = [
+            pkg_name
+            for pkg_name in pkgs
+            if not spack.repo.PATH.get_pkg_class(pkg_name).manual_download
+        ]
+
+    if not pkgs:
+        tty.warn("No packages were added or changed between the specified refs")
+        return 0
+
+    # Collect version specs that were added
+    specs_to_output = []
+
+    for pkg_name in pkgs:
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        path = spack.repo.PATH.package_path(pkg_name)
+
+        # Get all versions with checksums or commits
+        version_to_checksum: Dict[StandardVersion, str] = {}
+        for version in pkg_cls.versions:
+            version_dict = pkg_cls.versions[version]
+            if "sha256" in version_dict:
+                version_to_checksum[version] = version_dict["sha256"]
+            elif "commit" in version_dict:
+                version_to_checksum[version] = version_dict["commit"]
+
+        # Find versions added between the refs
+        with fs.working_dir(os.path.dirname(path)):
+            added_checksums = spack.ci.filter_added_checksums(
+                version_to_checksum.values(), path, from_ref=args.from_ref, to_ref=args.to_ref
+            )
+            new_versions = [v for v, c in version_to_checksum.items() if c in added_checksums]
+
+        # Create specs for new versions
+        for version in new_versions:
+            version_spec = spack.spec.Spec(pkg_name)
+            version_spec.versions = VersionList([version])
+            specs_to_output.append(version_spec)
+
+    # Filter out git versions if requested
+    if args.no_git_versions:
+        specs_to_output = [
+            spec
+            for spec in specs_to_output
+            if "commit" not in spack.repo.PATH.get_pkg_class(spec.name).versions[spec.version]
+        ]
+
+    # Filter out non-redistributable packages if requested
+    if args.only_redistributable:
+        specs_to_output = [
+            spec
+            for spec in specs_to_output
+            if spack.repo.PATH.get_pkg_class(spec.name).redistribute_source(spec)
+        ]
+
+    if not specs_to_output:
+        tty.warn("No new package versions found between the specified refs")
+        return 0
+
+    # Output specs one per line
+    for spec in specs_to_output:
+        print(spec)
+
+    return 0
+
+
 def repo(parser, args):
     return {
         "create": repo_create,
@@ -632,4 +734,5 @@ def repo(parser, args):
         "rm": repo_remove,
         "migrate": repo_migrate,
         "update": repo_update,
+        "show-updates": repo_show_updates,
     }[args.repo_command](args)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -641,8 +641,6 @@ def repo_update(args: Any) -> int:
     if active_flag:
         spack.config.set("repos", scope_repos, args.scope)
 
-    return 0
-
 
 def repo_show_updates(args: Any) -> int:
     """show version specs that were added between two commits"""
@@ -664,7 +662,7 @@ def repo_show_updates(args: Any) -> int:
         }
 
     if not pkgs:
-        tty.warn("No packages were added or changed between the specified refs")
+        tty.info("No packages were added or changed between the specified refs", stream=sys.stderr)
         return 0
 
     # Collect version specs that were added
@@ -693,7 +691,7 @@ def repo_show_updates(args: Any) -> int:
         # Create specs for new versions
         for version in new_versions:
             version_spec = spack.spec.Spec(pkg_name)
-            version_spec.versions = VersionList([version])
+            version_spec.constrain(f"@={version}")
             specs_to_output.append(version_spec)
 
     # Filter out git versions if requested
@@ -713,14 +711,12 @@ def repo_show_updates(args: Any) -> int:
         ]
 
     if not specs_to_output:
-        tty.warn("No new package versions found between the specified refs")
+        tty.info("No new package versions found between the specified refs", stream=sys.stderr)
         return 0
 
     # Output specs one per line
     for spec in specs_to_output:
         print(spec)
-
-    return 0
 
 
 def repo(parser, args):

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -25,7 +25,7 @@ import spack.util.spack_yaml
 from spack.cmd.common import arguments
 from spack.error import SpackError
 from spack.llnl.util.tty import color
-from spack.version import StandardVersion, VersionList
+from spack.version import StandardVersion
 
 description = "manage package source repositories"
 section = "config"

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -657,11 +657,11 @@ def repo_show_updates(args: Any) -> int:
 
     # Filter out manual packages if requested
     if args.no_manual_packages:
-        pkgs = [
+        pkgs = {
             pkg_name
             for pkg_name in pkgs
             if not spack.repo.PATH.get_pkg_class(pkg_name).manual_download
-        ]
+        }
 
     if not pkgs:
         tty.warn("No packages were added or changed between the specified refs")

--- a/lib/spack/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/spack/llnl/util/tty/__init__.py
@@ -233,21 +233,13 @@ def debug(
         info(message, *args, format=format, stream=stream_arg, **kwargs)
 
 
-def error(
-    message, *args, format: str = "*r", stream: Optional[IO[str]] = None, **kwargs
-) -> None:
+def error(message, *args, format: str = "*r", stream: Optional[IO[str]] = None, **kwargs) -> None:
     """Print an error message."""
     if not error_enabled():
         return
 
     stream = stream or sys.stderr
-    info(
-        f"Error: {message}",
-        *args,
-        format=format,
-        stream=stream,
-        **kwargs,
-    )
+    info(f"Error: {message}", *args, format=format, stream=stream, **kwargs)
 
 
 def warn(message, *args, format: str = "*Y", stream: Optional[IO[str]] = None, **kwargs) -> None:
@@ -256,13 +248,7 @@ def warn(message, *args, format: str = "*Y", stream: Optional[IO[str]] = None, *
         return
 
     stream = stream or sys.stderr
-    info(
-        f"Warning: {message}",
-        *args,
-        format=format,
-        stream=stream,
-        **kwargs,
-    )
+    info(f"Warning: {message}", *args, format=format, stream=stream, **kwargs)
 
 
 def die(message, *args, countback: int = 4, **kwargs) -> NoReturn:

--- a/lib/spack/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/spack/llnl/util/tty/__init__.py
@@ -11,7 +11,7 @@ import textwrap
 import traceback
 from datetime import datetime
 from types import TracebackType
-from typing import Callable, Iterator, NoReturn, Optional, Type, Union
+from typing import IO, Callable, Iterator, NoReturn, Optional, Type, Union
 
 from .color import cescape, clen, cprint, cwrite
 
@@ -185,7 +185,7 @@ def info(
     message: Union[Exception, str],
     *args,
     format: str = "*b",
-    stream: Optional[io.IOBase] = None,
+    stream: Optional[IO[str]] = None,
     wrap: bool = False,
     break_long_words: bool = False,
     countback: int = 3,
@@ -201,7 +201,7 @@ def info(
     cprint(
         "@%s{%s==>} %s%s"
         % (format, st_text, get_timestamp(), cescape(_output_filter(str(message)))),
-        stream=stream,  # type: ignore[arg-type]
+        stream=stream,
     )
     for arg in args:
         if wrap:
@@ -225,16 +225,16 @@ def verbose(message, *args, format: str = "c", **kwargs) -> None:
 
 
 def debug(
-    message, *args, level: int = 1, format: str = "g", stream: Optional[io.IOBase] = None, **kwargs
+    message, *args, level: int = 1, format: str = "g", stream: Optional[IO[str]] = None, **kwargs
 ) -> None:
     """Print a debug message if the debug level is set."""
     if is_debug(level):
         stream_arg = stream or sys.stderr
-        info(message, *args, format=format, stream=stream_arg, **kwargs)  # type: ignore[arg-type]
+        info(message, *args, format=format, stream=stream_arg, **kwargs)
 
 
 def error(
-    message, *args, format: str = "*r", stream: Optional[io.IOBase] = None, **kwargs
+    message, *args, format: str = "*r", stream: Optional[IO[str]] = None, **kwargs
 ) -> None:
     """Print an error message."""
     if not error_enabled():
@@ -245,12 +245,12 @@ def error(
         f"Error: {message}",
         *args,
         format=format,
-        stream=stream,  # type: ignore[arg-type]
+        stream=stream,
         **kwargs,
     )
 
 
-def warn(message, *args, format: str = "*Y", stream: Optional[io.IOBase] = None, **kwargs) -> None:
+def warn(message, *args, format: str = "*Y", stream: Optional[IO[str]] = None, **kwargs) -> None:
     """Print a warning message."""
     if not warn_enabled():
         return
@@ -260,7 +260,7 @@ def warn(message, *args, format: str = "*Y", stream: Optional[io.IOBase] = None,
         f"Warning: {message}",
         *args,
         format=format,
-        stream=stream,  # type: ignore[arg-type]
+        stream=stream,
         **kwargs,
     )
 

--- a/lib/spack/spack/llnl/util/tty/color.py
+++ b/lib/spack/spack/llnl/util/tty/color.py
@@ -64,7 +64,7 @@ import re
 import sys
 import textwrap
 from contextlib import contextmanager
-from typing import Iterator, List, NamedTuple, Optional, Tuple, Union
+from typing import IO, Iterator, List, NamedTuple, Optional, Tuple, Union
 
 
 class ColorParseError(Exception):
@@ -374,7 +374,7 @@ def cextra(string: str) -> int:
     return len("".join(re.findall(r"\033[^m]*m", string)))
 
 
-def cwrite(string: str, stream: Optional[io.IOBase] = None, color: Optional[bool] = None) -> None:
+def cwrite(string: str, stream: Optional[IO[str]] = None, color: Optional[bool] = None) -> None:
     """Replace all color expressions in string with ANSI control
     codes and write the result to the stream.  If color is
     False, this will write plain text with no color.  If True,
@@ -387,7 +387,7 @@ def cwrite(string: str, stream: Optional[io.IOBase] = None, color: Optional[bool
     stream.write(colorize(string, color=color))
 
 
-def cprint(string: str, stream: Optional[io.IOBase] = None, color: Optional[bool] = None) -> None:
+def cprint(string: str, stream: Optional[IO[str]] = None, color: Optional[bool] = None) -> None:
     """Same as cwrite, but writes a trailing newline to the stream."""
     cwrite(string + "\n", stream, color)
 

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -940,3 +940,106 @@ def test_repo_update_invalid_flags(monkeypatch, mutable_config, flags):
 
     with pytest.raises(SpackError):
         repo("update", *flags)
+
+
+def test_repo_show_updates_no_changes(mock_git_package_changes):
+    """Test that show-updates handles empty results gracefully"""
+    test_repo, _, commits = mock_git_package_changes
+
+    with spack.repo.use_repositories(test_repo):
+        # Use the same commit for both refs - no changes
+        output = repo("show-updates", test_repo.root, commits[-1], commits[-1])
+
+        # Should have warning message
+        assert (
+            "No new package versions found" in output or "No packages were added or changed" in output
+        )
+
+        # Should not have any specs
+        assert "diff-test@" not in output
+
+
+def test_repo_show_updates_success(mock_git_package_changes):
+    """Test that show-updates successfully outputs the correct specs"""
+    test_repo, _, commits = mock_git_package_changes
+
+    with spack.repo.use_repositories(test_repo):
+        # commits are ordered from newest to oldest after reversal
+        # commits[-2] = add v2.1.5, commits[-4] = add v2.1.7 and v2.1.8
+        # Find versions added between these commits
+        # Includes v2.1.6 (git version), v2.1.7, and v2.1.8 (sha256 versions)
+        output = repo("show-updates", test_repo.root, commits[-2], commits[-4])
+
+        # Verify all three versions are included
+        assert "diff-test@" in output
+        assert "2.1.6" in output
+        assert "2.1.7" in output
+        assert "2.1.8" in output
+
+        # Should have three specs
+        lines = [
+            line.strip()
+            for line in output.strip().split("\n")
+            if line.strip() and "Warning" not in line
+        ]
+        assert len(lines) == 3
+
+
+def test_repo_show_updates_excludes_manual_packages(monkeypatch, mock_git_package_changes):
+    """Test --no-manual-packages flag excludes packages with manual_download=True"""
+    test_repo, _, commits = mock_git_package_changes
+
+    with spack.repo.use_repositories(test_repo):
+        # Set manual_download=True on the package
+        pkg_class = spack.repo.PATH.get_pkg_class("diff-test")
+        monkeypatch.setattr(pkg_class, "manual_download", True)
+
+        # Run show-updates with --no-manual-packages flag
+        output = repo("show-updates", "--no-manual-packages", test_repo.root, commits[-2], commits[-4])
+
+        # Package should be excluded
+        assert "diff-test@" not in output
+        assert (
+            "No packages were added or changed" in output
+            or "No new package versions found" in output
+        )
+
+
+def test_repo_show_updates_excludes_non_redistributable(monkeypatch, mock_git_package_changes):
+    """Test --only-redistributable flag excludes packages where redistribute_source returns False"""
+    test_repo, _, commits = mock_git_package_changes
+
+    with spack.repo.use_repositories(test_repo):
+        # Set redistribute_source to return False
+        pkg_class = spack.repo.PATH.get_pkg_class("diff-test")
+        monkeypatch.setattr(
+            pkg_class, "redistribute_source", classmethod(lambda cls, spec: False)
+        )
+
+        # Run show-updates with --only-redistributable flag
+        output = repo("show-updates", "--only-redistributable", test_repo.root, commits[-2], commits[-4])
+
+        # Package should be excluded
+        assert "diff-test@" not in output
+        assert (
+            "No packages were added or changed" in output
+            or "No new package versions found" in output
+        )
+
+
+def test_repo_show_updates_excludes_git_versions(mock_git_package_changes):
+    """Test --no-git-versions flag excludes versions from git (tag/commit)"""
+    test_repo, _, commits = mock_git_package_changes
+
+    with spack.repo.use_repositories(test_repo):
+        # commits[-3] = add v2.1.6 (git version), commits[-4] = add v2.1.7 and v2.1.8 (sha256)
+        # Without --no-git-versions, v2.1.6 would be included
+        output = repo("show-updates", "--no-git-versions", test_repo.root, commits[-3], commits[-4])
+
+        # v2.1.6 (git version) should be excluded
+        assert "2.1.6" not in output
+
+        # v2.1.7 and v2.1.8 (sha256 versions) should be included
+        assert "diff-test@" in output
+        assert "2.1.7" in output
+        assert "2.1.8" in output

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -942,13 +942,13 @@ def test_repo_update_invalid_flags(monkeypatch, mutable_config, flags):
         repo("update", *flags)
 
 
-def test_repo_show_updates_no_changes(mock_git_package_changes):
-    """Test that show-updates handles empty results gracefully"""
+def test_repo_show_version_updates_no_changes(mock_git_package_changes):
+    """Test that show-version-updates handles empty results gracefully"""
     test_repo, _, commits = mock_git_package_changes
 
     with spack.repo.use_repositories(test_repo):
         # Use the same commit for both refs - no changes
-        output = repo("show-updates", test_repo.root, commits[-1], commits[-1])
+        output = repo("show-version-updates", test_repo.root, commits[-1], commits[-1])
 
         # Should have warning message
         assert "No packages were added or changed" in output
@@ -957,8 +957,8 @@ def test_repo_show_updates_no_changes(mock_git_package_changes):
         assert "diff-test@" not in output
 
 
-def test_repo_show_updates_success(mock_git_package_changes):
-    """Test that show-updates successfully outputs the correct specs"""
+def test_repo_show_version_updates_success(mock_git_package_changes):
+    """Test that show-version-updates successfully outputs the correct specs"""
     test_repo, _, commits = mock_git_package_changes
 
     with spack.repo.use_repositories(test_repo):
@@ -966,7 +966,7 @@ def test_repo_show_updates_success(mock_git_package_changes):
         # commits[-2] = add v2.1.5, commits[-4] = add v2.1.7 and v2.1.8
         # Find versions added between these commits
         # Includes v2.1.6 (git version), v2.1.7, and v2.1.8 (sha256 versions)
-        output = repo("show-updates", test_repo.root, commits[-2], commits[-4])
+        output = repo("show-version-updates", test_repo.root, commits[-2], commits[-4])
 
         # Verify all three versions are included
         assert "diff-test@" in output
@@ -983,7 +983,7 @@ def test_repo_show_updates_success(mock_git_package_changes):
         assert len(lines) == 3
 
 
-def test_repo_show_updates_excludes_manual_packages(monkeypatch, mock_git_package_changes):
+def test_repo_show_version_updates_excludes_manual_packages(monkeypatch, mock_git_package_changes):
     """Test --no-manual-packages flag excludes packages with manual_download=True"""
     test_repo, _, commits = mock_git_package_changes
 
@@ -992,9 +992,13 @@ def test_repo_show_updates_excludes_manual_packages(monkeypatch, mock_git_packag
         pkg_class = spack.repo.PATH.get_pkg_class("diff-test")
         monkeypatch.setattr(pkg_class, "manual_download", True)
 
-        # Run show-updates with --no-manual-packages flag
+        # Run show-version-updates with --no-manual-packages flag
         output = repo(
-            "show-updates", "--no-manual-packages", test_repo.root, commits[-2], commits[-4]
+            "show-version-updates",
+            "--no-manual-packages",
+            test_repo.root,
+            commits[-2],
+            commits[-4],
         )
 
         # Package should be excluded
@@ -1002,7 +1006,9 @@ def test_repo_show_updates_excludes_manual_packages(monkeypatch, mock_git_packag
         assert "No packages were added or changed" in output
 
 
-def test_repo_show_updates_excludes_non_redistributable(monkeypatch, mock_git_package_changes):
+def test_repo_show_version_updates_excludes_non_redistributable(
+    monkeypatch, mock_git_package_changes
+):
     """Test --only-redistributable flag excludes packages if redistribute_source returns False"""
     test_repo, _, commits = mock_git_package_changes
 
@@ -1011,9 +1017,13 @@ def test_repo_show_updates_excludes_non_redistributable(monkeypatch, mock_git_pa
         pkg_class = spack.repo.PATH.get_pkg_class("diff-test")
         monkeypatch.setattr(pkg_class, "redistribute_source", classmethod(lambda cls, spec: False))
 
-        # Run show-updates with --only-redistributable flag
+        # Run show-version-updates with --only-redistributable flag
         output = repo(
-            "show-updates", "--only-redistributable", test_repo.root, commits[-2], commits[-4]
+            "show-version-updates",
+            "--only-redistributable",
+            test_repo.root,
+            commits[-2],
+            commits[-4],
         )
 
         # Package should be excluded
@@ -1021,7 +1031,7 @@ def test_repo_show_updates_excludes_non_redistributable(monkeypatch, mock_git_pa
         assert "No new package versions found" in output
 
 
-def test_repo_show_updates_excludes_git_versions(mock_git_package_changes):
+def test_repo_show_version_updates_excludes_git_versions(mock_git_package_changes):
     """Test --no-git-versions flag excludes versions from git (tag/commit)"""
     test_repo, _, commits = mock_git_package_changes
 
@@ -1029,7 +1039,7 @@ def test_repo_show_updates_excludes_git_versions(mock_git_package_changes):
         # commits[-3] = add v2.1.6 (git version), commits[-4] = add v2.1.7 and v2.1.8 (sha256)
         # Without --no-git-versions, v2.1.6 would be included
         output = repo(
-            "show-updates", "--no-git-versions", test_repo.root, commits[-3], commits[-4]
+            "show-version-updates", "--no-git-versions", test_repo.root, commits[-3], commits[-4]
         )
 
         # v2.1.6 (git version) should be excluded

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -952,7 +952,8 @@ def test_repo_show_updates_no_changes(mock_git_package_changes):
 
         # Should have warning message
         assert (
-            "No new package versions found" in output or "No packages were added or changed" in output
+            "No new package versions found" in output
+            or "No packages were added or changed" in output
         )
 
         # Should not have any specs
@@ -995,7 +996,9 @@ def test_repo_show_updates_excludes_manual_packages(monkeypatch, mock_git_packag
         monkeypatch.setattr(pkg_class, "manual_download", True)
 
         # Run show-updates with --no-manual-packages flag
-        output = repo("show-updates", "--no-manual-packages", test_repo.root, commits[-2], commits[-4])
+        output = repo(
+            "show-updates", "--no-manual-packages", test_repo.root, commits[-2], commits[-4]
+        )
 
         # Package should be excluded
         assert "diff-test@" not in output
@@ -1006,18 +1009,18 @@ def test_repo_show_updates_excludes_manual_packages(monkeypatch, mock_git_packag
 
 
 def test_repo_show_updates_excludes_non_redistributable(monkeypatch, mock_git_package_changes):
-    """Test --only-redistributable flag excludes packages where redistribute_source returns False"""
+    """Test --only-redistributable flag excludes packages if redistribute_source returns False"""
     test_repo, _, commits = mock_git_package_changes
 
     with spack.repo.use_repositories(test_repo):
         # Set redistribute_source to return False
         pkg_class = spack.repo.PATH.get_pkg_class("diff-test")
-        monkeypatch.setattr(
-            pkg_class, "redistribute_source", classmethod(lambda cls, spec: False)
-        )
+        monkeypatch.setattr(pkg_class, "redistribute_source", classmethod(lambda cls, spec: False))
 
         # Run show-updates with --only-redistributable flag
-        output = repo("show-updates", "--only-redistributable", test_repo.root, commits[-2], commits[-4])
+        output = repo(
+            "show-updates", "--only-redistributable", test_repo.root, commits[-2], commits[-4]
+        )
 
         # Package should be excluded
         assert "diff-test@" not in output
@@ -1034,7 +1037,9 @@ def test_repo_show_updates_excludes_git_versions(mock_git_package_changes):
     with spack.repo.use_repositories(test_repo):
         # commits[-3] = add v2.1.6 (git version), commits[-4] = add v2.1.7 and v2.1.8 (sha256)
         # Without --no-git-versions, v2.1.6 would be included
-        output = repo("show-updates", "--no-git-versions", test_repo.root, commits[-3], commits[-4])
+        output = repo(
+            "show-updates", "--no-git-versions", test_repo.root, commits[-3], commits[-4]
+        )
 
         # v2.1.6 (git version) should be excluded
         assert "2.1.6" not in output

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -951,10 +951,7 @@ def test_repo_show_updates_no_changes(mock_git_package_changes):
         output = repo("show-updates", test_repo.root, commits[-1], commits[-1])
 
         # Should have warning message
-        assert (
-            "No new package versions found" in output
-            or "No packages were added or changed" in output
-        )
+        assert "No packages were added or changed" in output
 
         # Should not have any specs
         assert "diff-test@" not in output
@@ -1002,10 +999,7 @@ def test_repo_show_updates_excludes_manual_packages(monkeypatch, mock_git_packag
 
         # Package should be excluded
         assert "diff-test@" not in output
-        assert (
-            "No packages were added or changed" in output
-            or "No new package versions found" in output
-        )
+        assert "No packages were added or changed" in output
 
 
 def test_repo_show_updates_excludes_non_redistributable(monkeypatch, mock_git_package_changes):
@@ -1024,10 +1018,7 @@ def test_repo_show_updates_excludes_non_redistributable(monkeypatch, mock_git_pa
 
         # Package should be excluded
         assert "diff-test@" not in output
-        assert (
-            "No packages were added or changed" in output
-            or "No new package versions found" in output
-        )
+        assert "No new package versions found" in output
 
 
 def test_repo_show_updates_excludes_git_versions(mock_git_package_changes):

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -104,7 +104,16 @@ def git(required: bool = ...) -> Optional[GitExecutable]: ...
 
 
 def git(required: bool = False) -> Optional[GitExecutable]:
-    """Get a git executable. Raises CommandNotFoundError if ``required`` and git is not found."""
+    """Get a git executable.
+
+    The returned executable automatically unsets ``GIT_EXTERNAL_DIFF`` and ``GIT_DIFF_OPTS``
+    environment variables that can interfere with spack git diff operations.
+
+    Args:
+       required (bool): if True, raises CommandNotFoundError when git is not found
+
+    Returns: GitExecutable, or None if git is not found and required is False
+    """
     git_path = _find_git()
 
     if not git_path:
@@ -116,7 +125,7 @@ def git(required: bool = False) -> Optional[GitExecutable]:
 
     # If we're running under pytest, add this to ignore the fix for CVE-2022-39253 in
     # git 2.38.1+. Do this in one place; we need git to do this in all parts of Spack.
-    if git and "pytest" in sys.modules:
+    if "pytest" in sys.modules:
         git.add_default_arg("-c", "protocol.file.allow=always")
 
     # Blacklist environment variables that can interfere with git diff operations

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -128,12 +128,12 @@ def git(required: bool = False) -> Optional[GitExecutable]:
     if "pytest" in sys.modules:
         git.add_default_arg("-c", "protocol.file.allow=always")
 
-    # Blacklist environment variables that can interfere with git diff operations
+    # Block environment variables that can interfere with git diff operations
     # this can cause problems for spack ci verify-versions and spack repo show-version-updates
-    env_blacklist = EnvironmentModifications()
-    env_blacklist.unset("GIT_EXTERNAL_DIFF")
-    env_blacklist.unset("GIT_DIFF_OPTS")
-    git.add_default_envmod(env_blacklist)
+    env_blocklist = EnvironmentModifications()
+    env_blocklist.unset("GIT_EXTERNAL_DIFF")
+    env_blocklist.unset("GIT_DIFF_OPTS")
+    git.add_default_envmod(env_blocklist)
 
     return git
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -120,7 +120,7 @@ def git(required: bool = False) -> Optional[GitExecutable]:
         git.add_default_arg("-c", "protocol.file.allow=always")
 
     # Blacklist environment variables that can interfere with git diff operations
-    # this can cause problems for spack ci verify-versions and spack ci create-source-mirror
+    # this can cause problems for spack ci verify-versions and spack repo show-version-updates
     env_blacklist = EnvironmentModifications()
     env_blacklist.unset("GIT_EXTERNAL_DIFF")
     env_blacklist.unset("GIT_DIFF_OPTS")

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -14,6 +14,7 @@ from spack.vendor.typing_extensions import Literal
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.lang
 import spack.util.executable as exe
+from spack.util.environment import EnvironmentModifications
 
 # regex for a commit version
 COMMIT_VERSION = re.compile(r"^[a-f0-9]{40}$")
@@ -117,6 +118,13 @@ def git(required: bool = False) -> Optional[GitExecutable]:
     # git 2.38.1+. Do this in one place; we need git to do this in all parts of Spack.
     if git and "pytest" in sys.modules:
         git.add_default_arg("-c", "protocol.file.allow=always")
+
+    # Blacklist environment variables that can interfere with git diff operations
+    # this can cause problems for spack ci verify-versions and spack ci create-source-mirror
+    env_blacklist = EnvironmentModifications()
+    env_blacklist.unset("GIT_EXTERNAL_DIFF")
+    env_blacklist.unset("GIT_DIFF_OPTS")
+    git.add_default_envmod(env_blacklist)
 
     return git
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1802,7 +1802,7 @@ _spack_repo() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create list ls add set remove rm migrate update show-updates"
+        SPACK_COMPREPLY="create list ls add set remove rm migrate update show-version-updates"
     fi
 }
 
@@ -1877,7 +1877,7 @@ _spack_repo_update() {
     fi
 }
 
-_spack_repo_show_updates() {
+_spack_repo_show_version_updates() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help --no-manual-packages --no-git-versions --only-redistributable"

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1802,7 +1802,7 @@ _spack_repo() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create list ls add set remove rm migrate update"
+        SPACK_COMPREPLY="create list ls add set remove rm migrate update show-updates"
     fi
 }
 
@@ -1872,6 +1872,15 @@ _spack_repo_update() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help --remote -r --scope --branch -b --tag -t --commit -c"
+    else
+        SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_repo_show_updates() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --no-manual-packages --no-git-versions --only-redistributable"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2842,6 +2842,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 're
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a rm -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a migrate -d 'migrate a package repository to the latest Package API'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a update -d 'update one or more package repositories'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a show-updates -d 'show version specs that were added between two commits'
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -d 'show this help message and exit'
 
@@ -2948,6 +2949,18 @@ complete -c spack -n '__fish_spack_using_command repo update' -l tag -s t -r -f 
 complete -c spack -n '__fish_spack_using_command repo update' -l tag -s t -r -d 'name of a tag to change to'
 complete -c spack -n '__fish_spack_using_command repo update' -l commit -s c -r -f -a commit
 complete -c spack -n '__fish_spack_using_command repo update' -l commit -s c -r -d 'name of a commit to change to'
+
+# spack repo show-updates
+set -g __fish_spack_optspecs_spack_repo_show_updates h/help no-manual-packages no-git-versions only-redistributable
+
+complete -c spack -n '__fish_spack_using_command repo show-updates' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command repo show-updates' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command repo show-updates' -l no-manual-packages -f -a no_manual_packages
+complete -c spack -n '__fish_spack_using_command repo show-updates' -l no-manual-packages -d 'exclude manual packages'
+complete -c spack -n '__fish_spack_using_command repo show-updates' -l no-git-versions -f -a no_git_versions
+complete -c spack -n '__fish_spack_using_command repo show-updates' -l no-git-versions -d 'exclude versions from git'
+complete -c spack -n '__fish_spack_using_command repo show-updates' -l only-redistributable -f -a only_redistributable
+complete -c spack -n '__fish_spack_using_command repo show-updates' -l only-redistributable -d 'exclude non-redistributable packages'
 
 # spack resource
 set -g __fish_spack_optspecs_spack_resource h/help

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2842,7 +2842,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 're
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a rm -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a migrate -d 'migrate a package repository to the latest Package API'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a update -d 'update one or more package repositories'
-complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a show-updates -d 'show version specs that were added between two commits'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a show-version-updates -d 'show version specs that were added between two commits'
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -d 'show this help message and exit'
 
@@ -2950,17 +2950,17 @@ complete -c spack -n '__fish_spack_using_command repo update' -l tag -s t -r -d 
 complete -c spack -n '__fish_spack_using_command repo update' -l commit -s c -r -f -a commit
 complete -c spack -n '__fish_spack_using_command repo update' -l commit -s c -r -d 'name of a commit to change to'
 
-# spack repo show-updates
-set -g __fish_spack_optspecs_spack_repo_show_updates h/help no-manual-packages no-git-versions only-redistributable
+# spack repo show-version-updates
+set -g __fish_spack_optspecs_spack_repo_show_version_updates h/help no-manual-packages no-git-versions only-redistributable
 
-complete -c spack -n '__fish_spack_using_command repo show-updates' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command repo show-updates' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command repo show-updates' -l no-manual-packages -f -a no_manual_packages
-complete -c spack -n '__fish_spack_using_command repo show-updates' -l no-manual-packages -d 'exclude manual packages'
-complete -c spack -n '__fish_spack_using_command repo show-updates' -l no-git-versions -f -a no_git_versions
-complete -c spack -n '__fish_spack_using_command repo show-updates' -l no-git-versions -d 'exclude versions from git'
-complete -c spack -n '__fish_spack_using_command repo show-updates' -l only-redistributable -f -a only_redistributable
-complete -c spack -n '__fish_spack_using_command repo show-updates' -l only-redistributable -d 'exclude non-redistributable packages'
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l no-manual-packages -f -a no_manual_packages
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l no-manual-packages -d 'exclude manual packages'
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l no-git-versions -f -a no_git_versions
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l no-git-versions -d 'exclude versions from git'
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l only-redistributable -f -a only_redistributable
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l only-redistributable -d 'exclude non-redistributable packages'
 
 # spack resource
 set -g __fish_spack_optspecs_spack_resource h/help


### PR DESCRIPTION
Supersedes #52144.

This PR adds a spack repo show-version-updates command as proposed by @kwryankrattiger in #52144. 

To get the same functionality the previous PR we can execute both commands like this:

```
spack mirror create -d /path $(spack repo show-version-updates builtin HEAD^1 HEAD)
```

**Additional Details**
This show-version-updates command optionally takes 3 filtering flags to limit the specs that are output so that we can filter the specs here before attempting to create the mirror so that we don't encounter errors in CI when manual packages, non-redistributable packages, and versions coming from git are added into develop.