### PR TITLE
spack buildcache push: add `--group` argument

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -134,6 +134,15 @@ def setup_parser(subparser: argparse.ArgumentParser):
         action="store_true",
         help="for a private mirror, include non-redistributable packages",
     )
+    push.add_argument(
+        "--group",
+        action="append",
+        default=None,
+        dest="groups",
+        metavar="GROUP",
+        help="push only specs from the given environment group "
+        "(can be specified multiple times, requires an active environment)",
+    )
     arguments.add_common_arguments(push, ["specs", "jobs"])
     push.set_defaults(func=push_fn)
 
@@ -446,7 +455,20 @@ def _specs_to_be_packaged(
 
 def push_fn(args):
     """create a binary package and push it to a mirror"""
-    if args.specs:
+    if args.specs and args.groups:
+        tty.die("--group and explicit specs are mutually exclusive")
+
+    if args.groups:
+        env = spack.cmd.require_active_env(cmd_name="buildcache push")
+        available_groups = env.manifest.groups()
+        if any(g not in available_groups for g in args.groups):
+            tty.die(
+                f"Some of the groups do not exist in the environment. "
+                f"Available groups are: {', '.join(sorted(available_groups))}"
+            )
+
+        roots = [c for g in args.groups for _, c in env.concretized_specs_by(group=g)]
+    elif args.specs:
         roots = _matching_specs(spack.cmd.parse_specs(args.specs))
     else:
         roots = spack.cmd.require_active_env(cmd_name="buildcache push").concrete_roots()

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -360,6 +360,21 @@ def test_buildcache_create_install(
     cache_entry.destroy()
 
 
+def _mock_uploader(tmp_path: pathlib.Path):
+    class DontUpload(spack.binary_distribution.Uploader):
+        def __init__(self):
+            super().__init__(
+                spack.mirrors.mirror.Mirror.from_local_path(str(tmp_path)), False, False
+            )
+            self.pushed = []
+
+        def push(self, specs: List[spack.spec.Spec]):
+            self.pushed.extend(s.name for s in specs)
+            return [], []
+
+    return DontUpload()
+
+
 @pytest.mark.parametrize(
     "things_to_install,expected",
     [
@@ -411,18 +426,7 @@ def test_correct_specs_are_pushed(
     PackageInstaller([spec.package], explicit=True, fake=True).install()
     slash_hash = f"/{spec.dag_hash()}"
 
-    class DontUpload(spack.binary_distribution.Uploader):
-        def __init__(self):
-            super().__init__(
-                spack.mirrors.mirror.Mirror.from_local_path(str(tmp_path)), False, False
-            )
-            self.pushed = []
-
-        def push(self, specs: List[spack.spec.Spec]):
-            self.pushed.extend(s.name for s in specs)
-            return [], []  # nothing skipped, nothing errored
-
-    uploader = DontUpload()
+    uploader = _mock_uploader(tmp_path)
 
     monkeypatch.setattr(
         spack.binary_distribution, "make_uploader", lambda *args, **kwargs: uploader
@@ -1321,3 +1325,151 @@ def test_buildcache_check_index_full(
         assert "The index blob is missing" in out
         assert "Unindexed specs: 15" in out
         assert "Missing blobs: 1"
+
+
+def test_buildcache_push_with_group(
+    tmp_path: pathlib.Path, monkeypatch, install_mockery, mock_fetch, mutable_mock_env_path
+):
+    """Tests that --group pushes only specs from the requested group."""
+    env_dir = tmp_path / "myenv"
+    env_dir.mkdir()
+    (env_dir / "spack.yaml").write_text(
+        """\
+spack:
+  specs:
+  - libelf
+  - group: extra
+    specs:
+    - libdwarf
+  view: false
+"""
+    )
+
+    mirror_dir = tmp_path / "mirror"
+    mirror_dir.mkdir()
+
+    uploader = _mock_uploader(mirror_dir)
+    monkeypatch.setattr(
+        spack.binary_distribution, "make_uploader", lambda *args, **kwargs: uploader
+    )
+
+    with ev.Environment(env_dir) as e:
+        e.concretize()
+        e.write()
+        for _, root in e.concretized_specs():
+            PackageInstaller([root.package], explicit=True, fake=True).install()
+
+        buildcache("push", "--unsigned", "--only", "package", "--group", "extra", str(mirror_dir))
+
+    assert uploader.pushed == ["libdwarf"]
+
+
+def test_buildcache_push_with_multiple_groups(
+    tmp_path: pathlib.Path, monkeypatch, install_mockery, mock_fetch, mutable_mock_env_path
+):
+    """Tests that --group can be repeated to push specs from multiple groups."""
+    env_dir = tmp_path / "myenv"
+    env_dir.mkdir()
+    (env_dir / "spack.yaml").write_text(
+        """\
+spack:
+  specs:
+  - libelf
+  - group: extra
+    specs:
+    - libdwarf
+  view: false
+"""
+    )
+
+    mirror_dir = tmp_path / "mirror"
+    mirror_dir.mkdir()
+
+    uploader = _mock_uploader(mirror_dir)
+    monkeypatch.setattr(
+        spack.binary_distribution, "make_uploader", lambda *args, **kwargs: uploader
+    )
+
+    with ev.Environment(env_dir) as e:
+        e.concretize()
+        e.write()
+        for _, root in e.concretized_specs():
+            PackageInstaller([root.package], explicit=True, fake=True).install()
+
+        buildcache(
+            "push",
+            "--unsigned",
+            "--only",
+            "package",
+            "--group",
+            "default",
+            "--group",
+            "extra",
+            str(mirror_dir),
+        )
+
+    assert set(uploader.pushed) == {"libelf", "libdwarf"}
+    assert len(uploader.pushed) == len(set(uploader.pushed))
+
+
+def test_buildcache_push_group_nonexistent_errors(tmp_path: pathlib.Path, mutable_mock_env_path):
+    """Tests that --group with a nonexistent group name raises an error."""
+    env_dir = tmp_path / "myenv"
+    env_dir.mkdir()
+    (env_dir / "spack.yaml").write_text(
+        """\
+spack:
+  specs:
+  - libelf
+  view: false
+"""
+    )
+
+    mirror_dir = tmp_path / "mirror"
+    mirror_dir.mkdir()
+
+    with ev.Environment(env_dir):
+        with pytest.raises(spack.main.SpackCommandError):
+            buildcache(
+                "push", "--unsigned", "--group", "nonexistent", str(mirror_dir), fail_on_error=True
+            )
+
+
+def test_buildcache_push_group_and_specs_mutually_exclusive(
+    tmp_path: pathlib.Path, mutable_mock_env_path
+):
+    """Tests that --group and explicit specs on the command line are mutually exclusive."""
+    env_dir = tmp_path / "myenv"
+    env_dir.mkdir()
+    (env_dir / "spack.yaml").write_text(
+        """\
+spack:
+  specs:
+  - libelf
+  view: false
+"""
+    )
+
+    mirror_dir = tmp_path / "mirror"
+    mirror_dir.mkdir()
+
+    with ev.Environment(env_dir):
+        with pytest.raises(spack.main.SpackCommandError):
+            buildcache(
+                "push",
+                "--unsigned",
+                "--group",
+                "default",
+                str(mirror_dir),
+                "libelf",
+                fail_on_error=True,
+            )
+
+
+def test_buildcache_push_group_requires_active_env(tmp_path: pathlib.Path):
+    """Tests that ck--group without an active environment produces an error."""
+    mirror_dir = tmp_path / "mirror"
+    mirror_dir.mkdir()
+
+    with pytest.raises(spack.main.SpackCommandError):
+        buildcache("push", "--unsigned", "--group", "default", str(mirror_dir), fail_on_error=True)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -566,7 +566,7 @@ _spack_buildcache() {
 _spack_buildcache_push() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --unsigned -u --signed --key -k --update-index --rebuild-index --only --with-build-dependencies --without-build-dependencies --fail-fast --base-image --tag -t --private -j --jobs"
+        SPACK_COMPREPLY="-h --help -f --force --unsigned -u --signed --key -k --update-index --rebuild-index --only --with-build-dependencies --without-build-dependencies --fail-fast --base-image --tag -t --private --group -j --jobs"
     else
         _mirrors
     fi
@@ -575,7 +575,7 @@ _spack_buildcache_push() {
 _spack_buildcache_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --unsigned -u --signed --key -k --update-index --rebuild-index --only --with-build-dependencies --without-build-dependencies --fail-fast --base-image --tag -t --private -j --jobs"
+        SPACK_COMPREPLY="-h --help -f --force --unsigned -u --signed --key -k --update-index --rebuild-index --only --with-build-dependencies --without-build-dependencies --fail-fast --base-image --tag -t --private --group -j --jobs"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -707,7 +707,7 @@ complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -f -a 
 complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -d 'show this help message and exit'
 
 # spack buildcache push
-set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force u/unsigned signed k/key= update-index only= with-build-dependencies without-build-dependencies fail-fast base-image= t/tag= private j/jobs=
+set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force u/unsigned signed k/key= update-index only= with-build-dependencies without-build-dependencies fail-fast base-image= t/tag= private group= j/jobs=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache push' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -d 'show this help message and exit'
@@ -735,11 +735,13 @@ complete -c spack -n '__fish_spack_using_command buildcache push' -l tag -s t -r
 complete -c spack -n '__fish_spack_using_command buildcache push' -l tag -s t -r -d 'when pushing to an OCI registry, tag an image containing all root specs and their runtime dependencies'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l private -f -a private
 complete -c spack -n '__fish_spack_using_command buildcache push' -l private -d 'for a private mirror, include non-redistributable packages'
+complete -c spack -n '__fish_spack_using_command buildcache push' -l group -r -f -a groups
+complete -c spack -n '__fish_spack_using_command buildcache push' -l group -r -d 'push only specs from the given environment group (can be specified multiple times, requires an active environment)'
 complete -c spack -n '__fish_spack_using_command buildcache push' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command buildcache push' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 
 # spack buildcache create
-set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force u/unsigned signed k/key= update-index only= with-build-dependencies without-build-dependencies fail-fast base-image= t/tag= private j/jobs=
+set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force u/unsigned signed k/key= update-index only= with-build-dependencies without-build-dependencies fail-fast base-image= t/tag= private group= j/jobs=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache create' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -d 'show this help message and exit'
@@ -767,6 +769,8 @@ complete -c spack -n '__fish_spack_using_command buildcache create' -l tag -s t 
 complete -c spack -n '__fish_spack_using_command buildcache create' -l tag -s t -r -d 'when pushing to an OCI registry, tag an image containing all root specs and their runtime dependencies'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l private -f -a private
 complete -c spack -n '__fish_spack_using_command buildcache create' -l private -d 'for a private mirror, include non-redistributable packages'
+complete -c spack -n '__fish_spack_using_command buildcache create' -l group -r -f -a groups
+complete -c spack -n '__fish_spack_using_command buildcache create' -l group -r -d 'push only specs from the given environment group (can be specified multiple times, requires an active environment)'
 complete -c spack -n '__fish_spack_using_command buildcache create' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command buildcache create' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 


### PR DESCRIPTION
When an environment is active, `--group` can be used to push only the specs from that group. The option can be given multiple times.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
