### PR TITLE
config: allow env substitution for git include branch and tag

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1319,9 +1319,9 @@ class GitIncludePaths(OptionalInclude):
         super().__init__(entry)
         self.git = spack.util.path.substitute_path_variables(entry.get("git", ""))
 
-        self.branch = entry.get("branch", "")
+        self.branch = spack.util.path.substitute_path_variables(entry.get("branch", ""))
         self.commit = entry.get("commit", "")
-        self.tag = entry.get("tag", "")
+        self.tag = spack.util.path.substitute_path_variables(entry.get("tag", ""))
         self._paths = [
             spack.util.path.substitute_path_variables(path) for path in entry.get("paths", [])
         ]

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1814,11 +1814,12 @@ def test_included_path_git_unsat(
 
 
 def test_included_path_git_substitutions():
-    # check path substitutions for the git url *and* paths
+    # check path substitutions for the git url, branch, tag, and paths
     paths = ["./$platform/config.yaml", "$platform/packages.yaml"]
     entry = {
         "git": "https://example.com/$platform/configs.git",
-        "branch": "develop",
+        "branch": "$platform",
+        "tag": "$platform",
         "name": "site",
         "paths": paths,
         "when": 'platform == "test"',
@@ -1827,6 +1828,8 @@ def test_included_path_git_substitutions():
     assert isinstance(include, spack.config.GitIncludePaths)
     assert not include.optional and include.evaluate_condition()
     assert "test" in include.git, "Expected the git url to contain the platform"
+    assert include.branch == "test", "Expected the branch to contain the platform"
+    assert include.tag == "test", "Expected the tag to contain the platform"
     for path in include.paths:
         assert "test" in path, "Expected the included git path to contain the platform"
 


### PR DESCRIPTION
Users may want to do things like this in Git-included configs:

```
include:
  - name: myconf
  git: /path/to/myconf.git
  branch: $spack_short_version
  paths:
  - config.yaml
```

This PR adds support for env substitution for the `branch` and `tag` fields.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
