### PR TITLE
installer.py: avoid chmod when --fake

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -68,7 +68,6 @@ from spack.llnl.util.tty.color import colorize
 from spack.llnl.util.tty.log import log_output, preserve_terminal_settings
 from spack.url_buildcache import BuildcacheEntryError
 from spack.util.environment import EnvironmentModifications, dump_environment
-from spack.util.executable import which
 
 if TYPE_CHECKING:
     import spack.spec
@@ -286,10 +285,8 @@ def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
 
     # Install fake command
     fs.mkdirp(pkg.prefix.bin)
-    fs.touch(os.path.join(pkg.prefix.bin, command))
-    if sys.platform != "win32":
-        chmod = which("chmod", required=True)
-        chmod("+x", os.path.join(pkg.prefix.bin, command))
+    executable = lambda path, flags: os.open(path, flags, 0o700)
+    open(os.path.join(pkg.prefix.bin, command), "wb", opener=executable).close()
 
     # Install fake header file
     fs.mkdirp(pkg.prefix.include)


### PR DESCRIPTION
Avoid redundant, platform-dependent subprocess
