### PR TITLE
environment: fix failure to remove + create an environment

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -303,11 +303,7 @@ def root(name):
 
 
 def exists(name):
-    """Whether an environment with this name exists or not.
-
-    A managed environment exists when its directory AND its spack.yaml manifest are both present.
-    A directory without a spack.yaml is considered orphaned and does not constitute an environment.
-    """
+    """Whether an environment with this name exists or not."""
     if not valid_env_name(name):
         return False
     return os.path.lexists(os.path.join(_root(name), manifest_name))

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -303,8 +303,15 @@ def root(name):
 
 
 def exists(name):
-    """Whether an environment with this name exists or not."""
-    return valid_env_name(name) and os.path.isdir(_root(name))
+    """Whether an environment with this name exists or not.
+
+    A managed environment exists when its directory AND its spack.yaml manifest are both present.
+    A directory without a spack.yaml is considered orphaned and does not constitute an environment.
+    """
+    if not valid_env_name(name):
+        return False
+    env_root = _root(name)
+    return os.path.isdir(env_root) and os.path.exists(os.path.join(env_root, manifest_name))
 
 
 def active(name):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -310,8 +310,7 @@ def exists(name):
     """
     if not valid_env_name(name):
         return False
-    env_root = _root(name)
-    return os.path.isdir(env_root) and os.path.lexists(os.path.join(env_root, manifest_name))
+    return os.path.lexists(os.path.join(_root(name), manifest_name))
 
 
 def active(name):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -311,7 +311,7 @@ def exists(name):
     if not valid_env_name(name):
         return False
     env_root = _root(name)
-    return os.path.isdir(env_root) and os.path.exists(os.path.join(env_root, manifest_name))
+    return os.path.isdir(env_root) and os.path.lexists(os.path.join(env_root, manifest_name))
 
 
 def active(name):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -304,9 +304,7 @@ def root(name):
 
 def exists(name):
     """Whether an environment with this name exists or not."""
-    if not valid_env_name(name):
-        return False
-    return os.path.lexists(os.path.join(_root(name), manifest_name))
+    return valid_env_name(name) and os.path.lexists(os.path.join(_root(name), manifest_name))
 
 
 def active(name):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4945,3 +4945,22 @@ spack:
         # Sanity check: make sure the target we expect was applied to the
         # compiler entry
         assert libdwarf["c"].satisfies("gcc@12.100.100 languages:=c,c++ target=x86_64_v3")
+
+
+@pytest.mark.regression("52247")
+def test_create_with_orphaned_directory(mutable_mock_env_path: pathlib.Path):
+    """Tests that an orphaned environment directory (directory exists, no spack.yaml) must not
+    prevent 'spack env create' from creating a new environment with that name.
+    """
+    orphaned = mutable_mock_env_path / "test1"
+    orphaned_subdir = orphaned / ".spack-env"
+    orphaned_subdir.mkdir(parents=True)
+
+    # The orphaned directory must not be seen as an existing environment
+    assert not ev.exists("test1")
+
+    # Creating an environment over an orphaned directory must succeed
+    env("create", "test1")
+
+    assert ev.exists("test1")
+    assert "test1" in env("list")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4964,3 +4964,34 @@ def test_create_with_orphaned_directory(mutable_mock_env_path: pathlib.Path):
 
     assert ev.exists("test1")
     assert "test1" in env("list")
+
+
+@pytest.mark.parametrize(
+    "setup",
+    [
+        # valid environment: spack.yaml is a regular file
+        pytest.param("valid", id="valid"),
+        # orphaned directory: no spack.yaml at all
+        pytest.param("orphaned", id="orphaned"),
+        # broken manifest symlink: spack.yaml points to a non-existent target
+        pytest.param("broken_symlink", id="broken_symlink"),
+    ],
+)
+@pytest.mark.regression("52247")
+def test_exists_consistent_with_all_environment_names(
+    mutable_mock_env_path: pathlib.Path, setup: str
+):
+    """Tests that exists() and all_environment_names() agree on whether an environment exists."""
+    env_dir = mutable_mock_env_path / "myenv"
+    env_dir.mkdir(parents=True)
+    manifest = env_dir / ev.manifest_name
+
+    if setup == "valid":
+        manifest.write_text(ev.default_manifest_yaml())
+    elif setup == "orphaned":
+        pass  # no manifest
+    elif setup == "broken_symlink":
+        manifest.symlink_to("/nonexistent/spack.yaml")
+
+    listed = "myenv" in ev.all_environment_names()
+    assert ev.exists("myenv") == listed


### PR DESCRIPTION
fixes #52247

Removing and re-creating the same environment fails if upon removal the environment directory contains leftovers. This is due to the wrong assumption in `exists` that an environment exists if its directory exists. Here we fix the issue by requiring the manifest file to be present so that `spack env create` can recover from orphaned directories.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
