### PR TITLE
ctest_log_parser.py: faster and sequential

### DIFF
--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import io
 import sys
+import warnings
 
 import spack.llnl.util.tty as tty
 from spack.util.log_parse import make_log_context, parse_log_events
@@ -45,13 +47,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="wrap width: auto-size to terminal by default; 0 for no wrap",
     )
     subparser.add_argument(
-        "-j",
-        "--jobs",
-        action="store",
-        type=int,
-        default=None,
-        help="number of jobs to parse log file (default: 1 for short logs, "
-        "ncpus for long logs)",
+        "-j", "--jobs", action="store", type=int, default=None, help=argparse.SUPPRESS
     )
 
     subparser.add_argument("file", help="a log file containing build output, or - for stdin")
@@ -60,9 +56,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def log_parse(parser, args):
     input = args.file
     if args.file == "-":
-        input = sys.stdin
+        input = io.TextIOWrapper(
+            sys.stdin.buffer, encoding="utf-8", errors="replace", closefd=False
+        )
 
-    errors, warnings = parse_log_events(input, args.context, args.jobs, args.profile)
+    if args.jobs is not None:
+        warnings.warn("The --jobs option is deprecated and will be removed in Spack v1.3")
+
+    log_errors, log_warnings = parse_log_events(input, args.context, args.profile)
     if args.profile:
         return
 
@@ -73,10 +74,10 @@ def log_parse(parser, args):
 
     events = []
     if "errors" in types:
-        events.extend(errors)
-        print("%d errors" % len(errors))
+        events.extend(log_errors)
+        print("%d errors" % len(log_errors))
     if "warnings" in types:
-        events.extend(warnings)
-        print("%d warnings" % len(warnings))
+        events.extend(log_warnings)
+        print("%d warnings" % len(log_warnings))
 
     print(make_log_context(events, args.width))

--- a/lib/spack/spack/test/util/log_parser.py
+++ b/lib/spack/spack/test/util/log_parser.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import io
 import pathlib
 
 from spack.util.ctest_log_parser import CTestLogParser
@@ -35,3 +36,43 @@ configure: error: cannot run C compiled programs.                           E
 
     assert len(warnings) == 1
     assert all(w.text.endswith("W") for w in warnings)
+
+
+def test_log_parser_stream():
+    """parse() accepts a file-like object."""
+    log = io.StringIO(
+        "error: weird_error.c:145: something weird happened                 E\n"
+        "checking for gcc... irrelevant line\n"
+        "/var/tmp/build/foo.py:60: warning: some weird warning              W\n"
+    )
+    parser = CTestLogParser()
+    errors, warnings = parser.parse(log)
+
+    assert len(errors) == 1
+    assert errors[0].text.endswith("E")
+    assert len(warnings) == 1
+    assert warnings[0].text.endswith("W")
+
+
+def test_log_parser_preserves_leading_whitespace():
+    """Leading whitespace (e.g. compiler caret underlines) must not be stripped."""
+    log = io.StringIO(
+        "/path/to/file.c:10: error: use of undeclared identifier 'x'\n"
+        "    int y = x + 1;\n"
+        "            ^\n"
+    )
+    parser = CTestLogParser()
+    errors, _ = parser.parse(log, context=6)
+
+    assert len(errors) == 1
+    assert errors[0].post_context[0] == "    int y = x + 1;"
+    assert errors[0].post_context[1] == "            ^"
+
+
+def test_log_parser_non_utf8_bytes(tmp_path: pathlib.Path):
+    """parse() does not raise UnicodeDecodeError on non-UTF-8 log files."""
+    log_file = tmp_path / "log.bin"
+    log_file.write_bytes(b"checking things...\nerror: \x80\xff something broke\ndone\n")
+    parser = CTestLogParser()
+    errors, _ = parser.parse(str(log_file))
+    assert len(errors) == 1

--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -70,15 +70,11 @@ up to date with CTest, just make sure the ``*_matches`` and
 """
 import io
 import math
-import multiprocessing
 import re
-import sys
-import threading
 import time
+from collections import deque
 from contextlib import contextmanager
-from typing import List, Optional, TextIO, Tuple, Union
-
-import spack.config
+from typing import List, TextIO, Tuple, Union
 
 _error_matches = [
     "^FAIL: ",
@@ -89,21 +85,22 @@ _error_matches = [
     "^[Bb]us [Ee]rror",
     "^[Ss]egmentation [Vv]iolation",
     "^[Ss]egmentation [Ff]ault",
-    ":.*[Pp]ermission [Dd]enied",
-    "[^ :]:[0-9]+: [^ \\t]",
-    "[^:]: error[ \\t]*[0-9]+[ \\t]*:",
+    "Permission [Dd]enied",
+    "permission [Dd]enied",
+    ":[0-9]+: [^ \\t]",
+    ": error[ \\t]*[0-9]+[ \\t]*:",
     "^Error ([0-9]+):",
     "^Fatal",
     "^[Ee]rror: ",
     "^Error ",
-    "[0-9] ERROR: ",
+    " ERROR: ",
     '^"[^"]+", line [0-9]+: [^Ww]',
     "^cc[^C]*CC: ERROR File = ([^,]+), Line = ([0-9]+)",
     "^ld([^:])*:([ \\t])*ERROR([^:])*:",
     "^ild:([ \\t])*\\(undefined symbol\\)",
-    "[^ :] : (error|fatal error|catastrophic error)",
-    "[^:]: (Error:|error|undefined reference|multiply defined)",
-    "[^:]\\([^\\)]+\\) ?: (error|fatal error|catastrophic error)",
+    ": (error|fatal error|catastrophic error)",
+    ": (Error:|error|undefined reference|multiply defined)",
+    "\\([^\\)]+\\) ?: (error|fatal error|catastrophic error)",
     "^fatal error C[0-9]+:",
     ": syntax error ",
     "^collect2: ld returned 1 exit status",
@@ -154,28 +151,27 @@ _error_exceptions = [
     "    ok",
     "Note:",
     ":[ \\t]+Where:",
-    "[^ :]:[0-9]+: Warning",
+    ":[0-9]+: Warning",
     "------ Build started: .* ------",
 ]
 
 #: Regexes to match file/line numbers in error/warning messages
 _warning_matches = [
-    "[^ :]:[0-9]+: warning:",
-    "[^ :]:[0-9]+: note:",
+    ":[0-9]+: warning:",
+    ":[0-9]+: note:",
     "^cc[^C]*CC: WARNING File = ([^,]+), Line = ([0-9]+)",
     "^ld([^:])*:([ \\t])*WARNING([^:])*:",
-    "[^:]: warning [0-9]+:",
+    ": warning [0-9]+:",
     '^"[^"]+", line [0-9]+: [Ww](arning|arnung)',
-    "[^:]: warning[ \\t]*[0-9]+[ \\t]*:",
+    ": warning[ \\t]*[0-9]+[ \\t]*:",
     "^(Warning|Warnung) ([0-9]+):",
     "^(Warning|Warnung)[ :]",
     "WARNING: ",
-    "[^ :] : warning",
-    "[^:]: warning",
+    ": warning",
     '", line [0-9]+\\.[0-9]+: [0-9]+-[0-9]+ \\([WI]\\)',
     "^cxx: Warning:",
     "file: .* has no symbols",
-    "[^ :]:[0-9]+: (Warning|Warnung)",
+    ":[0-9]+: (Warning|Warnung)",
     "\\([0-9]*\\): remark #[0-9]*",
     '".*", line [0-9]+: remark\\([0-9]*\\):',
     "cc-[0-9]* CC: REMARK File = .*, Line = [0-9]*",
@@ -312,7 +308,7 @@ def _profile_match(matches, exceptions, line, match_times, exc_times):
         return True
 
 
-def _parse(lines, offset, profile):
+def _parse(stream, profile, context):
     def compile(regex_array):
         return [re.compile(regex) for regex in regex_array]
 
@@ -335,28 +331,63 @@ def _parse(lines, offset, profile):
 
     errors = []
     warnings = []
-    for i, line in enumerate(lines):
+    # rolling window of recent lines
+    pre_context = deque(maxlen=context)
+    # list of (event, remaining_post_context_lines)
+    pending_events: List[Tuple[LogEvent, int]] = []
+
+    for i, line in enumerate(stream):
+        rstripped_line = line.rstrip()
+
+        # feed this line into every event still collecting post_context
+        if pending_events:
+            active_events = []
+            for event, remaining in pending_events:
+                event.post_context.append(rstripped_line)
+                if remaining > 1:
+                    active_events.append((event, remaining - 1))
+                elif isinstance(event, BuildError):
+                    errors.append(event)
+                else:
+                    warnings.append(event)
+            pending_events = active_events
+
         # use CTest's regular expressions to scrape the log for events
         if matcher(error_matches, error_exceptions, line, *timings[:2]):
-            event = BuildError(line.strip(), offset + i + 1)
-            errors.append(event)
+            event = BuildError(rstripped_line, i + 1)
         elif matcher(warning_matches, warning_exceptions, line, *timings[2:]):
-            event = BuildWarning(line.strip(), offset + i + 1)
-            warnings.append(event)
+            event = BuildWarning(rstripped_line, i + 1)
         else:
+            pre_context.append(rstripped_line)
             continue
 
-        # get file/line number for each event, if possible
+        event.pre_context = list(pre_context)
+        event.post_context = []
+
+        # get file/line number for the event, if possible
         for flm in file_line_matches:
             match = flm.search(line)
             if match:
                 event.source_file, event.source_line_no = match.groups()
+                break
+
+        if context > 0:
+            pending_events.append((event, context))
+        elif isinstance(event, BuildError):
+            errors.append(event)
+        else:
+            warnings.append(event)
+
+        pre_context.append(rstripped_line)
+
+    # flush events whose post_context window extends past EOF
+    for event, _ in pending_events:
+        if isinstance(event, BuildError):
+            errors.append(event)
+        else:
+            warnings.append(event)
 
     return errors, warnings, timings
-
-
-def _parse_unpack(args):
-    return _parse(*args)
 
 
 class CTestLogParser:
@@ -388,7 +419,7 @@ class CTestLogParser:
             index += 1
 
     def parse(
-        self, stream: Union[str, TextIO], context: int = 6, jobs: Optional[int] = None
+        self, stream: Union[str, TextIO], context: int = 6
     ) -> Tuple[List[BuildError], List[BuildWarning]]:
         """Parse a log file by searching each line for errors and warnings.
 
@@ -400,51 +431,8 @@ class CTestLogParser:
             two lists containing :class:`BuildError` and :class:`BuildWarning` objects.
         """
         if isinstance(stream, str):
-            with open(stream) as f:
-                return self.parse(f, context, jobs)
+            with open(stream, encoding="utf-8", errors="replace") as f:
+                return self.parse(f, context)
 
-        lines = [line for line in stream]
-
-        if jobs is None:
-            jobs = spack.config.get("config:build_jobs", 16)
-
-        # single-thread small logs
-        if len(lines) < 10 * jobs:
-            errors, warnings, self.timings = _parse(lines, 0, self.profile)
-
-        else:
-            # Build arguments for parallel jobs
-            args = []
-            offset = 0
-            for chunk in chunks(lines, jobs):
-                args.append((chunk, offset, self.profile))
-                offset += len(chunk)
-
-            # create a pool and farm out the matching job
-            pool = multiprocessing.Pool(jobs)
-            try:
-                # this is a workaround for a Python bug in Pool with ctrl-C
-                if sys.version_info >= (3, 2):
-                    max_timeout = threading.TIMEOUT_MAX
-                else:
-                    max_timeout = 9999999
-                results = pool.map_async(_parse_unpack, args, 1).get(max_timeout)
-
-                errors, warnings, timings = zip(*results)
-            finally:
-                pool.terminate()
-
-            # merge results
-            errors = sum(errors, [])
-            warnings = sum(warnings, [])
-
-            if self.profile:
-                self.timings = [[sum(i) for i in zip(*t)] for t in zip(*timings)]
-
-        # add log context to all events
-        for event in errors + warnings:
-            i = event.line_no - 1
-            event.pre_context = [x.rstrip() for x in lines[i - context : i]]
-            event.post_context = [x.rstrip() for x in lines[i + 1 : i + context + 1]]
-
+        errors, warnings, self.timings = _parse(stream, self.profile, context)
         return errors, warnings

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -5,7 +5,7 @@
 import io
 import shutil
 import sys
-from typing import Optional, TextIO, Union
+from typing import TextIO, Union
 
 from spack.llnl.util.tty.color import cescape, colorize
 from spack.util.ctest_log_parser import BuildError, BuildWarning, CTestLogParser
@@ -13,15 +13,12 @@ from spack.util.ctest_log_parser import BuildError, BuildWarning, CTestLogParser
 __all__ = ["parse_log_events", "make_log_context"]
 
 
-def parse_log_events(
-    stream: Union[str, TextIO], context: int = 6, jobs: Optional[int] = None, profile: bool = False
-):
+def parse_log_events(stream: Union[str, TextIO], context: int = 6, profile: bool = False):
     """Extract interesting events from a log file as a list of LogEvent.
 
     Args:
         stream: build log name or file object
         context: lines of context to extract around each log event
-        jobs: number of jobs to parse with; default ncpus
         profile: print out profile information for parsing
 
     Returns:
@@ -37,7 +34,7 @@ def parse_log_events(
         parser = CTestLogParser(profile=profile)
         setattr(parse_log_events, "ctest_parser", parser)
 
-    result = parser.parse(stream, context, jobs)
+    result = parser.parse(stream, context)
     if profile:
         parser.print_timings()
     return result

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2302,7 +2302,6 @@ complete -c spack -n '__fish_spack_using_command log-parse' -s p -l profile -d '
 complete -c spack -n '__fish_spack_using_command log-parse' -s w -l width -r -f -a width
 complete -c spack -n '__fish_spack_using_command log-parse' -s w -l width -r -d 'wrap width: auto-size to terminal by default; 0 for no wrap'
 complete -c spack -n '__fish_spack_using_command log-parse' -s j -l jobs -r -f -a jobs
-complete -c spack -n '__fish_spack_using_command log-parse' -s j -l jobs -r -d 'number of jobs to parse log file (default: 1 for short logs, ncpus for long logs)'
 
 # spack logs
 set -g __fish_spack_optspecs_spack_logs h/help


### PR DESCRIPTION
This commit makes the following changes:

* make the log parser sequential and streaming, while running faster than
   the previous multithreaded version
* fix an issue when the log contains invalid UTF-8
* fix a bug where the parser called `line.strip()`, which drops leading whitespace,
   which is necessary for the ascii underlines or pointers used by compilers:
   ```
   foo bar
       ^^^
   ```
* deprecate the `spack log-parser -j` flag

The changes to the regexes make the sequential case run 2.5x faster than
the `-j6` case previously.

The idea is to give all regexes a positive anchor, instead of starting
with something negative like `[^ :]`. The latter results in many
attempts to match, that fail on the second byte, which comes with a
large performance penalty. The cost is up to 80x.

The new installer benefits from a sequential version, since it does log
parsing as part of a concurrent build loop.
