### PR TITLE
new_installer.py: new process group instead of session

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -474,8 +474,9 @@ def worker_function(
 
     global_state.restore()
 
-    # Start a new session, so our SIGTERM handler can kill all child processes.
-    os.setsid()
+    # Isolate the process group to shield against Ctrl+C and enable safe killpg() cleanup. In
+    # constrast to setsid(), this keeps a neat process group hierarchy for utils like pstree.
+    os.setpgid(0, 0)
 
     # Reset SIGTSTP to default in case the parent had a custom handler.
     signal.signal(signal.SIGTSTP, signal.SIG_DFL)


### PR DESCRIPTION
In build subprocesses, create a new process group instead of a new session.
The benefit is that tools like `pstree` neatly show the spack install process
with all its concurrent builds as a tree, making it easier to verify whether
the jobserver is working correctly: `-j N` <--> `N` leaf nodes.

For our purposes it's otherwise the same: shields against signal from the
terminal, and allows cleanup in the right order.

```
$ spack install -j16 ... &
$ pstree <spack pid>
python3─┬─python3─┬─make───sh───libtool───gcc───cc1
        │         └─{python3}
        ├─python3─┬─make───make───bash───make─┬─bash
        │         │                           └─2*[bash───gcc───cc1]
        │         └─{python3}
        ├─python3─┬─make───make───bash───gcc───cc1
        │         └─{python3}
        ├─python3─┬─make───sh───make───sh───make───4*[gcc───cc1]
        │         └─{python3}
        ├─python3─┬─make───make───bash───make───bash───make───bash───make
        │         └─{python3}
        ├─python3─┬─make───sh───make
        │         └─{python3}
        ├─python3─┬─make───make───bash───make───bash───bash
        │         └─{python3}
        ├─python3─┬─bash
        │         └─{python3}
        ├─python3─┬─configure
        │         └─{python3}
        └─python3─┬─make───2*[gcc───cc1]
                  └─{python3}
```

The above adds up, notice the `2*`/`4*`/`2*` deduplication. The `{python3}` leaf nodes are the "tee" threads for IO and don't count.

