### PR TITLE
display_specs: display abstract hash if present

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -486,7 +486,8 @@ def display_specs(specs, args=None, **kwargs):
         if flags:
             ffmt += " {compiler_flags}"
         vfmt = "{variants}" if variants else ""
-        format_string = nfmt + "{@version}" + vfmt + ffmt
+        hfmt = "{/abstract_hash}"
+        format_string = nfmt + "{@version}" + vfmt + ffmt + hfmt
 
     if specfile_format:
         format_string = "[{specfile_version}] " + format_string

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import io
 import json
 import os
 import pathlib
@@ -213,6 +214,15 @@ def test_display_json_deps(database, capfd):
     spack.cmd.display_specs_as_json(specs + specs + specs, deps=True)
     spec_list = json.loads(capfd.readouterr()[0])
     _check_json_output_deps(spec_list)
+
+
+@pytest.mark.regression("52219")
+def test_display_abstract_hash():
+    spec = spack.spec.Spec("/foobar")
+    out = io.StringIO()
+
+    spack.cmd.display_specs([spec], output=out)  # errors on failure
+    assert "/foobar" in out.getvalue()
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -17,6 +17,7 @@ import spack.environment as ev
 import spack.package_base
 import spack.paths
 import spack.repo
+import spack.spec
 import spack.store
 import spack.user_environment as uenv
 from spack.enums import InstallRecordStatus


### PR DESCRIPTION
Abstract specs may have an abstract hash and no name, even in contexts in which anonymous specs are generally not allowed.

This commit updates the default format string for `display_specs` to display the abstract hash if one exists. Otherwise, we pass empty strings to `tty.colify` and get a division by 0 error.

Fixes a bug reported offline by @nicholas-sly 