### PR TITLE
concretizer: raise a clear error on unknown concrete targets 

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2604,8 +2604,15 @@ class SpackSolverSetup:
             if not spec.architecture or not spec.architecture.target:
                 continue
 
-            target = spack.vendor.archspec.cpu.TARGETS.get(spec.target.name)
+            target_name = spec.target.name
+            target = spack.vendor.archspec.cpu.TARGETS.get(target_name)
             if not target:
+                if spec.architecture.target_concrete:
+                    raise spack.error.SpecError(
+                        f"the target '{target_name}' in '{spec} is not a known target. "
+                        f"Run 'spack arch --known-targets' to see valid targets."
+                    )
+                # range/list constraint (contains ':' or ','): keep existing path
                 self.target_ranges(spec, None)
                 continue
 

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -5,6 +5,8 @@ import enum
 import warnings
 from typing import List, NamedTuple, Optional, Sequence, Tuple, Union
 
+import spack.vendor.archspec.cpu
+
 import spack.config
 import spack.error
 import spack.package_base
@@ -16,6 +18,47 @@ import spack.util.spack_yaml
 from spack.enums import PropagationPolicy
 from spack.llnl.util import tty
 from spack.util.spack_yaml import get_mark_from_yaml_data
+
+
+def _mark_str(raw) -> str:
+    """Return a 'file:line: ' prefix from the YAML mark on *raw*, or empty string."""
+    mark = get_mark_from_yaml_data(raw)
+    return f"{mark.name}:{mark.line + 1}: " if mark else ""
+
+
+def _check_unknown_targets(
+    raw_strs: List[str], specs: List["spack.spec.Spec"], *, always_warn: bool = False
+) -> None:
+    """Either warns or raises for unknown concrete target names in a set of specs.
+
+    UserWarnings are emitted if *always_warn* is True or if there is at least one spec without
+    unknown targets. If all the specs have unknown targets raises an error.
+    """
+    specs_with_unknown_targets = [
+        (raw, spec)
+        for raw, spec in zip(raw_strs, specs)
+        if spec.architecture
+        and spec.architecture.target_concrete
+        and spec.target.name not in spack.vendor.archspec.cpu.TARGETS
+    ]
+    if not specs_with_unknown_targets:
+        return
+
+    errors = [
+        f"{_mark_str(raw)}'{spec}' contains unknown targets"
+        for raw, spec in specs_with_unknown_targets
+    ]
+    if len(errors) == 1:
+        msg = f"{errors[0]}. Run 'spack arch --known-targets' to see valid targets."
+    else:
+        details = "\n".join([f"{idx}. {part}" for idx, part in enumerate(errors, 1)])
+        msg = (
+            f"unknown targets have been detected in requirements\n{details}\n"
+            f"Run 'spack arch --known-targets' to see valid targets."
+        )
+    if not always_warn and len(specs_with_unknown_targets) == len(specs):
+        raise spack.error.SpecError(msg)
+    warnings.warn(msg)
 
 
 class RequirementKind(enum.Enum):
@@ -220,6 +263,8 @@ class RequirementParser:
             spec = self._parse_and_expand(item["spec"])
             condition = spack.spec.Spec(item.get("when"))
             message = item.get("message")
+        raw_key = item if isinstance(item, str) else item.get("spec", item)
+        _check_unknown_targets([raw_key], [spec], always_warn=True)
         return spec, condition, message
 
     def _raw_yaml_data(self, pkg_name: str, *, section: str, virtual: bool = False):
@@ -265,10 +310,12 @@ class RequirementParser:
                     self._maybe_warn_compiler_in_all(constraints, "require")
 
                 # validate specs from YAML first, and fail with line numbers if parsing fails.
+                raw_strs = list(constraints)
                 constraints = [
                     self._parse_and_expand(constraint, named=kind == RequirementKind.VIRTUAL)
-                    for constraint in constraints
+                    for constraint in raw_strs
                 ]
+                _check_unknown_targets(raw_strs, constraints)
                 when_str = requirement.get("when")
                 when = self._parse_and_expand(when_str) if when_str else spack.spec.Spec()
 

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -265,3 +265,14 @@ def test_package_py_driven_errors(
     with pytest.raises(spack.error.SpackError) as exc_info:
         spack.concretize.concretize_one(input_spec)
     assert_actionable_error(exc_info, *expected_handles)
+
+
+@pytest.mark.regression("52209")
+def test_unknown_concrete_target_in_input_spec(mock_packages, mutable_config) -> None:
+    """A spec with an unknown concrete target should fail with a clear message naming the bad
+    target, rather than a confusing 'cannot satisfy constraint' solver error.
+    """
+    s = spack.spec.Spec("pkg-a target=not-a-real-uarch")
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one(s)
+    assert_actionable_error(exc_info, "not-a-real-uarch", "not a known target", "pkg-a")

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -265,14 +265,3 @@ def test_package_py_driven_errors(
     with pytest.raises(spack.error.SpackError) as exc_info:
         spack.concretize.concretize_one(input_spec)
     assert_actionable_error(exc_info, *expected_handles)
-
-
-@pytest.mark.regression("52209")
-def test_unknown_concrete_target_in_input_spec(mock_packages, mutable_config) -> None:
-    """A spec with an unknown concrete target should fail with a clear message naming the bad
-    target, rather than a confusing 'cannot satisfy constraint' solver error.
-    """
-    s = spack.spec.Spec("pkg-a target=not-a-real-uarch")
-    with pytest.raises(spack.error.SpackError) as exc_info:
-        spack.concretize.concretize_one(s)
-    assert_actionable_error(exc_info, "not-a-real-uarch", "not a known target", "pkg-a")

--- a/lib/spack/spack/test/error_messages.py
+++ b/lib/spack/spack/test/error_messages.py
@@ -10,6 +10,8 @@ from typing import Iterable, Optional
 
 import pytest
 
+import spack.vendor.archspec.cpu
+
 import spack.config
 import spack.error
 import spack.repo
@@ -548,3 +550,81 @@ def test_warns_on_compiler_constraint_in_all(concretize_scope, mock_packages, se
     update_packages_config(f"packages:\n  all:\n    {section}:\n    - '%c=gcc'\n")
     with pytest.warns(UserWarning, match="packages: all:"):
         concretize_one("gmake")
+
+
+@pytest.mark.regression("52209")
+def test_unknown_concrete_target_in_input_spec(concretize_scope, test_repo):
+    """Tests that an input spec with an unknown concrete target raises a clear error naming
+    the bad target, rather than a confusing 'cannot satisfy constraint' solver error.
+    """
+    spec_str = "x4 target=not-a-real-uarch"
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        concretize_one(spec_str)
+    check_error(str(exc_info.value), should_mention=[spec_str, "not a known target"])
+
+
+@pytest.mark.regression("52209")
+def test_require_single_unknown_target_errors(concretize_scope, test_repo):
+    """Tests that a single-option require with an unknown target raises a clear error."""
+    target_str = "target=not-a-real-uarch"
+    update_packages_config(
+        f"""\
+packages:
+  x4:
+    require: {target_str}
+"""
+    )
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        concretize_one("x4")
+    check_error(str(exc_info.value), should_mention=[target_str, "unknown target"])
+
+
+@pytest.mark.regression("52209")
+def test_require_all_unknown_targets_errors(concretize_scope, test_repo):
+    """Tests that a group where every option has an unknown target also raises a clear error."""
+    update_packages_config(
+        """\
+packages:
+  x4:
+    require:
+    - any_of: ["target=not-a-real-uarch", "target=also-fake"]
+"""
+    )
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        concretize_one("x4")
+    check_error(
+        str(exc_info.value),
+        should_mention=["target=not-a-real-uarch", "target=also-fake", "unknown target"],
+    )
+
+
+@pytest.mark.regression("52209")
+@pytest.mark.skipif(
+    str(spack.vendor.archspec.cpu.host().family) != "x86_64", reason="test assumes x86_64 uarchs"
+)
+def test_require_mixed_unknown_and_valid_target_warns(concretize_scope, test_repo):
+    """Tests that a "require" group with at least one valid option just warns."""
+    update_packages_config(
+        """\
+packages:
+  x4:
+    require:
+    - one_of: ["target=not-a-real-uarch", "target=x86_64"]
+"""
+    )
+    with pytest.warns(UserWarning, match="not-a-real-uarch"):
+        concretize_one("x4")
+
+
+@pytest.mark.regression("52209")
+def test_prefer_unknown_target_warns(concretize_scope, test_repo):
+    """A preference with an unknown target has the @: fallback, so it only warns."""
+    update_packages_config(
+        """\
+packages:
+  x4:
+    prefer: ["target=not-a-real-uarch"]
+"""
+    )
+    with pytest.warns(UserWarning, match="not-a-real-uarch"):
+        concretize_one("x4")


### PR DESCRIPTION
fixes #52209 

Previously, when a user asked for a concrete target that is unknown to `archspec`, the solver would raise a confusing error message about unmatched target constraints.

Now user input is checked pre-solve and the error is clearer:
```console
$ spack solve zlib-ng target=foo
==> Error: the target 'foo' in 'zlib-ng target=foo' is not a known target. Run 'spack arch --known-targets' to see valid targets.
```
The errors have also been improved for requirements stemming from configuration files, In that case the behavior is to warn the user, if there is at least one option that could lead to a solvable problem, and error otherwise:
<img width="2007" height="357" alt="Screenshot from 2026-04-13 17-39-17" src="https://github.com/user-attachments/assets/b0b35f68-8b0b-41d1-9ad4-3bd90eaf1879" />
