### PR TITLE
Fix Dependabot Config and Add Coverage Requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,13 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-  # Requirements to run style checks and build documentation
+
   - package-ecosystem: "pip"
     directories:
-     - "/.github/workflows/requirements/style/*"
+     - "/.github/workflows/requirements/*"
      - "/lib/spack/docs"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Test a fix to the dependabot configuration to see if this re-kickstarts it.

(We'll want to watch the resulting validation job when this merges to see what happens.)