### PR TITLE
spack env create: do not call regen views unconditionally

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -127,7 +127,8 @@ def env_create(args):
     )
 
     # Generate views, only really useful for environments created from spack.lock files.
-    env.regenerate_views()
+    if args.envfile:
+        env.regenerate_views()
 
 
 def _env_create(


### PR DESCRIPTION
When creating a new, empty Spack environment, do just that. The view
regenerate call may trigger an unnecessary database read, which can be
a couple 100ms overhead.

Only generate views if the env is initialized from a spack.lock file.

