### PR TITLE
new_installer.py: bump log buffer

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -103,7 +103,7 @@ CLEANUP_TIMEOUT = 2.0
 DATABASE_WRITE_INTERVAL = 5.0
 
 #: Size of the output buffer for child processes
-OUTPUT_BUFFER_SIZE = 4096
+OUTPUT_BUFFER_SIZE = 32768
 
 #: Suffix for temporary backup during overwrite install
 OVERWRITE_BACKUP_SUFFIX = ".old"


### PR DESCRIPTION
Bump the number of bytes to read for the log to at most 32KB per
iteration instead of 4KB to reduce the number of event loop iterations
when the build produces lots of logging output.

