### PR TITLE
file_cache: drop init_entry/mtime, fix races

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -188,13 +188,9 @@ class BinaryCacheIndex:
     def _init_local_index_cache(self):
         if not self._index_file_cache_initialized:
             cache_key = self._index_contents_key
-            self._index_file_cache.init_entry(cache_key)
-
-            cache_path = self._index_file_cache.cache_path(cache_key)
-
             self._local_index_cache = {}
-            if os.path.isfile(cache_path):
-                with self._index_file_cache.read_transaction(cache_key) as cache_file:
+            with self._index_file_cache.read_transaction(cache_key) as cache_file:
+                if cache_file is not None:
                     self._local_index_cache = json.load(cache_file)
 
             self._index_file_cache_initialized = True
@@ -231,17 +227,17 @@ class BinaryCacheIndex:
         with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
             db = BuildCacheDatabase(tmpdir)
 
-            try:
-                with self._index_file_cache.read_transaction(cache_key) as f:
-                    if f is not None:
+            with self._index_file_cache.read_transaction(cache_key) as f:
+                if f is not None:
+                    try:
                         db._read_from_stream(f)
-            except spack.database.InvalidDatabaseVersionError as e:
-                tty.warn(
-                    "you need a newer Spack version to read the buildcache index for the "
-                    f"following v{mirror_metadata.version} mirror: '{mirror_metadata.url}'. "
-                    f"{e.database_version_message}"
-                )
-                return
+                    except spack.database.InvalidDatabaseVersionError as e:
+                        tty.warn(
+                            "you need a newer Spack version to read the buildcache index for the "
+                            f"following v{mirror_metadata.version} mirror: "
+                            f"'{mirror_metadata.url}'. {e.database_version_message}"
+                        )
+                        return
 
             spec_list = [
                 s
@@ -484,7 +480,6 @@ class BinaryCacheIndex:
         # Persist new index.json
         url_hash = compute_hash(str(mirror_metadata))
         cache_key = "{}_{}.json".format(url_hash[:10], result.hash[:10])
-        self._index_file_cache.init_entry(cache_key)
         with self._index_file_cache.write_transaction(cache_key) as (old, new):
             new.write(result.data)
 

--- a/lib/spack/spack/compilers/libraries.py
+++ b/lib/spack/spack/compilers/libraries.py
@@ -380,7 +380,6 @@ class FileCompilerCache(CompilerCache):
 
     def __init__(self, cache: "FileCache") -> None:
         self.cache = cache
-        self.cache.init_entry(self.name)
         self._data: Dict[str, Dict[str, Optional[str]]] = {}
 
     def _get_entry(self, key: str, *, allow_empty: bool) -> Optional[CompilerCacheEntry]:
@@ -395,13 +394,16 @@ class FileCompilerCache(CompilerCache):
 
     def get(self, compiler: spack.spec.Spec) -> CompilerCacheEntry:
         # Cache hit
-        try:
-            with self.cache.read_transaction(self.name) as f:
-                assert f is not None
-                self._data = json.loads(f.read())
-                assert isinstance(self._data, dict)
-        except (json.JSONDecodeError, AssertionError):
-            self._data = {}
+        with self.cache.read_transaction(self.name) as f:
+            if f is not None:
+                try:
+                    self._data = json.loads(f.read())
+                    if not isinstance(self._data, dict):
+                        self._data = {}
+                except json.JSONDecodeError:
+                    self._data = {}
+            else:
+                self._data = {}
 
         key = self._key(compiler)
         value = self._get_entry(key, allow_empty=False)
@@ -410,11 +412,14 @@ class FileCompilerCache(CompilerCache):
 
         # Cache miss
         with self.cache.write_transaction(self.name) as (old, new):
-            try:
-                assert old is not None
-                self._data = json.loads(old.read())
-                assert isinstance(self._data, dict)
-            except (json.JSONDecodeError, AssertionError):
+            if old is not None:
+                try:
+                    self._data = json.loads(old.read())
+                    if not isinstance(self._data, dict):
+                        self._data = {}
+                except json.JSONDecodeError:
+                    self._data = {}
+            else:
                 self._data = {}
 
             # Use cache entry that may have been created by another process in the meantime.

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -11,6 +11,7 @@ import importlib
 import importlib.machinery
 import importlib.util
 import itertools
+import math
 import os
 import re
 import shutil
@@ -661,40 +662,36 @@ class RepoIndex:
 
         cache_filename = f"{name}/{self.namespace}-specfile_v{SPECFILE_FORMAT_VERSION}-index.json"
 
-        # Compute which packages needs to be updated in the cache
-        index_mtime = self.cache.mtime(cache_filename)
+        with self.cache.read_transaction(cache_filename) as f:
+            # Get the mtime of the cache if it exists, of -inf.
+            index_mtime = os.fstat(f.fileno()).st_mtime if f is not None else -math.inf
 
-        index_existed = self.cache.init_entry(cache_filename)
-        if index_existed and allow_stale:
-            with self.cache.read_transaction(cache_filename) as f:
+            if f is not None and allow_stale:
+                # Cache exists and caller accepts stale data: skip the expensive modified_since.
                 indexer.read(f)
-            self.indexes[name] = indexer.index
-            return False
+                self.indexes[name] = indexer.index
+                return False
 
-        needs_update = self.checker.modified_since(index_mtime)
-        if index_existed and not needs_update:
-            # If the index exists and doesn't need an update, read it
-            with self.cache.read_transaction(cache_filename) as f:
+            needs_update = self.checker.modified_since(index_mtime)
+
+            if f is not None and not needs_update:
+                # Cache exists and is up to date.
                 indexer.read(f)
-            self.indexes[name] = indexer.index
-            return True
+                self.indexes[name] = indexer.index
+                return True
 
-        else:
-            # Otherwise update it and rewrite the cache file
-            with self.cache.write_transaction(cache_filename) as (old, new):
-                indexer.read(old) if old else indexer.create()
+        # Cache is missing or stale: acquire write lock and rebuild.
+        with self.cache.write_transaction(cache_filename) as (old, new):
+            old_mtime = os.fstat(old.fileno()).st_mtime if old is not None else -math.inf
+            # Re-check in case another writer updated the index while we waited for the lock.
+            if old_mtime != index_mtime:
+                needs_update = self.checker.modified_since(old_mtime)
+            indexer.read(old) if old is not None else indexer.create()
+            indexer.update({f"{self.namespace}.{pkg_name}" for pkg_name in needs_update})
+            indexer.write(new)
 
-                # Compute which packages needs to be updated **again** in case someone updated them
-                # while we waited for the lock
-                new_index_mtime = self.cache.mtime(cache_filename)
-                if new_index_mtime != index_mtime:
-                    needs_update = self.checker.modified_since(new_index_mtime)
-
-                indexer.update({f"{self.namespace}.{pkg_name}" for pkg_name in needs_update})
-                indexer.write(new)
-
-            self.indexes[name] = indexer.index
-            return True
+        self.indexes[name] = indexer.index
+        return True
 
 
 class RepoPath:

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -48,7 +48,7 @@ def test_failed_write_and_read_cache_file(file_cache):
     assert os.listdir(file_cache.root) == [".lock"]
 
     # File does not exist
-    assert not file_cache.init_entry("test.yaml")
+    assert not os.path.exists(file_cache.cache_path("test.yaml"))
 
 
 def test_write_and_remove_cache_file(file_cache):
@@ -84,39 +84,37 @@ def test_write_and_remove_cache_file(file_cache):
 
 @pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.skipif(fs.getuid() == 0, reason="user is root")
-def test_cache_init_entry_fails(file_cache):
-    """Test init_entry failures."""
+def test_bad_cache_permissions(file_cache, request):
+    """Test that transactions raise CacheError on permission problems."""
     relpath = fs.join_path("test-dir", "read-only-file.txt")
     cachefile = file_cache.cache_path(relpath)
     fs.touchp(cachefile)
 
-    # Ensure directory causes exception
+    # A directory where a file is expected raises CacheError on read
     with pytest.raises(CacheError, match="not a file"):
-        file_cache.init_entry(os.path.dirname(relpath))
+        with file_cache.read_transaction(os.path.dirname(relpath)) as _:
+            pass
 
-    # Ensure non-readable file causes exception
+    # A directory where a file is expected raises CacheError on write
+    with pytest.raises(CacheError, match="not a file"):
+        with file_cache.write_transaction(os.path.dirname(relpath)) as _:
+            pass
+
+    # A non-readable file raises CacheError on read
     os.chmod(cachefile, 0o200)
+    request.addfinalizer(lambda c=cachefile: os.chmod(c, 0o600))
     with pytest.raises(CacheError, match="Cannot access cache file"):
-        file_cache.init_entry(relpath)
+        with file_cache.read_transaction(relpath) as _:
+            pass
 
-    # Ensure read-only parent causes exception
-    relpath = fs.join_path("test-dir", "another-file.txxt")
-    cachefile = file_cache.cache_path(relpath)
-    os.chmod(os.path.dirname(cachefile), 0o400)
-    with pytest.raises(CacheError, match="Cannot access cache dir"):
-        file_cache.init_entry(relpath)
-
-
-@pytest.mark.skipif(fs.getuid() == 0, reason="user is root")
-def test_cache_write_readonly_cache_fails(file_cache):
-    """Test writing a read-only cached file."""
-    filename = "read-only-file.txt"
-    path = file_cache.cache_path(filename)
-    fs.touch(path)
-    os.chmod(path, 0o400)
-
-    with pytest.raises(CacheError, match="Insufficient permissions to write"):
-        file_cache.write_transaction(filename)
+    # A read-only parent directory raises CacheError on write
+    relpath2 = fs.join_path("test-dir", "another-file.txxt")
+    parent = str(file_cache.cache_path(relpath2).parent)
+    os.chmod(parent, 0o400)
+    request.addfinalizer(lambda p=parent: os.chmod(p, 0o700))
+    with pytest.raises(CacheError):
+        with file_cache.write_transaction(relpath2) as _:
+            pass
 
 
 @pytest.mark.regression("31475")

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -2,25 +2,26 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import errno
 import hashlib
-import math
 import os
 import pathlib
 import shutil
-from typing import IO, Dict, Optional, Tuple, Union
+from contextlib import contextmanager
+from typing import IO, Dict, Iterator, Optional, Tuple, Union
 
 from spack.error import SpackError
 from spack.llnl.util.filesystem import rename
-from spack.util.lock import Lock, ReadTransaction, WriteTransaction
+from spack.util.lock import Lock
 
 
 def _maybe_open(path: Union[str, pathlib.Path]) -> Optional[IO[str]]:
     try:
         return open(path, "r", encoding="utf-8")
-    except OSError as e:
-        if e.errno != errno.ENOENT:
-            raise
+    except IsADirectoryError:
+        raise CacheError("Cache file is not a file: %s" % path)
+    except PermissionError:
+        raise CacheError("Cannot access cache file: %s" % path)
+    except FileNotFoundError:
         return None
 
 
@@ -46,7 +47,16 @@ class WriteContextManager:
     def __enter__(self) -> Tuple[Optional[IO[str]], IO[str]]:
         """Return (old_file, new_file) file objects, where old_file is optional."""
         self.old_file = _maybe_open(self.path)
-        self.new_file = open(self.tmp_path, "w", encoding="utf-8")
+        try:
+            try:
+                self.new_file = open(self.tmp_path, "w", encoding="utf-8")
+            except FileNotFoundError:
+                os.makedirs(os.path.dirname(self.path), exist_ok=True)
+                self.new_file = open(self.tmp_path, "w", encoding="utf-8")
+        except PermissionError:
+            if self.old_file:
+                self.old_file.close()
+            raise CacheError(f"Insufficient permissions to write to file cache at {self.path}")
         return self.old_file, self.new_file
 
     def __exit__(self, type, value, traceback):
@@ -55,7 +65,10 @@ class WriteContextManager:
         self.new_file.close()
 
         if value:
-            os.remove(self.tmp_path)
+            try:
+                os.remove(self.tmp_path)
+            except OSError:
+                pass
         else:
             rename(self.tmp_path, self.path)
 
@@ -127,88 +140,58 @@ class FileCache:
             )
         return self._locks[key_str]
 
-    def init_entry(self, key: Union[str, pathlib.Path]):
-        """Ensure we can access a cache file. Create a lock for it if needed.
-
-        Return whether the cache file exists yet or not.
-        """
-        cache_path = self.cache_path(key)
-        # Avoid using pathlib here to allow the logic below to
-        # function as is
-        # TODO: Maybe refactor the following logic for pathlib
-        exists = os.path.exists(cache_path)
-        if exists:
-            if not cache_path.is_file():
-                raise CacheError("Cache file is not a file: %s" % cache_path)
-
-            if not os.access(cache_path, os.R_OK):
-                raise CacheError("Cannot access cache file: %s" % cache_path)
-        else:
-            # if the file is hierarchical, make parent directories
-            parent = cache_path.parent
-            if parent != self.root:
-                parent.mkdir(parents=True, exist_ok=True)
-
-            if not os.access(parent, os.R_OK | os.W_OK):
-                raise CacheError("Cannot access cache directory: %s" % parent)
-
-            # ensure lock is created for this key
-            self._get_lock(key)
-        return exists
-
-    def read_transaction(self, key: Union[str, pathlib.Path]):
+    @contextmanager
+    def read_transaction(self, key: Union[str, pathlib.Path]) -> Iterator[Optional[IO[str]]]:
         """Get a read transaction on a file cache item.
 
-        Returns a ReadTransaction context manager and opens the cache file for
-        reading.  You can use it like this::
+        Returns a context manager that yields an open file object for reading,
+        or None if the cache file does not exist.  You can use it like this::
 
            with file_cache_object.read_transaction(key) as cache_file:
-               cache_file.read()
+               if cache_file is not None:
+                   cache_file.read()
 
         """
-        path = self.cache_path(key)
-        return ReadTransaction(
-            self._get_lock(key), acquire=lambda: ReadContextManager(path)  # type: ignore
-        )
+        lock = self._get_lock(key)
+        lock.acquire_read()
+        try:
+            with ReadContextManager(self.cache_path(key)) as f:
+                yield f
+        finally:
+            lock.release_read()
 
-    def write_transaction(self, key: Union[str, pathlib.Path]):
+    @contextmanager
+    def write_transaction(
+        self, key: Union[str, pathlib.Path]
+    ) -> Iterator[Tuple[Optional[IO[str]], IO[str]]]:
         """Get a write transaction on a file cache item.
 
-        Returns a WriteTransaction context manager that opens a temporary file
-        for writing.  Once the context manager finishes, if nothing went wrong,
-        moves the file into place on top of the old file atomically.
+        Returns a context manager that yields (old_file, new_file) where old_file
+        is the existing cache file (or None), and new_file is a writable temporary
+        file.  Once the context manager exits cleanly, moves the temporary file
+        into place atomically.
 
         """
         path = self.cache_path(key)
-        if os.path.exists(path) and not os.access(path, os.W_OK):
+        lock = self._get_lock(key)
+        try:
+            lock.acquire_write()
+        except PermissionError:
             raise CacheError(f"Insufficient permissions to write to file cache at {path}")
-
-        return WriteTransaction(
-            self._get_lock(key), acquire=lambda: WriteContextManager(path)  # type: ignore
-        )
-
-    def mtime(self, key: Union[str, pathlib.Path]) -> float:
-        """Return modification time of cache file, or -inf if it does not exist.
-
-        Time is in units returned by os.stat in the mtime field, which is
-        platform-dependent.
-
-        """
-        if not self.init_entry(key):
-            return -math.inf
-        else:
-            return self.cache_path(key).stat().st_mtime
+        try:
+            with WriteContextManager(str(path)) as (old, new):
+                yield old, new
+        finally:
+            lock.release_write()
 
     def remove(self, key: Union[str, pathlib.Path]):
         file = self.cache_path(key)
         lock = self._get_lock(key)
+        lock.acquire_write()
         try:
-            lock.acquire_write()
             file.unlink()
-        except OSError as e:
-            # File not found is OK, so remove is idempotent.
-            if e.errno != errno.ENOENT:
-                raise
+        except FileNotFoundError:
+            pass
         finally:
             lock.release_write()
 

--- a/lib/spack/spack/version/git_ref_lookup.py
+++ b/lib/spack/spack/version/git_ref_lookup.py
@@ -60,9 +60,6 @@ class GitRefLookup(AbstractRefLookup):
             key_base = "git_metadata"
             self._cache_key = (Path(key_base) / self.repository_uri).as_posix()
 
-            # Cache data in MISC_CACHE
-            # If this is the first lazy access, initialize the cache as well
-            spack.caches.MISC_CACHE.init_entry(self.cache_key)
         return self._cache_key
 
     @property
@@ -103,8 +100,8 @@ class GitRefLookup(AbstractRefLookup):
 
     def load_data(self):
         """Load data if the path already exists."""
-        if os.path.isfile(self.cache_path):
-            with spack.caches.MISC_CACHE.read_transaction(self.cache_key) as cache_file:
+        with spack.caches.MISC_CACHE.read_transaction(self.cache_key) as cache_file:
+            if cache_file is not None:
                 self.data = sjson.load(cache_file)
 
     def get(self, ref) -> Tuple[Optional[str], int]:


### PR DESCRIPTION
Remove `FileCache.init_entry` and `FileCache.mtime` because they were
TOCTOU-prone (check existence/permissions, then open later) and required
every call site to remember a separate initialization step.

Instead, `read_transaction` and `write_transaction` are now
`@contextmanager` generators that acquire locks and open files directly:

- `read_transaction` yields an open file or `None` if missing.
- `write_transaction` yields `(old_file_or_none, new_file)` and creates
  parent directories on demand.

Typing ensures callers have to deal with the `None` case.

Errors (permission, not-a-file) are raised as `CacheError` at the point
of use rather than checked upfront with `os.access`.

Call sites in `binary_distribution`, `compilers/libraries`, `repo`, and
`git_ref_lookup` are updated to drop `init_entry` calls and handle the
`None` case from `read_transaction`.
