### PR TITLE
new_installer.py: fix cursor movement compatibility

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1398,7 +1398,7 @@ class BuildStatus:
 
         # Move cursor up to the start of the display area
         if self.active_area_rows > 0:
-            buffer.write(f"\033[{self.active_area_rows}F")
+            buffer.write(f"\033[{self.active_area_rows}A\r")
 
         if self.terminal_size_changed:
             self.terminal_size = self.get_terminal_size()
@@ -1485,7 +1485,7 @@ class BuildStatus:
         if self.total_lines > self.active_area_rows:
             buffer.write("\033[0m\033[K\n")  # reset, clear to EOL, newline
         else:
-            buffer.write("\033[0m\033[K\033[1E")  # reset, clear to EOL, move down 1 line
+            buffer.write("\033[0m\033[K\033[1B\r")  # reset, clear to EOL, move to next line
 
     def print_logs(self, build_id: str, data: bytes) -> None:
         if self.headless:

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -335,9 +335,9 @@ class TestOutputRendering:
         status.update()
         output1 = fake_stdout.getvalue()
 
-        # Count newlines (\n) and cursor movements (\033[1E = move down 1 line)
+        # Count newlines (\n) and cursor movements (\033[1B\r = move down 1 line)
         newlines1 = output1.count("\n")
-        cursor_moves1 = output1.count("\033[1E")
+        cursor_moves1 = output1.count("\033[1B\r")
 
         # Initially all lines should be newlines (nothing in history yet)
         assert newlines1 > 0
@@ -359,7 +359,7 @@ class TestOutputRendering:
         output2 = fake_stdout.getvalue()
 
         newlines2 = output2.count("\n")
-        cursor_moves2 = output2.count("\033[1E")
+        cursor_moves2 = output2.count("\033[1B\r")
 
         # Should have newlines for the 2 finished builds persisted to history
         # and cursor movements for the active area (header + 3 active builds)


### PR DESCRIPTION
`\033[<n>A` (Cursor Up) and `\033[<n>B` (Cursor Down) have been part of
the original VT100 spec since 1978, so every terminal emulator should
support them, including JuiceSSH.

