### PR TITLE
spack containerize: select groups for the final image 

### DIFF
--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -461,6 +461,33 @@ If finer tuning is needed, it can be obtained by adding the relevant metadata un
 
 A detailed description of the options available can be found in the :ref:`container_config_options` section.
 
+Excluding Build-only Groups From the Runtime Image
+"""""""""""""""""""""""""""""""""""""""""""""""""""
+
+When using :ref:`environment groups <environment-spec-groups>` to install a compiler separately from the rest of the software, the compiler would normally end up in the final container image because it is a root spec and ``spack gc`` never removes roots.
+The ``groups`` key under ``container`` lets you list only the groups that should survive into the runtime image.
+Groups not listed are removed before garbage collection, so their specs and any dependencies not needed by the runtime groups are pruned from the final layer.
+
+.. code-block:: yaml
+
+   spack:
+     specs:
+     - group: compilers
+       specs: [gcc]
+     - group: packages
+       needs: [compilers]
+       specs: [zlib, hdf5]
+
+     container:
+       format: docker
+       images:
+         os: "ubuntu:22.04"
+         spack: develop
+       # Only 'packages' ends up in the runtime image; 'compilers' is dropped after the build.
+       groups: [packages]
+
+Under the hood, the generated recipe calls ``spack gc -y --drop-group compilers``, which treats the compiler group's roots as non-roots for garbage collection purposes.
+
 Setting Base Images
 ^^^^^^^^^^^^^^^^^^^
 
@@ -903,6 +930,10 @@ The tables below describe all the configuration options that are currently suppo
    * - ``labels``
      - Labels to tag the image
      - Pairs of key-value strings
+     - No
+   * - ``groups``
+     - Groups that should survive into the runtime image; groups not listed are dropped before garbage collection
+     - List of group names defined in the environment
      - No
 
 .. list-table:: Configuration options specific to Singularity

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -41,6 +41,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="do not remove installed build-only dependencies of roots\n"
         "(default is to keep only link & run dependencies)",
     )
+    subparser.add_argument(
+        "--drop-group",
+        metavar="GROUP",
+        action="append",
+        default=[],
+        help="treat specs in this group as non-roots for garbage collection\n"
+        "(can be repeated; requires an active environment)",
+    )
     spack.cmd.common.arguments.add_common_arguments(subparser, ["yes_to_all", "constraint"])
 
 
@@ -79,6 +87,18 @@ def gc(parser, args):
 
     active_env = ev.active_environment()
 
+    if args.drop_group:
+        if not active_env:
+            tty.die("--drop-group requires an active environment")
+        if args.except_environment or args.except_any_environment:
+            tty.die("--drop-group cannot be combined with -e/--except-environment or -E")
+        unknown_groups = set(args.drop_group) - active_env.manifest.groups()
+        if unknown_groups:
+            tty.die(
+                f"some groups are not defined in the environment '{active_env.name}': "
+                f"{', '.join(sorted(unknown_groups))}"
+            )
+
     # wrap the whole command with a read transaction to avoid multiple
     with spack.store.STORE.db.read_transaction():
         if args.except_environment or args.except_any_environment:
@@ -92,6 +112,13 @@ def gc(parser, args):
             root_hashes = set(spack.store.STORE.db.all_hashes())  # keep everything
             root_hashes -= set(active_env.all_hashes())  # except this env
             root_hashes |= {x.hash for x in active_env.concretized_roots}  # but keep its roots
+
+            # remove roots belonging to dropped groups so they can be pruned
+            for group in args.drop_group:
+                drop_hashes = {
+                    c.dag_hash() for _, c in active_env.concretized_specs_by(group=group)
+                }
+                root_hashes -= drop_hashes
         else:
             # consider all explicit specs roots (the default for db.unused_specs())
             root_hashes = None

--- a/lib/spack/spack/container/writers.py
+++ b/lib/spack/spack/container/writers.py
@@ -273,6 +273,30 @@ class PathContext(tengine.Context):
         return os_pkg_manager
 
     @tengine.context_property
+    def gc_command(self):
+        groups_to_keep = self.container_config.get("groups")
+        if groups_to_keep is None:
+            return "spack gc -y"
+
+        env_group_names = {
+            item["group"]
+            for item in self.config.get("specs", [])
+            if isinstance(item, dict) and "group" in item
+        }
+        unknown = set(groups_to_keep) - env_group_names
+        if unknown:
+            raise spack.error.SpackError(
+                f"container:groups references groups not defined in the environment: "
+                f"{', '.join(sorted(unknown))}"
+            )
+
+        drop_groups = sorted(env_group_names - set(groups_to_keep))
+        if not drop_groups:
+            return "spack gc -y"
+        flags = " ".join(f"--drop-group {g}" for g in drop_groups)
+        return f"spack gc -y {flags}"
+
+    @tengine.context_property
     def labels(self):
         return self.container_config.get("labels", {})
 

--- a/lib/spack/spack/schema/container.py
+++ b/lib/spack/spack/schema/container.py
@@ -82,6 +82,8 @@ container_schema = {
         },
         "docker": {"type": "object", "additionalProperties": False, "default": {}},
         "depfile": {"type": "boolean", "default": False},
+        # Groups that should survive into the runtime image
+        "groups": {"type": "array", "items": {"type": "string"}},
     },
 }
 

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -11,6 +11,7 @@ import spack.deptypes as dt
 import spack.environment as ev
 import spack.main
 import spack.spec
+import spack.store
 import spack.traverse
 from spack.installer import PackageInstaller
 
@@ -165,3 +166,61 @@ def test_gc_except_specific_dir_env(
     assert "Restricting garbage collection" not in output
     assert "Successfully uninstalled zmpi" in output
     assert not mutable_database.query_local("zmpi")
+
+
+@pytest.mark.db
+def test_gc_drop_group(install_mockery, mock_fetch, mutable_mock_env_path, tmp_path: pathlib.Path):
+    """Tests that --drop-group removes the roots of the dropped group and their unique deps."""
+    spack_yaml = tmp_path / "spack.yaml"
+    spack_yaml.write_text(
+        """\
+spack:
+  specs:
+  - group: tools
+    specs:
+    - cmake
+  - group: apps
+    specs:
+    - libelf
+"""
+    )
+    e = ev.create("test_gc_drop_group", init_file=str(spack_yaml))
+    with e:
+        e.concretize()
+        e.install_all(fake=True)
+        e.write()
+        output = gc("-y", "--drop-group", "tools")
+
+    assert "Restricting garbage collection" in output
+    assert "Successfully uninstalled cmake" in output
+    assert not spack.store.STORE.db.query_local("cmake")
+    assert spack.store.STORE.db.query_local("libelf")
+
+
+@pytest.mark.db
+def test_gc_drop_group_requires_active_env(mutable_database):
+    """Tests that --drop-group fails without an active environment."""
+    output = gc("--drop-group", "tools", fail_on_error=False)
+    assert gc.returncode == 1
+    assert "--drop-group requires an active environment" in output
+
+
+@pytest.mark.db
+def test_gc_drop_group_unknown_group(mutable_mock_env_path):
+    """Tests that --drop-group fails when the group is not defined in the environment."""
+    e = ev.create("test_gc_bad_group")
+    with e:
+        add("cmake")
+        output = gc("--drop-group", "nonexistent", fail_on_error=False)
+    assert gc.returncode == 1
+    assert "nonexistent" in output
+
+
+@pytest.mark.db
+def test_gc_drop_group_incompatible_with_e(mutable_database, mutable_mock_env_path):
+    """Tests that --drop-group cannot be combined with -e."""
+    e = ev.create("test_gc_compat")
+    with e:
+        output = gc("--drop-group", "tools", "-e", "test_gc_compat", fail_on_error=False)
+    assert gc.returncode == 1
+    assert "--drop-group cannot be combined" in output

--- a/lib/spack/spack/test/container/docker.py
+++ b/lib/spack/spack/test/container/docker.py
@@ -6,6 +6,7 @@ import re
 import pytest
 
 import spack.container.writers as writers
+import spack.error
 
 
 def test_manifest(minimal_configuration):
@@ -144,3 +145,52 @@ def test_using_single_quotes_in_dockerfiles(minimal_configuration):
     manifest_in_docker = writers.create(minimal_configuration).manifest
     assert not re.search(r"echo\s*\"", manifest_in_docker, flags=re.MULTILINE)
     assert re.search(r"echo\s*'", manifest_in_docker)
+
+
+def test_gc_command_default(minimal_configuration):
+    """Tests the default spack gc command, if no groups are specified."""
+    writer = writers.create(minimal_configuration)
+    assert writer.gc_command == "spack gc -y"
+
+
+def test_gc_command_with_runtime_groups(minimal_configuration):
+    """Tests that with groups specified, only those groups are not dropped."""
+    minimal_configuration["spack"]["specs"] = [
+        {"group": "compilers", "specs": ["gcc"]},
+        {"group": "packages", "specs": ["zlib"]},
+    ]
+    minimal_configuration["spack"]["container"]["groups"] = ["packages"]
+    writer = writers.create(minimal_configuration)
+    assert writer.gc_command == "spack gc -y --drop-group compilers"
+
+
+def test_gc_command_multiple_drop_groups(minimal_configuration):
+    """Tests that we drop multiple groups when needed."""
+    minimal_configuration["spack"]["specs"] = [
+        {"group": "compilers", "specs": ["gcc"]},
+        {"group": "tools", "specs": ["cmake"]},
+        {"group": "packages", "specs": ["zlib"]},
+    ]
+    minimal_configuration["spack"]["container"]["groups"] = ["packages"]
+    writer = writers.create(minimal_configuration)
+    # drop_groups is sorted, so compilers before tools
+    assert writer.gc_command == "spack gc -y --drop-group compilers --drop-group tools"
+
+
+def test_gc_command_all_groups_are_runtime(minimal_configuration):
+    """Tests that if we explicitly specify all groups, we get the default `spack gc` command."""
+    minimal_configuration["spack"]["specs"] = [{"group": "tools", "specs": ["cmake"]}]
+    minimal_configuration["spack"]["container"]["groups"] = ["tools"]
+    writer = writers.create(minimal_configuration)
+    assert writer.gc_command == "spack gc -y"
+
+
+def test_gc_command_unknown_group_raises(minimal_configuration):
+    """Tests that a group name in container.groups that is not in the env raises SpackError."""
+    minimal_configuration["spack"]["specs"] = [
+        {"group": "compilers", "specs": ["gcc"]},
+        {"group": "packages", "specs": ["zlib"]},
+    ]
+    minimal_configuration["spack"]["container"]["groups"] = ["packages", "typo"]
+    with pytest.raises(spack.error.SpackError, match="typo"):
+        _ = writers.create(minimal_configuration).gc_command

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1246,7 +1246,7 @@ _spack_find() {
 _spack_gc() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -E --except-any-environment -e --except-environment -b --keep-build-dependencies -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help -E --except-any-environment -e --except-environment -b --keep-build-dependencies --drop-group -y --yes-to-all"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1945,7 +1945,7 @@ complete -c spack -n '__fish_spack_using_command find' -l end-date -r -f -a end_
 complete -c spack -n '__fish_spack_using_command find' -l end-date -r -d 'latest date of installation [YYYY-MM-DD]'
 
 # spack gc
-set -g __fish_spack_optspecs_spack_gc h/help E/except-any-environment e/except-environment= b/keep-build-dependencies y/yes-to-all
+set -g __fish_spack_optspecs_spack_gc h/help E/except-any-environment e/except-environment= b/keep-build-dependencies drop-group= y/yes-to-all
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 gc' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command gc' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gc' -s h -l help -d 'show this help message and exit'
@@ -1955,6 +1955,8 @@ complete -c spack -n '__fish_spack_using_command gc' -s e -l except-environment 
 complete -c spack -n '__fish_spack_using_command gc' -s e -l except-environment -r -d 'remove everything unless needed by specified environment'
 complete -c spack -n '__fish_spack_using_command gc' -s b -l keep-build-dependencies -f -a keep_build_dependencies
 complete -c spack -n '__fish_spack_using_command gc' -s b -l keep-build-dependencies -d 'do not remove installed build-only dependencies of roots'
+complete -c spack -n '__fish_spack_using_command gc' -l drop-group -r -f -a drop_group
+complete -c spack -n '__fish_spack_using_command gc' -l drop-group -r -d 'treat specs in this group as non-roots for garbage collection'
 complete -c spack -n '__fish_spack_using_command gc' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command gc' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -22,9 +22,9 @@ set -o noclobber \
 
 # Install the software, remove unnecessary deps
 {% if depfile %}
-RUN cd {{ paths.environment }} && spack env activate . && spack concretize && spack env depfile -o Makefile && make -j $(nproc) && spack gc -y
+RUN cd {{ paths.environment }} && spack env activate . && spack concretize && spack env depfile -o Makefile && make -j $(nproc) && {{ gc_command }}
 {% else %}
-RUN cd {{ paths.environment }} && spack env activate . && spack install --fail-fast && spack gc -y
+RUN cd {{ paths.environment }} && spack env activate . && spack install --fail-fast && {{ gc_command }}
 {% endif %}
 {% if strip %}
 

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -28,7 +28,7 @@ EOF
 {% else %}
   spack -e . install
 {% endif %}
-  spack gc -y
+  {{ gc_command }}
   spack env activate --sh -d . >> {{ paths.environment }}/environment_modifications.sh
 {% if strip %}
 


### PR DESCRIPTION
fixes #52214

Add `container:groups` in spack.yaml, to select which groups to keep in the final image.

This feature uses a new `--drop-group` option of `spack gc` that will consider the specs of the droppable groups as candidates for garbage collection.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
