### PR TITLE
environment: minor code cleanup

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -584,8 +584,8 @@ def validate_included_envs_concrete(include_concrete: List[str]) -> None:
     non_concrete_envs = set()
 
     for env_path in include_concrete:
-        if not os.path.exists(Environment(env_path).lock_path):
-            non_concrete_envs.add(Environment(env_path).name)
+        if not os.path.exists(os.path.join(env_path, lockfile_name)):
+            non_concrete_envs.add(environment_name(env_path))
 
     if non_concrete_envs:
         msg = "The following environment(s) are not concrete: {0}\nPlease run:".format(

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -3348,11 +3348,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         Args:
             include_concrete: list of already existing concrete environments to include
         """
-        self.configuration[lockfile_include_key] = []
-
-        for env_path in include_concrete:
-            self.configuration[lockfile_include_key].append(env_path)
-
+        self.configuration[lockfile_include_key] = list(include_concrete)
         self.changed = True
 
     def add_definition(self, user_spec: str, list_name: str) -> None:


### PR DESCRIPTION
Modifications:
- Replace two `Environment(env_path)` constructions, which come at the cost of additional YAML parsing and lock creation / destruction, with direct path and name computations.
- Shorten the creation of a list for `include_concrete`
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
