### PR TITLE
spec.py: avoid cache validation in satisfies

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -100,6 +100,7 @@ import spack.util.prefix
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
+import spack.version
 import spack.version as vn
 import spack.version.git_ref_lookup
 
@@ -121,7 +122,6 @@ __all__ = [
     "InvalidHashError",
     "SpecDeprecatedError",
 ]
-
 
 SPEC_FORMAT_RE = re.compile(
     r"(?:"  # this is one big or, with matches ordered by priority
@@ -3334,6 +3334,42 @@ class Spec:
         """
         return self._satisfies(other=other, deps=deps, resolve_virtuals=True)
 
+    def _provides_virtual(self, virtual_spec: "Spec") -> bool:
+        """Return True if this spec provides the given virtual spec.
+
+        Args:
+            virtual_spec: abstract virtual spec (e.g. ``"mpi"`` or ``"mpi@3:"``)
+        """
+        if not virtual_spec.name:
+            return False
+
+        # Get the package instance
+        if self.concrete:
+            try:
+                pkg = self.package
+            except spack.repo.UnknownPackageError:
+                return False
+        else:
+            try:
+                pkg_cls = spack.repo.PATH.get_pkg_class(self.fullname)
+                pkg = pkg_cls(self)
+            except spack.repo.UnknownEntityError:
+                # If we can't get package info on this spec, don't treat
+                # it as a provider of this vdep.
+                return False
+
+        for when_spec, provided in pkg.provided.items():
+            # Don't use satisfies for virtuals, because an abstract vs. abstract spec may use the
+            # repo index
+            if self.satisfies(when_spec, deps=False) and any(
+                provided_virtual.name == virtual_spec.name
+                and provided_virtual.versions.intersects(virtual_spec.versions)
+                for provided_virtual in provided
+            ):
+                return True
+
+        return False
+
     def _satisfies(
         self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
     ) -> bool:
@@ -3363,25 +3399,9 @@ class Spec:
                 return False
 
         # If the names are different, we need to consider virtuals
-        if self.name != other.name and self.name and other.name and resolve_virtuals:
-            # A concrete provider can satisfy a virtual dependency.
-            if not spack.repo.PATH.is_virtual(self.name) and spack.repo.PATH.is_virtual(
-                other.name
-            ):
-                try:
-                    # Here we might get an abstract spec
-                    pkg_cls = spack.repo.PATH.get_pkg_class(self.fullname)
-                    pkg = pkg_cls(self)
-                except spack.repo.UnknownEntityError:
-                    # If we can't get package info on this spec, don't treat
-                    # it as a provider of this vdep.
-                    return False
-
-                if pkg.provides(other.name):
-                    for when_spec, provided in pkg.provided.items():
-                        if self.satisfies(when_spec, deps=False):
-                            if any(vpkg.intersects(other) for vpkg in provided):
-                                return True
+        if self.name != other.name and self.name and other.name:
+            if self.concrete or resolve_virtuals:
+                return self._provides_virtual(other)
             return False
 
         # namespaces either match, or other doesn't require one.
@@ -3436,12 +3456,6 @@ class Spec:
             ):
                 continue
 
-            # If we are checking for ^mpi we need to verify if there is any edge
-            if resolve_virtuals and spack.repo.PATH.is_virtual(rhs_edge.spec.name):
-                # Don't mutate objects in memory that may be referred elsewhere
-                rhs_edge = rhs_edge.copy()
-                rhs_edge.update_virtuals(virtuals=(rhs_edge.spec.name,))
-
             if rhs_edge.direct:
                 # Note: this relies on abstract specs from string not being deeper than 2 levels
                 # e.g. in foo %fee ^bar %baz we cannot go deeper than "baz" and e.g. specify its
@@ -3458,22 +3472,58 @@ class Spec:
                     except KeyError:
                         return False
 
-                # If the branch is %<virtual> or ^<virtual>, check if we have a corresponding
-                # branch in the lhs
-                candidate_edges = []
-                if resolve_virtuals and spack.repo.PATH.is_virtual(rhs_edge.spec.name):
-                    candidate_edges = current_node.edges_to_dependencies(name=rhs_edge.spec.name)
-
-                name = (
-                    None
-                    if resolve_virtuals and spack.repo.PATH.is_virtual(rhs_edge.spec.name)
-                    else rhs_edge.spec.name
-                )
-                candidate_edges.extend(
-                    current_node.edges_to_dependencies(
-                        name=name, virtuals=rhs_edge.virtuals or None
+                if self.concrete:
+                    # For a concrete spec, virtual info is encoded in edge.virtuals.
+                    #
+                    # The rhs edge may name either a concrete package or a virtual. If virtuals are
+                    # already annotated on the rhs edge, the name AND virtual must match. Otherwise
+                    # try both a name-based lookup and a virtual-based lookup and union the results
+                    if rhs_edge.virtuals:
+                        candidate_edges = current_node.edges_to_dependencies(
+                            name=rhs_edge.spec.name, virtuals=rhs_edge.virtuals
+                        )
+                    else:
+                        dep_name = rhs_edge.spec.name
+                        candidate_edges = current_node.edges_to_dependencies(name=dep_name)
+                        # It _may_ be a virtual
+                        if not candidate_edges:
+                            candidate_edges = current_node.edges_to_dependencies(
+                                virtuals=(dep_name,)
+                            )
+                            # If this virtual doesn't impose further version constraints, avoid
+                            # Further checks that may require package.py
+                            if (
+                                candidate_edges
+                                and rhs_edge.spec.versions == spack.version.any_version
+                            ):
+                                # Don't mutate objects in memory that may be referred elsewhere
+                                rhs_edge = rhs_edge.copy()
+                                rhs_edge.update_virtuals(virtuals=(rhs_edge.spec.name,))
+                                rhs_edge.spec = EMPTY_SPEC
+                        candidate_edges = lang.dedupe(candidate_edges)
+                else:
+                    # For an abstract spec, consult the repo to determine whether the rhs dep
+                    # name is a virtual, annotate the edge, then build candidate_edges.
+                    rhs_is_virtual = resolve_virtuals and spack.repo.PATH.is_virtual(
+                        rhs_edge.spec.name
                     )
-                )
+                    if rhs_is_virtual:
+                        # Don't mutate objects in memory that may be referred elsewhere
+                        rhs_edge = rhs_edge.copy()
+                        dep_name = None
+                        rhs_edge.update_virtuals(virtuals=(rhs_edge.spec.name,))
+                        candidate_edges = current_node.edges_to_dependencies(
+                            name=rhs_edge.spec.name
+                        )
+                    else:
+                        dep_name = rhs_edge.spec.name
+                        candidate_edges = []
+
+                    candidate_edges.extend(
+                        current_node.edges_to_dependencies(
+                            name=dep_name, virtuals=rhs_edge.virtuals or None
+                        )
+                    )
 
                 # Select at least the deptypes on the rhs_edge, and conditional edges that
                 # constrain a bigger portion of the search space (so it's rhs.when <= lhs.when)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3383,8 +3383,169 @@ class Spec:
         """
         if other is EMPTY_SPEC:
             return True
-        other = self._autospec(other)
 
+        other = self._autospec(other)
+        if not self._satisfies_node(other, resolve_virtuals=resolve_virtuals):
+            return False
+
+        # If we need to descend into dependencies, do it, otherwise we're done.
+        if not deps:
+            return True
+
+        # If there are no constraints to satisfy, we're done.
+        if not other._dependencies:
+            return True
+
+        # If we arrived here, the lhs root node satisfies the rhs root node. Now we need to check
+        # all the edges that have an abstract parent, and verify that they match some edge in the
+        # lhs.
+        direct_edges, transitive_edges = [], []
+        for rhs_edge in other.traverse_edges(root=False, cover="edges"):
+            # It might happen that the rhs brings in concrete sub-DAGs. For those we don't need to
+            # verify the edge properties, cause everything is encoded in the hash of the nodes that
+            # will be verified later.
+            # TODO: Optimize by not iterating over these edges
+            if rhs_edge.parent.concrete:
+                continue
+
+            # None only in case rhs_edge has a parent that is not in lhs
+            lhs_parent = self._lhs_parent(rhs_edge)
+
+            # Check satisfaction of the dependency only if its "when" condition may apply
+            if lhs_parent and not lhs_parent._intersects(
+                rhs_edge.when, resolve_virtuals=resolve_virtuals
+            ):
+                continue
+
+            if lhs_parent is None:
+                # The only case where None could occur is that of a looking for a direct edge with
+                # a known parent, different from self, that the lhs doesn't have.
+                #
+                # Note: this relies on abstract specs from string not being deeper than 2 levels
+                # e.g. in foo %fee ^bar %baz we cannot go deeper than "baz" and e.g. specify its
+                # dependencies too.
+                #
+                # We also need to account for cases like gcc@<new> %gcc@<old> where the parent
+                # name is the same as the child name
+                #
+                # The same assumptions hold on Spec.constrain, and Spec.intersect
+                return False
+
+            if rhs_edge.direct:
+                direct_edges.append((lhs_parent, rhs_edge))
+            else:
+                transitive_edges.append(rhs_edge)
+
+        for lhs_parent, rhs_edge in direct_edges:
+            rhs_child = rhs_edge.spec
+            # Common case where the name identifies a real package i.e. %c=gcc or %gcc
+            candidate_edges = lhs_parent.edges_to_dependencies(
+                name=rhs_child.name, virtuals=rhs_edge.virtuals or None
+            )
+
+            if self.concrete and not candidate_edges:
+                # If we have no candidates the rhs may be a virtual i.e. %mpi or %mpi@3:
+                candidate_edges = lhs_parent.edges_to_dependencies(virtuals=(rhs_child.name,))
+                if candidate_edges and rhs_edge.spec.versions == spack.version.any_version:
+                    if not any(_compatible_edges(l, rhs_edge, resolve_virtuals=resolve_virtuals) for l in candidate_edges):
+                        return False
+                    # If this virtual doesn't impose version constraints, avoid checking package.py
+                    continue
+
+            elif not self.concrete and resolve_virtuals and spack.repo.PATH.is_virtual(rhs_child.name):
+                # If we know the rhs is a virtual package, we need to *also* consider edges with
+                # virtuals. We cannot consider only those, because the lhs itself can be of the
+                # form %mpi@3: since it's abstract
+                candidate_edges.extend(
+                    lhs_parent.edges_to_dependencies(virtuals=(rhs_child.name,))
+                )
+
+            # Select the child node from edges that have compatible properties
+            candidates = [
+                lhs_edge.spec
+                for lhs_edge in candidate_edges
+                if _compatible_edges(lhs_edge, rhs_edge, resolve_virtuals)
+            ]
+
+            # For old specs, consider compiler dependencies from annotations
+            if not candidates and lhs_parent.original_spec_format() < 5:
+                compiler_spec = lhs_parent.annotations.compiler_node_attribute
+                if compiler_spec is not None:
+                    candidates.append(compiler_spec)
+
+            if not any(
+                x._satisfies_node(rhs_edge.spec, resolve_virtuals=resolve_virtuals)
+                for x in candidates
+            ):
+                return False
+
+        if not transitive_edges:
+            return True
+
+        # Construct a map of the link/run subDAG + direct "build" edges, keyed by dependency name
+        lhs_edges: Dict[str, Set[DependencySpec]] = collections.defaultdict(set)
+        for lhs_edge in self.traverse_edges(root=False, cover="edges", deptype=("link", "run")):
+            lhs_edges[lhs_edge.spec.name].add(lhs_edge)
+            for virtual_name in lhs_edge.virtuals:
+                lhs_edges[virtual_name].add(lhs_edge)
+
+        build_edges = self.edges_to_dependencies(depflag=dt.BUILD)
+        for lhs_edge in build_edges:
+            lhs_edges[lhs_edge.spec.name].add(lhs_edge)
+            for virtual_name in lhs_edge.virtuals:
+                lhs_edges[virtual_name].add(lhs_edge)
+
+        for rhs_edge in transitive_edges:
+            rhs_child = rhs_edge.spec
+            # We don't have edges to this dependency
+            rhs_child_name = rhs_child.name
+            if rhs_child_name and rhs_child_name not in lhs_edges:
+                return False
+            elif rhs_child_name:
+                set_of_edges = lhs_edges[rhs_child_name]
+            else:
+                set_of_edges = set(itertools.chain(*lhs_edges.values()))
+
+            candidate_edges = [
+                lhs_edge
+                for lhs_edge in set_of_edges
+                if _compatible_edges(lhs_edge, rhs_edge, resolve_virtuals)
+            ]
+            if not candidate_edges:
+                return False
+
+            for virtual in rhs_edge.virtuals:
+                # Check the name because ^mpi has the "mpi" virtual
+                has_virtual = any(
+                    virtual in edge.virtuals or virtual == edge.spec.name
+                    for edge in candidate_edges
+                )
+                if not has_virtual:
+                    return False
+
+            for lhs_edge in candidate_edges:
+                if lhs_edge.spec._satisfies_node(rhs_edge.spec, resolve_virtuals=resolve_virtuals):
+                    break
+            else:
+                return False
+
+        return True
+
+    def _lhs_parent(self, rhs_edge: DependencySpec) -> Optional["Spec"]:
+        """Returns the parent node in self corresponding to the parent in rhs_edge.
+
+        If the rhs edge has no parent, self is returned. If the rhs has a parent not in self,
+        None is returned.
+        """
+        result = None
+        if not rhs_edge.parent.name or rhs_edge.parent.name == self.name:
+            result = self
+        elif rhs_edge.parent.name in self:
+            result = self[rhs_edge.parent.name]
+        return result
+
+    def _satisfies_node(self, other: "Spec", resolve_virtuals: bool = True) -> bool:
+        """Compares self and other without looking at dependencies"""
         if other.concrete:
             # The left-hand side must be the same singleton with identical hash. Notice that
             # package hashes can be different for otherwise indistinguishable concrete Spec
@@ -3426,183 +3587,6 @@ class Spec:
 
         if not self.compiler_flags.satisfies(other.compiler_flags):
             return False
-
-        # If we need to descend into dependencies, do it, otherwise we're done.
-        if not deps:
-            return True
-
-        # If there are no constraints to satisfy, we're done.
-        if not other._dependencies:
-            return True
-
-        # If we arrived here, the lhs root node satisfies the rhs root node. Now we need to check
-        # all the edges that have an abstract parent, and verify that they match some edge in the
-        # lhs.
-        #
-        # It might happen that the rhs brings in concrete sub-DAGs. For those we don't need to
-        # verify the edge properties, cause everything is encoded in the hash of the nodes that
-        # will be verified later.
-        lhs_edges: Dict[str, Set[DependencySpec]] = collections.defaultdict(set)
-        for rhs_edge in other.traverse_edges(root=False, cover="edges"):
-            # Check satisfaction of the dependency only if its when condition can apply
-            if not rhs_edge.parent.name or rhs_edge.parent.name == self.name:
-                test_spec = self
-            elif rhs_edge.parent.name in self:
-                test_spec = self[rhs_edge.parent.name]
-            else:
-                test_spec = None
-            if test_spec and not test_spec._intersects(
-                rhs_edge.when, resolve_virtuals=resolve_virtuals
-            ):
-                continue
-
-            if rhs_edge.direct:
-                # Note: this relies on abstract specs from string not being deeper than 2 levels
-                # e.g. in foo %fee ^bar %baz we cannot go deeper than "baz" and e.g. specify its
-                # dependencies too.
-                #
-                # We also need to account for cases like gcc@<new> %gcc@<old> where the parent
-                # name is the same as the child name
-                #
-                # The same assumptions hold on Spec.constrain, and Spec.intersect
-                current_node = self
-                if rhs_edge.parent.name and rhs_edge.parent.name != rhs_edge.spec.name:
-                    try:
-                        current_node = self[rhs_edge.parent.name]
-                    except KeyError:
-                        return False
-
-                if self.concrete:
-                    # For a concrete spec, virtual info is encoded in edge.virtuals.
-                    #
-                    # The rhs edge may name either a concrete package or a virtual. If virtuals are
-                    # already annotated on the rhs edge, the name AND virtual must match. Otherwise
-                    # try both a name-based lookup and a virtual-based lookup and union the results
-                    if rhs_edge.virtuals:
-                        candidate_edges = current_node.edges_to_dependencies(
-                            name=rhs_edge.spec.name, virtuals=rhs_edge.virtuals
-                        )
-                    else:
-                        dep_name = rhs_edge.spec.name
-                        candidate_edges = current_node.edges_to_dependencies(name=dep_name)
-                        # It _may_ be a virtual
-                        if not candidate_edges:
-                            candidate_edges = current_node.edges_to_dependencies(
-                                virtuals=(dep_name,)
-                            )
-                            # If this virtual doesn't impose further version constraints, avoid
-                            # Further checks that may require package.py
-                            if (
-                                candidate_edges
-                                and rhs_edge.spec.versions == spack.version.any_version
-                            ):
-                                # Don't mutate objects in memory that may be referred elsewhere
-                                rhs_edge = rhs_edge.copy()
-                                rhs_edge.update_virtuals(virtuals=(rhs_edge.spec.name,))
-                                rhs_edge.spec = EMPTY_SPEC
-                        candidate_edges = lang.dedupe(candidate_edges)
-                else:
-                    # For an abstract spec, consult the repo to determine whether the rhs dep
-                    # name is a virtual, annotate the edge, then build candidate_edges.
-                    rhs_is_virtual = resolve_virtuals and spack.repo.PATH.is_virtual(
-                        rhs_edge.spec.name
-                    )
-                    if rhs_is_virtual:
-                        # Don't mutate objects in memory that may be referred elsewhere
-                        rhs_edge = rhs_edge.copy()
-                        dep_name = None
-                        rhs_edge.update_virtuals(virtuals=(rhs_edge.spec.name,))
-                        candidate_edges = current_node.edges_to_dependencies(
-                            name=rhs_edge.spec.name
-                        )
-                    else:
-                        dep_name = rhs_edge.spec.name
-                        candidate_edges = []
-
-                    candidate_edges.extend(
-                        current_node.edges_to_dependencies(
-                            name=dep_name, virtuals=rhs_edge.virtuals or None
-                        )
-                    )
-
-                # Select at least the deptypes on the rhs_edge, and conditional edges that
-                # constrain a bigger portion of the search space (so it's rhs.when <= lhs.when)
-                candidates = [
-                    lhs_edge.spec
-                    for lhs_edge in candidate_edges
-                    if ((lhs_edge.depflag & rhs_edge.depflag) ^ rhs_edge.depflag) == 0
-                    and rhs_edge.when._satisfies(lhs_edge.when, resolve_virtuals=resolve_virtuals)
-                ]
-
-                # For old specs, consider compiler dependencies from annotations
-                if current_node.original_spec_format() < 5:
-                    compiler_spec = current_node.annotations.compiler_node_attribute
-                    if compiler_spec is not None:
-                        candidates.append(compiler_spec)
-
-                if not candidates or not any(
-                    x._satisfies(rhs_edge.spec, resolve_virtuals=resolve_virtuals)
-                    for x in candidates
-                ):
-                    return False
-
-                continue
-
-            # Skip edges from a concrete sub-DAG
-            if rhs_edge.parent.concrete:
-                continue
-
-            if not lhs_edges:
-                # Construct a map of the link/run subDAG + direct "build" edges,
-                # keyed by dependency name
-                for lhs_edge in self.traverse_edges(
-                    root=False, cover="edges", deptype=("link", "run")
-                ):
-                    lhs_edges[lhs_edge.spec.name].add(lhs_edge)
-                    for virtual_name in lhs_edge.virtuals:
-                        lhs_edges[virtual_name].add(lhs_edge)
-
-                build_edges = self.edges_to_dependencies(depflag=dt.BUILD)
-                for lhs_edge in build_edges:
-                    lhs_edges[lhs_edge.spec.name].add(lhs_edge)
-                    for virtual_name in lhs_edge.virtuals:
-                        lhs_edges[virtual_name].add(lhs_edge)
-
-            # We don't have edges to this dependency
-            current_dependency_name = rhs_edge.spec.name
-            if current_dependency_name and current_dependency_name not in lhs_edges:
-                return False
-
-            if not current_dependency_name:
-                # Here we have an anonymous spec e.g. ^ dev_path=*
-                candidate_edges = list(itertools.chain(*lhs_edges.values()))
-
-            else:
-                candidate_edges = [
-                    lhs_edge
-                    for lhs_edge in lhs_edges[current_dependency_name]
-                    if rhs_edge.when._satisfies(lhs_edge.when, resolve_virtuals=resolve_virtuals)
-                ]
-
-            if not candidate_edges:
-                return False
-
-            for virtual in rhs_edge.virtuals:
-                # Check the name because ^mpi has the "mpi" virtual
-                has_virtual = any(
-                    virtual in edge.virtuals or virtual == edge.spec.name
-                    for edge in candidate_edges
-                )
-                if not has_virtual:
-                    return False
-
-            for lhs_edge in candidate_edges:
-                if lhs_edge.spec._satisfies(
-                    rhs_edge.spec, deps=False, resolve_virtuals=resolve_virtuals
-                ):
-                    break
-            else:
-                return False
 
         return True
 
@@ -5221,6 +5205,25 @@ class Spec:
 
     def has_virtual_dependency(self, virtual: str) -> bool:
         return bool(self.dependencies(virtuals=(virtual,)))
+
+
+def _compatible_edges(
+    lhs_edge: DependencySpec, rhs_edge: DependencySpec, resolve_virtuals: bool
+) -> bool:
+    """Returns True if the lhs edge properties satisfy the rhs edge"""
+    return (
+        (
+            # All the deptypes of the rhs edge must be there
+            (lhs_edge.depflag & rhs_edge.depflag)
+            ^ rhs_edge.depflag
+        )
+        == 0
+        # All the rhs edge virtuals must be there
+        and all(v in lhs_edge.virtuals for v in rhs_edge.virtuals)
+        # Select conditional edges that constrain a bigger portion of the search space
+        # (so it's rhs.when <= lhs.when)
+        and rhs_edge.when._satisfies(lhs_edge.when, resolve_virtuals=resolve_virtuals)
+    )
 
 
 class VariantMap(lang.HashableMap[str, vt.VariantValue]):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1477,6 +1477,83 @@ def _anonymous_star(dep: DependencySpec, dep_format: str) -> str:
     return "*" if dep.spec.architecture else ""
 
 
+def _get_satisfying_edge(
+    lhs_node: "Spec", rhs_edge: DependencySpec, *, resolve_virtuals: bool
+) -> Optional[DependencySpec]:
+    """Search for an edge in ``lhs_node`` that satisfies ``rhs_edge``."""
+    # First check direct deps of all types.
+    for lhs_edge in lhs_node.edges_to_dependencies():
+        if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
+            return lhs_edge
+
+    # Include the historical compiler node if available as an ad-hoc edge.
+    compiler_spec = lhs_node.annotations.compiler_node_attribute
+    if compiler_spec is not None:
+        compiler_edge = DependencySpec(
+            lhs_node,
+            compiler_spec,
+            depflag=dt.BUILD,
+            virtuals=("c", "cxx", "fortran"),
+            direct=True,
+        )
+        if _satisfies_edge(compiler_edge, rhs_edge, resolve_virtuals):
+            return compiler_edge
+
+    if rhs_edge.direct:
+        return None
+
+    # BFS through link/run transitive deps (skip depth 1, already checked).
+    depflag = dt.LINK | dt.RUN
+    queue = collections.deque(lhs_node.edges_to_dependencies(depflag=depflag))
+    seen = {id(lhs_edge.spec) for lhs_edge in queue}
+    while queue:
+        lhs_edge = queue.popleft()
+
+        if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
+            return lhs_edge
+
+        for lhs_edge in lhs_edge.spec.edges_to_dependencies(depflag=depflag):
+            if id(lhs_edge.spec) not in seen:
+                seen.add(id(lhs_edge.spec))
+                queue.append(lhs_edge)
+
+    return None
+
+
+def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtuals: bool) -> bool:
+    """Helper function for satisfaction tests, which checks edge attributes and the target node.
+    It skips verification of the parent node."""
+    name_mismatch = rhs.spec.name and lhs.spec.name != rhs.spec.name
+    if name_mismatch and rhs.spec.name not in lhs.virtuals:
+        return False
+
+    if not rhs.when._satisfies(lhs.when, resolve_virtuals=resolve_virtuals):
+        return False
+
+    # Subset semantics for virtuals
+    for v in rhs.virtuals:
+        if v not in lhs.virtuals:
+            return False
+
+    # Subset semantics for dependency types
+    if (lhs.depflag & rhs.depflag) != rhs.depflag:
+        return False
+
+    if not name_mismatch:
+        return lhs.spec._satisfies_node(rhs.spec, resolve_virtuals=resolve_virtuals)
+
+    # Right-hand side is virtual provided by left-hand side. The only node attribute supported is
+    # the version of the virtual. Avoid expensive lookups for provider metadata if there's no
+    # version constraint to check.
+    if rhs.spec.versions == spack.version.any_version:
+        return True
+
+    if not resolve_virtuals:
+        return False
+
+    return lhs.spec._provides_virtual(rhs.spec)
+
+
 @lang.lazy_lexicographic_ordering(set_hash=False)
 class Spec:
     compiler = DeprecatedCompilerSpec()
@@ -3385,166 +3462,38 @@ class Spec:
             return True
 
         other = self._autospec(other)
+
         if not self._satisfies_node(other, resolve_virtuals=resolve_virtuals):
             return False
 
-        # If we need to descend into dependencies, do it, otherwise we're done.
-        if not deps:
+        # If there are no dependencies on the rhs, or we don't recurse, they are satisfied.
+        if not deps or not other._dependencies:
             return True
 
-        # If there are no constraints to satisfy, we're done.
-        if not other._dependencies:
-            return True
+        stack = [(self, other)]
 
-        # If we arrived here, the lhs root node satisfies the rhs root node. Now we need to check
-        # all the edges that have an abstract parent, and verify that they match some edge in the
-        # lhs.
-        direct_edges, transitive_edges = [], []
-        for rhs_edge in other.traverse_edges(root=False, cover="edges"):
-            # It might happen that the rhs brings in concrete sub-DAGs. For those we don't need to
-            # verify the edge properties, cause everything is encoded in the hash of the nodes that
-            # will be verified later.
-            # TODO: Optimize by not iterating over these edges
-            if rhs_edge.parent.concrete:
-                continue
+        while stack:
+            lhs, rhs = stack.pop()
 
-            # None only in case rhs_edge has a parent that is not in lhs
-            lhs_parent = self._lhs_parent(rhs_edge)
-
-            # Check satisfaction of the dependency only if its "when" condition may apply
-            if lhs_parent and not lhs_parent._intersects(
-                rhs_edge.when, resolve_virtuals=resolve_virtuals
-            ):
-                continue
-
-            if lhs_parent is None:
-                # The only case where None could occur is that of a looking for a direct edge with
-                # a known parent, different from self, that the lhs doesn't have.
-                #
-                # Note: this relies on abstract specs from string not being deeper than 2 levels
-                # e.g. in foo %fee ^bar %baz we cannot go deeper than "baz" and e.g. specify its
-                # dependencies too.
-                #
-                # We also need to account for cases like gcc@<new> %gcc@<old> where the parent
-                # name is the same as the child name
-                #
-                # The same assumptions hold on Spec.constrain, and Spec.intersect
-                return False
-
-            if rhs_edge.direct:
-                direct_edges.append((lhs_parent, rhs_edge))
-            else:
-                transitive_edges.append(rhs_edge)
-
-        for lhs_parent, rhs_edge in direct_edges:
-            rhs_child = rhs_edge.spec
-            # Common case where the name identifies a real package i.e. %c=gcc or %gcc
-            candidate_edges = lhs_parent.edges_to_dependencies(
-                name=rhs_child.name, virtuals=rhs_edge.virtuals or None
-            )
-
-            if self.concrete and not candidate_edges:
-                # If we have no candidates the rhs may be a virtual i.e. %mpi or %mpi@3:
-                candidate_edges = lhs_parent.edges_to_dependencies(virtuals=(rhs_child.name,))
-                if candidate_edges and rhs_edge.spec.versions == spack.version.any_version:
-                    if not any(_compatible_edges(l, rhs_edge, resolve_virtuals=resolve_virtuals) for l in candidate_edges):
-                        return False
-                    # If this virtual doesn't impose version constraints, avoid checking package.py
+            for rhs_edge in rhs.edges_to_dependencies():
+                # Skip rhs edges whose when condition doesn't apply to the lhs node.
+                if rhs_edge.when is not EMPTY_SPEC and not lhs._intersects(
+                    rhs_edge.when, resolve_virtuals=resolve_virtuals
+                ):
                     continue
 
-            elif not self.concrete and resolve_virtuals and spack.repo.PATH.is_virtual(rhs_child.name):
-                # If we know the rhs is a virtual package, we need to *also* consider edges with
-                # virtuals. We cannot consider only those, because the lhs itself can be of the
-                # form %mpi@3: since it's abstract
-                candidate_edges.extend(
-                    lhs_parent.edges_to_dependencies(virtuals=(rhs_child.name,))
-                )
+                lhs_edge = _get_satisfying_edge(lhs, rhs_edge, resolve_virtuals=resolve_virtuals)
 
-            # Select the child node from edges that have compatible properties
-            candidates = [
-                lhs_edge.spec
-                for lhs_edge in candidate_edges
-                if _compatible_edges(lhs_edge, rhs_edge, resolve_virtuals)
-            ]
-
-            # For old specs, consider compiler dependencies from annotations
-            if not candidates and lhs_parent.original_spec_format() < 5:
-                compiler_spec = lhs_parent.annotations.compiler_node_attribute
-                if compiler_spec is not None:
-                    candidates.append(compiler_spec)
-
-            if not any(
-                x._satisfies_node(rhs_edge.spec, resolve_virtuals=resolve_virtuals)
-                for x in candidates
-            ):
-                return False
-
-        if not transitive_edges:
-            return True
-
-        # Construct a map of the link/run subDAG + direct "build" edges, keyed by dependency name
-        lhs_edges: Dict[str, Set[DependencySpec]] = collections.defaultdict(set)
-        for lhs_edge in self.traverse_edges(root=False, cover="edges", deptype=("link", "run")):
-            lhs_edges[lhs_edge.spec.name].add(lhs_edge)
-            for virtual_name in lhs_edge.virtuals:
-                lhs_edges[virtual_name].add(lhs_edge)
-
-        build_edges = self.edges_to_dependencies(depflag=dt.BUILD)
-        for lhs_edge in build_edges:
-            lhs_edges[lhs_edge.spec.name].add(lhs_edge)
-            for virtual_name in lhs_edge.virtuals:
-                lhs_edges[virtual_name].add(lhs_edge)
-
-        for rhs_edge in transitive_edges:
-            rhs_child = rhs_edge.spec
-            # We don't have edges to this dependency
-            rhs_child_name = rhs_child.name
-            if rhs_child_name and rhs_child_name not in lhs_edges:
-                return False
-            elif rhs_child_name:
-                set_of_edges = lhs_edges[rhs_child_name]
-            else:
-                set_of_edges = set(itertools.chain(*lhs_edges.values()))
-
-            candidate_edges = [
-                lhs_edge
-                for lhs_edge in set_of_edges
-                if _compatible_edges(lhs_edge, rhs_edge, resolve_virtuals)
-            ]
-            if not candidate_edges:
-                return False
-
-            for virtual in rhs_edge.virtuals:
-                # Check the name because ^mpi has the "mpi" virtual
-                has_virtual = any(
-                    virtual in edge.virtuals or virtual == edge.spec.name
-                    for edge in candidate_edges
-                )
-                if not has_virtual:
+                if not lhs_edge:
                     return False
 
-            for lhs_edge in candidate_edges:
-                if lhs_edge.spec._satisfies_node(rhs_edge.spec, resolve_virtuals=resolve_virtuals):
-                    break
-            else:
-                return False
+                # Recursive case: `^zlib %gcc`
+                if not rhs_edge.spec.concrete and rhs_edge.spec._dependencies:
+                    stack.append((lhs_edge.spec, rhs_edge.spec))
 
         return True
 
-    def _lhs_parent(self, rhs_edge: DependencySpec) -> Optional["Spec"]:
-        """Returns the parent node in self corresponding to the parent in rhs_edge.
-
-        If the rhs edge has no parent, self is returned. If the rhs has a parent not in self,
-        None is returned.
-        """
-        result = None
-        if not rhs_edge.parent.name or rhs_edge.parent.name == self.name:
-            result = self
-        elif rhs_edge.parent.name in self:
-            result = self[rhs_edge.parent.name]
-        return result
-
-    def _satisfies_node(self, other: "Spec", resolve_virtuals: bool = True) -> bool:
+    def _satisfies_node(self, other: "Spec", resolve_virtuals: bool) -> bool:
         """Compares self and other without looking at dependencies"""
         if other.concrete:
             # The left-hand side must be the same singleton with identical hash. Notice that
@@ -3552,18 +3501,18 @@ class Spec:
             # objects.
             return self.concrete and self.dag_hash() == other.dag_hash()
 
+        if self.name != other.name and self.name and other.name:
+            # Name mismatch can still be satisfiable if lhs provides the virtual mentioned by rhs.
+            if not resolve_virtuals:
+                return False
+            return self._provides_virtual(other)
+
         # If the right-hand side has an abstract hash, make sure it's a prefix of the
         # left-hand side's (abstract) hash.
         if other.abstract_hash:
             compare_hash = self.dag_hash() if self.concrete else self.abstract_hash
             if not compare_hash or not compare_hash.startswith(other.abstract_hash):
                 return False
-
-        # If the names are different, we need to consider virtuals
-        if self.name != other.name and self.name and other.name:
-            if self.concrete or resolve_virtuals:
-                return self._provides_virtual(other)
-            return False
 
         # namespaces either match, or other doesn't require one.
         if (
@@ -5205,25 +5154,6 @@ class Spec:
 
     def has_virtual_dependency(self, virtual: str) -> bool:
         return bool(self.dependencies(virtuals=(virtual,)))
-
-
-def _compatible_edges(
-    lhs_edge: DependencySpec, rhs_edge: DependencySpec, resolve_virtuals: bool
-) -> bool:
-    """Returns True if the lhs edge properties satisfy the rhs edge"""
-    return (
-        (
-            # All the deptypes of the rhs edge must be there
-            (lhs_edge.depflag & rhs_edge.depflag)
-            ^ rhs_edge.depflag
-        )
-        == 0
-        # All the rhs edge virtuals must be there
-        and all(v in lhs_edge.virtuals for v in rhs_edge.virtuals)
-        # Select conditional edges that constrain a bigger portion of the search space
-        # (so it's rhs.when <= lhs.when)
-        and rhs_edge.when._satisfies(lhs_edge.when, resolve_virtuals=resolve_virtuals)
-    )
 
 
 class VariantMap(lang.HashableMap[str, vt.VariantValue]):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1935,7 +1935,7 @@ spack:
 
             gcc = next(x for _, x in e.concretized_specs_by(group="compiler"))
             assert gcc.satisfies("gcc@14") and not gcc.external
-            assert gcc.satisfies("%c,cxx,fortran=gcc")
+            assert gcc.satisfies("%c,cxx=gcc")
             gcc_hash = gcc.dag_hash()
 
             assert len(list(e.concretized_specs_by(group="scalapacks"))) == 4

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -675,6 +675,16 @@ class TestSpecSemantics:
         # We should not create again the index
         assert spack.repo.PATH._provider_index is None
 
+    def test_abstract_satisfies_with_lhs_provider_rhs_virtual(self):
+        """If the left-hand side mentions a provider among dependencies and the right-hand side
+        mentions a virtual among its deps, we only have satisfaction if the edge attribute
+        specifies this virtual is provided."""
+        assert not Spec("mpileaks ^mpich").satisfies("mpileaks ^mpi")
+        assert not Spec("mpileaks %mpich").satisfies("mpileaks %mpi")
+        assert Spec("mpileaks ^[virtuals=mpi] mpich").satisfies("mpileaks ^mpi")
+        assert Spec("mpileaks %[virtuals=mpi] mpich").satisfies("mpileaks ^mpi")
+        assert Spec("mpileaks %[virtuals=mpi] mpich").satisfies("mpileaks %mpi")
+
     def test_concrete_checks_on_virtual_names_dont_need_repo(
         self, default_mock_concretization, monkeypatch
     ):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -689,6 +689,8 @@ class TestSpecSemantics:
         assert concrete.satisfies("%c=gcc")
         assert concrete.satisfies("%mpi=mpich")
 
+        assert not concrete.satisfies("%c,mpi=mpich")
+
     def test_satisfies_single_valued_variant(self):
         """Tests that the case reported in
         https://github.com/spack/spack/pull/2386#issuecomment-282147639

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -12,6 +12,7 @@ import spack.directives
 import spack.llnl.util.lang
 import spack.package_base
 import spack.paths
+import spack.repo
 import spack.solver.asp
 import spack.spec
 import spack.spec_parser
@@ -621,6 +622,72 @@ class TestSpecSemantics:
         assert not concrete.satisfies("^zmpi")
         assert concrete.satisfies("^[when='^notapackage'] zmpi")
         assert not concrete.satisfies("^[when='^mpi'] zmpi")
+
+    def test_concrete_satisfies_does_not_consult_repo(
+        self, default_mock_concretization, monkeypatch
+    ):
+        """Tests that `satisfies()` on a concrete lhs doesn't need the provider index, when the rhs
+        contains a virtual name.
+        """
+        concrete = default_mock_concretization("mpileaks ^mpich")
+
+        # Reset the index, will raise if the `_provider_index` is ever removed as an attribute
+        monkeypatch.setattr(spack.repo.PATH, "_provider_index", None)
+
+        # Basic match and mismatch cases.
+        assert concrete.satisfies("mpileaks")
+        assert not concrete.satisfies("zlib")
+
+        # Virtuals on a direct edge
+        assert concrete.satisfies("%mpi")
+        assert concrete.satisfies("%mpi@3")
+        assert not concrete.satisfies("%mpi@5")
+        assert concrete.satisfies("%mpi=mpich")
+        assert not concrete.satisfies("%lapack")
+
+        # Virtuals on a transitive edge
+        assert concrete.satisfies("^mpi")
+        assert concrete.satisfies("^mpi=mpich")
+        assert not concrete.satisfies("^lapack")
+
+        # Concrete spec asking about one of its concrete deps.
+        mpich = concrete["mpich"]
+        assert mpich.satisfies("mpich")
+        assert mpich.satisfies("mpi")
+
+        # We should not create again the index
+        assert spack.repo.PATH._provider_index is None
+
+    def test_concrete_contains_does_not_consult_repo(
+        self, default_mock_concretization, monkeypatch
+    ):
+        """Tests that `foo in spec` on a concrete spec doesn't need the provider index, when the
+        item contains a virtual name.
+        """
+        concrete = default_mock_concretization("mpileaks ^mpich")
+
+        # Reset the index, will raise if the `_provider_index` is ever removed as an attribute
+        monkeypatch.setattr(spack.repo.PATH, "_provider_index", None)
+
+        assert "mpi" in concrete
+        assert "c" in concrete
+
+        # We should not create again the index
+        assert spack.repo.PATH._provider_index is None
+
+    def test_concrete_checks_on_virtual_names_dont_need_repo(
+        self, default_mock_concretization, monkeypatch
+    ):
+        """Tests that ``%mpi`` or similar on a concrete spec doesn't need the repo"""
+        concrete = default_mock_concretization("mpileaks ^mpich")
+
+        # We don't need the repo
+        monkeypatch.setattr(spack.repo, "PATH", None)
+
+        assert concrete.satisfies("%mpi")
+        assert concrete.satisfies("%c")
+        assert concrete.satisfies("%c=gcc")
+        assert concrete.satisfies("%mpi=mpich")
 
     def test_satisfies_single_valued_variant(self):
         """Tests that the case reported in


### PR DESCRIPTION
A further simplification of #52143.

The original goal was:

> Avoid consulting the virtual provider lookup, in particular in the common case of concrete lhs.

That was accomplished as follows:

1. The left-hand side provides edge attributes to which the right-hand side nodes can be matched.
2. If the right hand side is a known virtual and merely mentions a name `%mpi`, exit early
3. The only virtual attribute to (very rarely) check for satisfaction is the version `mpi@3`; here lookup the package metadata instead of the provider cache in case the left-hand side is concrete.

This PR on top of that unifies various code paths that were incorrectly considered "exceptions to the rule" and as a result reduces the branching in `_satisfies` considerably.

The assumption in this PR is that in the case of right-hand side abstract, its size is O(1) so that it's worst case linear time (early return). The previous implementation was best case linear time in the `^pkg` case. I don't think it's worth it generating a reverse lookup table for (virtual) name -> spec.

Lastly it defines and tests the behavior of `satisfies(%possible-provider, ^virtual)`. That statement is false since you can depend on a package that could provide a virtual without depending on the virtual.

Even lastlier, it fixes a bug where `assert s.satisfies("%c,cxx,fortran=gcc")` was true, even though `s` did not depend on `fortran`.