### PR TITLE
lock.py: fix release_write when _read > 0

### DIFF
--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -665,25 +665,23 @@ class Lock:
         release_fn = release_fn or true_fn
 
         locktype = "WRITE LOCK"
-        if self._writes == 1 and self._reads == 0:
+        if self._writes == 1:
             self._log_releasing(locktype)
 
             # we need to call release_fn before releasing the lock
             result = release_fn()
 
-            self._unlock()  # can raise LockError.
+            if self._reads > 0:
+                self._lock(LockType.READ)
+            else:
+                self._unlock()  # can raise LockError.
+
             self._writes = 0
             self._log_released(locktype)
             return result
         else:
             self._writes -= 1
-
-            # when the last *write* is released, we call release_fn here
-            # instead of immediately before releasing the lock.
-            if self._writes == 0:
-                return release_fn()
-            else:
-                return False
+            return False
 
     def cleanup(self) -> None:
         if self._reads == 0 and self._writes == 0:

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -648,6 +648,36 @@ def test_upgrade_read_to_write(private_lock_path):
     assert not lock._file_ref.fh.closed  # recycle the file handle for next lock
 
 
+def test_release_write_downgrades_to_shared(private_lock_path):
+    """Releasing a write lock while a read lock is held must downgrade the POSIX lock
+    from exclusive to shared, allowing other processes to acquire read locks."""
+    lock = lk.Lock(private_lock_path)
+    lock.acquire_read()
+    lock.acquire_write()
+    lock.release_write()
+    assert lock._reads == 1
+    assert lock._writes == 0
+
+    ctx = multiprocessing.get_context()
+    q = ctx.Queue()
+
+    # Another process must be able to acquire a shared read lock concurrently.
+    p = ctx.Process(target=_child_try_acquire_read, args=(private_lock_path, q))
+    p.start()
+    p.join()
+    assert q.get() is True
+
+    # But must not be able to acquire an exclusive write lock.
+    p = ctx.Process(target=_child_try_acquire_write, args=(private_lock_path, q))
+    p.start()
+    p.join()
+    assert q.get() is False
+
+    lock.release_read()
+    assert lock._reads == 0
+    assert lock._writes == 0
+
+
 @pytest.mark.skipif(getuid() == 0, reason="user is root")
 def test_upgrade_read_to_write_fails_with_readonly_file(private_lock_path):
     """Test that read-only file can be read-locked but not write-locked."""


### PR DESCRIPTION
Fix a bug where

```python
lock.acquire_read()
lock.acquire_write()
lock.release_write()
```

would continue to hold an exclusive lock; it should be a shared lock.

Even if this was intentional, for example because downgrade write->read lock wasn't atomic on ancient non-posix compliant filesystems (nfs3 from 1995?), then consider that the installer explicitly relies on downgrading write->read post install, so atomicity of lock downgrade is a strict filesystem requirement for Spack.
