### PR TITLE
Add more tests for error messages

### DIFF
--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -1,14 +1,23 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Regression tests for concretizer error messages.
 
+Every test asserts two properties:
+1. The correct exception type is raised.
+2. The message contains every "actionable part" -- a string from the user's
+   input (spec token, config key, package name) that helps identify what to
+   change.
+"""
 import pathlib
 from io import StringIO
+from typing import List
 
 import pytest
 
 import spack.concretize
 import spack.config
+import spack.error
 import spack.main
 import spack.solver.asp
 import spack.spec
@@ -106,3 +115,153 @@ def test_internal_error_handling_formatting(tmp_path: pathlib.Path):
     assert spack.spec.Spec.from_specfile(files["input-2.json"]) == spack.spec.Spec("bar+y")
     assert spack.spec.Spec.from_specfile(files["output-1.json"]) == spack.spec.Spec("foo@=1.0~x")
     assert spack.spec.Spec.from_specfile(files["output-2.json"]) == spack.spec.Spec("x@=1.0~y")
+
+
+def assert_actionable_error(exc_info, *required_part: str) -> None:
+    """Verify that the error message contains every required part, which is usually a string that
+    the user can recognize in their own input.
+    """
+    msg = str(exc_info.value)
+    missing = [h for h in required_part if h not in msg]
+    assert not missing, f"Error message is missing parts {missing!r}\n" f"Full message:\n{msg}"
+
+
+@pytest.mark.parametrize(
+    "input_spec,expected_parts",
+    [
+        # fftw is constrained to ~mpi by the explicit request, but quantum-espresso
+        # requires fftw+mpi when +invino. Both values cannot coexist.
+        pytest.param(
+            "quantum-espresso+invino^fftw~mpi", ["fftw", "mpi"], id="variant_value_conflict"
+        ),
+        # The user requests a variant that does not exist on the package.
+        pytest.param(
+            "quantum-espresso+nonexistent",
+            ["quantum-espresso", "nonexistent", "No such variant"],
+            id="variant_undefined",
+        ),
+        # quantum-espresso has only version 1.0; @:0.1 cannot be satisfied.
+        pytest.param(
+            "quantum-espresso@:0.1",
+            ["quantum-espresso@:0.1", "No version exists"],
+            id="version_constraint_unsatisfied",
+        ),
+        # hypre propagates ~~shared to its deps, but openblas is explicitly +shared.
+        pytest.param(
+            "hypre ~~shared ^openblas +shared",
+            ["shared", "hypre", "'openblas' requires conflicting variant values"],
+            id="propagation_excluded",
+        ),
+        # dependency-foo-bar (++bar) and direct-dep-foo-bar (~~bar) both propagate
+        # variant "bar" with different values to their shared transitive dependency.
+        pytest.param(
+            "parent-foo-bar ^dependency-foo-bar++bar ^direct-dep-foo-bar~~bar",
+            ["cannot both propagate variant 'bar'"],
+            id="propagation_conflict_to_dep",
+        ),
+        # gmake is a build dependency of a transitive dep, not directly reachable
+        # via link/run from multivalue-variant.
+        pytest.param(
+            "multivalue-variant ^gmake",
+            ["gmake is not a direct 'build' or"],
+            id="literal_not_in_dag",
+        ),
+        # mvapich2 file_systems uses auto_or_any_combination_of, but "auto" and "lustre"
+        # come from disjoint sets and cannot be combined.
+        pytest.param(
+            "mvapich2 file_systems=auto,lustre",
+            ["mvapich2", "file_systems", "the value 'auto' is mutually exclusive"],
+            id="variant_disjoint_sets",
+        ),
+    ],
+)
+def test_input_spec_driven_errors(
+    input_spec: str, expected_parts: List[str], mock_packages, mutable_config
+) -> None:
+    """Tests errors caused by a token in the CLI input spec. The message must name both the
+    affected package and the specific token (variant, version, flag, dep) the user supplied.
+    """
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one(input_spec)
+    assert_actionable_error(exc_info, *expected_parts)
+
+
+@pytest.mark.parametrize(
+    "packages_config,input_spec,expected_parts",
+    [
+        # quantum-espresso is set buildable:false; the available external does not
+        # satisfy +veritas, so no valid spec can be found.
+        pytest.param(
+            {
+                "packages:quantum-espresso": {
+                    "buildable": False,
+                    "externals": [
+                        {"spec": "quantum-espresso@1.0~veritas", "prefix": "/path/to/qe"}
+                    ],
+                }
+            },
+            "quantum-espresso+veritas",
+            ["quantum-espresso", "it is configured `buildable:false`"],
+            id="buildable_false",
+        ),
+        # The user provided a packages.yaml `require:` with a message field. The error must surface
+        # the custom message so the user knows the policy and the package name so they can find
+        # the config section.
+        pytest.param(
+            {
+                "packages:libelf": {
+                    "require": [{"spec": "%clang", "message": "must be compiled with clang"}]
+                }
+            },
+            "libelf%gcc",
+            ["libelf", "must be compiled with clang"],
+            id="requirement_unsatisfied_custom_message",
+        ),
+        # Generic message must still name the package so the user knows which entry to look at
+        pytest.param(
+            {"packages:libelf": {"require": ["%clang"]}},
+            "libelf%gcc",
+            ["libelf"],
+            id="requirement_unsatisfied_generic",
+        ),
+    ],
+)
+def test_config_driven_errors(
+    packages_config, input_spec: str, expected_parts: List[str], mock_packages, mutable_config
+) -> None:
+    """Tests errors caused by user configuration, e,g, a setting in packages.yaml. The message must
+    identify the package and the config value to fix.
+    """
+    for path, conf in packages_config.items():
+        spack.config.set(path, conf)
+
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one(input_spec)
+    assert_actionable_error(exc_info, *expected_parts)
+
+
+@pytest.mark.parametrize(
+    "input_spec,expected_handles",
+    [
+        # conflict-parent@0.9 has conflicts("^conflict~foo", when="@0.9"). When the user requests
+        # `^conflict~foo` the conflict fires. The auto-generated message includes the package name
+        # and the when-spec version, giving the user two places to look.
+        pytest.param(
+            "conflict-parent@0.9 ^conflict~foo",
+            ["conflict-parent", "'^conflict~foo' conflicts with '@0.9'"],
+            id="conflicts_directive",
+        ),
+        # requires-clang has `requires("%clang", msg="can only be compiled with Clang")`. When
+        # compiled with %gcc the requirement is unsatisfied and the custom message is shown
+        pytest.param("requires-clang %gcc", ["requires-clang", "Clang"], id="requires_directive"),
+    ],
+)
+def test_package_py_driven_errors(
+    input_spec: str, expected_handles: List[str], mock_packages, mutable_config
+) -> None:
+    """Tests errors involving directives in package.py recipes. The error message must name the
+    package whose directive caused the failure.
+    """
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one(input_spec)
+    assert_actionable_error(exc_info, *expected_handles)


### PR DESCRIPTION
Add three parametrized tests for error messages, partitioned by the "main" cause of the error:
1. User input on the CLI
2. User configuration
3. package.py directives

These tests capture the status quo, and check that the error messages contain specific strings.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
