### PR TITLE
CTest Log Parser: Respect configured concurrency level

### DIFF
--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -78,6 +78,8 @@ import time
 from contextlib import contextmanager
 from typing import List, Optional, TextIO, Tuple, Union
 
+import spack.config
+
 _error_matches = [
     "^FAIL: ",
     "^FATAL: ",
@@ -404,7 +406,7 @@ class CTestLogParser:
         lines = [line for line in stream]
 
         if jobs is None:
-            jobs = multiprocessing.cpu_count()
+            jobs = spack.config.get("config:build_jobs", 16)
 
         # single-thread small logs
         if len(lines) < 10 * jobs:


### PR DESCRIPTION
Respects the general concurrency level of Spack

Prevents a bug on large Windows machines where we create a pool of > 63 thread/process handles to wait on and trip an internal win32 api limit

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
