### PR TITLE
schema: reduce `env` schema size with `$ref`

### DIFF
--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -31,10 +31,9 @@ image_schema = {
     ]
 }
 
-# Additional attributes are allow
-# and will be forwarded directly to the
-# CI target YAML for each job.
-attributes_schema = {
+# Additional attributes are allowed and will be forwarded directly to the CI target YAML for each
+# job.
+ci_job_attributes = {
     "type": "object",
     "additionalProperties": True,
     "properties": {
@@ -50,6 +49,8 @@ attributes_schema = {
     },
 }
 
+ref_ci_job_attributes = {"$ref": "#/definitions/ci_job_attributes"}
+
 submapping_schema = {
     "type": "object",
     "additionalProperties": False,
@@ -64,8 +65,8 @@ submapping_schema = {
                 "required": ["match"],
                 "properties": {
                     "match": {"type": "array", "items": {"type": "string"}},
-                    "build-job": attributes_schema,
-                    "build-job-remove": attributes_schema,
+                    "build-job": ref_ci_job_attributes,
+                    "build-job-remove": ref_ci_job_attributes,
                 },
             },
         },
@@ -101,7 +102,10 @@ def job_schema(name: str):
     return {
         "type": "object",
         "additionalProperties": False,
-        "properties": {f"{name}-job": attributes_schema, f"{name}-job-remove": attributes_schema},
+        "properties": {
+            f"{name}-job": ref_ci_job_attributes,
+            f"{name}-job-remove": ref_ci_job_attributes,
+        },
     }
 
 
@@ -142,5 +146,6 @@ schema = {
     "title": "Spack CI configuration file schema",
     "type": "object",
     "additionalProperties": False,
+    "definitions": {"ci_job_attributes": ci_job_attributes},
     "properties": properties,
 }

--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -92,7 +92,7 @@ properties: Dict[str, Any] = {
                             ]
                         },
                         "implicit_rpaths": implicit_rpaths,
-                        "environment": spack.schema.environment.definition,
+                        "environment": spack.schema.environment.ref_env_modifications,
                         "extra_rpaths": extra_rpaths,
                     },
                 }
@@ -109,4 +109,5 @@ schema = {
     "type": "object",
     "additionalProperties": False,
     "properties": properties,
+    "definitions": {"env_modifications": spack.schema.environment.env_modifications},
 }

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -71,7 +71,7 @@ properties: Dict[str, Any] = {
                         "relocation of binaries (true for max length, integer for specific "
                         "length)",
                     },
-                    **spack.schema.projections.properties,
+                    **spack.schema.projections.ref_properties,
                 },
             },
             "install_hash_length": {
@@ -243,6 +243,7 @@ schema = {
     "type": "object",
     "additionalProperties": False,
     "properties": properties,
+    "definitions": {"projections": spack.schema.projections.projections},
 }
 
 

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -39,7 +39,7 @@ group_name_and_deps = {
         "type": "object",
         "description": "Top-most configuration scope for this group of specs",
         "additionalProperties": False,
-        "properties": {**spack.schema.merged.properties},
+        "properties": {**spack.schema.merged.ref_sections},
     },
 }
 
@@ -53,7 +53,7 @@ properties: Dict[str, Any] = {
         "additionalProperties": False,
         "properties": {
             # merged configuration scope schemas
-            **spack.schema.merged.properties,
+            **spack.schema.merged.ref_sections,
             # extra environment schema properties
             "specs": {
                 "type": "array",
@@ -98,6 +98,7 @@ schema = {
     "type": "object",
     "additionalProperties": False,
     "properties": properties,
+    "definitions": spack.schema.merged.defs,
 }
 
 

--- a/lib/spack/spack/schema/env_vars.py
+++ b/lib/spack/spack/schema/env_vars.py
@@ -10,7 +10,7 @@ from typing import Any, Dict
 
 import spack.schema.environment
 
-properties: Dict[str, Any] = {"env_vars": spack.schema.environment.definition}
+properties: Dict[str, Any] = {"env_vars": spack.schema.environment.ref_env_modifications}
 
 #: Full schema with metadata
 schema = {
@@ -19,4 +19,5 @@ schema = {
     "type": "object",
     "additionalProperties": False,
     "properties": properties,
+    "definitions": {"env_modifications": spack.schema.environment.env_modifications},
 }

--- a/lib/spack/spack/schema/environment.py
+++ b/lib/spack/spack/schema/environment.py
@@ -12,7 +12,7 @@ dictionary_of_strings_or_num = {
     "additionalProperties": {"anyOf": [{"type": "string"}, {"type": "number"}]},
 }
 
-definition: Dict[str, Any] = {
+env_modifications: Dict[str, Any] = {
     "type": "object",
     "description": "Environment variable modifications to apply at runtime",
     "default": {},
@@ -44,6 +44,9 @@ definition: Dict[str, Any] = {
         },
     },
 }
+
+#: $ref pointer for use in merged schema
+ref_env_modifications = {"$ref": "#/definitions/env_modifications"}
 
 
 def parse(config_obj):

--- a/lib/spack/spack/schema/merged.py
+++ b/lib/spack/spack/schema/merged.py
@@ -19,17 +19,19 @@ import spack.schema.container
 import spack.schema.definitions
 import spack.schema.develop
 import spack.schema.env_vars
+import spack.schema.environment
 import spack.schema.include
 import spack.schema.mirrors
 import spack.schema.modules
 import spack.schema.packages
+import spack.schema.projections
 import spack.schema.repos
 import spack.schema.toolchains
 import spack.schema.upstreams
 import spack.schema.view
 
 #: Properties for inclusion in other schemas
-properties: Dict[str, Any] = {
+sections: Dict[str, Any] = {
     **spack.schema.bootstrap.properties,
     **spack.schema.cdash.properties,
     **spack.schema.compilers.properties,
@@ -50,11 +52,28 @@ properties: Dict[str, Any] = {
     **spack.schema.view.properties,
 }
 
+#: Canonical definitions for JSON Schema $ref
+defs: Dict[str, Any] = {
+    # Section schemas, prefixed to avoid collisions with sub-schema definitions
+    **{f"section_{name}": schema for name, schema in sections.items()},
+    # Sub-schema definitions hoisted for $ref resolution in env.py
+    "ci_job_attributes": spack.schema.ci.ci_job_attributes,
+    "env_modifications": spack.schema.environment.env_modifications,
+    "module_file_configuration": spack.schema.modules.module_file_configuration,
+    "projections": spack.schema.projections.projections,
+}
+
+#: Properties using $ref pointers into $defs
+ref_sections: Dict[str, Any] = {
+    name: {"$ref": f"#/definitions/section_{name}"} for name in sections
+}
+
 #: Full schema with metadata
 schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Spack merged configuration file schema",
     "type": "object",
     "additionalProperties": False,
-    "properties": properties,
+    "properties": ref_sections,
+    "definitions": defs,
 }

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -67,15 +67,13 @@ module_file_configuration = {
             "additionalKeysAreSpecs": True,
             "additionalProperties": {"type": "string"},  # key
         },
-        "environment": {
-            **spack.schema.environment.definition,
-            "description": "Custom environment variable modifications to apply in this module "
-            "file",
-        },
+        "environment": spack.schema.environment.ref_env_modifications,
     },
 }
 
-projections_scheme = spack.schema.projections.properties["projections"]
+ref_module_file_configuration = {"$ref": "#/definitions/module_file_configuration"}
+
+projections_scheme = {"$ref": "#/definitions/projections"}
 
 common_props = {
     "verbose": {
@@ -125,10 +123,7 @@ common_props = {
         "description": "Custom directory structure and naming convention for module files using "
         "projection format",
     },
-    "all": {
-        **module_file_configuration,
-        "description": "Default configuration applied to all module files in this module set",
-    },
+    "all": ref_module_file_configuration,
 }
 
 tcl_configuration = {
@@ -138,7 +133,7 @@ tcl_configuration = {
     "Lmod",
     "additionalKeysAreSpecs": True,
     "properties": {**common_props},
-    "additionalProperties": module_file_configuration,
+    "additionalProperties": ref_module_file_configuration,
 }
 
 lmod_configuration = {
@@ -172,7 +167,7 @@ lmod_configuration = {
             "additionalProperties": array_of_strings,
         },
     },
-    "additionalProperties": module_file_configuration,
+    "additionalProperties": ref_module_file_configuration,
 }
 
 module_config_properties = {
@@ -259,5 +254,10 @@ schema = {
     "title": "Spack module file configuration file schema",
     "type": "object",
     "additionalProperties": False,
+    "definitions": {
+        "module_file_configuration": module_file_configuration,
+        "projections": spack.schema.projections.projections,
+        "env_modifications": spack.schema.environment.env_modifications,
+    },
     "properties": properties,
 }

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -289,7 +289,7 @@ properties: Dict[str, Any] = {
                                         "patternProperties": {r"^\w": {"type": "string"}},
                                         "additionalProperties": False,
                                     },
-                                    "environment": spack.schema.environment.definition,
+                                    "environment": spack.schema.environment.ref_env_modifications,
                                     "extra_rpaths": extra_rpaths,
                                     "implicit_rpaths": implicit_rpaths,
                                     "flags": flags,
@@ -360,6 +360,7 @@ schema = {
     "type": "object",
     "additionalProperties": False,
     "properties": properties,
+    "definitions": {"env_modifications": spack.schema.environment.env_modifications},
 }
 
 

--- a/lib/spack/spack/schema/projections.py
+++ b/lib/spack/spack/schema/projections.py
@@ -10,29 +10,30 @@
 from typing import Any, Dict
 
 #: Properties for inclusion in other schemas
-properties: Dict[str, Any] = {
-    "projections": {
-        "type": "object",
-        "description": "Customize directory structure and naming schemes by mapping specs to "
-        "format strings.",
-        "properties": {
-            "all": {
-                "type": "string",
-                "description": "Default projection format string used as fallback for all specs "
-                "that do not match other entries. Uses spec format syntax like "
-                '"{name}/{version}/{hash:16}".',
-            }
-        },
-        "additionalKeysAreSpecs": True,
-        "additionalProperties": {
+projections: Dict[str, Any] = {
+    "type": "object",
+    "description": "Customize directory structure and naming schemes by mapping specs to "
+    "format strings.",
+    "properties": {
+        "all": {
             "type": "string",
-            "description": "Projection format string for specs matching this key. Uses spec "
-            "format syntax supporting tokens like {name}, {version}, {compiler.name}, "
-            "{^dependency.name}, etc.",
-        },
-    }
+            "description": "Default projection format string used as fallback for all specs "
+            "that do not match other entries. Uses spec format syntax like "
+            '"{name}/{version}/{hash:16}".',
+        }
+    },
+    "additionalKeysAreSpecs": True,
+    "additionalProperties": {
+        "type": "string",
+        "description": "Projection format string for specs matching this key. Uses spec "
+        "format syntax supporting tokens like {name}, {version}, {compiler.name}, "
+        "{^dependency.name}, etc.",
+    },
 }
 
+
+#: $ref pointer for use in merged schema
+ref_properties: Dict[str, Any] = {"projections": {"$ref": "#/definitions/projections"}}
 
 #: Full schema with metadata
 schema = {
@@ -40,5 +41,6 @@ schema = {
     "title": "Spack view projection configuration file schema",
     "type": "object",
     "additionalProperties": False,
-    "properties": properties,
+    "properties": ref_properties,
+    "definitions": {"projections": projections},
 }

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -9,7 +9,6 @@
 """
 from typing import Any, Dict
 
-import spack.schema
 import spack.schema.projections
 
 #: Properties for inclusion in other schemas
@@ -75,7 +74,7 @@ properties: Dict[str, Any] = {
                             "description": "List of specs to exclude from the view "
                             "(default: exclude nothing)",
                         },
-                        **spack.schema.projections.properties,
+                        **spack.schema.projections.ref_properties,
                     },
                 },
             },
@@ -90,4 +89,5 @@ schema = {
     "type": "object",
     "additionalProperties": False,
     "properties": properties,
+    "definitions": {"projections": spack.schema.projections.projections},
 }


### PR DESCRIPTION
Commit bdfad3cad4 introduced `group_name_and_deps` containing an
`override` property that inlines the full
`spack.schema.merged.properties`. Combined with the existing top-level
copy, and both branches of an `anyOf`, this resulted in 3 copies of the
merged properties when serialized to JSON (238KB total for env.py's
schema).

This isn't a major problem for Spack runtime, where the object graph
uses references to the same objects, but it's suboptimal for publishing
schemas on https://github.com/spack/schemas.

Fix by introducing `merged.ref_properties`, a dict of `$ref` pointers,
and `merged.defs`, a single definitions dict placed in the schema's
`"definitions"` key.

Apply the same `$ref` technique to `ci.attributes_schema` (inlined 16x)
and `modules.module_file_configuration` (inlined 4x), which further
contribute to the savings.

This reduces the env.py schema from 238KB to 66KB as JSON.
It's also more readable for humans.