### PR TITLE
main: error on unrecognized top-level flags

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -969,7 +969,7 @@ def _main(argv=None):
     # them, which reduces startup latency.
     parser = make_argument_parser()
     parser.add_argument("command", nargs=argparse.REMAINDER)
-    args, unknown = parser.parse_known_args(argv)
+    args = parser.parse_args(argv)
 
     # Just print help and exit if run with no arguments at all
     no_args = (len(sys.argv) == 1) if argv is None else (len(argv) == 0)

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -98,6 +98,10 @@ def test_main_calls_get_version(capfd, working_env, monkeypatch):
     assert spack.spack_version == out.strip()
 
 
+def test_unrecognized_top_level_flag():
+    assert spack.main.main(["-o", "mirror", "list"]) != 0
+
+
 def test_get_version_bad_git(tmp_path: pathlib.Path, working_env, monkeypatch):
     bad_git = str(tmp_path / "git")
     with open(bad_git, "w", encoding="utf-8") as f:


### PR DESCRIPTION
After 7db386a018e2709bc4e22d61e18ab475ac8dbf33 changed `finish_parse_and_run` to parse `main_args.command`
instead of re-parsing `sys.argv`, unrecognized flags between `spack` and
the subcommand (e.g. `spack -o mirror list`) were silently ignored. Error
on them instead.

