### PR TITLE
installer.py: --until <last phase>

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -232,10 +232,6 @@ def _check_last_phase(pkg: "spack.package_base.PackageBase") -> None:
     if pkg.last_phase and pkg.last_phase not in phases:  # type: ignore[attr-defined]
         raise BadInstallPhase(pkg.name, pkg.last_phase)  # type: ignore[attr-defined]
 
-    # If we got a last_phase, make sure it's not already last
-    if pkg.last_phase and pkg.last_phase == phases[-1]:  # type: ignore[attr-defined]
-        pkg.last_phase = None  # type: ignore[attr-defined]
-
 
 def _handle_external_and_upstream(pkg: "spack.package_base.PackageBase", explicit: bool) -> bool:
     """

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -62,7 +62,8 @@ def test_dev_build_before(tmp_path: pathlib.Path, install_mockery, installer_var
     assert not os.path.exists(spec.prefix)
 
 
-def test_dev_build_until(tmp_path: pathlib.Path, install_mockery, installer_variant):
+@pytest.mark.parametrize("last_phase", ["edit", "install"])
+def test_dev_build_until(tmp_path: pathlib.Path, install_mockery, last_phase, installer_variant):
     spec = spack.concretize.concretize_one(
         spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmp_path}")
     )
@@ -71,7 +72,7 @@ def test_dev_build_until(tmp_path: pathlib.Path, install_mockery, installer_vari
         with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore
             f.write(spec.package.original_string)  # type: ignore
 
-        dev_build("-u", "edit", "dev-build-test-install@0.0.0")
+        dev_build("-u", last_phase, "dev-build-test-install@0.0.0")
 
         assert spec.package.filename in os.listdir(os.getcwd())  # type: ignore
         with open(spec.package.filename, "r", encoding="utf-8") as f:  # type: ignore
@@ -79,27 +80,6 @@ def test_dev_build_until(tmp_path: pathlib.Path, install_mockery, installer_vari
 
     assert not os.path.exists(spec.prefix)
     assert not spack.store.STORE.db.query(spec, installed=True)
-
-
-def test_dev_build_until_last_phase(tmp_path: pathlib.Path, install_mockery):
-    # Test that we ignore the last_phase argument if it is already last
-    spec = spack.concretize.concretize_one(
-        spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmp_path}")
-    )
-
-    with fs.working_dir(str(tmp_path)):
-        with open(spec.package.filename, "w", encoding="utf-8") as f:
-            f.write(spec.package.original_string)
-
-        dev_build("-u", "install", "dev-build-test-install@0.0.0")
-
-        assert spec.package.filename in os.listdir(os.getcwd())
-        with open(spec.package.filename, "r", encoding="utf-8") as f:
-            assert f.read() == spec.package.replacement_string
-
-    assert os.path.exists(spec.prefix)
-    assert spack.store.STORE.db.query(spec, installed=True)
-    assert os.path.exists(str(tmp_path))
 
 
 def test_dev_build_before_until(tmp_path: pathlib.Path, install_mockery, installer_variant):

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -72,7 +72,7 @@ def test_dev_build_until(tmp_path: pathlib.Path, install_mockery, last_phase, in
         with open(spec.package.filename, "w", encoding="utf-8") as f:  # type: ignore
             f.write(spec.package.original_string)  # type: ignore
 
-        dev_build("-u", last_phase, "dev-build-test-install@0.0.0")
+        dev_build("--until", last_phase, "dev-build-test-install@0.0.0")
 
         assert spec.package.filename in os.listdir(os.getcwd())  # type: ignore
         with open(spec.package.filename, "r", encoding="utf-8") as f:  # type: ignore


### PR DESCRIPTION
Currently `--until install` is handled as an exceptional case in the old
installer where it simplify continues installation as if no flag was
passed.

This makes it impossible to run until install without registering the
spec in the database, which could be a valid use case. Also makes it
hard to troubleshoot post-install hooks.

This commit removes the exceptional case so that the builds can stop
after completing the last phase. It adapts integrations tests accordingly,
ensuring the behavior is the same for the old and new installer.

