### PR TITLE
solver: fix weights for unshifted priorities

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2103,21 +2103,21 @@ opt_criterion(310, "requirement weight").
 }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
-opt_criterion(110, "number of packages to build (vs. reuse)").
-#minimize { 0@110: #true }.
-#minimize { 1@110,PackageNode : build(PackageNode), not treat_node_as_concrete(PackageNode) }.
+opt_criterion(120, "number of packages to build (vs. reuse)").
+#minimize { 0@120: #true }.
+#minimize { 1@120,PackageNode : build(PackageNode), not treat_node_as_concrete(PackageNode) }.
 
-opt_criterion(100, "number of nodes from the same package").
-#minimize { 0@100: #true }.
-#minimize { ID@100,Package : attr("node", node(ID, Package)), not self_build_requirement(_, node(ID, Package)) }.
-#minimize { ID@100,Package : attr("virtual_node", node(ID, Package)) }.
+opt_criterion(110, "number of nodes from the same package").
+#minimize { 0@110: #true }.
+#minimize { ID@110,Package : attr("node", node(ID, Package)), not self_build_requirement(_, node(ID, Package)) }.
+#minimize { ID@110,Package : attr("virtual_node", node(ID, Package)) }.
 #defined optimize_for_reuse/0.
 
 % Minimize the unification set ID used for build dependencies. This reduces the number of optimal
 % solutions that differ only by which node belongs to which unification set.
-opt_criterion(90, "build unification sets").
-#minimize{ 0@90: #true }.
-#minimize{ ID@90,ParentNode : build_set_id(ParentNode, ID) }.
+opt_criterion(100, "build unification sets").
+#minimize{ 0@100: #true }.
+#minimize{ ID@100,ParentNode : build_set_id(ParentNode, ID) }.
 
 % Minimize the number of deprecated versions being used
 opt_criterion(73, "deprecated versions used").


### PR DESCRIPTION
Without this the weight for "build unification sets" is duplicated and the report from:
```
spack solve ...
```
may print the weights in a wrong way. Note that this doesn't affect the solution, only how it's reported on screen by `spack solve`.

### Example

Using the following configuration, which uses a `prefer:` that cannot be satisfied:
```yaml
packages:
  all:
    prefer:
    - target=foo
```

**Before the PR**
<img width="1092" height="205" alt="2026-04-14_09-15" src="https://github.com/user-attachments/assets/d8204b9e-c96e-4960-a6eb-c33206e572ce" />

**After the PR**

<img width="1231" height="269" alt="2026-04-14_09-14" src="https://github.com/user-attachments/assets/14e9d47e-e523-4c5a-8ae4-920f5cffd936" />


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
