### PR TITLE
setup-env.sh: do not use spack installed module

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -42,7 +42,6 @@ import spack.paths
 import spack.platforms
 import spack.solver.asp
 import spack.spec
-import spack.store
 import spack.util.debug
 import spack.util.environment
 import spack.util.lock
@@ -848,17 +847,6 @@ def print_setup_info(*info):
         # instance are the highest-precedence.
         roots_val = ":".join(reversed(paths))
         shell_set("_sp_%s_roots" % name, roots_val)
-
-    # print environment module system if available. This can be expensive
-    # on clusters, so skip it if not needed.
-    if "modules" in info:
-        generic_arch = spack.vendor.archspec.cpu.host().family
-        module_spec = "environment-modules target={0}".format(generic_arch)
-        specs = spack.store.STORE.db.query(module_spec)
-        if specs:
-            shell_set("_sp_module_prefix", specs[-1].prefix)
-        else:
-            shell_set("_sp_module_prefix", "not_installed")
 
 
 def restore_macos_dyld_vars():

--- a/lib/spack/spack/test/cmd/print_shell_vars.py
+++ b/lib/spack/spack/test/cmd/print_shell_vars.py
@@ -23,23 +23,3 @@ def test_print_shell_vars_csh(capfd):
     assert "set _sp_tcl_roots = " in out
     assert "set _sp_lmod_roots = " in out
     assert "set _sp_module_prefix = " not in out
-
-
-def test_print_shell_vars_sh_modules(capfd):
-    print_setup_info("sh", "modules")
-    out, _ = capfd.readouterr()
-
-    assert "_sp_sys_type=" in out
-    assert "_sp_tcl_roots=" in out
-    assert "_sp_lmod_roots=" in out
-    assert "_sp_module_prefix=" in out
-
-
-def test_print_shell_vars_csh_modules(capfd):
-    print_setup_info("csh", "modules")
-    out, _ = capfd.readouterr()
-
-    assert "set _sp_sys_type = " in out
-    assert "set _sp_tcl_roots = " in out
-    assert "set _sp_lmod_roots = " in out
-    assert "set _sp_module_prefix = " in out

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -716,19 +716,9 @@ set -xg _sp_shell "fish"
 
 
 
-if test -z "$SPACK_SKIP_MODULES"
+if test -z "$SPACK_SKIP_MODULES"; and begin; type -q module; or type -q use; end
     #
-    # Check whether we need environment-variables (module) <= `use` is not available
-    #
-    set -l need_module "no"
-    if not functions -q use; and not functions -q module
-        set need_module "yes"
-    end
-
-
-
-    #
-    # Make environment-modules available to shell
+    # Make shell vars available to fish
     #
     function sp_apply_shell_vars -d "applies expressions of the type `a='b'` as `set a b`"
 
@@ -740,34 +730,10 @@ if test -z "$SPACK_SKIP_MODULES"
         set -xg $expr_token[1] (string split ":" $expr_token[2])
     end
 
+    set -l sp_shell_vars (command spack --print-shell-vars sh)
 
-    if test "$need_module" = "yes"
-        set -l sp_shell_vars (command spack --print-shell-vars sh,modules)
-
-        for sp_var_expr in $sp_shell_vars
-            sp_apply_shell_vars $sp_var_expr
-        end
-
-        # _sp_module_prefix is set by spack --print-shell-vars
-        if test "$_sp_module_prefix" != "not_installed"
-            set -xg MODULE_PREFIX $_sp_module_prefix
-            spack_pathadd PATH "$MODULE_PREFIX/bin"
-        end
-
-    else
-
-        set -l sp_shell_vars (command spack --print-shell-vars sh)
-
-        for sp_var_expr in $sp_shell_vars
-            sp_apply_shell_vars $sp_var_expr
-        end
-
-    end
-
-    if test "$need_module" = "yes"
-        function module -d "wrapper for the `module` command to point at Spack's modules instance" --inherit-variable MODULE_PREFIX
-            eval $MODULE_PREFIX/bin/modulecmd $SPACK_SHELL $argv
-        end
+    for sp_var_expr in $sp_shell_vars
+        sp_apply_shell_vars $sp_var_expr
     end
 
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -309,13 +309,6 @@ else
 fi
 _spack_pathadd PATH "${_sp_prefix%/}/bin"
 
-#
-# Check whether a function of the given name is defined
-#
-_spack_fn_exists() {
-    LANG= type $1 2>&1 | grep -q 'function'
-}
-
 # Define the spack shell function with some informative no-ops, so when users
 # run `which spack`, they see the path to spack and where the function is from.
 eval "spack() {
@@ -339,39 +332,9 @@ for cmd in "${SPACK_PYTHON:-}" python3 python python2; do
     fi
 done
 
-if [ -z "${SPACK_SKIP_MODULES+x}" ]; then
-    need_module="no"
-    if ! _spack_fn_exists use && ! _spack_fn_exists module; then
-        need_module="yes"
-    fi;
-
-    #
-    # make available environment-modules
-    #
-    if [ "${need_module}" = "yes" ]; then
-        eval `spack --print-shell-vars sh,modules`
-
-        # _sp_module_prefix is set by spack --print-sh-vars
-        if [ "${_sp_module_prefix}" != "not_installed" ]; then
-            # activate it!
-            # environment-modules@4: has a bin directory inside its prefix
-            _sp_module_bin="${_sp_module_prefix}/bin"
-            if [ ! -d "${_sp_module_bin}" ]; then
-                # environment-modules@3 has a nested bin directory
-                _sp_module_bin="${_sp_module_prefix}/Modules/bin"
-            fi
-
-            # _sp_module_bin and _sp_shell are evaluated here; the quoted
-            # eval statement and $* are deferred.
-            _sp_cmd="module() { eval \`${_sp_module_bin}/modulecmd ${_sp_shell} \$*\`; }"
-            eval "$_sp_cmd"
-            _spack_pathadd PATH "${_sp_module_bin}"
-        fi;
-    else
-        stdout="$(command spack --print-shell-vars sh)" || return
-        eval "$stdout"
-    fi;
-
+if [ -z "${SPACK_SKIP_MODULES+x}" ] && { type module > /dev/null 2>&1 || type use > /dev/null 2>&1; }; then
+    stdout="$(command spack --print-shell-vars sh)" || return
+    eval "$stdout"
 
     #
     # set module system roots


### PR DESCRIPTION
The `setup-env.sh` script is slow because it triggers a database search
for `environment-modules`.

This is bad for two reasons:

* we shouldn't endorse environment-modules over lmod, that's up to the
  user
* this triggers the infamous 8k stat calls, which is very bad UX,
  especially for people using Spack for the first time

This commit changes shell setup in the following ways:

* Only run `spack --print-shell-vars` when `module` is a shell function
  in the current shell. Let the user configure their shell accordingly.
* Never look in the database for something that can provide a `module`
  shell command.

Spack continues to set `MODULEPATH` for users who have `module`
available in their shell.
