### PR TITLE
two typos

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -1129,7 +1129,7 @@ def reproduce_ci_job(url, work_dir, autostart, gpg_url, runtime, use_local_head)
         process_command("reproducer", entrypoint_script, work_dir, run=autostart)
 
         inst_list.append("\nOnce on the tagged runner:\n\n")
-        inst_list.extent(
+        inst_list.extend(
             [
                 "    - Run the reproducer script",
                 f"       $ {work_dir}/reproducer.{platform_script_ext}",

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -93,10 +93,7 @@ def verify_versions(args):
     2. Installed package version not known by the package recipe
     3. Installed package version deprecated in the package recipe
     """
-    if args.specs:
-        specs = args.specs(installed=True)
-    else:
-        specs = spack.store.db.query(installed=True)
+    specs = args.specs(installed=True)
 
     msg_lines = _verify_version(specs)
     if msg_lines:


### PR DESCRIPTION
`spack.store.db` does not exist, but also the branch is impossible to hit
because `args.specs` is truthy.


