### PR TITLE
log parsing: change formatting

### DIFF
--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -39,12 +39,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="print out a profile of time spent in regexes during parse",
     )
     subparser.add_argument(
-        "-w",
-        "--width",
-        action="store",
-        type=int,
-        default=None,
-        help="wrap width: auto-size to terminal by default; 0 for no wrap",
+        "-w", "--width", action="store", type=int, default=None, help=argparse.SUPPRESS
     )
     subparser.add_argument(
         "-j", "--jobs", action="store", type=int, default=None, help=argparse.SUPPRESS
@@ -60,6 +55,8 @@ def log_parse(parser, args):
             sys.stdin.buffer, encoding="utf-8", errors="replace", closefd=False
         )
 
+    if args.width is not None:
+        warnings.warn("The --width option is deprecated and will be removed in Spack v1.3")
     if args.jobs is not None:
         warnings.warn("The --jobs option is deprecated and will be removed in Spack v1.3")
 
@@ -80,4 +77,4 @@ def log_parse(parser, args):
         events.extend(log_warnings)
         print("%d warnings" % len(log_warnings))
 
-    print(make_log_context(events, args.width))
+    print(make_log_context(events), end="")

--- a/lib/spack/spack/test/util/log_parser.py
+++ b/lib/spack/spack/test/util/log_parser.py
@@ -5,7 +5,9 @@
 import io
 import pathlib
 
+from spack.llnl.util.tty.color import color_when
 from spack.util.ctest_log_parser import CTestLogParser
+from spack.util.log_parse import make_log_context
 
 
 def test_log_parser(tmp_path: pathlib.Path):
@@ -67,6 +69,56 @@ def test_log_parser_preserves_leading_whitespace():
     assert len(errors) == 1
     assert errors[0].post_context[0] == "    int y = x + 1;"
     assert errors[0].post_context[1] == "            ^"
+
+
+def test_make_log_context_merges_overlapping_events(tmp_path: pathlib.Path):
+    """Overlapping or adjacent context windows should produce a single merged block."""
+
+    # Two errors close together: lines 5 and 10 with context=3 means windows overlap.
+    lines = [f"line {i}\n" for i in range(1, 21)]
+    lines[4] = "error: first problem\n"  # line 5
+    lines[9] = "error: second problem\n"  # line 10
+
+    log_file = tmp_path / "log.txt"
+    log_file.write_text("".join(lines))
+
+    parser = CTestLogParser()
+    errors, warnings = parser.parse(str(log_file), context=3)
+
+    log_events = sorted([*errors, *warnings], key=lambda e: e.line_no)
+    output = make_log_context(log_events)
+
+    # Should be exactly one header for the merged block, not two.
+    assert output.count("-- lines") == 1
+
+    # The header should cover the full merged range.
+    assert "-- lines 2 to 13 --" in output
+
+
+def test_make_log_context_warning_in_error_context_keeps_yellow(tmp_path: pathlib.Path):
+    """A warning line inside an error's context window must be highlighted yellow, not red."""
+    # Line 5 = error, line 8 = warning, context=3 so error window covers lines 2-11
+    # meaning the warning at line 8 falls inside the error's context.
+    lines = [f"line {i}\n" for i in range(1, 16)]
+    lines[4] = "error: something broke\n"  # line 5
+    lines[7] = "/tmp/foo.c:1: warning: something fishy\n"  # line 8
+
+    log_file = tmp_path / "log.txt"
+    log_file.write_text("".join(lines))
+
+    parser = CTestLogParser()
+    errors, warnings = parser.parse(str(log_file), context=3)
+
+    assert len(errors) == len(warnings) == 1
+
+    log_events = sorted([*errors, *warnings], key=lambda e: e.line_no)
+
+    with color_when("always"):
+        output = make_log_context(log_events)
+
+    # The error line should be red (ANSI 91), the warning yellow (ANSI 93).
+    assert "\x1b[0;91m> " in output and "something broke" in output
+    assert "\x1b[0;93m> " in output and "something fishy" in output
 
 
 def test_log_parser_non_utf8_bytes(tmp_path: pathlib.Path):

--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -212,6 +212,9 @@ _file_line_matches = [
 class LogEvent:
     """Class representing interesting events (e.g., errors) in a build log."""
 
+    #: color name when rendering in the terminal
+    color = ""
+
     def __init__(
         self,
         text,
@@ -262,9 +265,13 @@ class LogEvent:
 class BuildError(LogEvent):
     """LogEvent subclass for build errors."""
 
+    color = "R"
+
 
 class BuildWarning(LogEvent):
     """LogEvent subclass for build warnings."""
+
+    color = "Y"
 
 
 def chunks(xs, n):

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -3,12 +3,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import io
-import shutil
-import sys
-from typing import TextIO, Union
+from typing import List, TextIO, Union
 
 from spack.llnl.util.tty.color import cescape, colorize
-from spack.util.ctest_log_parser import BuildError, BuildWarning, CTestLogParser
+from spack.util.ctest_log_parser import CTestLogParser, LogEvent
 
 __all__ = ["parse_log_events", "make_log_context"]
 
@@ -44,75 +42,53 @@ def parse_log_events(stream: Union[str, TextIO], context: int = 6, profile: bool
 parse_log_events.ctest_parser = None  # type: ignore[attr-defined]
 
 
-def _wrap(text, width):
-    """Break text into lines of specific width."""
-    lines = []
-    pos = 0
-    while pos < len(text):
-        lines.append(text[pos : pos + width])
-        pos += width
-    return lines
-
-
-def make_log_context(log_events, width=None):
+def make_log_context(log_events: List[LogEvent]) -> str:
     """Get error context from a log file.
 
     Args:
-        log_events (list): list of events created by
-            ``ctest_log_parser.parse()``
-        width (int or None): wrap width; ``0`` for no limit; ``None`` to
-            auto-size for terminal
+        log_events: list of events created by ``ctest_log_parser.parse()``
+
     Returns:
         str: context from the build log with errors highlighted
 
-    Parses the log file for lines containing errors, and prints them out
-    with line numbers and context.  Errors are highlighted with ``>>`` and
-    with red highlighting (if color is enabled).
-
-    Events are sorted by line number before they are displayed.
+    Parses the log file for lines containing errors, and prints them out with context.
+    Errors are highlighted in red and warnings in yellow. Events are sorted by line number.
     """
-    error_lines = set(e.line_no for e in log_events)
+    event_colors = {e.line_no: e.color for e in log_events}
     log_events = sorted(log_events, key=lambda e: e.line_no)
-
-    num_width = len(str(max(error_lines or [0]))) + 4
-    line_fmt = "%%-%dd%%s" % num_width
-    indent = " " * (5 + num_width)
-
-    if width is None:
-        width = shutil.get_terminal_size().columns
-    if width <= 0:
-        width = sys.maxsize
-    wrap_width = width - num_width - 6
 
     out = io.StringIO()
     next_line = 1
+    block_start = -1
+    block_lines: List[str] = []
+
+    def flush_block():
+        block_end = block_start + len(block_lines) - 1
+        out.write(colorize("@c{-- lines %d to %d --}\n" % (block_start, block_end)))
+        out.writelines(block_lines)
+        block_lines.clear()
+
     for event in log_events:
         start = event.start
 
-        if isinstance(event, BuildError):
-            color = "R"
-        elif isinstance(event, BuildWarning):
-            color = "Y"
-        else:
-            color = "W"
-
-        if next_line != 1 and start > next_line:
-            out.write("\n     ...\n\n")
-
         if start < next_line:
             start = next_line
+        elif block_lines:
+            flush_block()
+
+        if not block_lines:
+            block_start = start
 
         for i in range(start, event.end):
-            # wrap to width
-            lines = _wrap(event[i], wrap_width)
-            lines[1:] = [indent + ln for ln in lines[1:]]
-            wrapped_line = line_fmt % (i, "\n".join(lines))
-
-            if i in error_lines:
-                out.write(colorize("  @%s{>> %s}\n" % (color, cescape(wrapped_line))))
+            if i in event_colors:
+                color = event_colors[i]
+                block_lines.append(colorize("@%s{> %s}\n" % (color, cescape(event[i]))))
             else:
-                out.write("     %s\n" % wrapped_line)
+                block_lines.append("  %s\n" % event[i])
 
         next_line = event.end
+
+    if block_lines:
+        flush_block()
 
     return out.getvalue()

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2300,7 +2300,6 @@ complete -c spack -n '__fish_spack_using_command log-parse' -s c -l context -r -
 complete -c spack -n '__fish_spack_using_command log-parse' -s p -l profile -f -a profile
 complete -c spack -n '__fish_spack_using_command log-parse' -s p -l profile -d 'print out a profile of time spent in regexes during parse'
 complete -c spack -n '__fish_spack_using_command log-parse' -s w -l width -r -f -a width
-complete -c spack -n '__fish_spack_using_command log-parse' -s w -l width -r -d 'wrap width: auto-size to terminal by default; 0 for no wrap'
 complete -c spack -n '__fish_spack_using_command log-parse' -s j -l jobs -r -f -a jobs
 
 # spack logs


### PR DESCRIPTION
* drop line wrapping in the log parser
* use a `grep` / `diff` style format
* fix bug where warning in error context is rendered red instead of yellow
* drop extra trailing newline in `spack log-parse`

Fixed line wrapping is problematic:

* cannot select and copy the full line by triple clicking
* error messages with "underline" on the next line are confusing with line wrapping:
  ```
  error: this is a long line
         ^^^^

  error: this is a lo
  ng line
         ^^^^
  ```

With this commit, the style is like this:

```
-- lines x to y --
  pre context a
  pre context b
> error: the error line
  post context a
  post context b
```


<img width="535" height="288" alt="Screenshot 2026-04-14 at 15 40 04" src="https://github.com/user-attachments/assets/78d8afdf-a46a-4b64-ad18-0c6b9d2bf0c7" />
