### PR TITLE
environment groups: add "explicit" attribute

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -998,6 +998,38 @@ The ``override:`` attribute allows us to override the configuration for a single
 The overridden part is always added as the *topmost* scope when the current group is concretized.
 This ensures the override always takes precedence over other sources of configuration.
 
+.. _environment-spec-groups-explicit:
+
+Controlling garbage collection with ``explicit: false``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+By default every spec group is treated as a set of *explicit* roots.
+This means its specs are preserved by ``spack gc`` even when nothing else depends on them.
+Setting ``explicit: false`` on a group marks its specs as *implicit*, making them eligible for garbage collection once no other installed spec depends on them:
+
+.. code-block:: yaml
+
+   spack:
+     specs:
+     - group: compiler
+       explicit: false
+       specs:
+       - gcc@15.2
+
+     - group: apps
+       needs: [compiler]
+       specs:
+       - hdf5 %gcc@15.2
+       - libtree %gcc@15.2
+
+After the apps are installed, ``spack gc`` will remove the compiler once no installed spec has a link or run dependency on it.
+
+.. note::
+
+   Flipping ``explicit: false`` on a group that has already been installed does **not** retroactively update the database record for the already-installed specs.
+   The flag takes effect only for specs installed, or re-installed, after the change.
+   To immediately mark an existing spec as implicit, use ``spack mark -i <spec>``.
+
 
 Modifying Environment Variables
 -------------------------------

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -67,7 +67,7 @@ def roots_from_environments(args, active_env):
     # add root hashes from all considered environments to list of roots
     root_hashes = set()
     for env in all_environments:
-        root_hashes |= {x.hash for x in env.concretized_roots}
+        root_hashes |= {x.hash for x in env.explicit_roots()}
 
     return root_hashes
 
@@ -91,7 +91,8 @@ def gc(parser, args):
             tty.msg(f"Restricting garbage collection to environment '{active_env.name}'")
             root_hashes = set(spack.store.STORE.db.all_hashes())  # keep everything
             root_hashes -= set(active_env.all_hashes())  # except this env
-            root_hashes |= {x.hash for x in active_env.concretized_roots}  # but keep its roots
+            # but keep its explicit roots
+            root_hashes |= {x.hash for x in active_env.explicit_roots()}
         else:
             # consider all explicit specs roots (the default for db.unused_specs())
             root_hashes = None

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1288,6 +1288,11 @@ class Environment:
         key = self._user_specs_key(group=group)
         return self.spec_lists[key]
 
+    def explicit_roots(self):
+        for x in self.concretized_roots:
+            if self.manifest.is_explicit(group=x.group):
+                yield x
+
     @property
     def dev_specs(self):
         dev_specs = {}
@@ -1979,10 +1984,10 @@ class Environment:
             *self._dev_specs_that_need_overwrite(),
         }
 
-        # Only environment roots are marked explicit
+        # Only environment roots in explicit groups are marked explicit
         install_args["explicit"] = {
             *install_args.get("explicit", ()),
-            *(s.dag_hash() for s in roots),
+            *(x.hash for x in self.explicit_roots()),
         }
 
         builder = spack.installer_dispatch.create_installer(
@@ -3158,6 +3163,8 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         self._user_specs: Dict[str, List] = {DEFAULT_USER_SPEC_GROUP: []}
         # Configuration overrides for each group
         self._config_override: Dict[str, Any] = {DEFAULT_USER_SPEC_GROUP: None}
+        # Whether specs in each group are marked explicit
+        self._explicit: Dict[str, bool] = {DEFAULT_USER_SPEC_GROUP: True}
         self._init_user_specs()
 
         self.changed = False
@@ -3181,6 +3188,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
                     self._user_specs[group] = []
                     self._groups[group] = tuple(item.get("needs", ()))
                     self._config_override[group] = item.get("override", None)
+                    self._explicit[group] = item.get("explicit", True)
 
                 if "matrix" in item:
                     # Short form if the group is composed of only one matrix
@@ -3192,6 +3200,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         self._user_specs = {DEFAULT_USER_SPEC_GROUP: []}
         self._groups = {DEFAULT_USER_SPEC_GROUP: tuple()}
         self._config_override = {DEFAULT_USER_SPEC_GROUP: None}
+        self._explicit = {DEFAULT_USER_SPEC_GROUP: True}
 
     def _all_matches(self, user_spec: str) -> List[str]:
         """Maps the input string to the first equivalent user spec in the manifest,
@@ -3235,6 +3244,15 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         group = self._ensure_group_exists(group)
         return self._groups[group]
 
+    def is_explicit(self, *, group: Optional[str] = None) -> bool:
+        """Returns whether specs in a group are marked explicit.
+
+        When False, specs in the group are installed as implicit dependencies
+        and are eligible for garbage collection once no other spec depends on them.
+        """
+        group = self._ensure_group_exists(group)
+        return self._explicit[group]
+
     def _ensure_group_exists(self, group: Optional[str]) -> str:
         group = DEFAULT_USER_SPEC_GROUP if group is None else group
         if group not in self._groups:
@@ -3277,6 +3295,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             self._groups[group] = tuple()
             self._config_override[group] = None
             self._user_specs[group] = []
+            self._explicit[group] = True
 
         return group_entry
 

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -30,6 +30,12 @@ include_concrete = {
 
 group_name_and_deps = {
     "group": {"type": "string", "description": "Name for this group of specs"},
+    "explicit": {
+        "type": "boolean",
+        "default": True,
+        "description": "When false, specs in this group are installed as implicit "
+        "dependencies and are eligible for garbage collection.",
+    },
     "needs": {
         "type": "array",
         "description": "Groups of specs that are needed by this group",

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -165,3 +165,69 @@ def test_gc_except_specific_dir_env(
     assert "Restricting garbage collection" not in output
     assert "Successfully uninstalled zmpi" in output
     assert not mutable_database.query_local("zmpi")
+
+
+@pytest.fixture
+def mock_installed_environment(mutable_database, mutable_mock_env_path):
+
+    def _create_environment(name, spack_yaml):
+        tmp_env = ev.create(name)
+        spack_yaml_path = pathlib.Path(tmp_env.path) / "spack.yaml"
+        spack_yaml_path.write_text(spack_yaml)
+        e = ev.read(name)
+        with ev.read(name):
+            e.concretize()
+            e.install_all(fake=True)
+            e.write()
+        return e
+
+    return _create_environment
+
+
+@pytest.mark.db
+@pytest.mark.parametrize(
+    "explicit,expected_explicit,expected_implicit",
+    [
+        (True, ["gcc@14.0.1", "openblas", "dyninst"], []),
+        (False, ["dyninst"], ["gcc@14.0.1", "openblas"]),
+    ],
+)
+def test_gc_with_explicit_groups(
+    explicit, expected_explicit, expected_implicit, mutable_database, mock_installed_environment
+):
+    """Tests the semantics of the "explicit" attribute of environment groups"""
+    e = mock_installed_environment(
+        "test_gc_explicit",
+        f"""
+spack:
+  config:
+    installer: new
+  specs:
+  - group: base
+    explicit: {explicit}
+    specs:
+    - gcc@14.0.1
+    - openblas
+  - group: apps
+    needs: [base]
+    specs:
+    - dyninst %c=gcc@14.0.1
+""",
+    )
+
+    # Test DB status
+    for query in expected_explicit:
+        assert mutable_database.query_local(query, explicit=True)
+
+    for query in expected_implicit:
+        assert mutable_database.query_local(query, explicit=False)
+
+    with e:
+        output = gc("-y")
+
+    # Test gc behavior
+    for query in expected_implicit:
+        assert f"Successfully uninstalled {query}" in output
+
+    for query in expected_explicit:
+        assert f"Successfully uninstalled {query}" not in output


### PR DESCRIPTION
fixes #52214 
closes #52233

With this attribute users can control whether root specs from groups are "explicit" or not (default is True). Root specs from `explicit: False` groups are eligible for garbage collection.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
