### PR TITLE
new_installer.py: take db write lock only if needed

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2453,12 +2453,13 @@ class PackageInstaller:
             # Flush any not-yet-written successful builds to the DB; save the exception on error
             # to be re-raised after best-effort cleanup.
             db_exc = None
-            try:
-                with self.db.write_transaction():
-                    for action in database_actions:
-                        action.save_to_db(self.db)
-            except Exception as e:
-                db_exc = e
+            if database_actions:
+                try:
+                    with self.db.write_transaction():
+                        for action in database_actions:
+                            action.save_to_db(self.db)
+                except Exception as e:
+                    db_exc = e
 
             # Send SIGTERM to running builds; this is a no-op in the successful case.
             for child in self.running_builds.values():


### PR DESCRIPTION
When the store is not writable, the prefix lock in the installer loop
will fail, reaching the finally block, which unconditionally takes
another database write lock, also failing, masking the original
problem.

Fix by taking a write lock in the finally bit iff something needs to be
persisted to the database.

Also has the benefit that `spack install` on an already installed env
will not take a write lock.