### PR TITLE
new_installer.py: fix stdin double buffering bug

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -20,6 +20,7 @@ output to both a log file and the UI process (if the UI process has requested it
 runs an event loop to listen for control messages from the UI process (to enable/disable echoing
 of logs), and for output from the build process."""
 
+import codecs
 import fcntl
 import glob
 import io
@@ -2143,6 +2144,28 @@ def _signal_children(running_builds: Dict[int, ChildInfo], sig: signal.Signals) 
             pass
 
 
+class StdinReader:
+    """Helper class to do non-blocking, incremental decoding of stdin, stripping ANSI escape
+    sequences. The input is the backing file descriptor for stdin (instead of the TextIOWrapper) to
+    avoid double buffering issues: the event loop triggers when the fd is ready to read, and if we
+    do a partial read from the TextIOWrapper, it will likely drain the fd and buffer the remainder
+    internally, which the event loop is not aware of, and user input doesn't come through."""
+
+    def __init__(self, fd: int) -> None:
+        self.fd = fd
+        #: Handle multi-byte UTF-8 characters
+        self.decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        #: For stripping out arrow and navigation keys
+        self.ansi_escape_re = re.compile(r"\x1b\[[0-9;]*[A-Za-z~]")
+
+    def read(self) -> str:
+        try:
+            chars = self.decoder.decode(os.read(self.fd, 1024))
+            return self.ansi_escape_re.sub("", chars)
+        except OSError:
+            return ""
+
+
 class PackageInstaller:
 
     explicit: Set[str]
@@ -2275,7 +2298,9 @@ class PackageInstaller:
 
         # Set up terminal handling (cbreak, signals, stdin registration)
         terminal: Optional[TerminalState] = None
+        stdin_reader: Optional[StdinReader] = None
         if sys.stdin.isatty():
+            stdin_reader = StdinReader(sys.stdin.fileno())
             terminal = TerminalState(
                 selector,
                 self.build_status,
@@ -2397,28 +2422,25 @@ class PackageInstaller:
                         child.proc.terminate()
                     self.pending_builds.clear()
 
-                if stdin_ready:
-                    try:
-                        char = sys.stdin.read(1)
-                    except OSError:
-                        continue
-                    overview = self.build_status.overview_mode
-                    if overview and self.build_status.search_mode:
-                        self.build_status.search_input(char)
-                    elif overview and char == "/":
-                        self.build_status.enter_search()
-                    elif char == "v" or char in ("q", "\x1b") and not overview:
-                        self.build_status.toggle()
-                    elif char == "n":
-                        self.build_status.next(1)
-                    elif char == "p" or char == "N":
-                        self.build_status.next(-1)
-                    elif char == "+":
-                        jobserver.increase_parallelism()
-                        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
-                    elif char == "-":
-                        jobserver.decrease_parallelism()
-                        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
+                if stdin_ready and stdin_reader is not None:
+                    for char in stdin_reader.read():
+                        overview = self.build_status.overview_mode
+                        if overview and self.build_status.search_mode:
+                            self.build_status.search_input(char)
+                        elif overview and char == "/":
+                            self.build_status.enter_search()
+                        elif char == "v" or char in ("q", "\x1b") and not overview:
+                            self.build_status.toggle()
+                        elif char == "n":
+                            self.build_status.next(1)
+                        elif char == "p" or char == "N":
+                            self.build_status.next(-1)
+                        elif char == "+":
+                            jobserver.increase_parallelism()
+                            self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
+                        elif char == "-":
+                            jobserver.decrease_parallelism()
+                            self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
 
                 # Insert into the database if we have any finished builds, and either the delay
                 # interval has passed, or we're done with all builds. The database save is not

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -17,7 +17,7 @@ from multiprocessing import Pipe
 from typing import List, Optional, Tuple
 
 import spack.new_installer as inst
-from spack.new_installer import BuildStatus
+from spack.new_installer import BuildStatus, StdinReader
 
 
 class MockConnection:
@@ -1459,3 +1459,47 @@ class TestHeadlessMode:
         status.dirty = True
         status.update()
         assert "[/] pkg0 pkg0@0.0 starting" in stdout.getvalue()
+
+
+class TestStdinReader:
+    def test_basic_ascii(self):
+        r, w = os.pipe()
+        try:
+            reader = StdinReader(r)
+            os.write(w, b"abc")
+            assert reader.read() == "abc"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_ansi_stripping(self):
+        r, w = os.pipe()
+        try:
+            reader = StdinReader(r)
+            os.write(w, b"hello\x1b[Aworld\x1b[B!")
+            assert reader.read() == "helloworld!"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_multibyte_utf8(self):
+        r, w = os.pipe()
+        try:
+            reader = StdinReader(r)
+            encoded = "é".encode("utf-8")  # 0xc3 0xa9
+            os.write(w, encoded[:1])
+            # First read: incomplete char, decoder buffers it
+            result1 = reader.read()
+            os.write(w, encoded[1:])
+            result2 = reader.read()
+            assert result1 + result2 == "é"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_oserror_returns_empty(self):
+        r, w = os.pipe()
+        os.close(w)
+        os.close(r)
+        reader = StdinReader(r)
+        assert reader.read() == ""


### PR DESCRIPTION
Fix a bug where pasting a dag hash or package name in `/` mode of the
TUI would result in only a single character being added to the filter.

The cause of this is double buffering (kernel + TextIOWrapper). The
idea was to read one character per event loop iteration. But after
`sys.stdin.read(1)` multiple bytes are `os.read` from the stdin fd,
draining the pipe and moving the data into the TextIOWrapper.
Another key press is needed for that to be read in a later iteration
of the event loop.

The fix does a bit more:

* handle multiple characters per event loop iteration so pasting text
  isn't laggy
* filter out ansi escape characters for cursor movement

The only buffering now is for multi-byte UTF-8 chars, which is
desirable.