### PR TITLE
reporters: disable when not needed

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -441,7 +441,9 @@ def install_without_active_env(args, install_kwargs, reporter):
     install_kwargs["explicit"] = [s.dag_hash() for s in concrete_specs]
 
     try:
-        builder = spack.installer_dispatch.create_installer(installs, **install_kwargs)
+        builder = spack.installer_dispatch.create_installer(
+            installs, create_reports=reporter is not None, **install_kwargs
+        )
         builder.install()
     finally:
         if reporter:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1986,7 +1986,7 @@ class Environment:
         }
 
         builder = spack.installer_dispatch.create_installer(
-            [spec.package for spec in specs], **install_args
+            [spec.package for spec in specs], create_reports=reporter is not None, **install_args
         )
 
         try:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -925,7 +925,8 @@ class Task:
         self.request = request
 
         # Report for tracking install success/failure
-        self.record = spack.report.InstallRecord(self.pkg.spec)
+        record_cls = self.request.install_args.get("record_cls", spack.report.InstallRecord)
+        self.record = record_cls(self.pkg.spec)
 
         # Initialize the status to an active state.  The status is used to
         # ensure priority queue invariants when tasks are "removed" from the
@@ -1485,6 +1486,7 @@ class PackageInstaller:
         concurrent_packages: Optional[int] = None,
         root_policy: InstallPolicy = "auto",
         dependencies_policy: InstallPolicy = "auto",
+        create_reports: bool = False,
     ) -> None:
         """
         Arguments:
@@ -1510,6 +1512,7 @@ class PackageInstaller:
             concurrent_packages: Max packages to be built concurrently
             root_policy: ``"auto"``, ``"cache_only"``, ``"source_only"``.
             dependencies_policy: ``"auto"``, ``"cache_only"``, ``"source_only"``.
+            create_reports: whether to generate reports for each install
         """
         if sys.platform == "win32":
             # No locks on Windows, we should always use 1 process
@@ -1554,6 +1557,11 @@ class PackageInstaller:
         # List of build requests
         self.build_requests = [BuildRequest(pkg, install_args) for pkg in packages]
 
+        # When no reporter is configured, use NullInstallRecord to skip log file reads.
+        if not create_reports:
+            for br in self.build_requests:
+                br.install_args["record_cls"] = spack.report.NullInstallRecord
+
         # Priority queue of tasks
         self.build_pq: List[Tuple[Tuple[int, int], Task]] = []
 
@@ -1586,12 +1594,17 @@ class PackageInstaller:
         self.max_active_tasks = self.concurrent_packages
 
         # Reports on install success/failure
-        self.reports: Dict[str, spack.report.RequestRecord] = {}
-        for build_request in self.build_requests:
-            # Skip reporting for already installed specs
-            request_record = spack.report.RequestRecord(build_request.pkg.spec)
-            request_record.skip_installed()
-            self.reports[build_request.pkg_id] = request_record
+        if create_reports:
+            self.reports: Dict[str, spack.report.RequestRecord] = {}
+            for build_request in self.build_requests:
+                # Skip reporting for already installed specs
+                request_record = spack.report.RequestRecord(build_request.pkg.spec)
+                request_record.skip_installed()
+                self.reports[build_request.pkg_id] = request_record
+        else:
+            self.reports = {
+                br.pkg_id: spack.report.NullRequestRecord() for br in self.build_requests
+            }
 
     def __repr__(self) -> str:
         """Returns a formal representation of the package installer."""

--- a/lib/spack/spack/installer_dispatch.py
+++ b/lib/spack/spack/installer_dispatch.py
@@ -40,6 +40,7 @@ def create_installer(
     concurrent_packages: Optional[int] = None,
     root_policy: Literal["auto", "cache_only", "source_only"] = "auto",
     dependencies_policy: Literal["auto", "cache_only", "source_only"] = "auto",
+    create_reports: bool = False,
 ) -> Union["spack.installer.PackageInstaller", "spack.new_installer.PackageInstaller"]:
     """Create an installer based on the current configuration and feature support."""
     use_old_installer = (
@@ -81,4 +82,5 @@ def create_installer(
         concurrent_packages=concurrent_packages,
         root_policy=root_policy,
         dependencies_policy=dependencies_policy,
+        create_reports=create_reports,
     )

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1995,6 +1995,26 @@ class ReportData:
                 reports[root_hash].append_record(record)
 
 
+class NullReportData(ReportData):
+    """No-op drop-in for ReportData when no reporter is configured.
+
+    Avoids creating InstallRecords and reading log files on every completed build."""
+
+    def __init__(self) -> None:
+        pass
+
+    def start_record(self, spec: spack.spec.Spec) -> None:
+        pass
+
+    def finish_record(self, spec: spack.spec.Spec, exitcode: int) -> None:
+        pass
+
+    def finalize(
+        self, reports: Dict[str, spack.report.RequestRecord], build_graph: "BuildGraph"
+    ) -> None:
+        pass
+
+
 class TerminalState:
     """Manages terminal settings, stdin selector registration, and suspend/resume signals.
 
@@ -2172,6 +2192,7 @@ class PackageInstaller:
         concurrent_packages: Optional[int] = None,
         root_policy: InstallPolicy = "auto",
         dependencies_policy: InstallPolicy = "auto",
+        create_reports: bool = False,
     ) -> None:
         assert install_package or install_deps, "Must install package, dependencies or both"
 
@@ -2261,10 +2282,13 @@ class PackageInstaller:
         else:
             self.capacity = concurrent_packages
 
-        #: The reports property is what the old installer has and used as public interface.
-        self.reports = {spec.dag_hash(): spack.report.RequestRecord(spec) for spec in specs}
-        #: Internal data collected for reports during installation.
-        self.report_data = ReportData(specs)
+        # The reports property is what the old installer has and used as public interface.
+        if create_reports:
+            self.reports = {spec.dag_hash(): spack.report.RequestRecord(spec) for spec in specs}
+            self.report_data = ReportData(specs)
+        else:
+            self.reports = {}
+            self.report_data = NullReportData()
 
     def install(self) -> None:
         self._installer()

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -148,6 +148,42 @@ class InstallRecord(SpecRecord):
         self.installed_from_binary_cache = self._package.installed_from_binary_cache
 
 
+class NullInstallRecord(InstallRecord):
+    """No-op drop-in for InstallRecord when no reporter is configured.
+
+    Avoids reading log files from disk on every completed build."""
+
+    def start(self) -> None:
+        pass
+
+    def succeed(self) -> None:
+        pass
+
+    def fail(self, exc) -> None:
+        pass
+
+    def skip(self, msg: str = "") -> None:
+        pass
+
+
+class NullRequestRecord(RequestRecord):
+    """No-op drop-in for RequestRecord when no reporter is configured.
+
+    Avoids traversing the DAG and accumulating data that will not be reported."""
+
+    def __init__(self) -> None:
+        dict.__init__(self)
+
+    def skip_installed(self) -> None:
+        pass
+
+    def append_record(self, record) -> None:
+        pass
+
+    def summarize(self) -> None:
+        pass
+
+
 class TestRecord(SpecRecord):
     """Record class with specialization for test logs."""
 


### PR DESCRIPTION
Reporters decompress a log file and read it entirely into memory, which is
something the new installer generally tries to avoid. Given that most users
don't use reporters, make them a no-op by default, unless the user passes
the relevant cdash/junit flags.
