### PR TITLE
spack env view: fix bash tab completion

### DIFF
--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -196,9 +196,7 @@ class BashCompletionWriter(ArgparseWriter):
         assert not (cmd.positionals and cmd.subcommands)  # one or the other
 
         # We only care about the arguments/flags, not the help messages
-        positionals: Tuple[str, ...] = ()
-        if cmd.positionals:
-            positionals, _, _, _ = zip(*cmd.positionals)
+        positionals = cmd.positionals or ()
         optionals, _, _, _, _ = zip(*cmd.optionals)
         subcommands: Tuple[str, ...] = ()
         if cmd.subcommands:
@@ -237,12 +235,12 @@ class BashCompletionWriter(ArgparseWriter):
         return "}\n"
 
     def body(
-        self, positionals: Sequence[str], optionals: Sequence[str], subcommands: Sequence[str]
+        self, positionals: Sequence, optionals: Sequence[str], subcommands: Sequence[str]
     ) -> str:
         """Return the body of the function.
 
         Args:
-            positionals: List of positional arguments.
+            positionals: List of positional argument tuples (name, choices, nargs, help).
             optionals: List of optional arguments.
             subcommands: List of subcommand parsers.
 
@@ -272,20 +270,30 @@ class BashCompletionWriter(ArgparseWriter):
     {self.optionals(optionals)}
 """
 
-    def positionals(self, positionals: Sequence[str]) -> str:
+    def positionals(self, positionals: Sequence) -> str:
         """Return the syntax for reporting positional arguments.
 
         Args:
-            positionals: List of positional arguments.
+            positionals: List of positional argument tuples (name, choices, nargs, help).
 
         Returns:
             Syntax for positional arguments.
         """
-        # If match found, return function name
-        for positional in positionals:
+        for name, choices, nargs, help in positionals:
+            # Check for a predefined subroutine mapping
             for key, value in _positional_to_subroutine.items():
-                if positional.startswith(key):
+                if name.startswith(key):
                     return value
+
+            # Use choices if available
+            if choices is not None:
+                if isinstance(choices, dict):
+                    choices = sorted(choices.keys())
+                elif isinstance(choices, (set, frozenset)):
+                    choices = sorted(choices)
+                else:
+                    choices = sorted(choices)
+                return 'SPACK_COMPREPLY="{}"'.format(" ".join(str(c) for c in choices))
 
         # If no matches found, return empty list
         return 'SPACK_COMPREPLY=""'

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -199,6 +199,14 @@ def test_bash_completion():
     assert "_spack_compiler_add() {" in out2
 
 
+def test_bash_completion_choices():
+    """Test that bash completion includes choices for positional arguments."""
+    out = commands("--format=bash")
+
+    # `spack env view` has a positional `action` with choices
+    assert 'SPACK_COMPREPLY="disable enable regenerate"' in out
+
+
 def test_fish_completion():
     """Test the fish completion writer."""
     out1 = commands("--format=fish")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1137,7 +1137,7 @@ _spack_env_view() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY=""
+        SPACK_COMPREPLY="disable enable regenerate"
     fi
 }
 


### PR DESCRIPTION
Currently `spack env view <tab>` autocompletes with fish, but  not with
bash. This fixes it.

