### PR TITLE
benchmarks: add micro-benchmarks for Spec.satisfies

### DIFF
--- a/lib/spack/spack/test/benchmarks/test_spec_satisfies.py
+++ b/lib/spack/spack/test/benchmarks/test_spec_satisfies.py
@@ -1,0 +1,105 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Micro-benchmarks for Spec.satisfies.
+
+Run with:
+    pytest lib/spack/spack/test/benchmarks/test_spec_satisfies.py --benchmark-only
+"""
+
+import pytest
+
+import spack.concretize
+import spack.spec
+
+# Cache concretized specs by their abstract string — concretization is expensive and
+# several test cases share the same lhs package.
+_CONCRETIZED: dict = {}
+
+pytestmark = pytest.mark.benchmark
+
+# id -> (lhs, rhs, expected) — parsed once at module scope, never inside the timed call
+_ABSTRACT_LHS = {
+    # root-only, no virtuals
+    "name-only": ("zlib", "zlib", True),
+    "version-satisfied": ("zlib@1.2.13", "zlib@1.2:", True),
+    "version-not-satisfied": ("zlib@1.2.13", "zlib@2:", False),
+    "variant-satisfied": ("zlib@1.2.13+shared", "zlib+shared", True),
+    "variant-not-satisfied": ("zlib@1.2.13~shared", "zlib+shared", False),
+    "version-and-variant": ("zlib@1.2.13+shared", "zlib@1.2:+shared", True),
+    # direct and transitive dependencies, no virtuals
+    "direct-dep-satisfied-with-direct": ("hdf5 %zlib@1.2.13", "hdf5 %zlib@1.2:", True),
+    "direct-dep-satisfied-with-transitive": ("hdf5 %zlib@1.2.13", "hdf5 ^zlib@1.2:", True),
+    "direct-dep-not-satisfied": ("hdf5 %zlib@1.2.13", "hdf5 ^zlib@2:", False),
+    "transitive-dep-satisfied": ("hdf5 ^openmpi@4 ^zlib@1.2.13", "hdf5 ^zlib@1.2:", True),
+    # virtuals — root
+    "mpi-provider-satisfies-virtual": ("openmpi@2.0.0", "mpi", True),
+    "mpi-provider-satisfies-versioned-virtual": ("openmpi@2.0.0", "mpi@2:", True),
+    "mpi-provider-does-not-satisfy-unrelated-virtual": ("openmpi@2.0.0", "blas", False),
+    "non-provider-does-not-satisfy-virtual": ("zlib@1.2.13", "mpi", False),
+    "blas-provider-satisfies-virtual": ("openblas", "blas", True),
+    # virtuals — dependency edge
+    "virtual-dep-provider-satisfies-virtual": (
+        "hdf5 ^[virtuals=mpi] openmpi@2.0.0",
+        "hdf5 ^mpi",
+        True,
+    ),
+    "virtual-dep-provider-satisfies-versioned-virtual": (
+        "hdf5 ^[virtuals=mpi] openmpi@2.0.0",
+        "hdf5 ^mpi@2:",
+        True,
+    ),
+    "virtual-dep-different-provider-satisfies-virtual": (
+        "hdf5 ^[virtuals=mpi] mpich@4",
+        "hdf5 ^mpi",
+        True,
+    ),
+}
+
+
+@pytest.fixture(scope="module", params=list(_ABSTRACT_LHS.values()), ids=list(_ABSTRACT_LHS))
+def abstract_lhs(request):
+    """Abstract lhs vs. abstract rhs"""
+    lhs_str, rhs_str, expected = request.param
+    return spack.spec.Spec(lhs_str), spack.spec.Spec(rhs_str), expected
+
+
+def test_satisfies_abstract_lhs(benchmark, abstract_lhs):
+    lhs, rhs, expected = abstract_lhs
+    result = benchmark(lhs.satisfies, rhs)
+    assert result == expected
+
+
+_CONCRETE_LHS = {
+    # root-only, no virtuals
+    "version-satisfied": ("zlib", "zlib@1.2:", True),
+    "version-not-satisfied": ("zlib", "zlib@2:", False),
+    "variant-satisfied": ("zlib", "zlib+shared", True),
+    # direct and transitive dependencies, no virtuals
+    "direct-dep-satisfied": ("hdf5+mpi", "hdf5 ^zlib-ng@1.2:", True),
+    "direct-dep-not-satisfied": ("hdf5+mpi", "hdf5 ^zlib-ng@99:", False),
+    "transitive-dep-satisfied": ("hdf5+mpi", "hdf5 ^openmpi ^zlib-ng@1:", True),
+    # virtuals — root
+    "provider-satisfies-virtual": ("openmpi", "mpi", True),
+    "provider-satisfies-versioned-virtual": ("openmpi", "mpi@3:", True),
+    # virtuals — dependency edge
+    "dep-satisfies-virtual-constraint": ("hdf5+mpi", "hdf5 ^mpi", True),
+    "dep-satisfies-versioned-virtual-constraint": ("hdf5+mpi", "hdf5 ^mpi@3:", True),
+    "dep-satisfies-named-provider-constraint": ("hdf5+mpi", "hdf5 ^[virtuals=mpi] openmpi", True),
+}
+
+
+@pytest.fixture(scope="module", params=list(_CONCRETE_LHS.values()), ids=list(_CONCRETE_LHS))
+def concrete_lhs(request):
+    """Concrete lhs vs. abstract rhs"""
+    lhs_str, rhs_str, expected = request.param
+    if lhs_str not in _CONCRETIZED:
+        _CONCRETIZED[lhs_str] = spack.concretize.concretize_one(spack.spec.Spec(lhs_str))
+    return _CONCRETIZED[lhs_str], spack.spec.Spec(rhs_str), expected
+
+
+def test_satisfies_concrete_lhs(benchmark, concrete_lhs):
+    lhs, rhs, expected = concrete_lhs
+    result = benchmark(lhs.satisfies, rhs)
+    assert result == expected

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 [pytest]
 addopts = --durations=30 -ra --strict-markers -p no:legacypath
 testpaths = lib/spack/spack/test
+norecursedirs = lib/spack/spack/test/benchmarks
 python_files = *.py
 pythonpath = lib/spack
 filterwarnings =
@@ -18,4 +19,5 @@ markers =
   require_provenance: tests that have enough infrastructure to test git binary provenance
   enable_parallelism: mark tests that require parallelism to be enabled
   use_package_hash: mark test to use real package hash computation instead of mock
+  benchmark: micro-benchmarks that are excluded from the default test run
 


### PR DESCRIPTION
Add a `pytest-benchmark` based micro-benchmark suite under lib/spack/spack/test/benchmarks/, excluded from the default test run via norecursedirs in pytest.ini.

Two test functions cover `Spec.satisfies` across representative cases:
- abstract lhs (no concretization): versions, variants, direct and transitive deps, virtual providers, and virtual dependency edges
- concrete lhs: same categories, with concretized specs cached at module scope to avoid paying solver cost more than once per package

Run with:
```console
pip install pytest pytest-benchmark
pytest lib/spack/spack/test/benchmarks/ --benchmark-only
```

**For later**
- We can probably add a non-blocking CI job that runs against the base develop commit, if certain files are changed, and warns if there's a detected slowdown in microbenchmarks.
- We can add microbenchmarks for other parts of Spack, e.g. the parser

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
