### PR TITLE
Add missing stacklevel to 44 warnings.warn() calls

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -1365,7 +1365,7 @@ def _test_detection_by_executable(pkgs, debug_log, error_cls):
     if not selected_pkgs:
         summary = "No detection test to run"
         details = [f'  "{p}" has no detection test' for p in pkgs]
-        warnings.warn("\n".join([summary] + details))
+        warnings.warn("\n".join([summary] + details), stacklevel=2)
         return errors
 
     for pkg_name in selected_pkgs:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2131,10 +2131,10 @@ def install_root_node(
     """
     # Early termination
     if spec.external or not spec.concrete:
-        warnings.warn("Skipping external or abstract spec {0}".format(spec.format()))
+        warnings.warn("Skipping external or abstract spec {0}".format(spec.format()), stacklevel=2)
         return
     elif spec.installed and not force:
-        warnings.warn("Package for spec {0} already installed.".format(spec.format()))
+        warnings.warn("Package for spec {0} already installed.".format(spec.format()), stacklevel=2)
         return
 
     tarball_stage = download_tarball(spec.build_spec, unsigned)

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -103,10 +103,10 @@ def _try_import_from_store(
                     "unexpected error while trying to import module "
                     f'"{module}" from spec "{candidate_spec}" [error="{str(exc)}"]'
                 )
-                warnings.warn(msg)
+                warnings.warn(msg, stacklevel=2)
             else:
                 msg = "Spec {0} did not provide module {1}"
-                warnings.warn(msg.format(candidate_spec, module))
+                warnings.warn(msg.format(candidate_spec, module), stacklevel=2)
 
         sys.path = path_before
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1449,7 +1449,7 @@ def complete_build_process(process: BuildProcess):
         timeout = process.timeout
         process.join(timeout=timeout)
         if process.is_alive():
-            warnings.warn(f"Terminating process, since the timeout of {timeout}s was exceeded")
+            warnings.warn(f"Terminating process, since the timeout of {timeout}s was exceeded", stacklevel=2)
             process.terminate()
     # If returns a StopPhase, raise it
     if isinstance(child_result, spack.error.StopPhase):

--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -100,9 +100,9 @@ def arch(parser, args):
         return
 
     if args.frontend:
-        warnings.warn("the argument --frontend is deprecated, and will be removed in Spack v1.0")
+        warnings.warn("the argument --frontend is deprecated, and will be removed in Spack v1.0", stacklevel=2)
     elif args.backend:
-        warnings.warn("the argument --backend is deprecated, and will be removed in Spack v1.0")
+        warnings.warn("the argument --backend is deprecated, and will be removed in Spack v1.0", stacklevel=2)
 
     host_platform = spack.platforms.host()
     host_os = host_platform.default_operating_system()

--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -53,9 +53,9 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 def change(parser, args):
     if args.all and args.concrete_only:
-        warnings.warn("'spack change --all' argument is ignored with '--concrete-only'")
+        warnings.warn("'spack change --all' argument is ignored with '--concrete-only'", stacklevel=2)
     if args.list_name != "specs" and args.concrete_only:
-        warnings.warn("'spack change --list-name' argument is ignored with '--concrete-only'")
+        warnings.warn("'spack change --list-name' argument is ignored with '--concrete-only'", stacklevel=2)
 
     env = spack.cmd.require_active_env(cmd_name="change")
 

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -738,14 +738,14 @@ def _check_spec_strings(
             with open(path, "r", encoding="utf-8") as f:
                 # skip files that are likely too large to be user code or config
                 if os.fstat(f.fileno()).st_size > 1024 * 1024:
-                    warnings.warn(f"skipping {path}: too large.")
+                    warnings.warn(f"skipping {path}: too large.", stacklevel=2)
                     continue
                 if is_json_or_yaml:
                     _spec_str_json_and_yaml(path, spack.util.spack_yaml.load_config(f), handler)
                 elif is_python:
                     _spec_str_ast(path, ast.parse(f.read()), handler)
         except (OSError, spack.util.spack_yaml.SpackYAMLError, SyntaxError, ValueError):
-            warnings.warn(f"skipping {path}")
+            warnings.warn(f"skipping {path}", stacklevel=2)
             continue
 
 

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -301,7 +301,8 @@ class CompilerFactory:
             except Exception:
                 warnings.warn(
                     f"[{__name__}] cannot detect {pkg_name} from the "
-                    f"following paths: {', '.join(filtered_paths)}"
+                    f"following paths: {', '.join(filtered_paths)}",
+                    stacklevel=2,
                 )
                 continue
 

--- a/lib/spack/spack/container/__init__.py
+++ b/lib/spack/spack/container/__init__.py
@@ -51,7 +51,7 @@ def validate(configuration_file):
                 'the subsection "{0}" in "{1}" is not used when generating'
                 " container recipes and will be discarded"
             )
-            warnings.warn(msg.format(subsection, configuration_file))
+            warnings.warn(msg.format(subsection, configuration_file), stacklevel=2)
             env_dict.pop(subsection)
 
     # Set the default value of the concretization strategy to unify and
@@ -61,7 +61,8 @@ def validate(configuration_file):
         warnings.warn(
             '"concretizer:unify" is not set to "true", which means the '
             "generated image may contain different variants of the same "
-            'packages. Set to "true" to get a consistent set of packages.'
+            'packages. Set to "true" to get a consistent set of packages.',
+            stacklevel=2,
         )
 
     # Check if the install tree was explicitly set to a custom value and warn
@@ -72,7 +73,7 @@ def validate(configuration_file):
             'the "config:install_tree" attribute has been set explicitly '
             "and will be overridden in the container image"
         )
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
 
     # Likewise for the view
     environment_view = env_dict.get("view", None)
@@ -81,7 +82,7 @@ def validate(configuration_file):
             'the "view" attribute has been set explicitly '
             "and will be overridden in the container image"
         )
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
 
     spack.vendor.jsonschema.validate(config, schema=env.schema)
     return config

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -68,7 +68,8 @@ def compiler_from_entry(entry: dict, *, manifest_path: str) -> Optional[spack.sp
             + "\n\t".join(missing_paths)
             + f"\nfor {entry['name']}@{entry['version']}"
             + f"\nin {manifest_path}"
-            + "\nPlease report this issue"
+            + "\nPlease report this issue",
+            stacklevel=2,
         )
 
     try:
@@ -254,7 +255,8 @@ def read(path, apply_updates):
         except Exception:
             warnings.warn(
                 f"Could not add compilers from manifest: {path}"
-                "\nPlease reexecute with 'spack -d' and include the stack trace"
+                "\nPlease reexecute with 'spack -d' and include the stack trace",
+                stacklevel=2,
             )
             tty.debug(f"Include this\n{traceback.format_exc()}")
     if apply_updates:

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -263,7 +263,8 @@ class Finder:
             warnings.warn(
                 f"{pkg.name} must define 'determine_spec_details' in order"
                 f" for Spack to detect externally-provided instances"
-                f" of the package."
+                f" of the package.",
+                stacklevel=2,
             )
             return []
 
@@ -288,7 +289,8 @@ class Finder:
                 else:
                     details = f"[{e.__class__.__name__}: {e}]"
                 warnings.warn(
-                    f'error detecting "{pkg.name}" from prefix {candidate_path}: {details}'
+                    f'error detecting "{pkg.name}" from prefix {candidate_path}: {details}',
+                    stacklevel=2,
                 )
 
             if not specs:
@@ -306,7 +308,8 @@ class Finder:
                 if spec in resolved_specs:
                     prior_prefix = resolved_specs[spec]
                     warnings.warn(
-                        f'"{spec}" detected in "{prefix}" was already detected in "{prior_prefix}"'
+                        f'"{spec}" detected in "{prefix}" was already detected in "{prior_prefix}"',
+                        stacklevel=2,
                     )
                     continue
 
@@ -321,7 +324,7 @@ class Finder:
                         f'"{spec}" has been detected on the system but will '
                         f"not be added to packages.yaml [reason={str(e)}]"
                     )
-                    warnings.warn(msg)
+                    warnings.warn(msg, stacklevel=2)
                     continue
 
                 if not spec.external_path:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2482,7 +2482,7 @@ class Environment:
                 "Note that versions of Spack older than {} may not be able to "
                 "use the updated configuration."
             )
-            warnings.warn(msg.format(self.name, self.name, ver))
+            warnings.warn(msg.format(self.name, self.name, ver), stacklevel=2)
 
     def _default_view_as_yaml(self):
         """This internal function assumes the default view is set"""

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -348,7 +348,7 @@ class ExternalSpecsParser:
                 )
                 continue
             except ExternalSpecError as e:
-                warnings.warn(f"{e}{line_info}")
+                warnings.warn(f"{e}{line_info}", stacklevel=2)
                 continue
 
             package_exists = spack.repo.PATH.exists(node.name)
@@ -381,7 +381,8 @@ class ExternalSpecsParser:
                 warnings.warn(
                     f"Spack is trying attach a Python dependency to '{node}'. This feature is "
                     f"deprecated, and will be removed in v1.2. Please make the dependency "
-                    f"explicit in your configuration."
+                    f"explicit in your configuration.",
+                    stacklevel=2,
                 )
                 external_dict.setdefault("dependencies", []).append({"spec": "python"})
 

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -1107,7 +1107,8 @@ class DeprecatedProperty:
 
         if self.error_lvl == 1:
             warnings.warn(
-                f"accessing the '{self.name}' property of '{instance}', which is deprecated"
+                f"accessing the '{self.name}' property of '{instance}', which is deprecated",
+                stacklevel=2,
             )
         elif self.error_lvl == 2:
             raise AttributeError(f"cannot access the '{self.name}' attribute of '{instance}'")

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -117,7 +117,8 @@ class LmodConfiguration(BaseConfiguration):
                 if len(set(candidates[language])) > 1:
                     warnings.warn(
                         f"{spec.short_spec} uses more than one compiler, and might not fit the "
-                        f"LMod hierarchy. Using {self.compiler.short_spec} as the LMod compiler."
+                        f"LMod hierarchy. Using {self.compiler.short_spec} as the LMod compiler.",
+                        stacklevel=2,
                     )
                 break
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -193,7 +193,8 @@ def get_package_dir_permissions(spec):
             warnings.warn(
                 "Directory {0} seems to be located on AFS. If you"
                 " encounter errors, try disabling the allow_sgid option"
-                " using: spack config add 'config:allow_sgid:false'".format(spec.prefix)
+                " using: spack config add 'config:allow_sgid:false'".format(spec.prefix),
+                stacklevel=2,
             )
     return perms
 

--- a/lib/spack/spack/platforms/_platform.py
+++ b/lib/spack/spack/platforms/_platform.py
@@ -52,7 +52,7 @@ class Platform:
     def target(self, name):
         name = str(name)
         if name in Platform.deprecated_names:
-            warnings.warn(f"target={name} is deprecated, use target={self.default} instead")
+            warnings.warn(f"target={name} is deprecated, use target={self.default} instead", stacklevel=2)
 
         if name in Platform.reserved_targets:
             name = self.default
@@ -73,7 +73,7 @@ class Platform:
 
     def operating_system(self, name):
         if name in Platform.deprecated_names:
-            warnings.warn(f"os={name} is deprecated, use os={self.default_os} instead")
+            warnings.warn(f"os={name} is deprecated, use os={self.default_os} instead", stacklevel=2)
 
         if name in Platform.reserved_oss:
             name = self.default_os

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1334,7 +1334,7 @@ class Repo:
                     if os.path.exists(patch.path):
                         fs.install(patch.path, path)
                     else:
-                        warnings.warn(f"Patch file did not exist: {patch.path}")
+                        warnings.warn(f"Patch file did not exist: {patch.path}", stacklevel=2)
 
         # Install the package.py file itself.
         fs.install(self.filename_for_package_name(spec.name), path)

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -129,7 +129,7 @@ class CDash(Reporter):
             else self.base_buildname
         )
         if len(buildname) > 190:
-            warnings.warn("Build name exceeds CDash 190 character maximum and will be truncated.")
+            warnings.warn("Build name exceeds CDash 190 character maximum and will be truncated.", stacklevel=2)
             buildname = buildname[:190]
         return buildname
 

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -60,7 +60,7 @@ def _deprecated_properties(validator, deprecated, instance, schema):
         if deprecations[name].error:
             errors.append(msg)
         else:
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
     if errors:
         yield jsonschema.ValidationError("\n".join(errors))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1003,7 +1003,7 @@ class PyclingoDriver:
                 header = f"Spack is taking more than {time_limit} seconds to solve for {specs_str}"
                 if error_on_timeout:
                     raise UnsatisfiableSpecError(f"{header}, stopping concretization")
-                warnings.warn(f"{header}, using the best configuration found so far")
+                warnings.warn(f"{header}, using the best configuration found so far", stacklevel=2)
                 handle.cancel()
 
             solve_result = handle.get()
@@ -3418,7 +3418,8 @@ def possible_compilers(*, configuration) -> Tuple[Set["spack.spec.Spec"], Set["s
             rejected.add(c)
             warnings.warn(
                 f"cannot detect libc from {c}. The compiler will not be used "
-                f"during concretization."
+                f"during concretization.",
+                stacklevel=2,
             )
             continue
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5351,7 +5351,8 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
                 parent_pkg = edge.parent.package
             except Exception as e:
                 warnings.warn(
-                    f"cannot reconstruct virtual dependencies on {edge.parent.name}: {e}"
+                    f"cannot reconstruct virtual dependencies on {edge.parent.name}: {e}",
+                    stacklevel=2,
                 )
                 continue
 
@@ -5372,7 +5373,8 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
                 child_pkg = edge.spec.package
             except Exception as e:
                 warnings.warn(
-                    f"cannot reconstruct virtual dependencies on {edge.parent.name}: {e}"
+                    f"cannot reconstruct virtual dependencies on {edge.parent.name}: {e}",
+                    stacklevel=2,
                 )
                 continue
             virtuals_provided[child_key].update(x.name for x in child_pkg.virtuals_provided)


### PR DESCRIPTION
## Summary

44 `warnings.warn()` calls across 22 files in `lib/spack/` (excluding vendored and test code) are missing `stacklevel`, causing warning messages to point to internal Spack lines rather than the caller's context.

### Problem

Without `stacklevel`, warnings reference internal Spack lines:
```
lib/spack/spack/spec.py:5351: UserWarning: cannot reconstruct virtual dependencies...
lib/spack/spack/solver/asp.py:1003: UserWarning: Spack is taking more than 120 seconds...
```

### Fix

With `stacklevel=2`, warnings correctly reference the caller:
```
spack.yaml:42: UserWarning: cannot reconstruct virtual dependencies...
my_script.py:15: UserWarning: Spack is taking more than 120 seconds...
```

### Scope

- 22 files in `lib/spack/spack/` (own code only)
- Vendored dependencies intentionally left unchanged
- All modified files pass `python -m py_compile`
